### PR TITLE
[core] print the list of unfinished spans if the debug_logging is activated

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -59,9 +59,15 @@ class Context(object):
             self._finished_spans += 1
             self._current_span = span._parent
 
-            # notify if the trace is not closed properly
+            # notify if the trace is not closed properly; this check is executed only
+            # if the tracer debug_logging is enabled and when the root span is closed
+            # for an unfinished trace. This logging is meant to be used for debugging
+            # reasons, and it doesn't mean that the trace is wrongly generated.
+            # In asynchronous environments, it's legit to close the root span before
+            # some children. On the other hand, asynchronous web frameworks still expect
+            # to close the root span after all the children.
             tracer = getattr(span, '_tracer', None)
-            if tracer and tracer.debug_logging and span._parent is None:
+            if tracer and tracer.debug_logging and span._parent is None and not self._is_finished():
                 opened_spans = len(self._trace) - self._finished_spans
                 log.debug('Root span "%s" closed, but the trace has %d unfinished spans:', span.name, opened_spans)
                 spans = [x for x in self._trace if not x._finished]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,7 +1,9 @@
+import mock
 import threading
 
 from unittest import TestCase
 from nose.tools import eq_, ok_
+from tests.test_tracer import get_dummy_tracer
 
 from ddtrace.span import Span
 from ddtrace.context import Context, ThreadLocalContext
@@ -83,6 +85,56 @@ class TestTracingContext(TestCase):
         # a Context is not finished if it's empty
         ctx = Context()
         ok_(ctx.is_finished() is False)
+
+    @mock.patch('logging.Logger.debug')
+    def test_log_unfinished_spans(self, log):
+        # when the root parent is finished, notify if there are spans still pending
+        tracer = get_dummy_tracer()
+        tracer.debug_logging = True
+        ctx = Context()
+        # manually create a root-child trace
+        root = Span(tracer=tracer, name='root')
+        child_1 = Span(tracer=tracer, name='child_1', trace_id=root.trace_id, parent_id=root.span_id)
+        child_2 = Span(tracer=tracer, name='child_2', trace_id=root.trace_id, parent_id=root.span_id)
+        child_1._parent = root
+        child_2._parent = root
+        ctx.add_span(root)
+        ctx.add_span(child_1)
+        ctx.add_span(child_2)
+        # close only the parent
+        root.finish()
+        ok_(ctx.is_finished() is False)
+        unfinished_spans_log = log.call_args_list[-3][0][2]
+        child_1_log = log.call_args_list[-2][0][1]
+        child_2_log = log.call_args_list[-1][0][1]
+        eq_(2, unfinished_spans_log)
+        ok_('name child_1' in child_1_log)
+        ok_('name child_2' in child_2_log)
+        ok_('duration 0.000000s' in child_1_log)
+        ok_('duration 0.000000s' in child_2_log)
+
+    @mock.patch('logging.Logger.debug')
+    def test_log_unfinished_spans_disabled(self, log):
+        # the trace finished status logging is disabled
+        tracer = get_dummy_tracer()
+        tracer.debug_logging = False
+        ctx = Context()
+        # manually create a root-child trace
+        root = Span(tracer=tracer, name='root')
+        child_1 = Span(tracer=tracer, name='child_1', trace_id=root.trace_id, parent_id=root.span_id)
+        child_2 = Span(tracer=tracer, name='child_2', trace_id=root.trace_id, parent_id=root.span_id)
+        child_1._parent = root
+        child_2._parent = root
+        ctx.add_span(root)
+        ctx.add_span(child_1)
+        ctx.add_span(child_2)
+        # close only the parent
+        root.finish()
+        ok_(ctx.is_finished() is False)
+        # the logger has never been invoked to print unfinished spans
+        for call, _ in log.call_args_list:
+            msg = call[0]
+            ok_('the trace has %d unfinished spans' not in msg)
 
     def test_thread_safe(self):
         # the Context must be thread-safe

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -203,6 +203,7 @@ def test_span_boolean_err():
 
 class DummyTracer(object):
     def __init__(self):
+        self.debug_logging = False
         self.last_span = None
         self.spans_recorded = 0
 


### PR DESCRIPTION
### What it does

When the root span of a trace is closed, it prints the number and the details of unfinished spans. This functionality is activated only if the ``tracer.debug_logging`` is set to `True`.

Actually the ``pprint()`` function is used so we have the full details of each unfinished spans.