### PR TITLE
Add automatic distributed tracing to Flask

### DIFF
--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -94,7 +94,7 @@ class TraceMiddleware(object):
                 span_type=http.TYPE,
             )
             g.flask_datadog_span.trace_id = trace_id
-            g.flask_datadog_span.span_id = parent_id
+            g.flask_datadog_span.parent_id = parent_id
         except Exception:
             self.app.logger.exception("error tracing request")
 

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -93,8 +93,10 @@ class TraceMiddleware(object):
                 service=self._service,
                 span_type=http.TYPE,
             )
-            g.flask_datadog_span.trace_id = trace_id
-            g.flask_datadog_span.parent_id = parent_id
+            if trace_id:
+                g.flask_datadog_span.trace_id = trace_id
+            if parent_id:
+                g.flask_datadog_span.parent_id = parent_id
         except Exception:
             self.app.logger.exception("error tracing request")
 


### PR DESCRIPTION
I'd like to get the ball rolling on automated distributed tracing in Python so I took the first step of adding it to the Flask integration.

Flask's `request` global makes it trivial to get the headers, so they can be conveniently injected if so desired. Since the only other implementation that I looked at (Ruby) has it turned off by default I disabled it by default in here too.