### PR TITLE
[django] provide a unique datadog_django app label

### DIFF
--- a/ddtrace/contrib/django/apps.py
+++ b/ddtrace/contrib/django/apps.py
@@ -17,6 +17,7 @@ log = logging.getLogger(__name__)
 
 class TracerConfig(AppConfig):
     name = 'ddtrace.contrib.django'
+    label = 'datadog_django'
 
     def ready(self):
         """


### PR DESCRIPTION
### What it does

Provide a unique app label for our tracing Django app: `datadog_django`