### PR TITLE
[mysql] CI tests only versions < 2.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,8 @@ deps =
     contrib: flask
     contrib: flask_cache
     contrib: mongoengine
-    contrib: mysql-connector
+# mysql-connector 2.2+ requires a protobuf configuration
+    contrib: mysql-connector<2.2
     contrib: psycopg2
     contrib: pylibmc
     contrib: pymongo


### PR DESCRIPTION
### What it does

The CI tests `mysql-connector<2.2` because the latest version requires a full `protobuf` configuration. This fixes our CI `contrib` tests.