### PR TITLE
Use elasticsearch serializer

### DIFF
--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -1,6 +1,5 @@
 import elasticsearch
 import wrapt
-import json
 
 from . import metadata
 from .quantize import quantize
@@ -70,7 +69,7 @@ def _perform_request(func, instance, args, kwargs):
         span.set_tag(metadata.URL, url)
         span.set_tag(metadata.PARAMS, urlencode(params))
         if method == "GET":
-            span.set_tag(metadata.BODY, json.dumps(body))
+            span.set_tag(metadata.BODY, instance.serializer.dumps(body))
 
         span = quantize(span)
 

--- a/ddtrace/contrib/elasticsearch/transport.py
+++ b/ddtrace/contrib/elasticsearch/transport.py
@@ -1,5 +1,3 @@
-import json
-
 from elasticsearch import Transport
 
 from .quantize import quantize
@@ -42,7 +40,7 @@ def get_traced_transport(datadog_tracer, datadog_service=DEFAULT_SERVICE):
                 s.set_tag(metadata.URL, url)
                 s.set_tag(metadata.PARAMS, urlencode(params))
                 if method == "GET":
-                    s.set_tag(metadata.BODY, json.dumps(body))
+                    s.set_tag(metadata.BODY, self.serializer.dumps(body))
 
                 s = quantize(s)
 


### PR DESCRIPTION
This makes it so queries with dates, decimals and UUIDs work.

https://github.com/elastic/elasticsearch-py/blob/d4efb81b0695f3d9f64784a35891b732823a9c32/elasticsearch/serializer.py#L24-L50

Right now any query with the above types will throw an exception:

```
  File "/tmp/example/env/lib/python2.7/site-packages/elasticsearch_dsl/search.py", line 593, in execute
    **self._params
  File "/tmp/example/env/lib/python2.7/site-packages/elasticsearch/client/utils.py", line 69, in _wrapped
    return func(*args, params=params, **kwargs)
  File "/tmp/example/env/lib/python2.7/site-packages/elasticsearch/client/__init__.py", line 531, in search
    doc_type, '_search'), params=params, body=body)
  File "/tmp/example/env/lib/python2.7/site-packages/ddtrace/contrib/elasticsearch/patch.py", line 73, in _perform_request
    span.set_tag(metadata.BODY, json.dumps(body))
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 243, in dumps
    return _default_encoder.encode(obj)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: datetime.datetime(2000, 11, 30, 5, 0, tzinfo=tzutc()) is not JSON serializable
```