### PR TITLE
django: Fix configuration casting

### DIFF
--- a/ddtrace/contrib/django/conf.py
+++ b/ddtrace/contrib/django/conf.py
@@ -26,7 +26,7 @@ DEFAULTS = {
     'ENABLED': True,
     'AUTO_INSTRUMENT': True,
     'AGENT_HOSTNAME': 'localhost',
-    'AGENT_PORT': '7777',
+    'AGENT_PORT': 7777,
 }
 
 # List of settings that may be in string import notation.


### PR DESCRIPTION
Django can recast strings as unicode strings, which invalidate the input
for `getaddrinfo()`.

Massive help from @brettlangdon on this!!

Regular Python shell:
```python
>>> from ddtrace import tracer
>>> tracer.writer.api.port
7777
```

Django 1.9.4 shell on Python 2.7.12:
```python
>>> from ddtrace import tracer
>>> tracer.writer.api.port
u'7777'
>>> from socket import *
>>> getaddrinfo(tracer.writer.api.hostname, tracer.writer.api.port, 0,
SOCK_STREAM)
Traceback (most recent call last):
  File "<console>", line 1, in <module>
error: getaddrinfo() argument 2 must be integer or string
>>> tracer.writer.api.port = 7777
>>> getaddrinfo(tracer.writer.api.hostname, tracer.writer.api.port, 0,
SOCK_STREAM)
[(2, 1, 6, '172.17.0.1', ('172.17.0.1', 7777))]
```

Signed-off-by: Mike Fiedler <miketheman@gmail.com>