### PR TITLE
flask: don't override code of already handled errors

### DIFF
--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -1,8 +1,8 @@
 """
-Datadog trace code for flask.
+Datadog tracing code for flask.
 
-Requires a modern version of flask and the `blinker` library (which is a
-dependency of flask signals).
+Installing the blinker library will allow the tracing middleware to collect
+more exception info.
 """
 
 # stdlib
@@ -27,10 +27,10 @@ class TraceMiddleware(object):
         self.app = app
         self.app.logger.info("initializing trace middleware")
 
-        # save our traces.
         self._tracer = tracer
         self._service = service
         self._use_distributed_tracing = distributed_tracing
+        self.use_signals = use_signals
 
         self._tracer.set_service_info(
             service=service,
@@ -38,36 +38,25 @@ class TraceMiddleware(object):
             app_type=AppTypes.web,
         )
 
-        # warn the user if signals are unavailable (because blinker isn't
-        # installed) if they are asking to use them.
+        # Install hooks which time requests.
+        self.app.before_request(self._before_request)
+        self.app.after_request(self._after_request)
+        self.app.teardown_request(self._teardown_request)
+
+        # Add exception handling signals. This will annotate exceptions that
+        # are caught and handled in custom user code.
+        # See https://github.com/DataDog/dd-trace-py/issues/390
         if use_signals and not signals.signals_available:
             self.app.logger.info(_blinker_not_installed_msg)
         self.use_signals = use_signals and signals.signals_available
-
-        # our signal receivers
-        self._receivers = []
-
-        # instrument request timings
         timing_signals = {
-            'request_started': self._request_started,
-            'request_finished': self._request_finished,
             'got_request_exception': self._request_exception,
         }
+        self._receivers = []
         if self.use_signals and _signals_exist(timing_signals):
             self._connect(timing_signals)
-        else:
-            # Fallback to request hooks. Won't catch exceptions.
-            # handle exceptions.
-            self.app.before_request(self._before_request)
-            self.app.after_request(self._after_request)
 
         _patch_render(tracer)
-
-    def _flask_signals_exist(self, names):
-        """ Return true if the current version of flask has all of the given
-            signals.
-        """
-        return all(getattr(signals, n, None) for n in names)
 
     def _connect(self, signal_to_handler):
         connected = True
@@ -85,7 +74,34 @@ class TraceMiddleware(object):
             self._receivers.append(handler)
         return connected
 
-    # common methods
+    def _before_request(self):
+        """ Starts tracing the current request and stores it in the global
+            request object.
+        """
+        self._start_span()
+
+    def _after_request(self, response):
+        """ Runs after the server can process a response. """
+        try:
+            self._process_response(response)
+        except Exception:
+            self.app.logger.exception("error tracing response")
+        return response
+
+    def _teardown_request(self, exception):
+        """ Runs at the end of a request. If there's an unhandled exception, it
+            will be passed in.
+        """
+        # when we teardown the span, ensure we have a clean slate.
+        span = getattr(g, 'flask_datadog_span', None)
+        setattr(g, 'flask_datadog_span', None)
+        if not span:
+            return
+
+        try:
+            self._finish_span(span, exception=exception)
+        except Exception:
+            self.app.logger.exception("error finishing span")
 
     def _start_span(self):
         if self._use_distributed_tracing:
@@ -103,78 +119,65 @@ class TraceMiddleware(object):
         except Exception:
             self.app.logger.exception("error tracing request")
 
-    def _finish_span(self, response=None, exception=None):
-        """ Close and finish the active span if it exists. """
+    def _process_response(self, response):
         span = getattr(g, 'flask_datadog_span', None)
-        if span:
-            if span.sampled:
-                error = 0
-                code = response.status_code if response else None
-                method = request.method if request else None
+        if not (span and span.sampled):
+            return
 
-                # if we didn't get a response, but we did get an exception, set
-                # codes accordingly.
-                if not response and exception:
-                    code = 500
-                    # The 3 next lines might not be strictly required, since `set_traceback`
-                    # also get the exception from the sys.exc_info (and fill the error meta).
-                    # Since we aren't sure it always work/for insuring no BC break, keep
-                    # these lines which get overridden anyway.
-                    error = 1
-                    span.set_tag(errors.ERROR_TYPE, type(exception))
-                    span.set_tag(errors.ERROR_MSG, exception)
-                    # The provided `exception` object doesn't have a stack trace attached,
-                    # so attach the stack trace with `set_traceback`.
-                    span.set_traceback()
-
-                # the endpoint that matched the request is None if an exception
-                # happened so we fallback to a common resource
-                resource = code if not request.endpoint else request.endpoint
-                span.resource = compat.to_unicode(resource).lower()
-                span.set_tag(http.URL, compat.to_unicode(request.base_url or ''))
-                span.set_tag(http.STATUS_CODE, code)
-                span.set_tag(http.METHOD, method)
-                span.error = error
-            span.finish()
-            # Clear our span just in case.
-            g.flask_datadog_span = None
-
-    # Request hook methods
-
-    def _before_request(self):
-        """ Starts tracing the current request and stores it in the global
-            request object.
-        """
-        self._start_span()
-
-    def _after_request(self, response):
-        """ handles a successful response. """
-        try:
-            self._finish_span(response=response)
-        except Exception:
-            self.app.logger.exception("error finishing trace")
-        finally:
-            return response
-
-    # signal handling methods
-
-    def _request_started(self, sender):
-        self._start_span()
-
-    def _request_finished(self, sender, response, **kwargs):
-        try:
-            self._finish_span(response=response)
-        except Exception:
-            self.app.logger.exception("error finishing trace")
-        return response
+        code = response.status_code if response else ''
+        span.set_tag(http.STATUS_CODE, code)
 
     def _request_exception(self, *args, **kwargs):
-        """ handles an error response. """
-        exception = kwargs.pop("exception", None)
+        exception = kwargs.get("exception", None)
+        span = getattr(g, 'flask_datadog_span', None)
+        if span and exception:
+            _set_error_on_span(span, exception)
+
+    def _finish_span(self, span, exception=None):
+        if not span or not span.sampled:
+            return
+
+        code = span.get_tag(http.STATUS_CODE) or 0
         try:
-            self._finish_span(exception=exception)
+            code = int(code)
         except Exception:
-            self.app.logger.exception("error tracing error")
+            code = 0
+
+        if exception:
+            # if the request has already had a code set, don't override it.
+            code = code or 500
+            _set_error_on_span(span, exception)
+
+        # the endpoint that matched the request is None if an exception
+        # happened so we fallback to a common resource
+        span.error = 0 if code < 500 else 1
+
+        # the request isn't guaranteed to exist here, so only use it carefully.
+        method = ''
+        endpoint = ''
+        url = ''
+        if request:
+            method = request.method
+            endpoint = request.endpoint or code
+            url = request.base_url or ''
+
+        resource = endpoint or code
+        span.resource = compat.to_unicode(resource).lower()
+        span.set_tag(http.URL, compat.to_unicode(url))
+        span.set_tag(http.STATUS_CODE, code)
+        span.set_tag(http.METHOD, method)
+        span.finish()
+
+def _set_error_on_span(span, exception):
+    # The 3 next lines might not be strictly required, since `set_traceback`
+    # also get the exception from the sys.exc_info (and fill the error meta).
+    # Since we aren't sure it always work/for insuring no BC break, keep
+    # these lines which get overridden anyway.
+    span.set_tag(errors.ERROR_TYPE, type(exception))
+    span.set_tag(errors.ERROR_MSG, exception)
+    # The provided `exception` object doesn't have a stack trace attached,
+    # so attach the stack trace with `set_traceback`.
+    span.set_traceback()
 
 def _patch_render(tracer):
     """ patch flask's render template methods with the given tracer. """


### PR DESCRIPTION
This is a refactoring of how we handle flask requests. We don't use
signals to teardown requests and instead use the `teardown_request`
handler. This always runs so it's a more reliable way of closing the
request. Signals are only used to annotate spans that received an error
(which a user may handler), and not to finish requests that may have been
successful.

This also reduces the difference between signal enabled and disabled
mode which is nice.

This should fix #390.