### PR TITLE
[docs] fix Pylons and monkey.py docstrings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -93,14 +93,6 @@ task :docs do
   end
 end
 
-task :'docs:loop' do
-  # FIXME do something real here
-  while true do
-    sleep 2
-    Rake::Task["docs"].execute
-  end
-end
-
 # Deploy tasks
 S3_BUCKET = 'pypi.datadoghq.com'
 S3_DIR = ENV['S3_DIR']

--- a/ddtrace/contrib/pylons/__init__.py
+++ b/ddtrace/contrib/pylons/__init__.py
@@ -15,8 +15,16 @@ the following::
 Then you can define your routes and views as usual.
 """
 
-from .middleware import PylonsTraceMiddleware
-from .patch import patch
+from ..util import require_modules
 
+required_modules = ['pylons.wsgiapp']
 
-__all__ = ['PylonsTraceMiddleware', 'patch']
+with require_modules(required_modules) as missing_modules:
+    if not missing_modules:
+        from .middleware import PylonsTraceMiddleware
+        from .patch import patch
+
+        __all__ = [
+            'patch',
+            'PylonsTraceMiddleware',
+        ]

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -48,12 +48,11 @@ class PatchException(Exception):
 
 
 def patch_all(**patch_modules):
-    """ Automatically patches all available modules.
+    """Automatically patches all available modules.
 
-    :param dict **patch_modules: Override whether particular modules
-            are patched or not.
+    :param dict \**patch_modules: Override whether particular modules are patched or not.
 
-    >>> patch_all({'redis': False, 'cassandra': False})
+        >>> patch_all({'redis': False, 'cassandra': False})
     """
     modules = PATCH_MODULES.copy()
     modules.update(patch_modules)
@@ -61,11 +60,12 @@ def patch_all(**patch_modules):
     patch(raise_errors=False, **modules)
 
 def patch(raise_errors=True, **patch_modules):
-    """ Patch a set of given modules
+    """Patch only a set of given modules.
 
     :param bool raise_errors: Raise error if one patch fail.
-    :param dict **patch_modules: List of modules to patch.
-        Example: {'psycopg': True, 'elasticsearch': True}
+    :param dict \**patch_modules: List of modules to patch.
+
+        >>> patch({'psycopg': True, 'elasticsearch': True})
     """
     modules = [m for (m, should_patch) in patch_modules.items() if should_patch]
     count = 0

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -182,13 +182,14 @@ class Tracer(object):
         You must call `finish` on all spans, either directly or with a context
         manager::
 
-        >>> span = tracer.trace("web.request")
-            try:
-                # do something
-            finally:
-                span.finish()
-        >>> with tracer.trace("web.request") as span:
-                # do something
+            >>> span = tracer.trace("web.request")
+                try:
+                    # do something
+                finally:
+                    span.finish()
+
+            >>> with tracer.trace("web.request") as span:
+                    # do something
 
         Trace will store the current active span and subsequent child traces will
         become its children::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -314,6 +314,8 @@ API
 
 .. autofunction:: ddtrace.monkey.patch_all
 
+.. autofunction:: ddtrace.monkey.patch
+
 .. toctree::
    :maxdepth: 2
 

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ deps =
     contrib: blinker
     contrib: bottle
     contrib: boto
-    contrib: moto
+    contrib: moto<1.0
     contrib: botocore
     contrib: cassandra-driver
     contrib: celery
@@ -101,9 +101,9 @@ deps =
     aiohttp_jinja013: aiohttp_jinja2>=0.13,<0.14
     blinker: blinker
     boto: boto
-    boto: moto
+    boto: moto<1.0
     botocore: botocore
-    botocore: moto
+    botocore: moto<1.0
     bottle12: bottle>=0.12
     bottle-autopatch12: bottle>=0.12
     cassandra35: cassandra-driver>=3.5,<3.6


### PR DESCRIPTION
### What it does

* fixes `pylons` documentation because it's not built in the current master. `pylons` was imported when building the doc from the docstring:
```
/home/ubuntu/dd-trace-py/docs/index.rst:138: WARNING: autodoc: failed to import module u'ddtrace.contrib.pylons'; the following exception was raised:
Traceback (most recent call last):
  File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/sphinx/ext/autodoc.py", line 551, in import_object
    __import__(self.modname)
  File "/home/ubuntu/dd-trace-py/ddtrace/contrib/pylons/__init__.py", line 19, in <module>
    from .patch import patch
  File "/home/ubuntu/dd-trace-py/ddtrace/contrib/pylons/patch.py", line 9, in <module>
    import pylons.wsgiapp
ImportError: No module named pylons.wsgiapp
```

* fixes also minor warnings and errors when building other modules:
```
/home/ubuntu/dd-trace-py/ddtrace/tracer.py:docstring of ddtrace.Tracer.trace:15: ERROR: Unexpected indentation.
/home/ubuntu/dd-trace-py/ddtrace/tracer.py:docstring of ddtrace.Tracer.trace:19: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/ubuntu/dd-trace-py/ddtrace/monkey.py:docstring of ddtrace.monkey.patch_all:3: WARNING: Inline strong start-string without end-string.
```

* adds the documentation for the `patch()` method