### PR TITLE
[core] drop legacy port 7777 in favor of 8126

### DIFF
--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -54,7 +54,7 @@ The available settings are:
   particular functions or views. If set to False, the request middleware will be
   disabled even if present.
 * ``AGENT_HOSTNAME`` (default: ``localhost``): define the hostname of the trace agent.
-* ``AGENT_PORT`` (default: ``7777``): define the port of the trace agent.
+* ``AGENT_PORT`` (default: ``8126``): define the port of the trace agent.
 """
 from ..util import require_modules
 

--- a/ddtrace/contrib/django/conf.py
+++ b/ddtrace/contrib/django/conf.py
@@ -26,7 +26,7 @@ DEFAULTS = {
     'ENABLED': True,
     'AUTO_INSTRUMENT': True,
     'AGENT_HOSTNAME': 'localhost',
-    'AGENT_PORT': 7777,
+    'AGENT_PORT': 8126,
     'TAGS': {},
 }
 

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -24,7 +24,7 @@ class Tracer(object):
         trace = tracer.trace("app.request", "web-server").finish()
     """
     DEFAULT_HOSTNAME = 'localhost'
-    DEFAULT_PORT = 7777
+    DEFAULT_PORT = 8126
 
     def __init__(self):
         """

--- a/ddtrace/writer.py
+++ b/ddtrace/writer.py
@@ -21,7 +21,7 @@ DEFAULT_TIMEOUT = 5
 
 class AgentWriter(object):
 
-    def __init__(self, hostname='localhost', port=7777):
+    def __init__(self, hostname='localhost', port=8126):
         self._pid = None
         self._traces = None
         self._services = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,4 +44,3 @@ ddagent:
         - DD_API_KEY=invalid_key_but_this_is_fine
     ports:
         - "127.0.0.1:8126:8126"
-        - "127.0.0.1:7777:7777"

--- a/tests/contrib/django/test_instrumentation.py
+++ b/tests/contrib/django/test_instrumentation.py
@@ -19,7 +19,7 @@ class DjangoInstrumentationTest(DjangoTraceTestCase):
     def test_tracer_flags(self):
         ok_(self.tracer.enabled)
         eq_(self.tracer.writer.api.hostname, 'localhost')
-        eq_(self.tracer.writer.api.port, 7777)
+        eq_(self.tracer.writer.api.port, 8126)
         eq_(self.tracer.tags, {'env': 'test'})
 
     def test_tracer_call(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -167,8 +167,8 @@ class TestAPITransport(TestCase):
         """
         # create a new API object to test the transport using synchronous calls
         self.tracer = get_dummy_tracer()
-        self.api_json = API('localhost', 7777, encoder=JSONEncoder())
-        self.api_msgpack = API('localhost', 7777, encoder=MsgpackEncoder())
+        self.api_json = API('localhost', 8126, encoder=JSONEncoder())
+        self.api_msgpack = API('localhost', 8126, encoder=MsgpackEncoder())
 
     def test_send_single_trace(self):
         # register a single trace with a span and send them to the trace agent
@@ -336,7 +336,7 @@ class TestAPIDowngrade(TestCase):
 
         # the encoder is right but we're targeting an API
         # endpoint that is not available
-        api = API('localhost', 7777)
+        api = API('localhost', 8126)
         api._traces = '/v0.0/traces'
         ok_(isinstance(api._encoder, MsgpackEncoder))
 


### PR DESCRIPTION
### What it does

**Breaking change**

The tracing client uses the port ``8126``. Using a Trace Agent older than version `5.11.0` will **not** work with the current version of the client.