### PR TITLE
[django] fixed tracing middleware for cases where the request object doesn't have the user attribute

### DIFF
--- a/ddtrace/contrib/django/middleware.py
+++ b/ddtrace/contrib/django/middleware.py
@@ -90,7 +90,7 @@ def _set_auth_tags(span, request):
     """ Patch any available auth tags from the request onto the span. """
     user = getattr(request, 'user', None)
     if not user:
-        return
+        return span
 
     if hasattr(user, 'is_authenticated'):
         span.set_tag('django.user.is_authenticated', user.is_authenticated())


### PR DESCRIPTION
### What it does

In some cases, the ``request`` object doesn't have the ``user`` attribute. To reproduce the error, it's enough that the ``django.contrib.auth.middleware.AuthenticationMiddleware`` is removed from the middleware list.

The caller indeed, [expects a span][1].

[1]: https://github.com/DataDog/dd-trace-py/blob/f1c516e0bcfdd82996773a7f19d283a6505728e9/ddtrace/contrib/django/middleware.py#L61-L62