### PR TITLE
Wait service correctly on CircleCI

### DIFF
--- a/tests/wait-for-services.py
+++ b/tests/wait-for-services.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
         'postgres': check_postgres,
         'mysql': check_mysql
     }
-    if len(sys.argv) > 2:
+    if len(sys.argv) >= 2:
         for service in sys.argv[1:]:
             check_functions[service]()
     else:

--- a/tests/wait-for-services.py
+++ b/tests/wait-for-services.py
@@ -1,6 +1,5 @@
 import sys
 import time
-import traceback
 
 import mysql.connector
 from psycopg2 import connect, OperationalError


### PR DESCRIPTION
This fixes the error reported and ignored by CircleCI:

```
WARNING:command failed but result from testenv is ignored
  cmd: InvocationError: '/root/project/.tox/wait/bin/python tests/wait-for-services.py mysql'
```

in mysqlconnector test. It cause test failure sometimes.

Thanks.