### PR TITLE
[core] provide a wrap_executor

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -79,9 +79,11 @@ class Tracer(object):
         :param int port: Port of the Trace Agent
         :param object sampler: A custom Sampler instance
         :param object context_provider: The ``ContextProvider`` that will be used to retrieve
-            automatically the current call context
+            automatically the current call context. This is an advanced option that usually
+            doesn't need to be changed from the default value
         :param object wrap_executor: callable that is used when a function is decorated with
-            ``Tracer.wrap()``
+            ``Tracer.wrap()``. This is an advanced option that usually doesn't need to be changed
+            from the default value
         """
         if enabled is not None:
             self.enabled = enabled

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -216,6 +216,32 @@ def test_tracer_wrap_class():
     eq_(sorted(names), sorted(["tests.test_tracer.%s" % n for n in ["s", "c", "i"]]))
 
 
+def test_tracer_wrap_factory():
+    # it should use a wrap_factory if defined
+    writer = DummyWriter()
+    tracer = Tracer()
+    tracer.writer = writer
+
+    def wrap_executor(tracer, fn, args, kwargs, span_name, service, resource, span_type):
+        with tracer.trace('wrap.overwrite') as span:
+            span.set_tag('args', args)
+            span.set_tag('kwargs', kwargs)
+            return fn(*args, **kwargs)
+
+    @tracer.wrap()
+    def wrapped_function(param, kw_param=None):
+        eq_(42, param)
+        eq_(42, kw_param)
+
+    # set the custom wrap factory after the wrapper has been called
+    tracer.configure(wrap_executor=wrap_executor)
+
+    # call the function expecting that the custom tracing wrapper is used
+    wrapped_function(42, kw_param=42)
+    eq_(writer.spans[0].name, 'wrap.overwrite')
+    eq_(writer.spans[0].get_tag('args'), '(42,)')
+    eq_(writer.spans[0].get_tag('kwargs'), '{\'kw_param\': 42}')
+
 
 def test_tracer_disabled():
     # add some dummy tracing code.

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -243,6 +243,39 @@ def test_tracer_wrap_factory():
     eq_(writer.spans[0].get_tag('kwargs'), '{\'kw_param\': 42}')
 
 
+def test_tracer_wrap_factory_nested():
+    # it should use a wrap_factory if defined even in nested tracing
+    writer = DummyWriter()
+    tracer = Tracer()
+    tracer.writer = writer
+
+    def wrap_executor(tracer, fn, args, kwargs, span_name, service, resource, span_type):
+        with tracer.trace('wrap.overwrite') as span:
+            span.set_tag('args', args)
+            span.set_tag('kwargs', kwargs)
+            return fn(*args, **kwargs)
+
+    @tracer.wrap()
+    def wrapped_function(param, kw_param=None):
+        eq_(42, param)
+        eq_(42, kw_param)
+
+    # set the custom wrap factory after the wrapper has been called
+    tracer.configure(wrap_executor=wrap_executor)
+
+    # call the function expecting that the custom tracing wrapper is used
+    with tracer.trace('wrap.parent', service='webserver'):
+        wrapped_function(42, kw_param=42)
+
+    eq_(writer.spans[0].name, 'wrap.parent')
+    eq_(writer.spans[0].service, 'webserver')
+
+    eq_(writer.spans[1].name, 'wrap.overwrite')
+    eq_(writer.spans[1].service, 'webserver')
+    eq_(writer.spans[1].get_tag('args'), '(42,)')
+    eq_(writer.spans[1].get_tag('kwargs'), '{\'kw_param\': 42}')
+
+
 def test_tracer_disabled():
     # add some dummy tracing code.
     writer = DummyWriter()

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -222,7 +222,7 @@ def test_tracer_wrap_factory():
     tracer = Tracer()
     tracer.writer = writer
 
-    def wrap_executor(tracer, fn, args, kwargs, span_name, service, resource, span_type):
+    def wrap_executor(tracer, fn, args, kwargs, span_name=None, service=None, resource=None, span_type=None):
         with tracer.trace('wrap.overwrite') as span:
             span.set_tag('args', args)
             span.set_tag('kwargs', kwargs)
@@ -249,7 +249,7 @@ def test_tracer_wrap_factory_nested():
     tracer = Tracer()
     tracer.writer = writer
 
-    def wrap_executor(tracer, fn, args, kwargs, span_name, service, resource, span_type):
+    def wrap_executor(tracer, fn, args, kwargs, span_name=None, service=None, resource=None, span_type=None):
         with tracer.trace('wrap.overwrite') as span:
             span.set_tag('args', args)
             span.set_tag('kwargs', kwargs)


### PR DESCRIPTION
### What it does

Adds a `wrap_executor` callback to the `Tracer.configure()` method, so that a contrib module can change the behavior of `Tracer.wrap()`. This is required because in some frameworks (i.e. Tornado), the `Tracer.wrap()` must handle "coroutine" executions that returns immediately a `Future` instance. On the other hand, we can't pollute the `Tracer.wrap()` with `contrib` code and PR goals are:
* if a `wrap_executor` is not defined, the `Tracer.wrap()` behaves as usual for regular functions or `asyncio` coroutines
* if a `wrap_executor` is defined, decorated functions are handled using this callable

#### Usage

```python
from ddtrace import tracer

# this is the default signature
def wrap_executor(tracer, fn, args, kwargs, span_name, service, resource, span_type):
    with tracer.trace(span_name, service=service, resource=resource, span_type=span_type):
        # do something before
        result = fn(*args, **kwargs)
        # do something after
        return result

# enable the custom decorator handler
tracer.configure(wrap_executor=wrap_executor)
```

#### Integration example

Look at the Tornado [integration][1] and [usage][2].

[1]: https://github.com/DataDog/dd-trace-py/pull/204/files#diff-3b957a6da0afb54a68360c040397e07aR1
[2]: https://github.com/DataDog/dd-trace-py/pull/204/files#diff-5f51e63c049b3482ffd304ad48535366R28

#### Limitation

The `wrap_executor` is executed each time the decorator is called. We can't use a `wrap_factory` that returns a new decorator because it could be too late. Indeed, users can decorate their functions *before* calling the `tracer.configure()` method. This may add a little overhead (order of nanoseconds) because the following is always evaluated for each call:
```python
if getattr(self, '_wrap_executor', None):
    # _wrap_executor call
```