### PR TITLE
Make HTTPPropagator safe

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1,4 +1,8 @@
+import logging
+
 from ..context import Context
+
+log = logging.getLogger(__name__)
 
 # HTTP headers one should set for distributed tracing.
 # These are cross-language (eg: Python, Go and other implementations should honor these)
@@ -55,14 +59,29 @@ class HTTPPropagator(object):
         if not headers:
             return Context()
 
-        trace_id = int(headers.get(HTTP_HEADER_TRACE_ID, 0))
-        parent_span_id = int(headers.get(HTTP_HEADER_PARENT_ID, 0))
-        sampling_priority = headers.get(HTTP_HEADER_SAMPLING_PRIORITY)
-        if sampling_priority is not None:
-            sampling_priority = int(sampling_priority)
+        try:
+            trace_id = int(headers.get(HTTP_HEADER_TRACE_ID, 0))
+            parent_span_id = int(headers.get(HTTP_HEADER_PARENT_ID, 0))
+            sampling_priority = headers.get(HTTP_HEADER_SAMPLING_PRIORITY)
+            if sampling_priority is not None:
+                sampling_priority = int(sampling_priority)
 
-        return Context(
-            trace_id=trace_id,
-            span_id=parent_span_id,
-            sampling_priority=sampling_priority,
-        )
+            return Context(
+                trace_id=trace_id,
+                span_id=parent_span_id,
+                sampling_priority=sampling_priority,
+            )
+        # If headers are invalid and cannot be parsed, return a new context and log the issue.
+        except Exception as error:
+            try:
+                log.debug(
+                    "invalid x-datadog-* headers, trace-id: %s, parent-id: %s, priority: %s, error: %s",
+                    headers.get(HTTP_HEADER_TRACE_ID, 0),
+                    headers.get(HTTP_HEADER_PARENT_ID, 0),
+                    headers.get(HTTP_HEADER_SAMPLING_PRIORITY),
+                    error,
+                )
+            # We might fail on string formatting errors ; in that case only format the first error
+            except Exception:
+                log.debug(error)
+            return Context()

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -30,7 +30,10 @@ class HTTPPropagator(object):
         """
         headers[HTTP_HEADER_TRACE_ID] = str(span_context.trace_id)
         headers[HTTP_HEADER_PARENT_ID] = str(span_context.span_id)
-        headers[HTTP_HEADER_SAMPLING_PRIORITY] = str(span_context.sampling_priority)
+        sampling_priority = span_context.sampling_priority
+        # Propagate priority only if defined
+        if sampling_priority is not None:
+            headers[HTTP_HEADER_SAMPLING_PRIORITY] = str(span_context.sampling_priority)
 
     def extract(self, headers):
         """Extract a Context from HTTP headers into a new Context.


### PR DESCRIPTION
- Don't serialize `None` priority when not defined
- Catch `extract` exceptions and log them