### PR TITLE
pyramid: catch BaseException since a SystemExit might've been raised.

### DIFF
--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -52,7 +52,7 @@ def trace_tween_factory(handler, registry):
                 response = None
                 try:
                     response = handler(request)
-                except Exception:
+                except BaseException:
                     span.set_tag(http.STATUS_CODE, 500)
                     raise
                 finally:


### PR DESCRIPTION
This happens if the request triggers a timeout for example. In that case, no `http_status` tag is set on the span.