### PR TITLE
[requests] provide a service name for the request Span

### DIFF
--- a/ddtrace/contrib/requests/__init__.py
+++ b/ddtrace/contrib/requests/__init__.py
@@ -32,5 +32,11 @@ required_modules = ['requests']
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        from .patch import TracedSession, patch, unpatch
-        __all__ = ['TracedSession', 'patch', 'unpatch']
+        from .patch import patch, unpatch
+        from .session import TracedSession
+
+        __all__ = [
+            'patch',
+            'unpatch',
+            'TracedSession',
+        ]

--- a/ddtrace/contrib/requests/__init__.py
+++ b/ddtrace/contrib/requests/__init__.py
@@ -1,29 +1,33 @@
 """
-To trace all HTTP calls from the requests library, patch the library like so::
+The ``requests`` integration traces all HTTP calls to internal or external services.
+Auto instrumentation is available using the ``patch`` function that **must be called
+before** importing the ``requests`` library. The following is an example::
 
-    # Patch the requests library.
-    from ddtrace.contrib.requests import patch
-    patch()
+    from ddtrace import patch
+    patch(requests=True)
 
     import requests
-    requests.get("http://www.datadog.com")
+    requests.get("https://www.datadoghq.com")
 
-If you would prefer finer grained control without monkeypatching the requests'
-code, use a TracedSession object as you would a requests.Session::
-
-    from ddtrace.contrib.requests import TracedSession
-
-    session = TracedSession()
-    session.get("http://www.datadog.com")
-
-To enable distributed tracing, for example if you call, from requests, a web service
-which is also instrumented and want to have traces including both client and server sides::
+If you would prefer finer grained control, use a ``TracedSession`` object as you would a
+``requests.Session``::
 
     from ddtrace.contrib.requests import TracedSession
 
     session = TracedSession()
-    session.distributed_tracing = True
-    session.get("http://host.lan/webservice")
+    session.get("https://www.datadoghq.com")
+
+The library can be configured globally and per instance, using the Configuration API::
+
+    from ddtrace import config
+
+    # enable distributed tracing globally
+    config.requests['distributed_tracing'] = True
+
+    # change the service name only for this session
+    session = Session()
+    cfg = config.get_from(session)
+    cfg['service_name'] = 'auth-api'
 """
 from ...utils.importlib import require_modules
 

--- a/ddtrace/contrib/requests/connection.py
+++ b/ddtrace/contrib/requests/connection.py
@@ -1,0 +1,56 @@
+import os
+import logging
+import ddtrace
+
+from ...ext import http
+from ...util import asbool
+from ...propagation.http import HTTPPropagator
+
+
+log = logging.getLogger(__name__)
+
+
+def _wrap_session_init(func, instance, args, kwargs):
+    """Configure tracing settings when the `Session` is initialized"""
+    func(*args, **kwargs)
+
+    # set tracer settings
+    distributed_tracing = asbool(os.environ.get('DATADOG_REQUESTS_DISTRIBUTED_TRACING')) or False
+    setattr(instance, 'distributed_tracing', distributed_tracing)
+
+
+def _wrap_request(func, instance, args, kwargs):
+    """Trace the `Session.request` instance method"""
+    tracer = getattr(instance, 'datadog_tracer', ddtrace.tracer)
+
+    # [TODO:christian] replace this with a unified way of handling options (eg, Pin)
+    distributed_tracing = getattr(instance, 'distributed_tracing', None)
+
+    # skip if tracing is not enabled
+    if not tracer.enabled:
+        return func(*args, **kwargs)
+
+    method = kwargs.get('method') or args[0]
+    url = kwargs.get('url') or args[1]
+    headers = kwargs.get('headers', {})
+
+    with tracer.trace("requests.request", span_type=http.TYPE) as span:
+        if distributed_tracing:
+            propagator = HTTPPropagator()
+            propagator.inject(span.context, headers)
+            kwargs['headers'] = headers
+
+        response = None
+        try:
+            response = func(*args, **kwargs)
+            return response
+        finally:
+            try:
+                span.set_tag(http.METHOD, method)
+                span.set_tag(http.URL, url)
+                if response is not None:
+                    span.set_tag(http.STATUS_CODE, response.status_code)
+                    # `span.error` must be an integer
+                    span.error = int(500 <= response.status_code)
+            except Exception:
+                log.debug("error patching tags", exc_info=True)

--- a/ddtrace/contrib/requests/connection.py
+++ b/ddtrace/contrib/requests/connection.py
@@ -2,6 +2,8 @@ import os
 import logging
 import ddtrace
 
+from .constants import DEFAULT_SERVICE
+
 from ...ext import http
 from ...util import asbool
 from ...propagation.http import HTTPPropagator
@@ -16,7 +18,29 @@ def _wrap_session_init(func, instance, args, kwargs):
 
     # set tracer settings
     distributed_tracing = asbool(os.environ.get('DATADOG_REQUESTS_DISTRIBUTED_TRACING')) or False
+    service_name = os.environ.get('DATADOG_REQUESTS_SERVICE_NAME') or DEFAULT_SERVICE
     setattr(instance, 'distributed_tracing', distributed_tracing)
+    setattr(instance, 'service_name', service_name)
+
+
+def _extract_service_name(session, span):
+    """Extracts the right service name based on the following logic:
+    - `requests` is the default service name
+    - users can change it via `session.service_name = 'clients'`
+    - if the Span doesn't have a parent, use the set service name
+      or fallback to the default
+    - if the Span has a parent, use the set service name or the
+      parent service value if the set service name is the default
+
+    The priority can be represented as:
+    Updated service name > parent service name > default to `requests`.
+    """
+    service_name = getattr(session, 'service_name', DEFAULT_SERVICE)
+    if (service_name == DEFAULT_SERVICE and
+            span._parent is not None and
+            span._parent.service is not None):
+        service_name = span._parent.service
+    return service_name
 
 
 def _wrap_request(func, instance, args, kwargs):
@@ -35,6 +59,9 @@ def _wrap_request(func, instance, args, kwargs):
     headers = kwargs.get('headers', {})
 
     with tracer.trace("requests.request", span_type=http.TYPE) as span:
+        # update the span service name before doing any action
+        span.service = _extract_service_name(instance, span)
+
         if distributed_tracing:
             propagator = HTTPPropagator()
             propagator.inject(span.context, headers)

--- a/ddtrace/contrib/requests/connection.py
+++ b/ddtrace/contrib/requests/connection.py
@@ -53,7 +53,7 @@ def _wrap_request(func, instance, args, kwargs):
         span.service = _extract_service_name(instance, span)
 
         # propagate distributed tracing headers
-        if config.get_from(instance)['distributed_tracing']:
+        if config.get_from(instance).get('distributed_tracing'):
             propagator = HTTPPropagator()
             propagator.inject(span.context, headers)
             kwargs['headers'] = headers
@@ -64,11 +64,11 @@ def _wrap_request(func, instance, args, kwargs):
             return response
         finally:
             try:
-                span.set_tag(http.METHOD, method)
+                span.set_tag(http.METHOD, method.upper())
                 span.set_tag(http.URL, url)
                 if response is not None:
                     span.set_tag(http.STATUS_CODE, response.status_code)
                     # `span.error` must be an integer
                     span.error = int(500 <= response.status_code)
             except Exception:
-                log.debug("error patching tags", exc_info=True)
+                log.debug("requests: error adding tags", exc_info=True)

--- a/ddtrace/contrib/requests/constants.py
+++ b/ddtrace/contrib/requests/constants.py
@@ -1,0 +1,1 @@
+DEFAULT_SERVICE = 'requests'

--- a/ddtrace/contrib/requests/legacy.py
+++ b/ddtrace/contrib/requests/legacy.py
@@ -1,0 +1,11 @@
+from ddtrace import config
+
+
+def _distributed_tracing(self):
+    """Backward compatibility"""
+    return config.get_from(self)['distributed_tracing']
+
+
+def _distributed_tracing_setter(self, value):
+    """Backward compatibility"""
+    config.get_from(self)['distributed_tracing'] = value

--- a/ddtrace/contrib/requests/legacy.py
+++ b/ddtrace/contrib/requests/legacy.py
@@ -1,11 +1,31 @@
+# [Deprecation]: this module contains deprecated functions
+# that will be removed in newer versions of the Tracer.
 from ddtrace import config
+
+from ...utils.deprecation import deprecation
 
 
 def _distributed_tracing(self):
-    """Backward compatibility"""
+    """Deprecated: this method has been deprecated in favor of
+    the configuration system. It will be removed in newer versions
+    of the Tracer.
+    """
+    deprecation(
+        name='client.distributed_tracing',
+        message='Use the configuration object instead `config.get_from(client)[\'distributed_tracing\'`',
+        version='1.0.0',
+    )
     return config.get_from(self)['distributed_tracing']
 
 
 def _distributed_tracing_setter(self, value):
-    """Backward compatibility"""
+    """Deprecated: this method has been deprecated in favor of
+    the configuration system. It will be removed in newer versions
+    of the Tracer.
+    """
+    deprecation(
+        name='client.distributed_tracing',
+        message='Use the configuration object instead `config.get_from(client)[\'distributed_tracing\'] = value`',
+        version='1.0.0',
+    )
     config.get_from(self)['distributed_tracing'] = value

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -1,17 +1,9 @@
-import os
-import logging
-
-import wrapt
-import ddtrace
 import requests
 
-from ...ext import http
-from ...propagation.http import HTTPPropagator
-from ...utils.formats import asbool
-from ...utils.wrappers import unwrap as _u
+from wrapt import wrap_function_wrapper as _w
 
-
-log = logging.getLogger(__name__)
+from ...util import unwrap as _u
+from .connection import _wrap_session_init, _wrap_request
 
 
 def patch():
@@ -20,8 +12,8 @@ def patch():
         return
     setattr(requests, '__datadog_patch', True)
 
-    wrapt.wrap_function_wrapper('requests', 'Session.__init__', _session_initializer)
-    wrapt.wrap_function_wrapper('requests', 'Session.request', _traced_request_func)
+    _w('requests', 'Session.__init__', _wrap_session_init)
+    _w('requests', 'Session.request', _wrap_request)
 
 
 def unpatch():
@@ -32,70 +24,3 @@ def unpatch():
 
     _u(requests.Session, '__init__')
     _u(requests.Session, 'request')
-
-
-def _session_initializer(func, instance, args, kwargs):
-    """Define settings when requests client is initialized"""
-    func(*args, **kwargs)
-
-    # set tracer settings
-    distributed_tracing = asbool(os.environ.get('DATADOG_REQUESTS_DISTRIBUTED_TRACING')) or False
-    setattr(instance, 'distributed_tracing', distributed_tracing)
-
-
-def _traced_request_func(func, instance, args, kwargs):
-    """ traced_request is a tracing wrapper for requests' Session.request
-        instance method.
-    """
-
-    # perhaps a global tracer isn't what we want, so permit individual requests
-    # sessions to have their own (with the standard global fallback)
-    tracer = getattr(instance, 'datadog_tracer', ddtrace.tracer)
-
-    # [TODO:christian] replace this with a unified way of handling options (eg, Pin)
-    distributed_tracing = getattr(instance, 'distributed_tracing', None)
-
-    # bail on the tracing if not enabled.
-    if not tracer.enabled:
-        return func(*args, **kwargs)
-
-    method = kwargs.get('method') or args[0]
-    url = kwargs.get('url') or args[1]
-    headers = kwargs.get('headers', {})
-
-    with tracer.trace("requests.request", span_type=http.TYPE) as span:
-        if distributed_tracing:
-            propagator = HTTPPropagator()
-            propagator.inject(span.context, headers)
-            kwargs['headers'] = headers
-
-        resp = None
-        try:
-            resp = func(*args, **kwargs)
-            return resp
-        finally:
-            try:
-                _apply_tags(span, method, url, resp)
-            except Exception:
-                log.debug("error patching tags", exc_info=True)
-
-
-def _apply_tags(span, method, url, response):
-    """ apply_tags will patch the given span with tags about the given request. """
-    span.set_tag(http.METHOD, method)
-    span.set_tag(http.URL, url)
-    if response is not None:
-        span.set_tag(http.STATUS_CODE, response.status_code)
-        # `span.error` must be an integer
-        span.error = int(500 <= response.status_code)
-
-
-class TracedSession(requests.Session):
-    """ TracedSession is a requests' Session that is already patched.
-    """
-    pass
-
-
-# Always patch our traced session with the traced method (cheesy way of sharing
-# code)
-wrapt.wrap_function_wrapper(TracedSession, 'request', _traced_request_func)

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -2,8 +2,20 @@ import requests
 
 from wrapt import wrap_function_wrapper as _w
 
-from ...util import unwrap as _u
-from .connection import _wrap_session_init, _wrap_request
+from ddtrace import config
+from ddtrace.pin import Pin
+
+from ...util import asbool, get_env, unwrap as _u
+from .legacy import _distributed_tracing, _distributed_tracing_setter
+from .constants import DEFAULT_SERVICE
+from .connection import _wrap_request
+
+
+# requests default settings
+config._add('requests',{
+    'service_name': get_env('requests', 'service_name', DEFAULT_SERVICE),
+    'distributed_tracing': asbool(get_env('requests', 'distributed_tracing', False)),
+})
 
 
 def patch():
@@ -12,8 +24,18 @@ def patch():
         return
     setattr(requests, '__datadog_patch', True)
 
-    _w('requests', 'Session.__init__', _wrap_session_init)
     _w('requests', 'Session.request', _wrap_request)
+    Pin(
+        service=config.requests['service_name'],
+        _config=config.requests,
+    ).onto(requests.Session)
+
+    # [Backward compatibility]: `session.distributed_tracing` should point and
+    # update the `Pin` configuration instead. This block adds a property so that
+    # old implementations work as expected
+    fn = property(_distributed_tracing)
+    fn = fn.setter(_distributed_tracing_setter)
+    requests.Session.distributed_tracing = fn
 
 
 def unpatch():
@@ -22,5 +44,4 @@ def unpatch():
         return
     setattr(requests, '__datadog_patch', False)
 
-    _u(requests.Session, '__init__')
     _u(requests.Session, 'request')

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -3,9 +3,10 @@ import requests
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
-from ddtrace.pin import Pin
 
-from ...util import asbool, get_env, unwrap as _u
+from ...pin import Pin
+from ...utils.formats import asbool, get_env
+from ...utils.wrappers import unwrap as _u
 from .legacy import _distributed_tracing, _distributed_tracing_setter
 from .constants import DEFAULT_SERVICE
 from .connection import _wrap_request

--- a/ddtrace/contrib/requests/session.py
+++ b/ddtrace/contrib/requests/session.py
@@ -1,0 +1,18 @@
+import requests
+
+from wrapt import wrap_function_wrapper as _w
+
+from .connection import _wrap_session_init, _wrap_request
+
+
+class TracedSession(requests.Session):
+    """TracedSession is a requests' Session that is already traced.
+    You can use it if you want a finer grained control for your
+    HTTP clients.
+    """
+    pass
+
+
+# always patch our `TracedSession` when imported
+_w(TracedSession, 'request', _wrap_session_init)
+_w(TracedSession, 'request', _wrap_request)

--- a/ddtrace/contrib/requests/session.py
+++ b/ddtrace/contrib/requests/session.py
@@ -2,7 +2,7 @@ import requests
 
 from wrapt import wrap_function_wrapper as _w
 
-from .connection import _wrap_session_init, _wrap_request
+from .connection import _wrap_request
 
 
 class TracedSession(requests.Session):
@@ -14,5 +14,4 @@ class TracedSession(requests.Session):
 
 
 # always patch our `TracedSession` when imported
-_w(TracedSession, 'request', _wrap_session_init)
 _w(TracedSession, 'request', _wrap_request)

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -1,8 +1,9 @@
 import unittest
 
 from requests import Session
-from nose.tools import eq_, assert_raises
+from nose.tools import eq_
 
+from ddtrace import config
 from ddtrace.ext import http, errors
 from ddtrace.contrib.requests import patch, unpatch
 
@@ -153,7 +154,8 @@ class TestRequests(BaseRequestTestCase):
 
     def test_user_set_service_name(self):
         # ensure a service name set by the user has precedence
-        self.session.service_name = 'clients'
+        cfg = config.get_from(self.session)
+        cfg['service_name'] = 'clients'
         out = self.session.get(URL_200)
         eq_(out.status_code, 200)
 
@@ -194,8 +196,9 @@ class TestRequests(BaseRequestTestCase):
     def test_user_service_name_precedence(self):
         # ensure the user service name takes precedence over
         # the parent Span
+        cfg = config.get_from(self.session)
+        cfg['service_name'] = 'clients'
         with self.tracer.trace('parent.span', service='web'):
-            self.session.service_name = 'clients'
             out = self.session.get(URL_200)
             eq_(out.status_code, 200)
 

--- a/tests/contrib/requests/test_requests_distributed.py
+++ b/tests/contrib/requests/test_requests_distributed.py
@@ -40,8 +40,7 @@ class TestRequestsDistributed(BaseRequestTestCase):
             eq_('bar', resp.text)
 
     def test_propagation_true(self):
-        # [Backward compatibility]: ensure users can switch the distributed
-        # tracing flag using the `Session` attribute
+        # ensure distributed tracing can be enabled
         cfg = config.get_from(self.session)
         cfg['distributed_tracing'] = True
         adapter = Adapter()
@@ -63,8 +62,7 @@ class TestRequestsDistributed(BaseRequestTestCase):
         eq_(root.span_id, req.parent_id)
 
     def test_propagation_false(self):
-        # [Backward compatibility]: ensure users can switch the distributed
-        # tracing flag using the `Session` attribute
+        # ensure distributed tracing can be disabled
         cfg = config.get_from(self.session)
         cfg['distributed_tracing'] = False
         adapter = Adapter()


### PR DESCRIPTION
### Overview

The current implementation doesn't provide any service name for the `requests` span. It means that all traces produced by `requests` as a root span will be dropped. With this patch we mainly:
* provide a default service name (that is `requests`), so that everytime it's a root span, the trace can be sent correctly
* allow users to change the service name for each client via:
```python
cfg = config.get_from(session)
cfg['service_name'] = 'client'
```
* the default service name can be changed also via environment variable `DD_REQUESTS_SERVICE_NAME` (or the legacy`DATADOG_REQUESTS_SERVICE_NAME`)
* if a parent is available and the service name has not been set by the user, use the parent service

During the process, minor refactoring has been done to split better the integration modules.

### Deprecated functionalities

The new configuration system has been used, but this patch is backward compatible so the legacy approach is still supported (but deprecated and will be removed in 1.0.0). Previously, to enable distributed tracing we had to:
```python
session.distributed_tracing = True
```
while now:
```python
cfg = config.get_from(session)
cfg['distributged_tracing'] = True
```