### PR TITLE
Reraise exception with original traceback

### DIFF
--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 from ...ext import http
 from ...ext import AppTypes
@@ -40,7 +41,7 @@ class PylonsTraceMiddleware(object):
                 return self.app(environ, _start_response)
             except Exception as e:
                 # "unexpected errors"
-                # exc_info set by __exit__ on current tracer
+                (typ, val, tb) = sys.exc_info()
 
                 # e.code can either be a string or an int
                 code = getattr(e, 'code', 500)
@@ -52,7 +53,8 @@ class PylonsTraceMiddleware(object):
                     code = 500
                 span.set_tag(http.STATUS_CODE, code)
                 span.error = 1
-                raise e
+                # Re-raise the original exception with its original traceback
+                raise typ, val, tb
             except SystemExit:
                 span.set_tag(http.STATUS_CODE, 500)
                 span.error = 1

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -40,7 +40,7 @@ class PylonsTraceMiddleware(object):
             try:
                 return self.app(environ, _start_response)
             except Exception as e:
-                # "unexpected errors"
+                # store current exceptions info so we can re-raise it later
                 (typ, val, tb) = sys.exc_info()
 
                 # e.code can either be a string or an int
@@ -53,7 +53,8 @@ class PylonsTraceMiddleware(object):
                     code = 500
                 span.set_tag(http.STATUS_CODE, code)
                 span.error = 1
-                # Re-raise the original exception with its original traceback
+
+                # re-raise the original exception with its original traceback
                 raise typ, val, tb
             except SystemExit:
                 span.set_tag(http.STATUS_CODE, 500)

--- a/tests/contrib/pylons/test_pylons.py
+++ b/tests/contrib/pylons/test_pylons.py
@@ -77,6 +77,9 @@ def test_pylons():
     eq_(s.meta.get(http.STATUS_CODE), '200')
 
 def test_pylons_exceptions():
+    # ensures the reported status code is 500 even if a wrong
+    # status code is set and that the stacktrace points to the
+    # right function
     writer = DummyWriter()
     tracer = Tracer()
     tracer.writer = writer
@@ -107,10 +110,10 @@ def test_pylons_exceptions():
     s = spans[0]
 
     eq_(s.error, 1)
-    eq_(s.get_tag("error.msg"), "Some exception")
-    sc = int(s.get_tag("http.status_code"))
-    eq_(sc, 500)
-    ok_(s.get_tag("error.stack"))
+    eq_(s.get_tag('error.msg'), 'Some exception')
+    eq_(int(s.get_tag('http.status_code')), 500)
+    ok_('start_response_exception' in s.get_tag('error.stack'))
+    ok_('Exception: Some exception' in s.get_tag('error.stack'))
 
 def test_pylons_string_code():
     writer = DummyWriter()


### PR DESCRIPTION
In Python, there is a subtle but important distinction between `raise e` and `raise`: the former has a traceback originating with the current location, whereas the latter uses the original traceback from before the exception was caught. In this case, I think it makes significantly more sense to preserve the original traceback.