### PR TITLE
[core] add a shortcut to retrieve Trace correlation identifiers

### DIFF
--- a/ddtrace/helpers.py
+++ b/ddtrace/helpers.py
@@ -1,0 +1,29 @@
+import ddtrace
+
+
+def get_correlation_ids():
+    """Retrieves the Correlation Identifiers for the current active ``Trace``.
+    This helper method can be achieved manually and should be considered
+    only a shortcut. The main reason is to abstract the current ``Tracer``
+    implementation so that these identifiers can be extracted either the
+    tracer is an OpenTracing tracer or a Datadog tracer.
+
+    OpenTracing users can still extract these values using the ``ScopeManager``
+    API, though this shortcut is a simple one-liner. The usage is:
+
+        from ddtrace import correlation
+
+        trace_id, span_id = correlation.get_correlation_ids()
+
+    :returns: a tuple containing the trace_id and span_id
+    """
+    # Consideration: currently we don't have another way to "define" a
+    # GlobalTracer. In the case of OpenTracing, ``opentracing.tracer`` is exposed
+    # and we're doing the same here for ``ddtrace.tracer``. Because this helper
+    # must work also with OpenTracing, we should take the right used ``Tracer``.
+    # At the time of writing, it's enough to support our Datadog Tracer.
+    tracer = ddtrace.tracer
+    span = tracer.current_span()
+    if span is None:
+        return None, None
+    return span.trace_id, span.span_id

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,32 @@
+from ddtrace import helpers
+
+from unittest import TestCase
+from nose.tools import eq_, ok_
+
+from .util import override_global_tracer
+from .test_tracer import get_dummy_tracer
+
+class HelpersTestCase(TestCase):
+    """Test suite for ``ddtrace`` helpers"""
+    def setUp(self):
+        # initializes a DummyTracer
+        self.tracer = get_dummy_tracer()
+
+    def test_correlation_identifiers(self):
+        # ensures the right correlation identifiers are
+        # returned when a Trace is active
+        with override_global_tracer(self.tracer):
+            span = self.tracer.trace('MockSpan')
+            active_trace_id, active_span_id = span.trace_id, span.span_id
+            trace_id, span_id = helpers.get_correlation_ids()
+
+        eq_(trace_id, active_trace_id)
+        eq_(span_id, active_span_id)
+
+    def test_correlation_identifiers_without_trace(self):
+        # ensures `None` is returned if no Traces are active
+        with override_global_tracer(self.tracer):
+            trace_id, span_id = helpers.get_correlation_ids()
+
+        ok_(trace_id is None)
+        ok_(span_id is None)


### PR DESCRIPTION
### Overview

If for some reasons at any time we need to retrieve the current correlation identifiers (`trace_id` and `span_id` at the time of writing), users need to:
* import the current active `Tracer`
* retrieve the current active `Span` or `Scope` depending on the implementation (OpenTracing compatible or not)
* find the `trace_id` and `span_id`
* add a safety check in case a `Trace` is not active
* return these values

This `helpers` module can be imported to provide a high-level API that abstracts all the steps above, providing a reasonable shortcut.

### Usage
```python
from ddtrace import helpers

trace_id, span_id = helpers.get_correlation_ids()
```