### PR TITLE
[contrib:requests] propagate distributed sampling context

### DIFF
--- a/ddtrace/contrib/requests/__init__.py
+++ b/ddtrace/contrib/requests/__init__.py
@@ -15,6 +15,15 @@ code, use a TracedSession object as you would a requests.Session::
 
     session = TracedSession()
     session.get("http://www.datadog.com")
+
+To enable distributed tracing, for example if you call, from requests, a web service
+which is also instrumented and want to have traces including both client and server sides::
+
+    from ddtrace.contrib.requests import TracedSession
+
+    session = TracedSession()
+    session.distributed_tracing_enabled = True
+    session.get("http://host.lan/webservice")
 """
 
 

--- a/ddtrace/contrib/requests/__init__.py
+++ b/ddtrace/contrib/requests/__init__.py
@@ -22,7 +22,7 @@ which is also instrumented and want to have traces including both client and ser
     from ddtrace.contrib.requests import TracedSession
 
     session = TracedSession()
-    session.distributed_tracing_enabled = True
+    session.distributed_tracing = True
     session.get("http://host.lan/webservice")
 """
 

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -39,8 +39,15 @@ def _traced_request_func(func, instance, args, kwargs):
 
     method = kwargs.get('method') or args[0]
     url = kwargs.get('url') or args[1]
+    headers = kwargs.get('headers', {})
 
     with tracer.trace("requests.request", span_type=http.TYPE) as span:
+        if 'x-datadog-trace-id' not in headers:
+            headers['x-datadog-trace-id'] = span.trace_id
+        if 'x-datadog-parent-id' not in headers:
+            headers['x-datadog-parent-id'] = span.span_id
+        kwargs['headers'] = headers
+
         resp = None
         try:
             resp = func(*args, **kwargs)

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -43,9 +43,9 @@ def _traced_request_func(func, instance, args, kwargs):
 
     with tracer.trace("requests.request", span_type=http.TYPE) as span:
         if http.TRACE_ID_HEADER not in headers:
-            headers[http.TRACE_ID_HEADER] = span.trace_id
+            headers[http.TRACE_ID_HEADER] = str(span.trace_id)
         if http.PARENT_ID_HEADER not in headers:
-            headers[http.PARENT_ID_HEADER] = span.span_id
+            headers[http.PARENT_ID_HEADER] = str(span.span_id)
         kwargs['headers'] = headers
 
         resp = None

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -34,6 +34,7 @@ def _traced_request_func(func, instance, args, kwargs):
     # sessions to have their own (with the standard global fallback)
     tracer = getattr(instance, 'datadog_tracer', ddtrace.tracer)
 
+    # [TODO:christian] replace this with a unified way of handling options (eg, Pin)
     distributed_tracing_enabled = getattr(instance, 'distributed_tracing_enabled', None)
 
     # bail on the tracing if not enabled.

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -14,6 +14,7 @@ import wrapt
 # project
 import ddtrace
 from ddtrace.ext import http
+from ...propagation.http import HTTPPropagator
 
 
 log = logging.getLogger(__name__)
@@ -42,10 +43,8 @@ def _traced_request_func(func, instance, args, kwargs):
     headers = kwargs.get('headers', {})
 
     with tracer.trace("requests.request", span_type=http.TYPE) as span:
-        if http.TRACE_ID_HEADER not in headers:
-            headers[http.TRACE_ID_HEADER] = str(span.trace_id)
-        if http.PARENT_ID_HEADER not in headers:
-            headers[http.PARENT_ID_HEADER] = str(span.span_id)
+        propagator = HTTPPropagator()
+        propagator.inject(span.context, headers)
         kwargs['headers'] = headers
 
         resp = None

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -42,10 +42,10 @@ def _traced_request_func(func, instance, args, kwargs):
     headers = kwargs.get('headers', {})
 
     with tracer.trace("requests.request", span_type=http.TYPE) as span:
-        if 'x-datadog-trace-id' not in headers:
-            headers['x-datadog-trace-id'] = span.trace_id
-        if 'x-datadog-parent-id' not in headers:
-            headers['x-datadog-parent-id'] = span.span_id
+        if http.TRACE_ID_HEADER not in headers:
+            headers[http.TRACE_ID_HEADER] = span.trace_id
+        if http.PARENT_ID_HEADER not in headers:
+            headers[http.PARENT_ID_HEADER] = span.span_id
         kwargs['headers'] = headers
 
         resp = None

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -35,7 +35,7 @@ def _traced_request_func(func, instance, args, kwargs):
     tracer = getattr(instance, 'datadog_tracer', ddtrace.tracer)
 
     # [TODO:christian] replace this with a unified way of handling options (eg, Pin)
-    distributed_tracing_enabled = getattr(instance, 'distributed_tracing_enabled', None)
+    distributed_tracing = getattr(instance, 'distributed_tracing', None)
 
     # bail on the tracing if not enabled.
     if not tracer.enabled:
@@ -46,7 +46,7 @@ def _traced_request_func(func, instance, args, kwargs):
     headers = kwargs.get('headers', {})
 
     with tracer.trace("requests.request", span_type=http.TYPE) as span:
-        if distributed_tracing_enabled:
+        if distributed_tracing:
             propagator = HTTPPropagator()
             propagator.inject(span.context, headers)
             kwargs['headers'] = headers

--- a/ddtrace/ext/http.py
+++ b/ddtrace/ext/http.py
@@ -18,8 +18,5 @@ STATUS_CODE = "http.status_code"
 # template render span type
 TEMPLATE = 'template'
 
-TRACE_ID_HEADER = 'x-datadog-trace-id'
-PARENT_ID_HEADER = 'x-datadog-parent-id'
-
 def normalize_status_code(code):
     return code.split(' ')[0]

--- a/ddtrace/ext/http.py
+++ b/ddtrace/ext/http.py
@@ -18,6 +18,8 @@ STATUS_CODE = "http.status_code"
 # template render span type
 TEMPLATE = 'template'
 
+TRACE_ID_HEADER = 'x-datadog-trace-id'
+PARENT_ID_HEADER = 'x-datadog-parent-id'
 
 def normalize_status_code(code):
     return code.split(' ')[0]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -243,6 +243,11 @@ Redis
 
 .. automodule:: ddtrace.contrib.redis
 
+Requests
+~~~~~
+
+.. automodule:: ddtrace.contrib.requests
+
 SQLAlchemy
 ~~~~~~~~~~
 

--- a/tests/contrib/requests/test_requests_distributed.py
+++ b/tests/contrib/requests/test_requests_distributed.py
@@ -31,7 +31,7 @@ class TestRequestsDistributed(object):
         adapter = Adapter()
         tracer, session = get_traced_session()
         session.mount('mock', adapter)
-        session.distributed_tracing_enabled = True
+        session.distributed_tracing = True
 
         with tracer.trace('root') as root:
             def matcher(request):
@@ -52,7 +52,7 @@ class TestRequestsDistributed(object):
         adapter = Adapter()
         tracer, session = get_traced_session()
         session.mount('mock', adapter)
-        session.distributed_tracing_enabled = False
+        session.distributed_tracing = False
 
         with tracer.trace('root'):
             def matcher(request):

--- a/tests/contrib/requests/test_requests_distributed.py
+++ b/tests/contrib/requests/test_requests_distributed.py
@@ -1,116 +1,63 @@
 
 # 3p
-from nose.tools import eq_, assert_not_equal
-from threading import Lock, Thread
-from sys import version_info
-if version_info[0] < 3:
-    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
-else:
-    from http.server import BaseHTTPRequestHandler, HTTPServer
-from time import sleep
+from nose.tools import eq_, assert_in, assert_not_in
+from requests_mock import Adapter
 
 # project
-from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.ext import http, errors
-from tests.test_tracer import get_dummy_tracer
 from .test_requests import get_traced_session
-
-# host/port on which our dumb server is listening
-_SERVER_ADDRESS = ('localhost', 8082)
-
-_lock = Lock()
-_running = None
-_client_tracer, _session = get_traced_session()
-_server_tracer = get_dummy_tracer()
-_httpd = None
-
-class DummyServer(BaseHTTPRequestHandler):
-    def do_GET(self):
-        propagator = HTTPPropagator()
-        context = propagator.extract(self.headers)
-        if context.trace_id:
-            _server_tracer.context_provider.activate(context)
-        with _server_tracer.trace('handle_request', service='http_server'):
-            self.send_response(200)
-            self.send_header('Content-type', 'text/html')
-            self.end_headers()
-            content = "<html><body><h1>hello world</h1></body></html>"
-            if version_info[0] < 3:
-                self.wfile.write(content)
-            else:
-                self.wfile.write(bytes(content, "utf-8"))
-
-def _serverThread():
-    while _keep_running():
-        _httpd.handle_request()
-    _httpd.server_close()
-
-def _keep_running():
-    with _lock:
-        return _running
-
-def _run(value):
-    global _running
-    with _lock:
-        _running = bool(value)
-
-def _test_propagation(distributed_tracing_enabled=None):
-    _session.distributed_tracing_enabled = distributed_tracing_enabled
-    url = ('http://%s:%d/' % _SERVER_ADDRESS) + str(distributed_tracing_enabled)
-    out = _session.get(url, timeout=3)
-    eq_(out.status_code, 200)
-    # client validation
-    spans = _client_tracer.writer.pop()
-    eq_(len(spans), 1)
-    client_span = spans[0]
-    eq_(client_span.get_tag(http.METHOD), 'GET')
-    eq_(client_span.get_tag(http.STATUS_CODE), '200')
-    eq_(client_span.error, 0)
-    eq_(client_span.span_type, http.TYPE)
-    # server validation
-    spans = _server_tracer.writer.pop()
-    eq_(len(spans), 1)
-    server_span = spans[0]
-    eq_(server_span.name, 'handle_request')
-    eq_(server_span.service, 'http_server')
-    eq_(server_span.error, 0)
-    # propagation check
-    if distributed_tracing_enabled:
-        eq_(server_span.trace_id, client_span.trace_id)
-        eq_(server_span.parent_id, client_span.span_id)
-    else:
-        assert_not_equal(server_span.trace_id, client_span.trace_id)
-        assert_not_equal(server_span.parent_id, client_span.span_id)
 
 class TestRequestsDistributed(object):
 
-    def setUp(self):
-        global _httpd
-        _httpd = HTTPServer(_SERVER_ADDRESS, DummyServer)
-        self.thread = Thread(target = _serverThread)
-        _run(True)
-        self.thread.start()
+    def headers_here(self, tracer, request, root_span):
+        # Use an additional matcher to query the request headers.
+        # This is because the parent_id can only been known within such a callback,
+        # as it's defined on the requests span, which is not available when calling register_uri
+        headers = request.headers
+        assert_in('x-datadog-trace-id', headers)
+        assert_in('x-datadog-parent-id', headers)
+        eq_(str(root_span.trace_id), headers['x-datadog-trace-id'])
+        req_span = root_span.context.get_current_span()
+        eq_('requests.request', req_span.name)
+        eq_(str(req_span.span_id), headers['x-datadog-parent-id'])
+        return True
 
-    def tearDown(self):
-        global _httpd
-        _run(False)
-        # run a dumb request to trigger a call to _keep_running()
-        url = 'http://%s:%d/quit' % _SERVER_ADDRESS
-        _session.get(url, timeout=3)
-        self.thread.join()
-        self.thread = None
-        _httpd = None
-        _client_tracer.writer.pop()
-        _server_tracer.writer.pop()
+    def headers_not_here(self, tracer, request):
+        headers = request.headers
+        assert_not_in('x-datadog-trace-id', headers)
+        assert_not_in('x-datadog-parent-id', headers)
+        return True
 
-    @staticmethod
-    def test_propagation_enabled():
-        _test_propagation(True)
+    def test_propagation_true(self):
+        adapter = Adapter()
+        tracer, session = get_traced_session()
+        session.mount('mock', adapter)
+        session.distributed_tracing_enabled = True
 
-    @staticmethod
-    def test_propagation_disabled():
-        _test_propagation(False)
+        with tracer.trace('root') as root:
+            def matcher(request):
+                return self.headers_here(tracer, request, root)
+            adapter.register_uri('GET', 'mock://datadog/foo', additional_matcher=matcher, text='bar')
+            resp = session.get('mock://datadog/foo')
+            eq_(200, resp.status_code)
+            eq_('bar', resp.text)
 
-    @staticmethod
-    def test_propagation_default():
-        _test_propagation(None)
+        spans = tracer.writer.spans
+        root, req = spans
+        eq_('root', root.name)
+        eq_('requests.request', req.name)
+        eq_(root.trace_id, req.trace_id)
+        eq_(root.span_id, req.parent_id)
+
+    def test_propagation_false(self):
+        adapter = Adapter()
+        tracer, session = get_traced_session()
+        session.mount('mock', adapter)
+        session.distributed_tracing_enabled = False
+
+        with tracer.trace('root'):
+            def matcher(request):
+                return self.headers_not_here(tracer, request)
+            adapter.register_uri('GET', 'mock://datadog/foo', additional_matcher=matcher, text='bar')
+            resp = session.get('mock://datadog/foo')
+            eq_(200, resp.status_code)
+            eq_('bar', resp.text)

--- a/tests/contrib/requests/test_requests_distributed.py
+++ b/tests/contrib/requests/test_requests_distributed.py
@@ -1,0 +1,116 @@
+
+# 3p
+from nose.tools import eq_, assert_not_equal
+from threading import Lock, Thread
+from sys import version_info
+if version_info[0] < 3:
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+else:
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+from time import sleep
+
+# project
+from ddtrace.propagation.http import HTTPPropagator
+from ddtrace.ext import http, errors
+from tests.test_tracer import get_dummy_tracer
+from .test_requests import get_traced_session
+
+# host/port on which our dumb server is listening
+_SERVER_ADDRESS = ('localhost', 8082)
+
+_lock = Lock()
+_running = None
+_client_tracer, _session = get_traced_session()
+_server_tracer = get_dummy_tracer()
+_httpd = None
+
+class DummyServer(BaseHTTPRequestHandler):
+    def do_GET(self):
+        propagator = HTTPPropagator()
+        context = propagator.extract(self.headers)
+        if context.trace_id:
+            _server_tracer.context_provider.activate(context)
+        with _server_tracer.trace('handle_request', service='http_server'):
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html')
+            self.end_headers()
+            content = "<html><body><h1>hello world</h1></body></html>"
+            if version_info[0] < 3:
+                self.wfile.write(content)
+            else:
+                self.wfile.write(bytes(content, "utf-8"))
+
+def _serverThread():
+    while _keep_running():
+        _httpd.handle_request()
+    _httpd.server_close()
+
+def _keep_running():
+    with _lock:
+        return _running
+
+def _run(value):
+    global _running
+    with _lock:
+        _running = bool(value)
+
+def _test_propagation(distributed_tracing_enabled=None):
+    _session.distributed_tracing_enabled = distributed_tracing_enabled
+    url = ('http://%s:%d/' % _SERVER_ADDRESS) + str(distributed_tracing_enabled)
+    out = _session.get(url, timeout=3)
+    eq_(out.status_code, 200)
+    # client validation
+    spans = _client_tracer.writer.pop()
+    eq_(len(spans), 1)
+    client_span = spans[0]
+    eq_(client_span.get_tag(http.METHOD), 'GET')
+    eq_(client_span.get_tag(http.STATUS_CODE), '200')
+    eq_(client_span.error, 0)
+    eq_(client_span.span_type, http.TYPE)
+    # server validation
+    spans = _server_tracer.writer.pop()
+    eq_(len(spans), 1)
+    server_span = spans[0]
+    eq_(server_span.name, 'handle_request')
+    eq_(server_span.service, 'http_server')
+    eq_(server_span.error, 0)
+    # propagation check
+    if distributed_tracing_enabled:
+        eq_(server_span.trace_id, client_span.trace_id)
+        eq_(server_span.parent_id, client_span.span_id)
+    else:
+        assert_not_equal(server_span.trace_id, client_span.trace_id)
+        assert_not_equal(server_span.parent_id, client_span.span_id)
+
+class TestRequestsDistributed(object):
+
+    def setUp(self):
+        global _httpd
+        _httpd = HTTPServer(_SERVER_ADDRESS, DummyServer)
+        self.thread = Thread(target = _serverThread)
+        _run(True)
+        self.thread.start()
+
+    def tearDown(self):
+        global _httpd
+        _run(False)
+        # run a dumb request to trigger a call to _keep_running()
+        url = 'http://%s:%d/quit' % _SERVER_ADDRESS
+        _session.get(url, timeout=3)
+        self.thread.join()
+        self.thread = None
+        _httpd = None
+        _client_tracer.writer.pop()
+        _server_tracer.writer.pop()
+
+    @staticmethod
+    def test_propagation_enabled():
+        _test_propagation(True)
+
+    @staticmethod
+    def test_propagation_disabled():
+        _test_propagation(False)
+
+    @staticmethod
+    def test_propagation_default():
+        _test_propagation(None)

--- a/tox.ini
+++ b/tox.ini
@@ -162,12 +162,19 @@ deps =
     redis29: redis>=2.9,<2.10
     redis210: redis>=2.10,<2.11
     requests200: requests>=2.0,<2.1
+    requests200: requests-mock>=1.3
     requests208: requests>=2.8,<2.9
+    requests208: requests-mock>=1.3
     requests209: requests>=2.9,<2.10
+    requests209: requests-mock>=1.3
     requests210: requests>=2.10,<2.11
+    requests210: requests-mock>=1.3
     requests211: requests>=2.11,<2.12
+    requests211: requests-mock>=1.3
     requests212: requests>=2.12,<2.13
+    requests212: requests-mock>=1.3
     requests213: requests>=2.13,<2.14
+    requests213: requests-mock>=1.3
     sqlalchemy10: sqlalchemy>=1.0,<1.1
     sqlalchemy11: sqlalchemy==1.1.0b3
     webtest: WebTest


### PR DESCRIPTION
This is a rework on top of https://github.com/DataDog/dd-trace-py/pull/356

It adds:

* recent context/propagator support
* forwards the sampling prority
* by default, this is disabled, needs to be activated by setting a session attribute (`distributed_tracing_enabled`)
* a small bug-fix in common code, `None` type would be converted in `'Node'` string when not defined