### PR TITLE
[pylons] ensure the middleware code is Python 3 compatible

### DIFF
--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -79,6 +79,25 @@ else:
     msgpack_type = bytes
     numeric_types = (int, float)
 
+if PY2:
+    # avoids Python 3 `SyntaxError`
+    # this block will be replaced with the `six` library
+    from .utils.reraise import _reraise as reraise
+else:
+    def reraise(tp, value, tb=None):
+        """Python 3 re-raise function. This function is internal and
+        will be replaced entirely with the `six` library.
+        """
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
+
 
 __all__ = [
     'httplib',
@@ -89,4 +108,5 @@ __all__ = [
     'StringIO',
     'urlencode',
     'parse',
+    'reraise',
 ]

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -7,6 +7,7 @@ from pylons import config
 from .renderer import trace_rendering
 from .constants import CONFIG_MIDDLEWARE
 
+from ...compat import reraise
 from ...ext import http, AppTypes
 from ...propagation.http import HTTPPropagator
 
@@ -78,7 +79,7 @@ class PylonsTraceMiddleware(object):
                 span.error = 1
 
                 # re-raise the original exception with its original traceback
-                raise typ, val, tb
+                reraise(typ, val, tb=tb)
             except SystemExit:
                 span.set_tag(http.STATUS_CODE, 500)
                 span.error = 1

--- a/ddtrace/utils/reraise.py
+++ b/ddtrace/utils/reraise.py
@@ -1,0 +1,5 @@
+def _reraise(tp, value, tb=None):
+    """Python 2 re-raise function. This function is internal and
+    will be replaced entirely with the `six` library.
+    """
+    raise tp, value, tb


### PR DESCRIPTION
### Overview

Closes #472 

Pylons is not Python 3 compatible, but our code must be. In that case, any import will generate a `SyntaxError`. With this approach, the `raise` keyword is replaced with a "six-like" approach that is Python 2 and Python 3 compatible.

### Follow-up

Because the number of compatibility functions is increasing, we may decide to move to `six` library. It will add a new dependency, but the compatibility code across python versions will be handled by the community. For the scope of this PR, migrating to `six` is not an option and a small change (that needs clean-up) fits better.