### PR TITLE
[contrib:bottle] get distributed tracing context

### DIFF
--- a/ddtrace/contrib/bottle/__init__.py
+++ b/ddtrace/contrib/bottle/__init__.py
@@ -9,6 +9,10 @@ plugin to your app::
     app = bottle.Bottle()
     plugin = TracePlugin(service="my-web-app")
     app.install(plugin)
+
+To enable distributed tracing::
+
+    plugin = TracePlugin(service="my-web-app", distributed_tracing=True)
 """
 
 from ..util import require_modules

--- a/tests/contrib/bottle/test_distributed.py
+++ b/tests/contrib/bottle/test_distributed.py
@@ -1,0 +1,92 @@
+import bottle
+import ddtrace
+import webtest
+
+from unittest import TestCase
+from nose.tools import eq_, assert_not_equal
+from tests.test_tracer import get_dummy_tracer
+
+from ddtrace import compat
+from ddtrace.contrib.bottle import TracePlugin
+
+
+SERVICE = 'bottle-app'
+
+
+class TraceBottleDistributedTest(TestCase):
+    """
+    Ensures that Bottle is properly traced.
+    """
+    def setUp(self):
+        # provide a dummy tracer
+        self.tracer = get_dummy_tracer()
+        self._original_tracer = ddtrace.tracer
+        ddtrace.tracer = self.tracer
+        # provide a Bottle app
+        self.app = bottle.Bottle()
+
+    def tearDown(self):
+        # restore the tracer
+        ddtrace.tracer = self._original_tracer
+
+    def _trace_app_distributed(self, tracer=None):
+        self.app.install(TracePlugin(service=SERVICE, tracer=tracer, distributed_tracing=True))
+        self.app = webtest.TestApp(self.app)
+
+    def _trace_app_not_distributed(self, tracer=None):
+        self.app.install(TracePlugin(service=SERVICE, tracer=tracer, distributed_tracing=False))
+        self.app = webtest.TestApp(self.app)
+
+    def test_distributed(self):
+        # setup our test app
+        @self.app.route('/hi/<name>')
+        def hi(name):
+            return 'hi %s' % name
+        self._trace_app_distributed(self.tracer)
+
+        # make a request
+        headers = {'x-datadog-trace-id': '123',
+                   'x-datadog-parent-id': '456'}
+        resp = self.app.get('/hi/dougie', headers=headers)
+        eq_(resp.status_int, 200)
+        eq_(compat.to_unicode(resp.body), u'hi dougie')
+
+        # validate it's traced
+        spans = self.tracer.writer.pop()
+        eq_(len(spans), 1)
+        s = spans[0]
+        eq_(s.name, 'bottle.request')
+        eq_(s.service, 'bottle-app')
+        eq_(s.resource, 'GET /hi/<name>')
+        eq_(s.get_tag('http.status_code'), '200')
+        eq_(s.get_tag('http.method'), 'GET')
+        # check distributed headers
+        eq_(123, s.trace_id)
+        eq_(456, s.parent_id)
+
+    def test_not_distributed(self):
+        # setup our test app
+        @self.app.route('/hi/<name>')
+        def hi(name):
+            return 'hi %s' % name
+        self._trace_app_not_distributed(self.tracer)
+
+        # make a request
+        headers = {'x-datadog-trace-id': '123',
+                   'x-datadog-parent-id': '456'}
+        resp = self.app.get('/hi/dougie', headers=headers)
+        eq_(resp.status_int, 200)
+        eq_(compat.to_unicode(resp.body), u'hi dougie')
+
+        # validate it's traced
+        spans = self.tracer.writer.pop()
+        eq_(len(spans), 1)
+        s = spans[0]
+        eq_(s.name, 'bottle.request')
+        eq_(s.service, 'bottle-app')
+        eq_(s.resource, 'GET /hi/<name>')
+        eq_(s.get_tag('http.status_code'), '200')
+        eq_(s.get_tag('http.method'), 'GET')
+        # check distributed headers
+        assert_not_equal(123, s.trace_id)
+        assert_not_equal(456, s.parent_id)


### PR DESCRIPTION
Read the HTTP headers to propagate context and build proper distributed traces when using Bottle.