### PR TITLE
[core] add Deprecation system with documentation

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -6,7 +6,7 @@ Add all monkey-patching that needs to run by default here
 import os
 import logging
 
-from ddtrace.util import asbool
+from ddtrace.utils.formats import asbool
 
 
 debug = os.environ.get("DATADOG_TRACE_DEBUG")

--- a/ddtrace/contrib/__init__.py
+++ b/ddtrace/contrib/__init__.py
@@ -1,1 +1,1 @@
-from .util import func_name, module_name, require_modules  # noqa
+from ..utils.importlib import func_name, module_name, require_modules  # noqa

--- a/ddtrace/contrib/aiobotocore/__init__.py
+++ b/ddtrace/contrib/aiobotocore/__init__.py
@@ -18,7 +18,7 @@ To enable it, you must run ``patch_all(botocore=True)``
     # This query generates a trace
     lambda_client.list_functions()
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 
 required_modules = ['aiobotocore.client']

--- a/ddtrace/contrib/aiobotocore/patch.py
+++ b/ddtrace/contrib/aiobotocore/patch.py
@@ -2,13 +2,13 @@ import asyncio
 import wrapt
 import aiobotocore.client
 
-from ddtrace import Pin
-from ddtrace.util import deep_getattr, unwrap
-
 from aiobotocore.endpoint import ClientResponseContentProxy
 
+from ...pin import Pin
 from ...ext import http, aws
 from ...compat import PYTHON_VERSION_INFO
+from ...utils.formats import deep_getattr
+from ...utils.wrappers import unwrap
 
 
 ARGS_NAME = ('action', 'params', 'path', 'verb')

--- a/ddtrace/contrib/aiohttp/__init__.py
+++ b/ddtrace/contrib/aiohttp/__init__.py
@@ -44,7 +44,7 @@ to the ``request`` object, so that it can be used in the application code::
         ctx = request['datadog_context']
         # do something with the tracing Context
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 required_modules = ['aiohttp']
 

--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -1,7 +1,7 @@
 import wrapt
 
 from ...pin import Pin
-from ddtrace.util import unwrap
+from ...utils.wrappers import unwrap
 
 
 try:

--- a/ddtrace/contrib/aiopg/__init__.py
+++ b/ddtrace/contrib/aiopg/__init__.py
@@ -15,7 +15,7 @@ Instrument `aiopg` to report a span for each executed Postgres queries::
     # Use a pin to specify metadata related to this connection
     Pin.override(db, service='postgres-users')
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 
 required_modules = ['aiopg']

--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -5,8 +5,7 @@ from aiopg.utils import _ContextManager
 
 from .. import dbapi
 from ...ext import sql
-
-from ddtrace import Pin
+from ...pin import Pin
 
 
 class AIOTracedCursor(wrapt.ObjectProxy):

--- a/ddtrace/contrib/aiopg/patch.py
+++ b/ddtrace/contrib/aiopg/patch.py
@@ -8,7 +8,7 @@ import wrapt
 from .connection import AIOTracedConnection
 from ..psycopg.patch import _patch_extensions, \
     _unpatch_extensions, patch_conn as psycppg_patch_conn
-from ...util import unwrap as _u
+from ...utils.wrappers import unwrap as _u
 
 
 def patch():

--- a/ddtrace/contrib/asyncio/__init__.py
+++ b/ddtrace/contrib/asyncio/__init__.py
@@ -39,7 +39,7 @@ A ``patch(asyncio=True)`` is available if you want to automatically use above
 wrappers without changing your code. In that case, the patch method **must be
 called before** importing stdlib functions.
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 
 required_modules = ['asyncio']

--- a/ddtrace/contrib/asyncio/patch.py
+++ b/ddtrace/contrib/asyncio/patch.py
@@ -3,7 +3,7 @@ import asyncio
 from wrapt import wrap_function_wrapper as _w
 
 from .helpers import _wrapped_create_task
-from ...util import unwrap as _u
+from ...utils.wrappers import unwrap as _u
 
 
 def patch():

--- a/ddtrace/contrib/boto/__init__.py
+++ b/ddtrace/contrib/boto/__init__.py
@@ -17,7 +17,7 @@ This integration ignores autopatching, it can be enabled via
     ec2.get_all_instances()
 """
 
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 required_modules = ['boto.connection']
 

--- a/ddtrace/contrib/boto/patch.py
+++ b/ddtrace/contrib/boto/patch.py
@@ -2,12 +2,10 @@ import boto.connection
 import wrapt
 import inspect
 
-from ddtrace import Pin
-from ddtrace.util import unwrap
+from ...pin import Pin
+from ...ext import http, aws
+from ...utils.wrappers import unwrap
 
-
-from ...ext import http
-from ...ext import aws
 
 # Original boto client class
 _Boto_client = boto.connection.AWSQueryConnection

--- a/ddtrace/contrib/botocore/__init__.py
+++ b/ddtrace/contrib/botocore/__init__.py
@@ -20,7 +20,7 @@ This integration ignores autopatching, it can be enabled via
 """
 
 
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 required_modules = ['botocore.client']
 

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -1,17 +1,15 @@
 """
 Trace queries to aws api done via botocore client
 """
-
-# project
-from ddtrace import Pin
-from ddtrace.util import deep_getattr, unwrap
-
 # 3p
 import wrapt
 import botocore.client
 
-from ...ext import http
-from ...ext import aws
+# project
+from ...pin import Pin
+from ...ext import http, aws
+from ...utils.formats import deep_getattr
+from ...utils.wrappers import unwrap
 
 
 # Original botocore client class

--- a/ddtrace/contrib/bottle/__init__.py
+++ b/ddtrace/contrib/bottle/__init__.py
@@ -15,7 +15,7 @@ To enable distributed tracing::
     plugin = TracePlugin(service="my-web-app", distributed_tracing=True)
 """
 
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 required_modules = ['bottle']
 

--- a/ddtrace/contrib/cassandra/__init__.py
+++ b/ddtrace/contrib/cassandra/__init__.py
@@ -21,7 +21,8 @@
     session = cluster.connect("my_keyspace")
     session.execute("select id from my_table limit 10;")
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
+
 
 required_modules = ['cassandra.cluster']
 

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -11,8 +11,8 @@ import wrapt
 from ddtrace import Pin
 from ddtrace.compat import stringify
 
+from ...utils.formats import deep_getattr
 from ...utils.deprecation import deprecated
-from ...util import deep_getattr
 from ...ext import net, cassandra as cassx, errors
 
 log = logging.getLogger(__name__)

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -10,7 +10,9 @@ import wrapt
 # project
 from ddtrace import Pin
 from ddtrace.compat import stringify
-from ...util import deep_getattr, deprecated
+
+from ...utils.deprecation import deprecated
+from ...util import deep_getattr
 from ...ext import net, cassandra as cassx, errors
 
 log = logging.getLogger(__name__)
@@ -257,7 +259,7 @@ def _sanitize_query(span, query):
 # DEPRECATED
 #
 
-@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
+@deprecated(message='Use patching instead (see the docs).', version='1.0.0')
 def get_traced_cassandra(*args, **kwargs):
     return _get_traced_cluster(*args, **kwargs)
 

--- a/ddtrace/contrib/celery/__init__.py
+++ b/ddtrace/contrib/celery/__init__.py
@@ -43,7 +43,7 @@ applications or tasks using a fine grain patching method::
     BaseClassTask = patch_task(BaseClassTask)
     fn_task = patch_task(fn_task)
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 
 required_modules = ['celery']

--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -65,7 +65,7 @@ The available settings are:
   rendering will not be instrumented. Only configurable when ``AUTO_INSTRUMENT``
   is set to ``True``.
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 
 required_modules = ['django']

--- a/ddtrace/contrib/django/restframework.py
+++ b/ddtrace/contrib/django/restframework.py
@@ -2,7 +2,7 @@ from wrapt import wrap_function_wrapper as wrap
 
 from rest_framework.views import APIView
 
-from ddtrace.util import unwrap
+from ...utils.wrappers import unwrap
 
 
 def patch_restframework(tracer):

--- a/ddtrace/contrib/elasticsearch/__init__.py
+++ b/ddtrace/contrib/elasticsearch/__init__.py
@@ -19,7 +19,7 @@
     Pin.override(es.transport, service='elasticsearch-videos')
     es.indices.create(index='videos', ignore=400)
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 required_modules = ['elasticsearch']
 

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -5,7 +5,7 @@ from elasticsearch.exceptions import TransportError
 from . import metadata
 from .quantize import quantize
 
-from ddtrace.util import unwrap
+from ...utils.wrappers import unwrap
 from ...compat import urlencode
 from ...pin import Pin
 from ...ext import http

--- a/ddtrace/contrib/elasticsearch/transport.py
+++ b/ddtrace/contrib/elasticsearch/transport.py
@@ -1,17 +1,18 @@
 from elasticsearch import Transport
 from elasticsearch.exceptions import TransportError
 
-from .quantize import quantize
 from . import metadata
+from .quantize import quantize
+
+from ...utils.deprecation import deprecated
 from ...compat import urlencode
 from ...ext import AppTypes, http
-from ...util import deprecated
 
 DEFAULT_SERVICE = 'elasticsearch'
 SPAN_TYPE = 'elasticsearch'
 
 
-@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
+@deprecated(message='Use patching instead (see the docs).', version='1.0.0')
 def get_traced_transport(datadog_tracer, datadog_service=DEFAULT_SERVICE):
 
     datadog_tracer.set_service_info(

--- a/ddtrace/contrib/falcon/__init__.py
+++ b/ddtrace/contrib/falcon/__init__.py
@@ -20,7 +20,7 @@ You can also use the autopatching functionality:
 To enable distributed tracing when using autopatching, set the
 DATADOG_FALCON_DISTRIBUTED_TRACING environment variable to true.
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 required_modules = ['falcon']
 

--- a/ddtrace/contrib/falcon/patch.py
+++ b/ddtrace/contrib/falcon/patch.py
@@ -5,7 +5,7 @@ import falcon
 from ddtrace import tracer
 
 from .middleware import TraceMiddleware
-from ...util import asbool
+from ...utils.formats import asbool
 
 
 def patch():

--- a/ddtrace/contrib/flask/__init__.py
+++ b/ddtrace/contrib/flask/__init__.py
@@ -32,7 +32,8 @@ Set `distributed_tracing=True` if this is called remotely from an instrumented a
 We suggest to enable it only for internal services where headers are under your control.
 """
 
-from ..util import require_modules
+from ...utils.importlib import require_modules
+
 
 required_modules = ['flask']
 

--- a/ddtrace/contrib/flask_cache/__init__.py
+++ b/ddtrace/contrib/flask_cache/__init__.py
@@ -32,7 +32,8 @@ Here is the end result, in a sample app::
 
 """
 
-from ..util import require_modules
+from ...utils.importlib import require_modules
+
 
 required_modules = ['flask_cache']
 

--- a/ddtrace/contrib/futures/__init__.py
+++ b/ddtrace/contrib/futures/__init__.py
@@ -15,11 +15,10 @@ as follows:
     # or, when instrumenting all libraries
     patch_all(futures=True)
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 
 required_modules = ['concurrent.futures']
-
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:

--- a/ddtrace/contrib/futures/patch.py
+++ b/ddtrace/contrib/futures/patch.py
@@ -3,7 +3,7 @@ from concurrent import futures
 from wrapt import wrap_function_wrapper as _w
 
 from .threading import _wrap_submit
-from ...util import unwrap as _u
+from ...utils.wrappers import unwrap as _u
 
 
 def patch():

--- a/ddtrace/contrib/gevent/__init__.py
+++ b/ddtrace/contrib/gevent/__init__.py
@@ -29,7 +29,7 @@ patch ``gevent`` **before importing** the library::
             with tracer.trace("greenlet.child_call") as child:
                 ...
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 
 required_modules = ['gevent']

--- a/ddtrace/contrib/httplib/patch.py
+++ b/ddtrace/contrib/httplib/patch.py
@@ -8,7 +8,7 @@ import wrapt
 from ...compat import httplib, PY2
 from ...ext import http as ext_http
 from ...pin import Pin
-from ...util import unwrap as _u
+from ...utils.wrappers import unwrap as _u
 
 
 span_name = 'httplib.request' if PY2 else 'http.client.request'

--- a/ddtrace/contrib/mongoengine/__init__.py
+++ b/ddtrace/contrib/mongoengine/__init__.py
@@ -17,7 +17,7 @@
     Pin.override(client, service="mongo-master")
 """
 
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 
 required_modules = ['mongoengine']

--- a/ddtrace/contrib/mongoengine/patch.py
+++ b/ddtrace/contrib/mongoengine/patch.py
@@ -1,7 +1,7 @@
 import mongoengine
 
 from .trace import WrappedConnect
-from ddtrace.util import deprecated
+from ...utils.deprecation import deprecated
 
 # Original connect function
 _connect = mongoengine.connect
@@ -13,7 +13,7 @@ def patch():
 def unpatch():
     setattr(mongoengine, 'connect', _connect)
 
-@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
+@deprecated(message='Use patching instead (see the docs).', version='1.0.0')
 def trace_mongoengine(*args, **kwargs):
     return _connect
 

--- a/ddtrace/contrib/mysql/__init__.py
+++ b/ddtrace/contrib/mysql/__init__.py
@@ -24,7 +24,7 @@ provided by _mysql_connector, is not supported yet.
 Help on mysql.connector can be found on:
 https://dev.mysql.com/doc/connector-python/en/
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 # check `mysql-connector` availability
 required_modules = ['mysql.connector']

--- a/ddtrace/contrib/mysql/tracers.py
+++ b/ddtrace/contrib/mysql/tracers.py
@@ -1,7 +1,8 @@
 import mysql.connector
 
-from ddtrace.util import deprecated
+from ...utils.deprecation import deprecated
 
-@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
+
+@deprecated(message='Use patching instead (see the docs).', version='1.0.0')
 def get_traced_mysql_connection(*args, **kwargs):
     return mysql.connector.MySQLConnection

--- a/ddtrace/contrib/mysqldb/__init__.py
+++ b/ddtrace/contrib/mysqldb/__init__.py
@@ -24,7 +24,7 @@ provided by _mysql, is not supported yet.
 Help on mysqlclient can be found on:
 https://mysqlclient.readthedocs.io/
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 required_modules = ['MySQLdb']
 

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -8,7 +8,7 @@ from ddtrace import Pin
 from ddtrace.contrib.dbapi import TracedConnection
 
 from ...ext import net, db
-from ...util import unwrap as _u
+from ...utils.wrappers import unwrap as _u
 
 
 KWPOS_BY_TAG = {

--- a/ddtrace/contrib/psycopg/__init__.py
+++ b/ddtrace/contrib/psycopg/__init__.py
@@ -17,7 +17,8 @@
     # Use a pin to specify metadata related to this connection
     Pin.override(db, service='postgres-users')
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
+
 
 required_modules = ['psycopg2']
 

--- a/ddtrace/contrib/psycopg/connection.py
+++ b/ddtrace/contrib/psycopg/connection.py
@@ -9,13 +9,13 @@ from ...ext import db
 from ...ext import net
 from ...ext import sql
 from ...ext import AppTypes
-from ...util import deprecated
+from ...utils.deprecation import deprecated
 
 # 3p
 from psycopg2.extensions import connection, cursor
 
 
-@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
+@deprecated(message='Use patching instead (see the docs).', version='1.0.0')
 def connection_factory(tracer, service="postgres"):
     """ Return a connection factory class that will can be used to trace
         postgres queries.

--- a/ddtrace/contrib/pylibmc/__init__.py
+++ b/ddtrace/contrib/pylibmc/__init__.py
@@ -19,7 +19,7 @@
     Pin.override(client, service="memcached-sessions")
 """
 
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 required_modules = ['pylibmc']
 

--- a/ddtrace/contrib/pylons/__init__.py
+++ b/ddtrace/contrib/pylons/__init__.py
@@ -18,7 +18,8 @@ set the following keyword argument::
     traced_app = PylonsTraceMiddleware(app, tracer, service='my-pylons-app', distributed_tracing=True)
 """
 
-from ..util import require_modules
+from ...utils.importlib import require_modules
+
 
 required_modules = ['pylons.wsgiapp']
 

--- a/ddtrace/contrib/pylons/patch.py
+++ b/ddtrace/contrib/pylons/patch.py
@@ -5,7 +5,7 @@ import pylons.wsgiapp
 from ddtrace import tracer, Pin
 
 from .middleware import PylonsTraceMiddleware
-from ...util import unwrap as _u
+from ...utils.wrappers import unwrap as _u
 
 
 def patch():

--- a/ddtrace/contrib/pymongo/__init__.py
+++ b/ddtrace/contrib/pymongo/__init__.py
@@ -21,7 +21,8 @@ network calls. Pymongo 3.0 and greater are the currently supported versions.
     client = pymongo.MongoClient()
     pin = Pin.override(client, service="mongo-master")
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
+
 
 required_modules = ['pymongo']
 

--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -9,11 +9,11 @@ from wrapt import ObjectProxy
 
 # project
 import ddtrace
+from ...utils.deprecation import deprecated
 from ...compat import iteritems
 from ...ext import AppTypes
 from ...ext import mongo as mongox
 from ...ext import net as netx
-from ...util import deprecated
 from .parse import parse_spec, parse_query, parse_msg
 
 # Original Client class
@@ -22,7 +22,7 @@ _MongoClient = pymongo.MongoClient
 log = logging.getLogger(__name__)
 
 
-@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
+@deprecated(message='Use patching instead (see the docs).', version='1.0.0')
 def trace_mongo_client(client, tracer, service=mongox.TYPE):
     tracer.set_service_info(
         service=service,

--- a/ddtrace/contrib/pymysql/__init__.py
+++ b/ddtrace/contrib/pymysql/__init__.py
@@ -18,7 +18,8 @@
     Pin.override(conn, service='pymysql-users')
 """
 
-from ..util import require_modules
+from ...utils.importlib import require_modules
+
 
 required_modules = ['pymysql']
 

--- a/ddtrace/contrib/pymysql/tracers.py
+++ b/ddtrace/contrib/pymysql/tracers.py
@@ -1,7 +1,8 @@
 import pymysql.connections
 
-from ddtrace.util import deprecated
+from ...utils.deprecation import deprecated
 
-@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
+
+@deprecated(message='Use patching instead (see the docs).', version='1.0.0')
 def get_traced_pymysql_connection(*args, **kwargs):
     return pymysql.connections.Connection

--- a/ddtrace/contrib/pyramid/__init__.py
+++ b/ddtrace/contrib/pyramid/__init__.py
@@ -38,7 +38,8 @@ explicitly to the list. For example::
 
 """
 
-from ..util import require_modules
+from ...utils.importlib import require_modules
+
 
 required_modules = ['pyramid']
 

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -2,7 +2,7 @@ import os
 
 from .trace import trace_pyramid, DD_TWEEN_NAME
 from .constants import SETTINGS_SERVICE, SETTINGS_DISTRIBUTED_TRACING
-from ...util import asbool
+from ...utils.formats import asbool
 
 import pyramid.config
 from pyramid.path import caller_package

--- a/ddtrace/contrib/redis/__init__.py
+++ b/ddtrace/contrib/redis/__init__.py
@@ -17,7 +17,7 @@
     Pin.override(client, service='redis-queue')
 """
 
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 required_modules = ['redis', 'redis.client']
 

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -1,12 +1,11 @@
-
 # 3p
 import redis
 import wrapt
 
 # project
-from ddtrace import Pin
-from ddtrace.ext import redis as redisx
-from ddtrace.util import unwrap
+from ...pin import Pin
+from ...ext import redis as redisx
+from ...utils.wrappers import unwrap
 from .util import format_command_args, _extract_conn_tags
 
 

--- a/ddtrace/contrib/redis/tracers.py
+++ b/ddtrace/contrib/redis/tracers.py
@@ -1,18 +1,20 @@
 from redis import StrictRedis
 
-from ...util import deprecated
+from ...utils.deprecation import deprecated
+
 
 DEFAULT_SERVICE = 'redis'
 
 
-@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
+@deprecated(message='Use patching instead (see the docs).', version='1.0.0')
 def get_traced_redis(ddtracer, service=DEFAULT_SERVICE, meta=None):
     return _get_traced_redis(ddtracer, StrictRedis, service, meta)
 
-@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
+
+@deprecated(message='Use patching instead (see the docs).', version='1.0.0')
 def get_traced_redis_from(ddtracer, baseclass, service=DEFAULT_SERVICE, meta=None):
     return _get_traced_redis(ddtracer, baseclass, service, meta)
 
+
 def _get_traced_redis(ddtracer, baseclass, service, meta):
     return baseclass
-

--- a/ddtrace/contrib/requests/__init__.py
+++ b/ddtrace/contrib/requests/__init__.py
@@ -25,9 +25,8 @@ which is also instrumented and want to have traces including both client and ser
     session.distributed_tracing = True
     session.get("http://host.lan/webservice")
 """
+from ...utils.importlib import require_modules
 
-
-from ..util import require_modules
 
 required_modules = ['requests']
 

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -2,13 +2,13 @@ import os
 import logging
 
 import wrapt
-import requests
-
 import ddtrace
+import requests
 
 from ...ext import http
 from ...propagation.http import HTTPPropagator
-from ...util import asbool, unwrap as _u
+from ...utils.formats import asbool
+from ...utils.wrappers import unwrap as _u
 
 
 log = logging.getLogger(__name__)

--- a/ddtrace/contrib/sqlalchemy/__init__.py
+++ b/ddtrace/contrib/sqlalchemy/__init__.py
@@ -15,9 +15,8 @@ using the patch method that **must be called before** importing sqlalchemy::
     # Use a PIN to specify metadata related to this engine
     Pin.override(engine, service='replica-db')
 """
+from ...utils.importlib import require_modules
 
-
-from ..util import require_modules
 
 required_modules = ['sqlalchemy', 'sqlalchemy.event']
 

--- a/ddtrace/contrib/sqlalchemy/patch.py
+++ b/ddtrace/contrib/sqlalchemy/patch.py
@@ -1,9 +1,9 @@
 import sqlalchemy
 
 from wrapt import wrap_function_wrapper as _w
-from ddtrace.util import unwrap
 
 from .engine import _wrap_create_engine
+from ...utils.wrappers import unwrap
 
 
 def patch():

--- a/ddtrace/contrib/sqlite3/connection.py
+++ b/ddtrace/contrib/sqlite3/connection.py
@@ -1,7 +1,8 @@
 from sqlite3 import Connection
 
-from ddtrace.util import deprecated
+from ...utils.deprecation import deprecated
 
-@deprecated(message='Use patching instead (see the docs).', version='0.6.0')
+
+@deprecated(message='Use patching instead (see the docs).', version='1.0.0')
 def connection_factory(*args, **kwargs):
     return Connection

--- a/ddtrace/contrib/tornado/__init__.py
+++ b/ddtrace/contrib/tornado/__init__.py
@@ -75,7 +75,7 @@ The available settings are:
 * ``agent_hostname`` (default: `localhost`): define the hostname of the APM agent.
 * ``agent_port`` (default: `8126`): define the port of the APM agent.
 """
-from ..util import require_modules
+from ...utils.importlib import require_modules
 
 
 required_modules = ['tornado']

--- a/ddtrace/contrib/tornado/patch.py
+++ b/ddtrace/contrib/tornado/patch.py
@@ -4,7 +4,7 @@ import tornado
 from wrapt import wrap_function_wrapper as _w
 
 from . import handlers, application, decorators, template, compat, context_provider
-from ...util import unwrap as _u
+from ...utils.wrappers import unwrap as _u
 
 
 def patch():

--- a/ddtrace/contrib/util.py
+++ b/ddtrace/contrib/util.py
@@ -1,33 +1,16 @@
-from importlib import import_module
+# [Backward compatibility]: keep importing modules functions
+from ..utils.deprecation import deprecation
+from ..utils.importlib import require_modules, func_name, module_name
 
 
-class require_modules(object):
-    """
-    Context manager to check the availability of required modules.
-    """
-    def __init__(self, modules):
-        self._missing_modules = []
-        for module in modules:
-            try:
-                import_module(module)
-            except ImportError:
-                self._missing_modules.append(module)
+deprecation(
+    name='ddtrace.contrib.util',
+    message='Use `ddtrace.utils.importlib` module instead',
+    version='1.0.0',
+)
 
-    def __enter__(self):
-        return self._missing_modules
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        return False
-
-
-def func_name(f):
-    """
-    Return a human readable version of the function's name.
-    """
-    if hasattr(f, '__module__'):
-        return "%s.%s" % (f.__module__, getattr(f, '__name__', f.__class__.__name__))
-    return getattr(f, '__name__', f.__class__.__name__)
-
-
-def module_name(instance):
-    return instance.__class__.__module__.split('.')[0]
+__all__ = [
+    'require_modules',
+    'func_name',
+    'module_name',
+]

--- a/ddtrace/util.py
+++ b/ddtrace/util.py
@@ -1,24 +1,6 @@
 import os
-import inspect
-import logging
 import wrapt
-
-from functools import wraps
-
-
-def deprecated(message='', version=None):
-    """Function decorator to report a deprecated function"""
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            logger = logging.getLogger(func.__module__)
-            logger.warning("%s is deprecated and will be remove in future versions%s. %s",
-                           func.__name__,
-                           ' (%s)' % version if version else '',
-                           message)
-            return func(*args, **kwargs)
-        return wrapper
-    return decorator
+import inspect
 
 
 def deep_getattr(obj, attr_string, default=None):

--- a/ddtrace/util.py
+++ b/ddtrace/util.py
@@ -1,8 +1,14 @@
 # [Backward compatibility]: keep importing modules functions
-from .utils.deprecation import deprecated
+from .utils.deprecation import deprecated, deprecation
 from .utils.formats import asbool, deep_getattr, get_env
 from .utils.wrappers import safe_patch, unwrap
 
+
+deprecation(
+    name='ddtrace.util',
+    message='Use `ddtrace.utils` package instead',
+    version='1.0.0',
+)
 
 __all__ = [
     'deprecated',

--- a/ddtrace/util.py
+++ b/ddtrace/util.py
@@ -1,119 +1,14 @@
-import os
-import wrapt
-import inspect
+# [Backward compatibility]: keep importing modules functions
+from .utils.deprecation import deprecated
+from .utils.formats import asbool, deep_getattr, get_env
+from .utils.wrappers import safe_patch, unwrap
 
 
-def deep_getattr(obj, attr_string, default=None):
-    """
-    Returns the attribute of `obj` at the dotted path given by `attr_string`
-    If no such attribute is reachable, returns `default`
-
-    >>> deep_getattr(cass, "cluster")
-    <cassandra.cluster.Cluster object at 0xa20c350
-
-    >>> deep_getattr(cass, "cluster.metadata.partitioner")
-    u'org.apache.cassandra.dht.Murmur3Partitioner'
-
-    >>> deep_getattr(cass, "i.dont.exist", default="default")
-    'default'
-    """
-    attrs = attr_string.split('.')
-    for attr in attrs:
-        try:
-            obj = getattr(obj, attr)
-        except AttributeError:
-            return default
-
-    return obj
-
-
-def safe_patch(patchable, key, patch_func, service, meta, tracer):
-    """ takes patch_func (signature: takes the orig_method that is
-    wrapped in the monkey patch == UNBOUND + service and meta) and
-    attach the patched result to patchable at patchable.key
-
-
-      - if this is the module/class we can rely on methods being unbound, and just have to
-      update the __dict__
-
-      - if this is an instance, we have to unbind the current and rebind our
-      patched method
-
-      - If patchable is an instance and if we've already patched at the module/class level
-      then patchable[key] contains an already patched command!
-      To workaround this, check if patchable or patchable.__class__ are _dogtraced
-      If is isn't, nothing to worry about, patch the key as usual
-      But if it is, search for a "__dd_orig_{key}" method on the class, which is
-      the original unpatched method we wish to trace.
-
-    """
-    def _get_original_method(thing, key):
-        orig = None
-        if hasattr(thing, '_dogtraced'):
-            # Search for original method
-            orig = getattr(thing, "__dd_orig_{}".format(key), None)
-        else:
-            orig = getattr(thing, key)
-            # Set it for the next time we attempt to patch `thing`
-            setattr(thing, "__dd_orig_{}".format(key), orig)
-
-        return orig
-
-    if inspect.isclass(patchable) or inspect.ismodule(patchable):
-        orig = _get_original_method(patchable, key)
-        if not orig:
-            # Should never happen
-            return
-    elif hasattr(patchable, '__class__'):
-        orig = _get_original_method(patchable.__class__, key)
-        if not orig:
-            # Should never happen
-            return
-    else:
-        return
-
-    dest = patch_func(orig, service, meta, tracer)
-
-    if inspect.isclass(patchable) or inspect.ismodule(patchable):
-        setattr(patchable, key, dest)
-    elif hasattr(patchable, '__class__'):
-        setattr(patchable, key, dest.__get__(patchable, patchable.__class__))
-
-
-def asbool(value):
-    """Convert the given String to a boolean object. Accepted
-    values are `True` and `1`."""
-    if value is None:
-        return False
-
-    if isinstance(value, bool):
-        return value
-
-    return value.lower() in ("true", "1")
-
-
-def get_env(integration, variable, default=None):
-    """Retrieves environment variables value for the given integration. It must be used
-    for consistency between integrations. The implementation is backward compatible
-    with legacy nomenclature:
-        * `DATADOG_` is a legacy prefix with lower priority
-        * `DD_` environment variables have the highest priority
-        * the environment variable is built concatenating `integration` and `variable`
-          arguments
-        * return `default` otherwise
-    """
-    key = '{}_{}'.format(integration, variable).upper()
-    legacy_env = 'DATADOG_{}'.format(key)
-    env = 'DD_{}'.format(key)
-
-    # [Backward compatibility]: `DATADOG_` variables should be supported;
-    # add a deprecation warning later if it's used, so that we can drop the key
-    # in newer releases.
-    value = os.getenv(env) or os.getenv(legacy_env)
-    return value if value else default
-
-
-def unwrap(obj, attr):
-    f = getattr(obj, attr, None)
-    if f and isinstance(f, wrapt.ObjectProxy) and hasattr(f, '__wrapped__'):
-        setattr(obj, attr, f.__wrapped__)
+__all__ = [
+    'deprecated',
+    'asbool',
+    'deep_getattr',
+    'get_env',
+    'safe_patch',
+    'unwrap',
+]

--- a/ddtrace/utils/deprecation.py
+++ b/ddtrace/utils/deprecation.py
@@ -3,6 +3,10 @@ import warnings
 from functools import wraps
 
 
+class RemovedInDDTrace10Warning(DeprecationWarning):
+    pass
+
+
 def format_message(name, message, version):
     """Message formatter to create `DeprecationWarning` messages
     such as:
@@ -18,7 +22,7 @@ def format_message(name, message, version):
 
 def warn(message, stacklevel=2):
     """Helper function used as a ``DeprecationWarning``."""
-    warnings.warn(message, DeprecationWarning, stacklevel=stacklevel)
+    warnings.warn(message, RemovedInDDTrace10Warning, stacklevel=stacklevel)
 
 
 def deprecation(name='', message='', version=None):

--- a/ddtrace/utils/deprecation.py
+++ b/ddtrace/utils/deprecation.py
@@ -1,0 +1,56 @@
+import warnings
+
+from functools import wraps
+
+
+def format_message(name, message, version):
+    """Message formatter to create `DeprecationWarning` messages
+    such as:
+
+        'fn' is deprecated and will be remove in future versions (1.0).
+    """
+    return "'{}' is deprecated and will be remove in future versions{}. {}".format(
+        name,
+        ' ({})'.format(version) if version else '',
+        message,
+    )
+
+
+def warn(message, stacklevel=2):
+    """Helper function used as a ``DeprecationWarning``."""
+    warnings.warn(message, DeprecationWarning, stacklevel=stacklevel)
+
+
+def deprecation(name='', message='', version=None):
+    """Function to report a ``DeprecationWarning``. Bear in mind that `DeprecationWarning`
+    are ignored by default so they're not available in user logs. To show them,
+    the application must be launched with a special flag:
+
+        $ python -Wall script.py
+
+    This approach is used by most of the frameworks, including Django
+    (ref: https://docs.djangoproject.com/en/2.0/howto/upgrade-version/#resolving-deprecation-warnings)
+    """
+    msg = format_message(name, message, version)
+    warn(msg, stacklevel=4)
+
+
+def deprecated(message='', version=None):
+    """Decorator function to report a ``DeprecationWarning``. Bear
+    in mind that `DeprecationWarning` are ignored by default so they're
+    not available in user logs. To show them, the application must be launched
+    with a special flag:
+
+        $ python -Wall script.py
+
+    This approach is used by most of the frameworks, including Django
+    (ref: https://docs.djangoproject.com/en/2.0/howto/upgrade-version/#resolving-deprecation-warnings)
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            msg = format_message(func.__name__, message, version)
+            warn(msg, stacklevel=3)
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/ddtrace/utils/formats.py
+++ b/ddtrace/utils/formats.py
@@ -1,0 +1,58 @@
+import os
+
+
+def get_env(integration, variable, default=None):
+    """Retrieves environment variables value for the given integration. It must be used
+    for consistency between integrations. The implementation is backward compatible
+    with legacy nomenclature:
+        * `DATADOG_` is a legacy prefix with lower priority
+        * `DD_` environment variables have the highest priority
+        * the environment variable is built concatenating `integration` and `variable`
+          arguments
+        * return `default` otherwise
+    """
+    key = '{}_{}'.format(integration, variable).upper()
+    legacy_env = 'DATADOG_{}'.format(key)
+    env = 'DD_{}'.format(key)
+
+    # [Backward compatibility]: `DATADOG_` variables should be supported;
+    # add a deprecation warning later if it's used, so that we can drop the key
+    # in newer releases.
+    value = os.getenv(env) or os.getenv(legacy_env)
+    return value if value else default
+
+
+def deep_getattr(obj, attr_string, default=None):
+    """
+    Returns the attribute of `obj` at the dotted path given by `attr_string`
+    If no such attribute is reachable, returns `default`
+
+    >>> deep_getattr(cass, "cluster")
+    <cassandra.cluster.Cluster object at 0xa20c350
+
+    >>> deep_getattr(cass, "cluster.metadata.partitioner")
+    u'org.apache.cassandra.dht.Murmur3Partitioner'
+
+    >>> deep_getattr(cass, "i.dont.exist", default="default")
+    'default'
+    """
+    attrs = attr_string.split('.')
+    for attr in attrs:
+        try:
+            obj = getattr(obj, attr)
+        except AttributeError:
+            return default
+
+    return obj
+
+
+def asbool(value):
+    """Convert the given String to a boolean object. Accepted
+    values are `True` and `1`."""
+    if value is None:
+        return False
+
+    if isinstance(value, bool):
+        return value
+
+    return value.lower() in ("true", "1")

--- a/ddtrace/utils/importlib.py
+++ b/ddtrace/utils/importlib.py
@@ -1,0 +1,30 @@
+from importlib import import_module
+
+
+class require_modules(object):
+    """Context manager to check the availability of required modules."""
+    def __init__(self, modules):
+        self._missing_modules = []
+        for module in modules:
+            try:
+                import_module(module)
+            except ImportError:
+                self._missing_modules.append(module)
+
+    def __enter__(self):
+        return self._missing_modules
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+def func_name(f):
+    """Return a human readable version of the function's name."""
+    if hasattr(f, '__module__'):
+        return "%s.%s" % (f.__module__, getattr(f, '__name__', f.__class__.__name__))
+    return getattr(f, '__name__', f.__class__.__name__)
+
+
+def module_name(instance):
+    """Return the instance module name."""
+    return instance.__class__.__module__.split('.')[0]

--- a/ddtrace/utils/importlib.py
+++ b/ddtrace/utils/importlib.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from importlib import import_module
 
 

--- a/ddtrace/utils/wrappers.py
+++ b/ddtrace/utils/wrappers.py
@@ -1,0 +1,62 @@
+import wrapt
+import inspect
+
+
+def unwrap(obj, attr):
+    f = getattr(obj, attr, None)
+    if f and isinstance(f, wrapt.ObjectProxy) and hasattr(f, '__wrapped__'):
+        setattr(obj, attr, f.__wrapped__)
+
+
+def safe_patch(patchable, key, patch_func, service, meta, tracer):
+    """ takes patch_func (signature: takes the orig_method that is
+    wrapped in the monkey patch == UNBOUND + service and meta) and
+    attach the patched result to patchable at patchable.key
+
+
+      - if this is the module/class we can rely on methods being unbound, and just have to
+      update the __dict__
+
+      - if this is an instance, we have to unbind the current and rebind our
+      patched method
+
+      - If patchable is an instance and if we've already patched at the module/class level
+      then patchable[key] contains an already patched command!
+      To workaround this, check if patchable or patchable.__class__ are _dogtraced
+      If is isn't, nothing to worry about, patch the key as usual
+      But if it is, search for a "__dd_orig_{key}" method on the class, which is
+      the original unpatched method we wish to trace.
+
+    """
+    def _get_original_method(thing, key):
+        orig = None
+        if hasattr(thing, '_dogtraced'):
+            # Search for original method
+            orig = getattr(thing, "__dd_orig_{}".format(key), None)
+        else:
+            orig = getattr(thing, key)
+            # Set it for the next time we attempt to patch `thing`
+            setattr(thing, "__dd_orig_{}".format(key), orig)
+
+        return orig
+
+    if inspect.isclass(patchable) or inspect.ismodule(patchable):
+        orig = _get_original_method(patchable, key)
+        if not orig:
+            # Should never happen
+            return
+    elif hasattr(patchable, '__class__'):
+        orig = _get_original_method(patchable.__class__, key)
+        if not orig:
+            # Should never happen
+            return
+    else:
+        return
+
+    dest = patch_func(orig, service, meta, tracer)
+
+    if inspect.isclass(patchable) or inspect.ismodule(patchable):
+        setattr(patchable, key, dest)
+    elif hasattr(patchable, '__class__'):
+        setattr(patchable, key, dest.__get__(patchable, patchable.__class__))
+

--- a/ddtrace/utils/wrappers.py
+++ b/ddtrace/utils/wrappers.py
@@ -1,6 +1,8 @@
 import wrapt
 import inspect
 
+from .deprecation import deprecated
+
 
 def unwrap(obj, attr):
     f = getattr(obj, attr, None)
@@ -8,6 +10,7 @@ def unwrap(obj, attr):
         setattr(obj, attr, f.__wrapped__)
 
 
+@deprecated('`wrapt` library is used instead', version='1.0.0')
 def safe_patch(patchable, key, patch_func, service, meta, tracer):
     """ takes patch_func (signature: takes the orig_method that is
     wrapped in the monkey patch == UNBOUND + service and meta) and

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -421,6 +421,22 @@ Information will be lost but it allows to control any potential performance impa
     tracer.sampler = RateSampler(sample_rate)
 
 
+Resolving deprecation warnings
+------------------------------
+Before upgrading, it’s a good idea to resolve any deprecation warnings raised by your project.
+These warnings must be fixed before upgrading, otherwise ``ddtrace`` library will not work
+as expected. Our deprecation messages include the version where the behavior is altered or
+removed.
+
+In Python, deprecation warnings are silenced by default, and to turn them on you may add the
+following flag or environment variable::
+
+    $ python -Wall app.py
+
+    # or
+
+    $ PYTHONWARNINGS=all python app.py
+
 
 Advanced Usage
 --------------

--- a/tests/contrib/test_utils.py
+++ b/tests/contrib/test_utils.py
@@ -1,8 +1,9 @@
 from nose.tools import eq_
 
-from ddtrace.contrib.util import func_name
-from ddtrace.util import asbool
 from functools import partial
+from ddtrace.utils.importlib import func_name
+from ddtrace.utils.formats import asbool
+
 
 class SomethingCallable(object):
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import unittest
 
 from nose.tools import eq_, ok_
 
-from ddtrace.util import asbool, get_env
+from ddtrace.utils.formats import asbool, get_env
 
 
 class TestUtilities(unittest.TestCase):
@@ -46,3 +46,7 @@ class TestUtilities(unittest.TestCase):
         os.environ['DATADOG_REQUESTS_DISTRIBUTED_TRACING'] = 'lowest'
         value = get_env('requests', 'distributed_tracing')
         eq_(value, 'highest')
+
+    def test_deprecation_formatter(self):
+        # ensure the formatter returns the proper message
+        pass

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,10 @@
 import os
 import unittest
+import warnings
 
 from nose.tools import eq_, ok_
 
+from ddtrace.utils.deprecation import deprecation, deprecated, format_message
 from ddtrace.utils.formats import asbool, get_env
 
 
@@ -49,4 +51,36 @@ class TestUtilities(unittest.TestCase):
 
     def test_deprecation_formatter(self):
         # ensure the formatter returns the proper message
-        pass
+        msg = format_message(
+            'deprecated_function',
+            'use something else instead',
+            '1.0.0',
+        )
+        expected = "'deprecated_function' is deprecated and will be remove in future versions (1.0.0). use something else instead"
+        eq_(msg, expected)
+
+    def test_deprecation(self):
+        # ensure `deprecation` properly raise a DeprecationWarning
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            deprecation(
+                name='fn',
+                message='message',
+                version='1.0.0'
+            )
+            ok_(len(w) == 1)
+            ok_(issubclass(w[-1].category, DeprecationWarning))
+            ok_('message' in str(w[-1].message))
+
+    def test_deprecated_decorator(self):
+        # ensure `deprecated` decorator properly raise a DeprecationWarning
+        @deprecated('decorator', version='1.0.0')
+        def fxn():
+            pass
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            fxn()
+            ok_(len(w) == 1)
+            ok_(issubclass(w[-1].category, DeprecationWarning))
+            ok_('decorator' in str(w[-1].message))


### PR DESCRIPTION
### Overview

This patch introduces a deprecation system via `warnings` module. It offers a way to add deprecation around our code, when we need to alter/remove a functionality in newer releases. The deprecation log is silent by default, though it could be activated via Python flag / environment variable. This approach should be considered "safe" especially because it's used by many web frameworks (i.e. Django) and well documented in the Python official docs.

* `ddtrace.util` -> `ddtrace.utils.*` (split in many modules)
* `ddtrace.contrib.util` -> `ddtrace.utils.importlib`

### User impact

No impact for the user since the `DeprecationWarning` is silent by default, so unless the production application is run via `-Wall`, nothing will be printed in users' logs.

### What is missing

It's more part of a process, but we should document somewhere (even with a simple list) every time we add a deprecation warning. In that way, users can find easily what's going to be changed in the next major release. A good example is Django: https://docs.djangoproject.com/en/dev/internals/deprecation/