### PR TITLE
Implement distributed tracing for Tornado web

### DIFF
--- a/ddtrace/contrib/tornado/__init__.py
+++ b/ddtrace/contrib/tornado/__init__.py
@@ -54,6 +54,7 @@ Tornado settings can be used to change some tracing configuration, like::
         'datadog_trace': {
             'default_service': 'my-tornado-app',
             'tags': {'env': 'production'},
+            'distributed_tracing': True,
         },
     }
 
@@ -66,8 +67,11 @@ The available settings are:
 * ``default_service`` (default: `tornado-web`): set the service name used by the tracer. Usually
   this configuration must be updated with a meaningful name.
 * ``tags`` (default: `{}`): set global tags that should be applied to all spans.
-* ``enabled`` (default: `true`): define if the tracer is enabled or not. If set to `false`, the
+* ``enabled`` (default: `True`): define if the tracer is enabled or not. If set to `false`, the
   code is still instrumented but no spans are sent to the APM agent.
+* ``distributed_tracing`` (default: `False`): enable distributed tracing if this is called
+remotely from an instrumented application.
+We suggest to enable it only for internal services where headers are under your control.
 * ``agent_hostname`` (default: `localhost`): define the hostname of the APM agent.
 * ``agent_port`` (default: `8126`): define the port of the APM agent.
 """

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -20,6 +20,7 @@ def tracer_config(__init__, app, args, kwargs):
     settings = {
         'tracer': ddtrace.tracer,
         'default_service': 'tornado-web',
+        'distributed_tracing': False,
     }
 
     # update defaults with users settings

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -288,13 +288,19 @@ Supported web frameworks:
 - Flask
 - Tornado
 
-HTTP client/server
-~~~~~~~~~~~~~~~~~~
-
-You can use the `HTTPPropagator` manually when used with an HTTP client or if your web framework isn't supported.
+For web servers not supported, you can extract the HTTP context from the headers using the `HTTPPropagator`.
 
 .. autoclass:: ddtrace.propagation.http.HTTPPropagator
-    :members:
+    :members: extract
+
+HTTP client
+~~~~~~~~~~~
+
+When calling a remote HTTP server part of the distributed trace, you have to propagate the HTTP headers.
+This is not done automatically to prevent your system from leaking tracing information to external services.
+
+.. autoclass:: ddtrace.propagation.http.HTTPPropagator
+    :members: inject
 
 Custom
 ~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -286,7 +286,7 @@ Supported web frameworks:
 
 - Django
 - Flask
-
+- Tornado
 
 HTTP client/server
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Use HTTPPropagator to propagate header in tornado web
- Add tests
- Have it off by default
- Document it + improve overall HTTP distributed tracing documentation

