### PR TITLE
respect DATADOG_TRACE_AGENT_HOSTNAME and DATADOG_TRACE_AGENT_PORT in ddtrace-run

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -19,12 +19,26 @@ EXTRA_PATCHED_MODULES = {
 
 try:
     from ddtrace import tracer
+    patch = True
 
     # Respect DATADOG_* environment variables in global tracer configuration
     enabled = os.environ.get("DATADOG_TRACE_ENABLED")
+    hostname = os.environ.get("DATADOG_TRACE_AGENT_HOSTNAME")
+    port = os.environ.get("DATADOG_TRACE_AGENT_PORT")
+    opts = {}
+
     if enabled and enabled.lower() == "false":
-        tracer.configure(enabled=False)
-    else:
+        opts["enabled"] = False
+        patch = False
+    if hostname:
+        opts["hostname"] = hostname
+    if port:
+        opts["port"] = int(port)
+
+    if opts:
+        tracer.configure(**opts)
+
+    if patch:
         from ddtrace import patch_all; patch_all(**EXTRA_PATCHED_MODULES) # noqa
 
     debug = os.environ.get("DATADOG_TRACE_DEBUG")

--- a/tests/commands/ddtrace_run_disabled.py
+++ b/tests/commands/ddtrace_run_disabled.py
@@ -1,9 +1,10 @@
 from __future__ import print_function
 
-from ddtrace import tracer
+from ddtrace import tracer, monkey
 
-from nose.tools import ok_
+from nose.tools import ok_, eq_
 
 if __name__ == '__main__':
     ok_(not tracer.enabled)
+    eq_(len(monkey.get_patched_modules()), 0)
     print("Test success")

--- a/tests/commands/ddtrace_run_hostname.py
+++ b/tests/commands/ddtrace_run_hostname.py
@@ -1,0 +1,10 @@
+from __future__ import print_function
+
+from ddtrace import tracer
+
+from nose.tools import eq_
+
+if __name__ == '__main__':
+    eq_(tracer.writer.api.hostname, "172.10.0.1")
+    eq_(tracer.writer.api.port, 58126)
+    print("Test success")

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -91,3 +91,15 @@ class DdtraceRunTest(unittest.TestCase):
             ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_debug.py']
         )
         assert out.startswith(b"Test success")
+
+    def test_host_port_from_env(self):
+        """
+        DATADOG_TRACE_AGENT_HOSTNAME|PORT point to the tracer
+        to the correct host/port for submission
+        """
+        os.environ["DATADOG_TRACE_AGENT_HOSTNAME"] = "172.10.0.1"
+        os.environ["DATADOG_TRACE_AGENT_PORT"] = "58126"
+        out = subprocess.check_output(
+            ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_hostname.py']
+        )
+        assert out.startswith(b"Test success")


### PR DESCRIPTION
this allows overriding the point of submission of the default tracer
when using `ddtrace-run <my_script>`