### PR TITLE
Set global tracer tags from django DATADOG_TRACE

### DIFF
--- a/ddtrace/contrib/django/apps.py
+++ b/ddtrace/contrib/django/apps.py
@@ -26,6 +26,9 @@ class TracerConfig(AppConfig):
         """
         tracer = settings.TRACER
 
+        if settings.TAGS:
+            tracer.set_tags(settings.TAGS)
+
         # define the service details
         tracer.set_service_info(
             app='django',

--- a/ddtrace/contrib/django/conf.py
+++ b/ddtrace/contrib/django/conf.py
@@ -27,6 +27,7 @@ DEFAULTS = {
     'AUTO_INSTRUMENT': True,
     'AGENT_HOSTNAME': 'localhost',
     'AGENT_PORT': 7777,
+    'TAGS': {},
 }
 
 # List of settings that may be in string import notation.

--- a/tests/contrib/django/app/settings.py
+++ b/tests/contrib/django/app/settings.py
@@ -112,4 +112,7 @@ DATADOG_TRACE = {
     # tracer with a DummyWriter
     'TRACER': 'tests.contrib.django.utils.tracer',
     'ENABLED': True,
+    'TAGS': {
+        'env': 'test',
+    },
 }

--- a/tests/contrib/django/app/settings.py
+++ b/tests/contrib/django/app/settings.py
@@ -112,4 +112,7 @@ DATADOG_TRACE = {
     # tracer with a DummyWriter
     'TRACER': 'tests.contrib.django.utils.tracer',
     'ENABLED': True,
+    'TAGS': {
+        'env': 'production',
+    },
 }

--- a/tests/contrib/django/app/settings.py
+++ b/tests/contrib/django/app/settings.py
@@ -112,7 +112,4 @@ DATADOG_TRACE = {
     # tracer with a DummyWriter
     'TRACER': 'tests.contrib.django.utils.tracer',
     'ENABLED': True,
-    'TAGS': {
-        'env': 'production',
-    },
 }

--- a/tests/contrib/django/test_cache_backends.py
+++ b/tests/contrib/django/test_cache_backends.py
@@ -36,6 +36,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django_redis.cache.RedisCache',
             'django.cache.key': 'missing_key',
+            'env': 'test',
         }
 
         eq_(span.meta, expected_meta)
@@ -64,6 +65,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django_redis.cache.RedisCache',
             'django.cache.key': str(['missing_key', 'another_key']),
+            'env': 'test',
         }
 
         eq_(span.meta, expected_meta)
@@ -92,6 +94,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.memcached.PyLibMCCache',
             'django.cache.key': 'missing_key',
+            'env': 'test',
         }
 
         eq_(span.meta, expected_meta)
@@ -120,6 +123,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.memcached.PyLibMCCache',
             'django.cache.key': str(['missing_key', 'another_key']),
+            'env': 'test',
         }
 
         eq_(span.meta, expected_meta)
@@ -148,6 +152,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.memcached.MemcachedCache',
             'django.cache.key': 'missing_key',
+            'env': 'test',
         }
 
         eq_(span.meta, expected_meta)
@@ -176,6 +181,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.memcached.MemcachedCache',
             'django.cache.key': str(['missing_key', 'another_key']),
+            'env': 'test',
         }
 
         eq_(span.meta, expected_meta)
@@ -204,6 +210,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django_pylibmc.memcached.PyLibMCCache',
             'django.cache.key': 'missing_key',
+            'env': 'test',
         }
 
         eq_(span.meta, expected_meta)
@@ -232,6 +239,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django_pylibmc.memcached.PyLibMCCache',
             'django.cache.key': str(['missing_key', 'another_key']),
+            'env': 'test',
         }
 
         eq_(span.meta, expected_meta)

--- a/tests/contrib/django/test_cache_client.py
+++ b/tests/contrib/django/test_cache_client.py
@@ -35,6 +35,7 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
             'django.cache.key': 'missing_key',
+            'env': 'test',
         }
 
         eq_(span.meta, expected_meta)
@@ -63,6 +64,7 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
             'django.cache.key': 'a_new_key',
+            'env': 'test',
         }
 
         eq_(span.meta, expected_meta)
@@ -91,6 +93,7 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
             'django.cache.key': 'a_new_key',
+            'env': 'test',
         }
 
         eq_(span.meta, expected_meta)
@@ -119,6 +122,7 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
             'django.cache.key': 'an_existing_key',
+            'env': 'test',
         }
 
         eq_(span.meta, expected_meta)
@@ -157,6 +161,7 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
             'django.cache.key': 'value',
+            'env': 'test',
         }
 
         eq_(span_get.meta, expected_meta)
@@ -202,6 +207,7 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
             'django.cache.key': 'value',
+            'env': 'test',
         }
 
         eq_(span_get.meta, expected_meta)
@@ -246,6 +252,7 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
             'django.cache.key': str(['missing_key', 'another_key']),
+            'env': 'test',
         }
 
         eq_(span_get_many.meta, expected_meta)

--- a/tests/contrib/django/test_cache_views.py
+++ b/tests/contrib/django/test_cache_views.py
@@ -49,11 +49,13 @@ class DjangoCacheViewTest(DjangoTraceTestCase):
         expected_meta_view = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
             'django.cache.key': 'views.decorators.cache.cache_page..GET.03cdc1cc4aab71b038a6764e5fcabb82.d41d8cd98f00b204e9800998ecf8427e.en-us',
+            'env': 'test',
         }
 
         expected_meta_header = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
             'django.cache.key': 'views.decorators.cache.cache_header..03cdc1cc4aab71b038a6764e5fcabb82.en-us',
+            'env': 'test',
         }
 
         eq_(span_view.meta, expected_meta_view)
@@ -88,6 +90,7 @@ class DjangoCacheViewTest(DjangoTraceTestCase):
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
             'django.cache.key': 'template.cache.users_list.d41d8cd98f00b204e9800998ecf8427e',
+            'env': 'test',
         }
 
         eq_(span_template_cache.meta, expected_meta)

--- a/tests/contrib/django/test_instrumentation.py
+++ b/tests/contrib/django/test_instrumentation.py
@@ -20,16 +20,7 @@ class DjangoInstrumentationTest(DjangoTraceTestCase):
         ok_(self.tracer.enabled)
         eq_(self.tracer.writer.api.hostname, 'localhost')
         eq_(self.tracer.writer.api.port, 7777)
-
-    @override_settings(DATADOG_TRACE={
-        'TRACER': 'tests.contrib.django.utils.tracer',
-        'ENABLED': True,
-        'TAGS': {
-            'env': 'production',
-        }
-    })
-    def test_tracer_global_tags_from_settings(self):
-        eq_(self.tracer.tags, {'env': 'production'})
+        eq_(self.tracer.tags, {'env': 'test'})
 
     def test_tracer_call(self):
         # test that current Django configuration is correct

--- a/tests/contrib/django/test_instrumentation.py
+++ b/tests/contrib/django/test_instrumentation.py
@@ -20,6 +20,7 @@ class DjangoInstrumentationTest(DjangoTraceTestCase):
         ok_(self.tracer.enabled)
         eq_(self.tracer.writer.api.hostname, 'localhost')
         eq_(self.tracer.writer.api.port, 7777)
+        eq_(self.tracer.tags, {'env': 'production'})
 
     def test_tracer_call(self):
         # test that current Django configuration is correct

--- a/tests/contrib/django/test_instrumentation.py
+++ b/tests/contrib/django/test_instrumentation.py
@@ -20,6 +20,15 @@ class DjangoInstrumentationTest(DjangoTraceTestCase):
         ok_(self.tracer.enabled)
         eq_(self.tracer.writer.api.hostname, 'localhost')
         eq_(self.tracer.writer.api.port, 7777)
+
+    @override_settings(DATADOG_TRACE={
+        'TRACER': 'tests.contrib.django.utils.tracer',
+        'ENABLED': True,
+        'TAGS': {
+            'env': 'production',
+        }
+    })
+    def test_tracer_global_tags_from_settings(self):
         eq_(self.tracer.tags, {'env': 'production'})
 
     def test_tracer_call(self):


### PR DESCRIPTION
This PR will allow specifying global tracer tags in your django `DATADOG_TRACE` config object. We'd like to use this to pass the appropriate `env` tag to the tracer from our django configuration. Alternately, we could import the tracer and call `set_tags` somewhere during the django boot process, but it would be easier to able to specify it directly in the configuration.

Thanks!