### PR TITLE
[django/celery] add `shared_task` decorator wrapper

### DIFF
--- a/ddtrace/contrib/celery/patch.py
+++ b/ddtrace/contrib/celery/patch.py
@@ -3,19 +3,24 @@ import celery
 from wrapt import wrap_function_wrapper as _w
 
 from .app import patch_app, unpatch_app
+from .task import _wrap_shared_task
 from .registry import _wrap_register
 from ...utils.wrappers import unwrap as _u
 
 
 def patch():
     """Instrument Celery base application and the `TaskRegistry` so
-    that any new registered task is automatically instrumented
+    that any new registered task is automatically instrumented. In the
+    case of Django-Celery integration, also the `@shared_task` decorator
+    must be instrumented because Django doesn't use the Celery registry.
     """
     setattr(celery, 'Celery', patch_app(celery.Celery))
     _w('celery.app.registry', 'TaskRegistry.register', _wrap_register)
+    _w('celery', 'shared_task', _wrap_shared_task)
 
 
 def unpatch():
     """Removes instrumentation from Celery"""
     setattr(celery, 'Celery', unpatch_app(celery.Celery))
     _u(celery.app.registry.TaskRegistry, 'register')
+    _u(celery, 'shared_task')

--- a/ddtrace/contrib/celery/task.py
+++ b/ddtrace/contrib/celery/task.py
@@ -79,6 +79,14 @@ def unpatch_task(task):
     return task
 
 
+def _wrap_shared_task(decorator, instance, args, kwargs):
+    """Wrapper for Django-Celery shared tasks. `shared_task` is a decorator
+    that returns a `Task` from the given function.
+    """
+    task = decorator(*args, **kwargs)
+    return patch_task(task)
+
+
 def _task_init(func, task, args, kwargs):
     func(*args, **kwargs)
 


### PR DESCRIPTION
### Overview

Closes #451 

When Django+Celery are used, Django users rely on the `@shared_task` decorator. This allows re-usable Django apps, while not depending on which Celery `app` is used. With this patch we're sure Celery tasks are properly instrumented, because Django doesn't rely on Celery registry when adding a new task. Because of that, our previous patch for `TaskRegistry.register` wasn't enough.

### Caveats

When testing this PR, bear in mind that our tracing system is disabled if Django is in debug mode (`DEBUG = True`).