### PR TITLE
[psycopg2] fix for quote_ident typing bug

### DIFF
--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -35,6 +35,8 @@ def patch_conn(conn, traced_conn_cls=dbapi.TracedConnection):
     # case we're only tracing some connections.
     _patch_extensions(_psycopg2_extensions)
 
+    c = traced_conn_cls(conn)
+
     # fetch tags from the dsn
     dsn = sql.parse_pg_dsn(conn.dsn)
     tags = {
@@ -44,14 +46,12 @@ def patch_conn(conn, traced_conn_cls=dbapi.TracedConnection):
         db.USER: dsn.get("user"),
         "db.application" : dsn.get("application_name"),
     }
-    pin = Pin(
+
+    Pin(
         service="postgres",
         app="postgres",
         app_type="db",
-        tags=tags,
-    )
-
-    c = traced_conn_cls(conn, pin)
+        tags=tags).onto(c)
 
     return c
 

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -101,19 +101,6 @@ def _extensions_adapt(func, _, args, kwargs):
     return adapt
 
 
-def _extensions_quote_ident(func, _, args, kwargs):
-    def _unroll_args(obj, scope=None):
-        return obj, scope
-    obj, scope = _unroll_args(*args, **kwargs)
-
-    # register_type performs a c-level check of the object
-    # type so we must be sure to pass in the actual db connection
-    if scope and isinstance(scope, wrapt.ObjectProxy):
-        scope = scope.__wrapped__
-
-    return func(obj, scope) if scope else func(obj)
-
-
 class AdapterWrapper(wrapt.ObjectProxy):
     def prepare(self, *args, **kwargs):
         func = self.__wrapped__.prepare
@@ -140,9 +127,6 @@ _psycopg2_extensions = [
     (psycopg2.extensions.adapt,
      psycopg2.extensions, 'adapt',
      _extensions_adapt),
-    (psycopg2.extensions.quote_ident,
-     psycopg2.extensions, 'quote_ident',
-     _extensions_quote_ident),
 ]
 
 # `_json` attribute is only available for psycopg >= 2.5
@@ -151,4 +135,12 @@ if getattr(psycopg2, '_json', None):
         (psycopg2._json.register_type,
          psycopg2._json, 'register_type',
          _extensions_register_type),
+    ]
+
+# `quote_ident` attribute is only available for psycopg >= 2.7
+if getattr(psycopg2, 'extensions', None) and getattr(psycopg2.extensions,
+                                                     'quote_ident', None):
+    _psycopg2_extensions += [(psycopg2.extensions.quote_ident,
+     psycopg2.extensions, 'quote_ident',
+     _extensions_register_type),
     ]

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -47,6 +47,7 @@ def patch_conn(conn, traced_conn_cls=dbapi.TracedConnection):
         "db.application" : dsn.get("application_name"),
     }
 
+    # why does this exist if the pin can be passed??
     Pin(
         service="postgres",
         app="postgres",

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -93,6 +93,17 @@ def _extensions_register_type(func, _, args, kwargs):
 
     return func(obj, scope) if scope else func(obj)
 
+def _extensions_quote_ident(func, _, args, kwargs):
+    def _unroll_args(obj, scope=None):
+        return obj, scope
+    obj, scope = _unroll_args(*args, **kwargs)
+
+    # register_type performs a c-level check of the object
+    # type so we must be sure to pass in the actual db connection
+    if scope and isinstance(scope, wrapt.ObjectProxy):
+        scope = scope.__wrapped__
+
+    return func(obj, scope) if scope else func(obj)
 
 def _extensions_adapt(func, _, args, kwargs):
     adapt = func(*args, **kwargs)
@@ -142,5 +153,5 @@ if getattr(psycopg2, 'extensions', None) and getattr(psycopg2.extensions,
                                                      'quote_ident', None):
     _psycopg2_extensions += [(psycopg2.extensions.quote_ident,
      psycopg2.extensions, 'quote_ident',
-     _extensions_register_type),
+     _extensions_quote_ident),
     ]

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -22,7 +22,6 @@ from tests.test_tracer import get_dummy_tracer
 
 PSYCOPG_VERSION = tuple(map(int, psycopg2.__version__.split()[0].split('.')))
 TEST_PORT = str(POSTGRES_CONFIG['port'])
-
 class PsycopgCore(object):
 
     # default service
@@ -125,7 +124,6 @@ class PsycopgCore(object):
         #   TypeError: argument 2 must be a connection, cursor or None
         extras.register_default_json(conn)
 
-
     def test_manual_wrap_extension_adapt(self):
         conn, _ = self._get_conn_and_tracer()
         # NOTE: this will crash if it doesn't work.
@@ -141,6 +139,16 @@ class PsycopgCore(object):
         #   TypeError: argument 2 must be a connection, cursor or None
         binary = extensions.adapt(b'12345')
         binary.prepare(conn)
+
+    def test_manual_wrap_extension_quote_ident(self):
+        from ddtrace import patch_all
+        from psycopg2.extensions import quote_ident
+        patch_all()
+
+        # NOTE: this will crash if it doesn't work.
+        #   TypeError: argument 2 must be a connection or a cursor
+        conn = psycopg2.connect(**POSTGRES_CONFIG)
+        quote_ident('foo', conn)
 
     def test_connect_factory(self):
         tracer = get_dummy_tracer()
@@ -221,15 +229,3 @@ def test_backwards_compatibilty_v3():
     conn.cursor().execute("select 'blah'")
 
 
-def test_connection():
-    from ddtrace import patch_all
-    import psycopg2
-    from psycopg2.extensions import quote_ident
-
-    patch_all()
-
-    conn = psycopg2.connect(**POSTGRES_CONFIG)
-
-    print(type(conn))
-
-    quote_ident('foo', conn)

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -23,7 +23,6 @@ from tests.test_tracer import get_dummy_tracer
 PSYCOPG_VERSION = tuple(map(int, psycopg2.__version__.split()[0].split('.')))
 TEST_PORT = str(POSTGRES_CONFIG['port'])
 
-
 class PsycopgCore(object):
 
     # default service
@@ -214,9 +213,23 @@ class TestPsycopgPatch(PsycopgCore):
         assert spans, spans
         eq_(len(spans), 1)
 
+
 def test_backwards_compatibilty_v3():
     tracer = get_dummy_tracer()
     factory = connection_factory(tracer, service="my-postgres-db")
     conn = psycopg2.connect(connection_factory=factory, **POSTGRES_CONFIG)
     conn.cursor().execute("select 'blah'")
 
+
+def test_connection():
+    from ddtrace import patch_all
+    import psycopg2
+    from psycopg2.extensions import quote_ident
+
+    patch_all()
+
+    conn = psycopg2.connect(**POSTGRES_CONFIG)
+
+    print(type(conn))
+
+    quote_ident('foo', conn)

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -140,6 +140,7 @@ class PsycopgCore(object):
         binary = extensions.adapt(b'12345')
         binary.prepare(conn)
 
+    @skipIf(PSYCOPG_VERSION < (2, 7), 'quote_ident not available in psycopg2<2.7')
     def test_manual_wrap_extension_quote_ident(self):
         from ddtrace import patch_all
         from psycopg2.extensions import quote_ident

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -143,8 +143,8 @@ class PsycopgCore(object):
     @skipIf(PSYCOPG_VERSION < (2, 7), 'quote_ident not available in psycopg2<2.7')
     def test_manual_wrap_extension_quote_ident(self):
         from ddtrace import patch_all
-        from psycopg2.extensions import quote_ident
         patch_all()
+        from psycopg2.extensions import quote_ident
 
         # NOTE: this will crash if it doesn't work.
         #   TypeError: argument 2 must be a connection or a cursor
@@ -230,3 +230,13 @@ def test_backwards_compatibilty_v3():
     conn.cursor().execute("select 'blah'")
 
 
+@skipIf(PSYCOPG_VERSION < (2, 7), 'quote_ident not available in psycopg2<2.7')
+def test_manual_wrap_extension_quote_ident_standalone():
+    from ddtrace import patch_all
+    patch_all()
+    from psycopg2.extensions import quote_ident
+
+    # NOTE: this will crash if it doesn't work.
+    #   TypeError: argument 2 must be a connection or a cursor
+    conn = psycopg2.connect(**POSTGRES_CONFIG)
+    quote_ident('foo', conn)


### PR DESCRIPTION
# Problem
Closes #474 and closes #383 
Related to #96.

# Solution
Use the method introduced in #96 to manually patch the `psycopg2.extensions.quote_ident` method if it exists on the version of `psycopg2` used.

This PR also introduces a test that replicates the bug.