### PR TITLE
make func_name account for Django class-based views

### DIFF
--- a/ddtrace/contrib/__init__.py
+++ b/ddtrace/contrib/__init__.py
@@ -1,7 +1,7 @@
 
 def func_name(f):
     """ Return a human readable version of the function's name. """
-    return "%s.%s" % (f.__module__, f.__name__)
+    return "%s.%s" % (f.__module__, getattr(f, '__name__', f.__class__.__name__))
 
 def module_name(instance):
     return instance.__class__.__module__.split('.')[0]


### PR DESCRIPTION
Django integration crashes when using class-based views and Python 2.7 with errors like `AttributeError: 'Details' object has no attribute '__name__'`, where `Details` is a view class. This PR fixes the issue.