### PR TITLE
[mysql] use a logging message instead of an ImportError

### DIFF
--- a/ddtrace/contrib/mysql/__init__.py
+++ b/ddtrace/contrib/mysql/__init__.py
@@ -24,6 +24,8 @@ provided by _mysql_connector, is not supported yet.
 Help on mysql.connector can be found on:
 https://dev.mysql.com/doc/connector-python/en/
 """
+import logging
+
 from ..util import require_modules
 
 # check `MySQL-python` availability
@@ -31,10 +33,8 @@ required_modules = ['_mysql']
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        # MySQL python package is not supported at the moment;
-        # here we raise an import error so that the external
-        # loader knows that the integration is not available
-        raise ImportError('No module named mysql-python')
+        # MySQL-python package is not supported at the moment
+        logging.debug('failed to patch mysql-python: integration not available')
 
 # check `mysql-connector` availability
 required_modules = ['mysql.connector']


### PR DESCRIPTION
### What it does

Uses a `logging.debug` instead of the loader exception handler. This allows to have both mysql connectors in the Python environment. Only `mysql-connector` will be used.

### Testing both libraries

Having `mysql-python` and `mysql-connector` installed in the same environment:

**Before the patch**
```
DEBUG:root:failed to patch mysql: integration not available
INFO:root:patched 1/11 modules (sqlite3)
```

**After the patch**
```
DEBUG:root:failed to patch mysql-python: integration not available
INFO:root:patched 2/11 modules (mysql,sqlite3)
```

### Testing mysql-python

Having only `mysql-python` installed in the environment:

**Before the patch**
```
DEBUG:root:failed to patch mysql: integration not available
INFO:root:patched 1/11 modules (sqlite3)
```

**After the patch**
```
DEBUG:root:failed to patch mysql-python: integration not available
DEBUG:root:failed to patch mysql: module not installed
INFO:root:patched 1/11 modules (sqlite3)
```