### PR TITLE
[ci] force downgrade of yarl for aiohttp tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-aiohttp-{{ checksum "tox.ini" }}
-      - run: tox -e '{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}' --result-json /tmp/aiohttp.results
+      - run: tox -e '{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl' --result-json /tmp/aiohttp.results
       - persist_to_workspace:
           root: /tmp
           paths:

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ envlist =
     {py27,py34,py35,py36}-ddtracerun
     {py34,py35,py36}-asyncio
     {py27}-pylons
-    {py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}
+    {py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
     {py27}-tornado{40,41,42,43,44}
     {py27}-tornado{40,41,42,43,44}-futures
     {py34,py35,py36}-tornado{40,41,42,43,44}
@@ -77,6 +77,9 @@ deps =
 # test dependencies installed in all envs
     mock
     nose
+# force the downgrade as a workaround
+# https://github.com/aio-libs/aiohttp/issues/2662
+    yarl: yarl==0.18.0
 # integrations
     aiobotocore04: aiobotocore>=0.4,<0.5
     aiobotocore03: aiobotocore>=0.3,<0.4


### PR DESCRIPTION
### Overview

Some versions of `aiohttp` may use `yarl>=1.0` that drops some methods. In that case it's not possible to run tests for `aiohttp` because of:
```
  File "/root/project/.tox/py34-aiohttp12-aiohttp_jinja012/lib/python3.4/site-packages/aiohttp/web_urldispatcher.py", line 14, in <module>
    from yarl import URL, quote, unquote
ImportError: cannot import name 'quote'
```

Pinning `yarl` to version 0.18 fixes the problem.