### PR TITLE
falcon: add autopatching

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -17,7 +17,7 @@ try:
     if enabled and enabled.lower() == "false":
         tracer.configure(enabled=False)
     else:
-        from ddtrace import patch_all; patch_all(django=True, flask=True, pylons=True) # noqa
+        from ddtrace import patch_all; patch_all(django=True, flask=True, pylons=True, falcon=True) # noqa
 
     debug = os.environ.get("DATADOG_TRACE_DEBUG")
     if debug and debug.lower() == "true":

--- a/ddtrace/contrib/falcon/__init__.py
+++ b/ddtrace/contrib/falcon/__init__.py
@@ -8,56 +8,13 @@ To trace the falcon web framework, install the trace middleware::
     mw = TraceMiddleware(tracer, 'my-falcon-app')
     falcon.API(middleware=[mw])
 """
-from ddtrace.ext import http as httpx, errors as errx
+from ..util import require_modules
 
+required_modules = ['falcon']
 
-class TraceMiddleware(object):
+with require_modules(required_modules) as missing_modules:
+    if not missing_modules:
+        from .middleware import TraceMiddleware
+        from .patch import patch
 
-    def __init__(self, tracer, service="falcon"):
-        self.tracer = tracer
-        self.service = service
-
-    def process_request(self, req, resp):
-        span = self.tracer.trace(
-            "falcon.request",
-            service=self.service,
-            span_type=httpx.TYPE,
-        )
-
-        span.set_tag(httpx.METHOD, req.method)
-        span.set_tag(httpx.URL, req.url)
-
-    def process_resource(self, req, resp, resource, params):
-        span = self.tracer.current_span()
-        if not span:
-            return  # unexpected
-        span.resource = "%s %s" % (req.method, _name(resource))
-
-    def process_response(self, req, resp, resource):
-        span = self.tracer.current_span()
-        if not span:
-            return  # unexpected
-
-        status = httpx.normalize_status_code(resp.status)
-
-        # FIXME[matt] falcon does not map errors or unmatched routes
-        # to proper status codes, so we we have to try to infer them
-        # here. See https://github.com/falconry/falcon/issues/606
-        if resource is None:
-            span.resource = "%s 404" % req.method
-            status = '404'
-
-        # If we have an active unhandled error, treat it as a 500
-        span.set_traceback()
-        err_msg = span.get_tag(errx.ERROR_MSG)
-        if err_msg and not _is_404(err_msg):
-            status = '500'
-
-        span.set_tag(httpx.STATUS_CODE, status)
-        span.finish()
-
-def _is_404(err_msg):
-    return 'HTTPNotFound' in err_msg
-
-def _name(r):
-    return "%s.%s" % (r.__module__, r.__class__.__name__)
+        __all__ = ['TraceMiddleware', 'patch']

--- a/ddtrace/contrib/falcon/middleware.py
+++ b/ddtrace/contrib/falcon/middleware.py
@@ -1,0 +1,53 @@
+from ddtrace.ext import http as httpx, errors as errx
+
+
+class TraceMiddleware(object):
+
+    def __init__(self, tracer, service="falcon"):
+        self.tracer = tracer
+        self.service = service
+
+    def process_request(self, req, resp):
+        span = self.tracer.trace(
+            "falcon.request",
+            service=self.service,
+            span_type=httpx.TYPE,
+        )
+
+        span.set_tag(httpx.METHOD, req.method)
+        span.set_tag(httpx.URL, req.url)
+
+    def process_resource(self, req, resp, resource, params):
+        span = self.tracer.current_span()
+        if not span:
+            return  # unexpected
+        span.resource = "%s %s" % (req.method, _name(resource))
+
+    def process_response(self, req, resp, resource):
+        span = self.tracer.current_span()
+        if not span:
+            return  # unexpected
+
+        status = httpx.normalize_status_code(resp.status)
+
+        # FIXME[matt] falcon does not map errors or unmatched routes
+        # to proper status codes, so we we have to try to infer them
+        # here. See https://github.com/falconry/falcon/issues/606
+        if resource is None:
+            span.resource = "%s 404" % req.method
+            status = '404'
+
+        # If we have an active unhandled error, treat it as a 500
+        span.set_traceback()
+        err_msg = span.get_tag(errx.ERROR_MSG)
+        if err_msg and not _is_404(err_msg):
+            status = '500'
+
+        span.set_tag(httpx.STATUS_CODE, status)
+        span.finish()
+
+def _is_404(err_msg):
+    return 'HTTPNotFound' in err_msg
+
+def _name(r):
+    return "%s.%s" % (r.__module__, r.__class__.__name__)

--- a/ddtrace/contrib/falcon/patch.py
+++ b/ddtrace/contrib/falcon/patch.py
@@ -1,0 +1,30 @@
+import os
+
+from .middleware import TraceMiddleware
+from ddtrace import tracer
+
+import falcon
+
+
+def patch():
+    """
+    Patch falcon.API to include contrib.falcon.TraceMiddleware
+    by default
+    """
+    if getattr(falcon, '_datadog_patch', False):
+        return
+
+    setattr(falcon, '_datadog_patch', True)
+    setattr(falcon, 'API', TracedAPI)
+
+
+class TracedAPI(falcon.API):
+
+    def __init__(self, *args, **kwargs):
+        mw = kwargs.pop("middleware", [])
+        service = os.environ.get("DATADOG_SERVICE_NAME") or "falcon"
+
+        mw.insert(0, TraceMiddleware(tracer, service))
+        kwargs["middleware"] = mw
+
+        super(TracedAPI, self).__init__(*args, **kwargs)

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -26,9 +26,12 @@ PATCH_MODULES = {
     'sqlalchemy': False,  # Prefer DB client instrumentation
     'sqlite3': True,
     'aiohttp': True,  # requires asyncio (Python 3.4+)
+
+    # Ignore some web framework integrations that might be configured explicitly in code
     'django': False,
     'flask': False,
     'pylons': False,
+    'falcon': False,
 }
 
 _LOCK = threading.Lock()

--- a/tests/contrib/falcon/test_autopatch.py
+++ b/tests/contrib/falcon/test_autopatch.py
@@ -1,0 +1,150 @@
+"""
+test for falcon. run this module with python to run the test web server.
+"""
+
+# stdlib
+from wsgiref import simple_server
+
+# 3p
+import falcon
+import falcon.testing
+from nose.tools import eq_, ok_
+from nose.plugins.attrib import attr
+
+# project
+from ddtrace import tracer
+from ddtrace.contrib.falcon import TraceMiddleware
+from ddtrace.ext import http as httpx
+from tests.test_tracer import DummyWriter
+
+
+class Resource200(object):
+
+    BODY = "yaasss"
+    ROUTE = "/200"
+
+    def on_get(self, req, resp, **kwargs):
+
+        # throw a handled exception here to ensure our use of
+        # set_traceback doesn't affect 200s
+        try:
+            1/0
+        except Exception:
+            pass
+
+        resp.status = falcon.HTTP_200
+        resp.body = self.BODY
+
+
+class Resource500(object):
+
+    BODY = "noo"
+    ROUTE = "/500"
+
+    def on_get(self, req, resp, **kwargs):
+        resp.status = falcon.HTTP_500
+        resp.body = self.BODY
+
+
+class ResourceExc(object):
+
+    ROUTE = "/exc"
+
+    def on_get(self, req, resp, **kwargs):
+        raise Exception("argh")
+
+
+class TestMiddleware(falcon.testing.TestCase):
+
+    def setUp(self):
+        self._tracer = tracer
+        self._writer = DummyWriter()
+        self._tracer.writer = self._writer
+        self._service = "my-falcon"
+
+        self.api = falcon.API()
+
+        resources = [
+            Resource200,
+            Resource500,
+            ResourceExc,
+        ]
+        for r in resources:
+            self.api.add_route(r.ROUTE, r())
+
+    def test_autopatched(self):
+        ok_(falcon._datadog_patch)
+
+    @attr('404')
+    def test_404(self):
+        out = self.simulate_get('/404')
+        eq_(out.status_code, 404)
+
+        spans = self._writer.pop()
+        eq_(len(spans), 1)
+        span = spans[0]
+        eq_(span.service, self._service)
+        eq_(span.resource, "GET 404")
+        eq_(span.get_tag(httpx.STATUS_CODE), '404')
+        eq_(span.name, "falcon.request")
+
+
+    def test_exception(self):
+        try:
+            self.simulate_get(ResourceExc.ROUTE)
+        except Exception:
+            pass
+        else:
+            assert 0
+
+        spans = self._writer.pop()
+        eq_(len(spans), 1)
+        span = spans[0]
+        eq_(span.service, self._service)
+        eq_(span.resource, "GET tests.contrib.falcon.test_autopatch.ResourceExc")
+        eq_(span.get_tag(httpx.STATUS_CODE), '500')
+        eq_(span.name, "falcon.request")
+
+    def test_200(self):
+        out = self.simulate_get(Resource200.ROUTE)
+        eq_(out.status_code, 200)
+        eq_(out.content.decode('utf-8'), Resource200.BODY)
+
+        spans = self._writer.pop()
+        eq_(len(spans), 1)
+        span = spans[0]
+        eq_(span.service, self._service)
+        eq_(span.resource, "GET tests.contrib.falcon.test_autopatch.Resource200")
+        eq_(span.get_tag(httpx.STATUS_CODE), '200')
+        eq_(span.name, "falcon.request")
+
+    def test_500(self):
+        out = self.simulate_get(Resource500.ROUTE)
+        eq_(out.status_code, 500)
+        eq_(out.content.decode('utf-8'), Resource500.BODY)
+
+        spans = self._writer.pop()
+        eq_(len(spans), 1)
+        span = spans[0]
+        eq_(span.service, self._service)
+        eq_(span.resource, "GET tests.contrib.falcon.test_autopatch.Resource500")
+        eq_(span.get_tag(httpx.STATUS_CODE), '500')
+        eq_(span.name, "falcon.request")
+
+
+if __name__ == '__main__':
+    app = falcon.API()
+
+    resources = [
+        Resource200,
+        Resource500,
+        ResourceExc,
+    ]
+    for r in resources:
+        app.add_route(r.ROUTE, r())
+
+    port = 8000
+    httpd = simple_server.make_server('127.0.0.1', port, app)
+    routes = [r.ROUTE for r in resources]
+    print('running test app on %s. routes: %s'  % (port, ' '.join(routes)))
+    httpd.serve_forever()

--- a/tox.ini
+++ b/tox.ini
@@ -142,7 +142,7 @@ commands =
 # integration tests
     integration: nosetests {posargs} tests/test_integration.py
 # run all tests for the release jobs except the ones with a different test runner
-    contrib: nosetests {posargs} --exclude=".*(django|asyncio|aiohttp|gevent).*" tests/contrib
+    contrib: nosetests {posargs} --exclude=".*(django|asyncio|aiohttp|gevent|falcon).*" tests/contrib
     asyncio: nosetests {posargs} tests/contrib/asyncio
     aiohttp{12,13}-aiohttp_jinja{012,013}: nosetests {posargs} tests/contrib/aiohttp
 # run subsets of the tests for particular library versions

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ envlist =
     {py27,py34,py35,py36}-celery{31,40}-redis
     {py27,py34,py35,py36}-elasticsearch{23,24,51,52}
     {py27,py34,py35,py36}-falcon{10,11}
+    {py27,py34,py35,py36}-falcon-autopatch{10,11}
     {py27,py34,py35,py36}-django{18,19,110}-djangopylibmc06-djangoredis45-pylibmc-redis-memcached
     {py27,py34,py35,py36}-flask{010,011,012}-blinker
     {py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis-blinker
@@ -89,6 +90,8 @@ deps =
     elasticsearch52: elasticsearch>=5.2,<5.3
     falcon10: falcon>=1.0,<1.1
     falcon11: falcon>=1.1,<1.2
+    falcon-autopatch10: falcon>=1.0,<1.1
+    falcon-autopatch11: falcon>=1.1,<1.2
     django18: django>=1.8,<1.9
     django19: django>=1.9,<1.10
     django110: django>=1.10,<1.11
@@ -150,7 +153,8 @@ commands =
     django{18,19,110}: python tests/contrib/django/runtests.py {posargs}
     flaskcache{012,013}: nosetests {posargs} tests/contrib/flask_cache
     flask{010,011,012}: nosetests {posargs} tests/contrib/flask
-    falcon{10,11}: nosetests {posargs} tests/contrib/falcon
+    falcon{10,11}: nosetests {posargs} tests/contrib/falcon/test.py
+    falcon-autopatch{10,11}: ddtrace-run nosetests {posargs} tests/contrib/falcon/test_autopatch.py
     gevent{11,12}: nosetests {posargs} tests/contrib/gevent
     gevent{10}: nosetests {posargs} tests/contrib/gevent
     mysqlconnector21: nosetests {posargs} tests/contrib/mysql
@@ -165,6 +169,7 @@ commands =
     sqlalchemy{10,11}: nosetests {posargs} tests/contrib/sqlalchemy
     ddtracerun: nosetests {posargs} tests/commands/test_runner.py
 
+
 [testenv:wait]
 commands=python tests/wait-for-services.py
 basepython=python
@@ -178,6 +183,35 @@ ignore_outcome=true
 deps=flake8==3.2.0
 commands=flake8 ddtrace
 basepython=python2
+
+[falcon_autopatch]
+setenv =
+    DATADOG_SERVICE_NAME=my-falcon
+
+[testenv:py27-falcon-autopatch10]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:py27-falcon-autopatch11]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:py34-falcon-autopatch10]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:py34-falcon-autopatch11]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:py35-falcon-autopatch10]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:py35-falcon-autopatch11]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:py36-falcon-autopatch10]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:py36-falcon-autopatch11]
+setenv =
+    {[falcon_autopatch]setenv}
 
 [flake8]
 ignore=W391,E231,E201,E202,E203,E261,E302,E128,E126,E124


### PR DESCRIPTION
Add an autopatcher into the falcon integration. The autopatcher will
_not_ run by default under `patch_all()` but will run by default under
`ddtrace-run`

Also replicates the existing falcon test case to run without explicit
patching, instead under `ddtrace-run`