### PR TITLE
[flask] fixed 404 pages

### DIFF
--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -116,7 +116,10 @@ class TraceMiddleware(object):
                     span.set_tag(errors.ERROR_TYPE, type(exception))
                     span.set_tag(errors.ERROR_MSG, exception)
 
-                span.resource = compat.to_unicode(request.endpoint or '').lower()
+                # the endpoint that matched the request is None if an exception
+                # happened so we fallback to the path attribute
+                resource = '404' if not request.endpoint else request.endpoint
+                span.resource = compat.to_unicode(resource).lower()
                 span.set_tag(http.URL, compat.to_unicode(request.base_url or ''))
                 span.set_tag(http.STATUS_CODE, code)
                 span.error = error

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -117,8 +117,8 @@ class TraceMiddleware(object):
                     span.set_tag(errors.ERROR_MSG, exception)
 
                 # the endpoint that matched the request is None if an exception
-                # happened so we fallback to the path attribute
-                resource = '404' if not request.endpoint else request.endpoint
+                # happened so we fallback to a common resource
+                resource = code if not request.endpoint else request.endpoint
                 span.resource = compat.to_unicode(resource).lower()
                 span.set_tag(http.URL, compat.to_unicode(request.base_url or ''))
                 span.set_tag(http.STATUS_CODE, code)

--- a/tests/contrib/flask/test_flask.py
+++ b/tests/contrib/flask/test_flask.py
@@ -279,3 +279,24 @@ class TestFlask(object):
         eq_(s.error, 0)
         eq_(s.meta.get(http.STATUS_CODE), '200')
         eq_(s.meta.get(http.URL), u'http://localhost/üŋïĉóđē')
+
+    def test_404(self):
+        start = time.time()
+        rv = app.get(u'/404/üŋïĉóđē')
+        end = time.time()
+
+        # ensure that we hit a 404
+        eq_(rv.status_code, 404)
+
+        # ensure trace worked
+        assert not tracer.current_span(), tracer.current_span().pprint()
+        spans = writer.pop()
+        eq_(len(spans), 1)
+        s = spans[0]
+        eq_(s.service, service)
+        eq_(s.resource, u'404')
+        assert s.start >= start
+        assert s.duration <= end - start
+        eq_(s.error, 0)
+        eq_(s.meta.get(http.STATUS_CODE), '404')
+        eq_(s.meta.get(http.URL), u'http://localhost/404/üŋïĉóđē')


### PR DESCRIPTION
### What it does

If a traced application returns a ``404``, the ``resource`` value that defaults to ``endpoint`` is ``None`` and so the trace is dropped by the ``dd-trace-agent``.

Documentation [here][1] (targets the latest version).

[1]: http://flask.pocoo.org/docs/0.12/api/#flask.Request.endpoint