### PR TITLE
Respect env agent host and port in Django apps

### DIFF
--- a/ddtrace/contrib/django/conf.py
+++ b/ddtrace/contrib/django/conf.py
@@ -14,16 +14,19 @@ from __future__ import unicode_literals
 
 import os
 import importlib
+import logging
 
 from django.conf import settings as django_settings
 
 from django.test.signals import setting_changed
 
 
+log = logging.getLogger(__name__)
+
 # List of available settings with their defaults
 DEFAULTS = {
-    'AGENT_HOSTNAME': os.environ.get('DATADOG_TRACE_AGENT_HOSTNAME', 'localhost'),
-    'AGENT_PORT': os.environ.get('DATADOG_TRACE_AGENT_PORT', 8126),
+    'AGENT_HOSTNAME': 'localhost',
+    'AGENT_PORT': 8126,
     'AUTO_INSTRUMENT': True,
     'INSTRUMENT_CACHE': True,
     'INSTRUMENT_DATABASE': True,
@@ -84,6 +87,17 @@ class DatadogSettings(object):
             self.defaults['TAGS'].update({'env': os.environ.get('DATADOG_ENV')})
         if os.environ.get('DATADOG_SERVICE_NAME'):
             self.defaults['DEFAULT_SERVICE'] = os.environ.get('DATADOG_SERVICE_NAME')
+        if os.environ.get('DATADOG_TRACE_AGENT_HOSTNAME'):
+            self.defaults['AGENT_HOSTNAME'] = os.environ.get('DATADOG_TRACE_AGENT_HOSTNAME')
+        if os.environ.get('DATADOG_TRACE_AGENT_PORT'):
+            # if the agent port is a string, the underlying library that creates the socket
+            # stops working
+            try:
+                port = int(os.environ.get('DATADOG_TRACE_AGENT_PORT'))
+            except ValueError:
+                log.warning('DATADOG_TRACE_AGENT_PORT is not an integer value; default to 8126')
+            else:
+                self.defaults['AGENT_PORT'] = port
 
         self.import_strings = import_strings or IMPORT_STRINGS
 

--- a/ddtrace/contrib/django/conf.py
+++ b/ddtrace/contrib/django/conf.py
@@ -22,8 +22,8 @@ from django.test.signals import setting_changed
 
 # List of available settings with their defaults
 DEFAULTS = {
-    'AGENT_HOSTNAME': 'localhost',
-    'AGENT_PORT': 8126,
+    'AGENT_HOSTNAME': os.environ.get('DATADOG_TRACE_AGENT_HOSTNAME', 'localhost'),
+    'AGENT_PORT': os.environ.get('DATADOG_TRACE_AGENT_PORT', 8126),
     'AUTO_INSTRUMENT': True,
     'INSTRUMENT_CACHE': True,
     'INSTRUMENT_DATABASE': True,

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,7 +1,10 @@
-import ddtrace
+import os
 import mock
-from contextlib import contextmanager
+import ddtrace
+
 from nose.tools import ok_
+from contextlib import contextmanager
+
 
 class FakeTime(object):
     """"Allow to mock time.time for tests
@@ -33,13 +36,16 @@ def patch_time():
     """Patch time.time with FakeTime"""
     return mock.patch('time.time', new_callable=FakeTime)
 
+
 def assert_dict_issuperset(a, b):
     ok_(set(a.items()).issuperset(set(b.items())),
             msg="{a} is not a superset of {b}".format(a=a, b=b))
 
+
 def assert_list_issuperset(a, b):
     ok_(set(a).issuperset(set(b)),
             msg="{a} is not a superset of {b}".format(a=a, b=b))
+
 
 @contextmanager
 def override_global_tracer(tracer):
@@ -52,3 +58,20 @@ def override_global_tracer(tracer):
     ddtrace.tracer = tracer
     yield
     ddtrace.tracer = original_tracer
+
+
+@contextmanager
+def set_env(**environ):
+    """
+    Temporarily set the process environment variables.
+
+    >>> with set_env(DEFAULT_SERVICE='my-webapp'):
+            # your test
+    """
+    old_environ = dict(os.environ)
+    os.environ.update(environ)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)


### PR DESCRIPTION
## What does this PR do?
Enable to override agent hostname and port via `DATADOG_TRACE_AGENT_HOSTNAME` and `DATADOG_TRACE_AGENT_PORT` .

## Motivation
To make dd-trace-py for Django work as expected.

Currently, dd-trace-py for Django ignores those environment variables in spite of [the document](http://pypi.datadoghq.com/trace/docs/#get-started) says it can be override via those environment variables.

## Additional Notes
This PR fixes https://github.com/DataDog/dd-trace-py/issues/332
