### PR TITLE
[ddtrace-run] enable Distributed Sampling via environment variable

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -6,6 +6,9 @@ Add all monkey-patching that needs to run by default here
 import os
 import logging
 
+from ddtrace.util import asbool
+
+
 debug = os.environ.get("DATADOG_TRACE_DEBUG")
 if debug and debug.lower() == "true":
     logging.basicConfig(level=logging.DEBUG)
@@ -46,6 +49,7 @@ try:
     enabled = os.environ.get("DATADOG_TRACE_ENABLED")
     hostname = os.environ.get("DATADOG_TRACE_AGENT_HOSTNAME")
     port = os.environ.get("DATADOG_TRACE_AGENT_PORT")
+    priority_sampling = os.environ.get("DATADOG_PRIORITY_SAMPLING")
 
     opts = {}
 
@@ -56,6 +60,8 @@ try:
         opts["hostname"] = hostname
     if port:
         opts["port"] = int(port)
+    if priority_sampling:
+        opts["priority_sampling"] = asbool(priority_sampling)
 
     if opts:
         tracer.configure(**opts)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,12 +41,13 @@ The available environment variables for `ddtrace-run` are:
 
 * ``DATADOG_TRACE_ENABLED=true|false`` (default: true): Enable web framework and library instrumentation. When false, your application code
   will not generate any traces.
-* ``DATADOG_ENV``  (no default): Set an application's environment e.g. ``prod``, ``pre-prod``, ``stage``
+* ``DATADOG_ENV`` (no default): Set an application's environment e.g. ``prod``, ``pre-prod``, ``stage``
 * ``DATADOG_TRACE_DEBUG=true|false`` (default: false): Enable debug logging in the tracer
 * ``DATADOG_SERVICE_NAME`` (no default): override the service name to be used for this program. This value is passed through when setting up middleware for web framework integrations (e.g. pylons, flask, django). For tracing without a web integration, prefer setting the service name in code.
-* ``DATADOG_PATCH_MODULES=module:patch,module:patch...`` e.g. ``boto:true,redis:false`` : override the modules patched for this execution of the program (default: none)
-* ``DATADOG_TRACE_AGENT_HOSTNAME=localhost`` : override the address of the trace agent host that the default tracer will attempt to submit to  (default: ``localhost``)
-* ``DATADOG_TRACE_AGENT_PORT=8126`` : override the port that the default tracer will submit to  (default: 8126)
+* ``DATADOG_PATCH_MODULES=module:patch,module:patch...`` e.g. ``boto:true,redis:false``: override the modules patched for this execution of the program (default: none)
+* ``DATADOG_TRACE_AGENT_HOSTNAME=localhost``: override the address of the trace agent host that the default tracer will attempt to submit to  (default: ``localhost``)
+* ``DATADOG_TRACE_AGENT_PORT=8126``: override the port that the default tracer will submit to  (default: 8126)
+* ``DATADOG_PRIORITY_SAMPLING`` (default: false): enables `Priority sampling`_
 
 ``ddtrace-run`` respects a variety of common entrypoints for web applications:
 

--- a/tests/commands/ddtrace_run_priority_sampling.py
+++ b/tests/commands/ddtrace_run_priority_sampling.py
@@ -1,0 +1,9 @@
+from __future__ import print_function
+
+from ddtrace import tracer
+
+from nose.tools import ok_
+
+if __name__ == '__main__':
+    ok_(tracer.priority_sampler is not None)
+    print("Test success")

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -95,6 +95,16 @@ class DdtraceRunTest(unittest.TestCase):
         )
         assert out.startswith(b"Test success")
 
+    def test_priority_sampling_from_env(self):
+        """
+        DATADOG_PRIORITY_SAMPLING enables Distributed Sampling
+        """
+        os.environ["DATADOG_PRIORITY_SAMPLING"] = "True"
+        out = subprocess.check_output(
+            ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_priority_sampling.py']
+        )
+        assert out.startswith(b"Test success")
+
     def test_patch_modules_from_env(self):
         """
         DATADOG_PATCH_MODULES overrides the defaults for patch_all()


### PR DESCRIPTION
### Overview

When `ddtrace-run` script is used, it's not possible to configure Distributed Sampling. With this patch you can enable it using `DATADOG_PRIORITY_SAMPLING=True`.