### PR TITLE
[tests] remove py34-gevent10 test env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,8 @@ envlist =
     {py27,py34}-django{18,19,110}-djangopylibmc06-djangoredis45-pylibmc-redis-memcached
     {py27,py34}-flask{010,011}-blinker
     {py27,py34}-flask{010,011}-flaskcache{013}-memcached-redis-blinker
-    {py27,py34}-gevent{10,11}
+    {py27}-gevent{10,11}
+    {py34}-gevent{11}
     {py27}-flask{010,011}-flaskcache{012}-memcached-redis-blinker
     {py27,py34}-mysqlconnector{21}
     {py27,py34}-pylibmc{140,150}


### PR DESCRIPTION
I was running into issues getting `rake test` to run successfully, the only test that was failing was the `py34-gevent10` test suite.

The reason it was failing was because `gevent` did not become Python 3 friendly until the `1.1` release.

I've never used `tox` before, so not entirely sure if this was the correct fix or not.

Also, I do not have access to view the failing build on circleci, so not sure if this is what is currently breaking the build or just an issue for me locally.