### PR TITLE
Cass norm

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,9 +19,16 @@ task :"test:envs", [:grep] do |t, args|
   end
 end
 
-task :up do
-  sh "docker-compose up -d | cat"
+namespace :docker do
+  task :up do
+    sh "docker-compose up -d | cat"
+  end
+  
+  task :down do
+    sh "docker-compose kill"
+  end
 end
+
 
 desc "install the library in dev mode"
 task :dev do

--- a/Rakefile
+++ b/Rakefile
@@ -23,9 +23,9 @@ namespace :docker do
   task :up do
     sh "docker-compose up -d | cat"
   end
-  
+
   task :down do
-    sh "docker-compose kill"
+    sh "docker-compose down"
   end
 end
 

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -46,7 +46,7 @@ def traced_execute(func, instance, args, kwargs):
     query = kwargs.get("kwargs") or args[0]
 
     with tracer.trace("cassandra.query", service=service, span_type=cassx.TYPE) as span:
-        span.resource = _sanitize_query(query)
+        span = _sanitize_query(span, query)
         span.set_tags(_extract_session_metas(instance))     # FIXME[matt] do once?
         span.set_tags(_extract_cluster_metas(cluster))
         result = None
@@ -57,62 +57,6 @@ def traced_execute(func, instance, args, kwargs):
             if result:
                 span.set_tags(_extract_result_metas(result))
 
-
-@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
-def get_traced_cassandra(tracer, service=SERVICE, meta=None):
-    return _get_traced_cluster(cassandra.cluster, tracer, service, meta)
-
-
-def _get_traced_cluster(cassandra, tracer, service="cassandra", meta=None):
-    """ Trace synchronous cassandra commands by patching the Session class """
-
-    tracer.set_service_info(
-        service=service,
-        app="cassandra",
-        app_type=AppTypes.db,
-    )
-
-    class TracedSession(cassandra.Session):
-        _dd_tracer = tracer
-        _dd_service = service
-        _dd_tags = meta
-
-        def __init__(self, *args, **kwargs):
-            super(TracedSession, self).__init__(*args, **kwargs)
-
-        def execute(self, query, *args, **options):
-            if not self._dd_tracer:
-                return super(TracedSession, self).execute(query, *args, **options)
-
-            with self._dd_tracer.trace("cassandra.query", service=self._dd_service) as span:
-                query_string = _sanitize_query(query)
-                span.resource = query_string
-                span.span_type = cassx.TYPE
-
-                span.set_tags(_extract_session_metas(self))
-                cluster = getattr(self, "cluster", None)
-                span.set_tags(_extract_cluster_metas(cluster))
-
-                result = None
-                try:
-                    result = super(TracedSession, self).execute(query, *args, **options)
-                    return result
-                finally:
-                    span.set_tags(_extract_result_metas(result))
-
-    class TracedCluster(cassandra.Cluster):
-
-        def connect(self, *args, **kwargs):
-            orig = cassandra.Session
-            cassandra.Session = TracedSession
-            traced_session = super(TracedCluster, self).connect(*args, **kwargs)
-
-            # unpatch the Session class so we don't wrap already traced sessions
-            cassandra.Session = orig
-
-            return traced_session
-
-    return TracedCluster
 
 def _extract_session_metas(session):
     metas = {}
@@ -130,10 +74,6 @@ def _extract_cluster_metas(cluster):
         metas[cassx.CLUSTER] = cluster.metadata.cluster_name
     if getattr(cluster, "port", None):
         metas[net.TARGET_PORT] = cluster.port
-    if getattr(cluster, "compression", None):
-        metas[cassx.COMPRESSION] = cluster.compression
-    if getattr(cluster, "cql_version", None):
-        metas[cassx.CQL_VERSION] = cluster.cql_version
 
     return metas
 
@@ -151,7 +91,7 @@ def _extract_result_metas(result):
             metas[cassx.CONSISTENCY_LEVEL] = query.consistency_level
         if getattr(query, "keyspace", None):
             # Overrides session.keyspace if the query has been prepared against a particular
-            # keyspace
+            # keyspace.
             metas[cassx.KEYSPACE] = query.keyspace.lower()
 
     if hasattr(result, "has_more_pages"):
@@ -166,14 +106,46 @@ def _extract_result_metas(result):
 
     return metas
 
-def _sanitize_query(query):
+def _sanitize_query(span, query):
     """ Sanitize the query to something ready for the agent receiver
     - Cast to unicode
     - truncate if needed
     """
     # TODO (aaditya): fix this hacky type check. we need it to avoid circular imports
-    if type(query).__name__ in ('SimpleStatement', 'PreparedStatement'):
-        # reset query if a string is available
-        query = getattr(query, "query_string", query)
+    t = type(query).__name__
 
-    return stringify(query)[:RESOURCE_MAX_LENGTH]
+    resource = None
+    if t in ('SimpleStatement', 'PreparedStatement'):
+        # reset query if a string is available
+        resource  = getattr(query, "query_string", query)
+    elif t == 'BatchStatement':
+        resource = 'BatchStatement'
+        q = "; ".join(q[1] for q in query._statements_and_parameters[:2])
+        span.set_tag("cassandra.query", q)
+        span.set_metric("cassandra.batch_size", len(query._statements_and_parameters))
+    elif t == 'BoundStatement':
+        ps = getattr(query, 'prepared_statement', None)
+        if ps:
+            resource = getattr(ps, 'query_string', None)
+    else:
+        resource = 'unknown-query-type' # FIXME[matt] what else do to here?
+
+    span.resource = stringify(resource)[:RESOURCE_MAX_LENGTH]
+    return span
+
+
+#
+# DEPRECATED
+#
+
+@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
+def get_traced_cassandra(tracer, service=SERVICE, meta=None):
+    return _get_traced_cluster(cassandra.cluster, tracer, service, meta)
+
+
+def _get_traced_cluster(cassandra, tracer, service="cassandra", meta=None):
+    """ Trace synchronous cassandra commands by patching the Session class """
+    return cassandra.Cluster
+
+
+

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -10,7 +10,6 @@ from ddtrace import Pin
 from ddtrace.compat import stringify
 from ...util import deep_getattr, deprecated
 from ...ext import net, cassandra as cassx
-from ...ext import AppTypes
 
 
 RESOURCE_MAX_LENGTH = 5000
@@ -117,7 +116,7 @@ def _sanitize_query(span, query):
     resource = None
     if t in ('SimpleStatement', 'PreparedStatement'):
         # reset query if a string is available
-        resource  = getattr(query, "query_string", query)
+        resource = getattr(query, "query_string", query)
     elif t == 'BatchStatement':
         resource = 'BatchStatement'
         q = "; ".join(q[1] for q in query._statements_and_parameters[:2])

--- a/ddtrace/ext/cassandra.py
+++ b/ddtrace/ext/cassandra.py
@@ -8,7 +8,3 @@ KEYSPACE = "cassandra.keyspace"
 CONSISTENCY_LEVEL = "cassandra.consistency_level"
 PAGINATED = "cassandra.paginated"
 ROW_COUNT = "cassandra.row_count"
-COMPRESSION = "cassandra.compression"
-CONTACT_POINTS = "cassandra.contact_points"
-CQL_VERSION = "cassandra.cql_version"
-

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
     {py27,py34}-integration
     {py27,py34}-contrib
     {py27,py34}-bottle{12}-webtest
-    {py27,py34}-cassandra
+    {py27,py34}-cassandra{35,36,37}
     {py27,py34}-elasticsearch{23}
     {py27,py34}-falcon{10}
     {py27,py34}-django{18,19,110}-djangopylibmc06-djangoredis45-pylibmc-redis-memcached
@@ -60,7 +60,9 @@ deps =
     contrib: WebTest
     blinker: blinker
     bottle12: bottle>=0.12
-    cassandra: cassandra-driver
+    cassandra35: cassandra-driver>=3.5,<3.6
+    cassandra36: cassandra-driver>=3.6,<3.7
+    cassandra37: cassandra-driver>=3.7
     elasticsearch23: elasticsearch>=2.3,<2.4
     falcon10: falcon>=1.0,<1.1
     django18: django>=1.8,<1.9
@@ -109,7 +111,7 @@ commands =
     {py27,py34}-contrib: nosetests {posargs} --exclude=".*(django).*" tests/contrib/
 # run subsets of the tests for particular library versions
     {py27,py34}-bottle{12}: nosetests {posargs} tests/contrib/bottle/
-    {py27,py34}-cassandra: nosetests {posargs} tests/contrib/cassandra
+    {py27,py34}-cassandra{35,36,37}: nosetests {posargs} tests/contrib/cassandra
     {py27,py34}-elasticsearch{23}: nosetests {posargs} tests/contrib/elasticsearch
     {py27,py34}-django{18,19,110}: python tests/contrib/django/runtests.py {posargs}
     {py27,py34}-flaskcache{013}: nosetests {posargs} tests/contrib/flask_cache


### PR DESCRIPTION
- properly normalizes batch and bound cassandra queries
- removes the old tracer (null interface still in place)

Should fix #126