### PR TITLE
[celery] patch TaskRegistry to support old-style task with `ddtrace-run`

### DIFF
--- a/ddtrace/contrib/celery/patch.py
+++ b/ddtrace/contrib/celery/patch.py
@@ -1,15 +1,21 @@
-# Third party
 import celery
 
-# Project
+from wrapt import wrap_function_wrapper as _w
+
 from .app import patch_app, unpatch_app
+from .registry import _wrap_register
+from ...utils.wrappers import unwrap as _u
 
 
 def patch():
-    """ patch will add all available tracing to the celery library """
+    """Instrument Celery base application and the `TaskRegistry` so
+    that any new registered task is automatically instrumented
+    """
     setattr(celery, 'Celery', patch_app(celery.Celery))
+    _w('celery.app.registry', 'TaskRegistry.register', _wrap_register)
 
 
 def unpatch():
-    """ unpatch will remove tracing from the celery library """
+    """Removes instrumentation from Celery"""
     setattr(celery, 'Celery', unpatch_app(celery.Celery))
+    _u(celery.app.registry.TaskRegistry, 'register')

--- a/ddtrace/contrib/celery/registry.py
+++ b/ddtrace/contrib/celery/registry.py
@@ -1,0 +1,15 @@
+from .task import patch_task
+
+
+def _wrap_register(func, instance, args, kwargs):
+    """Wraps the `TaskRegistry.register` function so that everytime
+    a `Task` is registered it is properly instrumented. This wrapper
+    is required because in old-style tasks (Celery 1.0+) we cannot
+    instrument the base class, otherwise a `Strategy` `KeyError`
+    exception is raised.
+    """
+    # the original signature requires one positional argument so the
+    # first and only parameter is the `Task` that must be instrumented
+    task = args[0]
+    patch_task(task)
+    func(*args, **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -128,8 +128,7 @@ deps =
     celery31: celery>=3.1,<3.2
     celery40: celery>=4.0,<4.1
     celery41: celery>=4.1,<4.2
-    # TODO[manu] update to a stable version of Celery
-    celery42: celery==4.2.0rc3
+    celery42: celery>=4.2,<4.3
     ddtracerun: redis
     ddtracerun: celery
     elasticsearch16: elasticsearch>=1.6,<1.7


### PR DESCRIPTION
### Overview

After solving #465 #469 to fix #423, we discovered that `ddtrace-run` wasn't instrumenting old-style tasks. The issue was related to the fact that `celery.task.Task` (`Task` base class) wasn't instrumented by our system; unfortunately, it wasn't possible to instrument it directly because of how the base class is used by Celery. Indeed, a direct instrumentation of `celery.task.Task` ended with the following exception:
```
[2018-06-11 12:37:50,595: ERROR/MainProcess] Received unregistered task of type u'_get_exec_options'.
The message has been ignored and discarded.

Did you remember to import the module containing this task?
Or maybe you're using relative imports?

Please see
http://docs.celeryq.org/en/latest/internals/protocol.html
for more information.

The full contents of the message body was:
'[[], {"stop": true}, {"chord": null, "callbacks": null, "errbacks": null, "chain": null}]' (89b)
Traceback (most recent call last):
  File "[...]/celery/worker/consumer/consumer.py", line 561, in on_task_received
    strategy = strategies[type_]
KeyError: u'_get_exec_options'
```

With this patch, we properly patch a `Task` when it's registered instead of doing it at import time.