### PR TITLE
[pyramid] add distributed tracing

### DIFF
--- a/ddtrace/contrib/pyramid/__init__.py
+++ b/ddtrace/contrib/pyramid/__init__.py
@@ -15,6 +15,12 @@ config::
     # use your config as normal.
     config.add_route('index', '/')
 
+Available settings are:
+
+* `datadog_trace_service`: change the `pyramid` service name
+* `datadog_trace_enabled`: sets if the Tracer is enabled or not
+* `datadog_distributed_tracing`: set it to `True` to enable Distributed Tracing
+
 If you use the 'pyramid.tweens' settings value to set the tweens for your
 application, you need to add 'ddtrace.contrib.pyramid:trace_tween_factory'
 explicitly to the list. For example::

--- a/ddtrace/contrib/pyramid/constants.py
+++ b/ddtrace/contrib/pyramid/constants.py
@@ -1,3 +1,4 @@
 SETTINGS_SERVICE = 'datadog_trace_service'
 SETTINGS_TRACER = 'datadog_tracer'
 SETTINGS_TRACE_ENABLED = 'datadog_trace_enabled'
+SETTINGS_DISTRIBUTED_TRACING = 'datadog_distributed_tracing'

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -16,6 +16,7 @@ from ...util import override_global_tracer
 
 
 class PyramidBase(object):
+    """Base Pyramid test application"""
     instrument = False
 
     def setUp(self):
@@ -37,6 +38,9 @@ class PyramidBase(object):
 
     def override_settings(self, settings):
         self.create_app(settings)
+
+class PyramidTestCase(PyramidBase):
+    """Pyramid TestCase that includes tests for automatic instrumentation"""
 
     def test_200(self):
         res = self.app.get('/', status=200)
@@ -248,7 +252,7 @@ def includeme(config):
     pass
 
 
-class TestPyramid(PyramidBase):
+class TestPyramid(PyramidTestCase):
     instrument = True
 
     def get_settings(self):

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -3,7 +3,6 @@ import webtest
 
 from nose.tools import eq_, assert_raises
 
-# project
 from ddtrace import compat
 from ddtrace.contrib.pyramid.patch import insert_tween_if_needed
 
@@ -267,3 +266,30 @@ class TestPyramid(PyramidTestCase):
         self.app.get('/json', status=200)
         spans = self.tracer.writer.pop()
         eq_(len(spans), 0)
+
+
+class TestPyramidDistributedTracing(PyramidBase):
+    instrument = True
+
+    def get_settings(self):
+        return {
+            'datadog_distributed_tracing': True,
+        }
+
+    def test_distributed_tracing(self):
+        # ensure the Context is properly created
+        # if distributed tracing is enabled
+        headers = {
+            'x-datadog-trace-id': '100',
+            'x-datadog-parent-id': '42',
+            'x-datadog-sampling-priority': '2',
+        }
+        res = self.app.get('/', headers=headers, status=200)
+        writer = self.tracer.writer
+        spans = writer.pop()
+        eq_(len(spans), 1)
+        # check the propagated Context
+        span = spans[0]
+        eq_(span.trace_id, 100)
+        eq_(span.parent_id, 42)
+        eq_(span.get_metric('_sampling_priority_v1'), 2)

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -13,15 +13,14 @@ from wsgiref.simple_server import make_server
 from ...test_tracer import get_dummy_tracer
 from ...util import override_global_tracer
 
-#from .test_pyramid import PyramidBase, get_app, custom_exception_view
-from .test_pyramid import PyramidBase
+from .test_pyramid import PyramidTestCase
 
 
-class TestPyramidAutopatch(PyramidBase):
+class TestPyramidAutopatch(PyramidTestCase):
     instrument = False
 
 
-class TestPyramidExplicitTweens(PyramidBase):
+class TestPyramidExplicitTweens(PyramidTestCase):
     instrument = False
 
     def get_settings(self):


### PR DESCRIPTION
### Overview

Introduces distributed tracing for `pyramid`. To activate, add the following to your pyramid settings:
```python
from pyramid.config import Configurator
from ddtrace.contrib.pyramid import trace_pyramid

settings = {
    'datadog_trace_service' : 'my-web-app-name',
    'datadog_distributed_tracing' : True,
}

config = Configurator(settings=settings)
trace_pyramid(config)
```