### PR TITLE
[pylons] add distributed tracing via kwarg and environment variable

### DIFF
--- a/ddtrace/contrib/pylons/__init__.py
+++ b/ddtrace/contrib/pylons/__init__.py
@@ -10,9 +10,12 @@ the following::
 
     app = PylonsApp(...)
 
-    traced_app = PylonsTraceMiddleware(app, tracer, service="my-pylons-app")
+    traced_app = PylonsTraceMiddleware(app, tracer, service='my-pylons-app')
 
-Then you can define your routes and views as usual.
+Then you can define your routes and views as usual. To enable distributed tracing,
+set the following keyword argument::
+
+    traced_app = PylonsTraceMiddleware(app, tracer, service='my-pylons-app', distributed_tracing=True)
 """
 
 from ..util import require_modules

--- a/ddtrace/contrib/pylons/patch.py
+++ b/ddtrace/contrib/pylons/patch.py
@@ -1,6 +1,5 @@
 import os
 import wrapt
-
 import pylons.wsgiapp
 
 from ddtrace import tracer, Pin
@@ -31,9 +30,10 @@ def traced_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
 
     # set tracing options and create the TraceMiddleware
-    service = os.environ.get('DATADOG_SERVICE_NAME') or 'pylons'
+    service = os.environ.get('DATADOG_SERVICE_NAME', 'pylons')
+    distributed_tracing = os.environ.get('DATADOG_PYLONS_DISTRIBUTED_TRACING', False)
     Pin(service=service, tracer=tracer).onto(instance)
-    traced_app = PylonsTraceMiddleware(instance, tracer, service=service)
+    traced_app = PylonsTraceMiddleware(instance, tracer, service=service, distributed_tracing=distributed_tracing)
 
     # re-order the middleware stack so that the first middleware is ours
     traced_app.app = instance.app


### PR DESCRIPTION
### Overview

Adds Distributed Tracing for `pylons` web framework. It could be activated using the `PylonsTraceMiddleware` with the following kwarg:

```python
traced_app = PylonsTraceMiddleware(app, tracer, service='my-pylons-app', distributed_tracing=True)
```

If `ddtrace-run` script is used, you can enable Distributed Tracing using the `DATADOG_PYLONS_DISTRIBUTED_TRACING=True` environment variable.