### PR TITLE
Raphael/boto bototrace fix

### DIFF
--- a/ddtrace/contrib/boto/patch.py
+++ b/ddtrace/contrib/boto/patch.py
@@ -41,7 +41,9 @@ def patched_query_request(original_func, instance, args, kwargs):
     with pin.tracer.trace('{}.command'.format(endpoint_name), service="{}.{}".format(pin.service, endpoint_name),
                           span_type=SPAN_TYPE) as span:
 
-        operation_name, _, _, _ = args
+        operation_name = None
+        if args and len(args) > 3:
+            operation_name = args[0]
 
         # Adding the args in AWS_QUERY_TRACED_ARGS if exist to the span
         if not aws.is_blacklist(endpoint_name):

--- a/ddtrace/contrib/boto/patch.py
+++ b/ddtrace/contrib/boto/patch.py
@@ -42,7 +42,7 @@ def patched_query_request(original_func, instance, args, kwargs):
                           span_type=SPAN_TYPE) as span:
 
         operation_name = None
-        if args and len(args) > 3:
+        if args:
             operation_name = args[0]
             span.resource = '%s.%s' % (endpoint_name, operation_name.lower())
         else:
@@ -98,7 +98,7 @@ def patched_auth_request(original_func, instance, args, kwargs):
             for arg in aws.unpacking_args(args, AWS_AUTH_ARGS_NAME, AWS_AUTH_TRACED_ARGS):
                 span.set_tag(arg[0], arg[1])
 
-        if args and len(args) > 0:
+        if args:
             http_method = args[0]
             span.resource = '%s.%s' % (endpoint_name, http_method.lower())
         else:

--- a/ddtrace/contrib/boto/patch.py
+++ b/ddtrace/contrib/boto/patch.py
@@ -46,7 +46,7 @@ def patched_query_request(original_func, instance, args, kwargs):
             operation_name = args[0]
             span.resource = '%s.%s' % (endpoint_name, operation_name.lower())
         else:
-            span.resource = '%s' % (endpoint_name)
+            span.resource = endpoint_name
 
         # Adding the args in AWS_QUERY_TRACED_ARGS if exist to the span
         if not aws.is_blacklist(endpoint_name):
@@ -102,7 +102,7 @@ def patched_auth_request(original_func, instance, args, kwargs):
             http_method = args[0]
             span.resource = '%s.%s' % (endpoint_name, http_method.lower())
         else:
-            span.resource = '%s' % (endpoint_name)
+            span.resource = endpoint_name
 
         # Obtaining region name
         region = getattr(instance, "region", None)

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -41,13 +41,15 @@ def patched_api_call(original_func, instance, args, kwargs):
         operation = None
         if args and len(args) > 1:
             operation = args[0]
+            span.resource = '%s.%s' % (endpoint_name, operation.lower())
+
+        else:
+            span.resource = '%s' % (endpoint_name)
 
         # Adding the args in TRACED_ARGS if exist to the span
         if not aws.is_blacklist(endpoint_name):
             for arg in aws.unpacking_args(args, ARGS_NAME, TRACED_ARGS):
                 span.set_tag(arg[0], arg[1])
-
-        span.resource = '%s.%s' % (endpoint_name, operation.lower())
 
         region_name = deep_getattr(instance, "meta.region_name")
 

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -38,7 +38,9 @@ def patched_api_call(original_func, instance, args, kwargs):
                           service="{}.{}".format(pin.service, endpoint_name),
                           span_type=SPAN_TYPE) as span:
 
-        operation, _ = args
+        operation = None
+        if args and len(args) > 1:
+            operation = args[0]
 
         # Adding the args in TRACED_ARGS if exist to the span
         if not aws.is_blacklist(endpoint_name):

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -44,7 +44,7 @@ def patched_api_call(original_func, instance, args, kwargs):
             span.resource = '%s.%s' % (endpoint_name, operation.lower())
 
         else:
-            span.resource = '%s' % (endpoint_name)
+            span.resource = endpoint_name
 
         # Adding the args in TRACED_ARGS if exist to the span
         if not aws.is_blacklist(endpoint_name):

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -39,7 +39,7 @@ def patched_api_call(original_func, instance, args, kwargs):
                           span_type=SPAN_TYPE) as span:
 
         operation = None
-        if args and len(args) > 1:
+        if args:
             operation = args[0]
             span.resource = '%s.%s' % (endpoint_name, operation.lower())
 


### PR DESCRIPTION
# Summary
Adding protection after the patch created an error in org 54558 aws_elasticache crawler.

# Fix
Error reproduced in https://github.com/DataDog/dd-trace-py/compare/raphael/boto_bototrace_fix?expand=1#diff-b2e499c54b0cce73427ace1ed1498f50R152
Solved by checking number of args before query, added same logic to botocore patch in case

# Test
test_elasticache_client() can only be called with valid AWS keys, no moto mocking exists for this AWS endpoint. Test skipped by default
