### PR TITLE
[contrib/gevent] pass sampling_priority

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -39,6 +39,21 @@ class Context(object):
         self._sampled = sampled
         self._sampling_priority = sampling_priority
 
+    @classmethod
+    def from_context(cls, ctx):
+        """
+        Create a new context that inherits the current span from the previous context.
+        """
+        with ctx._lock:
+            new_ctx = cls(
+                trace_id=ctx._parent_trace_id,
+                span_id=ctx._parent_span_id,
+                sampled=ctx._sampled,
+                sampling_priority=ctx._sampling_priority,
+            )
+            new_ctx._current_span = ctx._current_span
+            return new_ctx
+
     @property
     def trace_id(self):
         """Return current context trace_id."""

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -39,21 +39,6 @@ class Context(object):
         self._sampled = sampled
         self._sampling_priority = sampling_priority
 
-    @classmethod
-    def from_context(cls, ctx):
-        """
-        Create a new context that inherits the current span from the previous context.
-        """
-        with ctx._lock:
-            new_ctx = cls(
-                trace_id=ctx._parent_trace_id,
-                span_id=ctx._parent_span_id,
-                sampled=ctx._sampled,
-                sampling_priority=ctx._sampling_priority,
-            )
-            new_ctx._current_span = ctx._current_span
-            return new_ctx
-
     @property
     def trace_id(self):
         """Return current context trace_id."""
@@ -83,6 +68,21 @@ class Context(object):
         """Set sampling priority."""
         with self._lock:
             self._sampling_priority = value
+
+    def clone(self):
+        """
+        Partially clones the current context.
+        It copies everything EXCEPT the registered and finished spans.
+        """
+        with self._lock:
+            new_ctx = Context(
+                trace_id=self._parent_trace_id,
+                span_id=self._parent_span_id,
+                sampled=self._sampled,
+                sampling_priority=self._sampling_priority,
+            )
+            new_ctx._current_span = self._current_span
+            return new_ctx
 
     def get_current_span(self):
         """

--- a/ddtrace/contrib/gevent/greenlet.py
+++ b/ddtrace/contrib/gevent/greenlet.py
@@ -31,10 +31,10 @@ class TracedGreenlet(gevent.Greenlet):
             # create a new context that inherits the current active span
             # TODO: a better API for Context, should get the tuple at once
             new_ctx = Context(
-                trace_id=ctx._parent_trace_id,
-                span_id=ctx._parent_span_id,
-                sampled=ctx._sampled,
-                sampling_priority=ctx._sampling_priority,
+                trace_id=ctx.trace_id,
+                span_id=ctx.span_id,
+                sampled=ctx.sampled,
+                sampling_priority=ctx.sampling_priority,
             )
             new_ctx._current_span = ctx._current_span
             setattr(self, CONTEXT_ATTR, new_ctx)

--- a/ddtrace/contrib/gevent/greenlet.py
+++ b/ddtrace/contrib/gevent/greenlet.py
@@ -34,6 +34,7 @@ class TracedGreenlet(gevent.Greenlet):
                 trace_id=ctx._parent_trace_id,
                 span_id=ctx._parent_span_id,
                 sampled=ctx._sampled,
+                sampling_priority=ctx._sampling_priority,
             )
             new_ctx._current_span = ctx._current_span
             setattr(self, CONTEXT_ATTR, new_ctx)

--- a/ddtrace/contrib/gevent/greenlet.py
+++ b/ddtrace/contrib/gevent/greenlet.py
@@ -29,12 +29,5 @@ class TracedGreenlet(gevent.Greenlet):
         # the context is always available made exception of the main greenlet
         if ctx:
             # create a new context that inherits the current active span
-            # TODO: a better API for Context, should get the tuple at once
-            new_ctx = Context(
-                trace_id=ctx.trace_id,
-                span_id=ctx.span_id,
-                sampled=ctx.sampled,
-                sampling_priority=ctx.sampling_priority,
-            )
-            new_ctx._current_span = ctx._current_span
+            new_ctx = Context.from_context(ctx)
             setattr(self, CONTEXT_ATTR, new_ctx)

--- a/ddtrace/contrib/gevent/greenlet.py
+++ b/ddtrace/contrib/gevent/greenlet.py
@@ -2,8 +2,6 @@ import gevent
 
 from .provider import CONTEXT_ATTR
 
-from ...context import Context
-
 
 class TracedGreenlet(gevent.Greenlet):
     """
@@ -29,5 +27,5 @@ class TracedGreenlet(gevent.Greenlet):
         # the context is always available made exception of the main greenlet
         if ctx:
             # create a new context that inherits the current active span
-            new_ctx = Context.from_context(ctx)
+            new_ctx = ctx.clone()
             setattr(self, CONTEXT_ATTR, new_ctx)

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -1,8 +1,10 @@
 import gevent
 import ddtrace
 
+from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.context import Context
 from ddtrace.contrib.gevent import patch, unpatch
+from ddtrace.ext.priority import USER_KEEP
 
 from unittest import TestCase
 from nose.tools import eq_, ok_
@@ -126,6 +128,47 @@ class TestGeventTracer(TestCase):
         eq_(1, len(traces[0]))
         eq_('greenlet', traces[0][0].name)
         eq_('base', traces[0][0].resource)
+
+    def test_trace_sampling_priority_spawn_multiple_greenlets_multiple_traces(self):
+        # multiple greenlets must be part of the same trace
+        def entrypoint():
+            with self.tracer.trace('greenlet.main') as span:
+                span.context.sampling_priority = USER_KEEP
+                span.resource = 'base'
+                jobs = [gevent.spawn(green_1), gevent.spawn(green_2)]
+                gevent.joinall(jobs)
+
+        def green_1():
+            with self.tracer.trace('greenlet.worker') as span:
+                span.set_tag('worker_id', '1')
+                gevent.sleep(0.01)
+
+        def green_2():
+            with self.tracer.trace('greenlet.worker') as span:
+                span.set_tag('worker_id', '2')
+                gevent.sleep(0.01)
+
+        gevent.spawn(entrypoint).join()
+        traces = self.tracer.writer.pop_traces()
+        eq_(3, len(traces))
+        eq_(1, len(traces[0]))
+        parent_span = traces[2][0]
+        worker_1 = traces[0][0]
+        worker_2 = traces[1][0]
+        # check spans data and hierarchy
+        eq_(parent_span.name, 'greenlet.main')
+        eq_(parent_span.resource, 'base')
+        eq_(parent_span.get_metric(SAMPLING_PRIORITY_KEY), USER_KEEP)
+        eq_(worker_1.get_tag('worker_id'), '1')
+        eq_(worker_1.name, 'greenlet.worker')
+        eq_(worker_1.resource, 'greenlet.worker')
+        eq_(worker_1.parent_id, parent_span.span_id)
+        eq_(worker_1.get_metric(SAMPLING_PRIORITY_KEY), USER_KEEP)
+        eq_(worker_2.get_tag('worker_id'), '2')
+        eq_(worker_2.name, 'greenlet.worker')
+        eq_(worker_2.resource, 'greenlet.worker')
+        eq_(worker_2.parent_id, parent_span.span_id)
+        eq_(worker_2.get_metric(SAMPLING_PRIORITY_KEY), USER_KEEP)
 
     def test_trace_spawn_multiple_greenlets_multiple_traces(self):
         # multiple greenlets must be part of the same trace

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -155,19 +155,9 @@ class TestGeventTracer(TestCase):
         parent_span = traces[2][0]
         worker_1 = traces[0][0]
         worker_2 = traces[1][0]
-        # check spans data and hierarchy
-        eq_(parent_span.name, 'greenlet.main')
-        eq_(parent_span.resource, 'base')
+        # check sampling priority
         eq_(parent_span.get_metric(SAMPLING_PRIORITY_KEY), USER_KEEP)
-        eq_(worker_1.get_tag('worker_id'), '1')
-        eq_(worker_1.name, 'greenlet.worker')
-        eq_(worker_1.resource, 'greenlet.worker')
-        eq_(worker_1.parent_id, parent_span.span_id)
         eq_(worker_1.get_metric(SAMPLING_PRIORITY_KEY), USER_KEEP)
-        eq_(worker_2.get_tag('worker_id'), '2')
-        eq_(worker_2.name, 'greenlet.worker')
-        eq_(worker_2.resource, 'greenlet.worker')
-        eq_(worker_2.parent_id, parent_span.span_id)
         eq_(worker_2.get_metric(SAMPLING_PRIORITY_KEY), USER_KEEP)
 
     def test_trace_spawn_multiple_greenlets_multiple_traces(self):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -191,6 +191,24 @@ class TestTracingContext(TestCase):
 
         eq_(100, len(ctx._trace))
 
+    def test_clone(self):
+        ctx = Context()
+        ctx.sampling_priority = 2
+        # manually create a root-child trace
+        root = Span(tracer=None, name='root')
+        child = Span(tracer=None, name='child_1', trace_id=root.trace_id, parent_id=root.span_id)
+        child._parent = root
+        ctx.add_span(root)
+        ctx.add_span(child)
+        cloned_ctx = ctx.clone()
+        eq_(cloned_ctx._parent_trace_id, ctx._parent_trace_id)
+        eq_(cloned_ctx._parent_span_id, ctx._parent_span_id)
+        eq_(cloned_ctx._sampled, ctx._sampled)
+        eq_(cloned_ctx._sampling_priority, ctx._sampling_priority)
+        eq_(cloned_ctx._current_span, ctx._current_span)
+        eq_(cloned_ctx._trace, [])
+        eq_(cloned_ctx._finished_spans, 0)
+
 
 class TestThreadContext(TestCase):
     """


### PR DESCRIPTION
Otherwise it seems we might be losing traces.

While playing around with gevent and the tracing library, I noticed that we were losing some traces at the gevent new context creation for no obvious reason. Passing the sampling_priority seems to have fixed it.

It's not a really scientific approach, i.e. I'm not sure what this change does, but it seems to be working... Do you think it could explain some missing spans in a trace?

Happy to add a test if you can point me in the right direction. 😃 (and if this PR makes sense) 