### PR TITLE
[core] update the context propagation API

### DIFF
--- a/ddtrace/contrib/asyncio/helpers.py
+++ b/ddtrace/contrib/asyncio/helpers.py
@@ -18,6 +18,9 @@ def set_call_context(task, ctx):
     """
     Updates the ``Context`` for the given Task. Useful when you need to
     pass the context among different tasks.
+
+    This method is available for backward-compatibility. Use the
+    ``AsyncioContextProvider`` API to set the current active ``Context``.
     """
     setattr(task, CONTEXT_ATTR, ctx)
 
@@ -74,7 +77,7 @@ def _wrap_executor(fn, args, tracer, ctx):
     # the AsyncioContextProvider knows that this is a new thread
     # so it is legit to pass the Context in the thread-local storage;
     # fn() will be executed outside the asyncio loop as a synchronous code
-    tracer._context_provider._local.set(ctx)
+    tracer.context_provider.activate(ctx)
     return fn(*args)
 
 

--- a/ddtrace/contrib/asyncio/provider.py
+++ b/ddtrace/contrib/asyncio/provider.py
@@ -14,8 +14,28 @@ class AsyncioContextProvider(DefaultContextProvider):
     execution. It must be used in asynchronous programming that relies
     in the built-in ``asyncio`` library. Framework instrumentation that
     is built on top of the ``asyncio`` library, can use this provider.
+
+    This Context Provider inherits from ``DefaultContextProvider`` because
+    it uses a thread-local storage when the ``Context`` is propagated to
+    a different thread, than the one that is running the async loop.
     """
-    def __call__(self, loop=None):
+    def activate(self, context, loop=None):
+        """Sets the scoped ``Context`` for the current running ``Task``.
+        """
+        try:
+            loop = loop or asyncio.get_event_loop()
+        except RuntimeError:
+            # detects if a loop is available in the current thread;
+            # This happens when a new thread is created from the one that is running
+            # the async loop
+            return self._local.set(context)
+
+        # the current unit of work (if tasks are used)
+        task = asyncio.Task.current_task(loop=loop)
+        setattr(task, CONTEXT_ATTR, context)
+        return context
+
+    def active(self, loop=None):
         """
         Returns the scoped Context for this execution flow. The ``Context`` uses
         the current task as a carrier so if a single task is used for the entire application,

--- a/ddtrace/contrib/asyncio/provider.py
+++ b/ddtrace/contrib/asyncio/provider.py
@@ -28,7 +28,8 @@ class AsyncioContextProvider(DefaultContextProvider):
             # detects if a loop is available in the current thread;
             # This happens when a new thread is created from the one that is running
             # the async loop
-            return self._local.set(context)
+            self._local.set(context)
+            return context
 
         # the current unit of work (if tasks are used)
         task = asyncio.Task.current_task(loop=loop)

--- a/ddtrace/contrib/gevent/greenlet.py
+++ b/ddtrace/contrib/gevent/greenlet.py
@@ -29,7 +29,11 @@ class TracedGreenlet(gevent.Greenlet):
         # the context is always available made exception of the main greenlet
         if ctx:
             # create a new context that inherits the current active span
-            new_ctx = Context()
-            new_ctx._sampled = ctx._sampled
+            # TODO: a better API for Context, should get the tuple at once
+            new_ctx = Context(
+                trace_id=ctx._parent_trace_id,
+                span_id=ctx._parent_span_id,
+                sampled=ctx._sampled,
+            )
             new_ctx._current_span = ctx._current_span
             setattr(self, CONTEXT_ATTR, new_ctx)

--- a/ddtrace/contrib/gevent/provider.py
+++ b/ddtrace/contrib/gevent/provider.py
@@ -15,12 +15,19 @@ class GeventContextProvider(BaseContextProvider):
     in the ``gevent`` library. Framework instrumentation that uses the
     gevent WSGI server (or gevent in general), can use this provider.
     """
-    def __call__(self):
+    def activate(self, context):
+        """Sets the scoped ``Context`` for the current running ``Greenlet``.
+        """
+        current_g = gevent.getcurrent()
+        if current_g is not None:
+            setattr(current_g, CONTEXT_ATTR, context)
+            return context
+
+    def active(self):
         """
         Returns the scoped ``Context`` for this execution flow. The ``Context``
         uses the ``Greenlet`` class as a carrier, and everytime a greenlet
-        is created it receives the "parent" context. The main greenlet
-        will never have an attached ``Context``.
+        is created it receives the "parent" context.
         """
         current_g = gevent.getcurrent()
         ctx = getattr(current_g, CONTEXT_ATTR, None)
@@ -29,9 +36,14 @@ class GeventContextProvider(BaseContextProvider):
             return ctx
 
         # the Greenlet doesn't have a Context so it's created and attached
-        # unless it's the main greenlet; in that case we must be sure
-        # that no Context is generated
-        if current_g.parent:
+        # TODO: previous implementation avoided to add a Context to the main
+        # greenlet because it could have side-effects when switching back
+        # and forth between different executions. This results in issues such
+        # as: https://github.com/DataDog/dd-trace-py/issues/309
+        # and is required for Distributed Tracing when providing a new arbitrary
+        # Context. On the other hand, it's imperative to double check if there
+        # are side effects.
+        if current_g:
             ctx = Context()
             setattr(current_g, CONTEXT_ATTR, ctx)
             return ctx

--- a/ddtrace/contrib/gevent/provider.py
+++ b/ddtrace/contrib/gevent/provider.py
@@ -36,13 +36,8 @@ class GeventContextProvider(BaseContextProvider):
             return ctx
 
         # the Greenlet doesn't have a Context so it's created and attached
-        # TODO: previous implementation avoided to add a Context to the main
-        # greenlet because it could have side-effects when switching back
-        # and forth between different executions. This results in issues such
-        # as: https://github.com/DataDog/dd-trace-py/issues/309
-        # and is required for Distributed Tracing when providing a new arbitrary
-        # Context. On the other hand, it's imperative to double check if there
-        # are side effects.
+        # even to the main greenlet. This is required in Distributed Tracing
+        # when a new arbitrary Context is provided.
         if current_g:
             ctx = Context()
             setattr(current_g, CONTEXT_ATTR, ctx)

--- a/ddtrace/contrib/tornado/__init__.py
+++ b/ddtrace/contrib/tornado/__init__.py
@@ -78,11 +78,11 @@ required_modules = ['tornado']
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        # alias for API compatibility
         from .stack_context import run_with_trace_context, TracerStackContext
-        context_provider = TracerStackContext.current_context
-
         from .patch import patch, unpatch
+
+        # alias for API compatibility
+        context_provider = TracerStackContext
 
         __all__ = [
             'patch',

--- a/ddtrace/contrib/tornado/__init__.py
+++ b/ddtrace/contrib/tornado/__init__.py
@@ -78,11 +78,11 @@ required_modules = ['tornado']
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        from .patch import patch, unpatch
-        from .stack_context import run_with_trace_context, TracerStackContext
-
         # alias for API compatibility
+        from .stack_context import run_with_trace_context, TracerStackContext
         context_provider = TracerStackContext.current_context
+
+        from .patch import patch, unpatch
 
         __all__ = [
             'patch',

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -2,9 +2,8 @@ import ddtrace
 
 from tornado import template
 
-from . import decorators
+from . import decorators, context_provider
 from .constants import CONFIG_KEY
-from .stack_context import TracerStackContext
 
 from ...ext import AppTypes
 
@@ -37,7 +36,7 @@ def tracer_config(__init__, app, args, kwargs):
     # global tracer while here we can have a different instance (even if
     # this is not usual).
     tracer.configure(
-        context_provider=TracerStackContext.current_context,
+        context_provider=context_provider,
         wrap_executor=decorators.wrap_executor,
         enabled=settings.get('enabled', None),
         hostname=settings.get('agent_hostname', None),

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -2,7 +2,7 @@ import ddtrace
 
 from tornado import template
 
-from . import decorators, context_provider
+from . import decorators, TracerStackContext
 from .constants import CONFIG_KEY
 
 from ...ext import AppTypes
@@ -36,7 +36,7 @@ def tracer_config(__init__, app, args, kwargs):
     # global tracer while here we can have a different instance (even if
     # this is not usual).
     tracer.configure(
-        context_provider=context_provider,
+        context_provider=TracerStackContext,
         wrap_executor=decorators.wrap_executor,
         enabled=settings.get('enabled', None),
         hostname=settings.get('agent_hostname', None),

--- a/ddtrace/contrib/tornado/patch.py
+++ b/ddtrace/contrib/tornado/patch.py
@@ -3,8 +3,7 @@ import tornado
 
 from wrapt import wrap_function_wrapper as _w
 
-from . import handlers, application, decorators, template
-from .stack_context import TracerStackContext
+from . import handlers, application, decorators, template, context_provider
 from ...util import unwrap as _u
 
 
@@ -34,7 +33,7 @@ def patch():
 
     # configure the global tracer
     ddtrace.tracer.configure(
-        context_provider=TracerStackContext.current_context,
+        context_provider=context_provider,
         wrap_executor=decorators.wrap_executor,
     )
 

--- a/ddtrace/contrib/tornado/patch.py
+++ b/ddtrace/contrib/tornado/patch.py
@@ -3,7 +3,7 @@ import tornado
 
 from wrapt import wrap_function_wrapper as _w
 
-from . import handlers, application, decorators, template, context_provider
+from . import handlers, application, decorators, template, TracerStackContext
 from ...util import unwrap as _u
 
 
@@ -33,7 +33,7 @@ def patch():
 
     # configure the global tracer
     ddtrace.tracer.configure(
-        context_provider=context_provider,
+        context_provider=TracerStackContext,
         wrap_executor=decorators.wrap_executor,
     )
 

--- a/ddtrace/contrib/tornado/stack_context.py
+++ b/ddtrace/contrib/tornado/stack_context.py
@@ -55,7 +55,7 @@ class TracerStackContext(object):
         self.active = False
 
     @classmethod
-    def current_context(cls):
+    def active(cls):
         """
         Return the ``Context`` from the current execution flow. This method can be
         used inside a Tornado coroutine to retrieve and use the current tracing context.
@@ -63,6 +63,16 @@ class TracerStackContext(object):
         for ctx in reversed(_state.contexts[0]):
             if isinstance(ctx, cls) and ctx.active:
                 return ctx.context
+
+    @classmethod
+    def activate(cls, ctx):
+        """
+        Set the active ``Context`` for this async execution. If a ``TracerStackContext``
+        is not found, the context is discarded.
+        """
+        for stack_ctx in reversed(_state.contexts[0]):
+            if isinstance(stack_ctx, cls) and stack_ctx.active:
+                stack_ctx.context = ctx
 
 
 def run_with_trace_context(func, *args, **kwargs):

--- a/ddtrace/provider.py
+++ b/ddtrace/provider.py
@@ -7,16 +7,20 @@ class BaseContextProvider(object):
     for a callable class, capable to retrieve the current active
     ``Context`` instance. Context providers must inherit this class
     and implement:
-        * the ``__call__`` method, so that the class is callable
+        * the ``active`` method, that returns the current active ``Context``
+        * the ``activate`` method, that sets the current active ``Context``
     """
+    def activate(self, context):
+        raise NotImplementedError
+
+    def active(self):
+        raise NotImplementedError
 
     def __call__(self, *args, **kwargs):
+        """Method available for backward-compatibility. It proxies the call to
+        ``self.active()`` and must not do anything more.
         """
-        Makes the class callable so that the ``Tracer`` can invoke the
-        ``ContextProvider`` to retrieve the current context.
-        This class must be implemented.
-        """
-        raise NotImplementedError
+        return self.active()
 
 
 class DefaultContextProvider(BaseContextProvider):
@@ -28,9 +32,15 @@ class DefaultContextProvider(BaseContextProvider):
     def __init__(self):
         self._local = ThreadLocalContext()
 
-    def __call__(self, *args, **kwargs):
+    def activate(self, context):
+        """Makes the given ``context`` active, so that the provider calls
+        the thread-local storage implementation.
         """
-        Returns the global context for this tracer. Returned ``Context`` must be thread-safe
-        or thread-local.
+        return self._local.set(context)
+
+    def active(self):
+        """Returns the current active ``Context`` for this tracer. Returned
+        ``Context`` must be thread-safe or thread-local for this specific
+        implementation.
         """
         return self._local.get()

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -68,7 +68,7 @@ class Tracer(object):
         This method makes use of a ``ContextProvider`` that is automatically set during the tracer
         initialization, or while using a library instrumentation.
         """
-        return self._context_provider(*args, **kwargs)
+        return self._context_provider.active(*args, **kwargs)
 
     @property
     def context_provider(self):

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -70,6 +70,11 @@ class Tracer(object):
         """
         return self._context_provider(*args, **kwargs)
 
+    @property
+    def context_provider(self):
+        """Returns the current Tracer Context Provider"""
+        return self._context_provider
+
     def configure(self, enabled=None, hostname=None, port=None, sampler=None,
                 context_provider=None, wrap_executor=None, settings=None):
         """

--- a/tests/contrib/tornado/test_stack_context.py
+++ b/tests/contrib/tornado/test_stack_context.py
@@ -1,0 +1,49 @@
+from nose.tools import eq_, ok_
+
+from ddtrace.context import Context
+from ddtrace.contrib.tornado import TracerStackContext
+
+from .utils import TornadoTestCase
+from .web.compat import sleep
+
+
+class TestStackContext(TornadoTestCase):
+    def test_without_stack_context(self):
+        # without a TracerStackContext, propagation is not available
+        ctx = self.tracer.context_provider.active()
+        ok_(ctx is None)
+
+    def test_stack_context(self):
+        # a TracerStackContext should automatically propagate a tracing context
+        with TracerStackContext():
+            ctx = self.tracer.context_provider.active()
+
+        ok_(ctx is not None)
+
+    def test_propagation_with_new_context(self):
+        # inside a TracerStackContext it should be possible to set
+        # a new Context for distributed tracing
+        with TracerStackContext():
+            ctx = Context(trace_id=100, span_id=101)
+            self.tracer.context_provider.activate(ctx)
+            with self.tracer.trace('tornado'):
+                sleep(0.01)
+
+        traces = self.tracer.writer.pop_traces()
+        eq_(len(traces), 1)
+        eq_(len(traces[0]), 1)
+        eq_(traces[0][0].trace_id, 100)
+        eq_(traces[0][0].parent_id, 101)
+
+    def test_propagation_without_stack_context(self):
+        # a Context is discarded if not set inside a TracerStackContext
+        ctx = Context(trace_id=100, span_id=101)
+        self.tracer.context_provider.activate(ctx)
+        with self.tracer.trace('tornado'):
+            sleep(0.01)
+
+        traces = self.tracer.writer.pop_traces()
+        eq_(len(traces), 1)
+        eq_(len(traces[0]), 1)
+        ok_(traces[0][0].trace_id is not 100)
+        ok_(traces[0][0].parent_id is not 101)

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -375,6 +375,36 @@ def test_tracer_current_span():
     eq_(span, tracer.current_span())
 
 
+def test_default_provider_get():
+    # Tracer Context Provider must return a Context object
+    # even if empty
+    tracer = get_dummy_tracer()
+    ctx = tracer.context_provider.active()
+    ok_(isinstance(ctx, Context))
+    eq_(len(ctx._trace), 0)
+
+
+def test_default_provider_set():
+    # The Context Provider can set the current active Context;
+    # this could happen in distributed tracing
+    tracer = get_dummy_tracer()
+    ctx = Context(trace_id=42, span_id=100)
+    tracer.context_provider.activate(ctx)
+    span = tracer.trace('web.request')
+    eq_(span.trace_id, 42)
+    eq_(span.parent_id, 100)
+
+
+def test_default_provider_trace():
+    # Context handled by a default provider must be used
+    # when creating a trace
+    tracer = get_dummy_tracer()
+    span = tracer.trace('web.request')
+    ctx = tracer.context_provider.active()
+    eq_(len(ctx._trace), 1)
+    eq_(span._context, ctx)
+
+
 def test_start_span():
     # it should create a root Span
     tracer = get_dummy_tracer()


### PR DESCRIPTION
### Overview

Changes the way our `ContextProvider`s work. Before the change, the context provider was a callable that returns the current active `Context`. After the change, we have a manager that can get/set the current context. This allows an API similar to:
```python
trace_id, span_id, sampling_priority = get_params_somehow()
ctx = Context(trace_id=trace_id, span_id=span_id, sampling_priority=sampling_priority)
tracer.context_provider.activate(ctx)
with tracer.trace('web.request') as span:
    # for instance
    assert span.trace_id == trace_id
```

This work must extend the API to all current Providers:
* DefaultContextProvider
* AsyncioContextProvider
* GeventContextProvider
* TornadoContextProvider

### Backward compatibility

`__call__` method become a proxy to `context_provider.active()` that returns the current active `Context`. This has been done to keep backward compatibility with current implementations, even if this API was meant for internal machinery. New developers that want to set the current active context, must use this new (and only) API.