### PR TITLE
No-op if span.finish() is called more than once

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -69,20 +69,25 @@ class Span(object):
         self._tracer = tracer
         self._parent = None
 
+        # state
+        self._finished = False
+
     def finish(self, finish_time=None):
         """ Mark the end time of the span and submit it to the tracer.
-            If the span has already been finished (that is, it has a duration),
-            don't do anything
+            If the span has already been finished don't do anything
 
             :param int finish_time: the end time of the span in seconds.
                                     Defaults to now.
         """
-        if self.duration is not None:
+        if self._finished:
             return
+        self._finished = True
 
-        ft = finish_time or time.time()
-        # be defensive so we don't die if start isn't set
-        self.duration = ft - (self.start or ft)
+        if self.duration is None:
+            ft = finish_time or time.time()
+            # be defensive so we don't die if start isn't set
+            self.duration = ft - (self.start or ft)
+
         if self._tracer:
             self._tracer.record(self)
 

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -68,9 +68,8 @@ def test_finish_called_multiple_times():
 
 
 def test_finish_set_span_duration():
-    # If set the duration on a span, the span should be recorded
-    # with this duration
-    # TODO elijah: this fails right now
+    # If set the duration on a span, the span should be recorded with this
+    # duration
     dt = DummyTracer()
     assert dt.last_span is None
     s = Span(dt, 'foo')


### PR DESCRIPTION
I've run into a situation where I want to record a span's duration, so I did the following:

``` python
duration = 0
with tracer.trace('span_name') as s:
    # ...
    s.finish()
    duration = s.duration
# ...
# do something with duration
```

However, this reports the span twice (once in my context and once in the span's `__exit__` function).

Another way to do this would be to do the following:

``` python
duration = 0
span = tracer.trace('span_name')
try:
    # ...
finally:
    span.finish()
    duration = span.duration
```

I prefer the context manager notation as it requires fewer lines, and makes it a bit easier to see the code contained within the span. This PR allows me to use the context manager version of the code. I could change my code to use the `try`/`finally` version of the code, but I have a feeling that other people will run into this situation so we'd want to have this anyway.

Seem reasonable? @clutchski @LotharSee 
