### PR TITLE
Depend on msgpack instead msgpack-python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     packages=find_packages(exclude=['tests*']),
     install_requires=[
         "wrapt",
-        "msgpack-python",
+        "msgpack",
     ],
     # plugin tox
     tests_require=['tox', 'flake8'],


### PR DESCRIPTION
The package msgpack-python was renamed msgpack in PyPI.