### PR TITLE
Library patching for pylibmc

### DIFF
--- a/ddtrace/contrib/autopatch.py
+++ b/ddtrace/contrib/autopatch.py
@@ -21,6 +21,7 @@ autopatch_modules = [
     'requests',
     'sqlite3',
     'psycopg',
+    'pylibmc',
     'redis',
 ]
 

--- a/ddtrace/contrib/pylibmc/__init__.py
+++ b/ddtrace/contrib/pylibmc/__init__.py
@@ -1,16 +1,31 @@
 """
-To trace the pylibmc Memcached client, wrap its connections with the traced
-client::
+A patched pylibmc Memcached client will wrap report spans for any Memcached call.
+
+Basic usage::
 
     import pylibmc
-    from ddtrace import tracer
+    import ddtrace
+    from ddtrace.monkey import patch_all
 
-    client = TracedClient(
-        client=pylibmc.Client(["localhost:11211"]),
-        tracer=tracer,
-        service="my-cache-cluster")
+    # patch the library
+    patch_all()
 
-    client.set("key", "value")
+    # one client with default configuration
+    client = pylibmc.Client(["localhost:11211"]
+    client.set("key1", "value1")
+
+    # Configure one client
+    ddtrace.Pin(service='my-cache-cluster')).onto(client)
+
 """
 
-from .client import TracedClient # flake8: noqa
+from ..util import require_modules
+
+required_modules = ['pylibmc']
+
+with require_modules(required_modules) as missing_modules:
+    if not missing_modules:
+        from .client import TracedClient
+        from .patch import patch
+
+        __all__ = ['TracedClient', 'patch']

--- a/ddtrace/contrib/pylibmc/patch.py
+++ b/ddtrace/contrib/pylibmc/patch.py
@@ -1,0 +1,14 @@
+import pylibmc
+
+from .client import TracedClient
+
+# Original Client class
+_Client = pylibmc.Client
+
+
+def patch():
+    setattr(pylibmc, 'Client', TracedClient)
+
+def unpatch():
+    setattr(pylibmc, 'Elasticsearch', _Client)
+


### PR DESCRIPTION
- implement `patch` (and `unpatch`, not exported, only used during tests)
- Upgrade the `TracedClient ` to support both the indirect instantiation as `TracedClient(client=pylibmc.Client(["localhost:11211"]))` or the direct one a patched client. `pylibmc.Client(["localhost:11211"])`
- Update doc about how to use the patching and Pin (will be unified/cleaned later)
- Update tests, add new cases to check for the default Pin service and a customized service

