### PR TITLE
Remove unneeded python setup from CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,9 +3,11 @@ machine:
     - docker
   environment:
     CASS_DRIVER_NO_EXTENSIONS: 1
+  post:
+    - pyenv global 2.7.11 3.4.4
+
 dependencies:
   pre:
-    - pip install tox
     # Pre-pull containers
     - docker pull elasticsearch:2.3
     - docker pull cassandra:3


### PR DESCRIPTION
Since we've started using Tox, we don't need to run a bunch of Python setup in CI. We don't even need to install Tox, since Circle does this automatically if it sees a `tox.ini` file! This PR removes the unneeded Python setup steps from CI.

[Here](https://circleci.com/gh/DataDog/dd-trace-py/380) is a passing build using this version of `circle.yml`. I cleared the cache for this build to make sure that Tox actually sets up all the Python dependencies we need. 

One this that remains to be tested is the deployment step, but I think it should work. I think the best way to test that is to merge and make sure it passes when running CI off master.

@clutchski 
