### PR TITLE
[pylon] handle exception with non standard 'code' attribute

### DIFF
--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -49,7 +49,7 @@ class PylonsTraceMiddleware(object):
                     code = int(code)
                     if not 100 <= code < 600:
                         code = 500
-                except ValueError:
+                except:
                     code = 500
                 span.set_tag(http.STATUS_CODE, code)
                 span.error = 1

--- a/tests/contrib/pylons/test_pylons.py
+++ b/tests/contrib/pylons/test_pylons.py
@@ -9,6 +9,13 @@ from ddtrace.ext import http
 from ...test_tracer import DummyWriter
 
 
+class ExceptionWithCodeMethod(Exception):
+    def __init__(self, message):
+        super(ExceptionWithCodeMethod, self).__init__(message)
+
+    def code():
+        pass
+
 class FakeWSGIApp(object):
 
     code = None
@@ -36,6 +43,9 @@ class FakeWSGIApp(object):
         e = Exception("Custom exception")
         e.code = '512'
         raise e
+
+    def start_response_exception_code_method(self, status, headers):
+        raise ExceptionWithCodeMethod('Exception with code method')
 
 
 def test_pylons():
@@ -114,6 +124,38 @@ def test_pylons_exceptions():
     eq_(int(s.get_tag('http.status_code')), 500)
     ok_('start_response_exception' in s.get_tag('error.stack'))
     ok_('Exception: Some exception' in s.get_tag('error.stack'))
+
+def test_pylons_exception_with_code_method():
+    writer = DummyWriter()
+    tracer = Tracer()
+    tracer.writer = writer
+    app = FakeWSGIApp()
+    traced = PylonsTraceMiddleware(app, tracer, service="p")
+    app.code = '200 OK'
+    app.body = ['woo']
+    app.environ = {
+        'REQUEST_METHOD':'GET',
+        'pylons.routes_dict' : {
+            'controller' : 'foo',
+            'action' : 'bar',
+        }
+    }
+
+    try:
+        out = traced(app.environ,  app.start_response_exception_code_method)
+        assert False
+    except ExceptionWithCodeMethod:
+        pass
+
+
+    spans = writer.pop()
+    ok_(spans, spans)
+    eq_(len(spans), 1)
+    s = spans[0]
+
+    eq_(s.error, 1)
+    eq_(s.get_tag('error.msg'), 'Exception with code method')
+    eq_(int(s.get_tag('http.status_code')), 500)
 
 def test_pylons_string_code():
     writer = DummyWriter()


### PR DESCRIPTION
The code supposed that if the middleware caught an exception with a `code` attribute, it would be a string or an int which is not always the case. For instance we got a bug report where an exception of type `grpc._channel._Rendezvous` with a code method was caught and caused the code to throw a `TypeError` exception.

Now the middleware now catches this exception properly.