### PR TITLE
Fix flake8 error, pin flake8 version

### DIFF
--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -53,6 +53,7 @@ def to_unicode(s):
     #   e.g. `to_unicode(1)`, `to_unicode(dict(key='value'))`
     return stringify(s)
 
+
 if PY2:
     string_type = basestring
     numeric_types = (int, long, float)

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -194,6 +194,7 @@ def _signals_exist(names):
     """
     return all(getattr(signals, n, False) for n in names)
 
+
 _blinker_not_installed_msg = (
     "please install blinker to use flask signals. "
     "http://flask.pocoo.org/docs/0.11/signals/"

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -77,6 +77,7 @@ class TracedSession(requests.Session):
     """
     pass
 
+
 # Always patch our traced session with the traced method (cheesy way of sharing
 # code)
 wrapt.wrap_function_wrapper(TracedSession, 'request', _traced_request_func)

--- a/tox.ini
+++ b/tox.ini
@@ -126,7 +126,7 @@ deps=
 ignore_outcome=true
 
 [testenv:flake8]
-deps=flake8
+deps=flake8==3.2.0
 commands=flake8 ddtrace
 basepython=python
 


### PR DESCRIPTION
Was breaking the CI because of a recent flake8 upgrade, introducing new errors.

```
ddtrace/compat.py:56:1: E305 expected 2 blank lines after class or function definition, found 1
ddtrace/contrib/flask/middleware.py:197:1: E305 expected 2 blank lines after class or function definition, found 1
ddtrace/contrib/requests/patch.py:82:1: E305 expected 2 blank lines after class or function definition, found 1
```

Fix the errors, pin flake8 to the latest version for it not to happen randomly again.