### PR TITLE
[requests] ensure span.error is an int

### DIFF
--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -68,7 +68,8 @@ def _apply_tags(span, method, url, response):
     span.set_tag(http.URL, url)
     if response is not None:
         span.set_tag(http.STATUS_CODE, response.status_code)
-        span.error = 500 <= response.status_code
+        # `span.error` must be an integer
+        span.error = int(500 <= response.status_code)
 
 
 class TracedSession(requests.Session):


### PR DESCRIPTION
`span.error` is getting set as a boolean which is causing a trace agent error when unmarshaling the request json.

```
2016-10-31 20:30:36 ERROR (receiver.go:100) - request error, code:500 tags:[handler:traces v:0] err: json: cannot unmarshal bool into Go value of type int32
```

/cc @clutchski 