### PR TITLE
Exclude cassandra from generic contrib tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,6 @@ deps =
     contrib: boto
     contrib: moto<1.0
     contrib: botocore
-    contrib: cassandra-driver
     contrib: celery
     contrib: elasticsearch
     contrib: falcon
@@ -209,7 +208,7 @@ commands =
 # integration tests
     integration: nosetests {posargs} tests/test_integration.py
 # run all tests for the release jobs except the ones with a different test runner
-    contrib: nosetests {posargs} --exclude=".*(django|asyncio|aiohttp|aiobotocore|aiopg|gevent|falcon|flask_autopatch|bottle|pylons|pyramid).*" tests/contrib
+    contrib: nosetests {posargs} --exclude=".*(django|asyncio|aiohttp|aiobotocore|aiopg|cassandra|gevent|falcon|flask_autopatch|bottle|pylons|pyramid).*" tests/contrib
     asyncio: nosetests {posargs} tests/contrib/asyncio
     aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}: nosetests {posargs} tests/contrib/aiohttp
     tornado{40,41,42,43,44}: nosetests {posargs} tests/contrib/tornado


### PR DESCRIPTION
This is minor but since the Cassandra tests are the flakiest this should help make the CI great again :)