### PR TITLE
Use from elasticsearch import ... syntax in doc

### DIFF
--- a/ddtrace/contrib/elasticsearch/__init__.py
+++ b/ddtrace/contrib/elasticsearch/__init__.py
@@ -4,18 +4,18 @@
 ::
 
     from ddtrace import Pin, patch
-    import elasticsearch
+    from elasticsearch import Elasticsearch
 
     # If not patched yet, you can patch elasticsearch specifically
     patch(elasticsearch=True)
 
     # This will report spans with the default instrumentation
-    es = elasticsearch.Elasticsearch(port=ELASTICSEARCH_CONFIG['port'])
+    es = Elasticsearch(port=ELASTICSEARCH_CONFIG['port'])
     # Example of instrumented query
     es.indices.create(index='books', ignore=400)
 
     # Use a pin to specify metadata related to this client
-    es = elasticsearch.Elasticsearch(port=ELASTICSEARCH_CONFIG['port'])
+    es = Elasticsearch(port=ELASTICSEARCH_CONFIG['port'])
     Pin.override(es.transport, service='elasticsearch-videos')
     es.indices.create(index='videos', ignore=400)
 """


### PR DESCRIPTION
Since https://github.com/DataDog/dd-trace-py/pull/238
We can use a more common way of importing ES. So updating the doc (the tests already do it) to suggest this syntax instead.