### PR TITLE
Add http method to flask

### DIFF
--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -111,6 +111,7 @@ class TraceMiddleware(object):
             if span.sampled:
                 error = 0
                 code = response.status_code if response else None
+                method = request.method if response else None
 
                 # if we didn't get a response, but we did get an exception, set
                 # codes accordingly.
@@ -126,6 +127,7 @@ class TraceMiddleware(object):
                 span.resource = compat.to_unicode(resource).lower()
                 span.set_tag(http.URL, compat.to_unicode(request.base_url or ''))
                 span.set_tag(http.STATUS_CODE, code)
+                span.set_tag(http.METHOD, method)
                 span.error = error
             span.finish()
             # Clear our span just in case.

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -111,7 +111,7 @@ class TraceMiddleware(object):
             if span.sampled:
                 error = 0
                 code = response.status_code if response else None
-                method = request.method if response else None
+                method = request.method if request else None
 
                 # if we didn't get a response, but we did get an exception, set
                 # codes accordingly.

--- a/tests/contrib/flask/test_flask.py
+++ b/tests/contrib/flask/test_flask.py
@@ -153,6 +153,7 @@ class TestFlask(object):
         assert s.duration <= end - start
         eq_(s.error, 0)
         eq_(s.meta.get(http.STATUS_CODE), '200')
+        eq_(s.meta.get(http.METHOD), 'GET')
 
         services = writer.pop_services()
         expected = {
@@ -181,6 +182,7 @@ class TestFlask(object):
         assert s.duration <= end - start
         eq_(s.error, 0)
         eq_(s.meta.get(http.STATUS_CODE), '200')
+        eq_(s.meta.get(http.METHOD), 'GET')
 
         t = by_name["flask.template"]
         eq_(t.get_tag("flask.template"), "test.html")
@@ -278,6 +280,7 @@ class TestFlask(object):
         assert s.duration <= end - start
         eq_(s.error, 0)
         eq_(s.meta.get(http.STATUS_CODE), '200')
+        eq_(s.meta.get(http.METHOD), 'GET')
         eq_(s.meta.get(http.URL), u'http://localhost/üŋïĉóđē')
 
     def test_404(self):
@@ -299,4 +302,5 @@ class TestFlask(object):
         assert s.duration <= end - start
         eq_(s.error, 0)
         eq_(s.meta.get(http.STATUS_CODE), '404')
+        eq_(s.meta.get(http.METHOD), 'GET')
         eq_(s.meta.get(http.URL), u'http://localhost/404/üŋïĉóđē')

--- a/tests/contrib/flask/test_flask.py
+++ b/tests/contrib/flask/test_flask.py
@@ -212,6 +212,7 @@ class TestFlask(object):
         assert s.duration <= end - start
         eq_(s.error, 1)
         eq_(s.meta.get(http.STATUS_CODE), '500')
+        eq_(s.meta.get(http.METHOD), 'GET')
 
     def test_error(self):
         start = time.time()
@@ -232,6 +233,7 @@ class TestFlask(object):
         assert s.start >= start
         assert s.duration <= end - start
         eq_(s.meta.get(http.STATUS_CODE), '500')
+        eq_(s.meta.get(http.METHOD), 'GET')
 
     def test_fatal(self):
         if not traced_app.use_signals:
@@ -256,6 +258,7 @@ class TestFlask(object):
         assert s.start >= start
         assert s.duration <= end - start
         eq_(s.meta.get(http.STATUS_CODE), '500')
+        eq_(s.meta.get(http.METHOD), 'GET')
         assert "ZeroDivisionError" in s.meta.get(errors.ERROR_TYPE)
         msg = s.meta.get(errors.ERROR_MSG)
         assert "by zero" in msg, msg


### PR DESCRIPTION
Flask integration doesn't add the http.method (GET, POST, etc...) in the flask.request span.
This PR adds the http method to flask spans.
