### PR TITLE
Add distributed tracing functionality to flask middleware

### DIFF
--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -101,6 +101,14 @@ class TraceMiddleware(object):
                 service=self._service,
                 span_type=http.TYPE,
             )
+
+            # Distributed tracing
+            parent_trace_id = request.headers.get('X-Datadog-Trace-Id')
+            parent_span_id = request.headers.get('X-Datadog-Parent-Id')
+           
+            if parent_trace_id and parent_span_id:
+                g.flask_datadog_span.trace_id = int(parent_trace_id)
+                g.flask_datadog_span.parent_id = int(parent_span_id)
         except Exception:
             self.app.logger.exception("error tracing request")
 


### PR DESCRIPTION
distributed tracing requires linking a child request to a parent with a
trace id and parent id. Currently the flask middleware doesn't check the
request headers for x-datadog-trace-id and x-datadog-parent-id and then
set that on the new span created in the child request. This merge adds
this logic so that child spans are automatically linked to parents if
the headers exist in the request.