### PR TITLE
[presampler] Adding X-Datadog-Trace-Count header

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -1,7 +1,6 @@
 # stdlib
 import logging
 import time
-import copy
 
 # project
 from .encoding import get_encoder, JSONEncoder
@@ -80,7 +79,7 @@ class API(object):
 
         headers = self._headers
         if count:
-            headers = copy.copy(self._headers)
+            headers = dict(self._headers)
             headers[TRACE_COUNT_HEADER] = str(count)
 
         conn.request("PUT", endpoint, data, headers)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -36,9 +36,9 @@ class FlawedAPI(API):
     """
     Deliberately report data with an incorrect method to trigger a 4xx response
     """
-    def _put(self, endpoint, data):
+    def _put(self, endpoint, data, count=0):
         conn = httplib.HTTPConnection(self.hostname, self.port)
-        conn.request("HEAD", endpoint, data, self._headers)
+        conn.request('HEAD', endpoint, data, self._headers)
         return conn.getresponse()
 
 


### PR DESCRIPTION
Pre-sampling on the agent side requires this header to be here,
to know how many traces are in the payload without decoding the
payload for real.