### PR TITLE
Fixing typo in the doc

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,7 +73,7 @@ Instrumentation
 Web
 ~~~
 
-We support many `web frameworks`. Install the middleware for yours.
+We support many `web frameworks`_. Install the middleware for yours.
 
 .. _web frameworks: #web-frameworks
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,7 +73,10 @@ Instrumentation
 Web
 ~~~
 
-We support many :ref:`web-frameworks`. Install the middleware for yours.
+We support many `web frameworks`. Install the middleware for yours.
+
+.. _web frameworks: #web-frameworks
+
 
 Databases
 ~~~~~~~~~


### PR DESCRIPTION
Just fixing an hyperlink cross reference bug in the docs.