### PR TITLE
Add process id in root spans metadata

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,11 @@ docker <https://www.docker.com/products/docker>`__ and
 `docker-compose <https://www.docker.com/products/docker-compose>`__
 using the instructions provided by your platform.
 
+The test suite requires also ``tox`` to be ran. You can install it with:
+
+::
+    $ pip install tox
+
 You can launch the test matrix using the following rake command:
 
 ::

--- a/ddtrace/ext/system.py
+++ b/ddtrace/ext/system.py
@@ -1,0 +1,5 @@
+"""
+Standard system tags
+"""
+
+PID = "system.pid"

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -1,12 +1,14 @@
 import functools
 import logging
 
+from .ext import system
 from .provider import DefaultContextProvider
 from .context import Context
 from .sampler import AllSampler
 from .writer import AgentWriter
 from .span import Span
 from . import compat
+from os import getpid
 
 
 log = logging.getLogger(__name__)
@@ -157,6 +159,7 @@ class Tracer(object):
                 resource=resource,
                 span_type=span_type,
             )
+            span.set_tag(system.PID, getpid())
             self.sampler.sample(span)
 
         # add common tags

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -4,6 +4,7 @@ import timeit
 from ddtrace import Tracer
 
 from .test_tracer import DummyWriter
+from os import getpid
 
 
 REPEAT = 10
@@ -72,7 +73,14 @@ def benchmark_tracer_wrap():
     result = timer.repeat(repeat=REPEAT, number=NUMBER)
     print("- method execution time: {:8.6f}".format(min(result)))
 
+def benchmark_getpid():
+    timer = timeit.Timer(getpid)
+    result = timer.repeat(repeat=REPEAT, number=NUMBER)
+    print("## getpid wrapper benchmark: {} loops ##".format(NUMBER))
+    print("- getpid execution time: {:8.6f}".format(min(result)))
+
 
 if __name__ == '__main__':
     benchmark_tracer_wrap()
     benchmark_tracer_trace()
+    benchmark_getpid()

--- a/tests/contrib/celery/test_task.py
+++ b/tests/contrib/celery/test_task.py
@@ -11,6 +11,7 @@ from ddtrace.contrib.celery.task import patch_task, unpatch_task
 
 from ..config import REDIS_CONFIG
 from ...test_tracer import get_dummy_tracer
+from ...util import assert_list_issuperset
 
 
 class CeleryTaskTest(unittest.TestCase):
@@ -110,16 +111,12 @@ class CeleryTaskTest(unittest.TestCase):
         span = spans[0]
         self.assert_items_equal(
             span.to_dict().keys(),
-            ['service', 'resource', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+            ['service', 'resource', 'meta', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
         )
         self.assertEqual(span.service, 'celery-test')
         self.assertEqual(span.resource, 'mock.mock.patched_task')
         self.assertEqual(span.name, 'celery.task.run')
         self.assertEqual(span.error, 0)
-
-        # Assert the metadata is correct
-        meta = span.meta
-        self.assertDictEqual(meta, dict())
 
     def test_task___call__(self):
         """
@@ -148,16 +145,12 @@ class CeleryTaskTest(unittest.TestCase):
         span = spans[0]
         self.assert_items_equal(
             span.to_dict().keys(),
-            ['service', 'resource', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
+            ['service', 'resource', 'meta', 'name', 'parent_id', 'trace_id', 'duration', 'error', 'start', 'span_id']
         )
         self.assertEqual(span.service, 'celery-test')
         self.assertEqual(span.resource, 'mock.mock.patched_task')
         self.assertEqual(span.name, 'celery.task.run')
         self.assertEqual(span.error, 0)
-
-        # Assert the metadata is correct
-        meta = span.meta
-        self.assertDictEqual(meta, dict())
 
     def test_task_apply_async(self):
         """
@@ -199,7 +192,7 @@ class CeleryTaskTest(unittest.TestCase):
 
         # Assert the metadata is correct
         meta = span.meta
-        self.assert_items_equal(meta.keys(), ['id', 'state'])
+        assert_list_issuperset(meta.keys(), ['id', 'state'])
         self.assertEqual(meta['state'], 'SUCCESS')
 
         # Assert the celery service span for calling `run`
@@ -216,7 +209,7 @@ class CeleryTaskTest(unittest.TestCase):
 
         # Assert the metadata is correct
         meta = span.meta
-        self.assert_items_equal(
+        assert_list_issuperset(
             meta.keys(),
             ['celery.delivery_info', 'celery.id']
         )
@@ -263,7 +256,7 @@ class CeleryTaskTest(unittest.TestCase):
 
         # Assert the metadata is correct
         meta = span.meta
-        self.assert_items_equal(meta.keys(), ['id'])
+        assert_list_issuperset(meta.keys(), ['id'])
 
     def test_task_apply_eager(self):
         """
@@ -308,7 +301,7 @@ class CeleryTaskTest(unittest.TestCase):
 
         # Assert the metadata is correct
         meta = span.meta
-        self.assert_items_equal(meta.keys(), ['id'])
+        assert_list_issuperset(meta.keys(), ['id'])
 
         span = spans[1]
         self.assert_items_equal(
@@ -326,7 +319,7 @@ class CeleryTaskTest(unittest.TestCase):
 
         # Assert the metadata is correct
         meta = span.meta
-        self.assert_items_equal(meta.keys(), ['id', 'state'])
+        assert_list_issuperset(meta.keys(), ['id', 'state'])
         self.assertEqual(meta['state'], 'SUCCESS')
 
         # The last span emitted
@@ -343,7 +336,7 @@ class CeleryTaskTest(unittest.TestCase):
 
         # Assert the metadata is correct
         meta = span.meta
-        self.assert_items_equal(
+        assert_list_issuperset(
             meta.keys(),
             ['celery.delivery_info', 'celery.id']
         )
@@ -390,7 +383,7 @@ class CeleryTaskTest(unittest.TestCase):
 
         # Assert the metadata is correct
         meta = span.meta
-        self.assert_items_equal(meta.keys(), ['id'])
+        assert_list_issuperset(meta.keys(), ['id'])
 
     def test_task_delay_eager(self):
         """
@@ -435,7 +428,7 @@ class CeleryTaskTest(unittest.TestCase):
 
         # Assert the metadata is correct
         meta = span.meta
-        self.assert_items_equal(meta.keys(), ['id'])
+        assert_list_issuperset(meta.keys(), ['id'])
 
         span = spans[1]
         self.assert_items_equal(
@@ -453,7 +446,7 @@ class CeleryTaskTest(unittest.TestCase):
 
         # Assert the metadata is correct
         meta = span.meta
-        self.assert_items_equal(meta.keys(), ['id', 'state'])
+        assert_list_issuperset(meta.keys(), ['id', 'state'])
         self.assertEqual(meta['state'], 'SUCCESS')
 
         # The last span emitted
@@ -470,7 +463,7 @@ class CeleryTaskTest(unittest.TestCase):
 
         # Assert the metadata is correct
         meta = span.meta
-        self.assert_items_equal(
+        assert_list_issuperset(
             meta.keys(),
             ['celery.delivery_info', 'celery.id']
         )

--- a/tests/contrib/django/test_cache_backends.py
+++ b/tests/contrib/django/test_cache_backends.py
@@ -6,6 +6,7 @@ from django.core.cache import caches
 
 # testing
 from .utils import DjangoTraceTestCase
+from ...util import assert_dict_issuperset
 
 
 class DjangoCacheRedisTest(DjangoTraceTestCase):
@@ -39,7 +40,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
         assert start < span.start < span.start + span.duration < end
 
     def test_cache_redis_get_many(self):
@@ -68,7 +69,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
         assert start < span.start < span.start + span.duration < end
 
     def test_cache_pylibmc_get(self):
@@ -97,7 +98,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
         assert start < span.start < span.start + span.duration < end
 
     def test_cache_pylibmc_get_many(self):
@@ -126,7 +127,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
         assert start < span.start < span.start + span.duration < end
 
     def test_cache_memcached_get(self):
@@ -155,7 +156,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
         assert start < span.start < span.start + span.duration < end
 
     def test_cache_memcached_get_many(self):
@@ -184,7 +185,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
         assert start < span.start < span.start + span.duration < end
 
     def test_cache_django_pylibmc_get(self):
@@ -213,7 +214,7 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
         assert start < span.start < span.start + span.duration < end
 
     def test_cache_django_pylibmc_get_many(self):
@@ -242,5 +243,5 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
         assert start < span.start < span.start + span.duration < end

--- a/tests/contrib/django/test_cache_client.py
+++ b/tests/contrib/django/test_cache_client.py
@@ -6,6 +6,7 @@ from django.core.cache import caches
 
 # testing
 from .utils import DjangoTraceTestCase
+from ...util import assert_dict_issuperset
 
 
 class DjangoCacheWrapperTest(DjangoTraceTestCase):
@@ -38,7 +39,7 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
         assert start < span.start < span.start + span.duration < end
 
     def test_cache_set(self):
@@ -67,7 +68,7 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
         assert start < span.start < span.start + span.duration < end
 
     def test_cache_add(self):
@@ -96,7 +97,7 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
         assert start < span.start < span.start + span.duration < end
 
     def test_cache_delete(self):
@@ -125,7 +126,7 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
         assert start < span.start < span.start + span.duration < end
 
     def test_cache_incr(self):
@@ -164,8 +165,8 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span_get.meta, expected_meta)
-        eq_(span_incr.meta, expected_meta)
+        assert_dict_issuperset(span_get.meta, expected_meta)
+        assert_dict_issuperset(span_incr.meta, expected_meta)
         assert start < span_incr.start < span_incr.start + span_incr.duration < end
 
     def test_cache_decr(self):
@@ -210,9 +211,9 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span_get.meta, expected_meta)
-        eq_(span_incr.meta, expected_meta)
-        eq_(span_decr.meta, expected_meta)
+        assert_dict_issuperset(span_get.meta, expected_meta)
+        assert_dict_issuperset(span_incr.meta, expected_meta)
+        assert_dict_issuperset(span_decr.meta, expected_meta)
         assert start < span_decr.start < span_decr.start + span_decr.duration < end
 
     def test_cache_get_many(self):
@@ -255,7 +256,7 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span_get_many.meta, expected_meta)
+        assert_dict_issuperset(span_get_many.meta, expected_meta)
         assert start < span_get_many.start < span_get_many.start + span_get_many.duration < end
 
     def test_cache_set_many(self):

--- a/tests/contrib/flask_cache/test.py
+++ b/tests/contrib/flask_cache/test.py
@@ -15,6 +15,7 @@ from flask import Flask
 # testing
 from ..config import REDIS_CONFIG, MEMCACHED_CONFIG
 from ...test_tracer import DummyWriter
+from ...util import assert_dict_issuperset
 
 
 class FlaskCacheTest(unittest.TestCase):
@@ -48,7 +49,7 @@ class FlaskCacheTest(unittest.TestCase):
             "flask_cache.backend": "simple",
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
 
     def test_simple_cache_set(self):
         # initialize the dummy writer
@@ -76,7 +77,7 @@ class FlaskCacheTest(unittest.TestCase):
             "flask_cache.backend": "simple",
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
 
     def test_simple_cache_add(self):
         # initialize the dummy writer
@@ -104,7 +105,7 @@ class FlaskCacheTest(unittest.TestCase):
             "flask_cache.backend": "simple",
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
 
     def test_simple_cache_delete(self):
         # initialize the dummy writer
@@ -132,7 +133,7 @@ class FlaskCacheTest(unittest.TestCase):
             "flask_cache.backend": "simple",
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
 
     def test_simple_cache_delete_many(self):
         # initialize the dummy writer
@@ -160,7 +161,7 @@ class FlaskCacheTest(unittest.TestCase):
             "flask_cache.backend": "simple",
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
 
     def test_simple_cache_clear(self):
         # initialize the dummy writer
@@ -187,7 +188,7 @@ class FlaskCacheTest(unittest.TestCase):
             "flask_cache.backend": "simple",
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
 
     def test_simple_cache_get_many(self):
         # initialize the dummy writer
@@ -215,7 +216,7 @@ class FlaskCacheTest(unittest.TestCase):
             "flask_cache.backend": "simple",
         }
 
-        eq_(span.meta, expected_meta)
+        assert_dict_issuperset(span.meta, expected_meta)
 
     def test_simple_cache_set_many(self):
         # initialize the dummy writer
@@ -240,11 +241,6 @@ class FlaskCacheTest(unittest.TestCase):
         eq_(span.name, "flask_cache.cmd")
         eq_(span.span_type, "cache")
         eq_(span.error, 0)
-
-        expected_meta = {
-            "flask_cache.key": "['first_complex_op', 'second_complex_op']",
-            "flask_cache.backend": "simple",
-        }
 
         eq_(span.meta["flask_cache.backend"], "simple")
         ok_("first_complex_op" in span.meta["flask_cache.key"])

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -14,6 +14,7 @@ from ddtrace.pin import Pin
 
 from .utils import override_global_tracer
 from ...test_tracer import get_dummy_tracer
+from ...util import assert_dict_issuperset
 
 
 if PY2:
@@ -142,7 +143,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, unittest.TestCase):
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
         self.assertEqual(span.error, 0)
-        self.assertDictEqual(
+        assert_dict_issuperset(
             span.meta,
             {
                 'http.method': 'GET',
@@ -172,7 +173,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, unittest.TestCase):
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
         self.assertEqual(span.error, 0)
-        self.assertDictEqual(
+        assert_dict_issuperset(
             span.meta,
             {
                 'http.method': 'GET',
@@ -201,7 +202,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, unittest.TestCase):
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
         self.assertEqual(span.error, 0)
-        self.assertDictEqual(
+        assert_dict_issuperset(
             span.meta,
             {
                 'http.method': 'POST',
@@ -229,7 +230,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, unittest.TestCase):
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
         self.assertEqual(span.error, 0)
-        self.assertDictEqual(
+        assert_dict_issuperset(
             span.meta,
             {
                 'http.method': 'GET',

--- a/tests/contrib/mysql/test_mysql.py
+++ b/tests/contrib/mysql/test_mysql.py
@@ -7,6 +7,7 @@ from ddtrace import Pin
 from ddtrace.contrib.mysql.patch import patch, unpatch
 from tests.test_tracer import get_dummy_tracer
 from tests.contrib.config import MYSQL_CONFIG
+from ...util import assert_dict_issuperset
 
 
 class MySQLCore(object):
@@ -39,7 +40,7 @@ class MySQLCore(object):
         eq_(span.name, 'mysql.query')
         eq_(span.span_type, 'sql')
         eq_(span.error, 0)
-        eq_(span.meta, {
+        assert_dict_issuperset(span.meta, {
             'out.host': u'127.0.0.1',
             'out.port': u'53306',
             'db.name': u'test',
@@ -126,7 +127,7 @@ class MySQLCore(object):
         eq_(span.name, 'mysql.query')
         eq_(span.span_type, 'sql')
         eq_(span.error, 0)
-        eq_(span.meta, {
+        assert_dict_issuperset(span.meta, {
             'out.host': u'127.0.0.1',
             'out.port': u'53306',
             'db.name': u'test',
@@ -191,7 +192,7 @@ class TestMysqlPatch(MySQLCore):
             eq_(span.name, 'mysql.query')
             eq_(span.span_type, 'sql')
             eq_(span.error, 0)
-            eq_(span.meta, {
+            assert_dict_issuperset(span.meta, {
                 'out.host': u'127.0.0.1',
                 'out.port': u'53306',
                 'db.name': u'test',

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,4 +1,5 @@
 import mock
+from nose.tools import ok_
 
 class FakeTime(object):
     """"Allow to mock time.time for tests
@@ -29,3 +30,11 @@ class FakeTime(object):
 def patch_time():
     """Patch time.time with FakeTime"""
     return mock.patch('time.time', new_callable=FakeTime)
+
+def assert_dict_issuperset(a, b):
+    ok_(set(a.items()).issuperset(set(b.items())),
+            msg="{a} is not a superset of {b}".format(a=a, b=b))
+
+def assert_list_issuperset(a, b):
+    ok_(set(a).issuperset(set(b)),
+            msg="{a} is not a superset of {b}".format(a=a, b=b))


### PR DESCRIPTION
This will make it possible to associate traces with running processes on the host.