### PR TITLE
[ci] Don't run `python setup.py test` in CI since we now use Tox

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,10 +37,9 @@ database:
     - until nc -v -z localhost 9042 ; do sleep 0.2 ; done
     # Wait for Postgres to be ready
     - until PGPASSWORD=test PGUSER=test PGDATABASE=test psql -h localhost -p 5432 -c "select 1" ; do sleep 0.2 ; done
-# test:
-#   override:
-#     - python2.7 setup.py test
-#     - python3.4 setup.py test
+test:
+  override:
+    - tox
 deployment:
   dev:
     branch: /(master)|(develop)/


### PR DESCRIPTION
Since we started running CI tests using `tox`, we've also been running `python setup.py test` as part of the test step. It seems that if no test step is specified in `circle.yml`, it will run `python setup.py test` by default.

@clutchski 
