### PR TITLE
Attach stack trace to Flask errors

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -53,7 +53,7 @@ class API(object):
             self._downgrade()
             return self.send_traces(traces)
 
-        log.debug("reported %d spans in %.5fs", len(traces), time.time() - start)
+        log.debug("reported %d traces in %.5fs", len(traces), time.time() - start)
         return response
 
     def send_services(self, services):

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -116,10 +116,17 @@ class TraceMiddleware(object):
                 # if we didn't get a response, but we did get an exception, set
                 # codes accordingly.
                 if not response and exception:
-                    error = 1
                     code = 500
+                    # The 3 next lines might not be strictly required, since `set_traceback`
+                    # also get the exception from the sys.exc_info (and fill the error meta).
+                    # Since we aren't sure it always work/for insuring no BC break, keep
+                    # these lines which get overridden anyway.
+                    error = 1
                     span.set_tag(errors.ERROR_TYPE, type(exception))
                     span.set_tag(errors.ERROR_MSG, exception)
+                    # The provided `exception` object doesn't have a stack trace attached,
+                    # so attach the stack trace with `set_traceback`.
+                    span.set_traceback()
 
                 # the endpoint that matched the request is None if an exception
                 # happened so we fallback to a common resource

--- a/tests/contrib/flask/test_flask.py
+++ b/tests/contrib/flask/test_flask.py
@@ -3,6 +3,7 @@
 import time
 import logging
 import os
+import re
 
 # 3p
 from flask import Flask, render_template
@@ -260,8 +261,8 @@ class TestFlask(object):
         eq_(s.meta.get(http.STATUS_CODE), '500')
         eq_(s.meta.get(http.METHOD), 'GET')
         assert "ZeroDivisionError" in s.meta.get(errors.ERROR_TYPE)
-        msg = s.meta.get(errors.ERROR_MSG)
-        assert "by zero" in msg, msg
+        assert "by zero" in s.meta.get(errors.ERROR_MSG)
+        assert re.search('File ".*/contrib/flask/test_flask.py", line [0-9]+, in fatal', s.meta.get(errors.ERROR_STACK))
 
     def test_unicode(self):
         start = time.time()


### PR DESCRIPTION
Based on tests, `span.set_traceback()` works perfectly, I kept the former way in case my test coverage wasn't enough. I could also drop it.