### PR TITLE
pylons: catch BaseException since a SystemExit might've been raised.

### DIFF
--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -38,7 +38,7 @@ class PylonsTraceMiddleware(object):
 
             try:
                 return self.app(environ, _start_response)
-            except Exception as e:
+            except BaseException as e:
                 # "unexpected errors"
                 # exc_info set by __exit__ on current tracer
                 span.set_tag(http.STATUS_CODE, getattr(e, 'code', 500))


### PR DESCRIPTION
This happens if the request triggers a timeout for example. In that case, no `http_status` tag is set on the span.