### PR TITLE
[docs] fixed priority_sampling kwarg in the configure method

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -363,9 +363,9 @@ for distributed traces. Its value gives indication to the Agent and to the backe
 - 2: The user asked the keep the trace.
 
 For now, priority sampling is disabled by default. Enabling it ensures that your sampled distributed traces will be complete.
-To enable the priorty sampling::
+To enable the priority sampling::
 
-    tracer.configure(distributed_sampling=True)
+    tracer.configure(priority_sampling=True)
 
 Once enabled, the sampler will automatically assign a priority of 0 or 1 to traces, depending on their service and volume.
 


### PR DESCRIPTION
### Overview

We wrote a wrong kwarg in the documentation, it is `priority_sampling`.