### PR TITLE
[tornado] better compatibility with `futures` instrumentation

### DIFF
--- a/ddtrace/contrib/tornado/compat.py
+++ b/ddtrace/contrib/tornado/compat.py
@@ -1,9 +1,12 @@
-from ..util import require_modules
-
-
-optional_modules = ['concurrent.futures']
-
-with require_modules(optional_modules) as missing_modules:
+try:
     # detect if concurrent.futures is available as a Python
     # stdlib or Python 2.7 backport
-    futures_available = len(missing_modules) == 0
+    from ..futures import patch as wrap_futures, unpatch as unwrap_futures
+    futures_available = True
+except ImportError:
+    def wrap_futures():
+        pass
+
+    def unwrap_futures():
+        pass
+    futures_available = False


### PR DESCRIPTION
### Overview

`tornado` was wrapping directly the unbound method `submit`, avoiding the safe-guard we have when using `wrapt`. With this new approach we use directly the `patch()` and `unpatch()` functions from the `futures` integration, so that we don't need to think what needs to be patched. Furthermore, avoids double wrapping the same unbound method.