### PR TITLE
Requests should pass distributed tracing headers

### DIFF
--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -39,8 +39,15 @@ def _traced_request_func(func, instance, args, kwargs):
 
     method = kwargs.get('method') or args[0]
     url = kwargs.get('url') or args[1]
+    headers = kwargs.get('headers', {})
 
     with tracer.trace("requests.request", span_type=http.TYPE) as span:
+        if 'x-datadog-trace-id' not in headers:
+            headers['x-datadog-trace-id'] = span.trace_id
+        if 'x-datadog-parent-id' not in headers:
+            headers['x-datadog-parent-id'] = span.span_id
+        kwargs['headers'] = headers
+
         resp = None
         try:
             resp = func(*args, **kwargs)

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -43,9 +43,9 @@ def _traced_request_func(func, instance, args, kwargs):
 
     with tracer.trace("requests.request", span_type=http.TYPE) as span:
         if http.TRACE_ID_HEADER not in headers:
-            headers[http.TRACE_ID_HEADER] = span.trace_id
+            headers[http.TRACE_ID_HEADER] = str(span.trace_id)
         if http.PARENT_ID_HEADER not in headers:
-            headers[http.PARENT_ID_HEADER] = span.span_id
+            headers[http.PARENT_ID_HEADER] = str(span.span_id)
         kwargs['headers'] = headers
 
         resp = None

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -42,10 +42,10 @@ def _traced_request_func(func, instance, args, kwargs):
     headers = kwargs.get('headers', {})
 
     with tracer.trace("requests.request", span_type=http.TYPE) as span:
-        if 'x-datadog-trace-id' not in headers:
-            headers['x-datadog-trace-id'] = span.trace_id
-        if 'x-datadog-parent-id' not in headers:
-            headers['x-datadog-parent-id'] = span.span_id
+        if http.TRACE_ID_HEADER not in headers:
+            headers[http.TRACE_ID_HEADER] = span.trace_id
+        if http.PARENT_ID_HEADER not in headers:
+            headers[http.PARENT_ID_HEADER] = span.span_id
         kwargs['headers'] = headers
 
         resp = None

--- a/ddtrace/ext/http.py
+++ b/ddtrace/ext/http.py
@@ -18,6 +18,8 @@ STATUS_CODE = "http.status_code"
 # template render span type
 TEMPLATE = 'template'
 
+TRACE_ID_HEADER = 'x-datadog-trace-id'
+PARENT_ID_HEADER = 'x-datadog-parent-id'
 
 def normalize_status_code(code):
     return code.split(' ')[0]


### PR DESCRIPTION
Similar to my Flask PR, but for Requests this time around.

The issue is that most `patch`ed modules - unlike middlewares -  don't support configuration, so at the moment there's no way to make it optional. The Ruby version seems to support configuration on the Pin objects, so maybe the Python version should as well?