### PR TITLE
[flask] avoid using weak references when instrumented via Blinker

### DIFF
--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -84,7 +84,11 @@ class TraceMiddleware(object):
                 connected = False
                 log.warn("trying to instrument missing signal %s", name)
                 continue
-            s.connect(handler, sender=self.app)
+            # we should connect to the signal without using weak references
+            # otherwise they will be garbage collected and our handlers
+            # will be disconnected after the first call; for more details check:
+            # https://github.com/jek/blinker/blob/207446f2d97/blinker/base.py#L106-L108
+            s.connect(handler, sender=self.app, weak=False)
             self._receivers.append(handler)
         return connected
 

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -1,11 +1,11 @@
 import os
+import flask
+import wrapt
 
-from .middleware import TraceMiddleware
 from ddtrace import tracer
 
-import flask
+from .middleware import TraceMiddleware
 
-import wrapt
 
 def patch():
     """Patch the instrumented Flask object
@@ -16,11 +16,9 @@ def patch():
     setattr(flask, '_datadog_patch', True)
     wrapt.wrap_function_wrapper('flask', 'Flask.__init__', traced_init)
 
+
 def traced_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
 
-    service = os.environ.get("DATADOG_SERVICE_NAME") or "flask"
-    traced_app = TraceMiddleware(instance, tracer, service=service)
-
-    # Keep a reference to our blinker signal receivers to prevent them from being garbage collected
-    setattr(instance, '_datadog_receivers', traced_app._receivers)
+    service = os.environ.get('DATADOG_SERVICE_NAME') or 'flask'
+    TraceMiddleware(instance, tracer, service=service)

--- a/tests/contrib/flask/test_signals.py
+++ b/tests/contrib/flask/test_signals.py
@@ -1,0 +1,57 @@
+import gc
+
+from unittest import TestCase
+from nose.tools import eq_
+
+from ddtrace.contrib.flask import TraceMiddleware
+from ...test_tracer import get_dummy_tracer
+
+from flask import Flask
+
+
+class FlaskBlinkerCase(TestCase):
+    """Ensures that the integration between Flask and Blinker
+    to trace Flask endpoints works as expected
+    """
+    def get_app(self):
+        """Creates a new Flask App"""
+        app = Flask(__name__)
+
+        # add testing routes here
+        @app.route('/')
+        def index():
+            return 'Hello world!'
+
+        return app
+
+    def setUp(self):
+        # initialize a traced app with a dummy tracer
+        app = self.get_app()
+        self.tracer = get_dummy_tracer()
+        self.traced_app = TraceMiddleware(app, self.tracer)
+
+        # make the app testable
+        app.config['TESTING'] = True
+        self.app = app.test_client()
+
+    def test_signals_without_weak_references(self):
+        # it should work when the traced_app reference is not
+        # stored by the user and the garbage collection starts
+        self.traced_app = None
+        gc.collect()
+
+        r = self.app.get('/')
+        eq_(r.status_code, 200)
+
+        traces = self.tracer.writer.pop_traces()
+        eq_(len(traces), 1)
+        eq_(len(traces[0]), 1)
+
+        span = traces[0][0]
+        eq_(span.service, 'flask')
+        eq_(span.name, 'flask.request')
+        eq_(span.span_type, 'http')
+        eq_(span.resource, 'index')
+        eq_(span.get_tag('http.status_code'), '200')
+        eq_(span.get_tag('http.url'), 'http://localhost/')
+        eq_(span.error, 0)


### PR DESCRIPTION
### What it does

When connecting to a signal, Blinker stores by default a weak reference that may be removed when it goes out of scope or it is garbage collected.

In many Flask application it's reasonable that the `traced_app` shown in our examples, is not stored somewhere and so the object will be lost (and so our signals) during a garbage collection. If that happens, Blinker signals are automatically disconnected and Flask will not be instrumented.

This PR avoids using weak references through the `weak=False` kwarg.