### PR TITLE
Add graphql tracing support

### DIFF
--- a/ddtrace/contrib/graphql/__init__.py
+++ b/ddtrace/contrib/graphql/__init__.py
@@ -1,0 +1,20 @@
+"""
+"""
+
+
+from ..util import require_modules
+
+required_modules = ['graphql']
+
+with require_modules(required_modules) as missing_modules:
+    if not missing_modules:
+        from .patch import (
+            TracedGraphQLSchema,
+            patch, unpatch, traced_graphql,
+            TYPE, SERVICE, QUERY, ERRORS, INVALID, RES
+        )
+        __all__ = [
+            'TracedGraphQLSchema',
+            'patch', 'unpatch', 'traced_graphql',
+            'TYPE', 'SERVICE', 'QUERY', 'ERRORS', 'INVALID', 'RES'
+        ]

--- a/ddtrace/contrib/graphql/__init__.py
+++ b/ddtrace/contrib/graphql/__init__.py
@@ -1,4 +1,18 @@
 """
+To trace all GraphQL requests, patch the library like so::
+
+    from ddtrace.contrib.graphql import patch
+    patch()
+
+    from graphql import graphql
+    result = graphql(schema, query)
+
+
+If you do not want to monkeypatch ``graphql.graphql`` function or want to trace
+only certain calls you can use the ``traced_graphql`` function::
+
+    from ddtrace.contrib.graphql import traced_graphql
+    traced_graphql(schema, query)
 """
 
 

--- a/ddtrace/contrib/graphql/patch.py
+++ b/ddtrace/contrib/graphql/patch.py
@@ -1,0 +1,95 @@
+"""
+Tracing for the graphql-core library.
+
+https://github.com/graphql-python/graphql-core
+"""
+
+# stdlib
+import sys
+import logging
+
+# 3p
+import wrapt
+import graphql
+from graphql.language.ast import Document
+
+# project
+import ddtrace
+from ddtrace.util import unwrap
+
+
+logger = logging.getLogger(__name__)
+
+_graphql = graphql.graphql
+
+TYPE = 'graphql'
+SERVICE = 'graphql'
+QUERY = 'graphql.query'
+ERRORS = 'graphql.errors'
+INVALID = 'graphql.invalid'
+RES = 'graphql.graphql'
+
+
+class TracedGraphQLSchema(graphql.GraphQLSchema):
+    def __init__(self, *args, **kwargs):
+        if 'datadog_tracer' in kwargs:
+            self.datadog_tracer = kwargs.pop('datadog_tracer')
+            logger.debug(
+                'For schema %s using own tracer %s',
+                self, self.datadog_tracer)
+        super(TracedGraphQLSchema, self).__init__(*args, **kwargs)
+
+
+def patch():
+    """Monkeypatch the graphql-core library to trace graphql calls execution."""
+    logger.debug('Patching `graphql.graphql` function.')
+    wrapt.wrap_function_wrapper(graphql, 'graphql', _traced_graphql)
+
+
+def unpatch():
+    logger.debug('Unpatching `graphql.graphql` function.')
+    unwrap(graphql, 'graphql')
+
+
+def _traced_graphql(func, _, args, kwargs):
+    """Wrapper for graphql.graphql function."""
+
+    schema = args[0]
+
+    # get the query as a string
+    if len(args) > 1:
+        request_string = args[1]
+    else:
+        request_string = kwargs.get('request_string')
+
+    if isinstance(request_string, Document):
+        query = request_string.loc.source.body
+    else:
+        query = request_string
+
+    # allow schamas their own tracer with fallback to the global
+    tracer = getattr(schema, 'datadog_tracer', ddtrace.tracer)
+
+    if not tracer.enabled:
+        return func(*args, **kwargs)
+
+    with tracer.trace(RES, span_type=TYPE, service=SERVICE,) as span:
+        span.set_tag(QUERY, query)
+        result = None
+        try:
+            result = func(*args, **kwargs)
+            return result
+        finally:
+            # `span.error` must be integer
+            span.error = int(result is None or result.invalid)
+            if result is not None:
+                span.set_tag(ERRORS, result.errors)
+                span.set_tag(INVALID, result.invalid)
+            else:
+                logger.debug(
+                    'Uncaught exception occured during graphql execution.',
+                    exc_info=True)
+
+
+def traced_graphql(*args, **kwargs):
+    return _traced_graphql(_graphql, None, args, kwargs)

--- a/ddtrace/contrib/graphql/patch.py
+++ b/ddtrace/contrib/graphql/patch.py
@@ -5,7 +5,6 @@ https://github.com/graphql-python/graphql-core
 """
 
 # stdlib
-import sys
 import logging
 
 # 3p

--- a/ddtrace/contrib/graphql/patch.py
+++ b/ddtrace/contrib/graphql/patch.py
@@ -84,10 +84,6 @@ def _traced_graphql(func, _, args, kwargs):
             if result is not None:
                 span.set_tag(ERRORS, result.errors)
                 span.set_metric(INVALID, int(result.invalid))
-            else:
-                logger.debug(
-                    'Uncaught exception occurred during graphql execution.',
-                    exc_info=True)
 
 
 def traced_graphql(*args, **kwargs):

--- a/ddtrace/contrib/graphql/patch.py
+++ b/ddtrace/contrib/graphql/patch.py
@@ -83,7 +83,7 @@ def _traced_graphql(func, _, args, kwargs):
             span.error = int(result is None or result.invalid)
             if result is not None:
                 span.set_tag(ERRORS, result.errors)
-                span.set_tag(INVALID, result.invalid)
+                span.set_metric(INVALID, int(result.invalid))
             else:
                 logger.debug(
                     'Uncaught exception occured during graphql execution.',

--- a/ddtrace/contrib/graphql/patch.py
+++ b/ddtrace/contrib/graphql/patch.py
@@ -66,7 +66,7 @@ def _traced_graphql(func, _, args, kwargs):
     else:
         query = request_string
 
-    # allow schamas their own tracer with fallback to the global
+    # allow schemas their own tracer with fall-back to the global
     tracer = getattr(schema, 'datadog_tracer', ddtrace.tracer)
 
     if not tracer.enabled:
@@ -86,7 +86,7 @@ def _traced_graphql(func, _, args, kwargs):
                 span.set_metric(INVALID, int(result.invalid))
             else:
                 logger.debug(
-                    'Uncaught exception occured during graphql execution.',
+                    'Uncaught exception occurred during graphql execution.',
                     exc_info=True)
 
 

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -28,6 +28,7 @@ PATCH_MODULES = {
     'pylibmc': True,
     'pymongo': True,
     'redis': True,
+    'graphql': True,
     'requests': False,  # Not ready yet
     'sqlalchemy': False,  # Prefer DB client instrumentation
     'sqlite3': True,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -195,6 +195,11 @@ Cassandra
 
 .. automodule:: ddtrace.contrib.cassandra
 
+Celery
+~~~~~~
+
+.. automodule:: ddtrace.contrib.celery
+
 Elasticsearch
 ~~~~~~~~~~~~~
 
@@ -205,10 +210,11 @@ Flask Cache
 
 .. automodule:: ddtrace.contrib.flask_cache
 
-Celery
-~~~~~~
+GraphQL
+~~~~~~~
 
-.. automodule:: ddtrace.contrib.celery
+.. automodule:: ddtrace.contrib.graphql
+
 
 MongoDB
 ~~~~~~~

--- a/tests/contrib/graphql/test_graphql.py
+++ b/tests/contrib/graphql/test_graphql.py
@@ -1,0 +1,64 @@
+# 3p
+from nose.tools import eq_, assert_raises
+from graphql import (
+    GraphQLSchema,
+    GraphQLObjectType,
+    GraphQLField,
+    GraphQLString
+)
+import graphql
+
+# project
+from ddtrace.ext import errors
+from tests.test_tracer import get_dummy_tracer
+import ddtrace
+from ddtrace.contrib.graphql import patch, unpatch, QUERY, TracedGraphQLSchema, traced_graphql
+
+
+
+class TestGraphQL(object):
+
+    @staticmethod
+    def test_query():
+        patch()
+        tracer = get_dummy_tracer()
+        schema = TracedGraphQLSchema(
+          query= GraphQLObjectType(
+            name='RootQueryType',
+            fields={
+              'hello': GraphQLField(
+                type= GraphQLString,
+                resolver=lambda *_: 'world'
+              )
+            }
+          ),
+          datadog_tracer=tracer,
+        )
+        query = '{ hello world }'
+        result = graphql.graphql(schema, query)
+        # assert result.data['hello'] == 'world'
+        spans = tracer.writer.pop()
+        eq_(len(spans), 1)
+        s = spans[0]
+        eq_(s.get_tag(QUERY), query)
+        eq_(s.error, 1)
+
+        unpatch()
+        tracer = get_dummy_tracer()
+        schema = TracedGraphQLSchema(
+          query= GraphQLObjectType(
+            name='RootQueryType',
+            fields={
+              'hello': GraphQLField(
+                type= GraphQLString,
+                resolver=lambda *_: 'world'
+              )
+            }
+          ),
+          datadog_tracer=tracer,
+        )
+        query = '{ hello }'
+        result = graphql.graphql(schema, query)
+        spans = tracer.writer.pop()
+        assert result.data['hello'] == 'world'
+        eq_(len(spans), 0)

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ envlist =
     {py27,py34,py35,py36}-redis{26,27,28,29,210}
     {py27,py34,py35,py36}-sqlite3
     {py27,py34}-msgpack{03,04}
+    {py27,py34,py35,py36}-graphql
 
 [testenv]
 basepython =
@@ -78,6 +79,7 @@ deps =
     contrib: falcon
     contrib: flask
     contrib: flask_cache
+    contrib: graphql-core
     contrib: msgpack-python
     contrib: mongoengine
 # mysql-connector 2.2+ requires a protobuf configuration
@@ -103,6 +105,7 @@ deps =
     aiohttp20: aiohttp>=2.0,<2.1
     aiohttp21: aiohttp>=2.1,<2.2
     aiohttp22: aiohttp>=2.2,<2.3
+    graphql: graphql-core
     tornado40: tornado>=4.0,<4.1
     tornado41: tornado>=4.1,<4.2
     tornado42: tornado>=4.2,<4.3
@@ -239,6 +242,7 @@ commands =
     redis{26,27,28,29,210}: nosetests {posargs} tests/contrib/redis
     sqlite3: nosetests {posargs} tests/contrib/sqlite3
     requests{200,208,209,210,211,212,213}: nosetests {posargs} tests/contrib/requests
+    graphql: nosetests {posargs} tests/contrib/graphql
     sqlalchemy{10,11}: nosetests {posargs} tests/contrib/sqlalchemy
     ddtracerun: nosetests {posargs} tests/commands/test_runner.py
     msgpack{03,04}: nosetests {posargs} tests/test_encoders.py


### PR DESCRIPTION
This PR adds support for tracing `graphql.graphql` from [graphql-core](https://github.com/graphql-python/graphql-core) library.
