### PR TITLE
Add a method to globally `set_tags` in tracer

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -50,6 +50,9 @@ class Tracer(object):
         # things.
         self._services = {}
 
+        # globally set tags
+        self.tags = {}
+
     def configure(self, enabled=None, hostname=None, port=None, sampler=None):
         """Configure an existing Tracer the easy way.
 
@@ -126,6 +129,9 @@ class Tracer(object):
                 span_type=span_type,
             )
             self.sampler.sample(span)
+
+        if self.tags:
+            span.set_tags(self.tags)
 
         # Note the current trace.
         self.span_buffer.set(span)
@@ -234,3 +240,11 @@ class Tracer(object):
             return func_wrapper
 
         return wrap_decorator
+
+    def set_tags(self, tags):
+        """ Set some tags at the tracer level.
+        This will append those tags to each span created by the tracer.
+
+        :param str tags: dict of tags to set at tracer level
+        """
+        self.tags.update(tags)

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -264,6 +264,24 @@ def test_tracer_disabled_mem_leak():
     s2.finish()
     assert not p1, p1
 
+def test_tracer_global_tags():
+    writer = DummyWriter()
+    tracer = Tracer()
+    tracer.writer = writer
+
+    s1 = tracer.trace('brie')
+    s1.finish()
+    assert not s1.meta
+
+    tracer.set_tags({'env': 'prod'})
+    s2 = tracer.trace('camembert')
+    s2.finish()
+    assert s2.meta == {'env': 'prod'}
+
+    tracer.set_tags({'env': 'staging', 'other': 'tag'})
+    s3 = tracer.trace('gruyere')
+    s3.finish()
+    assert s3.meta == {'env': 'staging', 'other': 'tag'}
 
 class DummyWriter(AgentWriter):
     """ DummyWriter is a small fake writer used for tests. not thread-safe. """


### PR DESCRIPTION
This will populate all the spans metadata, it can be useful for tags
like `env`.