### PR TITLE
[boto] Use frames directly without calling getouterframes()

### DIFF
--- a/ddtrace/contrib/boto/patch.py
+++ b/ddtrace/contrib/boto/patch.py
@@ -90,12 +90,10 @@ def patched_auth_request(original_func, instance, args, kwargs):
 
     # Catching the name of the operation that called make_request()
     operation_name = None
-    for frame in inspect.getouterframes(inspect.currentframe()):
-        # Going backwards in the traceback till first call outside off ddtrace before make_request
-        if len(frame) > 3:
-            if "ddtrace" not in frame[1].split('/') and frame[3] != 'make_request':
-                operation_name = frame[3]
-                break
+    frame = inspect.currentframe()
+    # go up the call stack twice to get into the boto frame
+    boto_frame = frame.f_back.f_back
+    operation_name = boto_frame.f_code.co_name
 
     pin = Pin.get_from(instance)
     if not pin or not pin.enabled():


### PR DESCRIPTION
Using `inspect.py`'s `getouterframes()` function can have a performance cost; in the attached flamegraph, it looks like it spends as much time in there as it does fetching.

Luckily, it looks like we only need the name of the frame above, which does not require a full call to `getouterframes()`. This PR asks for the parent of the parent's name, and uses that.

![screen shot 2017-04-04 at 1 25 01 pm](https://cloud.githubusercontent.com/assets/245071/24671533/c7093aea-193f-11e7-9eed-a2955e8775d8.png)
