### PR TITLE
Pyramid errs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -86,12 +86,16 @@ namespace :pypi do
     FileUtils.rm_rf(RELEASE_DIR)
   end
 
+  task :install do
+    sh 'pip install twine'
+  end
+
   task :build => :clean do
     puts "building release in #{RELEASE_DIR}"
     sh "python setup.py -q sdist -d #{RELEASE_DIR}"
   end
 
-  task :release => :build do
+  task :release => [:install, :build] do
     builds = Dir.entries(RELEASE_DIR).reject {|f| f == '.' || f == '..'}
     if builds.length == 0
         fail "no build found in #{RELEASE_DIR}"

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -62,7 +62,8 @@ def trace_tween_factory(handler, registry):
                     # set response tags
                     if response:
                         span.set_tag(http.STATUS_CODE, response.status_code)
-                        span.error = 500 <= response.status_code < 600
+                        if 500 <= response.status_code < 600:
+                            span.error = 1
                 return response
         return trace_tween
 

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -175,12 +175,6 @@ class Span(object):
         return self.metrics.get(key)
 
     def to_dict(self):
-        # a common mistake is to set the error field to a boolean instead of an
-        # int. let's special case that here, because it's sure to happen in
-        # customer code.
-        if self.error and type(self.error) == bool:
-            self.error = 1
-
         d = {
             'trace_id' : self.trace_id,
             'parent_id' : self.parent_id,
@@ -191,6 +185,12 @@ class Span(object):
             'error': self.error,
         }
 
+        # a common mistake is to set the error field to a boolean instead of an
+        # int. let's special case that here, because it's sure to happen in
+        # customer code.
+        err = d.get('error')
+        if err and type(err) == bool:
+            d['error'] = 1
 
         if self.start:
             d['start'] = int(self.start * 1e9)  # ns

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -175,6 +175,12 @@ class Span(object):
         return self.metrics.get(key)
 
     def to_dict(self):
+        # a common mistake is to set the error field to a boolean instead of an
+        # int. let's special case that here, because it's sure to happen in
+        # customer code.
+        if self.error and type(self.error) == bool:
+            self.error = 1
+
         d = {
             'trace_id' : self.trace_id,
             'parent_id' : self.parent_id,
@@ -184,6 +190,7 @@ class Span(object):
             'name' : self.name,
             'error': self.error,
         }
+
 
         if self.start:
             d['start'] = int(self.start * 1e9)  # ns

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -91,6 +91,7 @@ def test_500():
     eq_(s.span_type, 'http')
     eq_(s.meta.get('http.status_code'), '500')
     eq_(s.meta.get('http.url'), '/error')
+    assert type(s.error) == int
 
 def test_json():
     app, tracer = _get_test_app(service='foobar')

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -182,6 +182,19 @@ def test_span_to_dict():
     eq_(d["parent_id"], s.parent_id)
     eq_(d["meta"], {"a": "1", "b": "2"})
     eq_(d["type"], "foo")
+    eq_(d["error"], 0)
+    eq_(type(d["error"]), int)
+
+def test_span_boolean_err():
+    s = Span(tracer=None, name="foo.bar", service="s",  resource="r")
+    s.error = True
+    s.finish()
+
+    d = s.to_dict()
+    assert d
+    eq_(d["error"], 1)
+    eq_(type(d["error"]), int)
+
 
 
 class DummyTracer(object):


### PR DESCRIPTION
fixes a msgpack encoding issue when the error flag is set to true (as well as handling this case in general)