### PR TITLE
[span] adding a default 'python' service is none is given

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -14,6 +14,8 @@ log = logging.getLogger(__name__)
 
 class Span(object):
 
+    DEFAULT_SERVICE = 'python'
+
     __slots__ = [
         # Public span attributes
         'service',

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -148,6 +148,7 @@ class Tracer(object):
     def record(self, span):
         """Record the given finished span."""
         spans = []
+        span.service = span.service or Span.DEFAULT_SERVICE
         with self._spans_lock:
             self._spans.append(span)
             parent = span._parent


### PR DESCRIPTION
It's technically possible to create a span without a service, and this is valid, it should inherit the service from its parent in that case. However root spans have no parent so it's impossible to infer/guess a valid name. This patch provides a default value (`python`) in that case.