### PR TITLE
pyramid: use a function wrapper to maintain introspection abilities

### DIFF
--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -130,6 +130,7 @@ def _get_app(service=None, tracer=None):
         return {'a':1}
 
     config = Configurator()
+    import pdb ; pdb.set_trace()
     config.add_route('index', '/')
     config.add_route('error', '/error')
     config.add_route('exception', '/exception')

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -130,7 +130,6 @@ def _get_app(service=None, tracer=None):
         return {'a':1}
 
     config = Configurator()
-    import pdb ; pdb.set_trace()
     config.add_route('index', '/')
     config.add_route('error', '/error')
     config.add_route('exception', '/exception')


### PR DESCRIPTION
pyramid's name_resolver relies on the Configurator not fudging
it's import path, since this is consulted to retrieve models, views etc.

this change uses `wrapt.wrap_function_wrapper` to ensure
pyramid.config.Configurator remains introspectable