### PR TITLE
[celery] fixing ddtrace-run broke celery support

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -70,6 +70,9 @@ try:
     if opts:
         tracer.configure(**opts)
 
+    if not hasattr(sys, 'argv'):
+        sys.argv = ['']
+
     if patch:
         update_patched_modules()
         from ddtrace import patch_all; patch_all(**EXTRA_PATCHED_MODULES) # noqa

--- a/tests/commands/ddtrace_run_argv.py
+++ b/tests/commands/ddtrace_run_argv.py
@@ -1,0 +1,10 @@
+from __future__ import print_function
+
+from ddtrace import tracer
+
+from nose.tools import eq_
+import sys
+
+if __name__ == '__main__':
+    eq_(sys.argv[1:], ['foo', 'bar'])
+    print("Test success")

--- a/tests/commands/ddtrace_run_patched_modules.py
+++ b/tests/commands/ddtrace_run_patched_modules.py
@@ -6,4 +6,5 @@ from nose.tools import ok_
 
 if __name__ == '__main__':
     ok_('redis' in monkey.get_patched_modules())
+    ok_('celery' in monkey.get_patched_modules())
     print("Test success")

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -169,3 +169,9 @@ class DdtraceRunTest(unittest.TestCase):
             env=env,
         )
         assert out.startswith(b"Test success")
+
+    def test_argv_passed(self):
+        out = subprocess.check_output(
+            ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_argv.py', 'foo', 'bar']
+        )
+        assert out.startswith(b"Test success")

--- a/tox.ini
+++ b/tox.ini
@@ -131,6 +131,7 @@ deps =
     # TODO[manu] update to a stable version of Celery
     celery42: celery==4.2.0rc3
     ddtracerun: redis
+    ddtracerun: celery
     elasticsearch16: elasticsearch>=1.6,<1.7
     elasticsearch17: elasticsearch>=1.7,<1.8
     elasticsearch18: elasticsearch>=1.8,<1.9


### PR DESCRIPTION
This PR solves [this issue](https://github.com/DataDog/dd-trace-py/issues/423) : when patching celery with the `ddtrace-run` command, the import fails silently and Celery is not patched. The exception raised is `'module' object has no attribute 'argv'`, stemming from the way our tracer patches libraries: `argv` is not passed, and causes the fail celery import as the library needs it.

The PR replaces argv when it is required.

I have tested this change with a Celery app and a `pymysql` app, it seems to work fine.