### PR TITLE
[core] add a TraceContextFilter to inject Correlation Identifiers in Python logs

### DIFF
--- a/ddtrace/logs.py
+++ b/ddtrace/logs.py
@@ -1,0 +1,22 @@
+import logging
+
+from . import helpers
+
+
+class TraceContextFilter(logging.Filter):
+    """Injects Tracing Correlation Identifiers in the current log record.
+    This action is executed everytime a debug(), info() etc. are used, but
+    it requires adding the ``Filter`` in all ``Handler``s. To add a Filter,
+    simply:
+
+        from ddtrace.logs import TraceContextFilter
+
+        trace_filter = TraceContextFilter()
+        for handler in logging.root.handlers:
+            handler.addFilter(trace_filter)
+    """
+    def filter(self, record):
+        trace_id, span_id = helpers.get_correlation_ids()
+        record.trace_id = trace_id
+        record.span_id = span_id
+        return True

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,49 @@
+import logging
+
+from ddtrace.logs import TraceContextFilter
+
+from unittest import TestCase
+from nose.tools import eq_, ok_
+
+from .util import override_global_tracer
+from .test_tracer import get_dummy_tracer
+
+
+class LogFilterTestCase(TestCase):
+    """Test suite for Trace and Logs integration"""
+    def setUp(self):
+        # initializes a DummyTracer and store the `LogCapture` instance
+        self.tracer = get_dummy_tracer()
+        self.handler = logging.root.handlers[0]
+        self.handler.setFormatter(logging.Formatter('dd.trace_id=%(trace_id)s dd.span_id=%(span_id)s %(message)s'))
+        self.handler.setLevel(logging.INFO)
+        self.handler.addFilter(TraceContextFilter())
+        self.handler.truncate()
+        self.log = logging.getLogger(__name__)
+
+    def test_log_includes_correlation_identifiers(self):
+        # ensures the right correlation identifiers are present in all log lines
+        with override_global_tracer(self.tracer):
+            span = self.tracer.trace('MockSpan')
+            active_trace_id, active_span_id = span.trace_id, span.span_id
+            self.log.info('Info notice')
+            self.log.warn('Warning notice')
+            self.log.error('Error notice')
+
+        eq_(len(self.handler.buffer), 3)
+        for record in self.handler.buffer:
+            ok_(str(active_trace_id) in record)
+            ok_(str(active_span_id) in record)
+
+    def test_correlation_identifiers_without_trace(self):
+        # empty Correlation Identifiers are present even if a Trace is not
+        # currently active
+        with override_global_tracer(self.tracer):
+            self.log.info('Info notice')
+            self.log.warn('Warning notice')
+            self.log.error('Error notice')
+
+        eq_(len(self.handler.buffer), 3)
+        for record in self.handler.buffer:
+            ok_('dd.trace_id=None' in record)
+            ok_('dd.span_id=None' in record)


### PR DESCRIPTION
### Overview

Follow-up for #488.

This PR adds a `TraceContextFilter` that retrieves the Correlation Identifiers (`trace_id` and `span_id`) when any logging functionality is used. In this way, when a `log.info()`, `log.warn()` etc. are used, these values are automatically appended in logs, if the `Logger` format has been properly updated.

This functionality is still manual and no OOTB instrumentation is provided.

### Usage

To use this functionality, users must:
* update their logging format, adding `'dd.trace_id=%(trace_id)s dd.span_id=%(span_id)s` or similar
* be sure that `TraceContextFilter` is added in all handlers; if not, the application may throw (and log) `KeyError`. This is a legit case because it's how the Python logging system works.

### Working example

In this `gist` you can find a full working example: https://gist.github.com/palazzem/b494b238a2abe5dc208c5cf05ac79ed1

### What's missing
* [ ] Test the functionality in a real environment
* [ ] Snippets extracted from the "Working example" on what needs to be manually changed in real applications
* [ ] Test if it works with a JSON exporter