### PR TITLE
[requests] adding missing app_type and app name to pin

### DIFF
--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -10,7 +10,7 @@ from ...utils.wrappers import unwrap as _u
 from .legacy import _distributed_tracing, _distributed_tracing_setter
 from .constants import DEFAULT_SERVICE
 from .connection import _wrap_request
-
+from ...ext import AppTypes
 
 # requests default settings
 config._add('requests',{
@@ -29,6 +29,8 @@ def patch():
     _w('requests', 'Session.request', _wrap_request)
     Pin(
         service=config.requests['service_name'],
+        app='requests',
+        app_type=AppTypes.web,
         _config=config.requests,
     ).onto(requests.Session)
 


### PR DESCRIPTION
The `requests` library did not set up `app_type` and `app`, resulting in errors on the agent when reporting services:
`ERROR:failed_to_send services to Agent: HTTP error status 400, reason Bad Request, message Content-Type: text/plain; charset=utf-8`

This PR just adds these attributes to the `Pin`.

I have checked all other integrations and it seems `requests` was the last one with these attributes missing, so this bug should not happen again with other integrations.