### PR TITLE
[asyncio] safety tests when the default context_provider is wrongly used in async code

### DIFF
--- a/ddtrace/provider.py
+++ b/ddtrace/provider.py
@@ -10,7 +10,7 @@ class BaseContextProvider(object):
         * the ``__call__`` method, so that the class is callable
     """
 
-    def __call__(self):
+    def __call__(self, *args, **kwargs):
         """
         Makes the class callable so that the ``Tracer`` can invoke the
         ``ContextProvider`` to retrieve the current context.
@@ -28,7 +28,7 @@ class DefaultContextProvider(BaseContextProvider):
     def __init__(self):
         self._local = ThreadLocalContext()
 
-    def __call__(self):
+    def __call__(self, *args, **kwargs):
         """
         Returns the global context for this tracer. Returned ``Context`` must be thread-safe
         or thread-local.

--- a/tests/contrib/aiohttp/app/web.py
+++ b/tests/contrib/aiohttp/app/web.py
@@ -1,5 +1,6 @@
 import os
 import jinja2
+import asyncio
 import aiohttp_jinja2
 
 from aiohttp import web
@@ -56,6 +57,11 @@ async def template_error(request):
     return {}
 
 
+async def delayed_handler(request):
+    await asyncio.sleep(0.01)
+    return web.Response(text='Done')
+
+
 def setup_app(loop):
     """
     Use this method to create the app. It must receive
@@ -65,6 +71,7 @@ def setup_app(loop):
     # configure the app
     app = web.Application(loop=loop)
     app.router.add_get('/', home)
+    app.router.add_get('/delayed/', delayed_handler)
     app.router.add_get('/echo/{name}', name)
     app.router.add_get('/chaining/', coroutine_chaining)
     app.router.add_get('/exception', route_exception)

--- a/tests/contrib/asyncio/test_tracer_safety.py
+++ b/tests/contrib/asyncio/test_tracer_safety.py
@@ -1,0 +1,58 @@
+import asyncio
+
+from nose.tools import eq_, ok_
+
+from ddtrace.provider import DefaultContextProvider
+from .utils import AsyncioTestCase, mark_asyncio
+
+
+class TestAsyncioSafety(AsyncioTestCase):
+    """
+    Ensure that if the ``AsyncioTracer`` is not properly configured,
+    bad traces are produced but the ``Context`` object will not
+    leak memory.
+    """
+    def setUp(self):
+        # Asyncio TestCase with the wrong context provider
+        super(TestAsyncioSafety, self).setUp()
+        self.tracer.configure(context_provider=DefaultContextProvider())
+
+    @mark_asyncio
+    def test_get_call_context(self):
+        # it should return a context even if not attached to the Task
+        ctx = self.tracer.get_call_context()
+        ok_(ctx is not None)
+        # test that it behaves the wrong way
+        task = asyncio.Task.current_task()
+        task_ctx = getattr(task, '__datadog_context', None)
+        ok_(task_ctx is None)
+
+    @mark_asyncio
+    def test_trace_coroutine(self):
+        # it should use the task context when invoked in a coroutine
+        with self.tracer.trace('coroutine') as span:
+            span.resource = 'base'
+
+        traces = self.tracer.writer.pop_traces()
+        eq_(1, len(traces))
+        eq_(1, len(traces[0]))
+        eq_('coroutine', traces[0][0].name)
+        eq_('base', traces[0][0].resource)
+
+    @mark_asyncio
+    def test_trace_multiple_calls(self):
+        async def coro():
+            # another traced coroutine
+            with self.tracer.trace('coroutine'):
+                await asyncio.sleep(0.01)
+
+        ctx = self.tracer.get_call_context()
+        futures = [asyncio.ensure_future(coro()) for x in range(1000)]
+        for future in futures:
+            yield from future
+
+        # the trace is wrong but the Context is finished
+        traces = self.tracer.writer.pop_traces()
+        eq_(1, len(traces))
+        eq_(1000, len(traces[0]))
+        eq_(0, len(ctx._trace))


### PR DESCRIPTION
### What it does

Cover different test cases when concurrent calls are executed in asynchronous instrumentation.