### PR TITLE
[dbapi] remove `sql.query` tag so that the content is obfuscated in the Agent

### DIFF
--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -33,7 +33,6 @@ class TracedCursor(wrapt.ObjectProxy):
 
         with pin.tracer.trace(self._self_datadog_name, service=service, resource=resource) as s:
             s.span_type = sql.TYPE
-            s.set_tag(sql.QUERY, resource)
             s.set_tags(pin.tags)
             s.set_tags(extra_tags)
 

--- a/tests/contrib/mysqldb/test_mysql.py
+++ b/tests/contrib/mysqldb/test_mysql.py
@@ -3,7 +3,7 @@ import MySQLdb
 from ddtrace import Pin
 from ddtrace.contrib.mysqldb.patch import patch, unpatch
 
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 
 from ..config import MYSQL_CONFIG
 from ...util import assert_dict_issuperset
@@ -53,7 +53,6 @@ class MySQLCore(object):
             'out.port': u'3306',
             'db.name': u'test',
             'db.user': u'test',
-            'sql.query': u'SELECT 1',
         })
 
     def test_simple_query_with_positional_args(self):
@@ -76,7 +75,6 @@ class MySQLCore(object):
             'out.port': u'3306',
             'db.name': u'test',
             'db.user': u'test',
-            'sql.query': u'SELECT 1',
         })
 
     def test_query_with_several_rows(self):
@@ -90,7 +88,7 @@ class MySQLCore(object):
         spans = writer.pop()
         eq_(len(spans), 1)
         span = spans[0]
-        eq_(span.get_tag('sql.query'), query)
+        ok_(span.get_tag('sql.query') is None)
 
     def test_query_many(self):
         # tests that the executemany method is correctly wrapped.
@@ -123,7 +121,7 @@ class MySQLCore(object):
         spans = writer.pop()
         eq_(len(spans), 2)
         span = spans[-1]
-        eq_(span.get_tag('sql.query'), query)
+        ok_(span.get_tag('sql.query') is None)
         cursor.execute("drop table if exists dummy")
 
     def test_query_proc(self):
@@ -166,8 +164,8 @@ class MySQLCore(object):
             'out.port': u'3306',
             'db.name': u'test',
             'db.user': u'test',
-            'sql.query': u'sp_sum',
         })
+        ok_(span.get_tag('sql.query') is None)
 
 
 class TestMysqlPatch(MySQLCore):
@@ -252,8 +250,8 @@ class TestMysqlPatch(MySQLCore):
                 'out.port': u'3306',
                 'db.name': u'test',
                 'db.user': u'test',
-                'sql.query': u'SELECT 1',
             })
+            ok_(span.get_tag('sql.query') is None)
 
         finally:
             unpatch()

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -6,7 +6,7 @@ import psycopg2
 from psycopg2 import _psycopg
 from psycopg2 import extensions
 from psycopg2 import extras
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 
 # project
 from ddtrace.contrib.psycopg import connection_factory
@@ -56,7 +56,7 @@ class PsycopgCore(object):
         eq_(span.name, "postgres.query")
         eq_(span.resource, q)
         eq_(span.service, service)
-        eq_(span.meta["sql.query"], q)
+        ok_(span.get_tag("sql.query") is None)
         eq_(span.error, 0)
         eq_(span.span_type, "sql")
         assert start <= span.start <= end
@@ -78,7 +78,7 @@ class PsycopgCore(object):
         eq_(span.name, "postgres.query")
         eq_(span.resource, q)
         eq_(span.service, service)
-        eq_(span.meta["sql.query"], q)
+        ok_(span.get_tag("sql.query") is None)
         eq_(span.error, 1)
         eq_(span.meta["out.host"], "localhost")
         eq_(span.meta["out.port"], TEST_PORT)

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -3,7 +3,7 @@ import sqlite3
 import time
 
 # 3p
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 
 # project
 import ddtrace
@@ -78,7 +78,7 @@ class TestSQLite(object):
             eq_(span.span_type, "sql")
             eq_(span.resource, q)
             eq_(span.service, service)
-            eq_(span.meta["sql.query"], q)
+            ok_(span.get_tag("sql.query") is None)
             eq_(span.error, 0)
             assert start <= span.start <= end
             assert span.duration <= end - start
@@ -98,7 +98,7 @@ class TestSQLite(object):
             eq_(span.name, "sqlite.query")
             eq_(span.resource, q)
             eq_(span.service, service)
-            eq_(span.meta["sql.query"], q)
+            ok_(span.get_tag("sql.query") is None)
             eq_(span.error, 1)
             eq_(span.span_type, "sql")
             assert span.get_tag(errors.ERROR_STACK)


### PR DESCRIPTION
### Overview

This patch removes the `sql.query` tag otherwise it's not properly obfuscated in the Trace Agent (reference: https://github.com/DataDog/datadog-trace-agent/blob/0067fb9a869a949e018e15befadb56338c5fa798/quantizer/sql.go#L228-L236). This issue impacts only MySQL integrations and NOT `psycopg2` or `sqlalchemy` with Postgres driver.