### PR TITLE
[aiohttp] convert stateful TraceMiddleware in a trace_middleware

### DIFF
--- a/ddtrace/contrib/aiohttp/__init__.py
+++ b/ddtrace/contrib/aiohttp/__init__.py
@@ -30,6 +30,13 @@ instrumented, so you must use the ``patch()`` function::
 
 Modules that are currently supported by the ``patch()`` method are:
 * ``aiohttp_jinja2``
+
+When the request span is created, the ``Context`` for this logical execution is attached to the
+``aiohttp`` request object, so that it can be freely used in the application code::
+
+    async def home_handler(request):
+        ctx = request['datadog_context']
+        # do something with the request Context
 """
 from ..util import require_modules
 

--- a/ddtrace/contrib/aiohttp/__init__.py
+++ b/ddtrace/contrib/aiohttp/__init__.py
@@ -1,42 +1,31 @@
 """
 The ``aiohttp`` integration traces all requests defined in the application handlers.
-Auto instrumentation is available through a middleware and a ``on_prepare`` signal
-handler that can be activated using the ``trace_app`` function::
-
-    from aiohttp import web
-    from ddtrace import tracer
-    from ddtrace.contrib.aiohttp import trace_app
-
-    # create your application
-    app = web.Application()
-    app.router.add_get('/', home_handler)
-
-    # trace your application
-    trace_app(app, tracer, service='async-api')
-    web.run_app(app, port=8000)
-
-External modules for database calls and templates rendering are not automatically
-instrumented, so you must use the ``patch()`` function::
+Auto instrumentation is available using the ``trace_app`` function::
 
     from aiohttp import web
     from ddtrace import tracer, patch
     from ddtrace.contrib.aiohttp import trace_app
 
-    # patch external modules like aiohttp_jinja2
+    # patch third-party modules like aiohttp_jinja2
     patch(aiohttp=True)
 
-    # the application code
-    # ...
+    # create your application
+    app = web.Application()
+    app.router.add_get('/', home_handler)
 
-Modules that are currently supported by the ``patch()`` method are:
+    # trace your application handlers
+    trace_app(app, tracer, service='async-api')
+    web.run_app(app, port=8000)
+
+Third-party modules that are currently supported by the ``patch()`` method are:
 * ``aiohttp_jinja2``
 
-When the request span is created, the ``Context`` for this logical execution is attached to the
-``aiohttp`` request object, so that it can be freely used in the application code::
+When the request span is automatically created, the ``Context`` for this logical execution
+is attached to the ``request`` object, so that it can be used in the application code::
 
     async def home_handler(request):
         ctx = request['datadog_context']
-        # do something with the request Context
+        # do something with the tracing Context
 """
 from ..util import require_modules
 

--- a/ddtrace/contrib/aiohttp/__init__.py
+++ b/ddtrace/contrib/aiohttp/__init__.py
@@ -1,22 +1,35 @@
 """
-The ``aiohttp`` integration traces all requests received by defined routes
-and handlers. External modules for database calls and templates rendering
-are not automatically instrumented, so you must use the ``patch()`` function::
+The ``aiohttp`` integration traces all requests defined in the application handlers.
+Auto instrumentation is available through a middleware and a ``on_prepare`` signal
+handler that can be activated using the ``trace_app`` function::
 
     from aiohttp import web
-    from ddtrace import tracer, patch
-    from ddtrace.contrib.aiohttp.middlewares import TraceMiddleware
-
-    # patch external modules like aiohttp_jinja2
-    patch(aiohttp=True)
+    from ddtrace import tracer
+    from ddtrace.contrib.aiohttp import trace_app
 
     # create your application
     app = web.Application()
     app.router.add_get('/', home_handler)
 
-    # add the tracing middleware
-    TraceMiddleware(app, tracer, service='async-api')
+    # trace your application
+    trace_app(app, tracer, service='async-api')
     web.run_app(app, port=8000)
+
+External modules for database calls and templates rendering are not automatically
+instrumented, so you must use the ``patch()`` function::
+
+    from aiohttp import web
+    from ddtrace import tracer, patch
+    from ddtrace.contrib.aiohttp import trace_app
+
+    # patch external modules like aiohttp_jinja2
+    patch(aiohttp=True)
+
+    # the application code
+    # ...
+
+Modules that are currently supported by the ``patch()`` method are:
+* ``aiohttp_jinja2``
 """
 from ..util import require_modules
 
@@ -25,10 +38,10 @@ required_modules = ['aiohttp']
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
         from .patch import patch, unpatch
-        from .middlewares import TraceMiddleware
+        from .middlewares import trace_app
 
         __all__ = [
             'patch',
             'unpatch',
-            'TraceMiddleware',
+            'trace_app',
         ]

--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -29,9 +29,12 @@ class TraceMiddleware(object):
             app_type=AppTypes.web,
         )
 
-        # add the async tracer middleware
-        self.app.middlewares.append(self.middleware_factory())
-        self.app.on_response_prepare.append(self.signal_factory())
+        # add the async tracer middleware as a first middleware
+        # and be sure that the on_prepare signal is the last one
+        self._middleware = self.middleware_factory()
+        self._on_prepare = self.signal_factory()
+        self.app.middlewares.insert(0, self._middleware)
+        self.app.on_response_prepare.append(self._on_prepare)
 
     def middleware_factory(self):
         """

--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -3,98 +3,101 @@ from ...ext import AppTypes, http
 from ...compat import stringify
 
 
-class TraceMiddleware(object):
+CONFIG_KEY = 'datadog_trace'
+REQUEST_CONTEXT_KEY = 'datadog_context'
+REQUEST_SPAN_KEY = '__datadog_request_span'
+
+
+async def trace_middleware(app, handler):
     """
-    aiohttp Middleware class that will append a middleware coroutine to trace
-    incoming traffic.
+    ``aiohttp`` middleware that traces the handler execution.
+    Because handlers are run in different tasks for each request, we attach the Context
+    instance both to the Task and to the Request objects. In this way:
+        * the Task is used by the internal automatic instrumentation
+        * the ``Context`` attached to the request can be freely used in the application code
     """
-    def __init__(self, app, tracer, service='aiohttp-web'):
-        # safe-guard: don't add the middleware twice
-        if getattr(app, '__datadog_middleware', False):
-            return
-        setattr(app, '__datadog_middleware', True)
+    async def attach_context(request):
+        # application configs
+        tracer = app[CONFIG_KEY]['tracer']
+        service = app[CONFIG_KEY]['service']
 
-        # keep the references
-        self.app = app
-        self._tracer = tracer
-        self._service = service
-
-        # the tracer must work with asynchronous Context propagation
-        self._tracer.configure(context_provider=context_provider)
-
-        # configure the current service
-        self._tracer.set_service_info(
+        # trace the handler
+        request_span = tracer.trace(
+            'aiohttp.request',
             service=service,
-            app='aiohttp',
-            app_type=AppTypes.web,
+            span_type=http.TYPE,
         )
 
-        # add the async tracer middleware as a first middleware
-        # and be sure that the on_prepare signal is the last one
-        self._middleware = self.middleware_factory()
-        self._on_prepare = self.signal_factory()
-        self.app.middlewares.insert(0, self._middleware)
-        self.app.on_response_prepare.append(self._on_prepare)
+        # attach the context and the root span to the request; the Context
+        # may be freely used by the application code
+        request[REQUEST_CONTEXT_KEY] = request_span.context
+        request[REQUEST_SPAN_KEY] = request_span
+        try:
+            return await handler(request)
+        except Exception:
+            request_span.set_traceback()
+            raise
+    return attach_context
 
-    def middleware_factory(self):
-        """
-        The middleware factory returns an aiohttp middleware that traces the handler execution.
-        Because handlers are run in different tasks for each request, we attach the Context
-        instance both to the Task and to the Request objects. In this way:
-            * the Task may be used by the internal tracing
-            * the Request remains the main Context carrier if it should be passed as argument
-              to the tracer.trace() method
-        """
-        async def middleware(app, handler):
-            async def attach_context(request):
-                # trace the handler
-                request_span = self._tracer.trace(
-                    'aiohttp.request',
-                    service=self._service,
-                    span_type=http.TYPE,
-                )
 
-                # attach the context and the root span to the request; the Context
-                # may be freely used by the application code
-                request['datadog_context'] = request_span.context
-                request['__datadog_request_span'] = request_span
-                try:
-                    return await handler(request)
-                except Exception:
-                    request_span.set_traceback()
-                    raise
-            return attach_context
-        return middleware
+async def on_prepare(request, response):
+    """
+    The on_prepare signal is used to close the request span that is created during
+    the trace middleware execution.
+    """
+    # safe-guard: discard if we don't have a request span
+    request_span = request.get(REQUEST_SPAN_KEY, None)
+    if not request_span:
+        return
 
-    def signal_factory(self):
-        """
-        The signal factory returns the on_prepare signal that is sent while the Response is
-        being prepared. The signal is used to close the request span that is created during
-        the trace middleware execution.
-        """
-        async def on_prepare(request, response):
-            # safe-guard: discard if we don't have a request span
-            request_span = request.get('__datadog_request_span', None)
-            if not request_span:
-                return
+    # default resource name
+    resource = stringify(response.status)
 
-            # default resource name
-            resource = stringify(response.status)
+    if request.match_info.route.resource:
+        # collect the resource name based on http resource type
+        res_info = request.match_info.route.resource.get_info()
 
-            if request.match_info.route.resource:
-                # collect the resource name based on http resource type
-                res_info = request.match_info.route.resource.get_info()
+        if res_info.get('path'):
+            resource = res_info.get('path')
+        elif res_info.get('formatter'):
+            resource = res_info.get('formatter')
+        elif res_info.get('prefix'):
+            resource = res_info.get('prefix')
 
-                if res_info.get('path'):
-                    resource = res_info.get('path')
-                elif res_info.get('formatter'):
-                    resource = res_info.get('formatter')
-                elif res_info.get('prefix'):
-                    resource = res_info.get('prefix')
+    request_span.resource = resource
+    request_span.set_tag('http.method', request.method)
+    request_span.set_tag('http.status_code', response.status)
+    request_span.set_tag('http.url', request.path)
+    request_span.finish()
 
-            request_span.resource = resource
-            request_span.set_tag('http.method', request.method)
-            request_span.set_tag('http.status_code', response.status)
-            request_span.set_tag('http.url', request.path)
-            request_span.finish()
-        return on_prepare
+
+def trace_app(app, tracer, service='aiohttp-web'):
+    """
+    Tracing function that patches the ``aiohttp`` application so that it will be
+    traced using the given ``tracer``.
+    """
+    # safe-guard: don't trace an application twice
+    if getattr(app, '__datadog_trace', False):
+        return
+    setattr(app, '__datadog_trace', True)
+
+    # configure datadog settings
+    app[CONFIG_KEY] = {
+        'tracer': tracer,
+        'service': service,
+    }
+
+    # the tracer must work with asynchronous Context propagation
+    tracer.configure(context_provider=context_provider)
+
+    # configure the current service
+    tracer.set_service_info(
+        service=service,
+        app='aiohttp',
+        app_type=AppTypes.web,
+    )
+
+    # add the async tracer middleware as a first middleware
+    # and be sure that the on_prepare signal is the last one
+    app.middlewares.insert(0, trace_middleware)
+    app.on_response_prepare.append(on_prepare)

--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -54,8 +54,9 @@ class TraceMiddleware(object):
                     span_type=http.TYPE,
                 )
 
-                # attach the context and the root span to the request
-                request['__datadog_context'] = request_span.context
+                # attach the context and the root span to the request; the Context
+                # may be freely used by the application code
+                request['datadog_context'] = request_span.context
                 request['__datadog_request_span'] = request_span
                 try:
                     return await handler(request)

--- a/ddtrace/contrib/aiohttp/template.py
+++ b/ddtrace/contrib/aiohttp/template.py
@@ -2,7 +2,7 @@ import aiohttp_jinja2
 
 from ddtrace import Pin
 
-from ...ext import http, errors, AppTypes
+from ...ext import http
 
 
 def _trace_render_template(func, module, args, kwargs):

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -24,8 +24,7 @@ PATCH_MODULES = {
     'requests': False,  # Not ready yet
     'sqlalchemy': False,  # Prefer DB client instrumentation
     'sqlite3': True,
-    # TODO: it works if set to True?
-    'aiohttp': False,  # requires asyncio (Python 3.4+)
+    'aiohttp': True,  # requires asyncio (Python 3.4+)
 }
 
 _LOCK = threading.Lock()

--- a/tests/contrib/aiohttp/app/web.py
+++ b/tests/contrib/aiohttp/app/web.py
@@ -39,13 +39,19 @@ def route_exception(request):
 def route_async_exception(request):
     raise Exception('error')
 
-async def route_wrapped_coroutine(request):
+
+@asyncio.coroutine
+def route_wrapped_coroutine(request):
     tracer = get_tracer(request)
+
     @tracer.wrap('nested')
-    async def nested():
-        await asyncio.sleep(0.25)
-    await nested()
+    @asyncio.coroutine
+    def nested():
+        yield from asyncio.sleep(0.25)
+
+    yield from nested()
     return web.Response(text='OK')
+
 
 @asyncio.coroutine
 def coro_2(request):

--- a/tests/contrib/aiohttp/app/web.py
+++ b/tests/contrib/aiohttp/app/web.py
@@ -62,6 +62,13 @@ async def delayed_handler(request):
     return web.Response(text='Done')
 
 
+async def noop_middleware(app, handler):
+    async def middleware_handler(request):
+        # noop middleware
+        return await handler(request)
+    return middleware_handler
+
+
 def setup_app(loop):
     """
     Use this method to create the app. It must receive
@@ -69,7 +76,12 @@ def setup_app(loop):
     ``AioHTTPTestCase`` class.
     """
     # configure the app
-    app = web.Application(loop=loop)
+    app = web.Application(
+        loop=loop,
+        middlewares=[
+            noop_middleware,
+        ],
+    )
     app.router.add_get('/', home)
     app.router.add_get('/delayed/', delayed_handler)
     app.router.add_get('/echo/{name}', name)

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -1,7 +1,7 @@
 from nose.tools import eq_, ok_
 from aiohttp.test_utils import unittest_run_loop
 
-from ddtrace.contrib.aiohttp.middlewares import TraceMiddleware
+from ddtrace.contrib.aiohttp.middlewares import trace_app, trace_middleware
 
 from .utils import TraceTestCase
 from .app.web import setup_app, noop_middleware
@@ -13,7 +13,7 @@ class TestTraceMiddleware(TraceTestCase):
     the beginning of a request.
     """
     def enable_tracing(self):
-        TraceMiddleware(self.app, self.tracer)
+        trace_app(self.app, self.tracer)
 
     @unittest_run_loop
     async def test_tracing_service(self):
@@ -136,13 +136,13 @@ class TestTraceMiddleware(TraceTestCase):
         eq_(1, len(app.middlewares))
         eq_(noop_middleware, app.middlewares[0])
         # the middleware is present (with the noop middleware)
-        wrapper = TraceMiddleware(app, self.tracer)
+        trace_app(app, self.tracer)
         eq_(2, len(app.middlewares))
         # applying the middleware twice doesn't add it again
-        TraceMiddleware(app, self.tracer)
+        trace_app(app, self.tracer)
         eq_(2, len(app.middlewares))
         # and the middleware is always the first
-        eq_(wrapper._middleware, app.middlewares[0])
+        eq_(trace_middleware, app.middlewares[0])
         eq_(noop_middleware, app.middlewares[1])
 
     @unittest_run_loop

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -189,10 +189,11 @@ class TestTraceMiddleware(TraceTestCase):
         ok_('Exception: error' in span.get_tag('error.stack'))
 
     @unittest_run_loop
-    async def test_wrapped_coroutine(self):
-        request = await self.client.request('GET', '/wrapped_coroutine')
+    @asyncio.coroutine
+    def test_wrapped_coroutine(self):
+        request = yield from self.client.request('GET', '/wrapped_coroutine')
         eq_(200, request.status)
-        text = await request.text()
+        text = yield from request.text()
         eq_('OK', text)
 
         traces = self.tracer.writer.pop_traces()

--- a/tests/contrib/aiohttp/test_request.py
+++ b/tests/contrib/aiohttp/test_request.py
@@ -8,7 +8,7 @@ from aiohttp.test_utils import unittest_run_loop
 
 from ddtrace.pin import Pin
 from ddtrace.contrib.aiohttp.patch import patch, unpatch
-from ddtrace.contrib.aiohttp.middlewares import TraceMiddleware
+from ddtrace.contrib.aiohttp.middlewares import trace_app
 
 from .utils import TraceTestCase
 
@@ -21,7 +21,7 @@ class TestRequestTracing(TraceTestCase):
         # enabled tracing:
         #   * middleware
         #   * templates
-        TraceMiddleware(self.app, self.tracer)
+        trace_app(self.app, self.tracer)
         patch()
         Pin.override(aiohttp_jinja2, tracer=self.tracer)
 

--- a/tests/contrib/aiohttp/test_request.py
+++ b/tests/contrib/aiohttp/test_request.py
@@ -29,12 +29,13 @@ class TestRequestTracing(TraceTestCase):
         unpatch()
 
     @unittest_run_loop
-    async def test_full_request(self):
+    @asyncio.coroutine
+    def test_full_request(self):
         # it should create a root span when there is a handler hit
         # with the proper tags
-        request = await self.client.request('GET', '/template/')
+        request = yield from self.client.request('GET', '/template/')
         eq_(200, request.status)
-        await request.text()
+        yield from request.text()
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         eq_(1, len(traces))
@@ -51,7 +52,8 @@ class TestRequestTracing(TraceTestCase):
         eq_('aiohttp.template', template_span.resource)
 
     @unittest_run_loop
-    async def test_multiple_full_request(self):
+    @asyncio.coroutine
+    def test_multiple_full_request(self):
         # it should handle multiple requests using the same loop
         def make_requests():
             url = self.client.make_url('/delayed/')
@@ -66,7 +68,7 @@ class TestRequestTracing(TraceTestCase):
 
         # we should yield so that this loop can handle
         # threads' requests
-        await asyncio.sleep(0.5)
+        yield from asyncio.sleep(0.5)
         for t in threads:
             t.join(timeout=0.5)
 

--- a/tests/contrib/aiohttp/test_request_safety.py
+++ b/tests/contrib/aiohttp/test_request_safety.py
@@ -31,12 +31,13 @@ class TestAiohttpSafety(TraceTestCase):
         unpatch()
 
     @unittest_run_loop
-    async def test_full_request(self):
+    @asyncio.coroutine
+    def test_full_request(self):
         # it should create a root span when there is a handler hit
         # with the proper tags
-        request = await self.client.request('GET', '/template/')
+        request = yield from self.client.request('GET', '/template/')
         eq_(200, request.status)
-        await request.text()
+        yield from request.text()
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         eq_(1, len(traces))
@@ -53,7 +54,8 @@ class TestAiohttpSafety(TraceTestCase):
         eq_('aiohttp.template', template_span.resource)
 
     @unittest_run_loop
-    async def test_multiple_full_request(self):
+    @asyncio.coroutine
+    def test_multiple_full_request(self):
         # it should produce a wrong trace, but the Context must
         # be finished
         def make_requests():
@@ -70,7 +72,7 @@ class TestAiohttpSafety(TraceTestCase):
 
         # we should yield so that this loop can handle
         # threads' requests
-        await asyncio.sleep(0.5)
+        yield from asyncio.sleep(0.5)
         for t in threads:
             t.join(timeout=0.5)
 

--- a/tests/contrib/aiohttp/test_request_safety.py
+++ b/tests/contrib/aiohttp/test_request_safety.py
@@ -9,7 +9,7 @@ from aiohttp.test_utils import unittest_run_loop
 from ddtrace.pin import Pin
 from ddtrace.provider import DefaultContextProvider
 from ddtrace.contrib.aiohttp.patch import patch, unpatch
-from ddtrace.contrib.aiohttp.middlewares import TraceMiddleware
+from ddtrace.contrib.aiohttp.middlewares import trace_app
 
 from .utils import TraceTestCase
 
@@ -22,7 +22,7 @@ class TestAiohttpSafety(TraceTestCase):
     """
     def enable_tracing(self):
         # aiohttp TestCase with the wrong context provider
-        TraceMiddleware(self.app, self.tracer)
+        trace_app(self.app, self.tracer)
         patch()
         Pin.override(aiohttp_jinja2, tracer=self.tracer)
         self.tracer.configure(context_provider=DefaultContextProvider())

--- a/tests/contrib/aiohttp/test_templates.py
+++ b/tests/contrib/aiohttp/test_templates.py
@@ -1,3 +1,4 @@
+import asyncio
 import aiohttp_jinja2
 
 from nose.tools import eq_, ok_
@@ -22,11 +23,12 @@ class TestTraceTemplate(TraceTestCase):
         unpatch()
 
     @unittest_run_loop
-    async def test_template_rendering(self):
+    @asyncio.coroutine
+    def test_template_rendering(self):
         # it should trace a template rendering
-        request = await self.client.request('GET', '/template/')
+        request = yield from self.client.request('GET', '/template/')
         eq_(200, request.status)
-        text = await request.text()
+        text = yield from request.text()
         eq_('OK', text)
         # the trace is created
         traces = self.tracer.writer.pop_traces()
@@ -40,12 +42,13 @@ class TestTraceTemplate(TraceTestCase):
         eq_(0, span.error)
 
     @unittest_run_loop
-    async def test_template_rendering_filesystem(self):
+    @asyncio.coroutine
+    def test_template_rendering_filesystem(self):
         # it should trace a template rendering with a FileSystemLoader
         set_filesystem_loader(self.app)
-        request = await self.client.request('GET', '/template/')
+        request = yield from self.client.request('GET', '/template/')
         eq_(200, request.status)
-        text = await request.text()
+        text = yield from request.text()
         eq_('OK', text)
         # the trace is created
         traces = self.tracer.writer.pop_traces()
@@ -59,12 +62,13 @@ class TestTraceTemplate(TraceTestCase):
         eq_(0, span.error)
 
     @unittest_run_loop
-    async def test_template_rendering_package(self):
+    @asyncio.coroutine
+    def test_template_rendering_package(self):
         # it should trace a template rendering with a PackageLoader
         set_package_loader(self.app)
-        request = await self.client.request('GET', '/template/')
+        request = yield from self.client.request('GET', '/template/')
         eq_(200, request.status)
-        text = await request.text()
+        text = yield from request.text()
         eq_('OK', text)
         # the trace is created
         traces = self.tracer.writer.pop_traces()
@@ -78,11 +82,12 @@ class TestTraceTemplate(TraceTestCase):
         eq_(0, span.error)
 
     @unittest_run_loop
-    async def test_template_decorator(self):
+    @asyncio.coroutine
+    def test_template_decorator(self):
         # it should trace a template rendering
-        request = await self.client.request('GET', '/template_decorator/')
+        request = yield from self.client.request('GET', '/template_decorator/')
         eq_(200, request.status)
-        text = await request.text()
+        text = yield from request.text()
         eq_('OK', text)
         # the trace is created
         traces = self.tracer.writer.pop_traces()
@@ -96,11 +101,12 @@ class TestTraceTemplate(TraceTestCase):
         eq_(0, span.error)
 
     @unittest_run_loop
-    async def test_template_error(self):
+    @asyncio.coroutine
+    def test_template_error(self):
         # it should trace a template rendering
-        request = await self.client.request('GET', '/template_error/')
+        request = yield from self.client.request('GET', '/template_error/')
         eq_(500, request.status)
-        await request.text()
+        yield from request.text()
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         eq_(1, len(traces))

--- a/tests/contrib/aiohttp/test_templates.py
+++ b/tests/contrib/aiohttp/test_templates.py
@@ -100,7 +100,7 @@ class TestTraceTemplate(TraceTestCase):
         # it should trace a template rendering
         request = await self.client.request('GET', '/template_error/')
         eq_(500, request.status)
-        text = await request.text()
+        await request.text()
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         eq_(1, len(traces))

--- a/tests/contrib/aiohttp/utils.py
+++ b/tests/contrib/aiohttp/utils.py
@@ -22,7 +22,7 @@ class TraceTestCase(AioHTTPTestCase):
         super(TraceTestCase, self).tearDown()
         self.disable_tracing()
 
-    async def get_app(self, loop):
+    def get_app(self, loop):
         """
         Override the get_app method to return the test application
         """

--- a/tests/contrib/aiohttp/utils.py
+++ b/tests/contrib/aiohttp/utils.py
@@ -1,8 +1,6 @@
 import asyncio
 
 from aiohttp.test_utils import AioHTTPTestCase
-from ddtrace.contrib.asyncio import context_provider
-from ddtrace.contrib.aiohttp.middlewares import TraceMiddleware
 
 from .app.web import setup_app
 from ...test_tracer import get_dummy_tracer

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
     {py27,py34}-integration
     {py27,py34}-contrib
     {py35,py36}-async
-    {py35,py36}-aiohttp-aiohttp_jinja
+    {py35,py36}-aiohttp{12,13}-aiohttp_jinja{012,013}
     {py27,py34}-bottle{12}-webtest
     {py27,py34}-cassandra{35,36,37}
     {py27,py34}-elasticsearch{23}
@@ -46,8 +46,6 @@ deps =
     nose
     msgpack-python
 # integrations
-    aiohttp: aiohttp
-    aiohttp_jinja: aiohttp_jinja2
     contrib: blinker
     contrib: bottle
     contrib: cassandra-driver
@@ -66,6 +64,10 @@ deps =
     contrib: requests
     contrib: sqlalchemy
     contrib: WebTest
+    aiohttp12: aiohttp>=1.2,<1.3
+    aiohttp13: aiohttp>=1.3,<1.4
+    aiohttp_jinja012: aiohttp_jinja2>=0.12,<0.13
+    aiohttp_jinja013: aiohttp_jinja2>=0.13,<0.14
     blinker: blinker
     bottle12: bottle>=0.12
     cassandra35: cassandra-driver>=3.5,<3.6
@@ -121,7 +123,7 @@ commands =
 # run all tests for the release jobs except the ones with a different test runner
     {py27,py34}-contrib: nosetests {posargs} --exclude=".*(django|asyncio|aiohttp).*" tests/contrib/
     {py35,py36}-async: nosetests {posargs} tests/contrib/asyncio
-    {py35,py36}-aiohttp-aiohttp_jinja: nosetests {posargs} tests/contrib/aiohttp
+    {py35,py36}-aiohttp{12,13}-aiohttp_jinja{012,013}: nosetests {posargs} tests/contrib/aiohttp
 # run subsets of the tests for particular library versions
     {py27,py34}-bottle{12}: nosetests {posargs} tests/contrib/bottle/
     {py27,py34}-cassandra{35,36,37}: nosetests {posargs} tests/contrib/cassandra

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
     {py27,py34}-integration
     {py27,py34}-contrib
     {py35,py36}-async
-    {py35,py36}-aiohttp{12,13}-aiohttp_jinja{012,013}
+    {py34,py35,py36}-aiohttp{12,13}-aiohttp_jinja{012,013}
     {py27,py34}-bottle{12}-webtest
     {py27,py34}-cassandra{35,36,37}
     {py27,py34}-elasticsearch{23}
@@ -123,7 +123,7 @@ commands =
 # run all tests for the release jobs except the ones with a different test runner
     {py27,py34}-contrib: nosetests {posargs} --exclude=".*(django|asyncio|aiohttp).*" tests/contrib/
     {py35,py36}-async: nosetests {posargs} tests/contrib/asyncio
-    {py35,py36}-aiohttp{12,13}-aiohttp_jinja{012,013}: nosetests {posargs} tests/contrib/aiohttp
+    {py34,py35,py36}-aiohttp{12,13}-aiohttp_jinja{012,013}: nosetests {posargs} tests/contrib/aiohttp
 # run subsets of the tests for particular library versions
     {py27,py34}-bottle{12}: nosetests {posargs} tests/contrib/bottle/
     {py27,py34}-cassandra{35,36,37}: nosetests {posargs} tests/contrib/cassandra
@@ -163,6 +163,4 @@ basepython=python2
 [flake8]
 ignore=W391,E231,E201,E202,E203,E261,E302,E128,E126,E124
 max-line-length=120
-# excluding tests and async Python3.5 files
-# TODO: make the syntax Python3.4 compatible
-exclude=tests,ddtrace/contrib/aiohttp,ddtrace/contrib/asyncio
+exclude=tests,ddtrace/contrib/asyncio


### PR DESCRIPTION
### What it does

Makes the ``aiohttp`` auto instrumentation more clear, providing:
* ``trace_middleware`` used to start recording the request span
* ``on_prepare`` signal to stop recording the request span
* ``trace_app(app, tracer, service='')`` function that automatically instrument the given app
* test matrix to support latest releases

Auto instrumentation becomes more readable:
```python
    from aiohttp import web
    from ddtrace import tracer
    from ddtrace.contrib.aiohttp import trace_app

    # create your application
    app = web.Application(
        middlewares=[
            custom_middleware,
            another_middleware,
        ]
    )
    app.router.add_get('/', home_handler)

    # trace your application
    trace_app(app, tracer, service='async-api')
    web.run_app(app, port=8000)
```

When the request span is created, the ``Context`` for this logical execution is attached to the ``aiohttp`` request so that it can be freely used in the application code (if needed):
```python
async def home_handler(request):
    ctx = request['datadog_context']
    # do something with the request Context
```