### PR TITLE
Enable old psycopg2 tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,9 +48,7 @@ envlist =
     {py27,py34,py35,py36}-pyramid-autopatch{17,18}-webtest
     {py27,py34,py35,py36}-requests{208,209,210,211,212,213}
     {py27,py34,py35,py36}-sqlalchemy{10,11}-psycopg2{27}-mysqlconnector{21}
-    # TODO: bring back psycopg2 25,26 with CircleCI 2
-    # {py27,py34,py35,py36}-psycopg2{25,26,27}
-    {py27,py34,py35,py36}-psycopg2{27}
+    {py27,py34,py35,py36}-psycopg2{25,26,27}
     {py34,py35,py36}-aiobotocore{02,03,04}
     {py34,py35,py36}-aiopg{012,013}
     {py27,py34,py35,py36}-redis{26,27,28,29,210}


### PR DESCRIPTION
### Overview

Reverting the commit when we migrate to CircleCI 2. Related to #367.