### PR TITLE
[aiobotocore] Fixing tests dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -91,6 +91,7 @@ deps =
     aiobotocore04: aiobotocore>=0.4,<0.5
     aiobotocore03: aiobotocore>=0.3,<0.4
     aiobotocore02: aiobotocore>=0.2,<0.3
+    py{34}-aiobotocore{03,04}: typing
     aiopg012: aiopg>=0.12,<0.13
     aiopg013: aiopg>=0.13,<0.14
     aiopg: sqlalchemy


### PR DESCRIPTION
The `aiobotocore` test suite did not pass because of a dependencies issue. It seems that the library doesn't pin the version of their dependencies, creating errors on the test suite.

As a reference, see [this build failing](https://circleci.com/gh/DataDog/dd-trace-py/16095).

This PR forces the use of the `typing` module when missing.