### PR TITLE
[core] provide an environment getter utility to ensure consistency between env vars

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,9 @@
+import os
 import unittest
 
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 
-from ddtrace.util import asbool
+from ddtrace.util import asbool, get_env
 
 
 class TestUtilities(unittest.TestCase):
@@ -17,3 +18,31 @@ class TestUtilities(unittest.TestCase):
         eq_(asbool(""), False)
         eq_(asbool(True), True)
         eq_(asbool(False), False)
+
+    def test_get_env(self):
+        # ensure `get_env` returns a default value if environment variables
+        # are not set
+        value = get_env('django', 'distributed_tracing')
+        ok_(value is None)
+        value = get_env('django', 'distributed_tracing', False)
+        ok_(value is False)
+
+    def test_get_env_found(self):
+        # ensure `get_env` returns a value if the environment variable is set
+        os.environ['DD_REQUESTS_DISTRIBUTED_TRACING'] = '1'
+        value = get_env('requests', 'distributed_tracing')
+        eq_(value, '1')
+
+    def test_get_env_found_legacy(self):
+        # ensure `get_env` returns a value if legacy environment variables
+        # are used
+        os.environ['DATADOG_REQUESTS_DISTRIBUTED_TRACING'] = '1'
+        value = get_env('requests', 'distributed_tracing')
+        eq_(value, '1')
+
+    def test_get_env_key_priority(self):
+        # ensure `get_env` use `DD_` with highest priority
+        os.environ['DD_REQUESTS_DISTRIBUTED_TRACING'] = 'highest'
+        os.environ['DATADOG_REQUESTS_DISTRIBUTED_TRACING'] = 'lowest'
+        value = get_env('requests', 'distributed_tracing')
+        eq_(value, 'highest')


### PR DESCRIPTION
### Overview

Depending on the integration, there isn't a clear consistency in environment variables nomenclature. With this patch we:
* expose an API to retrieve a setting from an environment variable (`get_env`)
* get the value from `DD_` prefix, with highest priority
* if `DD_` is not found, look for `DATADOG_` prefix (backward compatibility)
* if no environment variables are found, return a default

### Example

```python
# requests default settings
config._add('requests',{
    'service_name': get_env('requests', 'service_name', DEFAULT_SERVICE),
    'distributed_tracing': asbool(get_env('requests', 'distributed_tracing', False)),
})
```