### PR TITLE
Add missing trove classifiers for Pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,5 +67,12 @@ setup(
         'console_scripts': [
             'ddtrace-run = ddtrace.commands.ddtrace_run:main'
         ]
-    }
+    },
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
 )


### PR DESCRIPTION
The classifiers are not only useful for indicating the supported Python versions for a human, but they are also consumed by tools such as `caniusepython3` for indicating if a project supports Python 3 or not.
