### PR TITLE
django: Fix <1.7 compatibility in middleware

### DIFF
--- a/ddtrace/contrib/django/middleware.py
+++ b/ddtrace/contrib/django/middleware.py
@@ -7,7 +7,6 @@ from ...ext import http
 from ...contrib import func_name
 
 # 3p
-from django.apps import apps
 from django.core.exceptions import MiddlewareNotUsed
 
 try:
@@ -57,10 +56,7 @@ class TraceMiddleware(MiddlewareClass):
             span = _get_req_span(request)
             if span:
                 span.set_tag(http.STATUS_CODE, response.status_code)
-
-                if apps.is_installed("django.contrib.auth"):
-                    span = _set_auth_tags(span, request)
-
+                span = _set_auth_tags(span, request)
                 span.finish()
 
         except Exception:


### PR DESCRIPTION
Checking for `django.contrib.auth` as an installed app is unnecessary
here since `_set_auth_tags` is graceful in itself by feature detecting
for `request.user`.

Refs: GH-134