### PR TITLE
Set pyramid request span tags for HTTP method and route name

### DIFF
--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -15,6 +15,7 @@ def trace_pyramid(config):
     if not isinstance(pyramid.renderers.RendererHelper.render, wrapt.ObjectProxy):
         wrapt.wrap_function_wrapper('pyramid.renderers', 'RendererHelper.render', trace_render)
 
+
 def trace_render(func, instance, args, kwargs):
     # get the tracer from the request or fall back to the global version
     def _tracer(value, system_values, request=None):
@@ -28,6 +29,7 @@ def trace_render(func, instance, args, kwargs):
     with t.trace('pyramid.render') as span:
         span.span_type = http.TEMPLATE
         return func(*args, **kwargs)
+
 
 def trace_tween_factory(handler, registry):
     # configuration
@@ -57,8 +59,10 @@ def trace_tween_factory(handler, registry):
                     span.span_type = http.TYPE
                     # set request tags
                     span.set_tag(http.URL, request.path)
+                    span.set_tag(http.METHOD, request.method)
                     if request.matched_route:
                         span.resource = request.matched_route.name
+                        span.set_tag("pyramid.route.name", request.matched_route.name)
                     # set response tags
                     if response:
                         span.set_tag(http.STATUS_CODE, response.status_code)

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -32,20 +32,22 @@ def test_200():
     eq_(s.resource, 'index')
     eq_(s.error, 0)
     eq_(s.span_type, 'http')
+    eq_(s.meta.get('http.method'), 'GET')
     eq_(s.meta.get('http.status_code'), '200')
     eq_(s.meta.get('http.url'), '/')
+    eq_(s.meta.get('pyramid.route.name'), 'index')
 
-    # ensure services are set correcgly
+    # ensure services are set correctly
     services = writer.pop_services()
     expected = {
-        'foobar': {"app":"pyramid", "app_type":"web"}
+        'foobar': {"app": "pyramid", "app_type": "web"}
     }
     eq_(services, expected)
 
 
 def test_404():
     app, tracer = _get_test_app(service='foobar')
-    res = app.get('/404', status=404)
+    app.get('/404', status=404)
 
     writer = tracer.writer
     spans = writer.pop()
@@ -55,6 +57,7 @@ def test_404():
     eq_(s.resource, '404')
     eq_(s.error, 0)
     eq_(s.span_type, 'http')
+    eq_(s.meta.get('http.method'), 'GET')
     eq_(s.meta.get('http.status_code'), '404')
     eq_(s.meta.get('http.url'), '/404')
 
@@ -74,8 +77,11 @@ def test_exception():
     eq_(s.resource, 'exception')
     eq_(s.error, 1)
     eq_(s.span_type, 'http')
+    eq_(s.meta.get('http.method'), 'GET')
     eq_(s.meta.get('http.status_code'), '500')
     eq_(s.meta.get('http.url'), '/exception')
+    eq_(s.meta.get('pyramid.route.name'), 'exception')
+
 
 def test_500():
     app, tracer = _get_test_app(service='foobar')
@@ -89,9 +95,12 @@ def test_500():
     eq_(s.resource, 'error')
     eq_(s.error, 1)
     eq_(s.span_type, 'http')
+    eq_(s.meta.get('http.method'), 'GET')
     eq_(s.meta.get('http.status_code'), '500')
     eq_(s.meta.get('http.url'), '/error')
+    eq_(s.meta.get('pyramid.route.name'), 'error')
     assert type(s.error) == int
+
 
 def test_json():
     app, tracer = _get_test_app(service='foobar')
@@ -108,13 +117,16 @@ def test_json():
     eq_(s.resource, 'json')
     eq_(s.error, 0)
     eq_(s.span_type, 'http')
+    eq_(s.meta.get('http.method'), 'GET')
     eq_(s.meta.get('http.status_code'), '200')
     eq_(s.meta.get('http.url'), '/json')
+    eq_(s.meta.get('pyramid.route.name'), 'json')
 
     s = spans_by_name['pyramid.render']
     eq_(s.service, 'foobar')
     eq_(s.error, 0)
     eq_(s.span_type, 'template')
+
 
 def _get_app(service=None, tracer=None):
     """ return a pyramid wsgi app with various urls. """


### PR DESCRIPTION
This PR sets the following tags for the pyramid.request span:

1. http.METHOD
2. pyramid.route.name