### PR TITLE
[core] ensure users sitecustomize.py is called

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -4,6 +4,8 @@ Add all monkey-patching that needs to run by default here
 """
 
 import os
+import imp
+import sys
 import logging
 
 from ddtrace.utils.formats import asbool
@@ -46,6 +48,8 @@ try:
     patch = True
 
     # Respect DATADOG_* environment variables in global tracer configuration
+    # TODO: these variables are deprecated; use utils method and update our documentation
+    # correct prefix should be DD_*
     enabled = os.environ.get("DATADOG_TRACE_ENABLED")
     hostname = os.environ.get("DATADOG_TRACE_AGENT_HOSTNAME")
     port = os.environ.get("DATADOG_TRACE_AGENT_PORT")
@@ -76,5 +80,24 @@ try:
 
     if 'DATADOG_ENV' in os.environ:
         tracer.set_tags({"env": os.environ["DATADOG_ENV"]})
+
+    # Ensure sitecustomize.py is properly called if available in application directories:
+    # * exclude `bootstrap_dir` from the search
+    # * find a user `sitecustomize.py` module
+    # * import that module via `imp`
+    bootstrap_dir = os.path.dirname(__file__)
+    path = list(sys.path)
+    path.remove(bootstrap_dir)
+
+    try:
+        (f, path, description) = imp.find_module('sitecustomize', path)
+    except ImportError:
+        pass
+    else:
+        # `sitecustomize.py` found, load it
+        log.debug('sitecustomize from user found in: %s', path)
+        imp.load_module('sitecustomize', f, path, description)
+
+
 except Exception as e:
     log.warn("error configuring Datadog tracing", exc_info=True)

--- a/tests/commands/bootstrap/sitecustomize.py
+++ b/tests/commands/bootstrap/sitecustomize.py
@@ -1,0 +1,1 @@
+CORRECT_IMPORT = True

--- a/tests/commands/ddtrace_run_sitecustomize.py
+++ b/tests/commands/ddtrace_run_sitecustomize.py
@@ -1,0 +1,10 @@
+from __future__ import print_function
+
+from ddtrace import tracer
+from nose.tools import ok_
+
+
+if __name__ == '__main__':
+    import sitecustomize
+    ok_(sitecustomize.CORRECT_IMPORT)
+    print('Test success')

--- a/tests/commands/ddtrace_run_sitecustomize.py
+++ b/tests/commands/ddtrace_run_sitecustomize.py
@@ -1,10 +1,19 @@
 from __future__ import print_function
 
+import sys
 from ddtrace import tracer
 from nose.tools import ok_
 
 
 if __name__ == '__main__':
+    # detect if `-S` is used
+    suppress = len(sys.argv) == 2 and sys.argv[1] is '-S'
+    if suppress:
+        ok_('sitecustomize' not in sys.modules)
+    else:
+        ok_('sitecustomize' in sys.modules)
+
+    # ensure the right `sitecustomize` will be imported
     import sitecustomize
     ok_(sitecustomize.CORRECT_IMPORT)
     print('Test success')


### PR DESCRIPTION
### Overview

Our current `ddtrace-run` implementation doesn't support users' `sitecustomize.py`. This module is auto-loaded when the interpreter starts, and with the current implementation this is what is happening:

* when you run `ddtrace-run`, users `sitecustomize.py` is executed
* then we spawn a new interpreter via `execl` running users' app for real
* at this point `sitecustomize.py` is executed again, but it's ours because we're first in the `PYTHONPATH`.
* if users change something globally (i.e. UTF encoding instead of ASCII), that change is discarded because the `sitecustomize.py` should be called twice.

With this patch, we exclude our `boostrap/sitecustomize.py` from the path, so that the original one can be loaded again.

### What is missing (WIP)

* [x] Test to reproduce the regression