### PR TITLE
tracer should reference the result of the previous line

### DIFF
--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -15,7 +15,7 @@ class TracePlugin(object):
     def __init__(self, service="bottle", tracer=None):
         self.service = service
         self.tracer = tracer or ddtrace.tracer
-        tracer.set_service_info(
+        self.tracer.set_service_info(
             service=service,
             app="bottle",
             app_type=AppTypes.web)


### PR DESCRIPTION
When I attempt to install the tracer plugin in bottle, I get the following exception
'''
AttributeError: 'NoneType' object has no attribute 'set_service_info'
'''

This appears to be linked to the included change. In the scope provided, tracer would reference the __init__ argument. Instead, we want to tracer selected as a result of the previous line.