### PR TITLE
pyramid: add autopatching

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -9,6 +9,14 @@ import logging
 logging.basicConfig()
 log = logging.getLogger(__name__)
 
+EXTRA_PATCHED_MODULES = {
+    "django": True,
+    "flask": True,
+    "pylons": True,
+    "falcon": True,
+    "pyramid": True,
+}
+
 try:
     from ddtrace import tracer
 
@@ -17,7 +25,7 @@ try:
     if enabled and enabled.lower() == "false":
         tracer.configure(enabled=False)
     else:
-        from ddtrace import patch_all; patch_all(django=True, flask=True, pylons=True) # noqa
+        from ddtrace import patch_all; patch_all(**EXTRA_PATCHED_MODULES) # noqa
 
     debug = os.environ.get("DATADOG_TRACE_DEBUG")
     if debug and debug.lower() == "true":

--- a/ddtrace/contrib/pyramid/__init__.py
+++ b/ddtrace/contrib/pyramid/__init__.py
@@ -23,7 +23,10 @@ required_modules = ['pyramid']
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
         from .trace import trace_pyramid, trace_tween_factory
+        from .patch import patch
+
         __all__ = [
+            'patch',
             'trace_pyramid',
             'trace_tween_factory',
         ]

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -1,7 +1,6 @@
 import os
 
 from .trace import trace_pyramid
-from ddtrace import tracer
 
 import pyramid.config
 

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -1,0 +1,32 @@
+import os
+
+from .trace import trace_pyramid
+from ddtrace import tracer
+
+import pyramid.config
+
+
+def patch():
+    """
+    Patch pyramid.config.Configurator
+    """
+    if getattr(pyramid.config, '_datadog_patch', False):
+        return
+
+    setattr(pyramid.config, '_datadog_patch', True)
+    setattr(pyramid.config, 'Configurator', TracedConfigurator)
+
+
+class TracedConfigurator(pyramid.config.Configurator):
+
+    def __init__(self, *args, **kwargs):
+        settings = kwargs.pop("settings", {})
+        service = os.environ.get("DATADOG_SERVICE_NAME") or "pyramid"
+        trace_settings = {
+            'datadog_trace_service' : service,
+        }
+        settings.update(trace_settings)
+        kwargs["settings"] = settings
+
+        super(TracedConfigurator, self).__init__(*args, **kwargs)
+        trace_pyramid(self)

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -29,6 +29,8 @@ PATCH_MODULES = {
     'django': False,
     'flask': False,
     'pylons': False,
+    'falcon': False,
+    'pyramid': False,
 }
 
 _LOCK = threading.Lock()

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -1,0 +1,160 @@
+# stdlib
+import logging
+import json
+import sys
+from wsgiref.simple_server import make_server
+
+# 3p
+from pyramid.response import Response
+from pyramid.config import Configurator
+from pyramid.view import view_config
+from pyramid.httpexceptions import HTTPInternalServerError
+import webtest
+from nose.tools import eq_
+
+# project
+import ddtrace
+from ddtrace import compat
+from ddtrace.contrib.pyramid import trace_pyramid
+
+
+def test_200():
+    app, tracer = _get_test_app(service='foobar')
+    res = app.get('/', status=200)
+    assert b'idx' in res.body
+
+    writer = tracer.writer
+    spans = writer.pop()
+    eq_(len(spans), 1)
+    s = spans[0]
+    eq_(s.service, 'foobar')
+    eq_(s.resource, 'index')
+    eq_(s.error, 0)
+    eq_(s.span_type, 'http')
+    eq_(s.meta.get('http.status_code'), '200')
+    eq_(s.meta.get('http.url'), '/')
+
+    # ensure services are set correcgly
+    services = writer.pop_services()
+    expected = {
+        'foobar': {"app":"pyramid", "app_type":"web"}
+    }
+    eq_(services, expected)
+
+
+def test_404():
+    app, tracer = _get_test_app(service='foobar')
+    res = app.get('/404', status=404)
+
+    writer = tracer.writer
+    spans = writer.pop()
+    eq_(len(spans), 1)
+    s = spans[0]
+    eq_(s.service, 'foobar')
+    eq_(s.resource, '404')
+    eq_(s.error, 0)
+    eq_(s.span_type, 'http')
+    eq_(s.meta.get('http.status_code'), '404')
+    eq_(s.meta.get('http.url'), '/404')
+
+
+def test_exception():
+    app, tracer = _get_test_app(service='foobar')
+    try:
+        app.get('/exception', status=500)
+    except ZeroDivisionError:
+        pass
+
+    writer = tracer.writer
+    spans = writer.pop()
+    eq_(len(spans), 1)
+    s = spans[0]
+    eq_(s.service, 'foobar')
+    eq_(s.resource, 'exception')
+    eq_(s.error, 1)
+    eq_(s.span_type, 'http')
+    eq_(s.meta.get('http.status_code'), '500')
+    eq_(s.meta.get('http.url'), '/exception')
+
+def test_500():
+    app, tracer = _get_test_app(service='foobar')
+    app.get('/error', status=500)
+
+    writer = tracer.writer
+    spans = writer.pop()
+    eq_(len(spans), 1)
+    s = spans[0]
+    eq_(s.service, 'foobar')
+    eq_(s.resource, 'error')
+    eq_(s.error, 1)
+    eq_(s.span_type, 'http')
+    eq_(s.meta.get('http.status_code'), '500')
+    eq_(s.meta.get('http.url'), '/error')
+    assert type(s.error) == int
+
+def test_json():
+    app, tracer = _get_test_app(service='foobar')
+    res = app.get('/json', status=200)
+    parsed = json.loads(compat.to_unicode(res.body))
+    eq_(parsed, {'a':1})
+
+    writer = tracer.writer
+    spans = writer.pop()
+    eq_(len(spans), 2)
+    spans_by_name = {s.name:s for s in spans}
+    s = spans_by_name['pyramid.request']
+    eq_(s.service, 'foobar')
+    eq_(s.resource, 'json')
+    eq_(s.error, 0)
+    eq_(s.span_type, 'http')
+    eq_(s.meta.get('http.status_code'), '200')
+    eq_(s.meta.get('http.url'), '/json')
+
+    s = spans_by_name['pyramid.render']
+    eq_(s.service, 'foobar')
+    eq_(s.error, 0)
+    eq_(s.span_type, 'template')
+
+def _get_app(service=None, tracer=None):
+    """ return a pyramid wsgi app with various urls. """
+
+    def index(request):
+        return Response('idx')
+
+    def error(request):
+        raise HTTPInternalServerError("oh no")
+
+    def exception(request):
+        1/0
+
+    def json(request):
+        return {'a':1}
+
+    config = Configurator()
+    config.add_route('index', '/')
+    config.add_route('error', '/error')
+    config.add_route('exception', '/exception')
+    config.add_route('json', '/json')
+    config.add_view(index, route_name='index')
+    config.add_view(error, route_name='error')
+    config.add_view(exception, route_name='exception')
+    config.add_view(json, route_name='json', renderer='json')
+    return config.make_wsgi_app()
+
+
+def _get_test_app(service=None):
+    """ return a webtest'able version of our test app. """
+    from tests.test_tracer import get_dummy_tracer
+    tracer = get_dummy_tracer()
+    app = _get_app(service=service, tracer=tracer)
+    return webtest.TestApp(app), tracer
+
+
+if __name__ == '__main__':
+    logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+    ddtrace.tracer.debug_logging = True
+    app = _get_app()
+    port = 8080
+    server = make_server('0.0.0.0', port, app)
+    print('running on %s' % port)
+    server.serve_forever()

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -15,7 +15,6 @@ from nose.tools import eq_
 # project
 import ddtrace
 from ddtrace import compat
-from ddtrace.contrib.pyramid import trace_pyramid
 
 
 def test_200():
@@ -144,10 +143,11 @@ def _get_app(service=None, tracer=None):
 
 def _get_test_app(service=None):
     """ return a webtest'able version of our test app. """
-    from tests.test_tracer import get_dummy_tracer
-    tracer = get_dummy_tracer()
-    app = _get_app(service=service, tracer=tracer)
-    return webtest.TestApp(app), tracer
+    from tests.test_tracer import DummyWriter
+    ddtrace.tracer.writer = DummyWriter()
+
+    app = _get_app(service=service, tracer=ddtrace.tracer)
+    return webtest.TestApp(app), ddtrace.tracer
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ envlist =
     {py27,py34,py35,py36}-pylibmc{140,150}
     {py27,py34,py35,py36}-pymongo{30,31,32,33,34}-mongoengine
     {py27,py34,py35,py36}-pyramid{17,18}-webtest
+    {py27,py34,py35,py36}-pyramid-autopatch{17,18}-webtest
     {py27,py34,py35,py36}-requests{208,209,210,211,212,213}
     {py27,py34,py35,py36}-sqlalchemy{10,11}-psycopg2
     {py27,py34,py35,py36}-redis
@@ -115,6 +116,8 @@ deps =
     pymongo34: pymongo>=3.4,<3.5
     pyramid17: pyramid>=1.7,<1.8
     pyramid18: pyramid>=1.8,<1.9
+    pyramid-autopatch17: pyramid>=1.7,<1.8
+    pyramid-autopatch18: pyramid>=1.8,<1.9
     psycopg2: psycopg2
     redis: redis
     requests200: requests>=2.0,<2.1
@@ -156,7 +159,8 @@ commands =
     mysqlconnector21: nosetests {posargs} tests/contrib/mysql
     pylibmc{140,150}: nosetests {posargs} tests/contrib/pylibmc
     pymongo{30,31,32,33,34}: nosetests {posargs} tests/contrib/pymongo
-    pyramid{17,18}: nosetests {posargs} tests/contrib/pyramid
+    pyramid{17,18}: nosetests {posargs} tests/contrib/pyramid/test_pyramid.py
+    pyramid-autopatch{17,18}: ddtrace-run nosetests {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
     mongoengine: nosetests {posargs} tests/contrib/mongoengine
     psycopg2: nosetests {posargs} tests/contrib/psycopg
     redis: nosetests {posargs} tests/contrib/redis
@@ -178,6 +182,41 @@ ignore_outcome=true
 deps=flake8==3.2.0
 commands=flake8 ddtrace
 basepython=python2
+
+[pyramid_autopatch]
+setenv =
+    DATADOG_SERVICE_NAME = foobar
+
+[testenv:py27-pyramid-autopatch17-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+
+[testenv:py27-pyramid-autopatch18-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+
+[testenv:py34-pyramid-autopatch17-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:py34-pyramid-autopatch18-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+
+[testenv:py35-pyramid-autopatch17-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+
+[testenv:py35-pyramid-autopatch18-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+
+[testenv:py36-pyramid-autopatch17-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+
+[testenv:py36-pyramid-autopatch18-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
 
 [flake8]
 ignore=W391,E231,E201,E202,E203,E261,E302,E128,E126,E124


### PR DESCRIPTION
Adds pyramid autopatching - disabled in `patch_all()` by default, but enabled under `ddtrace-run`

the existing pyramid test suite has been replicated to run without explicit patching.
instead it runs under `ddtrace-run nosetests ...` and behaves identically
