### PR TITLE
Gabin/correct msgpack version bug

### DIFF
--- a/ddtrace/encoding.py
+++ b/ddtrace/encoding.py
@@ -10,6 +10,8 @@ try:
     from msgpack._packer import Packer  # noqa
     from msgpack._unpacker import unpack, unpackb, Unpacker  # noqa
     from msgpack._version import version
+    # use_bin_type kwarg only exists since msgpack-python v0.4.0
+    MSGPACK_PARAMS = { 'use_bin_type': True } if version >= (0, 4, 0) else {}
     MSGPACK_ENCODING = True
 except ImportError:
     MSGPACK_ENCODING = False
@@ -74,11 +76,7 @@ class MsgpackEncoder(Encoder):
         self.content_type = 'application/msgpack'
 
     def _encode(self, obj):
-        # use_bin_type kwarg only exists since msgpack-python v0.4.0
-        if version >= (0, 4, 0):
-            return msgpack.packb(obj, use_bin_type=True)
-        else:
-            return msgpack.packb(obj)
+        return msgpack.packb(obj, **MSGPACK_PARAMS)
 
 def get_encoder():
     """

--- a/ddtrace/encoding.py
+++ b/ddtrace/encoding.py
@@ -9,6 +9,7 @@ try:
     import msgpack
     from msgpack._packer import Packer  # noqa
     from msgpack._unpacker import unpack, unpackb, Unpacker  # noqa
+    from msgpack._version import version
     MSGPACK_ENCODING = True
 except ImportError:
     MSGPACK_ENCODING = False
@@ -73,8 +74,11 @@ class MsgpackEncoder(Encoder):
         self.content_type = 'application/msgpack'
 
     def _encode(self, obj):
-        return msgpack.packb(obj, use_bin_type=True)
-
+        # use_bin_type kwarg only exists since msgpack-python v0.4.0
+        if version >= (0, 4, 0):
+            return msgpack.packb(obj, use_bin_type=True)
+        else:
+            return msgpack.packb(obj)
 
 def get_encoder():
     """

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -37,7 +37,7 @@ class TestEncoders(TestCase):
         eq_(len(items[1]), 2)
 
     def test_encode_traces_msgpack(self):
-        # test encoding for JSON format
+        # test encoding for MsgPack format
         traces = []
         traces.append([
             Span(name='client.testing', tracer=None),

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ envlist =
     {py27,py34,py35,py36}-psycopg2{25,26,27}
     {py27,py34,py35,py36}-redis{26,27,28,29,210}
     {py27,py34,py35,py36}-sqlite3
+    {py27,py34}-msgpack{03,04}
 
 [testenv]
 basepython =
@@ -60,6 +61,9 @@ deps =
     mock
     nose
     msgpack-python
+# msgpack
+    msgpack03: msgpack-python>=0.3,<0.4
+    msgpack04: msgpack-python>=0.4,<0.5
 # integrations
     contrib: blinker
     contrib: bottle
@@ -208,6 +212,7 @@ commands =
     requests{200,208,209,210,211,212,213}: nosetests {posargs} tests/contrib/requests
     sqlalchemy{10,11}: nosetests {posargs} tests/contrib/sqlalchemy
     ddtracerun: nosetests {posargs} tests/commands/test_runner.py
+    msgpack: nosetests {posargs} tests/test_encoders.py
 
 setenv =
     DJANGO_SETTINGS_MODULE = app.settings

--- a/tox.ini
+++ b/tox.ini
@@ -60,10 +60,6 @@ deps =
 # test dependencies installed in all envs
     mock
     nose
-    msgpack-python
-# msgpack
-    msgpack03: msgpack-python>=0.3,<0.4
-    msgpack04: msgpack-python>=0.4,<0.5
 # integrations
     contrib: blinker
     contrib: bottle
@@ -76,6 +72,7 @@ deps =
     contrib: falcon
     contrib: flask
     contrib: flask_cache
+    contrib: msgpack-python
     contrib: mongoengine
 # mysql-connector 2.2+ requires a protobuf configuration
     contrib: mysql-connector<2.2
@@ -134,6 +131,8 @@ deps =
     flaskcache012: flask_cache>=0.12,<0.13
     flaskcache013: flask_cache>=0.13,<0.14
     memcached: python-memcached
+    msgpack03: msgpack-python>=0.3,<0.4
+    msgpack04: msgpack-python>=0.4,<0.5
     mongoengine011: mongoengine>=0.11,<0.12
     mysqlconnector21: mysql-connector>=2.1,<2.2
     pylons: pylons
@@ -212,7 +211,7 @@ commands =
     requests{200,208,209,210,211,212,213}: nosetests {posargs} tests/contrib/requests
     sqlalchemy{10,11}: nosetests {posargs} tests/contrib/sqlalchemy
     ddtracerun: nosetests {posargs} tests/commands/test_runner.py
-    msgpack: nosetests {posargs} tests/test_encoders.py
+    msgpack{03,04}: nosetests {posargs} tests/test_encoders.py
 
 setenv =
     DJANGO_SETTINGS_MODULE = app.settings


### PR DESCRIPTION
Msgpack is used to serialize data sent from the dd-trace-py to the agent. Serialization happens via the Encoder object that makes use of msgpack if the CPP implementation is available.

The current state is:
- check the msgpack decoder (https://github.com/DataDog/dd-trace-py/blob/master/ddtrace/encoding.py#L76) when it uses use_bin_type
- generally speaking, we should always use the use_bin_type (performance reasons) that is False by default in msgpack 0.4.x
- newer implementation of msgpack will have use_bin_type set to True by default
the issue is related to using a msgpack version < 0.4.0 where the use_bin_type kwarg is not available.

What we should do is:
- be sure that it could work even for msgpack 0.3.0 (early versions may be ignored)
be sure that use_bin_type is always set to True when it's available; removing the keyword is not an option
