### PR TITLE
[encoder] using JSONEncoder by default

### DIFF
--- a/ddtrace/encoding.py
+++ b/ddtrace/encoding.py
@@ -1,5 +1,4 @@
 import json
-import msgpack
 import logging
 
 
@@ -7,6 +6,7 @@ import logging
 # pure Python implementation that is really slow, so the ``Encoder`` should use
 # a different encoding format
 try:
+    import msgpack
     from msgpack._packer import Packer  # noqa
     from msgpack._unpacker import unpack, unpackb, Unpacker  # noqa
     MSGPACK_CPP = True

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
     packages=find_packages(exclude=['tests*']),
     install_requires=[
         "wrapt",
-        "msgpack-python",
     ],
     # plugin tox
     tests_require=['tox', 'flake8'],


### PR DESCRIPTION
### What it does

Use ``JSONEncoder`` by default, removing ``msgpack-python`` from dependencies. In this way, users should install msgpack manually if the want to use the new encoder (decoder in the agent).

This makes the code more robust in this transition, so that in version 0.5.0 we can switch to msgpack immediately.