### PR TITLE
code factorising _unwrap

### DIFF
--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -1,6 +1,7 @@
 import wrapt
 
 from ...pin import Pin
+from ddtrace.util import unwrap
 
 
 try:
@@ -35,10 +36,4 @@ def unpatch():
     if template_module:
         if getattr(aiohttp_jinja2, '__datadog_patch', False):
             setattr(aiohttp_jinja2, '__datadog_patch', False)
-            _unwrap(aiohttp_jinja2, 'render_template')
-
-
-def _unwrap(obj, attr):
-    f = getattr(obj, attr, None)
-    if f and isinstance(f, wrapt.ObjectProxy) and hasattr(f, '__wrapped__'):
-        setattr(obj, attr, f.__wrapped__)
+            unwrap(aiohttp_jinja2, 'render_template')

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -5,6 +5,7 @@ from elasticsearch.exceptions import TransportError
 from . import metadata
 from .quantize import quantize
 
+from ddtrace.util import unwrap
 from ...compat import urlencode
 from ...pin import Pin
 from ...ext import http
@@ -27,14 +28,7 @@ def patch():
 def unpatch():
     if getattr(elasticsearch, '_datadog_patch', False):
         setattr(elasticsearch, '_datadog_patch', False)
-        _unwrap(elasticsearch.transport.Transport, 'perform_request')
-
-
-def _unwrap(obj, attr):
-    f = getattr(obj, attr, None)
-    if f and isinstance(f, wrapt.ObjectProxy) and hasattr(f, '__wrapped__'):
-        setattr(obj, attr, f.__wrapped__)
-
+        unwrap(elasticsearch.transport.Transport, 'perform_request')
 
 def _perform_request(func, instance, args, kwargs):
     pin = Pin.get_from(instance)

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -6,6 +6,7 @@ import wrapt
 # project
 from ddtrace import Pin
 from ddtrace.ext import redis as redisx
+from ddtrace.util import unwrap
 from .util import format_command_args, _extract_conn_tags
 
 
@@ -30,18 +31,11 @@ def patch():
 def unpatch():
     if getattr(redis, '_datadog_patch', False):
         setattr(redis, '_datadog_patch', False)
-        _unwrap(redis.StrictRedis, 'execute_command')
-        _unwrap(redis.StrictRedis, 'pipeline')
-        _unwrap(redis.Redis, 'pipeline')
-        _unwrap(redis.client.BasePipeline, 'execute')
-        _unwrap(redis.client.BasePipeline, 'immediate_execute_command')
-
-
-def _unwrap(obj, attr):
-    f = getattr(obj, attr, None)
-    if f and isinstance(f, wrapt.ObjectProxy) and hasattr(f, '__wrapped__'):
-        setattr(obj, attr, f.__wrapped__)
-
+        unwrap(redis.StrictRedis, 'execute_command')
+        unwrap(redis.StrictRedis, 'pipeline')
+        unwrap(redis.Redis, 'pipeline')
+        unwrap(redis.client.BasePipeline, 'execute')
+        unwrap(redis.client.BasePipeline, 'immediate_execute_command')
 
 #
 # tracing functions


### PR DESCRIPTION
All contribs  needing an `_unwrap` method had it written in there patch.py.
For boto/botocore I had already set them to call `unwrap` from ddtrace.util, quick fix so that the other contribs (aiohttp/elasticsearch/redis) are also refactored. The others don't use this function