### PR TITLE
celery: add celery app and task patching

### DIFF
--- a/ddtrace/contrib/celery/__init__.py
+++ b/ddtrace/contrib/celery/__init__.py
@@ -1,0 +1,57 @@
+"""
+Supported versions:
+
+- Celery 3.1.x
+- Celery 4.0.x
+
+Patch the celery library to trace task method calls::
+
+    import celery
+    from ddtrace.contrib.celery import patch; patch()
+
+    app = celery.Celery()
+
+    @app.task
+    def my_task():
+        pass
+
+
+    class MyTask(app.Task):
+        def run(self):
+            pass
+
+
+You may also manually patch celery apps or tasks for tracing::
+
+    import celery
+    from ddtrace.contrib.celery import patch_app, patch_task
+
+    app = celery.Celery()
+    app = patch_app(app)
+
+    @app.task
+    def my_task():
+        pass
+
+    # We don't have to patch this task since we patched `app`,
+    # but we could patch a single task like this if we wanted to
+    my_task = patch_task(my_task)
+
+
+    class MyTask(celery.Task):
+        def run(self):
+            pass
+
+    MyTask = patch_task(MyTask)
+"""
+
+from ..util import require_modules
+
+required_modules = ['celery']
+
+with require_modules(required_modules) as missing_modules:
+    if not missing_modules:
+        from .app import patch_app, unpatch_app
+        from .patch import patch, unpatch
+        from .task import patch_task, unpatch_task
+        __all__ = ['patch', 'patch_app', 'patch_task', 'unpatch', 'unpatch_app', 'unpatch_task']

--- a/ddtrace/contrib/celery/app.py
+++ b/ddtrace/contrib/celery/app.py
@@ -1,0 +1,69 @@
+# Standard library
+import types
+
+# Third party
+import wrapt
+
+# Project
+from ddtrace import Pin
+from ddtrace.ext import AppTypes
+from .task import patch_task
+from .util import APP, SERVICE, require_pin
+
+
+def patch_app(app, pin=None):
+    """ patch_app will add tracing to a celery app """
+    pin = pin or Pin(service=SERVICE, app=APP, app_type=AppTypes.worker)
+    patch_methods = [
+        ('task', _app_task),
+    ]
+    for method_name, wrapper in patch_methods:
+        # Get the original method
+        method = getattr(app, method_name, None)
+        if method is None:
+            continue
+
+        # Do not patch if method is already patched
+        if isinstance(method, wrapt.ObjectProxy):
+            continue
+
+        # Patch method
+        setattr(app, method_name, wrapt.FunctionWrapper(method, wrapper))
+
+    # Attach our pin to the app
+    pin.onto(app)
+    return app
+
+
+def unpatch_app(app):
+    """ unpatch_app will remove tracing from a celery app """
+    patched_methods = [
+        'task',
+    ]
+    for method_name in patched_methods:
+        # Get the wrapped method
+        wrapper = getattr(app, method_name, None)
+        if wrapper is None:
+            continue
+
+        # Only unpatch if the wrapper is an `ObjectProxy`
+        if not isinstance(wrapper, wrapt.ObjectProxy):
+            continue
+
+        # Restore original method
+        setattr(app, method_name, wrapper.__wrapped__)
+
+    return app
+
+
+@require_pin
+def _app_task(pin, func, app, args, kwargs):
+    task = func(*args, **kwargs)
+
+    # `app.task` is a decorator which may return a function wrapper
+    if isinstance(task, types.FunctionType):
+        def wrapper(func, instance, args, kwargs):
+            return patch_task(func(*args, **kwargs), pin=pin)
+        return wrapt.FunctionWrapper(task, wrapper)
+
+    return patch_task(task, pin=pin)

--- a/ddtrace/contrib/celery/patch.py
+++ b/ddtrace/contrib/celery/patch.py
@@ -1,0 +1,18 @@
+# Third party
+import celery
+
+# Project
+from .app import patch_app, unpatch_app
+from .task import patch_task, unpatch_task
+
+
+def patch():
+    """ patch will add all available tracing to the celery library """
+    setattr(celery, 'Celery', patch_app(celery.Celery))
+    setattr(celery, 'Task', patch_task(celery.Task))
+
+
+def unpatch():
+    """ unpatch will remove tracing from the celery library """
+    setattr(celery, 'Celery', unpatch_app(celery.Celery))
+    setattr(celery, 'Task', unpatch_task(celery.Task))

--- a/ddtrace/contrib/celery/task.py
+++ b/ddtrace/contrib/celery/task.py
@@ -1,0 +1,122 @@
+# Third party
+import wrapt
+
+# Project
+from ddtrace import Pin
+from ddtrace.ext import AppTypes
+from ...ext import errors
+from .util import APP, SERVICE, meta_from_context, require_pin
+
+# Task operations
+TASK_APPLY = 'celery.task.apply'
+TASK_APPLY_ASYNC = 'celery.task.apply_async'
+TASK_RUN = 'celery.task.run'
+
+
+def patch_task(task, pin=None):
+    """ patch_task will add tracing to a celery task """
+    pin = pin or Pin(service=SERVICE, app=APP, app_type=AppTypes.worker)
+
+    patch_methods = [
+        ('__init__', _task_init),
+        ('run', _task_run),
+        ('apply', _task_apply),
+        ('apply_async', _task_apply_async),
+    ]
+    for method_name, wrapper in patch_methods:
+        # Get original method
+        method = getattr(task, method_name, None)
+        if method is None:
+            continue
+
+        # Do not patch if method is already patched
+        if isinstance(method, wrapt.ObjectProxy):
+            continue
+
+        # Patch method
+        # DEV: Using `BoundFunctionWrapper` ensures our `task` wrapper parameter is properly set
+        setattr(task, method_name, wrapt.BoundFunctionWrapper(method, task, wrapper))
+
+    # Attach our pin to the app
+    pin.onto(task)
+    return task
+
+
+def unpatch_task(task):
+    """ unpatch_task will remove tracing from a celery task """
+    patched_methods = [
+        '__init__',
+        'run',
+        'apply',
+        'apply_async',
+    ]
+    for method_name in patched_methods:
+        # Get wrapped method
+        wrapper = getattr(task, method_name, None)
+        if wrapper is None:
+            continue
+
+        # Only unpatch if wrapper is an `ObjectProxy`
+        if not isinstance(wrapper, wrapt.ObjectProxy):
+            continue
+
+        # Restore original method
+        setattr(task, method_name, wrapper.__wrapped__)
+
+    return task
+
+
+def _task_init(func, task, args, kwargs):
+    func(*args, **kwargs)
+
+    # Patch this task if our pin is enabled
+    pin = Pin.get_from(task)
+    if pin and pin.enabled():
+        patch_task(task, pin=pin)
+
+
+@require_pin
+def _task_run(pin, func, task, args, kwargs):
+    with pin.tracer.trace(TASK_RUN, service=pin.service, resource=task.name) as span:
+        # Set meta data from task request
+        span.set_metas(meta_from_context(task.request))
+
+        # Call original `run` function
+        return func(*args, **kwargs)
+
+
+@require_pin
+def _task_apply(pin, func, task, args, kwargs):
+    with pin.tracer.trace(TASK_APPLY, resource=task.name) as span:
+        # Call the original `apply` function
+        res = func(*args, **kwargs)
+
+        # Set meta data from response
+        span.set_meta('id', res.id)
+        span.set_meta('state', res.state)
+        if res.traceback:
+            span.error = 1
+            span.set_meta(errors.STACK, res.traceback)
+        return res
+
+
+@require_pin
+def _task_apply_async(pin, func, task, args, kwargs):
+    with pin.tracer.trace(TASK_APPLY_ASYNC, resource=task.name) as span:
+        # Extract meta data from `kwargs`
+        meta_keys = (
+            'compression', 'countdown', 'eta', 'exchange', 'expires',
+            'priority', 'routing_key', 'serializer', 'queue',
+        )
+        for name in meta_keys:
+            if name in kwargs:
+                span.set_meta(name, kwargs[name])
+
+        # Call the original `apply_async` function
+        res = func(*args, **kwargs)
+
+        # Set meta data from response
+        # DEV: Calling `res.traceback` or `res.state` will make an
+        #   API call to the backend for the properties
+        span.set_meta('id', res.id)
+        return res

--- a/ddtrace/contrib/celery/util.py
+++ b/ddtrace/contrib/celery/util.py
@@ -1,0 +1,46 @@
+# Project
+from ddtrace import Pin
+
+# Service info
+APP = 'celery'
+SERVICE = 'celery'
+
+
+def meta_from_context(context):
+    """ helper to extract meta values from a celery context """
+    meta_keys = (
+        'correlation_id', 'delivery_info', 'eta', 'expires', 'hostname',
+        'id', 'reply_to', 'retries', 'timelimit',
+    )
+
+    meta = dict()
+    for name in meta_keys:
+        value = context.get(name)
+
+        # Skip this key if it is not set
+        if value is None:
+            continue
+
+        # Skip `timelimit` if it is not set (it's default/unset value is `(None, None)`)
+        if name == 'timelimie' and value == (None, None):
+            continue
+
+        # Skip `retries` if it's value is `0`
+        if name == 'retries' and value == 0:
+            continue
+
+        meta[name] = value
+    return meta
+
+
+def require_pin(decorated):
+    """ decorator for extracting the `Pin` from a wrapped method """
+    def wrapper(wrapped, instance, args, kwargs):
+        pin = Pin.get_from(instance)
+        # Execute the original method if pin is not enabled
+        if not pin or not pin.enabled():
+            return wrapped(*args, **kwargs)
+
+        # Execute our decorated function
+        return decorated(pin, wrapped, instance, args, kwargs)
+    return wrapper

--- a/ddtrace/ext/__init__.py
+++ b/ddtrace/ext/__init__.py
@@ -1,6 +1,6 @@
-
 class AppTypes(object):
 
     web = "web"
     db = "db"
     cache = "cache"
+    worker = "worker"

--- a/tests/contrib/celery/test_app.py
+++ b/tests/contrib/celery/test_app.py
@@ -1,0 +1,42 @@
+import unittest
+
+import celery
+import wrapt
+
+from ddtrace.contrib.celery.app import patch_app, unpatch_app
+
+
+class CeleryAppTest(unittest.TestCase):
+    def setUp(self):
+        patch_app(celery.Celery)
+
+    def tearDown(self):
+        unpatch_app(celery.Celery)
+
+    def test_patch_app(self):
+        """
+        When celery.App is patched
+            the task() method will return a patched task
+        """
+        # Assert the base class has the wrapped function
+        self.assertIsInstance(celery.Celery.task, wrapt.BoundFunctionWrapper)
+
+        # Create an instance of `celery.Celery`
+        app = celery.Celery()
+
+        # Assert the instance method is the wrapped function
+        self.assertIsInstance(app.task, wrapt.BoundFunctionWrapper)
+
+    def test_unpatch_app(self):
+        """
+        When unpatch_app is called on a patched app
+            we unpatch the `task()` method
+        """
+        # Assert it is patched before we start
+        self.assertIsInstance(celery.Celery.task, wrapt.BoundFunctionWrapper)
+
+        # Unpatch the app
+        unpatch_app(celery.Celery)
+
+        # Assert the method is not patched
+        self.assertFalse(isinstance(celery.Celery.task, wrapt.BoundFunctionWrapper))

--- a/tests/contrib/celery/test_task.py
+++ b/tests/contrib/celery/test_task.py
@@ -1,0 +1,489 @@
+import unittest
+
+import celery
+import mock
+import wrapt
+
+from ddtrace import Pin
+from ddtrace.compat import PY2
+from ddtrace.contrib.celery.app import patch_app, unpatch_app
+from ddtrace.contrib.celery.task import patch_task, unpatch_task
+
+from ..config import REDIS_CONFIG
+from ...test_tracer import get_dummy_tracer
+
+
+class CeleryTaskTest(unittest.TestCase):
+    def assert_items_equal(self, a, b):
+        if PY2:
+            return self.assertItemsEqual(a, b)
+        return self.assertCountEqual(a, b)
+
+    def setUp(self):
+        self.broker_url = 'redis://127.0.0.1:{port}/0'.format(port=REDIS_CONFIG['port'])
+        self.tracer = get_dummy_tracer()
+        self.pin = Pin(service='celery-test', tracer=self.tracer)
+        patch_app(celery.Celery, pin=self.pin)
+        patch_task(celery.Task, pin=self.pin)
+
+    def tearDown(self):
+        unpatch_app(celery.Celery)
+        unpatch_task(celery.Task)
+
+    def test_patch_task(self):
+        """
+        When celery.Task is patched
+            we patch the __init__, apply, apply_async, and run methods
+        """
+        # Assert base class methods are patched
+        self.assertIsInstance(celery.Task.__init__, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(celery.Task.apply, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(celery.Task.apply_async, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(celery.Task.run, wrapt.BoundFunctionWrapper)
+
+        # Create an instance of a Task
+        task = celery.Task()
+
+        # Assert instance methods are patched
+        self.assertIsInstance(task.__init__, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(task.apply, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(task.apply_async, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(task.run, wrapt.BoundFunctionWrapper)
+
+    def test_unpatch_task(self):
+        """
+        When unpatch_task is called on a patched task
+            we unpatch the __init__, apply, apply_async, and run methods
+        """
+        # Assert base class methods are patched
+        self.assertIsInstance(celery.Task.__init__, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(celery.Task.apply, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(celery.Task.apply_async, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(celery.Task.run, wrapt.BoundFunctionWrapper)
+
+        # Unpatch the base class
+        unpatch_task(celery.Task)
+
+        # Assert the methods are no longer wrapper
+        self.assertFalse(isinstance(celery.Task.__init__, wrapt.BoundFunctionWrapper))
+        self.assertFalse(isinstance(celery.Task.apply, wrapt.BoundFunctionWrapper))
+        self.assertFalse(isinstance(celery.Task.apply_async, wrapt.BoundFunctionWrapper))
+        self.assertFalse(isinstance(celery.Task.run, wrapt.BoundFunctionWrapper))
+
+    def test_task_init(self):
+        """
+        Creating an instance of a patched celery.Task
+            will yield a patched instance
+        """
+        task = celery.Task()
+
+        # Assert instance methods are patched
+        self.assertIsInstance(task.__init__, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(task.apply, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(task.apply_async, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(task.run, wrapt.BoundFunctionWrapper)
+
+    def test_task_run(self):
+        """
+        Calling the run method of a patched task
+            calls the original run() method
+            creates a span for the call
+        """
+        # Create an instance of our patched app
+        # DEV: No broker url is needed, we this task is run directly
+        app = celery.Celery()
+
+        # Create our test task
+        task_spy = mock.Mock(__name__='patched_task')
+        patched_task = app.task(task_spy)
+
+        # Call the run method
+        patched_task.run()
+
+        # Assert it was called
+        task_spy.assert_called_once()
+
+        # Assert we created a span
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+
+        span = spans[0]
+        self.assert_items_equal(
+            span.to_dict().keys(),
+            ['service', 'resource', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+        )
+        self.assertEqual(span.service, 'celery-test')
+        self.assertEqual(span.resource, 'mock.mock.patched_task')
+        self.assertEqual(span.name, 'celery.task.run')
+        self.assertEqual(span.error, 0)
+
+        # Assert the metadata is correct
+        meta = span.meta
+        self.assertDictEqual(meta, dict())
+
+    def test_task___call__(self):
+        """
+        Calling the task directly as a function
+            calls the original method
+            creates a span for the call
+        """
+        # Create an instance of our patched app
+        # DEV: No broker url is needed, we this task is run directly
+        app = celery.Celery()
+
+        # Create our test task
+        task_spy = mock.Mock(__name__='patched_task')
+        patched_task = app.task(task_spy)
+
+        # Call the task
+        patched_task()
+
+        # Assert it was called
+        task_spy.assert_called_once()
+
+        # Assert we created a span
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+
+        span = spans[0]
+        self.assert_items_equal(
+            span.to_dict().keys(),
+            ['service', 'resource', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+        )
+        self.assertEqual(span.service, 'celery-test')
+        self.assertEqual(span.resource, 'mock.mock.patched_task')
+        self.assertEqual(span.name, 'celery.task.run')
+        self.assertEqual(span.error, 0)
+
+        # Assert the metadata is correct
+        meta = span.meta
+        self.assertDictEqual(meta, dict())
+
+    def test_task_apply_async(self):
+        """
+        Calling the apply_async method of a patched task
+            calls the original run() method
+            creates a span for the call
+        """
+        # Create an instance of our patched app
+        app = celery.Celery()
+
+        # Create our test task
+        task_spy = mock.Mock(__name__='patched_task')
+        patched_task = app.task(task_spy)
+
+        # Call the apply method
+        patched_task.apply()
+
+        # Assert it was called
+        task_spy.assert_called_once()
+
+        # Assert we created a span
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 2)
+
+        # Assert the first span for calling `apply`
+        span = spans[1]
+        self.assert_items_equal(
+            span.to_dict().keys(),
+            ['service', 'resource', 'meta', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+        )
+        # DEV: The service is None since `apply` is usually called from the context of another service (e.g. flask)
+        self.assertIsNone(span.service)
+        self.assertEqual(span.resource, 'mock.mock.patched_task')
+        self.assertEqual(span.name, 'celery.task.apply')
+        self.assertIsNone(span.parent_id)
+        self.assertEqual(span.error, 0)
+
+        # Save for later
+        parent_span_id = span.span_id
+
+        # Assert the metadata is correct
+        meta = span.meta
+        self.assert_items_equal(meta.keys(), ['id', 'state'])
+        self.assertEqual(meta['state'], 'SUCCESS')
+
+        # Assert the celery service span for calling `run`
+        span = spans[0]
+        self.assert_items_equal(
+            span.to_dict().keys(),
+            ['service', 'resource', 'meta', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+        )
+        self.assertEqual(span.service, 'celery-test')
+        self.assertEqual(span.resource, 'mock.mock.patched_task')
+        self.assertEqual(span.name, 'celery.task.run')
+        self.assertEqual(span.parent_id, parent_span_id)
+        self.assertEqual(span.error, 0)
+
+        # Assert the metadata is correct
+        meta = span.meta
+        self.assert_items_equal(
+            meta.keys(),
+            ['delivery_info', 'id']
+        )
+        self.assertNotEqual(meta['id'], 'None')
+
+        # DEV: Assert as endswith, since PY3 gives us `u'is_eager` and PY2 gives us `'is_eager'`
+        self.assertTrue(meta['delivery_info'].endswith('\'is_eager\': True}'))
+
+    def test_task_apply(self):
+        """
+        Calling the apply method of a patched task
+            we do not call the original task method
+            creates a span for the call
+        """
+        # Create an instance of our patched app
+        # DEV: We need a broker now since we are publishing a task
+        app = celery.Celery('test_task_apply', broker=self.broker_url)
+
+        # Create our test task
+        task_spy = mock.Mock(__name__='patched_task')
+        patched_task = app.task(task_spy)
+        patched_task.__header__ = mock.Mock()
+
+        # Call the apply method
+        patched_task.apply_async()
+
+        # Assert it was called
+        task_spy.assert_not_called()
+
+        # Assert we created a span
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+
+        span = spans[0]
+        self.assert_items_equal(
+            span.to_dict().keys(),
+            ['service', 'resource', 'meta', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+        )
+        # DEV: The service is None since `apply` is usually called from the context of another service (e.g. flask)
+        self.assertIsNone(span.service)
+        self.assertEqual(span.resource, 'mock.mock.patched_task')
+        self.assertEqual(span.name, 'celery.task.apply_async')
+        self.assertIsNone(span.parent_id)
+        self.assertEqual(span.error, 0)
+
+        # Assert the metadata is correct
+        meta = span.meta
+        self.assert_items_equal(meta.keys(), ['id'])
+
+    def test_task_apply_eager(self):
+        """
+        Calling the apply method of a patched task
+            when we are executing tasks eagerly
+                we do call the original task method
+                creates a span for the call
+        """
+        # Create an instance of our patched app
+        # DEV: We need a broker now since we are publishing a task
+        app = celery.Celery('test_task_apply_eager', broker=self.broker_url)
+        app.conf['CELERY_ALWAYS_EAGER'] = True
+
+        # Create our test task
+        task_spy = mock.Mock(__name__='patched_task')
+        patched_task = app.task(task_spy)
+        patched_task.__header__ = mock.Mock()
+
+        # Call the apply method
+        patched_task.apply_async()
+
+        # Assert it was called
+        task_spy.assert_called_once()
+
+        # Assert we created a span
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 3)
+
+        span = spans[2]
+        self.assert_items_equal(
+            span.to_dict().keys(),
+            ['service', 'resource', 'meta', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+        )
+        # DEV: The service is None since `apply` is usually called from the context of another service (e.g. flask)
+        self.assertIsNone(span.service, None)
+        self.assertEqual(span.resource, 'mock.mock.patched_task')
+        self.assertEqual(span.name, 'celery.task.apply_async')
+        self.assertIsNone(span.parent_id)
+        self.assertEqual(span.error, 0)
+
+        # Save for later
+        parent_span_id = span.span_id
+
+        # Assert the metadata is correct
+        meta = span.meta
+        self.assert_items_equal(meta.keys(), ['id'])
+
+        span = spans[1]
+        self.assert_items_equal(
+            span.to_dict().keys(),
+            ['service', 'resource', 'meta', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+        )
+        # DEV: The service is None since `apply` is usually called from the context of another service (e.g. flask)
+        self.assertIsNone(span.service, None)
+        self.assertEqual(span.resource, 'mock.mock.patched_task')
+        self.assertEqual(span.name, 'celery.task.apply')
+        self.assertEqual(span.parent_id, parent_span_id)
+        self.assertEqual(span.error, 0)
+
+        # Save for later
+        parent_span_id = span.span_id
+
+        # Assert the metadata is correct
+        meta = span.meta
+        self.assert_items_equal(meta.keys(), ['id', 'state'])
+        self.assertEqual(meta['state'], 'SUCCESS')
+
+        # The last span emitted
+        span = spans[0]
+        self.assert_items_equal(
+            span.to_dict().keys(),
+            ['service', 'resource', 'meta', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+        )
+        # DEV: The service is None since `apply` is usually called from the context of another service (e.g. flask)
+        self.assertEqual(span.service, 'celery-test')
+        self.assertEqual(span.resource, 'mock.mock.patched_task')
+        self.assertEqual(span.name, 'celery.task.run')
+        self.assertEqual(span.parent_id, parent_span_id)
+        self.assertEqual(span.error, 0)
+
+        # Assert the metadata is correct
+        meta = span.meta
+        self.assert_items_equal(
+            meta.keys(),
+            ['delivery_info', 'id']
+        )
+        self.assertNotEqual(meta['id'], 'None')
+
+        # DEV: Assert as endswith, since PY3 gives us `u'is_eager` and PY2 gives us `'is_eager'`
+        self.assertTrue(meta['delivery_info'].endswith('\'is_eager\': True}'))
+
+    def test_task_delay(self):
+        """
+        Calling the delay method of a patched task
+            we do not call the original task method
+            creates a span for the call
+        """
+        # Create an instance of our patched app
+        # DEV: We need a broker now since we are publishing a task
+        app = celery.Celery('test_task_delay', broker=self.broker_url)
+
+        # Create our test task
+        task_spy = mock.Mock(__name__='patched_task')
+        patched_task = app.task(task_spy)
+        patched_task.__header__ = mock.Mock()
+
+        # Call the apply method
+        patched_task.delay()
+
+        # Assert it was called
+        task_spy.assert_not_called()
+
+        # Assert we created a span
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+
+        span = spans[0]
+        self.assert_items_equal(
+            span.to_dict().keys(),
+            ['service', 'resource', 'meta', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+        )
+        # DEV: The service is None since `apply` is usually called from the context of another service (e.g. flask)
+        self.assertIsNone(span.service)
+        self.assertEqual(span.resource, 'mock.mock.patched_task')
+        self.assertEqual(span.name, 'celery.task.apply_async')
+        self.assertIsNone(span.parent_id)
+        self.assertEqual(span.error, 0)
+
+        # Assert the metadata is correct
+        meta = span.meta
+        self.assert_items_equal(meta.keys(), ['id'])
+
+    def test_task_delay_eager(self):
+        """
+        Calling the delay method of a patched task
+            when we are executing tasks eagerly
+                we do call the original task method
+                creates a span for the call
+        """
+        # Create an instance of our patched app
+        # DEV: We need a broker now since we are publishing a task
+        app = celery.Celery('test_task_delay_eager', broker=self.broker_url)
+        app.conf['CELERY_ALWAYS_EAGER'] = True
+
+        # Create our test task
+        task_spy = mock.Mock(__name__='patched_task')
+        patched_task = app.task(task_spy)
+        patched_task.__header__ = mock.Mock()
+
+        # Call the apply method
+        patched_task.delay()
+
+        # Assert it was called
+        task_spy.assert_called_once()
+
+        # Assert we created a span
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 3)
+
+        span = spans[2]
+        self.assert_items_equal(
+            span.to_dict().keys(),
+            ['service', 'resource', 'meta', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+        )
+        # DEV: The service is None since `apply` is usually called from the context of another service (e.g. flask)
+        self.assertIsNone(span.service, None)
+        self.assertEqual(span.resource, 'mock.mock.patched_task')
+        self.assertEqual(span.name, 'celery.task.apply_async')
+        self.assertIsNone(span.parent_id)
+        self.assertEqual(span.error, 0)
+
+        # Save for later
+        parent_span_id = span.span_id
+
+        # Assert the metadata is correct
+        meta = span.meta
+        self.assert_items_equal(meta.keys(), ['id'])
+
+        span = spans[1]
+        self.assert_items_equal(
+            span.to_dict().keys(),
+            ['service', 'resource', 'meta', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+        )
+        # DEV: The service is None since `apply` is usually called from the context of another service (e.g. flask)
+        self.assertIsNone(span.service, None)
+        self.assertEqual(span.resource, 'mock.mock.patched_task')
+        self.assertEqual(span.name, 'celery.task.apply')
+        self.assertEqual(span.parent_id, parent_span_id)
+        self.assertEqual(span.error, 0)
+
+        # Save for later
+        parent_span_id = span.span_id
+
+        # Assert the metadata is correct
+        meta = span.meta
+        self.assert_items_equal(meta.keys(), ['id', 'state'])
+        self.assertEqual(meta['state'], 'SUCCESS')
+
+        # The last span emitted
+        span = spans[0]
+        self.assert_items_equal(
+            span.to_dict().keys(),
+            ['service', 'resource', 'meta', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+        )
+        # DEV: The service is None since `apply` is usually called from the context of another service (e.g. flask)
+        self.assertEqual(span.service, 'celery-test')
+        self.assertEqual(span.resource, 'mock.mock.patched_task')
+        self.assertEqual(span.name, 'celery.task.run')
+        self.assertEqual(span.parent_id, parent_span_id)
+        self.assertEqual(span.error, 0)
+
+        # Assert the metadata is correct
+        meta = span.meta
+        self.assert_items_equal(
+            meta.keys(),
+            ['delivery_info', 'id']
+        )
+        self.assertNotEqual(meta['id'], 'None')
+
+        # DEV: Assert as endswith, since PY3 gives us `u'is_eager` and PY2 gives us `'is_eager'`
+        self.assertTrue(meta['delivery_info'].endswith('\'is_eager\': True}'))

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ envlist =
     {py27,py34}-contrib
     {py27,py34}-bottle{12}-webtest
     {py27,py34}-cassandra{35,36,37}
+    {py27,py34}-celery{31,40}-redis
     {py27,py34}-elasticsearch{23}
     {py27,py34}-falcon{10}
     {py27,py34}-django{18,19,110}-djangopylibmc06-djangoredis45-pylibmc-redis-memcached
@@ -45,6 +46,7 @@ deps =
     contrib: blinker
     contrib: bottle
     contrib: cassandra-driver
+    contrib: celery
     contrib: elasticsearch
     contrib: falcon
     contrib: flask
@@ -65,6 +67,8 @@ deps =
     cassandra35: cassandra-driver>=3.5,<3.6
     cassandra36: cassandra-driver>=3.6,<3.7
     cassandra37: cassandra-driver>=3.7
+    celery31: celery>=3.1,<3.2
+    celery40: celery>=4.0,<4.1
     elasticsearch23: elasticsearch>=2.3,<2.4
     falcon10: falcon>=1.0,<1.1
     django18: django>=1.8,<1.9
@@ -117,6 +121,7 @@ commands =
 # run subsets of the tests for particular library versions
     {py27,py34}-bottle{12}: nosetests {posargs} tests/contrib/bottle/
     {py27,py34}-cassandra{35,36,37}: nosetests {posargs} tests/contrib/cassandra
+    {py27,py34}-celery{31,40}: nosetests {posargs} tests/contrib/celery
     {py27,py34}-elasticsearch{23}: nosetests {posargs} tests/contrib/elasticsearch
     {py27,py34}-django{18,19,110}: python tests/contrib/django/runtests.py {posargs}
     {py27,py34}-flaskcache{013}: nosetests {posargs} tests/contrib/flask_cache


### PR DESCRIPTION
Fixes #87 

This PR adds the contrib module for [celery](celeryproject.org) and the ability to patch the `celery` module to trace task execution.

Example:

```python
from ddtrace.contrib.celery import patch
patch()

import celery

app = celery.Celery()

@app.task
def my_task():
    pass

my_task.delay()
```

I also have some example screenshots of how these traces look.

**Task being executed by a worker**
![image](https://cloud.githubusercontent.com/assets/1320353/21280231/9a602d88-c3b2-11e6-9e00-1941bad29d58.png)


**Task execution started by a Flask request**
![image](https://cloud.githubusercontent.com/assets/1320353/21280251/c47d776a-c3b2-11e6-97d3-a4c16c6688cb.png)

This one is more for fun, since it requires using redis with `celery` and having the redis library patching enabled.

**Redis calls to schedule celery task**
![image](https://cloud.githubusercontent.com/assets/1320353/21280314/2f8c6980-c3b3-11e6-8a7d-dcf88fc57722.png)

![image](https://cloud.githubusercontent.com/assets/1320353/21280290/09e0add6-c3b3-11e6-8b40-e59d4bd25aad.png)
