### PR TITLE
[ci] pin moto library version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ deps =
     contrib: blinker
     contrib: bottle
     contrib: boto
-    contrib: moto
+    contrib: moto<1.0
     contrib: botocore
     contrib: cassandra-driver
     contrib: celery
@@ -101,9 +101,9 @@ deps =
     aiohttp_jinja013: aiohttp_jinja2>=0.13,<0.14
     blinker: blinker
     boto: boto
-    boto: moto
+    boto: moto<1.0
     botocore: botocore
-    botocore: moto
+    botocore: moto<1.0
     bottle12: bottle>=0.12
     bottle-autopatch12: bottle>=0.12
     cassandra35: cassandra-driver>=3.5,<3.6


### PR DESCRIPTION
### What it does

`moto` version 1.0.0+ introduces a breaking change so that all moto decorator stops working. This patch pin the library to the latest working version.