### PR TITLE
[django] Remove MIDDLEWARE_CLASSES deprecation warning from tests

### DIFF
--- a/tests/contrib/django/app/settings.py
+++ b/tests/contrib/django/app/settings.py
@@ -84,7 +84,7 @@ if (1, 10) <= django.VERSION < (2, 0):
     ]
 
 # Django 2.0 has different defaults
-if django.VERSION >= (2, 0):
+elif django.VERSION >= (2, 0):
     MIDDLEWARE = [
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.common.CommonMiddleware',
@@ -97,20 +97,20 @@ if django.VERSION >= (2, 0):
         'tests.contrib.django.app.middlewares.CatchExceptionMiddleware',
     ]
 
-# Always add the legacy conf to make sure we handle it properly
 # Pre 1.10 style
-MIDDLEWARE_CLASSES = [
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.security.SecurityMiddleware',
+else:
+    MIDDLEWARE_CLASSES = [
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        'django.middleware.security.SecurityMiddleware',
 
-    'tests.contrib.django.app.middlewares.CatchExceptionMiddleware',
-]
+        'tests.contrib.django.app.middlewares.CatchExceptionMiddleware',
+    ]
 
 INSTALLED_APPS = [
     'django.contrib.admin',

--- a/tests/contrib/django/test_autopatching.py
+++ b/tests/contrib/django/test_autopatching.py
@@ -43,9 +43,13 @@ class DjangoAutopatchTest(DjangoTraceTestCase):
         ok_(django._datadog_patch)
         ok_('ddtrace.contrib.django' in settings.INSTALLED_APPS)
         eq_(settings.MIDDLEWARE[0], 'ddtrace.contrib.django.TraceMiddleware')
-        ok_('ddtrace.contrib.django.TraceMiddleware' not in settings.MIDDLEWARE_CLASSES)
+        # MIDDLEWARE_CLASSES gets created internally in django 1.10 & 1.11 but doesn't
+        # exist at all in 2.0.
+        ok_(not getattr(settings, 'MIDDLEWARE_CLASSES', None) or
+            'ddtrace.contrib.django.TraceMiddleware' not in settings.MIDDLEWARE_CLASSES)
         eq_(settings.MIDDLEWARE[-1], 'ddtrace.contrib.django.TraceExceptionMiddleware')
-        ok_('ddtrace.contrib.django.TraceExceptionMiddleware' not in settings.MIDDLEWARE_CLASSES)
+        ok_(not getattr(settings, 'MIDDLEWARE_CLASSES', None) or
+            'ddtrace.contrib.django.TraceExceptionMiddleware' not in settings.MIDDLEWARE_CLASSES)
 
 
     @skipIf(django.VERSION < (1, 10), 'skip if version is below 1.10')
@@ -58,9 +62,13 @@ class DjangoAutopatchTest(DjangoTraceTestCase):
         eq_(found_app, 1)
 
         eq_(settings.MIDDLEWARE[0], 'ddtrace.contrib.django.TraceMiddleware')
-        ok_('ddtrace.contrib.django.TraceMiddleware' not in settings.MIDDLEWARE_CLASSES)
+        # MIDDLEWARE_CLASSES gets created internally in django 1.10 & 1.11 but doesn't
+        # exist at all in 2.0.
+        ok_(not getattr(settings, 'MIDDLEWARE_CLASSES', None) or
+            'ddtrace.contrib.django.TraceMiddleware' not in settings.MIDDLEWARE_CLASSES)
         eq_(settings.MIDDLEWARE[-1], 'ddtrace.contrib.django.TraceExceptionMiddleware')
-        ok_('ddtrace.contrib.django.TraceExceptionMiddleware' not in settings.MIDDLEWARE_CLASSES)
+        ok_(not getattr(settings, 'MIDDLEWARE_CLASSES', None) or
+            'ddtrace.contrib.django.TraceExceptionMiddleware' not in settings.MIDDLEWARE_CLASSES)
 
         found_mw = settings.MIDDLEWARE.count('ddtrace.contrib.django.TraceMiddleware')
         eq_(found_mw, 1)

--- a/tests/contrib/djangorestframework/app/settings.py
+++ b/tests/contrib/djangorestframework/app/settings.py
@@ -41,7 +41,7 @@ TEMPLATES = [
     },
 ]
 
-if django.VERSION >= (1, 10):
+if (1, 10) <= django.VERSION < (2, 0):
     MIDDLEWARE = [
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.common.CommonMiddleware',
@@ -56,7 +56,7 @@ if django.VERSION >= (1, 10):
     ]
 
 # Django 2.0 has different defaults
-if django.VERSION >= (2, 0):
+elif django.VERSION >= (2, 0):
     MIDDLEWARE = [
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.common.CommonMiddleware',
@@ -69,20 +69,20 @@ if django.VERSION >= (2, 0):
         'tests.contrib.django.app.middlewares.CatchExceptionMiddleware',
     ]
 
-# Always add the legacy conf to make sure we handle it properly
 # Pre 1.10 style
-MIDDLEWARE_CLASSES = [
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.security.SecurityMiddleware',
+else:
+    MIDDLEWARE_CLASSES = [
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        'django.middleware.security.SecurityMiddleware',
 
-    'tests.contrib.django.app.middlewares.CatchExceptionMiddleware',
-]
+        'tests.contrib.django.app.middlewares.CatchExceptionMiddleware',
+    ]
 
 INSTALLED_APPS = [
     'django.contrib.admin',


### PR DESCRIPTION
We just had our test/sample project set up incorrectly to have both a redundant MIDDLEWARE_CLASSES as well as a MIDDLEWARE when django >= (1,10). The warning wasn't present in 2.0 but was shown for earlier new-middlware versions.

I just made it only use MIDDLEWARE_CLASSES for supported versions.