### PR TITLE
Add MySQLdb integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,6 +403,56 @@ jobs:
           paths:
             - .tox
 
+  mysqlpython:
+    docker:
+      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - image: mysql:5.7
+        env:
+            - MYSQL_ROOT_PASSWORD=admin
+            - MYSQL_PASSWORD=test
+            - MYSQL_USER=test
+            - MYSQL_DATABASE=test
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+              - tox-cache-mysqlpython-{{ checksum "tox.ini" }}
+      - run: tox -e 'wait' mysql
+      - run: tox -e '{py27,py34,py35,py36}-mysqlclient{13}' --result-json /tmp/mysqlpython.results
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - mysqlpython.results
+      - save_cache:
+          key: tox-cache-mysqlpython-{{ checksum "tox.ini" }}
+          paths:
+            - .tox
+
+  mysqldb:
+    docker:
+      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - image: mysql:5.7
+        env:
+            - MYSQL_ROOT_PASSWORD=admin
+            - MYSQL_PASSWORD=test
+            - MYSQL_USER=test
+            - MYSQL_DATABASE=test
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+              - tox-cache-mysqldb-{{ checksum "tox.ini" }}
+      - run: tox -e 'wait' mysql
+      - run: tox -e '{py27}-mysqldb{12}' --result-json /tmp/mysqldb.results
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - mysqldb.results
+      - save_cache:
+          key: tox-cache-mysqldb-{{ checksum "tox.ini" }}
+          paths:
+            - .tox
+
   pylibmc:
     docker:
       - image: datadog/docker-library:dd_trace_py_1_0_0
@@ -704,6 +754,8 @@ workflows:
       - gevent
       - httplib
       - mysqlconnector
+      - mysqlpython
+      - mysqldb
       - pylibmc
       - pymongo
       - pyramid
@@ -736,6 +788,8 @@ workflows:
             - gevent
             - httplib
             - mysqlconnector
+            - mysqlpython
+            - mysqldb
             - pylibmc
             - pymongo
             - pyramid

--- a/ddtrace/contrib/mysql/__init__.py
+++ b/ddtrace/contrib/mysql/__init__.py
@@ -24,20 +24,7 @@ provided by _mysql_connector, is not supported yet.
 Help on mysql.connector can be found on:
 https://dev.mysql.com/doc/connector-python/en/
 """
-import logging
-
 from ..util import require_modules
-
-
-log = logging.getLogger(__name__)
-
-# check `MySQL-python` availability
-required_modules = ['_mysql']
-
-with require_modules(required_modules) as missing_modules:
-    if not missing_modules:
-        # MySQL-python package is not supported at the moment
-        log.debug('failed to patch mysql-python: integration not available')
 
 # check `mysql-connector` availability
 required_modules = ['mysql.connector']

--- a/ddtrace/contrib/mysqldb/__init__.py
+++ b/ddtrace/contrib/mysqldb/__init__.py
@@ -1,0 +1,35 @@
+"""Instrument mysqlclient / MySQL-python to report MySQL queries.
+
+``patch_all`` will automatically patch your mysql connection to make it work.
+::
+
+    from ddtrace import Pin, patch
+    from MySQLdb import connect
+
+    # If not patched yet, you can patch mysqldb specifically
+    patch(mysqldb=True)
+
+    # This will report a span with the default settings
+    conn = connect(user="alice", passwd="b0b", host="localhost", port=3306, db="test")
+    cursor = conn.cursor()
+    cursor.execute("SELECT 6*7 AS the_answer;")
+
+    # Use a pin to specify metadata related to this connection
+    Pin.override(conn, service='mysql-users')
+
+This package works for mysqlclient or MySQL-python
+Only the default full-Python integration works. The binary C connector,
+provided by _mysql, is not supported yet.
+
+Help on mysqlclient can be found on:
+https://mysqlclient.readthedocs.io/
+"""
+from ..util import require_modules
+
+required_modules = ['MySQLdb']
+
+with require_modules(required_modules) as missing_modules:
+    if not missing_modules:
+        from .patch import patch
+
+        __all__ = ['patch']

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -1,0 +1,47 @@
+# 3p
+import wrapt
+import MySQLdb
+
+# project
+from ddtrace import Pin
+from ddtrace.contrib.dbapi import TracedConnection
+from ...ext import net, db
+
+
+KWPOS_BY_TAG = {
+    net.TARGET_HOST: ('host', 0),
+    db.USER: ('user', 1),
+    db.NAME: ('db', 3),
+}
+
+def patch():
+    wrapt.wrap_function_wrapper('MySQLdb', 'Connect', _connect)
+    # `Connection` and `connect` are aliases for `Connect`, patch them too
+    if hasattr(MySQLdb, 'Connection'):
+        MySQLdb.Connection = MySQLdb.Connect
+    if hasattr(MySQLdb, 'connect'):
+        MySQLdb.connect = MySQLdb.Connect
+
+def unpatch():
+    if isinstance(MySQLdb.Connect, wrapt.ObjectProxy):
+        MySQLdb.Connect = MySQLdb.Connect.__wrapped__
+        if hasattr(MySQLdb, 'Connection'):
+            MySQLdb.Connection = MySQLdb.Connect
+        if hasattr(MySQLdb, 'connect'):
+            MySQLdb.connect = MySQLdb.Connect
+
+def _connect(func, instance, args, kwargs):
+    conn = func(*args, **kwargs)
+    return patch_conn(conn, *args, **kwargs)
+
+def patch_conn(conn, *args, **kwargs):
+    tags = {t: kwargs[k] if k in kwargs else args[p]
+            for t, (k, p) in KWPOS_BY_TAG.items()
+            if k in kwargs or len(args) > p}
+    tags[net.TARGET_PORT] = conn.port
+    pin = Pin(service="mysql", app="mysql", app_type="db", tags=tags)
+
+    # grab the metadata from the conn
+    wrapped = TracedConnection(conn)
+    pin.onto(wrapped)
+    return wrapped

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -24,6 +24,7 @@ PATCH_MODULES = {
     'elasticsearch': True,
     'mongoengine': True,
     'mysql': True,
+    'mysqldb': True,
     'psycopg': True,
     'pylibmc': True,
     'pymongo': True,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -231,7 +231,13 @@ Memcached
 MySQL
 ~~~~~
 
+**mysql-connector**
+
 .. automodule:: ddtrace.contrib.mysql
+
+**mysqlclient / MySQL-python**
+
+.. automodule:: ddtrace.contrib.mysqldb
 
 Postgres
 ~~~~~~~~
@@ -557,6 +563,8 @@ We officially support Python 2.7, 3.4 and above.
 +-----------------+--------------------+
 | mysql-connector | >= 2.1             |
 +-----------------+--------------------+
+| mysqlclient     | >= 1.13.12         |
++-----------------+--------------------+
 | psycopg2        | >= 2.5             |
 +-----------------+--------------------+
 | pylibmc         | >= 1.4             |
@@ -586,6 +594,7 @@ soon as possible in your Python entrypoint.
 
 * sqlite3
 * mysql
+* mysqldb
 * psycopg
 * redis
 * cassandra

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -235,7 +235,7 @@ MySQL
 
 .. automodule:: ddtrace.contrib.mysql
 
-**mysqlclient / MySQL-python**
+**mysqlclient and MySQL-python**
 
 .. automodule:: ddtrace.contrib.mysqldb
 
@@ -563,7 +563,9 @@ We officially support Python 2.7, 3.4 and above.
 +-----------------+--------------------+
 | mysql-connector | >= 2.1             |
 +-----------------+--------------------+
-| mysqlclient     | >= 1.13.12         |
+| MySQL-python    | >= 1.2.3           |
++-----------------+--------------------+
+| mysqlclient     | >= 1.3             |
 +-----------------+--------------------+
 | psycopg2        | >= 2.5             |
 +-----------------+--------------------+

--- a/tests/contrib/mysqldb/test_mysql.py
+++ b/tests/contrib/mysqldb/test_mysql.py
@@ -1,0 +1,271 @@
+# 3p
+import MySQLdb
+from nose.tools import eq_
+
+# project
+from ddtrace import Pin
+from ddtrace.contrib.mysqldb.patch import patch, unpatch
+from tests.test_tracer import get_dummy_tracer
+from tests.contrib.config import MYSQL_CONFIG
+from ...util import assert_dict_issuperset
+
+
+class MySQLCore(object):
+
+    # Reuse the connection across tests
+    conn = None
+    TEST_SERVICE = 'test-mysql'
+
+    def tearDown(self):
+        if self.conn:
+            try:
+                self.conn.ping()
+            except MySQLdb.InterfaceError:
+                pass
+            else:
+                self.conn.close()
+        unpatch()
+
+    def _get_conn_tracer(self):
+        # implement me
+        pass
+
+    def test_simple_query(self):
+        conn, tracer = self._get_conn_tracer()
+        writer = tracer.writer
+        cursor = conn.cursor()
+        cursor.execute("SELECT 1")
+        rows = cursor.fetchall()
+        eq_(len(rows), 1)
+        spans = writer.pop()
+        eq_(len(spans), 1)
+
+        span = spans[0]
+        eq_(span.service, self.TEST_SERVICE)
+        eq_(span.name, 'mysql.query')
+        eq_(span.span_type, 'sql')
+        eq_(span.error, 0)
+        assert_dict_issuperset(span.meta, {
+            'out.host': u'127.0.0.1',
+            'out.port': u'53306',
+            'db.name': u'test',
+            'db.user': u'test',
+            'sql.query': u'SELECT 1',
+        })
+        # eq_(span.get_metric('sql.rows'), -1)
+
+    def test_simple_query_with_positional_args(self):
+        conn, tracer = self._get_conn_tracer_with_positional_args()
+        writer = tracer.writer
+        cursor = conn.cursor()
+        cursor.execute("SELECT 1")
+        rows = cursor.fetchall()
+        eq_(len(rows), 1)
+        spans = writer.pop()
+        eq_(len(spans), 1)
+
+        span = spans[0]
+        eq_(span.service, self.TEST_SERVICE)
+        eq_(span.name, 'mysql.query')
+        eq_(span.span_type, 'sql')
+        eq_(span.error, 0)
+        assert_dict_issuperset(span.meta, {
+            'out.host': u'127.0.0.1',
+            'out.port': u'53306',
+            'db.name': u'test',
+            'db.user': u'test',
+            'sql.query': u'SELECT 1',
+        })
+        # eq_(span.get_metric('sql.rows'), -1)
+
+    def test_query_with_several_rows(self):
+        conn, tracer = self._get_conn_tracer()
+        writer = tracer.writer
+        cursor = conn.cursor()
+        query = "SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m"
+        cursor.execute(query)
+        rows = cursor.fetchall()
+        eq_(len(rows), 3)
+        spans = writer.pop()
+        eq_(len(spans), 1)
+        span = spans[0]
+        eq_(span.get_tag('sql.query'), query)
+        # eq_(span.get_tag('sql.rows'), 3)
+
+    def test_query_many(self):
+        # tests that the executemany method is correctly wrapped.
+        conn, tracer = self._get_conn_tracer()
+        writer = tracer.writer
+        tracer.enabled = False
+        cursor = conn.cursor()
+
+        cursor.execute("""
+            create table if not exists dummy (
+                dummy_key VARCHAR(32) PRIMARY KEY,
+                dummy_value TEXT NOT NULL)""")
+        tracer.enabled = True
+
+        stmt = "INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)"
+        data = [("foo","this is foo"),
+                ("bar","this is bar")]
+        cursor.executemany(stmt, data)
+        query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
+        cursor.execute(query)
+        rows = cursor.fetchall()
+        eq_(len(rows), 2)
+        eq_(rows[0][0], "bar")
+        eq_(rows[0][1], "this is bar")
+        eq_(rows[1][0], "foo")
+        eq_(rows[1][1], "this is foo")
+
+        spans = writer.pop()
+        eq_(len(spans), 2)
+        span = spans[-1]
+        eq_(span.get_tag('sql.query'), query)
+        cursor.execute("drop table if exists dummy")
+
+    def test_query_proc(self):
+        conn, tracer = self._get_conn_tracer()
+        writer = tracer.writer
+
+        # create a procedure
+        tracer.enabled = False
+        cursor = conn.cursor()
+        cursor.execute("DROP PROCEDURE IF EXISTS sp_sum")
+        cursor.execute("""
+            CREATE PROCEDURE sp_sum (IN p1 INTEGER, IN p2 INTEGER, OUT p3 INTEGER)
+            BEGIN
+                SET p3 := p1 + p2;
+            END;""")
+
+        tracer.enabled = True
+        proc = "sp_sum"
+        data = (40, 2, None)
+        output = cursor.callproc(proc, data)
+        eq_(len(output), 3)
+        # resulted p3 isn't stored on output[2], we need to fetch it with select
+        # http://mysqlclient.readthedocs.io/user_guide.html#cursor-objects
+        cursor.execute("SELECT @_sp_sum_2;")
+        eq_(cursor.fetchone()[0], 42)
+
+        spans = writer.pop()
+        assert spans, spans
+
+        # number of spans depends on MySQL implementation details,
+        # typically, internal calls to execute, but at least we
+        # can expect the next to the last closed span to be our proc.
+        span = spans[-2]
+        eq_(span.service, self.TEST_SERVICE)
+        eq_(span.name, 'mysql.query')
+        eq_(span.span_type, 'sql')
+        eq_(span.error, 0)
+        assert_dict_issuperset(span.meta, {
+            'out.host': u'127.0.0.1',
+            'out.port': u'53306',
+            'db.name': u'test',
+            'db.user': u'test',
+            'sql.query': u'sp_sum',
+        })
+        # eq_(span.get_metric('sql.rows'), 1)
+
+
+class TestMysqlPatch(MySQLCore):
+
+    def setUp(self):
+        patch()
+
+    def tearDown(self):
+        unpatch()
+        MySQLCore.tearDown(self)
+
+    def _connect_with_kwargs(self):
+        return MySQLdb.Connect(**{
+            'host': MYSQL_CONFIG['host'],
+            'user': MYSQL_CONFIG['user'],
+            'passwd': MYSQL_CONFIG['password'],
+            'db': MYSQL_CONFIG['database'],
+            'port': MYSQL_CONFIG['port']})
+
+    def _get_conn_tracer(self):
+        if not self.conn:
+            tracer = get_dummy_tracer()
+            self.conn = self._connect_with_kwargs()
+            self.conn.ping()
+            # Ensure that the default pin is there, with its default value
+            pin = Pin.get_from(self.conn)
+            assert pin
+            assert pin.service == 'mysql'
+            # Customize the service
+            # we have to apply it on the existing one since new one won't inherit `app`
+            pin.clone(
+                service=self.TEST_SERVICE, tracer=tracer).onto(self.conn)
+
+            return self.conn, tracer
+
+    def _get_conn_tracer_with_positional_args(self):
+        if not self.conn:
+            tracer = get_dummy_tracer()
+            self.conn = MySQLdb.Connect(MYSQL_CONFIG['host'],
+                                        MYSQL_CONFIG['user'],
+                                        MYSQL_CONFIG['password'],
+                                        MYSQL_CONFIG['database'],
+                                        MYSQL_CONFIG['port'])
+            self.conn.ping()
+            # Ensure that the default pin is there, with its default value
+            pin = Pin.get_from(self.conn)
+            assert pin
+            assert pin.service == 'mysql'
+            # Customize the service
+            # we have to apply it on the existing one since new one won't inherit `app`
+            pin.clone(
+                service=self.TEST_SERVICE, tracer=tracer).onto(self.conn)
+
+            return self.conn, tracer
+
+    def test_patch_unpatch(self):
+        unpatch()
+        # assert we start unpatched
+        conn = self._connect_with_kwargs()
+        assert not Pin.get_from(conn)
+        conn.close()
+
+        patch()
+        try:
+            tracer = get_dummy_tracer()
+            writer = tracer.writer
+            conn = self._connect_with_kwargs()
+            pin = Pin.get_from(conn)
+            assert pin
+            pin.clone(
+                service=self.TEST_SERVICE, tracer=tracer).onto(conn)
+            conn.ping()
+
+            cursor = conn.cursor()
+            cursor.execute("SELECT 1")
+            rows = cursor.fetchall()
+            eq_(len(rows), 1)
+            spans = writer.pop()
+            eq_(len(spans), 1)
+
+            span = spans[0]
+            eq_(span.service, self.TEST_SERVICE)
+            eq_(span.name, 'mysql.query')
+            eq_(span.span_type, 'sql')
+            eq_(span.error, 0)
+            assert_dict_issuperset(span.meta, {
+                'out.host': u'127.0.0.1',
+                'out.port': u'53306',
+                'db.name': u'test',
+                'db.user': u'test',
+                'sql.query': u'SELECT 1',
+            })
+
+        finally:
+            unpatch()
+
+            # assert we finish unpatched
+            conn = self._connect_with_kwargs()
+            assert not Pin.get_from(conn)
+            conn.close()
+
+        patch()

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,7 @@ envlist =
     {py27}-gevent{10}
     {py27,py34,py35,py36}-httplib
     {py27,py34,py35,py36}-mysqlconnector{21}
+    {py27}-mysqldb
     {py27,py34,py35,py36}-mysqlclient
     {py27,py34,py35,py36}-pylibmc{140,150}
     {py27,py34,py35,py36}-pymongo{30,31,32,33,34}-mongoengine{011}
@@ -164,6 +165,7 @@ deps =
     msgpack04: msgpack-python>=0.4,<0.5
     mongoengine011: mongoengine>=0.11,<0.12
     mysqlconnector21: mysql-connector>=2.1,<2.2
+    mysqldb: mysql-python
     mysqlclient: mysqlclient
 # webob is required for Pylons < 1.0
     pylons096: pylons>=0.9.6,<0.9.7
@@ -250,6 +252,7 @@ commands =
     gevent{10}: nosetests {posargs} tests/contrib/gevent
     httplib: nosetests {posargs} tests/contrib/httplib
     mysqlconnector21: nosetests {posargs} tests/contrib/mysql
+    mysqldb: nosetests {posargs} tests/contrib/mysqldb
     mysqlclient: nosetests {posargs} tests/contrib/mysqldb
     pylibmc{140,150}: nosetests {posargs} tests/contrib/pylibmc
     pymongo{30,31,32,33,34}: nosetests {posargs} tests/contrib/pymongo

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,7 @@ envlist =
     {py27}-gevent{10}
     {py27,py34,py35,py36}-httplib
     {py27,py34,py35,py36}-mysqlconnector{21}
+    {py27,py34,py35,py36}-mysqlclient
     {py27,py34,py35,py36}-pylibmc{140,150}
     {py27,py34,py35,py36}-pymongo{30,31,32,33,34}-mongoengine{011}
     {py27,py34,py35,py36}-pyramid{17,18,19}-webtest
@@ -163,6 +164,7 @@ deps =
     msgpack04: msgpack-python>=0.4,<0.5
     mongoengine011: mongoengine>=0.11,<0.12
     mysqlconnector21: mysql-connector>=2.1,<2.2
+    mysqlclient: mysqlclient
 # webob is required for Pylons < 1.0
     pylons096: pylons>=0.9.6,<0.9.7
     pylons096: webob<1.1
@@ -248,6 +250,7 @@ commands =
     gevent{10}: nosetests {posargs} tests/contrib/gevent
     httplib: nosetests {posargs} tests/contrib/httplib
     mysqlconnector21: nosetests {posargs} tests/contrib/mysql
+    mysqlclient: nosetests {posargs} tests/contrib/mysqldb
     pylibmc{140,150}: nosetests {posargs} tests/contrib/pylibmc
     pymongo{30,31,32,33,34}: nosetests {posargs} tests/contrib/pymongo
     pyramid{17,18,19}: nosetests {posargs} tests/contrib/pyramid/test_pyramid.py

--- a/tox.ini
+++ b/tox.ini
@@ -53,8 +53,8 @@ envlist =
     {py27}-gevent{10}
     {py27,py34,py35,py36}-httplib
     {py27,py34,py35,py36}-mysqlconnector{21}
-    {py27}-mysqldb
-    {py27,py34,py35,py36}-mysqlclient
+    {py27}-mysqldb{12}
+    {py27,py34,py35,py36}-mysqlclient{13}
     {py27,py34,py35,py36}-pylibmc{140,150}
     {py27,py34,py35,py36}-pymongo{30,31,32,33,34}-mongoengine{011}
     {py27,py34,py35,py36}-pyramid{17,18,19}-webtest
@@ -165,8 +165,8 @@ deps =
     msgpack04: msgpack-python>=0.4,<0.5
     mongoengine011: mongoengine>=0.11,<0.12
     mysqlconnector21: mysql-connector>=2.1,<2.2
-    mysqldb: mysql-python
-    mysqlclient: mysqlclient
+    mysqldb12: mysql-python>=1.2,<1.3
+    mysqlclient13: mysqlclient>=1.3,<1.4
 # webob is required for Pylons < 1.0
     pylons096: pylons>=0.9.6,<0.9.7
     pylons096: webob<1.1
@@ -252,8 +252,8 @@ commands =
     gevent{10}: nosetests {posargs} tests/contrib/gevent
     httplib: nosetests {posargs} tests/contrib/httplib
     mysqlconnector21: nosetests {posargs} tests/contrib/mysql
-    mysqldb: nosetests {posargs} tests/contrib/mysqldb
-    mysqlclient: nosetests {posargs} tests/contrib/mysqldb
+    mysqldb{12}: nosetests {posargs} tests/contrib/mysqldb
+    mysqlclient{13}: nosetests {posargs} tests/contrib/mysqldb
     pylibmc{140,150}: nosetests {posargs} tests/contrib/pylibmc
     pymongo{30,31,32,33,34}: nosetests {posargs} tests/contrib/pymongo
     pyramid{17,18,19}: nosetests {posargs} tests/contrib/pyramid/test_pyramid.py


### PR DESCRIPTION
This PR adds MySQLdb integration. MySQLdb is widely used db connector implementation:

* https://pypi.python.org/pypi/MySQL-python/1.2.5
* https://pypi.python.org/pypi/mysqlclient (fork of MySQL-python with Python3 support)

Difference from existing mysql (mysql-connector) integration:

* Did not port ddtrace.contrib.mysql.tracers since it is marked as deprecated.
* The factory function is Connect. Its aliases are connect and Connection.
* Genarate tags from arguments (positional arguments and keyword arguments), since connection parameters aren't stored as attributes of connection except port.

Modify test to work with MySQLdb:

* Keyword arguments are slightly different (password -> passwd, database -> db).
* cursor.callproc() doesn't return output value (same as PyMySQL, its integration proposed in https://github.com/DataDog/dd-trace-py/pull/296).
* conn.is_connected() doesn't exist, use conn.ping() instead.

Regards,