### PR TITLE
Use pyramid HTTPExceptions as valid response types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -449,8 +449,8 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-pyramid-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-pyramid{17,18}-webtest' --result-json /tmp/pyramid.1.results
-      - run: tox -e '{py27,py34,py35,py36}-pyramid-autopatch{17,18}-webtest' --result-json /tmp/pyramid.2.results
+      - run: tox -e '{py27,py34,py35,py36}-pyramid{17,18,19}-webtest' --result-json /tmp/pyramid.1.results
+      - run: tox -e '{py27,py34,py35,py36}-pyramid-autopatch{17,18,19}-webtest' --result-json /tmp/pyramid.2.results
       - persist_to_workspace:
           root: /tmp
           paths:

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -3,6 +3,7 @@
 import logging
 import pyramid.renderers
 from pyramid.settings import asbool
+from pyramid.httpexceptions import HTTPException
 import wrapt
 
 # project
@@ -63,6 +64,12 @@ def trace_tween_factory(handler, registry):
                 response = None
                 try:
                     response = handler(request)
+                except HTTPException as e:
+                    # If the exception is a pyramid HTTPException,
+                    # that's still valuable information that isn't necessarily
+                    # a 500. For instance, HTTPFound is a 302.
+                    response = e  # Pyramid exceptions are all valid response types
+                    raise
                 except BaseException:
                     span.set_tag(http.STATUS_CODE, 500)
                     raise

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -68,7 +68,9 @@ def trace_tween_factory(handler, registry):
                     # If the exception is a pyramid HTTPException,
                     # that's still valuable information that isn't necessarily
                     # a 500. For instance, HTTPFound is a 302.
-                    response = e  # Pyramid exceptions are all valid response types
+                    # As described in docs, Pyramid exceptions are all valid
+                    # response types
+                    response = e
                     raise
                 except BaseException:
                     span.set_tag(http.STATUS_CODE, 500)

--- a/tests/contrib/pyramid/app/__init__.py
+++ b/tests/contrib/pyramid/app/__init__.py
@@ -1,0 +1,1 @@
+from .web import create_app  # noqa

--- a/tests/contrib/pyramid/app/web.py
+++ b/tests/contrib/pyramid/app/web.py
@@ -1,0 +1,71 @@
+from ddtrace.contrib.pyramid import trace_pyramid
+
+from pyramid.response import Response
+from pyramid.config import Configurator
+from pyramid.renderers import render_to_response
+from pyramid.httpexceptions import (
+    HTTPInternalServerError,
+    HTTPFound,
+    HTTPNotFound,
+    HTTPException,
+    HTTPNoContent,
+)
+
+
+def create_app(settings, instrument):
+    """Return a pyramid wsgi app"""
+
+    def index(request):
+        return Response('idx')
+
+    def error(request):
+        raise HTTPInternalServerError("oh no")
+
+    def exception(request):
+        1 / 0
+
+    def json(request):
+        return {'a': 1}
+
+    def renderer(request):
+        return render_to_response('template.pt', {'foo': 'bar'}, request=request)
+
+    def raise_redirect(request):
+        raise HTTPFound()
+
+    def raise_no_content(request):
+        raise HTTPNoContent()
+
+    def custom_exception_view(context, request):
+        """Custom view that forces a HTTPException when no views
+        are found to handle given request
+        """
+        if 'raise_exception' in request.url:
+            raise HTTPNotFound()
+        else:
+            return HTTPNotFound()
+
+    config = Configurator(settings=settings)
+    config.add_route('index', '/')
+    config.add_route('error', '/error')
+    config.add_route('exception', '/exception')
+    config.add_route('json', '/json')
+    config.add_route('renderer', '/renderer')
+    config.add_route('raise_redirect', '/redirect')
+    config.add_route('raise_no_content', '/nocontent')
+    config.add_view(index, route_name='index')
+    config.add_view(error, route_name='error')
+    config.add_view(exception, route_name='exception')
+    config.add_view(json, route_name='json', renderer='json')
+    config.add_view(renderer, route_name='renderer', renderer='template.pt')
+    config.add_view(raise_redirect, route_name='raise_redirect')
+    config.add_view(raise_no_content, route_name='raise_no_content')
+    # required to reproduce a regression test
+    config.add_notfound_view(custom_exception_view)
+    # required for rendering tests
+    renderer = config.testing_add_renderer('template.pt')
+
+    if instrument:
+        trace_pyramid(config)
+
+    return config.make_wsgi_app(), renderer

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -1,8 +1,5 @@
 # stdlib
-import logging
 import json
-import sys
-from wsgiref.simple_server import make_server
 
 # 3p
 from pyramid.response import Response
@@ -19,7 +16,6 @@ import webtest
 from nose.tools import eq_, assert_raises
 
 # project
-import ddtrace
 from ddtrace import compat
 from ddtrace.contrib.pyramid import trace_pyramid
 from ddtrace.contrib.pyramid.patch import insert_tween_if_needed
@@ -160,8 +156,9 @@ class PyramidBase(object):
         eq_(s.span_type, 'template')
 
     def test_renderer(self):
-        res = self.app.get('/renderer', status=200)
+        self.app.get('/renderer', status=200)
         assert self.rend._received['request'] is not None
+
         self.rend.assert_(foo='bar')
         writer = self.tracer.writer
         spans = writer.pop()

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -8,7 +8,11 @@ from wsgiref.simple_server import make_server
 from pyramid.response import Response
 from pyramid.config import Configurator
 from pyramid.renderers import render_to_response
-from pyramid.httpexceptions import HTTPInternalServerError
+from pyramid.httpexceptions import (
+    HTTPInternalServerError,
+    HTTPFound,
+    HTTPNoContent
+)
 import webtest
 from nose.tools import eq_
 
@@ -58,6 +62,36 @@ class PyramidBase(object):
         eq_(s.meta.get('http.method'), 'GET')
         eq_(s.meta.get('http.status_code'), '404')
         eq_(s.meta.get('http.url'), '/404')
+
+    def test_302(self):
+        self.app.get('/redirect', status=302)
+
+        writer = self.tracer.writer
+        spans = writer.pop()
+        eq_(len(spans), 1)
+        s = spans[0]
+        eq_(s.service, 'foobar')
+        eq_(s.resource, 'GET raise_redirect')
+        eq_(s.error, 0)
+        eq_(s.span_type, 'http')
+        eq_(s.meta.get('http.method'), 'GET')
+        eq_(s.meta.get('http.status_code'), '302')
+        eq_(s.meta.get('http.url'), '/redirect')
+
+    def test_204(self):
+        self.app.get('/nocontent', status=204)
+
+        writer = self.tracer.writer
+        spans = writer.pop()
+        eq_(len(spans), 1)
+        s = spans[0]
+        eq_(s.service, 'foobar')
+        eq_(s.resource, 'GET raise_no_content')
+        eq_(s.error, 0)
+        eq_(s.span_type, 'http')
+        eq_(s.meta.get('http.method'), 'GET')
+        eq_(s.meta.get('http.status_code'), '204')
+        eq_(s.meta.get('http.url'), '/nocontent')
 
     def test_exception(self):
         try:
@@ -241,16 +275,26 @@ def get_app(config):
     def renderer(request):
         return render_to_response('template.pt', {'foo': 'bar'}, request=request)
 
+    def raise_redirect(request):
+        raise HTTPFound
+
+    def raise_no_content(request):
+        raise HTTPNoContent
+
     config.add_route('index', '/')
     config.add_route('error', '/error')
     config.add_route('exception', '/exception')
     config.add_route('json', '/json')
     config.add_route('renderer', '/renderer')
+    config.add_route('raise_redirect', '/redirect')
+    config.add_route('raise_no_content', '/nocontent')
     config.add_view(index, route_name='index')
     config.add_view(error, route_name='error')
     config.add_view(exception, route_name='exception')
     config.add_view(json, route_name='json', renderer='json')
     config.add_view(renderer, route_name='renderer', renderer='template.pt')
+    config.add_view(raise_redirect, route_name='raise_redirect')
+    config.add_view(raise_no_content, route_name='raise_no_content')
     return config.make_wsgi_app()
 
 

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -1,30 +1,42 @@
-# stdlib
 import json
-
-# 3p
-from pyramid.response import Response
-from pyramid.config import Configurator
-from pyramid.renderers import render_to_response
-from pyramid.httpexceptions import (
-    HTTPInternalServerError,
-    HTTPFound,
-    HTTPNotFound,
-    HTTPException,
-    HTTPNoContent,
-)
 import webtest
+
 from nose.tools import eq_, assert_raises
 
 # project
 from ddtrace import compat
-from ddtrace.contrib.pyramid import trace_pyramid
 from ddtrace.contrib.pyramid.patch import insert_tween_if_needed
+
+from pyramid.httpexceptions import HTTPException
+
+from .app import create_app
 
 from ...test_tracer import get_dummy_tracer
 from ...util import override_global_tracer
 
 
 class PyramidBase(object):
+    instrument = False
+
+    def setUp(self):
+        self.tracer = get_dummy_tracer()
+        self.create_app()
+
+    def create_app(self, settings=None):
+        # get default settings or use what is provided
+        settings = settings or self.get_settings()
+        # always set the dummy tracer as a default tracer
+        settings.update({'datadog_tracer': self.tracer})
+
+        app, renderer = create_app(settings, self.instrument)
+        self.app = webtest.TestApp(app)
+        self.renderer = renderer
+
+    def get_settings(self):
+        return {}
+
+    def override_settings(self, settings):
+        self.create_app(settings)
 
     def test_200(self):
         res = self.app.get('/', status=200)
@@ -157,9 +169,9 @@ class PyramidBase(object):
 
     def test_renderer(self):
         self.app.get('/renderer', status=200)
-        assert self.rend._received['request'] is not None
+        assert self.renderer._received['request'] is not None
 
-        self.rend.assert_(foo='bar')
+        self.renderer.assert_(foo='bar')
         writer = self.tracer.writer
         spans = writer.pop()
         eq_(len(spans), 2)
@@ -195,134 +207,59 @@ class PyramidBase(object):
         eq_(s.meta.get('http.status_code'), '404')
         eq_(s.meta.get('http.url'), '/404/raise_exception')
 
+    def test_insert_tween_if_needed_already_set(self):
+        settings = {'pyramid.tweens': 'ddtrace.contrib.pyramid:trace_tween_factory'}
+        insert_tween_if_needed(settings)
+        eq_(settings['pyramid.tweens'], 'ddtrace.contrib.pyramid:trace_tween_factory')
+
+    def test_insert_tween_if_needed_none(self):
+        settings = {'pyramid.tweens': ''}
+        insert_tween_if_needed(settings)
+        eq_(settings['pyramid.tweens'], '')
+
+    def test_insert_tween_if_needed_excview(self):
+        settings = {'pyramid.tweens': 'pyramid.tweens.excview_tween_factory'}
+        insert_tween_if_needed(settings)
+        eq_(settings['pyramid.tweens'], 'ddtrace.contrib.pyramid:trace_tween_factory\npyramid.tweens.excview_tween_factory')
+
+    def test_insert_tween_if_needed_excview_and_other(self):
+        settings = {'pyramid.tweens': 'a.first.tween\npyramid.tweens.excview_tween_factory\na.last.tween\n'}
+        insert_tween_if_needed(settings)
+        eq_(settings['pyramid.tweens'],
+            'a.first.tween\n'
+            'ddtrace.contrib.pyramid:trace_tween_factory\n'
+            'pyramid.tweens.excview_tween_factory\n'
+            'a.last.tween\n')
+
+    def test_insert_tween_if_needed_others(self):
+        settings = {'pyramid.tweens': 'a.random.tween\nand.another.one'}
+        insert_tween_if_needed(settings)
+        eq_(settings['pyramid.tweens'], 'a.random.tween\nand.another.one\nddtrace.contrib.pyramid:trace_tween_factory')
+
+    def test_include_conflicts(self):
+        # test that includes do not create conflicts
+        self.override_settings({'pyramid.includes': 'tests.contrib.pyramid.test_pyramid'})
+        self.app.get('/404', status=404)
+        spans = self.tracer.writer.pop()
+        eq_(len(spans), 1)
+
 
 def includeme(config):
     pass
 
-def test_include_conflicts():
-    """ Test that includes do not create conflicts """
-    tracer = get_dummy_tracer()
-    with override_global_tracer(tracer):
-        config = Configurator(settings={'pyramid.includes': 'tests.contrib.pyramid.test_pyramid'})
-        trace_pyramid(config)
-        app = webtest.TestApp(config.make_wsgi_app())
-        app.get('/', status=404)
-        spans = tracer.writer.pop()
-        assert spans
-        eq_(len(spans), 1)
-
-def test_tween_overriden():
-    """ In case our tween is overriden by the user config we should not log
-    rendering """
-    tracer = get_dummy_tracer()
-    with override_global_tracer(tracer):
-        config = Configurator(settings={'pyramid.tweens': 'pyramid.tweens.excview_tween_factory'})
-        trace_pyramid(config)
-
-        def json(request):
-            return {'a': 1}
-        config.add_route('json', '/json')
-        config.add_view(json, route_name='json', renderer='json')
-        app = webtest.TestApp(config.make_wsgi_app())
-        app.get('/json', status=200)
-        spans = tracer.writer.pop()
-        assert not spans
-
-def test_insert_tween_if_needed_already_set():
-    settings = {'pyramid.tweens': 'ddtrace.contrib.pyramid:trace_tween_factory'}
-    insert_tween_if_needed(settings)
-    eq_(settings['pyramid.tweens'], 'ddtrace.contrib.pyramid:trace_tween_factory')
-
-def test_insert_tween_if_needed_none():
-    settings = {'pyramid.tweens': ''}
-    insert_tween_if_needed(settings)
-    eq_(settings['pyramid.tweens'], '')
-
-def test_insert_tween_if_needed_excview():
-    settings = {'pyramid.tweens': 'pyramid.tweens.excview_tween_factory'}
-    insert_tween_if_needed(settings)
-    eq_(settings['pyramid.tweens'], 'ddtrace.contrib.pyramid:trace_tween_factory\npyramid.tweens.excview_tween_factory')
-
-def test_insert_tween_if_needed_excview_and_other():
-    settings = {'pyramid.tweens': 'a.first.tween\npyramid.tweens.excview_tween_factory\na.last.tween\n'}
-    insert_tween_if_needed(settings)
-    eq_(settings['pyramid.tweens'],
-        'a.first.tween\n'
-        'ddtrace.contrib.pyramid:trace_tween_factory\n'
-        'pyramid.tweens.excview_tween_factory\n'
-        'a.last.tween\n')
-
-
-def test_insert_tween_if_needed_others():
-    settings = {'pyramid.tweens': 'a.random.tween\nand.another.one'}
-    insert_tween_if_needed(settings)
-    eq_(settings['pyramid.tweens'], 'a.random.tween\nand.another.one\nddtrace.contrib.pyramid:trace_tween_factory')
-
-
-def get_app(config):
-    """ return a pyramid wsgi app with various urls. """
-
-    def index(request):
-        return Response('idx')
-
-    def error(request):
-        raise HTTPInternalServerError("oh no")
-
-    def exception(request):
-        1 / 0
-
-    def json(request):
-        return {'a': 1}
-
-    def renderer(request):
-        return render_to_response('template.pt', {'foo': 'bar'}, request=request)
-
-    def raise_redirect(request):
-        raise HTTPFound()
-
-    def raise_no_content(request):
-        raise HTTPNoContent()
-
-    config.add_route('index', '/')
-    config.add_route('error', '/error')
-    config.add_route('exception', '/exception')
-    config.add_route('json', '/json')
-    config.add_route('renderer', '/renderer')
-    config.add_route('raise_redirect', '/redirect')
-    config.add_route('raise_no_content', '/nocontent')
-    config.add_view(index, route_name='index')
-    config.add_view(error, route_name='error')
-    config.add_view(exception, route_name='exception')
-    config.add_view(json, route_name='json', renderer='json')
-    config.add_view(renderer, route_name='renderer', renderer='template.pt')
-    config.add_view(raise_redirect, route_name='raise_redirect')
-    config.add_view(raise_no_content, route_name='raise_no_content')
-    return config.make_wsgi_app()
-
-
-def custom_exception_view(context, request):
-    """Custom view that forces a HTTPException when no views
-    are found to handle given request
-    """
-    if 'raise_exception' in request.url:
-        raise HTTPNotFound()
-    else:
-        return HTTPNotFound()
-
 
 class TestPyramid(PyramidBase):
-    def setUp(self):
-        self.tracer = get_dummy_tracer()
-        settings = {
+    instrument = True
+
+    def get_settings(self):
+        return {
             'datadog_trace_service': 'foobar',
-            'datadog_tracer': self.tracer,
         }
 
-        config = Configurator(settings=settings)
-        self.rend = config.testing_add_renderer('template.pt')
-        # required to reproduce a regression test
-        config.add_notfound_view(custom_exception_view)
-        trace_pyramid(config)
-
-        app = get_app(config)
-        self.app = webtest.TestApp(app)
+    def test_tween_overridden(self):
+        # in case our tween is overriden by the user config we should
+        # not log rendering
+        self.override_settings({'pyramid.tweens': 'pyramid.tweens.excview_tween_factory'})
+        self.app.get('/json', status=200)
+        spans = self.tracer.writer.pop()
+        eq_(len(spans), 0)

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -10,7 +10,7 @@ from wsgiref.simple_server import make_server
 
 # project
 import ddtrace
-from .test_pyramid import PyramidBase, get_app
+from .test_pyramid import PyramidBase, get_app, custom_exception_view
 
 class TestPyramidAutopatch(PyramidBase):
     def setUp(self):
@@ -20,6 +20,8 @@ class TestPyramidAutopatch(PyramidBase):
 
         config = Configurator()
         self.rend = config.testing_add_renderer('template.pt')
+        # required to reproduce a regression test
+        config.add_notfound_view(custom_exception_view)
         app = get_app(config)
         self.app = webtest.TestApp(app)
 
@@ -31,6 +33,8 @@ class TestPyramidExplicitTweens(PyramidBase):
 
         config = Configurator(settings={'pyramid.tweens': 'pyramid.tweens.excview_tween_factory\n'})
         self.rend = config.testing_add_renderer('template.pt')
+        # required to reproduce a regression test
+        config.add_notfound_view(custom_exception_view)
         app = get_app(config)
         self.app = webtest.TestApp(app)
 

--- a/tox.ini
+++ b/tox.ini
@@ -55,8 +55,8 @@ envlist =
     {py27,py34,py35,py36}-mysqlconnector{21}
     {py27,py34,py35,py36}-pylibmc{140,150}
     {py27,py34,py35,py36}-pymongo{30,31,32,33,34}-mongoengine{011}
-    {py27,py34,py35,py36}-pyramid{17,18}-webtest
-    {py27,py34,py35,py36}-pyramid-autopatch{17,18}-webtest
+    {py27,py34,py35,py36}-pyramid{17,18,19}-webtest
+    {py27,py34,py35,py36}-pyramid-autopatch{17,18,19}-webtest
     {py27,py34,py35,py36}-requests{208,209,210,211,212,213}
     {py27,py34,py35,py36}-sqlalchemy{10,11}-psycopg2{27}-mysqlconnector{21}
     {py27,py34,py35,py36}-psycopg2{25,26,27}
@@ -174,8 +174,10 @@ deps =
     pymongo34: pymongo>=3.4,<3.5
     pyramid17: pyramid>=1.7,<1.8
     pyramid18: pyramid>=1.8,<1.9
+    pyramid19: pyramid>=1.9,<1.10
     pyramid-autopatch17: pyramid>=1.7,<1.8
     pyramid-autopatch18: pyramid>=1.8,<1.9
+    pyramid-autopatch19: pyramid>=1.9,<1.10
     psycopg225: psycopg2>=2.5,<2.6
     psycopg226: psycopg2>=2.6,<2.7
     psycopg227: psycopg2>=2.7,<2.8
@@ -241,8 +243,8 @@ commands =
     mysqlconnector21: nosetests {posargs} tests/contrib/mysql
     pylibmc{140,150}: nosetests {posargs} tests/contrib/pylibmc
     pymongo{30,31,32,33,34}: nosetests {posargs} tests/contrib/pymongo
-    pyramid{17,18}: nosetests {posargs} tests/contrib/pyramid/test_pyramid.py
-    pyramid-autopatch{17,18}: ddtrace-run nosetests {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
+    pyramid{17,18,19}: nosetests {posargs} tests/contrib/pyramid/test_pyramid.py
+    pyramid-autopatch{17,18,19}: ddtrace-run nosetests {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
     mongoengine: nosetests {posargs} tests/contrib/mongoengine
     psycopg2{25,26,27}: nosetests {posargs} tests/contrib/psycopg
     py{34}-aiopg{012,013}: nosetests {posargs} --exclude=".*(test_aiopg_35).*" tests/contrib/aiopg
@@ -329,10 +331,19 @@ setenv =
 setenv =
     {[pyramid_autopatch]setenv}
 
+[testenv:py27-pyramid-autopatch19-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+
 [testenv:py34-pyramid-autopatch17-webtest]
 setenv =
     {[pyramid_autopatch]setenv}
+
 [testenv:py34-pyramid-autopatch18-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+
+[testenv:py34-pyramid-autopatch19-webtest]
 setenv =
     {[pyramid_autopatch]setenv}
 
@@ -344,11 +355,19 @@ setenv =
 setenv =
     {[pyramid_autopatch]setenv}
 
+[testenv:py35-pyramid-autopatch19-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+
 [testenv:py36-pyramid-autopatch17-webtest]
 setenv =
     {[pyramid_autopatch]setenv}
 
 [testenv:py36-pyramid-autopatch18-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+
+[testenv:py36-pyramid-autopatch19-webtest]
 setenv =
     {[pyramid_autopatch]setenv}
 


### PR DESCRIPTION
### Overview

As defined in [pyramid docs](https://docs.pylonsproject.org/projects/pyramid/en/latest/api/httpexceptions.html), each `HTTPException` class is also a `Response` object.
It also adds Pylons 1.9 to the test matrix.

### Contributor

Original PR #386: @TylerLubeck 