### PR TITLE
[trace/redis] inherit from the correct class

### DIFF
--- a/ddtrace/contrib/redis/tracers.py
+++ b/ddtrace/contrib/redis/tracers.py
@@ -24,7 +24,13 @@ def get_traced_redis_from(ddtracer, baseclass, service=DEFAULT_SERVICE, meta=Non
 
 # pylint: disable=protected-access
 def _get_traced_redis(ddtracer, baseclass, service, meta):
-    class TracedPipeline(StrictPipeline):
+    basepipeline = StrictPipeline
+    try:
+        basepipeline = baseclass().pipeline().__class__
+    except:
+        pass
+
+    class TracedPipeline(basepipeline):
         _datadog_tracer = ddtracer
         _datadog_service = service
         _datadog_meta = meta


### PR DESCRIPTION
If using something else than the recommended class StrictRedis, like the
backwards-compatible redis.Redis, attaching a StrictPipeline to a
redis.Redis leads to unexpected behavior.

for instance:

```
r = redis.Redis()
r.zadd(key, member, score) # fine but should be (key, score, member) in
                           # StrictRedis
p = r.pipeline()
p.zadd(key, member, score) # does not work because it's strict...
```
