### PR TITLE
[encoder] more integration tests; ensure that resource is properly encoded

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -180,6 +180,45 @@ class TestAPITransport(TestCase):
         ok_(response)
         eq_(response.status, 200)
 
+    def test_send_single_with_wrong_errors(self):
+        # if the error field is set to True, it must be cast as int so
+        # that the agent decoder handles that properly without providing
+        # a decoding error
+        span = self.tracer.trace('client.testing')
+        span.error = True
+        span.finish()
+        trace = self.tracer.writer.pop()
+        traces = [trace]
+
+        # test JSON encoder
+        response = self.api_json.send_traces(traces)
+        ok_(response)
+        eq_(response.status, 200)
+
+        # test Msgpack encoder
+        response = self.api_msgpack.send_traces(traces)
+        ok_(response)
+        eq_(response.status, 200)
+
+    def test_send_single_with_wrong_resource(self):
+        # the resource must be a string but in the code we can set it as
+        # an integer (i.e. status code). It must be casted to string
+        span = self.tracer.trace('client.testing')
+        span.resource = 404
+        span.finish()
+        trace = self.tracer.writer.pop()
+        traces = [trace]
+
+        # test JSON encoder
+        response = self.api_json.send_traces(traces)
+        ok_(response)
+        eq_(response.status, 200)
+
+        # test Msgpack encoder
+        response = self.api_msgpack.send_traces(traces)
+        ok_(response)
+        eq_(response.status, 200)
+
     def test_send_multiple_traces(self):
         # register some traces and send them to the trace agent
         self.tracer.trace('client.testing').finish()

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -195,6 +195,13 @@ def test_span_boolean_err():
     eq_(d["error"], 1)
     eq_(type(d["error"]), int)
 
+def test_span_resource_type():
+    s = Span(tracer=None, name="foo.bar", service="s",  resource=404)
+    s.finish()
+
+    d = s.to_dict()
+    assert d
+    eq_(d['resource'], '404')
 
 
 class DummyTracer(object):


### PR DESCRIPTION
### What it does

* Integration tests using the wrong type in msgpack encoding
* `Span.resource` is enforced to string type, in case it is set to another value (i.e. an `int` for a status_code)