### PR TITLE
[contrib:django] fixing django request resource when view is partial

### DIFF
--- a/ddtrace/contrib/util.py
+++ b/ddtrace/contrib/util.py
@@ -24,7 +24,9 @@ def func_name(f):
     """
     Return a human readable version of the function's name.
     """
-    return "%s.%s" % (f.__module__, getattr(f, '__name__', f.__class__.__name__))
+    if hasattr(f, '__module__'):
+        return "%s.%s" % (f.__module__, getattr(f, '__name__', f.__class__.__name__))
+    return getattr(f, '__name__', f.__class__.__name__)
 
 
 def module_name(instance):

--- a/tests/contrib/django/app/views.py
+++ b/tests/contrib/django/app/views.py
@@ -1,6 +1,9 @@
 """
 Class based views used for Django tests.
 """
+
+from functools import partial
+
 from django.http import HttpResponse
 from django.conf.urls import url
 
@@ -50,6 +53,11 @@ class FeedView(Feed):
     def item_description(self, item):
         return 'empty'
 
+partial_view = partial(function_view)
+
+# disabling flake8 test below, yes, declaring a func like this is bad, we know
+lambda_view = lambda : function_view()  # NOQA
+
 # use this url patterns for tests
 urlpatterns = [
     url(r'^users/$', UserList.as_view(), name='users-list'),
@@ -58,5 +66,7 @@ urlpatterns = [
     url(r'^fail-view/$', ForbiddenView.as_view(), name='forbidden-view'),
     url(r'^fn-view/$', function_view, name='fn-view'),
     url(r'^feed-view/$', FeedView(), name='feed-view'),
+    url(r'^partial-view/$', partial_view, name='partial-view'),
+    url(r'^lambda-view/$', lambda_view, name='lambda-view'),
     url(r'^error-500/$', error_500, name='error-500'),
 ]

--- a/tests/contrib/django/app/views.py
+++ b/tests/contrib/django/app/views.py
@@ -56,7 +56,7 @@ class FeedView(Feed):
 partial_view = partial(function_view)
 
 # disabling flake8 test below, yes, declaring a func like this is bad, we know
-lambda_view = lambda : function_view()  # NOQA
+lambda_view = lambda request: function_view(request)  # NOQA
 
 # use this url patterns for tests
 urlpatterns = [

--- a/tests/contrib/django/test_middleware.py
+++ b/tests/contrib/django/test_middleware.py
@@ -92,6 +92,34 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         eq_(span.get_tag('http.url'), '/feed-view/')
         eq_(span.resource, 'tests.contrib.django.app.views.FeedView')
 
+    def test_middleware_trace_partial_based_view(self):
+        # ensures that the internals are properly traced when using a function views
+        url = reverse('partial-view')
+        response = self.client.get(url)
+        eq_(response.status_code, 200)
+
+        # check for spans
+        spans = self.tracer.writer.pop()
+        eq_(len(spans), 1)
+        span = spans[0]
+        eq_(span.get_tag('http.status_code'), '200')
+        eq_(span.get_tag('http.url'), '/partial-view/')
+        eq_(span.resource, 'partial')
+
+    def test_middleware_trace_lambda_based_view(self):
+        # ensures that the internals are properly traced when using a function views
+        url = reverse('lambda-view')
+        response = self.client.get(url)
+        eq_(response.status_code, 200)
+
+        # check for spans
+        spans = self.tracer.writer.pop()
+        eq_(len(spans), 1)
+        span = spans[0]
+        eq_(span.get_tag('http.status_code'), '200')
+        eq_(span.get_tag('http.url'), '/lambda-view/')
+        eq_(span.resource, 'tests.contrib.django.app.views.<lambda>')
+
     @modify_settings(
         MIDDLEWARE={
             'remove': 'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/tests/contrib/test_utils.py
+++ b/tests/contrib/test_utils.py
@@ -1,7 +1,7 @@
 from nose.tools import eq_
 
 from ddtrace.contrib.util import func_name
-
+from functools import partial
 
 class SomethingCallable(object):
     """
@@ -30,6 +30,13 @@ def some_function():
     """
     return 'nothing'
 
+def minus(a,b):
+    return a - b
+
+minus_two = partial(minus, b=2) # partial funcs need special handling (no module)
+
+# disabling flake8 test below, yes, declaring a func like this is bad, we know
+plus_three = lambda x : x + 3  # NOQA
 
 class TestContrib(object):
     """
@@ -50,3 +57,9 @@ class TestContrib(object):
         eq_('tests.contrib.test_utils.add', func_name(f.add))
         eq_(42, f.answer())
         eq_('tests.contrib.test_utils.answer', func_name(f.answer))
+
+        eq_('tests.contrib.test_utils.minus', func_name(minus))
+        eq_(5, minus_two(7))
+        eq_('partial', func_name(minus_two))
+        eq_(10, plus_three(7))
+        eq_('tests.contrib.test_utils.<lambda>', func_name(plus_three))


### PR DESCRIPTION
In some cases, getting the module of a callable item does not make sense, and this breaks our instrumentation as we used this to set up the resource request (from the view `__module__.__name__`). This patch tries to provide reasonable defaults when `__module__` is not here. Additionally, has a tests for the `lambda` case, this one was not reported, but technically, it could expose the problem too.