### PR TITLE
[distributed sampling] setting service as early as possible

### DIFF
--- a/ddtrace/contrib/psycopg/connection.py
+++ b/ddtrace/contrib/psycopg/connection.py
@@ -49,12 +49,11 @@ class TracedCursor(cursor):
         if not self._datadog_tracer:
             return cursor.execute(self, query, vars)
 
-        with self._datadog_tracer.trace("postgres.query") as s:
+        with self._datadog_tracer.trace("postgres.query", service=self._datadog_service) as s:
             if not s.sampled:
                 return super(TracedCursor, self).execute(query, vars)
 
             s.resource = query
-            s.service = self._datadog_service
             s.span_type = sql.TYPE
             s.set_tags(self._datadog_tags)
             try:

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -21,8 +21,9 @@ class PylonsTraceMiddleware(object):
         )
 
     def __call__(self, environ, start_response):
-        with self._tracer.trace("pylons.request") as span:
-            span.service = self._service
+        with self._tracer.trace("pylons.request", service=self._service) as span:
+            # Set the service in tracer.trace() as priority sampling requires it to be
+            # set as early as possible when different services share one single agent.
             span.span_type = http.TYPE
 
             if not span.sampled:


### PR DESCRIPTION
To have better sampling ratio, the information about the service should be send to the trace constructor. This patches fixes for pylons and psycopg.