### PR TITLE
updating the Tracer API

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -44,6 +44,7 @@ class Context(object):
             self._current_span = span
             self._sampled = span.sampled
             self._trace.append(span)
+            span._context = self
 
     def close_span(self, span):
         """

--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -44,16 +44,15 @@ class TraceMiddleware(object):
         """
         async def middleware(app, handler):
             async def attach_context(request):
-                # attach the context to the request
-                ctx = self._tracer.get_call_context(loop=request.app.loop)
-                request['__datadog_context'] = ctx
                 # trace the handler
                 request_span = self._tracer.trace(
                     'aiohttp.request',
-                    ctx=ctx,
                     service=self._service,
                     span_type=http.TYPE,
                 )
+
+                # attach the context and the root span to the request
+                request['__datadog_context'] = request_span.context
                 request['__datadog_request_span'] = request_span
                 try:
                     return await handler(request)

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -32,9 +32,9 @@ class Span(object):
         'sampled',
         # Internal attributes
         '_tracer',
+        '_context',
         '_finished',
         '_parent',
-        '_context',
     ]
 
     def __init__(
@@ -49,13 +49,13 @@ class Span(object):
         span_id=None,
         parent_id=None,
         start=None,
-        ctx=None,
+        context=None,
     ):
         """
         Create a new span. Call `finish` once the traced operation is over.
 
-        :param Tracer tracer: the tracer that will submit this span when
-                              finished.
+        :param Tracer tracer: the tracer that will submit this span when finished.
+        :param object context: the context of the span.
         :param str name: the name of the traced operation.
 
         :param str service: the service name
@@ -67,7 +67,6 @@ class Span(object):
         :param int span_id: the id of this span.
 
         :param int start: the start time of request as a unix epoch in seconds
-        :param Context ctx: the context of the span.
         """
         # required span info
         self.name = name
@@ -93,13 +92,11 @@ class Span(object):
         self.sampled = True
 
         self._tracer = tracer
+        self._context = context
         self._parent = None
 
         # state
         self._finished = False
-
-        # context
-        self._context = ctx
 
     def finish(self, finish_time=None):
         """ Mark the end time of the span and submit it to the tracer.
@@ -262,6 +259,15 @@ class Span(object):
 
         lines.extend((" ", "%s:%s" % kv) for kv in sorted(self.meta.items()))
         return "\n".join("%10s %s" % l for l in lines)
+
+    @property
+    def context(self):
+        """
+        Provides access to the ``Context`` associated with this ``Span``.
+        The ``Context`` contains state that propagates from span to span in a
+        larger trace.
+        """
+        return self._context
 
     # TODO: these context managers will not work for async code; add __a*__
     def __enter__(self):

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -2,6 +2,7 @@ import functools
 import logging
 
 from .provider import DefaultContextProvider
+from .context import Context
 from .sampler import AllSampler
 from .writer import AgentWriter
 from .span import Span
@@ -80,6 +81,120 @@ class Tracer(object):
         if context_provider is not None:
             self._context_provider = context_provider
 
+    def start_span(self, name, service=None, resource=None, span_type=None):
+        """
+        Starts and returns a new ``Span`` representing a unit of work.
+
+        :param str name: the name of the operation being traced.
+        :param str service: the name of the service being traced.
+        :param str resource: an optional name of the resource being tracked.
+        :param str span_type: an optional operation type.
+
+        To start a new root span::
+
+            >>> span = tracer.start_span("web.request")
+        """
+        span = Span(
+            self,
+            name,
+            service=service,
+            resource=resource,
+            span_type=span_type,
+        )
+        self.sampler.sample(span)
+
+        # add common tags
+        if self.tags:
+            span.set_tags(self.tags)
+
+        # create a new context for the root span
+        context = Context()
+        context.add_span(span)
+        return span
+
+    def start_child_span(self, name, parent_span, service=None, resource=None, span_type=None):
+        """
+        Starts and returns a new child ``Span`` from the given parent, representing a unit of work.
+
+        :param str name: the name of the operation being traced.
+        :param object parent_span: the parent span that creates this child.
+        :param str service: the name of the service being traced. If not set,
+                            it will inherit the service from its parent.
+        :param str resource: an optional name of the resource being tracked.
+        :param str span_type: an optional operation type.
+
+        To start a new child span::
+
+            >>> parent_span = tracer.start_span("web.request")
+            >>> span = tracer.start_child_span("web.worker", parent_span)
+        """
+        span = Span(
+            self,
+            name,
+            service=(service or parent_span.service),
+            resource=resource,
+            span_type=span_type,
+            trace_id=parent_span.trace_id,
+            parent_id=parent_span.span_id,
+        )
+        span._parent = parent_span
+        span.sampled = parent_span.sampled
+
+        # add common tags
+        if self.tags:
+            span.set_tags(self.tags)
+
+        # get the context from the parent span
+        parent_span.context.add_span(span)
+        return span
+
+    def start_child_from_context(self, name, context, service=None, resource=None, span_type=None):
+        """
+        Starts and returns a new ``Span`` in the given ``Context``. If the ``Context`` is empty,
+        the ``Span`` becomes a root span, otherwise a child of the current active span.
+
+        :param str name: the name of the operation being traced.
+        :param object context: the context related to this tracing operation.
+        :param str service: the name of the service being traced. If not set,
+                            it will inherit the service from its parent.
+        :param str resource: an optional name of the resource being tracked.
+        :param str span_type: an optional operation type.
+
+        To start a new span from a context::
+
+            >>> ctx = Context()
+            >>> root = tracer.start_span_from_context("web.request", ctx)
+            >>> child = tracer.start_span_from_context("web.worker", ctx)
+            >>> child.parent == root
+            >>> # True
+        """
+        # find the current active span from the given context
+        parent = context.get_current_span()
+
+        if not parent:
+            # this is a root span
+            span = Span(
+                self,
+                name,
+                service=service,
+                resource=resource,
+                span_type=span_type,
+                context=context,
+            )
+            self.sampler.sample(span)
+
+            # add common tags
+            if self.tags:
+                span.set_tags(self.tags)
+
+            # add it to the current context
+            context.add_span(span)
+        else:
+            # this is a child span
+            span = self.start_child_span(name, parent, service=service, resource=resource, span_type=span_type)
+
+        return span
+
     def trace(self, name, service=None, resource=None, span_type=None, ctx=None, span_parent=None):
         """
         Return a span that will trace an operation called `name`. The context that generated
@@ -131,7 +246,7 @@ class Tracer(object):
                 span_type=span_type,
                 trace_id=parent.trace_id,
                 parent_id=parent.span_id,
-                ctx=context,
+                context=context,
             )
             span._parent = parent
             span.sampled = parent.sampled
@@ -143,7 +258,7 @@ class Tracer(object):
                 service=service,
                 resource=resource,
                 span_type=span_type,
-                ctx=context,
+                context=context,
             )
             self.sampler.sample(span)
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -19,6 +19,7 @@ class TestTracingContext(TestCase):
         ctx.add_span(span)
         eq_(1, len(ctx._trace))
         eq_('fake_span', ctx._trace[0].name)
+        eq_(ctx, span.context)
 
     def test_context_sampled(self):
         # a context is sampled if the spans are sampled

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -9,7 +9,7 @@ from ddtrace.ext import errors
 
 
 def test_ids():
-    s = Span(tracer=None, name="test_ids")
+    s = Span(tracer=None, name="span.test")
     assert s.trace_id
     assert s.span_id
     assert not s.parent_id
@@ -21,7 +21,7 @@ def test_ids():
 
 
 def test_tags():
-    s = Span(tracer=None, name="foo")
+    s = Span(tracer=None, name="test.span")
     s.set_tag("a", "a")
     s.set_tag("b", 1)
     s.set_tag("c", "1")
@@ -34,7 +34,7 @@ def test_tags():
     eq_(d["meta"], expected)
 
 def test_set_valid_metrics():
-    s = Span(tracer=None, name="foo")
+    s = Span(tracer=None, name="test.span")
     s.set_metric("a", 0)
     s.set_metric("b", -12)
     s.set_metric("c", 12.134)
@@ -51,7 +51,7 @@ def test_set_valid_metrics():
     eq_(d["metrics"], expected)
 
 def test_set_invalid_metric():
-    s = Span(tracer=None, name="foo")
+    s = Span(tracer=None, name="test.span")
 
     invalid_metrics = [
         None,
@@ -74,7 +74,7 @@ def test_set_numpy_metric():
         import numpy as np
     except ImportError:
         raise SkipTest("numpy not installed")
-    s = Span(tracer=None, name="foo")
+    s = Span(tracer=None, name="test.span")
     s.set_metric("a", np.int64(1))
     eq_(s.get_metric("a"), 1)
     eq_(type(s.get_metric("a")), float)
@@ -85,14 +85,14 @@ def test_tags_not_string():
         def __repr__(self):
             1/0
 
-    s = Span(tracer=None, name="foo")
+    s = Span(tracer=None, name="test.span")
     s.set_tag("a", Foo())
 
 def test_finish():
     # ensure finish will record a span
     dt = DummyTracer()
     ctx = Context()
-    s = Span(dt, "foo", ctx=ctx)
+    s = Span(dt, "test.span", context=ctx)
     ctx.add_span(s)
     assert s.duration is None
 
@@ -106,14 +106,14 @@ def test_finish():
 
 def test_finish_no_tracer():
     # ensure finish works with no tracer without raising exceptions
-    s = Span(tracer=None, name="foo")
+    s = Span(tracer=None, name="test.span")
     s.finish()
 
 def test_finish_called_multiple_times():
     # we should only record a span the first time finish is called on it
     dt = DummyTracer()
     ctx = Context()
-    s = Span(dt, 'bar', ctx=ctx)
+    s = Span(dt, 'bar', context=ctx)
     ctx.add_span(s)
     s.finish()
     s.finish()
@@ -123,13 +123,13 @@ def test_finish_called_multiple_times():
 def test_finish_set_span_duration():
     # If set the duration on a span, the span should be recorded with this
     # duration
-    s = Span(tracer=None, name='foo')
+    s = Span(tracer=None, name='test.span')
     s.duration = 1337.0
     s.finish()
     assert s.duration == 1337.0
 
 def test_traceback_with_error():
-    s = Span(None, "foo")
+    s = Span(None, "test.span")
     try:
         1/0
     except ZeroDivisionError:
@@ -143,7 +143,7 @@ def test_traceback_with_error():
     assert s.get_tag(errors.ERROR_STACK)
 
 def test_traceback_without_error():
-    s = Span(None, "foo")
+    s = Span(None, "test.span")
     s.set_traceback()
     assert not s.error
     assert not s.get_tag(errors.ERROR_MSG)
@@ -173,7 +173,7 @@ def test_ctx_mgr():
         assert 0, "should have failed"
 
 def test_span_to_dict():
-    s = Span(tracer=None, name="foo.bar", service="s",  resource="r")
+    s = Span(tracer=None, name="test.span", service="s",  resource="r")
     s.span_type = "foo"
     s.set_tag("a", "1")
     s.set_meta("b", "2")
@@ -189,7 +189,6 @@ def test_span_to_dict():
 
 
 class DummyTracer(object):
-
     def __init__(self):
         self.last_span = None
         self.spans_recorded = 0

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -4,7 +4,7 @@ tests for Tracer and utilities.
 
 import time
 
-from nose.tools import assert_raises, eq_
+from nose.tools import assert_raises, eq_, ok_
 from unittest.case import SkipTest
 
 from ddtrace.encoding import JSONEncoder, MsgpackEncoder
@@ -310,6 +310,79 @@ def test_trace_with_context():
     eq_(0, len(tracer.get_call_context()._trace))
     eq_(1, len(ctx._trace))
     eq_(span, ctx._trace[0])
+
+
+def test_start_span():
+    # it should create a root Span
+    tracer = get_dummy_tracer()
+    span = tracer.start_span('web.request')
+    eq_('web.request', span.name)
+    eq_(tracer, span._tracer)
+    ok_(span._parent is None)
+    ok_(span.parent_id is None)
+    ok_(span._context is not None)
+    eq_(span, span._context._current_span)
+
+
+def test_start_span_optional():
+    # it should create a root Span with arguments
+    tracer = get_dummy_tracer()
+    span = tracer.start_span('web.request', service='web', resource='/', span_type='http')
+    eq_('web.request', span.name)
+    eq_('web', span.service)
+    eq_('/', span.resource)
+    eq_('http', span.span_type)
+
+
+def test_start_child_span():
+    # it should create a child Span for the given parent
+    tracer = get_dummy_tracer()
+    parent = tracer.start_span('web.request')
+    child = tracer.start_child_span('web.worker', parent)
+    eq_('web.worker', child.name)
+    eq_(tracer, child._tracer)
+    eq_(parent, child._parent)
+    eq_(parent.span_id, child.parent_id)
+    eq_(parent.trace_id, child.trace_id)
+    eq_(parent._context, child._context)
+    eq_(child, child._context._current_span)
+
+
+def test_start_child_span_attributes():
+    # it should create a child Span with parent's attributes
+    tracer = get_dummy_tracer()
+    parent = tracer.start_span('web.request', service='web', resource='/', span_type='http')
+    child = tracer.start_child_span('web.worker', parent)
+    eq_('web.worker', child.name)
+    eq_('web', child.service)
+
+
+def test_start_root_from_context():
+    # it should create a root span with an empty Context
+    tracer = get_dummy_tracer()
+    context = Context()
+    span = tracer.start_child_from_context('web.request', context)
+    eq_('web.request', span.name)
+    eq_(tracer, span._tracer)
+    ok_(span._parent is None)
+    ok_(span.parent_id is None)
+    eq_(context, span._context)
+    eq_(span, span.context._current_span)
+
+
+def test_start_child_from_context():
+    # it should create a child span with a populated Context
+    tracer = get_dummy_tracer()
+    context = Context()
+    root = tracer.start_child_from_context('web.request', context)
+    child = tracer.start_child_from_context('web.worker', context)
+    eq_('web.worker', child.name)
+    eq_(tracer, child._tracer)
+    eq_(root, child._parent)
+    eq_(root.span_id, child.parent_id)
+    eq_(root.trace_id, child.trace_id)
+    eq_(root._context, child._context)
+    eq_(child, child._context._current_span)
 
 
 class DummyWriter(AgentWriter):

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -301,17 +301,6 @@ def test_tracer_current_span():
     eq_(span, tracer.current_span())
 
 
-def test_trace_with_context():
-    # tracer.trace() could accept a different Context
-    tracer = get_dummy_tracer()
-    ctx = Context()
-    span = tracer.trace('fake_span', ctx=ctx)
-    # the default is empty while the other should have
-    eq_(0, len(tracer.get_call_context()._trace))
-    eq_(1, len(ctx._trace))
-    eq_(span, ctx._trace[0])
-
-
 def test_start_span():
     # it should create a root Span
     tracer = get_dummy_tracer()

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -327,7 +327,7 @@ def test_start_child_span():
     # it should create a child Span for the given parent
     tracer = get_dummy_tracer()
     parent = tracer.start_span('web.request')
-    child = tracer.start_child_span('web.worker', parent)
+    child = tracer.start_span('web.worker', child_of=parent)
     eq_('web.worker', child.name)
     eq_(tracer, child._tracer)
     eq_(parent, child._parent)
@@ -341,30 +341,17 @@ def test_start_child_span_attributes():
     # it should create a child Span with parent's attributes
     tracer = get_dummy_tracer()
     parent = tracer.start_span('web.request', service='web', resource='/', span_type='http')
-    child = tracer.start_child_span('web.worker', parent)
+    child = tracer.start_span('web.worker', child_of=parent)
     eq_('web.worker', child.name)
     eq_('web', child.service)
-
-
-def test_start_root_from_context():
-    # it should create a root span with an empty Context
-    tracer = get_dummy_tracer()
-    context = Context()
-    span = tracer.start_child_from_context('web.request', context)
-    eq_('web.request', span.name)
-    eq_(tracer, span._tracer)
-    ok_(span._parent is None)
-    ok_(span.parent_id is None)
-    eq_(context, span._context)
-    eq_(span, span.context._current_span)
 
 
 def test_start_child_from_context():
     # it should create a child span with a populated Context
     tracer = get_dummy_tracer()
-    context = Context()
-    root = tracer.start_child_from_context('web.request', context)
-    child = tracer.start_child_from_context('web.worker', context)
+    root = tracer.start_span('web.request')
+    context = root.context
+    child = tracer.start_span('web.worker', child_of=context)
     eq_('web.worker', child.name)
     eq_(tracer, child._tracer)
     eq_(root, child._parent)


### PR DESCRIPTION
### What it does

Major change that updates the ``Tracer`` API to provide:
* ``start_span(name, **kwargs)`` to create root spans
* ``start_child_span(name, parent, **kwargs)`` to create a child span from the given ``parent``
* ``start_child_from_context(name, context, **kwargs)`` to create a new span for the given ``context``; this span could be the root span or the child span of the ``context.current_span()``
* ``trace(name)`` that automatically handles everything, using the [ContextProvider][1] to retrieve the current ``Context`` and parent ``Span``

#### Notes

* not sure that we really need a ``start_child_from_context()``
* the ``start_child_span()`` may handle also the ``Context`` like it does in the [reference implementation of OT][2]
* the ``context`` kwarg can become a required argument as defined in [the OT reference][3]

[1]: https://github.com/DataDog/dd-trace-py/blob/palazzem/async-new-api/ddtrace/provider.py
[2]: https://github.com/opentracing/opentracing-python/blob/master/opentracing/tracer.py#L72-L74
[3]: https://github.com/opentracing/opentracing-python/blob/master/opentracing/span.py#L71