### PR TITLE
[asyncio] make the tracer.wrap() works with coroutines

### DIFF
--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -25,6 +25,19 @@ try:
 except ImportError:
     from urllib import parse as urlparse
 
+try:
+    from asyncio import iscoroutinefunction
+    from .compat_async import _make_async_decorator as make_async_decorator
+except ImportError:
+    # asyncio is missing so we can't have coroutines; these
+    # functions are used only to ensure code executions in case
+    # of an unexpected behavior
+    def iscoroutinefunction(fn):
+        return False
+
+    def make_async_decorator(tracer, fn, *params, **kw_params):
+        return fn
+
 
 def iteritems(obj, **kwargs):
     func = getattr(obj, "iteritems", None)

--- a/ddtrace/compat_async.py
+++ b/ddtrace/compat_async.py
@@ -1,0 +1,28 @@
+"""
+Async compat module that includes all asynchronous syntax that is not
+Python 2 compatible. It MUST be used only in the ``compat``
+module that owns the logic to import it or not.
+"""
+import functools
+import asyncio
+
+
+def _make_async_decorator(tracer, coro, *params, **kw_params):
+    """
+    Decorator factory that creates an asynchronous wrapper that yields
+    a coroutine result. This factory is required to handle Python 2
+    compatibilities.
+
+    :param object tracer: the tracer instance that is used
+    :param function f: the coroutine that must be executed
+    :param tuple params: arguments given to the Tracer.trace()
+    :param dict kw_params: keyword arguments given to the Tracer.trace()
+    """
+    @functools.wraps(coro)
+    @asyncio.coroutine
+    def func_wrapper(*args, **kwargs):
+        with tracer.trace(*params, **kw_params):
+            result = yield from coro(*args, **kwargs)  # noqa: E999
+            return result
+
+    return func_wrapper

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -260,8 +260,20 @@ class Tracer(object):
         >>> @tracer.wrap('my.wrapped.function', service='my.service')
             def run():
                 return 'run'
-        >>> @tracer.wrap()  # name will default to 'execute' if unset
+
+        >>> # name will default to 'execute' if unset
+            @tracer.wrap()
             def execute():
+                return 'executed'
+
+        >>> # or use it in asyncio coroutines
+            @tracer.wrap()
+            async def coroutine():
+                return 'executed'
+
+        >>> @tracer.wrap()
+            @asyncio.coroutine
+            def coroutine():
                 return 'executed'
 
         You can access the current span using `tracer.current_span()` to set

--- a/tests/contrib/aiohttp/app/web.py
+++ b/tests/contrib/aiohttp/app/web.py
@@ -35,6 +35,13 @@ def route_exception(request):
 async def route_async_exception(request):
     raise Exception('error')
 
+async def route_wrapped_coroutine(request):
+    tracer = get_tracer(request)
+    @tracer.wrap('nested')
+    async def nested():
+        await asyncio.sleep(0.25)
+    await nested()
+    return web.Response(text='OK')
 
 async def coro_2(request):
     tracer = get_tracer(request)
@@ -76,6 +83,7 @@ def setup_app(loop):
     app.router.add_get('/chaining/', coroutine_chaining)
     app.router.add_get('/exception', route_exception)
     app.router.add_get('/async_exception', route_async_exception)
+    app.router.add_get('/wrapped_coroutine', route_wrapped_coroutine)
     app.router.add_static('/statics', STATIC_DIR)
     # configure templates
     set_memory_loader(app)

--- a/tests/contrib/asyncio/test_tracer.py
+++ b/tests/contrib/asyncio/test_tracer.py
@@ -182,13 +182,15 @@ class TestAsyncioTracer(AsyncioTestCase):
     @mark_asyncio
     def test_wrapped_coroutine(self):
         @self.tracer.wrap('f1')
-        async def f1():
-            await asyncio.sleep(0.25)
+        @asyncio.coroutine
+        def f1():
+            yield from asyncio.sleep(0.25)
+
         yield from f1()
+
         traces = self.tracer.writer.pop_traces()
         eq_(1, len(traces))
         spans = traces[0]
         eq_(1, len(spans))
         span = spans[0]
-        ok_(span.duration > 0.25,
-            msg="span.duration={0}".format(span.duration))
+        ok_(span.duration > 0.25, msg='span.duration={}'.format(span.duration))

--- a/tests/contrib/asyncio/test_tracer.py
+++ b/tests/contrib/asyncio/test_tracer.py
@@ -178,3 +178,17 @@ class TestAsyncioTracer(AsyncioTestCase):
         eq_(10, len(traces))
         eq_(1, len(traces[0]))
         eq_('coroutine', traces[0][0].name)
+
+    @mark_asyncio
+    def test_wrapped_coroutine(self):
+        @self.tracer.wrap('f1')
+        async def f1():
+            await asyncio.sleep(0.25)
+        yield from f1()
+        traces = self.tracer.writer.pop_traces()
+        eq_(1, len(traces))
+        spans = traces[0]
+        eq_(1, len(spans))
+        span = spans[0]
+        ok_(span.duration > 0.25,
+            msg="span.duration={0}".format(span.duration))


### PR DESCRIPTION
### What it does

Allows the use of ``tracer.wrap()`` also for coroutines. In that way:
```python
# python 3.5+ syntax
@tracer.wrap()
async def coroutine():
  return 'executed'

# python 3.4 (the order of wrap() decorator doesn't matter)
@tracer.wrap()
@asyncio.coroutine
def coroutine():
  return 'executed'
```

If python 2 is used, that part of the code is never executed. The evaluation is done only once when the method `tracer.wrap()` is invoked.

#### Notes
We have to use a separated file to store the `yield from` call otherwise we got a Syntax Error in Python 2.