### PR TITLE
Bring distributed tracing to Flask

### DIFF
--- a/ddtrace/contrib/flask/__init__.py
+++ b/ddtrace/contrib/flask/__init__.py
@@ -10,7 +10,7 @@ To install the middleware, add::
 
 and create a `TraceMiddleware` object::
 
-    traced_app = TraceMiddleware(app, tracer, service="my-flask-app")
+    traced_app = TraceMiddleware(app, tracer, service="my-flask-app", distributed_tracing=False)
 
 Here is the end result, in a sample app::
 
@@ -22,12 +22,14 @@ Here is the end result, in a sample app::
 
     app = Flask(__name__)
 
-    traced_app = TraceMiddleware(app, tracer, service="my-flask-app")
+    traced_app = TraceMiddleware(app, tracer, service="my-flask-app", distributed_tracing=False)
 
     @app.route("/")
     def home():
         return "hello world"
 
+Set `distributed_tracing=True` if this is called remotely from an instrumented application.
+We suggest to enable it only for internal services where headers are under your control.
 """
 
 from ..util import require_modules

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -23,14 +23,14 @@ log = logging.getLogger(__name__)
 
 class TraceMiddleware(object):
 
-    def __init__(self, app, tracer, service="flask", use_signals=True, use_distributed_tracing=False):
+    def __init__(self, app, tracer, service="flask", use_signals=True, distributed_tracing=False):
         self.app = app
         self.app.logger.info("initializing trace middleware")
 
         # save our traces.
         self._tracer = tracer
         self._service = service
-        self._use_distributed_tracing = use_distributed_tracing
+        self._use_distributed_tracing = distributed_tracing
 
         self._tracer.set_service_info(
             service=service,

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -12,7 +12,6 @@ import logging
 from ... import compat
 from ...ext import http, errors, AppTypes
 from ...propagation.http import HTTPPropagator
-from ...context import Context
 
 # 3p
 import flask.templating

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -94,7 +94,7 @@ class TraceMiddleware(object):
                 span_type=http.TYPE,
             )
             g.flask_datadog_span.trace_id = trace_id
-            g.flask_datadog_span.span_id = parent_id
+            g.flask_datadog_span.parent_id = parent_id
         except Exception:
             self.app.logger.exception("error tracing request")
 

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -93,8 +93,10 @@ class TraceMiddleware(object):
                 service=self._service,
                 span_type=http.TYPE,
             )
-            g.flask_datadog_span.trace_id = trace_id
-            g.flask_datadog_span.parent_id = parent_id
+            if trace_id:
+                g.flask_datadog_span.trace_id = trace_id
+            if parent_id:
+                g.flask_datadog_span.parent_id = parent_id
         except Exception:
             self.app.logger.exception("error tracing request")
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -285,6 +285,7 @@ For that, refer to the configuration of the given integration.
 Supported web frameworks:
 
 - Django
+- Flask
 
 
 HTTP client/server

--- a/tests/contrib/flask/test_flask.py
+++ b/tests/contrib/flask/test_flask.py
@@ -11,6 +11,7 @@ from nose.tools import eq_
 
 # project
 from ddtrace import Tracer
+from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.contrib.flask import TraceMiddleware
 from ddtrace.ext import http, errors
 from ...test_tracer import DummyWriter
@@ -91,7 +92,7 @@ def handle_my_exception(e):
 # work)
 service = "test.flask.service"
 assert not writer.pop()  # should always be empty
-traced_app = TraceMiddleware(app, tracer, service=service)
+traced_app = TraceMiddleware(app, tracer, service=service, use_distributed_tracing=True)
 
 # make the app testable
 app.config['TESTING'] = True
@@ -341,3 +342,25 @@ class TestFlask(object):
         eq_(s.meta.get(http.STATUS_CODE), '404')
         eq_(s.meta.get(http.METHOD), 'GET')
         eq_(s.meta.get(http.URL), u'http://localhost/404/üŋïĉóđē')
+
+    def test_propagation(self):
+        rv = app.get('/', headers={
+            'x-datadog-trace-id': '1234',
+            'x-datadog-parent-id': '4567',
+            'x-datadog-sampling-priority': '2'
+        })
+
+        # ensure request worked
+        eq_(rv.status_code, 200)
+        eq_(rv.data, b'hello')
+
+        # ensure trace worked
+        assert not tracer.current_span(), tracer.current_span().pprint()
+        spans = writer.pop()
+        eq_(len(spans), 1)
+        s = spans[0]
+
+        # ensure the propagation worked well
+        eq_(s.trace_id, 1234)
+        eq_(s.parent_id, 4567)
+        eq_(s.get_metric(SAMPLING_PRIORITY_KEY), 2)

--- a/tests/contrib/flask/test_flask.py
+++ b/tests/contrib/flask/test_flask.py
@@ -92,7 +92,7 @@ def handle_my_exception(e):
 # work)
 service = "test.flask.service"
 assert not writer.pop()  # should always be empty
-traced_app = TraceMiddleware(app, tracer, service=service, use_distributed_tracing=True)
+traced_app = TraceMiddleware(app, tracer, service=service, distributed_tracing=True)
 
 # make the app testable
 app.config['TESTING'] = True


### PR DESCRIPTION
Extend work from https://github.com/DataDog/dd-trace-py/pull/331 and https://github.com/DataDog/dd-trace-py/pull/355 to bring distributed tracing to Flask.

- Use the HTTPPropagator
- Add test
- Disable it by default

To be discussed: what do we think of this `use_distributed_tracing` API?