### PR TITLE
pylons: in case of SystemExit, set HTTP status code to 500.

### DIFF
--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -38,10 +38,14 @@ class PylonsTraceMiddleware(object):
 
             try:
                 return self.app(environ, _start_response)
-            except BaseException as e:
+            except Exception as e:
                 # "unexpected errors"
                 # exc_info set by __exit__ on current tracer
                 span.set_tag(http.STATUS_CODE, getattr(e, 'code', 500))
+                span.error = 1
+                raise
+            except SystemExit:
+                span.set_tag(http.STATUS_CODE, 500)
                 span.error = 1
                 raise
             finally:


### PR DESCRIPTION
9569c72 fixes the issue with missing hHTTP status code, but `getattr(e, 'code', 500))` returns 1 on SystemExit exceptions. This commit makes sure it is set to 500.