### PR TITLE
Move sampling priority fully to the context

### DIFF
--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -1,2 +1,3 @@
 FILTERS_KEY = 'FILTERS'
+SAMPLE_RATE_METRIC_KEY = "_sample_rate"
 SAMPLING_PRIORITY_KEY = '_sampling_priority_v1'

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -151,10 +151,9 @@ class Context(object):
                 trace = self._trace
                 sampled = self._sampled
                 sampling_priority = self._sampling_priority
-                # attach the sampling priority to the spans
-                if sampled and sampling_priority is not None:
-                    for span in trace:
-                        span.set_metric(SAMPLING_PRIORITY_KEY, sampling_priority)
+                # attach the sampling priority to the context root span
+                if sampled and sampling_priority is not None and trace:
+                    trace[0].set_metric(SAMPLING_PRIORITY_KEY, sampling_priority)
 
                 # clean the current state
                 self._trace = []

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -14,7 +14,6 @@ MAX_TRACE_ID = 2 ** 64
 
 # Has to be the same factor and key as the Agent to allow chained sampling
 KNUTH_FACTOR = 1111111111111111111
-SAMPLE_RATE_METRIC_KEY = "_sample_rate"
 
 class AllSampler(object):
     """Sampler sampling all the traces"""

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -7,7 +7,6 @@ import traceback
 
 from .compat import StringIO, stringify, iteritems, numeric_types
 from .ext import errors
-from .constants import SAMPLING_PRIORITY_KEY
 
 
 log = logging.getLogger(__name__)
@@ -36,7 +35,6 @@ class Span(object):
         '_context',
         '_finished',
         '_parent',
-        '_sampling_priority',
     ]
 
     def __init__(
@@ -92,7 +90,6 @@ class Span(object):
 
         # sampling
         self.sampled = True
-        self._sampling_priority = None
 
         self._tracer = tracer
         self._context = context
@@ -217,12 +214,6 @@ class Span(object):
         if self.span_type:
             d['type'] = self.span_type
 
-        if self._sampling_priority is not None:
-            if d.get('metrics'):
-                d['metrics'][SAMPLING_PRIORITY_KEY] = self._sampling_priority
-            else:
-                d['metrics'] = {SAMPLING_PRIORITY_KEY : self._sampling_priority}
-
         return d
 
     def set_traceback(self, limit=20):
@@ -269,7 +260,6 @@ class Span(object):
             ("start", self.start),
             ("end", "" if not self.duration else self.start + self.duration),
             ("duration", "%fs" % (self.duration or 0)),
-            ("sampling_priority", self._sampling_priority),
             ("error", self.error),
             ("tags", "")
         ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -349,7 +349,7 @@ You can also set this the priority manually to either drop an non-interesting tr
 For that, set the `context.sampling_priority` to 0 or 2. It has to be done before any context propagation (fork, RPC calls)
 to be effective::
 
-    context = tracer.get_call_context()
+    context = tracer.context_provider.active()
     # Indicate to not keep the trace
     context.sampling_priority = 0
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -266,27 +266,9 @@ gevent
 
 .. automodule:: ddtrace.contrib.gevent
 
-Tutorials
----------
-
-Sampling
-~~~~~~~~
-
-It is possible to sample traces with `ddtrace`.
-While the Trace Agent already samples traces to reduce the bandwidth usage, this client sampling
-reduces performance overhead.
-
-`RateSampler` samples a ratio of the traces. Its usage is simple::
-
-    from ddtrace.sampler import RateSampler
-
-    # Sample rate is between 0 (nothing sampled) to 1 (everything sampled).
-    # Sample 50% of the traces.
-    sample_rate = 0.5
-    tracer.sampler = RateSampler(sample_rate)
 
 Distributed Tracing
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 To trace requests across hosts, the spans on the secondary hosts must be linked together by setting `trace_id`, `parent_id` and `sampling_priority`.
 
@@ -341,6 +323,55 @@ function that call a `method` and propagate a `rpc_metadata` dictionary over the
 
         with tracer.trace("child_span") as span:
             span.set_meta('my_rpc_method', method)
+
+
+Sampling
+--------
+
+Priority sampling
+~~~~~~~~~~~~~~~~~
+
+Priority sampling consists in deciding if a trace will be kept by using a `priority` attribute that will be propagated
+for distributed traces. Its value gives indication to the Agent and to the backend on how important the trace is.
+
+- 0: Don't keep the trace.
+- 1: The sampler automatically decided to keep the trace.
+- 2: The user asked the keep the trace.
+
+For now, priority sampling is disabled by default. Enabling it ensures that your sampled distributed traces will be complete.
+To enable the priorty sampling::
+
+    tracer.configure(distributed_sampling=True)
+
+Once enabled, the sampler will automatically assign a priority of 0 or 1 to traces, depending on their service and volume.
+
+You can also set this the priority manually to either drop an non-interesting trace or to keep an important one.
+For that, set the `context.sampling_priority` to 0 or 2. It has to be done before any context propagation (fork, RPC calls)
+to be effective::
+
+    context = tracer.get_call_context()
+    # Indicate to not keep the trace
+    context.sampling_priority = 0
+
+    # Indicate to keep the trace
+    span.context.sampling_priority = 2
+
+
+Pre-sampling
+~~~~~~~~~~~~
+
+Pre-sampling will completely disable instrumentation of some transactions and drop the trace at the client level.
+Information will be lost but it allows to control any potential perfomrance impact.
+
+`RateSampler` ramdomly samples a percentage of traces. Its usage is simple::
+
+    from ddtrace.sampler import RateSampler
+
+    # Sample rate is between 0 (nothing sampled) to 1 (everything sampled).
+    # Keep 20% of the traces.
+    sample_rate = 0.2
+    tracer.sampler = RateSampler(sample_rate)
+
 
 
 Advanced Usage

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -5,6 +5,7 @@ from aiohttp.test_utils import unittest_run_loop
 
 from ddtrace.contrib.aiohttp.middlewares import trace_app, trace_middleware
 from ddtrace.sampler import RateSampler
+from ddtrace.constants import SAMPLING_PRIORITY_KEY
 
 from .utils import TraceTestCase
 from .app.web import setup_app, noop_middleware
@@ -230,7 +231,7 @@ class TestTraceMiddleware(TraceTestCase):
         # with the right trace_id and parent_id
         eq_(span.trace_id, 100)
         eq_(span.parent_id, 42)
-        eq_(span.context.sampling_priority, None)
+        eq_(span.get_metric(SAMPLING_PRIORITY_KEY), None)
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -257,7 +258,7 @@ class TestTraceMiddleware(TraceTestCase):
         # with the right trace_id and parent_id
         eq_(100, span.trace_id)
         eq_(42, span.parent_id)
-        eq_(1, span.context.sampling_priority)
+        eq_(1, span.get_metric(SAMPLING_PRIORITY_KEY))
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -284,7 +285,7 @@ class TestTraceMiddleware(TraceTestCase):
         # with the right trace_id and parent_id
         eq_(100, span.trace_id)
         eq_(42, span.parent_id)
-        eq_(0, span.context.sampling_priority)
+        eq_(0, span.get_metric(SAMPLING_PRIORITY_KEY))
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -333,8 +334,8 @@ class TestTraceMiddleware(TraceTestCase):
         # with the right trace_id and parent_id
         eq_(100, span.trace_id)
         eq_(42, span.parent_id)
-        eq_(0, span.context.sampling_priority)
+        eq_(0, span.get_metric(SAMPLING_PRIORITY_KEY))
         # check parenting is OK with custom sub-span created within server code
         eq_(100, sub_span.trace_id)
         eq_(span.span_id, sub_span.parent_id)
-        eq_(0, span.context.sampling_priority)
+        eq_(0, sub_span.get_metric(SAMPLING_PRIORITY_KEY))

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -338,4 +338,4 @@ class TestTraceMiddleware(TraceTestCase):
         # check parenting is OK with custom sub-span created within server code
         eq_(100, sub_span.trace_id)
         eq_(span.span_id, sub_span.parent_id)
-        eq_(0, sub_span.get_metric(SAMPLING_PRIORITY_KEY))
+        eq_(None, sub_span.get_metric(SAMPLING_PRIORITY_KEY))

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -230,7 +230,7 @@ class TestTraceMiddleware(TraceTestCase):
         # with the right trace_id and parent_id
         eq_(span.trace_id, 100)
         eq_(span.parent_id, 42)
-        eq_(span._sampling_priority, None)
+        eq_(span.context.sampling_priority, None)
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -257,7 +257,7 @@ class TestTraceMiddleware(TraceTestCase):
         # with the right trace_id and parent_id
         eq_(100, span.trace_id)
         eq_(42, span.parent_id)
-        eq_(1, span._sampling_priority)
+        eq_(1, span.context.sampling_priority)
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -284,7 +284,7 @@ class TestTraceMiddleware(TraceTestCase):
         # with the right trace_id and parent_id
         eq_(100, span.trace_id)
         eq_(42, span.parent_id)
-        eq_(0, span._sampling_priority)
+        eq_(0, span.context.sampling_priority)
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -333,8 +333,8 @@ class TestTraceMiddleware(TraceTestCase):
         # with the right trace_id and parent_id
         eq_(100, span.trace_id)
         eq_(42, span.parent_id)
-        eq_(0, span._sampling_priority)
+        eq_(0, span.context.sampling_priority)
         # check parenting is OK with custom sub-span created within server code
         eq_(100, sub_span.trace_id)
         eq_(span.span_id, sub_span.parent_id)
-        eq_(0, span._sampling_priority)
+        eq_(0, span.context.sampling_priority)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -29,6 +29,7 @@ class TestTracingContext(TestCase):
         span = Span(tracer=None, name='fake_span')
         ctx.add_span(span)
         ok_(ctx._sampled is True)
+        ok_(ctx.sampling_priority is None)
 
     def test_current_span(self):
         # it should return the current active span

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -4,10 +4,11 @@ import unittest
 import random
 
 from ddtrace.span import Span
-from ddtrace.sampler import RateSampler, AllSampler, RateByServiceSampler, SAMPLE_RATE_METRIC_KEY, _key, _default_key
+from ddtrace.sampler import RateSampler, AllSampler, RateByServiceSampler, _key, _default_key
 from ddtrace.compat import iteritems
 from tests.test_tracer import get_dummy_tracer
 from .util import patch_time
+from ddtrace.constants import SAMPLING_PRIORITY_KEY, SAMPLE_RATE_METRIC_KEY
 
 
 class RateSamplerTest(unittest.TestCase):
@@ -91,11 +92,11 @@ class RateByServiceSamplerTest(unittest.TestCase):
             samples = writer.pop()
             samples_with_high_priority = 0
             for sample in samples:
-                if sample._sampling_priority:
-                    if sample._sampling_priority > 0:
+                if sample.get_metric(SAMPLING_PRIORITY_KEY) is not None:
+                    if sample.get_metric(SAMPLING_PRIORITY_KEY) > 0:
                         samples_with_high_priority += 1
                 else:
-                    assert 0 == sample._sampling_priority, "when priority sampling is on, priority should be 0 when trace is to be dropped"
+                    assert 0 == sample.get_metric(SAMPLING_PRIORITY_KEY), "when priority sampling is on, priority should be 0 when trace is to be dropped"
 
             # We must have at least 1 sample, check that it has its sample rate properly assigned
             assert samples[0].get_metric(SAMPLE_RATE_METRIC_KEY) is None

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -19,11 +19,6 @@ def test_ids():
     eq_(s2.span_id, 2)
     eq_(s2.parent_id, 1)
 
-def test_sampled():
-    s = Span(tracer=None, name="span.test")
-    assert s.sampled
-    assert s._sampling_priority is None
-
 def test_tags():
     s = Span(tracer=None, name="test.span")
     s.set_tag("a", "a")
@@ -175,10 +170,6 @@ def test_ctx_mgr():
     else:
         assert 0, "should have failed"
 
-def test_span_priority():
-    s = Span(tracer=None, name="test.span", service="s", resource="r")
-    eq_(None, s._sampling_priority, 'by default, no sampling priority defined')
-
 def test_span_to_dict():
     s = Span(tracer=None, name="test.span", service="s", resource="r")
     s.span_type = "foo"
@@ -231,7 +222,6 @@ def test_span_to_dict_priority():
         s.span_type = "foo"
         s.set_tag("a", "1")
         s.set_meta("b", "2")
-        s._sampling_priority = i
         s.finish()
 
         d = s.to_dict()
@@ -240,7 +230,6 @@ def test_span_to_dict_priority():
         eq_(d["trace_id"], s.trace_id)
         eq_(d["parent_id"], s.parent_id)
         eq_(d["meta"], {"a": "1", "b": "2"})
-        eq_(d["metrics"], {"_sampling_priority_v1": i})
         eq_(d["type"], "foo")
         eq_(d["error"], 0)
         eq_(type(d["error"]), int)


### PR DESCRIPTION
Move the `sampling_priority` fully to the `Context` object and document its usage.

- Remove priority from the span, moving it fully to the Context.
- Now the `SAMPLING_PRIORITY_KEY` metric is set when we flush the context.
- Provide a setter to allow changing the Context priority.
- Document how the priority sampling work and how to manually update the priority
- Update the tests accordingly
