### PR TITLE
[tracer] keep hostname and port when calling configure()

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -114,9 +114,15 @@ class Tracer(object):
 
         if hostname is not None or port is not None or filters is not None or \
                 priority_sampling is not None:
+            # Preserve hostname and port when overriding filters or priority sampling
+            default_hostname = self.DEFAULT_HOSTNAME
+            default_port = self.DEFAULT_PORT
+            if hasattr(self, 'writer') and hasattr(self.writer, 'api'):
+                default_hostname = self.writer.api.hostname
+                default_port = self.writer.api.port
             self.writer = AgentWriter(
-                hostname or self.DEFAULT_HOSTNAME,
-                port or self.DEFAULT_PORT,
+                hostname or default_hostname,
+                port or default_port,
                 filters=filters,
                 priority_sampler=self.priority_sampler,
             )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -535,6 +535,6 @@ class TestConfigure(TestCase):
         tracer.configure(hostname='127.0.0.1', port=8127)
         eq_('127.0.0.1', tracer.writer.api.hostname)
         eq_(8127, tracer.writer.api.port)
-        tracer.configure(priority_sampling = True)
+        tracer.configure(priority_sampling=True)
         eq_('127.0.0.1', tracer.writer.api.hostname)
         eq_(8127, tracer.writer.api.port)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -518,3 +518,23 @@ class TestRateByService(TestCase):
         response = self.api_msgpack.send_traces(traces)
         ok_(response)
         eq_(response.status, 200)
+
+@skipUnless(
+    os.environ.get('TEST_DATADOG_INTEGRATION', False),
+    'You should have a running trace agent and set TEST_DATADOG_INTEGRATION=1 env variable'
+)
+class TestConfigure(TestCase):
+    """
+    Ensures that when calling configure without specifying hostname and port,
+    previous overrides have been kept.
+    """
+    def test_configure_keeps_api_hostname_and_port(self):
+        tracer = Tracer() # use real tracer with real api
+        eq_('localhost', tracer.writer.api.hostname)
+        eq_(8126, tracer.writer.api.port)
+        tracer.configure(hostname='127.0.0.1', port=8127)
+        eq_('127.0.0.1', tracer.writer.api.hostname)
+        eq_(8127, tracer.writer.api.port)
+        tracer.configure(priority_sampling = True)
+        eq_('127.0.0.1', tracer.writer.api.hostname)
+        eq_(8127, tracer.writer.api.port)


### PR DESCRIPTION
When custom hostname and port is required (typically, running the app in a container) calling configure() without specifying explicitly hostname and port actually sets it back to the default `localhost:8126` value. Which is usually not what you want when it was set up explicitly before, the
named parameter interface suggest you can, indeed, omit parameters.