### PR TITLE
[django] remove setting_changed signal from the DatadogSettings

### DIFF
--- a/ddtrace/contrib/django/conf.py
+++ b/ddtrace/contrib/django/conf.py
@@ -18,8 +18,6 @@ import logging
 
 from django.conf import settings as django_settings
 
-from django.test.signals import setting_changed
-
 
 log = logging.getLogger(__name__)
 
@@ -152,6 +150,3 @@ def reload_settings(*args, **kwargs):
     setting, value = kwargs['setting'], kwargs['value']
     if setting == 'DATADOG_TRACE':
         settings = DatadogSettings(value, DEFAULTS, IMPORT_STRINGS)
-
-
-setting_changed.connect(reload_settings)


### PR DESCRIPTION
### Overview

Closes #435.

Our legacy test suite used the `setting_changed()` signal to connect our reloading function when settings are updated via `django.test.TestCase.settings()` context manager or `@django.test.override_settings` decorator ([reference](https://docs.djangoproject.com/en/2.0/ref/signals/#setting-changed)). This signal is not required in order to run our tests (see the CI result).

The main issue is related to the testing code that is imported in our `conf.py` module, resulting in side effects when the `ddtrace-run` script is used. In this specific case, the `DatabaseWrapper` object was owned by the main thread, but the preloading process that happens in `gunicorn` or `uwsgi` assigned (correctly) the object to another thread (Django has a [safe-guard](https://github.com/django/django/blob/3e36ecedffebb81e7e7bb8723f26fbd5056e9fe9/django/db/backends/base/base.py#L516-L532)).