### PR TITLE
Make flask TracerMiddleware a proper PEP333 middleware

### DIFF
--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -67,6 +67,14 @@ class TraceMiddleware(object):
         else:
             _patch_render(tracer)
 
+    def __call__(self, environ, start_response):
+        """
+        Because tracing happens via signals, the purpose of this middleware
+        is only to comply to PEP333 and be able to wrapped with other WSGI apps
+        """
+        for chunk in self.app(environ, start_response):
+            yield chunk
+
     def _flask_signals_exist(self, names):
         """ Return true if the current version of flask has all of the given
             signals.


### PR DESCRIPTION
Solves https://github.com/DataDog/dd-trace-py/issues/187

`tox|tox -e py27` command on mac os exits with -9 due to the memory issue. (16GB of RAM)