### PR TITLE
[logging] use specific logger instead of the root one

### DIFF
--- a/ddtrace/contrib/mysql/__init__.py
+++ b/ddtrace/contrib/mysql/__init__.py
@@ -28,13 +28,16 @@ import logging
 
 from ..util import require_modules
 
+
+log = logging.getLogger(__name__)
+
 # check `MySQL-python` availability
 required_modules = ['_mysql']
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
         # MySQL-python package is not supported at the moment
-        logging.debug('failed to patch mysql-python: integration not available')
+        log.debug('failed to patch mysql-python: integration not available')
 
 # check `mysql-connector` availability
 required_modules = ['mysql.connector']

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -11,6 +11,8 @@ import importlib
 import threading
 
 
+log = logging.getLogger(__name__)
+
 # Default set of modules to automatically patch or not
 PATCH_MODULES = {
     'boto': False,
@@ -74,7 +76,7 @@ def patch(raise_errors=True, **patch_modules):
         if patched:
             count += 1
 
-    logging.info("patched %s/%s modules (%s)",
+    log.info("patched %s/%s modules (%s)",
         count,
         len(modules),
         ",".join(get_patched_modules()))
@@ -90,7 +92,7 @@ def patch_module(module, raise_errors=True):
     except Exception as exc:
         if raise_errors:
             raise
-        logging.debug("failed to patch %s: %s", module, exc)
+        log.debug("failed to patch %s: %s", module, exc)
         return False
 
 def get_patched_modules():
@@ -107,7 +109,7 @@ def _patch_module(module):
     path = 'ddtrace.contrib.%s' % module
     with _LOCK:
         if module in _PATCHED_MODULES:
-            logging.debug("already patched: %s", path)
+            log.debug("already patched: %s", path)
             return False
 
         try:


### PR DESCRIPTION
### What it does

Closes #280 

Uses `logging.getLogger(__name__)` everywhere instead of using the root logger.

**Testing code**
```python
import logging
logging.basicConfig(level=logging.DEBUG)

from ddtrace import patch, patch_all
patch_all(fake_integration=True)
```

**Output**
```
DEBUG:ddtrace.encoding:using Msgpack encoder
DEBUG:ddtrace.writer:resetting queues. pids(old:None new:42)
DEBUG:ddtrace.writer:starting flush thread
DEBUG:ddtrace.monkey:failed to patch fake_integration: integration not available
DEBUG:ddtrace.monkey:failed to patch mongoengine: module not installed
INFO:ddtrace.monkey:patched 10/12 modules (aiohttp,cassandra,celery,elasticsearch,mysql,psycopg,pylibmc,pymongo,redis,sqlite3)
```