### PR TITLE
Fix flask instrumentation not closing spans

### DIFF
--- a/tests/contrib/flask/test_templates/render_err.html
+++ b/tests/contrib/flask/test_templates/render_err.html
@@ -1,0 +1,1 @@
+hello {{object.method()}}


### PR DESCRIPTION
The flask instrumentation was not closing spans if an exception
happened during the rendering of a template for flask > 0.10

To fix the issue I chose to always use `_patch_render` because the `template_rendered` signal is not called if an exception occurs during the rendering. Another possibility would be to check if a we have a span for template rendering when we get the `got_request_exception`. It has the advantage of leveraging signals instead of wrapping a private method when we can but I don't like how it spreads the logic between two seemingly unrelated signal handlers, IMO it makes the code more complicated.