### PR TITLE
Better CI DB initialization

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,8 @@ dependencies:
 database:
   override:
     - sudo service postgresql stop
+    # Wait for Postgres to stop, sometimes this takes a bit of time
+    - while nc -v -z localhost 5432 ; do sleep 0.2 ; done
     - sudo service redis-server stop
     - docker run -d -p 9200:9200 elasticsearch:2.3
     - docker run -d -p 9042:9042 cassandra:3


### PR DESCRIPTION
This PR addresses https://github.com/DataDog/dd-trace-py/issues/26, where CI hangs if Postgres fails to start. 

When commands in the `test` section of `circle.yml` fail, the build continues to run. Sometimes Postgres would fail to start, and the subsequent command that verifies that Postgres started correctly loops indefinitely.

I've moved the DB setup steps to the `database` section of `circle.yml`, where a failed command will fail the entire CI run. I also added a check to make sure that Postgres is stopped before we start our own instance, which means that Postgres should always be able to start.

@LotharSee 
