### PR TITLE
create settings to append database prefix name

### DIFF
--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -58,6 +58,7 @@ The available settings are:
   disabled even if present.
 * ``AGENT_HOSTNAME`` (default: ``localhost``): define the hostname of the trace agent.
 * ``AGENT_PORT`` (default: ``8126``): define the port of the trace agent.
+* ``DEFAULT_DATABASE_PREFIX`` (default: ``''``): set a prefix value to database services.
 """
 from ..util import require_modules
 

--- a/ddtrace/contrib/django/conf.py
+++ b/ddtrace/contrib/django/conf.py
@@ -22,13 +22,14 @@ from django.test.signals import setting_changed
 
 # List of available settings with their defaults
 DEFAULTS = {
-    'TRACER': 'ddtrace.tracer',
-    'DEFAULT_SERVICE': 'django',
-    'ENABLED': True,
-    'AUTO_INSTRUMENT': True,
     'AGENT_HOSTNAME': 'localhost',
     'AGENT_PORT': 8126,
+    'AUTO_INSTRUMENT': True,
+    'DEFAULT_DATABASE_PREFIX': '',
+    'DEFAULT_SERVICE': 'django',
+    'ENABLED': True,
     'TAGS': {},
+    'TRACER': 'ddtrace.tracer',
 }
 
 # List of settings that may be in string import notation.
@@ -77,9 +78,9 @@ class DatadogSettings(object):
 
         self.defaults = defaults or DEFAULTS
         if os.environ.get('DATADOG_ENV'):
-            self.defaults["TAGS"].update({"env": os.environ.get('DATADOG_ENV')})
+            self.defaults['TAGS'].update({'env': os.environ.get('DATADOG_ENV')})
         if os.environ.get('DATADOG_SERVICE_NAME'):
-            self.defaults["DEFAULT_SERVICE"] = os.environ.get('DATADOG_SERVICE_NAME')
+            self.defaults['DEFAULT_SERVICE'] = os.environ.get('DATADOG_SERVICE_NAME')
 
         self.import_strings = import_strings or IMPORT_STRINGS
 

--- a/tests/contrib/django/test_connection.py
+++ b/tests/contrib/django/test_connection.py
@@ -2,14 +2,18 @@ import time
 
 # 3rd party
 from nose.tools import eq_
-from django.test import TransactionTestCase
 from django.contrib.auth.models import User
-
-# project
-from ddtrace.tracer import Tracer
+from django.test import override_settings
 
 # testing
 from .utils import DjangoTraceTestCase
+
+
+NEW_SETTINGS = {
+    'TRACER': 'tests.contrib.django.utils.tracer',
+    'ENABLED': True,
+    'DEFAULT_DATABASE_PREFIX': 'my_prefix_db'
+}
 
 
 class DjangoConnectionTest(DjangoTraceTestCase):
@@ -36,3 +40,14 @@ class DjangoConnectionTest(DjangoTraceTestCase):
         eq_(span.get_tag('django.db.alias'), 'default')
         eq_(span.get_tag('sql.query'), 'SELECT COUNT(*) AS "__count" FROM "auth_user"')
         assert start < span.start < span.start + span.duration < end
+
+    @override_settings(DATADOG_TRACE=NEW_SETTINGS)
+    def test_should_append_database_prefix(self):
+        # trace a simple query
+        User.objects.count()
+
+        # tests
+        spans = self.tracer.writer.pop()
+        span = spans[0]
+
+        eq_(span.service, 'my_prefix_db-defaultdb')

--- a/tests/contrib/django/utils.py
+++ b/tests/contrib/django/utils.py
@@ -1,7 +1,5 @@
 # 3rd party
-from django.db import connections
 from django.test import TestCase
-from django.template import Template
 
 # project
 from ddtrace.tracer import Tracer

--- a/tests/contrib/django/utils.py
+++ b/tests/contrib/django/utils.py
@@ -27,7 +27,9 @@ class DjangoTraceTestCase(TestCase):
         # empty the tracer spans from previous operations
         # such as database creation queries
         self.tracer.writer.spans = []
+        self.tracer.writer.pop_traces()
 
     def tearDown(self):
         # empty the tracer spans from test operations
         self.tracer.writer.spans = []
+        self.tracer.writer.pop_traces()


### PR DESCRIPTION
# Why?

When I have many django projects with one database, all data goes to `defaultdb` service. 