### PR TITLE
httplib: add patching for httplib and http.lib

### DIFF
--- a/ddtrace/contrib/httplib/__init__.py
+++ b/ddtrace/contrib/httplib/__init__.py
@@ -1,0 +1,31 @@
+"""
+Patch the built-in httplib/http.client libraries to trace all HTTP calls.
+
+
+Usage::
+
+    # Patch all supported modules/functions
+    from ddtrace import patch
+    patch(httplib=True)
+
+    # Python 2
+    from ddtrace import Pin
+    import httplib
+    import urllib
+
+    # Use a Pin to specify metadata for all http requests
+    Pin.override(httplib, service='httplib')
+    resp = urllib.urlopen('http://www.datadog.com/')
+
+    # Python 3
+    from ddtrace import Pin
+    import http.client
+    import urllib.request
+
+    # Use a Pin to specify metadata for all http requests
+    Pin.override(http.client, service='httplib')
+    resp = urllib.request.urlopen('http://www.datadog.com/')
+
+"""
+from .patch import patch, unpatch
+__all__ = ['patch', 'unpatch']

--- a/ddtrace/contrib/httplib/patch.py
+++ b/ddtrace/contrib/httplib/patch.py
@@ -1,0 +1,108 @@
+# Standard library
+import logging
+
+# Third party
+import wrapt
+
+# Project
+from ...compat import httplib, PY2
+from ...ext import http as ext_http
+from ...pin import Pin
+from ...util import unwrap as _u
+
+
+span_name = 'httplib.request' if PY2 else 'http.client.request'
+
+log = logging.getLogger(__name__)
+
+
+def _wrap_init(func, instance, args, kwargs):
+    Pin(app='httplib', service=None, app_type=ext_http.TYPE).onto(instance)
+    return func(*args, **kwargs)
+
+
+def _wrap_getresponse(func, instance, args, kwargs):
+    # Use any attached tracer if available, otherwise use the global tracer
+    pin = Pin.get_from(instance)
+    if not pin or not pin.enabled():
+        return func(*args, **kwargs)
+
+    resp = None
+    try:
+        resp = func(*args, **kwargs)
+        return resp
+    finally:
+        try:
+            # Get the span attached to this instance, if available
+            span = getattr(instance, '_datadog_span', None)
+            if not span:
+                return
+
+            if resp:
+                span.set_tag(ext_http.STATUS_CODE, resp.status)
+                span.error = int(500 <= resp.status)
+
+            span.finish()
+            delattr(instance, '_datadog_span')
+        except Exception:
+            log.debug('error applying request tags', exc_info=True)
+
+
+def _wrap_putrequest(func, instance, args, kwargs):
+    # Use any attached tracer if available, otherwise use the global tracer
+    pin = Pin.get_from(instance)
+    if should_skip_request(pin, instance):
+        return func(*args, **kwargs)
+
+    try:
+        # Create a new span and attach to this instance (so we can retrieve/update/close later on the response)
+        span = pin.tracer.trace(span_name, span_type=ext_http.TYPE)
+        setattr(instance, '_datadog_span', span)
+
+        method, path = args[:2]
+        scheme = 'https' if isinstance(instance, httplib.HTTPSConnection) else 'http'
+        port = ':{port}'.format(port=instance.port)
+        if (scheme == 'http' and instance.port == 80) or (scheme == 'https' and instance.port == 443):
+            port = ''
+        url = '{scheme}://{host}{port}{path}'.format(scheme=scheme, host=instance.host, port=port, path=path)
+        span.set_tag(ext_http.URL, url)
+        span.set_tag(ext_http.METHOD, method)
+    except Exception:
+        log.debug('error applying request tags', exc_info=True)
+
+    return func(*args, **kwargs)
+
+
+def should_skip_request(pin, request):
+    """Helper to determine if the provided request should be traced"""
+    if not pin or not pin.enabled():
+        return True
+
+    api = pin.tracer.writer.api
+    return request.host == api.hostname and request.port == api.port
+
+
+def patch():
+    """ patch the built-in urllib/httplib/httplib.client methods for tracing"""
+    if getattr(httplib, '__datadog_patch', False):
+        return
+    setattr(httplib, '__datadog_patch', True)
+
+    # Patch the desired methods
+    setattr(httplib.HTTPConnection, '__init__',
+            wrapt.FunctionWrapper(httplib.HTTPConnection.__init__, _wrap_init))
+    setattr(httplib.HTTPConnection, 'getresponse',
+            wrapt.FunctionWrapper(httplib.HTTPConnection.getresponse, _wrap_getresponse))
+    setattr(httplib.HTTPConnection, 'putrequest',
+            wrapt.FunctionWrapper(httplib.HTTPConnection.putrequest, _wrap_putrequest))
+
+
+def unpatch():
+    """ unpatch any previously patched modules """
+    if not getattr(httplib, '__datadog_patch', False):
+        return
+    setattr(httplib, '__datadog_patch', False)
+
+    _u(httplib.HTTPConnection, '__init__')
+    _u(httplib.HTTPConnection, 'getresponse')
+    _u(httplib.HTTPConnection, 'putrequest')

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -29,6 +29,7 @@ PATCH_MODULES = {
     'sqlalchemy': False,  # Prefer DB client instrumentation
     'sqlite3': True,
     'aiohttp': True,  # requires asyncio (Python 3.4+)
+    'httplib': False,
 
     # Ignore some web framework integrations that might be configured explicitly in code
     "django": False,

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -11,7 +11,10 @@ from ddtrace.compat import httplib, PY2
 from ddtrace.contrib.httplib import patch, unpatch
 from ddtrace.contrib.httplib.patch import should_skip_request
 from ddtrace.pin import Pin
+
+from .utils import override_global_tracer
 from ...test_tracer import get_dummy_tracer
+
 
 if PY2:
     from urllib2 import urlopen, build_opener, Request
@@ -316,7 +319,9 @@ class HTTPLibTestCase(HTTPLibBaseMixin, unittest.TestCase):
            we return the original response
            we capture a span for the request
         """
-        resp = urlopen('http://httpstat.us/200')
+        with override_global_tracer(self.tracer):
+            resp = urlopen('http://httpstat.us/200')
+
         self.assertEqual(self.to_str(resp.read()), '200 OK')
         self.assertEqual(resp.getcode(), 200)
 
@@ -338,7 +343,9 @@ class HTTPLibTestCase(HTTPLibBaseMixin, unittest.TestCase):
                we return the original response
                we capture a span for the request
         """
-        resp = urlopen('https://httpbin.org/status/200')
+        with override_global_tracer(self.tracer):
+            resp = urlopen('https://httpbin.org/status/200')
+
         self.assertEqual(self.to_str(resp.read()), '')
         self.assertEqual(resp.getcode(), 200)
 
@@ -361,7 +368,9 @@ class HTTPLibTestCase(HTTPLibBaseMixin, unittest.TestCase):
                we capture a span for the request
         """
         req = Request('http://httpstat.us/200')
-        resp = urlopen(req)
+        with override_global_tracer(self.tracer):
+            resp = urlopen(req)
+
         self.assertEqual(self.to_str(resp.read()), '200 OK')
         self.assertEqual(resp.getcode(), 200)
 
@@ -383,7 +392,9 @@ class HTTPLibTestCase(HTTPLibBaseMixin, unittest.TestCase):
            we capture a span for the request
         """
         opener = build_opener()
-        resp = opener.open('http://httpstat.us/200')
+        with override_global_tracer(self.tracer):
+            resp = opener.open('http://httpstat.us/200')
+
         self.assertEqual(self.to_str(resp.read()), '200 OK')
         self.assertEqual(resp.getcode(), 200)
 
@@ -410,7 +421,9 @@ if PY2:
                we return the original response
                we capture a span for the request
             """
-            resp = urllib.urlopen('http://httpstat.us/200')
+            with override_global_tracer(self.tracer):
+                resp = urllib.urlopen('http://httpstat.us/200')
+
             self.assertEqual(resp.read(), '200 OK')
             self.assertEqual(resp.getcode(), 200)
 
@@ -432,7 +445,9 @@ if PY2:
                    we return the original response
                    we capture a span for the request
             """
-            resp = urllib.urlopen('https://httpbin.org/status/200')
+            with override_global_tracer(self.tracer):
+                resp = urllib.urlopen('https://httpbin.org/status/200')
+
             self.assertEqual(resp.read(), '')
             self.assertEqual(resp.getcode(), 200)
 

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -1,0 +1,448 @@
+# Standard library
+import contextlib
+import sys
+import unittest
+
+# Third party
+import wrapt
+
+# Project
+from ddtrace.compat import httplib, PY2
+from ddtrace.contrib.httplib import patch, unpatch
+from ddtrace.contrib.httplib.patch import should_skip_request
+from ddtrace.pin import Pin
+from ...test_tracer import get_dummy_tracer
+
+if PY2:
+    from urllib2 import urlopen, build_opener, Request
+else:
+    from urllib.request import urlopen, build_opener, Request
+
+
+# Base test mixin for shared tests between Py2 and Py3
+class HTTPLibBaseMixin(object):
+    SPAN_NAME = 'httplib.request' if PY2 else 'http.client.request'
+
+    def to_str(self, value):
+        return value.decode('utf-8')
+
+    def setUp(self):
+        patch()
+        self.tracer = get_dummy_tracer()
+        Pin.override(httplib, tracer=self.tracer)
+
+    def tearDown(self):
+        unpatch()
+
+
+# Main test cases for httplib/http.client and urllib2/urllib.request
+class HTTPLibTestCase(HTTPLibBaseMixin, unittest.TestCase):
+    SPAN_NAME = 'httplib.request' if PY2 else 'http.client.request'
+
+    def to_str(self, value):
+        """Helper method to decode a string or byte object to a string"""
+        return value.decode('utf-8')
+
+    def get_http_connection(self, *args, **kwargs):
+        conn = httplib.HTTPConnection(*args, **kwargs)
+        Pin.override(conn, tracer=self.tracer)
+        return conn
+
+    def get_https_connection(self, *args, **kwargs):
+        conn = httplib.HTTPSConnection(*args, **kwargs)
+        Pin.override(conn, tracer=self.tracer)
+        return conn
+
+    def setUp(self):
+        patch()
+        self.tracer = get_dummy_tracer()
+
+    def tearDown(self):
+        unpatch()
+
+    def test_patch(self):
+        """
+        When patching httplib
+            we patch the correct module/methods
+        """
+        self.assertIsInstance(httplib.HTTPConnection.__init__, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(httplib.HTTPConnection.putrequest, wrapt.BoundFunctionWrapper)
+        self.assertIsInstance(httplib.HTTPConnection.getresponse, wrapt.BoundFunctionWrapper)
+
+    def test_unpatch(self):
+        """
+        When unpatching httplib
+            we restore the correct module/methods
+        """
+        original_init = httplib.HTTPConnection.__init__.__wrapped__
+        original_putrequest = httplib.HTTPConnection.putrequest.__wrapped__
+        original_getresponse = httplib.HTTPConnection.getresponse.__wrapped__
+        unpatch()
+
+        self.assertEqual(httplib.HTTPConnection.__init__, original_init)
+        self.assertEqual(httplib.HTTPConnection.putrequest, original_putrequest)
+        self.assertEqual(httplib.HTTPConnection.getresponse, original_getresponse)
+
+    def test_should_skip_request(self):
+        """
+        When calling should_skip_request
+            with an enabled Pin and non-internal request
+                returns False
+            with a disabled Pin and non-internal request
+                returns True
+            with an enabled Pin and internal request
+                returns True
+            with a disabled Pin and internal request
+                returns True
+        """
+        # Enabled Pin and non-internal request
+        self.tracer.enabled = True
+        request = self.get_http_connection('httpstat.us')
+        pin = Pin.get_from(request)
+        self.assertFalse(should_skip_request(pin, request))
+
+        # Disabled Pin and non-internal request
+        self.tracer.enabled = False
+        request = self.get_http_connection('httpstat.us')
+        pin = Pin.get_from(request)
+        self.assertTrue(should_skip_request(pin, request))
+
+        # Enabled Pin and internal request
+        self.tracer.enabled = True
+        request = self.get_http_connection(self.tracer.writer.api.hostname, self.tracer.writer.api.port)
+        pin = Pin.get_from(request)
+        self.assertTrue(should_skip_request(pin, request))
+
+        # Disabled Pin and internal request
+        self.tracer.enabled = False
+        request = self.get_http_connection(self.tracer.writer.api.hostname, self.tracer.writer.api.port)
+        pin = Pin.get_from(request)
+        self.assertTrue(should_skip_request(pin, request))
+
+    def test_httplib_request_get_request(self):
+        """
+        When making a GET request via httplib.HTTPConnection.request
+            we return the original response
+            we capture a span for the request
+        """
+        conn = self.get_http_connection('httpstat.us')
+        with contextlib.closing(conn):
+            conn.request('GET', '/200')
+            resp = conn.getresponse()
+            self.assertEqual(self.to_str(resp.read()), '200 OK')
+            self.assertEqual(resp.status, 200)
+
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.span_type, 'http')
+        self.assertIsNone(span.service)
+        self.assertEqual(span.name, self.SPAN_NAME)
+        self.assertEqual(span.error, 0)
+        self.assertDictEqual(
+            span.meta,
+            {
+                'http.method': 'GET',
+                'http.status_code': '200',
+                'http.url': 'http://httpstat.us/200',
+            }
+        )
+
+    def test_httplib_request_get_request_https(self):
+        """
+        When making a GET request via httplib.HTTPConnection.request
+            when making an HTTPS connection
+                we return the original response
+                we capture a span for the request
+        """
+        conn = self.get_https_connection('httpbin.org')
+        with contextlib.closing(conn):
+            conn.request('GET', '/status/200')
+            resp = conn.getresponse()
+            self.assertEqual(self.to_str(resp.read()), '')
+            self.assertEqual(resp.status, 200)
+
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.span_type, 'http')
+        self.assertIsNone(span.service)
+        self.assertEqual(span.name, self.SPAN_NAME)
+        self.assertEqual(span.error, 0)
+        self.assertDictEqual(
+            span.meta,
+            {
+                'http.method': 'GET',
+                'http.status_code': '200',
+                'http.url': 'https://httpbin.org/status/200',
+            }
+        )
+
+    def test_httplib_request_post_request(self):
+        """
+        When making a POST request via httplib.HTTPConnection.request
+            we return the original response
+            we capture a span for the request
+        """
+        conn = self.get_http_connection('httpstat.us')
+        with contextlib.closing(conn):
+            conn.request('POST', '/200', body='key=value')
+            resp = conn.getresponse()
+            self.assertEqual(self.to_str(resp.read()), '200 OK')
+            self.assertEqual(resp.status, 200)
+
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.span_type, 'http')
+        self.assertIsNone(span.service)
+        self.assertEqual(span.name, self.SPAN_NAME)
+        self.assertEqual(span.error, 0)
+        self.assertDictEqual(
+            span.meta,
+            {
+                'http.method': 'POST',
+                'http.status_code': '200',
+                'http.url': 'http://httpstat.us/200',
+            }
+        )
+
+    def test_httplib_request_get_request_query_string(self):
+        """
+        When making a GET request with a query string via httplib.HTTPConnection.request
+            we capture a the entire url in the span
+        """
+        conn = self.get_http_connection('httpstat.us')
+        with contextlib.closing(conn):
+            conn.request('GET', '/200?key=value&key2=value2')
+            resp = conn.getresponse()
+            self.assertEqual(self.to_str(resp.read()), '200 OK')
+            self.assertEqual(resp.status, 200)
+
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.span_type, 'http')
+        self.assertIsNone(span.service)
+        self.assertEqual(span.name, self.SPAN_NAME)
+        self.assertEqual(span.error, 0)
+        self.assertDictEqual(
+            span.meta,
+            {
+                'http.method': 'GET',
+                'http.status_code': '200',
+                'http.url': 'http://httpstat.us/200?key=value&key2=value2',
+            }
+        )
+
+    def test_httplib_request_500_request(self):
+        """
+        When making a GET request via httplib.HTTPConnection.request
+            when the response is a 500
+                we raise the original exception
+                we mark the span as an error
+                we capture the correct span tags
+        """
+        try:
+            conn = self.get_http_connection('httpstat.us')
+            with contextlib.closing(conn):
+                conn.request('GET', '/500')
+                conn.getresponse()
+        except httplib.HTTPException:
+            resp = sys.exc_info()[1]
+            self.assertEqual(self.to_str(resp.read()), '500 Internal Server Error')
+            self.assertEqual(resp.status, 500)
+
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.span_type, 'http')
+        self.assertIsNone(span.service)
+        self.assertEqual(span.name, self.SPAN_NAME)
+        self.assertEqual(span.error, 1)
+        self.assertEqual(span.get_tag('http.method'), 'GET')
+        self.assertEqual(span.get_tag('http.status_code'), '500')
+        self.assertEqual(span.get_tag('http.url'), 'http://httpstat.us/500')
+
+    def test_httplib_request_non_200_request(self):
+        """
+        When making a GET request via httplib.HTTPConnection.request
+            when the response is a non-200
+                we raise the original exception
+                we mark the span as an error
+                we capture the correct span tags
+        """
+        try:
+            conn = self.get_http_connection('httpstat.us')
+            with contextlib.closing(conn):
+                conn.request('GET', '/404')
+                conn.getresponse()
+        except httplib.HTTPException:
+            resp = sys.exc_info()[1]
+            self.assertEqual(self.to_str(resp.read()), '404 Not Found')
+            self.assertEqual(resp.status, 404)
+
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.span_type, 'http')
+        self.assertIsNone(span.service)
+        self.assertEqual(span.name, self.SPAN_NAME)
+        self.assertEqual(span.error, 0)
+        self.assertEqual(span.get_tag('http.method'), 'GET')
+        self.assertEqual(span.get_tag('http.status_code'), '404')
+        self.assertEqual(span.get_tag('http.url'), 'http://httpstat.us/404')
+
+    def test_httplib_request_get_request_disabled(self):
+        """
+        When making a GET request via httplib.HTTPConnection.request
+            when the tracer is disabled
+                we do not capture any spans
+        """
+        self.tracer.enabled = False
+        conn = self.get_http_connection('httpstat.us')
+        with contextlib.closing(conn):
+            conn.request('GET', '/200')
+            resp = conn.getresponse()
+            self.assertEqual(self.to_str(resp.read()), '200 OK')
+            self.assertEqual(resp.status, 200)
+
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 0)
+
+    def test_urllib_request(self):
+        """
+        When making a request via urllib.request.urlopen
+           we return the original response
+           we capture a span for the request
+        """
+        resp = urlopen('http://httpstat.us/200')
+        self.assertEqual(self.to_str(resp.read()), '200 OK')
+        self.assertEqual(resp.getcode(), 200)
+
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.span_type, 'http')
+        self.assertIsNone(span.service)
+        self.assertEqual(span.name, self.SPAN_NAME)
+        self.assertEqual(span.error, 0)
+        self.assertEqual(span.get_tag('http.method'), 'GET')
+        self.assertEqual(span.get_tag('http.status_code'), '200')
+        self.assertEqual(span.get_tag('http.url'), 'http://httpstat.us/200')
+
+    def test_urllib_request_https(self):
+        """
+        When making a request via urllib.request.urlopen
+           when making an HTTPS connection
+               we return the original response
+               we capture a span for the request
+        """
+        resp = urlopen('https://httpbin.org/status/200')
+        self.assertEqual(self.to_str(resp.read()), '')
+        self.assertEqual(resp.getcode(), 200)
+
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.span_type, 'http')
+        self.assertIsNone(span.service)
+        self.assertEqual(span.name, self.SPAN_NAME)
+        self.assertEqual(span.error, 0)
+        self.assertEqual(span.get_tag('http.method'), 'GET')
+        self.assertEqual(span.get_tag('http.status_code'), '200')
+        self.assertEqual(span.get_tag('http.url'), 'https://httpbin.org/status/200')
+
+    def test_urllib_request_object(self):
+        """
+        When making a request via urllib.request.urlopen
+           with a urllib.request.Request object
+               we return the original response
+               we capture a span for the request
+        """
+        req = Request('http://httpstat.us/200')
+        resp = urlopen(req)
+        self.assertEqual(self.to_str(resp.read()), '200 OK')
+        self.assertEqual(resp.getcode(), 200)
+
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.span_type, 'http')
+        self.assertIsNone(span.service)
+        self.assertEqual(span.name, self.SPAN_NAME)
+        self.assertEqual(span.error, 0)
+        self.assertEqual(span.get_tag('http.method'), 'GET')
+        self.assertEqual(span.get_tag('http.status_code'), '200')
+        self.assertEqual(span.get_tag('http.url'), 'http://httpstat.us/200')
+
+    def test_urllib_request_opener(self):
+        """
+        When making a request via urllib.request.OpenerDirector
+           we return the original response
+           we capture a span for the request
+        """
+        opener = build_opener()
+        resp = opener.open('http://httpstat.us/200')
+        self.assertEqual(self.to_str(resp.read()), '200 OK')
+        self.assertEqual(resp.getcode(), 200)
+
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.span_type, 'http')
+        self.assertIsNone(span.service)
+        self.assertEqual(span.name, self.SPAN_NAME)
+        self.assertEqual(span.error, 0)
+        self.assertEqual(span.get_tag('http.method'), 'GET')
+        self.assertEqual(span.get_tag('http.status_code'), '200')
+        self.assertEqual(span.get_tag('http.url'), 'http://httpstat.us/200')
+
+
+# Additional Python2 test cases for urllib
+if PY2:
+    import urllib
+
+    class HTTPLibPython2Test(HTTPLibBaseMixin, unittest.TestCase):
+        def test_urllib_request(self):
+            """
+            When making a request via urllib.urlopen
+               we return the original response
+               we capture a span for the request
+            """
+            resp = urllib.urlopen('http://httpstat.us/200')
+            self.assertEqual(resp.read(), '200 OK')
+            self.assertEqual(resp.getcode(), 200)
+
+            spans = self.tracer.writer.pop()
+            self.assertEqual(len(spans), 1)
+            span = spans[0]
+            self.assertEqual(span.span_type, 'http')
+            self.assertIsNone(span.service)
+            self.assertEqual(span.name, 'httplib.request')
+            self.assertEqual(span.error, 0)
+            self.assertEqual(span.get_tag('http.method'), 'GET')
+            self.assertEqual(span.get_tag('http.status_code'), '200')
+            self.assertEqual(span.get_tag('http.url'), 'http://httpstat.us/200')
+
+        def test_urllib_request_https(self):
+            """
+            When making a request via urllib.urlopen
+               when making an HTTPS connection
+                   we return the original response
+                   we capture a span for the request
+            """
+            resp = urllib.urlopen('https://httpbin.org/status/200')
+            self.assertEqual(resp.read(), '')
+            self.assertEqual(resp.getcode(), 200)
+
+            spans = self.tracer.writer.pop()
+            self.assertEqual(len(spans), 1)
+            span = spans[0]
+            self.assertEqual(span.span_type, 'http')
+            self.assertIsNone(span.service)
+            self.assertEqual(span.name, 'httplib.request')
+            self.assertEqual(span.error, 0)
+            self.assertEqual(span.get_tag('http.method'), 'GET')
+            self.assertEqual(span.get_tag('http.status_code'), '200')
+            self.assertEqual(span.get_tag('http.url'), 'https://httpbin.org/status/200')

--- a/tests/contrib/httplib/utils.py
+++ b/tests/contrib/httplib/utils.py
@@ -1,0 +1,16 @@
+import ddtrace
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def override_global_tracer(tracer):
+    """Helper functions that overrides the global tracer available in the
+    `ddtrace` package. This is required because in some `httplib` tests we
+    can't get easily the PIN object attached to the `HTTPConnection` to
+    replace the used tracer with a dummy tracer.
+    """
+    original_tracer = ddtrace.tracer
+    ddtrace.tracer = tracer
+    yield
+    ddtrace.tracer = original_tracer

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ envlist =
     {py27,py34,py35,py36}-gevent{11,12}
 # gevent 1.0 is not python 3 compatible
     {py27}-gevent{10}
+    {py27,py34,py35,py36}-httplib
     {py27,py34,py35,py36}-mysqlconnector{21}
     {py27,py34,py35,py36}-pylibmc{140,150}
     {py27,py34,py35,py36}-pymongo{30,31,32,33,34}-mongoengine{011}
@@ -210,6 +211,7 @@ commands =
     falcon-autopatch{10,11}: ddtrace-run nosetests {posargs} tests/contrib/falcon/test_autopatch.py
     gevent{11,12}: nosetests {posargs} tests/contrib/gevent
     gevent{10}: nosetests {posargs} tests/contrib/gevent
+    httplib: nosetests {posargs} tests/contrib/httplib
     mysqlconnector21: nosetests {posargs} tests/contrib/mysql
     pylibmc{140,150}: nosetests {posargs} tests/contrib/pylibmc
     pymongo{30,31,32,33,34}: nosetests {posargs} tests/contrib/pymongo


### PR DESCRIPTION
This PR adds in tracing support for the base `httplib.HTTPConnection` (Py2) and `http.lib.HTTPConnection` (Py3) classes.

Patching these classes allows us expand our support for tracing external HTTP requests.

This tracing is setup similar to the tracing for `requests`. There is no service being set, and we are capturing the basic tags of `http.method`, `http.status_code`, and `http.url`.

```python
from ddtrace.contrib.httplib import patch
patch()

# Python 2
import urllib
resp = urllib.urlopen('http://www.datadog.com/')

import urllib2
resp = urllib2.urlopen('http://www.datadog.com/')

# Python 3
import urllib.request
resp = urllib.request.urlopen('http://www.datadog.com/')

import urllib.request
resp = urllib.request.urlopen('http://www.datadog.com/')
```