### PR TITLE
Log deprecated methods

### DIFF
--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -8,7 +8,7 @@ import wrapt
 # project
 from ddtrace import Pin
 from ddtrace.compat import stringify
-from ...util import deep_getattr
+from ...util import deep_getattr, deprecated
 from ...ext import net, cassandra as cassx
 from ...ext import AppTypes
 
@@ -58,7 +58,7 @@ def traced_execute(func, instance, args, kwargs):
                 span.set_tags(_extract_result_metas(result))
 
 
-# deprecated
+@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
 def get_traced_cassandra(tracer, service=SERVICE, meta=None):
     return _get_traced_cluster(cassandra.cluster, tracer, service, meta)
 

--- a/ddtrace/contrib/elasticsearch/transport.py
+++ b/ddtrace/contrib/elasticsearch/transport.py
@@ -4,12 +4,13 @@ from .quantize import quantize
 from . import metadata
 from ...compat import json, urlencode
 from ...ext import AppTypes
+from ...util import deprecated
 
 DEFAULT_SERVICE = 'elasticsearch'
 SPAN_TYPE = 'elasticsearch'
 
 
-# deprecated
+@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
 def get_traced_transport(datadog_tracer, datadog_service=DEFAULT_SERVICE):
 
     datadog_tracer.set_service_info(

--- a/ddtrace/contrib/mysql/tracers.py
+++ b/ddtrace/contrib/mysql/tracers.py
@@ -1,10 +1,7 @@
-import logging
-
 import mysql.connector
 
-logger = logging.getLogger(__name__)
+from ddtrace.util import deprecated
 
-# deprecated
+@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
 def get_traced_mysql_connection(*args, **kwargs):
-    logger.warn("get_traced_mysql_connection is deprecated")
     return mysql.connector.MySQLConnection

--- a/ddtrace/contrib/psycopg/connection.py
+++ b/ddtrace/contrib/psycopg/connection.py
@@ -9,12 +9,13 @@ from ...ext import db
 from ...ext import net
 from ...ext import sql
 from ...ext import AppTypes
+from ...util import deprecated
 
 # 3p
 from psycopg2.extensions import connection, cursor
 
 
-# deprecated
+@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
 def connection_factory(tracer, service="postgres"):
     """ Return a connection factory class that will can be used to trace
         postgres queries.

--- a/ddtrace/contrib/pylibmc/client.py
+++ b/ddtrace/contrib/pylibmc/client.py
@@ -35,6 +35,9 @@ class TracedClient(ObjectProxy):
             # We are in the patched situation, just pass down all arguments to the pylibmc.Client
             # Note that, in that case, client isn't a real client (just the first argument)
             client = _Client(client, *args, **kwargs)
+        else:
+            log.warning("TracedClient instantiation is deprecated and will be remove "
+                        "in future versions (0.6.0). Use patching instead (see the docs).")
 
         super(TracedClient, self).__init__(client)
 

--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -13,6 +13,7 @@ from ...compat import iteritems, json
 from ...ext import AppTypes
 from ...ext import mongo as mongox
 from ...ext import net as netx
+from ...util import deprecated
 from .parse import parse_spec, parse_query, parse_msg
 
 # Original Client class
@@ -21,6 +22,7 @@ _MongoClient = pymongo.MongoClient
 log = logging.getLogger(__name__)
 
 
+@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
 def trace_mongo_client(client, tracer, service=mongox.TYPE):
     tracer.set_service_info(
         service=service,

--- a/ddtrace/contrib/redis/tracers.py
+++ b/ddtrace/contrib/redis/tracers.py
@@ -8,11 +8,12 @@ import wrapt
 from ...ext import AppTypes
 from .patch import traced_execute_command, traced_pipeline
 from ...pin import Pin
-
+from ...util import deprecated
 
 DEFAULT_SERVICE = 'redis'
 
 
+@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
 def get_traced_redis(ddtracer, service=DEFAULT_SERVICE, meta=None):
     """ DEPRECATED """
     return _get_traced_redis(ddtracer, StrictRedis, service, meta)

--- a/ddtrace/contrib/sqlite3/connection.py
+++ b/ddtrace/contrib/sqlite3/connection.py
@@ -1,6 +1,7 @@
 from sqlite3 import Connection
 
+from ddtrace.util import deprecated
 
+@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
 def connection_factory(*args, **kwargs):
-    # DEPRECATED
     return Connection

--- a/ddtrace/util.py
+++ b/ddtrace/util.py
@@ -2,8 +2,23 @@
 Generic utilities for tracers
 """
 
+from functools import wraps
 import inspect
+import logging
 
+def deprecated(message='', version=None):
+    """Function decorator to report a deprecated function"""
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            logger = logging.getLogger(func.__module__)
+            logger.warning("%s is deprecated and will be remove in future versions%s. %s",
+                           func.__name__,
+                           ' (%s)' % version if version else '',
+                           message)
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator
 
 def deep_getattr(obj, attr_string, default=None):
     """


### PR DESCRIPTION
log.warn the usage of deprecated methods. The message contains a message telling what to use instead, plus the version when it will be dropped.
Add a `@deprecated` decorator for that.