### PR TITLE
flask: ensure template timings tracked in < 0.11

### DIFF
--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -79,6 +79,7 @@ class TraceMiddleware(object):
             if not s:
                 connected = False
                 log.warn("trying to instrument missing signal %s", name)
+                continue
             s.connect(handler, sender=self.app)
         return connected
 


### PR DESCRIPTION
the before_template signal was added in 0.11. fallback to the uglier
way of patching the template method directly
