### PR TITLE
[mysqlb] Fixing missing db type

### DIFF
--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -12,6 +12,7 @@ import wrapt
 from ddtrace import Pin
 from ddtrace.ext import sql
 
+from ...ext import AppTypes
 
 log = logging.getLogger(__name__)
 
@@ -72,10 +73,8 @@ class TracedConnection(wrapt.ObjectProxy):
     def __init__(self, conn, pin=None):
         super(TracedConnection, self).__init__(conn)
         name = _get_vendor(conn)
-        if pin and pin.enabled():
-            pin.onto(self)
-        else:
-            Pin(service=name, app=name, app_type="db").onto(self)
+        db_pin = pin or Pin(service=name, app=name, app_type=AppTypes.db)
+        db_pin.onto(self)
 
     def cursor(self, *args, **kwargs):
         cursor = self.__wrapped__.cursor(*args, **kwargs)

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -69,10 +69,13 @@ class TracedCursor(wrapt.ObjectProxy):
 class TracedConnection(wrapt.ObjectProxy):
     """ TracedConnection wraps a Connection with tracing code. """
 
-    def __init__(self, conn):
+    def __init__(self, conn, pin=None):
         super(TracedConnection, self).__init__(conn)
         name = _get_vendor(conn)
-        Pin(service=name, app=name).onto(self)
+        if pin and pin.enabled():
+            pin.onto(self)
+        else:
+            Pin(service=name, app=name, app_type="db").onto(self)
 
     def cursor(self, *args, **kwargs):
         cursor = self.__wrapped__.cursor(*args, **kwargs)

--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -5,7 +5,7 @@ import mysql.connector
 # project
 from ddtrace import Pin
 from ddtrace.contrib.dbapi import TracedConnection
-from ...ext import net, db
+from ...ext import net, db, AppTypes
 
 
 CONN_ATTR_BY_TAG = {
@@ -34,9 +34,9 @@ def _connect(func, instance, args, kwargs):
 def patch_conn(conn):
 
     tags = {t: getattr(conn, a) for t, a in CONN_ATTR_BY_TAG.items() if getattr(conn, a, '') != ''}
-    pin = Pin(service="mysql", app="mysql", app_type="db", tags=tags)
+    pin = Pin(service="mysql", app="mysql", app_type=AppTypes.db, tags=tags)
 
     # grab the metadata from the conn
-    wrapped = TracedConnection(conn)
+    wrapped = TracedConnection(conn, pin=pin)
     pin.onto(wrapped)
     return wrapped

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -58,6 +58,6 @@ def patch_conn(conn, *args, **kwargs):
     pin = Pin(service="mysql", app="mysql", app_type="db", tags=tags)
 
     # grab the metadata from the conn
-    wrapped = TracedConnection(conn)
+    wrapped = TracedConnection(conn, pin)
     pin.onto(wrapped)
     return wrapped

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -7,7 +7,7 @@ from wrapt import wrap_function_wrapper as _w
 from ddtrace import Pin
 from ddtrace.contrib.dbapi import TracedConnection
 
-from ...ext import net, db
+from ...ext import net, db, AppTypes
 from ...utils.wrappers import unwrap as _u
 
 
@@ -55,9 +55,9 @@ def patch_conn(conn, *args, **kwargs):
             for t, (k, p) in KWPOS_BY_TAG.items()
             if k in kwargs or len(args) > p}
     tags[net.TARGET_PORT] = conn.port
-    pin = Pin(service="mysql", app="mysql", app_type="db", tags=tags)
+    pin = Pin(service="mysql", app="mysql", app_type=AppTypes.db, tags=tags)
 
     # grab the metadata from the conn
-    wrapped = TracedConnection(conn, pin)
+    wrapped = TracedConnection(conn, pin=pin)
     pin.onto(wrapped)
     return wrapped

--- a/ddtrace/contrib/pymysql/patch.py
+++ b/ddtrace/contrib/pymysql/patch.py
@@ -5,7 +5,7 @@ import pymysql
 # project
 from ddtrace import Pin
 from ddtrace.contrib.dbapi import TracedConnection
-from ...ext import net, db
+from ...ext import net, db, AppTypes
 
 CONN_ATTR_BY_TAG = {
     net.TARGET_HOST: 'host',
@@ -31,9 +31,9 @@ def _connect(func, instance, args, kwargs):
 
 def patch_conn(conn):
     tags = {t: getattr(conn, a, '') for t, a in CONN_ATTR_BY_TAG.items()}
-    pin = Pin(service="pymysql", app="pymysql", app_type="db", tags=tags)
+    pin = Pin(service="pymysql", app="pymysql", app_type=AppTypes.db, tags=tags)
 
     # grab the metadata from the conn
-    wrapped = TracedConnection(conn)
+    wrapped = TracedConnection(conn, pin=pin)
     pin.onto(wrapped)
     return wrapped


### PR DESCRIPTION
The way the `MySQLdb` library is patched uses `dbapi`. Then when initializing a `TracedConnection` object, a new Pin was created that did not have `type`, that where the error came from.

This PR solves this issue and prevents from getting 2 services reported for the `MySQLdb` integration. If passing the pin parameter when initializing, it will not create a new one.