### PR TITLE
[django] Fix gunicorn gevent worker causing database connection unpatch

### DIFF
--- a/tests/contrib/django/utils.py
+++ b/tests/contrib/django/utils.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 # project
 from ddtrace.tracer import Tracer
 from ddtrace.contrib.django.conf import settings
-from ddtrace.contrib.django.db import unpatch_db
+from ddtrace.contrib.django.db import patch_db, unpatch_db
 from ddtrace.contrib.django.cache import unpatch_cache
 from ddtrace.contrib.django.templates import unpatch_template
 from ddtrace.contrib.django.middleware import remove_exception_middleware, remove_trace_middleware
@@ -35,6 +35,8 @@ class DjangoTraceTestCase(TestCase):
         # such as database creation queries
         self.tracer.writer.spans = []
         self.tracer.writer.pop_traces()
+        # gets unpatched for some tests
+        patch_db(self.tracer)
 
     def tearDown(self):
         # empty the tracer spans from test operations


### PR DESCRIPTION
When running django via gunicorn and using gevent workers new connections are created after a greenlet fork, and they are unpatched. That results in still seeing django traces but losing DB traces.

This simply makes connection patching slightly more robust, by patching the ConnectionHandler object. The patched ConnectionHandler makes sure that every connection it handles is patched.