### PR TITLE
fix sample code issue

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -276,8 +276,8 @@ Users can pass along the parent_trace_id and parent_span_id via whatever method 
 
     def child_rpc_call(parent_trace_id, parent_span_id):
         with tracer.trace("child_span") as span:
-            span.parent_id = parent_span_id
-            span.trace_id = parent_trace_id
+            span.parent_id = int(parent_span_id)
+            span.trace_id = int(parent_trace_id)
 
 Advanced Usage
 --------------


### PR DESCRIPTION
I wrote some examples for a cross service tracing, if as this example, passed as a string, tracer-agent will got some error:

```
2017-03-30 10:04:52 ERROR (receiver_logger.go:21) - cannot decode v0.3 traces payload: json: cannot unmarshal string into Go value of type uint64
```
It's a type mismatch.