### PR TITLE
changing doc after pin change

### DIFF
--- a/ddtrace/contrib/elasticsearch/__init__.py
+++ b/ddtrace/contrib/elasticsearch/__init__.py
@@ -16,7 +16,7 @@
 
     # Use a pin to specify metadata related to this client
     es = elasticsearch.Elasticsearch(port=ELASTICSEARCH_CONFIG['port'])
-    Pin.override(es, service='elasticsearch-videos')
+    Pin.override(es.transport, service='elasticsearch-videos')
     es.indices.create(index='videos', ignore=400)
 """
 from ..util import require_modules


### PR DESCRIPTION
Pin is now set on the Transport object found on Elasticsearch.transport, updating doc