### PR TITLE
[ci] update Python version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
     CASS_DRIVER_NO_EXTENSIONS: 1
     AGENT_BUILD_PATH: "/home/ubuntu/agent"
   post:
-    - pyenv global 2.7.12 3.4.4 3.5.2 3.6.0
+    - pyenv global 2.7.12 3.4.4 3.5.2 3.6.1
 
 dependencies:
   pre:


### PR DESCRIPTION
### Overview

CircleCI has only some Python versions and `3.6.0` was removed. We will update all language versions and dependencies later in another PR, since this is only a quick-fix.