### PR TITLE
Fix bug in pyramid, the application was not traced when the tween list was explicitely specified

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -6,7 +6,12 @@ Add all monkey-patching that needs to run by default here
 import os
 import logging
 
-logging.basicConfig()
+debug = os.environ.get("DATADOG_TRACE_DEBUG")
+if debug and debug.lower() == "true":
+    logging.basicConfig(level=logging.DEBUG)
+else:
+    logging.basicConfig()
+
 log = logging.getLogger(__name__)
 
 EXTRA_PATCHED_MODULES = {

--- a/ddtrace/contrib/pyramid/__init__.py
+++ b/ddtrace/contrib/pyramid/__init__.py
@@ -14,6 +14,11 @@ config::
 
     # use your config as normal.
     config.add_route('index', '/')
+
+If you use the 'pyramid.tweens' settings value to set the tweens for your
+application, you need to add 'ddtrace.contrib.pyramid:trace_tween_factory'
+explicitely to the list.
+
 """
 
 from ..util import require_modules

--- a/ddtrace/contrib/pyramid/__init__.py
+++ b/ddtrace/contrib/pyramid/__init__.py
@@ -17,7 +17,18 @@ config::
 
 If you use the 'pyramid.tweens' settings value to set the tweens for your
 application, you need to add 'ddtrace.contrib.pyramid:trace_tween_factory'
-explicitly to the list.
+explicitly to the list. For example::
+
+    settings = {
+        'datadog_trace_service' : 'my-web-app-name',
+        'pyramid.tweens', 'your_tween_no_1\nyour_tween_no_2\nddtrace.contrib.pyramid:trace_tween_factory',
+    }
+
+    config = Configurator(settings=settings)
+    trace_pyramid(config)
+
+    # use your config as normal.
+    config.add_route('index', '/')
 
 """
 

--- a/ddtrace/contrib/pyramid/__init__.py
+++ b/ddtrace/contrib/pyramid/__init__.py
@@ -17,7 +17,7 @@ config::
 
 If you use the 'pyramid.tweens' settings value to set the tweens for your
 application, you need to add 'ddtrace.contrib.pyramid:trace_tween_factory'
-explicitely to the list.
+explicitly to the list.
 
 """
 

--- a/ddtrace/contrib/pyramid/constants.py
+++ b/ddtrace/contrib/pyramid/constants.py
@@ -1,0 +1,3 @@
+SETTINGS_SERVICE = 'datadog_trace_service'
+SETTINGS_TRACER = 'datadog_tracer'
+SETTINGS_TRACE_ENABLED = 'datadog_trace_enabled'

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -1,21 +1,23 @@
 import os
 
 from .trace import trace_pyramid, DD_TWEEN_NAME
+from .constants import SETTINGS_SERVICE
 
 import pyramid.config
 from pyramid.path import caller_package
 
 import wrapt
 
+DD_PATCH = '_datadog_patch'
 
 def patch():
     """
     Patch pyramid.config.Configurator
     """
-    if getattr(pyramid.config, '_datadog_patch', False):
+    if getattr(pyramid.config, DD_PATCH, False):
         return
 
-    setattr(pyramid.config, '_datadog_patch', True)
+    setattr(pyramid.config, DD_PATCH, True)
     _w = wrapt.wrap_function_wrapper
     _w('pyramid.config', 'Configurator.__init__', traced_init)
 
@@ -23,7 +25,7 @@ def traced_init(wrapped, instance, args, kwargs):
     settings = kwargs.pop('settings', {})
     service = os.environ.get('DATADOG_SERVICE_NAME') or 'pyramid'
     trace_settings = {
-        'datadog_trace_service' : service,
+        SETTINGS_SERVICE : service,
     }
     settings.update(trace_settings)
     # If the tweens are explicitly set with 'pyramid.tweens', we need to

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -53,6 +53,9 @@ def insert_tween_if_needed(settings):
     # If the our tween is already there, nothing to do
     if DD_TWEEN_NAME in tweens:
         return
+    # pyramid.tweens.EXCVIEW is the name of built-in exception view provided by
+    # pyramid.  We need our tween to be before it, otherwise unhandled
+    # exceptions will be caught before they reach our tween.
     idx = tweens.find(pyramid.tweens.EXCVIEW)
     if idx is -1:
         settings['pyramid.tweens'] = tweens + '\n' + DD_TWEEN_NAME

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -45,16 +45,16 @@ def traced_init(wrapped, instance, args, kwargs):
 def insert_tween_if_needed(settings):
     if 'pyramid.tweens' not in settings:
         return
-    tweens_list = settings['pyramid.tweens']
+    tweens = settings['pyramid.tweens']
     # If the list is empty, pyramid does not consider the tweens have been
     # set explicitly so we will insert the tween with add_tween.
-    if not tweens_list.strip():
+    if not tweens.strip():
         return
     # If the our tween is already there, nothing to do
-    if DD_TWEEN_NAME in tweens_list:
+    if DD_TWEEN_NAME in tweens:
         return
-    idx = tweens_list.find(pyramid.tweens.EXCVIEW)
+    idx = tweens.find(pyramid.tweens.EXCVIEW)
     if idx is -1:
-        settings['pyramid.tweens'] = tweens_list + '\n' + DD_TWEEN_NAME
+        settings['pyramid.tweens'] = tweens + '\n' + DD_TWEEN_NAME
     else:
-        settings['pyramid.tweens'] = tweens_list[:idx] + DD_TWEEN_NAME + "\n" + tweens_list[idx:]
+        settings['pyramid.tweens'] = tweens[:idx] + DD_TWEEN_NAME + "\n" + tweens[idx:]

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -43,15 +43,11 @@ def traced_init(wrapped, instance, args, kwargs):
     trace_pyramid(instance)
 
 def insert_tween_if_needed(settings):
-    if 'pyramid.tweens' not in settings:
-        return
-    tweens = settings['pyramid.tweens']
+    tweens = settings.get('pyramid.tweens')
     # If the list is empty, pyramid does not consider the tweens have been
-    # set explicitly so we will insert the tween with add_tween.
-    if not tweens.strip():
-        return
-    # If the our tween is already there, nothing to do
-    if DD_TWEEN_NAME in tweens:
+    # set explicitly.
+    # And if our tween is already there, nothing to do
+    if not tweens or not tweens.strip() or DD_TWEEN_NAME in tweens:
         return
     # pyramid.tweens.EXCVIEW is the name of built-in exception view provided by
     # pyramid.  We need our tween to be before it, otherwise unhandled

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -26,7 +26,7 @@ def traced_init(wrapped, instance, args, kwargs):
         'datadog_trace_service' : service,
     }
     settings.update(trace_settings)
-    # If the tweens are explicitely set with 'pyramid.tweens', we need to
+    # If the tweens are explicitly set with 'pyramid.tweens', we need to
     # explicitly set our tween too since `add_tween` will be ignored.
     insert_tween_if_needed(settings)
     kwargs['settings'] = settings
@@ -45,7 +45,7 @@ def insert_tween_if_needed(settings):
         return
     tweens_list = settings['pyramid.tweens']
     # If the list is empty, pyramid does not consider the tweens have been
-    # set explicitely so we will insert the tween with add_tween.
+    # set explicitly so we will insert the tween with add_tween.
     if not tweens_list.strip():
         return
     # If the our tween is already there, nothing to do

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -8,6 +8,7 @@ import wrapt
 # project
 import ddtrace
 from ...ext import http, AppTypes
+from .constants import SETTINGS_SERVICE, SETTINGS_TRACE_ENABLED, SETTINGS_TRACER
 
 log = logging.getLogger(__name__)
 
@@ -44,9 +45,9 @@ def trace_render(func, instance, args, kwargs):
 def trace_tween_factory(handler, registry):
     # configuration
     settings = registry.settings
-    service = settings.get('datadog_trace_service') or 'pyramid'
-    tracer = settings.get('datadog_tracer') or ddtrace.tracer
-    enabled = asbool(settings.get('datadog_trace_enabled', tracer.enabled))
+    service = settings.get(SETTINGS_SERVICE) or 'pyramid'
+    tracer = settings.get(SETTINGS_TRACER) or ddtrace.tracer
+    enabled = asbool(settings.get(SETTINGS_TRACE_ENABLED, tracer.enabled))
 
     # set the service info
     tracer.set_service_info(
@@ -58,7 +59,7 @@ def trace_tween_factory(handler, registry):
         # make a request tracing function
         def trace_tween(request):
             with tracer.trace('pyramid.request', service=service, resource='404') as span:
-                setattr(request, 'DD_SPAN', span)  # used to find the tracer in templates
+                setattr(request, DD_SPAN, span)  # used to find the tracer in templates
                 response = None
                 try:
                     response = handler(request)

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -12,6 +12,7 @@ from ...ext import http, AppTypes
 log = logging.getLogger(__name__)
 
 DD_TWEEN_NAME = 'ddtrace.contrib.pyramid:trace_tween_factory'
+DD_SPAN = '_datadog_span'
 
 def trace_pyramid(config):
     config.include('ddtrace.contrib.pyramid')
@@ -30,7 +31,7 @@ def trace_render(func, instance, args, kwargs):
     if not request:
         log.debug("No request passed to render, will not be traced")
         return func(*args, **kwargs)
-    span = getattr(request, '_datadog_span', None)
+    span = getattr(request, DD_SPAN, None)
     if not span:
         log.debug("No span found in request, will not be traced")
         return func(*args, **kwargs)
@@ -57,7 +58,7 @@ def trace_tween_factory(handler, registry):
         # make a request tracing function
         def trace_tween(request):
             with tracer.trace('pyramid.request', service=service, resource='404') as span:
-                setattr(request, '_datadog_span', span)  # used to find the tracer in templates
+                setattr(request, 'DD_SPAN', span)  # used to find the tracer in templates
                 response = None
                 try:
                     response = handler(request)

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -1,6 +1,7 @@
 
 # 3p
 import pyramid.renderers
+from pyramid.interfaces import ITweens
 from pyramid.settings import asbool
 import wrapt
 
@@ -8,12 +9,14 @@ import wrapt
 import ddtrace
 from ...ext import http, AppTypes
 
+DD_TWEEN_NAME = 'ddtrace.contrib.pyramid:trace_tween_factory'
 
 def trace_pyramid(config):
     config.include('ddtrace.contrib.pyramid')
 
 def includeme(config):
-    config.add_tween('ddtrace.contrib.pyramid:trace_tween_factory')
+    # Add our tween just before the default exception handler
+    config.add_tween(DD_TWEEN_NAME, over=pyramid.tweens.EXCVIEW)
     # ensure we only patch the renderer once.
     if not isinstance(pyramid.renderers.RendererHelper.render, wrapt.ObjectProxy):
         wrapt.wrap_function_wrapper('pyramid.renderers', 'RendererHelper.render', trace_render)

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -2,7 +2,6 @@
 # 3p
 import logging
 import pyramid.renderers
-from pyramid.interfaces import ITweens
 from pyramid.settings import asbool
 import wrapt
 

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -176,6 +176,20 @@ def test_include():
         assert spans
         eq_(len(spans), 1)
 
+def test_explicit_tweens_declaration():
+    """ Test that includes do not create conflicts """
+    from ...test_tracer import get_dummy_tracer
+    from ...util import override_global_tracer
+    tracer = get_dummy_tracer()
+    with override_global_tracer(tracer):
+        config = Configurator(settings={'pyramid.tweens': 'pyramid.tweens.excview_tween_factory'})
+        trace_pyramid(config)
+        app = webtest.TestApp(config.make_wsgi_app())
+        app.get('/', status=404)
+        spans = tracer.writer.pop()
+        assert spans
+        eq_(len(spans), 1)
+
 def _get_test_app(service=None):
     """ return a webtest'able version of our test app. """
     from tests.test_tracer import get_dummy_tracer

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -7,7 +7,6 @@ from wsgiref.simple_server import make_server
 # 3p
 from pyramid.response import Response
 from pyramid.config import Configurator
-from pyramid.view import view_config
 from pyramid.httpexceptions import HTTPInternalServerError
 import webtest
 from nose.tools import eq_
@@ -44,7 +43,6 @@ class PyramidBase(object):
         }
         eq_(services, expected)
 
-
     def test_404(self):
         self.app.get('/404', status=404)
 
@@ -59,7 +57,6 @@ class PyramidBase(object):
         eq_(s.meta.get('http.method'), 'GET')
         eq_(s.meta.get('http.status_code'), '404')
         eq_(s.meta.get('http.url'), '/404')
-
 
     def test_exception(self):
         try:
@@ -80,7 +77,6 @@ class PyramidBase(object):
         eq_(s.meta.get('http.url'), '/exception')
         eq_(s.meta.get('pyramid.route.name'), 'exception')
 
-
     def test_500(self):
         self.app.get('/error', status=500)
 
@@ -97,7 +93,6 @@ class PyramidBase(object):
         eq_(s.meta.get('http.url'), '/error')
         eq_(s.meta.get('pyramid.route.name'), 'error')
         assert type(s.error) == int
-
 
     def test_json(self):
         res = self.app.get('/json', status=200)
@@ -164,6 +159,7 @@ def test_tween_overriden():
     with override_global_tracer(tracer):
         config = Configurator(settings={'pyramid.tweens': 'pyramid.tweens.excview_tween_factory'})
         trace_pyramid(config)
+
         def json(request):
             return {'a': 1}
         config.add_route('json', '/json')
@@ -191,7 +187,11 @@ def test_insert_tween_if_needed_excview():
 def test_insert_tween_if_needed_excview_and_other():
     settings = {'pyramid.tweens': 'a.first.tween\npyramid.tweens.excview_tween_factory\na.last.tween\n'}
     insert_tween_if_needed(settings)
-    eq_(settings['pyramid.tweens'], 'a.first.tween\nddtrace.contrib.pyramid:trace_tween_factory\npyramid.tweens.excview_tween_factory\na.last.tween\n')
+    eq_(settings['pyramid.tweens'],
+        'a.first.tween\n'
+        'ddtrace.contrib.pyramid:trace_tween_factory\n'
+        'pyramid.tweens.excview_tween_factory\n'
+        'a.last.tween\n')
 
 def test_insert_tween_if_needed_others():
     settings = {'pyramid.tweens': 'a.random.tween\nand.another.one'}
@@ -228,9 +228,9 @@ if __name__ == '__main__':
     logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
     ddtrace.tracer.debug_logging = True
     settings = {
-            'datadog_trace_service': 'foobar',
-            'datadog_tracer': ddtrace.tracer
-            }
+        'datadog_trace_service': 'foobar',
+        'datadog_tracer': ddtrace.tracer
+    }
     config = Configurator(settings=settings)
     trace_pyramid(config)
     app = get_app(config)

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -141,7 +141,7 @@ class TestPyramid(PyramidBase):
 def includeme(config):
     pass
 
-def test_include():
+def test_include_conflicts():
     """ Test that includes do not create conflicts """
     from ...test_tracer import get_dummy_tracer
     from ...util import override_global_tracer

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -15,6 +15,18 @@ from wsgiref.simple_server import make_server
 # project
 import ddtrace
 from ddtrace import compat
+from .test_pyramid import PyramidBase, get_app
+
+class TestPyramidAutopatch(PyramidBase):
+    def setUp(self):
+        from tests.test_tracer import DummyWriter
+        self.tracer = ddtrace.tracer
+        self.tracer.writer = DummyWriter()
+
+        config = Configurator()
+
+        app = get_app(config)
+        self.app = webtest.TestApp(app)
 
 def _include_me(config):
     pass
@@ -24,109 +36,6 @@ def test_config_include():
     application is run with ddtrace-run """
     config = Configurator()
     config.include('._include_me')
-
-def test_200():
-    app, tracer = _get_test_app(service='foobar')
-    res = app.get('/', status=200)
-    assert b'idx' in res.body
-
-    writer = tracer.writer
-    spans = writer.pop()
-    eq_(len(spans), 1)
-    s = spans[0]
-    eq_(s.service, 'foobar')
-    eq_(s.resource, 'GET index')
-    eq_(s.error, 0)
-    eq_(s.span_type, 'http')
-    eq_(s.meta.get('http.method'), 'GET')
-    eq_(s.meta.get('http.status_code'), '200')
-    eq_(s.meta.get('http.url'), '/')
-
-    # ensure services are set correctly
-    services = writer.pop_services()
-    expected = {
-        'foobar': {"app": "pyramid", "app_type": "web"}
-    }
-    eq_(services, expected)
-
-
-def test_404():
-    app, tracer = _get_test_app(service='foobar')
-    app.get('/404', status=404)
-
-    writer = tracer.writer
-    spans = writer.pop()
-    eq_(len(spans), 1)
-    s = spans[0]
-    eq_(s.service, 'foobar')
-    eq_(s.resource, '404')
-    eq_(s.error, 0)
-    eq_(s.span_type, 'http')
-    eq_(s.meta.get('http.method'), 'GET')
-    eq_(s.meta.get('http.status_code'), '404')
-    eq_(s.meta.get('http.url'), '/404')
-
-
-def test_exception():
-    app, tracer = _get_test_app(service='foobar')
-    try:
-        app.get('/exception', status=500)
-    except ZeroDivisionError:
-        pass
-
-    writer = tracer.writer
-    spans = writer.pop()
-    eq_(len(spans), 1)
-    s = spans[0]
-    eq_(s.service, 'foobar')
-    eq_(s.resource, 'GET exception')
-    eq_(s.error, 1)
-    eq_(s.span_type, 'http')
-    eq_(s.meta.get('http.status_code'), '500')
-    eq_(s.meta.get('http.url'), '/exception')
-
-
-def test_500():
-    app, tracer = _get_test_app(service='foobar')
-    app.get('/error', status=500)
-
-    writer = tracer.writer
-    spans = writer.pop()
-    eq_(len(spans), 1)
-    s = spans[0]
-    eq_(s.service, 'foobar')
-    eq_(s.resource, 'GET error')
-    eq_(s.error, 1)
-    eq_(s.span_type, 'http')
-    eq_(s.meta.get('http.method'), 'GET')
-    eq_(s.meta.get('http.status_code'), '500')
-    eq_(s.meta.get('http.url'), '/error')
-    assert type(s.error) == int
-
-
-def test_json():
-    app, tracer = _get_test_app(service='foobar')
-    res = app.get('/json', status=200)
-    parsed = json.loads(compat.to_unicode(res.body))
-    eq_(parsed, {'a': 1})
-
-    writer = tracer.writer
-    spans = writer.pop()
-    eq_(len(spans), 2)
-    spans_by_name = {s.name: s for s in spans}
-    s = spans_by_name['pyramid.request']
-    eq_(s.service, 'foobar')
-    eq_(s.resource, 'GET json')
-    eq_(s.error, 0)
-    eq_(s.span_type, 'http')
-    eq_(s.meta.get('http.method'), 'GET')
-    eq_(s.meta.get('http.status_code'), '200')
-    eq_(s.meta.get('http.url'), '/json')
-
-    s = spans_by_name['pyramid.render']
-    eq_(s.service, 'foobar')
-    eq_(s.error, 0)
-    eq_(s.span_type, 'template')
 
 def includeme(config):
     pass
@@ -157,46 +66,10 @@ def test_explicit_tweens_declaration():
         assert spans
         eq_(len(spans), 1)
 
-def _get_app(service=None, tracer=None):
-    """ return a pyramid wsgi app with various urls. """
-
-    def index(request):
-        return Response('idx')
-
-    def error(request):
-        raise HTTPInternalServerError("oh no")
-
-    def exception(request):
-        1 / 0
-
-    def json(request):
-        return {'a': 1}
-
-    config = Configurator()
-    config.add_route('index', '/')
-    config.add_route('error', '/error')
-    config.add_route('exception', '/exception')
-    config.add_route('json', '/json')
-    config.add_view(index, route_name='index')
-    config.add_view(error, route_name='error')
-    config.add_view(exception, route_name='exception')
-    config.add_view(json, route_name='json', renderer='json')
-    return config.make_wsgi_app()
-
-
-def _get_test_app(service=None):
-    """ return a webtest'able version of our test app. """
-    from tests.test_tracer import DummyWriter
-    ddtrace.tracer.writer = DummyWriter()
-
-    app = _get_app(service=service, tracer=ddtrace.tracer)
-    return webtest.TestApp(app), ddtrace.tracer
-
-
 if __name__ == '__main__':
     logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
     ddtrace.tracer.debug_logging = True
-    app = _get_app()
+    app = get_app()
     port = 8080
     server = make_server('0.0.0.0', port, app)
     print('running on %s' % port)

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -1,20 +1,15 @@
 # stdlib
-import json
 import logging
 import sys
 import webtest
 from nose.tools import eq_
 from pyramid.config import Configurator
-from pyramid.httpexceptions import HTTPInternalServerError
 
 # 3p
-from pyramid.response import Response
-from pyramid.view import view_config
 from wsgiref.simple_server import make_server
 
 # project
 import ddtrace
-from ddtrace import compat
 from .test_pyramid import PyramidBase, get_app
 
 class TestPyramidAutopatch(PyramidBase):
@@ -63,6 +58,7 @@ def test_include_conflicts():
         spans = tracer.writer.pop()
         assert spans
         eq_(len(spans), 1)
+
 
 if __name__ == '__main__':
     logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -144,6 +144,19 @@ def test_include():
         assert spans
         eq_(len(spans), 1)
 
+def test_explicit_tweens_declaration():
+    """ Test that tracing still works when tweens are explicitely set """
+    from ...test_tracer import get_dummy_tracer
+    from ...util import override_global_tracer
+    tracer = get_dummy_tracer()
+    with override_global_tracer(tracer):
+        config = Configurator(settings={'pyramid.tweens': 'pyramid.tweens.excview_tween_factory'})
+        app = webtest.TestApp(config.make_wsgi_app())
+        app.get('/', status=404)
+        spans = tracer.writer.pop()
+        assert spans
+        eq_(len(spans), 1)
+
 def _get_app(service=None, tracer=None):
     """ return a pyramid wsgi app with various urls. """
 


### PR DESCRIPTION
This addresses #313 

There are two ways to add tweens to a pyramid app, either through the `config.add_tween` method, or by passing a 'pyramid.tweens' setting. In case the 'pyramid.tweens' setting is used, all calls to `config.add_tween` are ignored. This is what happened here.

To fix the issue I've chosen to automatically add our tween to the 'pyramid.tweens' setting when the app is automatically instrumented with ddtrace-run, and for user that instrument manually their application I've updated the doc to clarify that if the tweens are set with the 'pyramid.tweens' setting, our tween must be added there too. (that behavior is consistent with what is done for the native exception view: https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hooks.html#explicit-tween-ordering)

I also changed the behavior of the rendering tracing for pyramid to make sure that we don't trace the rendering if the request itself is not traced. (this is what caused the original bug, since there is no service name set in that case).

In the process I've also done a couple of other changes:
- I have added some code in "ddtrace/bootstrap/sitecustomize.py" to make sure we enable debug logging when the "DATADOG_TRACE_DEBUG" environment variable is set since I hit the issue when troubleshooting
- I refactored the pyramid tests since a lot of code was duplicated between the manual and autopatch version
