### PR TITLE
[mysql] remove docs typo

### DIFF
--- a/ddtrace/contrib/mysql/__init__.py
+++ b/ddtrace/contrib/mysql/__init__.py
@@ -1,4 +1,4 @@
-"""Instrumeent mysql to report MySQL queries.
+"""Instrument mysql to report MySQL queries.
 
 ``patch_all`` will automatically patch your mysql connection to make it work.
 ::


### PR DESCRIPTION
### Overview

Small typo in `mysql` docs.