### PR TITLE
[mysql] distinguish mysql-python instrumentation

### DIFF
--- a/ddtrace/contrib/mysql/__init__.py
+++ b/ddtrace/contrib/mysql/__init__.py
@@ -26,6 +26,17 @@ https://dev.mysql.com/doc/connector-python/en/
 """
 from ..util import require_modules
 
+# check `MySQL-python` availability
+required_modules = ['_mysql']
+
+with require_modules(required_modules) as missing_modules:
+    if not missing_modules:
+        # MySQL python package is not supported at the moment;
+        # here we raise an import error so that the external
+        # loader knows that the integration is not available
+        raise ImportError('No module named mysql-python')
+
+# check `mysql-connector` availability
 required_modules = ['mysql.connector']
 
 with require_modules(required_modules) as missing_modules:


### PR DESCRIPTION
### What it does

The current `mysql` integration supports only `mysql-connector` package. Other libraries such as `MySQL-Python`, must be handled differently. However, the current integration loader ( available in the `monkey` module) doesn't give the right feedback to developers, and indeed the error output is misleading.

#### Testing the loader
```
import logging

logger = logging.getLogger()
logger.setLevel(logging.DEBUG)

from ddtrace import patch, patch_all
patch_all()
```
The library `MySQL-Python` is installed in the environment so `patch_all()` should not find this integration.

**Before the patch**
```
DEBUG:root:failed to patch mysql: module not installed
```
It seems that `mysql` is not installed while it is.

**After the patch**
```
DEBUG:root:failed to patch mysql: integration not available
```
The integration `mysql` is not available for this package.