### PR TITLE
Disable autocommit in pyramid patching

### DIFF
--- a/ddtrace/contrib/pyramid/__init__.py
+++ b/ddtrace/contrib/pyramid/__init__.py
@@ -22,11 +22,12 @@ required_modules = ['pyramid']
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        from .trace import trace_pyramid, trace_tween_factory
+        from .trace import trace_pyramid, trace_tween_factory, includeme
         from .patch import patch
 
         __all__ = [
             'patch',
             'trace_pyramid',
             'trace_tween_factory',
+            'includeme',
         ]

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -29,10 +29,6 @@ def traced_init(wrapped, instance, args, kwargs):
     settings.update(trace_settings)
     kwargs['settings'] = settings
 
-    # Commit actions immediately after they are configured so as to
-    # skip conflict resolution when adding our tween
-    kwargs['autocommit'] = True
-
     # `caller_package` works by walking a fixed amount of frames up the stack
     # to find the calling package. So if we let the original `__init__`
     # function call it, our wrapper will mess things up.

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -10,6 +10,9 @@ from ...ext import http, AppTypes
 
 
 def trace_pyramid(config):
+    config.include('ddtrace.contrib.pyramid')
+
+def includeme(config):
     config.add_tween('ddtrace.contrib.pyramid:trace_tween_factory')
     # ensure we only patch the renderer once.
     if not isinstance(pyramid.renderers.RendererHelper.render, wrapt.ObjectProxy):

--- a/tests/contrib/pyramid/__init__.py
+++ b/tests/contrib/pyramid/__init__.py
@@ -1,0 +1,3 @@
+from .test_pyramid_autopatch import _include_me
+
+__all__ = ['_include_me']

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -159,6 +159,22 @@ def _get_app(service=None, tracer=None):
     config.add_view(json, route_name='json', renderer='json')
     return config.make_wsgi_app()
 
+def includeme(config):
+    pass
+
+def test_include():
+    """ Test that includes do not create conflicts """
+    from ...test_tracer import get_dummy_tracer
+    from ...util import override_global_tracer
+    tracer = get_dummy_tracer()
+    with override_global_tracer(tracer):
+        config = Configurator(settings={'pyramid.includes': 'tests.contrib.pyramid.test_pyramid'})
+        trace_pyramid(config)
+        app = webtest.TestApp(config.make_wsgi_app())
+        app.get('/', status=404)
+        spans = tracer.writer.pop()
+        assert spans
+        eq_(len(spans), 1)
 
 def _get_test_app(service=None):
     """ return a webtest'able version of our test app. """

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -6,6 +6,7 @@ import webtest
 from nose.tools import eq_
 from pyramid.config import Configurator
 from pyramid.httpexceptions import HTTPInternalServerError
+
 # 3p
 from pyramid.response import Response
 from pyramid.view import view_config
@@ -127,6 +128,21 @@ def test_json():
     eq_(s.error, 0)
     eq_(s.span_type, 'template')
 
+def includeme(config):
+    pass
+
+def test_include():
+    """ Test that includes do not create conflicts """
+    from ...test_tracer import get_dummy_tracer
+    from ...util import override_global_tracer
+    tracer = get_dummy_tracer()
+    with override_global_tracer(tracer):
+        config = Configurator(settings={'pyramid.includes': 'tests.contrib.pyramid.test_pyramid_autopatch'})
+        app = webtest.TestApp(config.make_wsgi_app())
+        app.get('/', status=404)
+        spans = tracer.writer.pop()
+        assert spans
+        eq_(len(spans), 1)
 
 def _get_app(service=None, tracer=None):
     """ return a pyramid wsgi app with various urls. """

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -24,7 +24,6 @@ def test_config_include():
     config = Configurator()
     config.include('._include_me')
 
-
 def test_200():
     app, tracer = _get_test_app(service='foobar')
     res = app.get('/', status=200)

--- a/tox.ini
+++ b/tox.ini
@@ -204,7 +204,7 @@ commands =
 # integration tests
     integration: nosetests {posargs} tests/test_integration.py
 # run all tests for the release jobs except the ones with a different test runner
-    contrib: nosetests {posargs} --exclude=".*(django|asyncio|aiohttp|aiobotocore|aiopg|gevent|falcon|flask_autopatch|bottle|pylons).*" tests/contrib
+    contrib: nosetests {posargs} --exclude=".*(django|asyncio|aiohttp|aiobotocore|aiopg|gevent|falcon|flask_autopatch|bottle|pylons|pyramid).*" tests/contrib
     asyncio: nosetests {posargs} tests/contrib/asyncio
     aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}: nosetests {posargs} tests/contrib/aiohttp
     tornado{40,41,42,43,44}: nosetests {posargs} tests/contrib/tornado


### PR DESCRIPTION
Forcing autocommit to `True` changes the behavior of the `Configurator`and a previously working application might break when we patch it since it becomes sensitive to the order of the configuration methods calls. (we had a bug report on this)

AFAIK autocommit was needed to avoid conflicts when the tween was added several time. (for instance this happens when using `include`since it calls `Configurator.__init__' another time.) Adding our tween in an `include` changes the conflict resolution rules used by pyramid and avoid that problem.