### PR TITLE
[gevent] create a new Context when a new Greenlet is created

### DIFF
--- a/ddtrace/contrib/gevent/greenlet.py
+++ b/ddtrace/contrib/gevent/greenlet.py
@@ -2,6 +2,8 @@ import gevent
 
 from .provider import CONTEXT_ATTR
 
+from ...context import Context
+
 
 class TracedGreenlet(gevent.Greenlet):
     """
@@ -26,4 +28,8 @@ class TracedGreenlet(gevent.Greenlet):
 
         # the context is always available made exception of the main greenlet
         if ctx:
-            setattr(self, CONTEXT_ATTR, ctx)
+            # create a new context that inherits the current active span
+            new_ctx = Context()
+            new_ctx._sampled = ctx._sampled
+            new_ctx._current_span = ctx._current_span
+            setattr(self, CONTEXT_ATTR, new_ctx)


### PR DESCRIPTION
### Overview

Creates a new `Context` instance when a `Greenlet` is created so that the current active span (and the sampling) is propagated, while the hierarchy will be different for each one.

* In the previous approach, each `Greenlet` propagates the same `Context`, but this causes new greenlets to have the previous greenlets `Span` as a parent, instead of the common one.
* tests have been changed to represent the new state, so if we create 3 greenlets, 3 different traces will be generated