### PR TITLE
log: downgrade high throughput log messages to debug

### DIFF
--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -101,7 +101,7 @@ def _get_vendor(conn):
     try:
         name = _get_module_name(conn)
     except Exception:
-        log.warn("couldnt parse module name", exc_info=True)
+        log.debug("couldnt parse module name", exc_info=True)
         name = "sql"
     return sql.normalize_vendor(name)
 

--- a/ddtrace/contrib/django/middleware.py
+++ b/ddtrace/contrib/django/middleware.py
@@ -44,7 +44,7 @@ class TraceMiddleware(MiddlewareClass):
             span.set_tag(http.URL, request.path)
             _set_req_span(request, span)
         except Exception:
-            log.exception('error tracing request')
+            log.debug('error tracing request', exc_info=True)
 
     def process_view(self, request, view_func, *args, **kwargs):
         span = _get_req_span(request)
@@ -58,9 +58,8 @@ class TraceMiddleware(MiddlewareClass):
                 span.set_tag(http.STATUS_CODE, response.status_code)
                 span = _set_auth_tags(span, request)
                 span.finish()
-
         except Exception:
-            log.exception("error tracing request")
+            log.debug("error tracing request", exc_info=True)
         finally:
             return response
 
@@ -71,7 +70,7 @@ class TraceMiddleware(MiddlewareClass):
                 span.set_tag(http.STATUS_CODE, '500')
                 span.set_traceback() # will set the exception info
         except Exception:
-            log.exception("error processing exception")
+            log.debug("error processing exception", exc_info=True)
 
 
 def _get_req_span(request):

--- a/ddtrace/contrib/flask_cache/tracers.py
+++ b/ddtrace/contrib/flask_cache/tracers.py
@@ -64,7 +64,7 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
                 try:
                     s.set_tags(_extract_conn_tags(self.cache._client))
                 except Exception:
-                    log.exception("error parsing connection tags")
+                    log.debug("error parsing connection tags", exc_info=True)
 
             return s
 

--- a/ddtrace/contrib/pylibmc/client.py
+++ b/ddtrace/contrib/pylibmc/client.py
@@ -48,7 +48,7 @@ class TracedClient(ObjectProxy):
         try:
             self._addresses = parse_addresses(client.addresses)
         except Exception:
-            log.exception("error setting addresses")
+            log.debug("error setting addresses", exc_info=True)
 
         # attempt to set the service info
         try:
@@ -57,7 +57,7 @@ class TracedClient(ObjectProxy):
                 app=memcached.SERVICE,
                 app_type=memcached.TYPE)
         except Exception:
-            log.exception("error setting service info")
+            log.debug("error setting service info", exc_info=True)
 
     def clone(self, *args, **kwargs):
         # rewrap new connections.
@@ -144,8 +144,7 @@ class TracedClient(ObjectProxy):
             try:
                 self._tag_span(span)
             except Exception:
-                log.exception("error tagging span")
-
+                log.debug("error tagging span", exc_info=True)
             return span
 
     def _tag_span(self, span):

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -49,7 +49,7 @@ def _traced_request_func(func, instance, args, kwargs):
             try:
                 _apply_tags(span, method, url, resp)
             except Exception:
-                log.warn("error patching tags", exc_info=True)
+                log.debug("error patching tags", exc_info=True)
 
 
 def _apply_tags(span, method, url, response):

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -87,7 +87,7 @@ class Pin(object):
             try:
                 self._send()
             except Exception:
-                log.warn("can't send pin info", exc_info=True)
+                log.debug("can't send pin info", exc_info=True)
 
         # Actually patch it on the object.
         try:
@@ -95,7 +95,7 @@ class Pin(object):
                 return obj.__setddpin__(self)
             return setattr(obj, '_datadog_pin', self)
         except AttributeError:
-            log.warn("can't pin onto object. skipping", exc_info=True)
+            log.debug("can't pin onto object. skipping", exc_info=True)
 
     def clone(self, service=None, app=None, app_type=None, tags=None, tracer=None):
         """ Return a clone of the pin with the given attributes replaced. """

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -125,7 +125,7 @@ class Span(object):
         try:
             self.meta[key] = stringify(value)
         except Exception:
-            log.warning("error setting tag %s, ignoring it", key, exc_info=True)
+            log.debug("error setting tag %s, ignoring it", key, exc_info=True)
 
     def get_tag(self, key):
         """ Return the given tag or None if it doesn't exist.
@@ -156,12 +156,12 @@ class Span(object):
             try:
                 value = float(value)
             except (ValueError, TypeError):
-                log.warn("ignoring not number metric %s:%s", key, value)
+                log.debug("ignoring not number metric %s:%s", key, value)
                 return
 
         # don't allow nan or inf
         if math.isnan(value) or math.isinf(value):
-            log.warn("ignoring not real metric %s:%s", key, value)
+            log.debug("ignoring not real metric %s:%s", key, value)
             return
 
         self.metrics[key] = value

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -194,7 +194,7 @@ class Tracer(object):
                 # queue them for writes.
                 self.writer.write(services=services)
         except Exception:
-            log.exception("error setting service info")
+            log.debug("error setting service info", exc_info=True)
 
     def wrap(self, name=None, service=None, resource=None, span_type=None):
         """A decorator used to trace an entire function.


### PR DESCRIPTION
so they don't flood by default.