### PR TITLE
[Celery] Set service name from env variable

### DIFF
--- a/ddtrace/contrib/celery/util.py
+++ b/ddtrace/contrib/celery/util.py
@@ -1,9 +1,11 @@
+import os
+
 # Project
 from ddtrace import Pin
 
 # Service info
-APP = 'celery'
-SERVICE = 'celery'
+APP = os.environ.get('DATADOG_SERVICE_NAME') or 'celery'
+SERVICE = os.environ.get('DATADOG_SERVICE_NAME') or 'celery'
 
 
 def meta_from_context(context):


### PR DESCRIPTION
with the current version unfortunately some services are still getting sent to `celery` instead of `DATADOG_SERVICE_NAME`