### PR TITLE
[opentracer] Remaining tracer pieces

### DIFF
--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -70,7 +70,7 @@ class Span(OpenTracingSpan):
             return
 
         # finish the datadog span
-        self._dd_span.finish()
+        self._dd_span.finish(finish_time)
         self.finished = True
 
     def set_baggage_item(self, key, value):

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -50,7 +50,7 @@ class Span(OpenTracingSpan):
         super(Span, self).__init__(tracer, context)
 
         # use a datadog span
-        self._dd_span = DatadogSpan(tracer._tracer, operation_name,
+        self._dd_span = DatadogSpan(tracer._dd_tracer, operation_name,
                                     context=context._dd_context)
 
         self.log = SpanLog()

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -57,17 +57,17 @@ class Tracer(opentracing.Tracer):
 
         # default to using a threadlocal scope manager
         # TODO: should this be some kind of configuration option?
-        self._scope_manager = ThreadLocalScopeManager()
+        self._scope_manager = scope_manager or ThreadLocalScopeManager()
 
-        self._tracer = DatadogTracer()
-        self._tracer.configure(enabled=self._enabled,
-                               hostname=self._config.get(keys.AGENT_HOSTNAME),
-                               port=self._config.get(keys.AGENT_PORT),
-                               sampler=self._config.get(keys.SAMPLER),
-                               settings=self._config.get(keys.SETTINGS),
-                               context_provider=self._config.get(keys.CONTEXT_PROVIDER),
-                               priority_sampling=self._config.get(keys.PRIORITY_SAMPLING),
-                               )
+        self._dd_tracer = DatadogTracer()
+        self._dd_tracer.configure(enabled=self._enabled,
+                                  hostname=self._config.get(keys.AGENT_HOSTNAME),
+                                  port=self._config.get(keys.AGENT_PORT),
+                                  sampler=self._config.get(keys.SAMPLER),
+                                  settings=self._config.get(keys.SETTINGS),
+                                  context_provider=self._config.get(keys.CONTEXT_PROVIDER),
+                                  priority_sampling=self._config.get(keys.PRIORITY_SAMPLING),
+                                  )
         self._propagators = {
             Format.HTTP_HEADERS: HTTPPropagator(),
             Format.TEXT_MAP: HTTPPropagator(),
@@ -203,7 +203,7 @@ class Tracer(opentracing.Tracer):
 
         # create a new otspan and ddspan using the ddtracer and associate it with the new otspan
         otspan = Span(self, ot_parent_context, operation_name)
-        ddspan = self._tracer.start_span(name=operation_name, child_of=dd_parent)
+        ddspan = self._dd_tracer.start_span(name=operation_name, child_of=dd_parent)
         ddspan.start = start_time or ddspan.start  # set the start time if one is specified
         if tags is not None:
             ddspan.set_tags(tags)

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -168,6 +168,10 @@ class Tracer(opentracing.Tracer):
         ot_parent_context = None  # the parent span's context
         dd_parent = None          # the child_of to pass to the ddtracer
 
+        if references and isinstance(references, list):
+            # we currently only support child_of relations to one span
+            ot_parent = references[0].referenced_context
+
         # Okay so here's the deal for ddtracer.start_span:
         #  - whenever child_of is not None ddspans with parent-child relationships
         #    will share a ddcontext which maintains a hierarchy of ddspans for

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -2,12 +2,22 @@ import pytest
 
 from ddtrace.opentracer import Tracer
 
+
+def get_dummy_ot_tracer(service_name='', config={}, scope_manager=None):
+    from ..test_tracer import get_dummy_tracer
+    tracer = Tracer(service_name=service_name, config=config, scope_manager=scope_manager)
+    tracer._dd_tracer = get_dummy_tracer()
+    return tracer
+
+
 @pytest.fixture
 def nop_tracer():
-    from ..test_tracer import get_dummy_tracer
-    tracer = Tracer(service_name='mysvc', config={})
-    tracer._tracer = get_dummy_tracer()
-    return tracer
+    return get_dummy_ot_tracer(service_name='mysvc')
+
+
+# helper to get the spans from a nop_tracer
+def get_spans(tracer):
+    return tracer._dd_tracer.writer.pop()
 
 
 class TestTracerConfig(object):
@@ -81,7 +91,7 @@ class TestTracerConfig(object):
         # span should be finished when the context manager exits
         assert span.finished
 
-        spans = nop_tracer._tracer.writer.pop()
+        spans = get_spans(nop_tracer)
         assert len(spans) == 1
 
     def test_start_span_references(self, nop_tracer):
@@ -91,7 +101,7 @@ class TestTracerConfig(object):
         with nop_tracer.start_span('one', references=[child_of()]):
             pass
 
-        spans = nop_tracer._tracer.writer.pop()
+        spans = get_spans(nop_tracer)
         assert spans[0].parent_id is None
 
         root = nop_tracer.start_span('root')
@@ -101,7 +111,7 @@ class TestTracerConfig(object):
                 pass
         root.finish()
 
-        spans = nop_tracer._tracer.writer.pop()
+        spans = get_spans(nop_tracer)
         assert spans[2].parent_id is spans[0].span_id
 
     def test_start_span_custom_start_time(self, nop_tracer):
@@ -129,7 +139,7 @@ class TestTracerConfig(object):
         assert span.finished
         assert span2.finished
 
-        spans = nop_tracer._tracer.writer.pop()
+        spans = get_spans(nop_tracer)
         assert len(spans) == 2
 
         # ensure proper parenting
@@ -164,7 +174,7 @@ class TestTracerConfig(object):
         assert span2.finished
         assert span3.finished
 
-        spans = nop_tracer._tracer.writer.pop()
+        spans = get_spans(nop_tracer)
 
         # check spans are captured in the trace
         assert span1._dd_span is spans[0]
@@ -198,7 +208,7 @@ class TestTracerConfig(object):
         assert span2.finished
         assert span3.finished
 
-        spans = nop_tracer._tracer.writer.pop()
+        spans = get_spans(nop_tracer)
 
         # check spans are captured in the trace
         assert span1._dd_span is spans[0]
@@ -223,21 +233,23 @@ class TestTracerConfig(object):
 
         root = nop_tracer.start_span('zero')
 
-        with nop_tracer.start_span('one', child_of=root) as span1:
+        with nop_tracer.start_span('one', child_of=root):
             time.sleep(0.009)
-            with nop_tracer.start_span('two', child_of=root) as span2:
+            with nop_tracer.start_span('two', child_of=root):
                 time.sleep(0.007)
-                with nop_tracer.start_span('three', child_of=root) as span3:
+                with nop_tracer.start_span('three', child_of=root):
                     time.sleep(0.005)
         root.finish()
 
-        spans = nop_tracer._tracer.writer.pop()
+        spans = get_spans(nop_tracer)
 
         assert spans[0].parent_id is None
         # ensure each child span is a child of root
         assert spans[1].parent_id is root._dd_span.span_id
         assert spans[2].parent_id is root._dd_span.span_id
         assert spans[3].parent_id is root._dd_span.span_id
+        assert spans[0].trace_id == spans[1].trace_id and \
+            spans[1].trace_id == spans[2].trace_id
 
     def test_start_span_no_active_span(self, nop_tracer):
         """Start spans without using a scope manager.
@@ -252,12 +264,16 @@ class TestTracerConfig(object):
             with nop_tracer.start_span('three', ignore_active_span=True) as span3:
                 time.sleep(0.005)
 
-        spans = nop_tracer._tracer.writer.pop()
+        spans = get_spans(nop_tracer)
 
         # ensure each span does not have a parent
         assert spans[0].parent_id is None
         assert spans[1].parent_id is None
         assert spans[2].parent_id is None
+        # and that each span is a new trace
+        assert spans[0].trace_id != spans[1].trace_id and \
+               spans[1].trace_id != spans[2].trace_id and \
+               spans[0].trace_id != spans[2].trace_id
 
     def test_start_span_child_finish_after_parent(self, nop_tracer):
         """Start a child span and finish it after its parent."""
@@ -269,7 +285,7 @@ class TestTracerConfig(object):
         time.sleep(0.005)
         span2.finish()
 
-        spans = nop_tracer._tracer.writer.pop()
+        spans = get_spans(nop_tracer)
         assert len(spans) is 2
         assert spans[0].parent_id is None
         assert spans[1].parent_id is span1._dd_span.span_id
@@ -316,7 +332,7 @@ class TestTracerConfig(object):
         # wait for threads to finish
         time.sleep(0.018)
 
-        spans = nop_tracer._tracer.writer.pop()
+        spans = get_spans(nop_tracer)
 
         # trace_one will finish before trace_two so its spans should be written
         # before the spans from trace_two, let's confirm this
@@ -337,13 +353,23 @@ class TestTracerConfig(object):
         assert spans[4].parent_id is spans[3].span_id
         assert spans[5].parent_id is spans[3].span_id
 
+        # finally we should ensure that the trace_ids are reasonable
+        # trace_one
+        assert spans[0].trace_id == spans[1].trace_id and \
+            spans[1].trace_id == spans[2].trace_id
+        # traces should be independent
+        assert spans[2].trace_id != spans[3].trace_id
+        # trace_two
+        assert spans[3].trace_id == spans[4].trace_id and \
+            spans[4].trace_id == spans[5].trace_id
+
     def test_start_active_span(self, nop_tracer):
         with nop_tracer.start_active_span('one') as scope:
             pass
 
         assert scope.span._dd_span.name == 'one'
         assert scope.span.finished
-        spans = nop_tracer._tracer.writer.pop()
+        spans = get_spans(nop_tracer)
         assert spans
 
     def test_start_active_span_finish_on_close(self, nop_tracer):
@@ -352,7 +378,7 @@ class TestTracerConfig(object):
 
         assert scope.span._dd_span.name == 'one'
         assert not scope.span.finished
-        spans = nop_tracer._tracer.writer.pop()
+        spans = get_spans(nop_tracer)
         assert not spans
 
 @pytest.fixture

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -317,6 +317,23 @@ class TestTracerConfig(object):
         assert spans[4].parent_id is spans[3].span_id
         assert spans[5].parent_id is spans[3].span_id
 
+    def test_start_active_span(self, nop_tracer):
+        with nop_tracer.start_active_span('one') as scope:
+            pass
+
+        assert scope.span._dd_span.name == 'one'
+        assert scope.span.finished
+        spans = nop_tracer._tracer.writer.pop()
+        assert spans
+
+    def test_start_active_span_finish_on_close(self, nop_tracer):
+        with nop_tracer.start_active_span('one', finish_on_close=False) as scope:
+            pass
+
+        assert scope.span._dd_span.name == 'one'
+        assert not scope.span.finished
+        spans = nop_tracer._tracer.writer.pop()
+        assert not spans
 
 @pytest.fixture
 def nop_span_ctx():

--- a/tests/opentracer/test_tracer_asyncio.py
+++ b/tests/opentracer/test_tracer_asyncio.py
@@ -1,0 +1,134 @@
+import asyncio
+import opentracing
+import pytest
+from nose.tools import eq_, ok_
+
+from opentracing.ext.scope_manager.asyncio import AsyncioScopeManager
+from tests.opentracer.test_tracer import get_dummy_ot_tracer
+from tests.contrib.asyncio.utils import AsyncioTestCase, mark_asyncio
+
+
+def get_dummy_asyncio_tracer():
+    return get_dummy_ot_tracer('asyncio_svc', {}, AsyncioScopeManager())
+
+
+def nop_tracer():
+    return get_dummy_asyncio_tracer()
+
+
+class TestTracerAsyncio(AsyncioTestCase):
+    @mark_asyncio
+    def test_trace_coroutine(self):
+        tracer = nop_tracer()
+        # it should use the task context when invoked in a coroutine
+        with tracer.start_span('coroutine'):
+            pass
+
+        traces = tracer._dd_tracer.writer.pop_traces()
+
+        eq_(1, len(traces))
+        eq_(1, len(traces[0]))
+        eq_('coroutine', traces[0][0].name)
+
+    @mark_asyncio
+    def test_trace_multiple_coroutines(self):
+        tracer = nop_tracer()
+        # if multiple coroutines have nested tracing, they must belong
+        # to the same trace
+        @asyncio.coroutine
+        def coro():
+            # another traced coroutine
+            with tracer.start_span('coroutine_2'):
+                return 42
+
+        with tracer.start_span('coroutine_1'):
+            value = yield from coro()
+
+        # the coroutine has been called correctly
+        eq_(42, value)
+        # a single trace has been properly reported
+        traces = tracer._dd_tracer.writer.pop_traces()
+        eq_(1, len(traces))
+        eq_(2, len(traces[0]))
+        eq_('coroutine_1', traces[0][0].name)
+        eq_('coroutine_2', traces[0][1].name)
+        # the parenting is correct
+        eq_(traces[0][0], traces[0][1]._parent)
+        eq_(traces[0][0].trace_id, traces[0][1].trace_id)
+
+    @mark_asyncio
+    def test_exception(self):
+        tracer = nop_tracer()
+        @asyncio.coroutine
+        def f1():
+            with tracer.start_span('f1'):
+                raise Exception('f1 error')
+
+        with self.assertRaises(Exception):
+            yield from f1()
+
+        traces = tracer._dd_tracer.writer.pop_traces()
+        eq_(1, len(traces))
+        spans = traces[0]
+        eq_(1, len(spans))
+        span = spans[0]
+        eq_(1, span.error)
+        eq_('f1 error', span.get_tag('error.msg'))
+        ok_('Exception: f1 error' in span.get_tag('error.stack'))
+
+    @mark_asyncio
+    def test_trace_multiple_calls(self):
+        tracer = nop_tracer()
+        # create multiple futures so that we expect multiple
+        # traces instead of a single one (helper not used)
+        @asyncio.coroutine
+        def coro():
+            # another traced coroutine
+            with tracer.start_span('coroutine'):
+                yield from asyncio.sleep(0.01)
+
+        futures = [asyncio.ensure_future(coro()) for x in range(10)]
+        for future in futures:
+            yield from future
+
+        traces = tracer._dd_tracer.writer.pop_traces()
+        eq_(10, len(traces))
+        eq_(1, len(traces[0]))
+        eq_('coroutine', traces[0][0].name)
+
+    @mark_asyncio
+    def test_concurrent_chaining(self):
+        """TODO: this test does not work for opentracing.
+        It is unclear as to what the behaviour should be when crossing thread
+        boundaries.
+        """
+        tracer = nop_tracer()
+        # ensures that the context is correctly propagated when
+        # concurrent tasks are created from a common tracing block
+        # @asyncio.coroutine
+        # def f1():
+        #     with tracer.start_span('f1'):
+        #         yield from asyncio.sleep(0.01)
+
+        # @asyncio.coroutine
+        # def f2():
+        #     with tracer.start_span('f2'):
+        #         yield from asyncio.sleep(0.01)
+
+        # with tracer.start_span('main_task'):
+        #     yield from asyncio.gather(f1(), f2())
+
+        # traces = tracer._dd_tracer.writer.pop_traces()
+        # print(traces)
+        # eq_(len(traces), 3)
+        # eq_(len(traces[0]), 1)
+        # eq_(len(traces[1]), 1)
+        # eq_(len(traces[2]), 1)
+        # child_1 = traces[0][0]
+        # child_2 = traces[1][0]
+        # main_task = traces[2][0]
+        # # check if the context has been correctly propagated
+        # eq_(child_1.trace_id, main_task.trace_id)
+        # eq_(child_1.parent_id, main_task.span_id)
+        # eq_(child_2.trace_id, main_task.trace_id)
+        # eq_(child_2.parent_id, main_task.span_id)

--- a/tests/opentracer/test_tracer_gevent.py
+++ b/tests/opentracer/test_tracer_gevent.py
@@ -46,7 +46,7 @@ class TestTracerGevent(object):
 from unittest import TestCase
 from nose.tools import eq_, ok_
 
-class TestTracerGevent(TestCase):
+class TestTracerGeventCompat(TestCase):
     """Converted Gevent tests for the regular tracer.
 
     Ensures that greenlets are properly traced when using

--- a/tests/opentracer/test_tracer_gevent.py
+++ b/tests/opentracer/test_tracer_gevent.py
@@ -1,0 +1,192 @@
+import pytest
+import gevent
+import opentracing
+
+from opentracing.ext.scope_manager.gevent import GeventScopeManager
+from tests.opentracer.test_tracer import get_dummy_ot_tracer
+
+
+def get_dummy_gevent_tracer():
+    return get_dummy_ot_tracer('gevent', {}, GeventScopeManager())
+
+
+@pytest.fixture()
+def nop_tracer():
+    return get_dummy_gevent_tracer()
+
+
+class TestTracerGevent(object):
+    def test_no_threading(self, nop_tracer):
+        with nop_tracer.start_span('span') as span:
+            span.set_tag('tag', 'value')
+
+        assert span.finished
+
+    def test_greenlets(self, nop_tracer):
+        def f():
+            with nop_tracer.start_span('f') as span:
+                gevent.sleep(0.04)
+                span.set_tag('f', 'yes')
+
+        def g():
+            with nop_tracer.start_span('g') as span:
+                gevent.sleep(0.03)
+                span.set_tag('g', 'yes')
+
+        with nop_tracer.start_span('root'):
+            gevent.joinall([
+                gevent.spawn(f),
+                gevent.spawn(g),
+            ])
+
+        traces = nop_tracer._dd_tracer.writer.pop_traces()
+        assert len(traces) == 3
+
+
+from unittest import TestCase
+from nose.tools import eq_, ok_
+
+class TestTracerGevent(TestCase):
+    """Converted Gevent tests for the regular tracer.
+
+    Ensures that greenlets are properly traced when using
+    the default Tracer.
+    """
+    def setUp(self):
+        # use a dummy tracer
+        self.tracer = get_dummy_gevent_tracer()
+
+    def tearDown(self):
+        pass
+
+    def test_trace_greenlet(self):
+        # a greenlet can be traced using the trace API
+        def greenlet():
+            with self.tracer.start_span('greenlet') as span:
+                pass
+
+        gevent.spawn(greenlet).join()
+        traces = self.tracer._dd_tracer.writer.pop_traces()
+        eq_(1, len(traces))
+        eq_(1, len(traces[0]))
+        eq_('greenlet', traces[0][0].name)
+
+    def test_trace_later_greenlet(self):
+        # a greenlet can be traced using the trace API
+        def greenlet():
+            with self.tracer.start_span('greenlet') as span:
+                pass
+
+        gevent.spawn_later(0.01, greenlet).join()
+        traces = self.tracer._dd_tracer.writer.pop_traces()
+        eq_(1, len(traces))
+        eq_(1, len(traces[0]))
+        eq_('greenlet', traces[0][0].name)
+
+    def test_trace_spawn_multiple_greenlets_multiple_traces(self):
+        """TODO: this test's behaviour might be different for opentracing
+        than for regular tracing. It is undefined so far as to how/if opentracing
+        will patch threading libraries to handle scope management.
+        """
+        # multiple greenlets must be part of the same trace
+        def entrypoint():
+            with self.tracer.start_span('greenlet.main') as span:
+                jobs = [gevent.spawn(green_1), gevent.spawn(green_2)]
+                gevent.joinall(jobs)
+
+        def green_1():
+            with self.tracer.start_span('greenlet.worker') as span:
+                span.set_tag('worker_id', '1')
+                gevent.sleep(0.01)
+
+        def green_2():
+            with self.tracer.start_span('greenlet.worker') as span:
+                span.set_tag('worker_id', '2')
+                gevent.sleep(0.01)
+
+        gevent.spawn(entrypoint).join()
+        traces = self.tracer._dd_tracer.writer.pop_traces()
+        eq_(3, len(traces))
+        eq_(1, len(traces[0]))
+        parent_span = traces[2][0]
+        worker_1 = traces[0][0]
+        worker_2 = traces[1][0]
+        # check spans data and hierarchy
+        eq_(parent_span.name, 'greenlet.main')
+        eq_(worker_1.get_tag('worker_id'), '1')
+        eq_(worker_1.name, 'greenlet.worker')
+        # TODO:
+        # eq_(worker_1.parent_id, parent_span.span_id)
+        eq_(worker_2.get_tag('worker_id'), '2')
+        eq_(worker_2.name, 'greenlet.worker')
+        # TODO:
+        # eq_(worker_2.parent_id, parent_span.span_id)
+
+    def test_trace_spawn_later_multiple_greenlets_multiple_traces(self):
+        """TODO: see previous test's TODO."""
+        # multiple greenlets must be part of the same trace
+        def entrypoint():
+            with self.tracer.start_span('greenlet.main') as span:
+                jobs = [gevent.spawn_later(0.01, green_1), gevent.spawn_later(0.01, green_2)]
+                gevent.joinall(jobs)
+
+        def green_1():
+            with self.tracer.start_span('greenlet.worker') as span:
+                span.set_tag('worker_id', '1')
+                gevent.sleep(0.01)
+
+        def green_2():
+            with self.tracer.start_span('greenlet.worker') as span:
+                span.set_tag('worker_id', '2')
+                gevent.sleep(0.01)
+
+        gevent.spawn(entrypoint).join()
+        traces = self.tracer._dd_tracer.writer.pop_traces()
+        eq_(3, len(traces))
+        eq_(1, len(traces[0]))
+        parent_span = traces[2][0]
+        worker_1 = traces[0][0]
+        worker_2 = traces[1][0]
+        # check spans data and hierarchy
+        eq_(parent_span.name, 'greenlet.main')
+        eq_(worker_1.get_tag('worker_id'), '1')
+        eq_(worker_1.name, 'greenlet.worker')
+        eq_(worker_1.resource, 'greenlet.worker')
+        # TODO:
+        # eq_(worker_1.parent_id, parent_span.span_id)
+        eq_(worker_2.get_tag('worker_id'), '2')
+        eq_(worker_2.name, 'greenlet.worker')
+        eq_(worker_2.resource, 'greenlet.worker')
+        # TODO:
+        # eq_(worker_2.parent_id, parent_span.span_id)
+
+    def test_trace_concurrent_calls(self):
+        # create multiple futures so that we expect multiple
+        # traces instead of a single one
+        def greenlet():
+            with self.tracer.start_span('greenlet'):
+                gevent.sleep(0.01)
+
+        jobs = [gevent.spawn(greenlet) for x in range(100)]
+        gevent.joinall(jobs)
+
+        traces = self.tracer._dd_tracer.writer.pop_traces()
+        eq_(100, len(traces))
+        eq_(1, len(traces[0]))
+        eq_('greenlet', traces[0][0].name)
+
+    def test_trace_concurrent_spawn_later_calls(self):
+        # create multiple futures so that we expect multiple
+        # traces instead of a single one, even if greenlets
+        # are delayed
+        def greenlet():
+            with self.tracer.start_span('greenlet'):
+                gevent.sleep(0.01)
+
+        jobs = [gevent.spawn_later(0.01, greenlet) for x in range(100)]
+        gevent.joinall(jobs)
+
+        traces = self.tracer._dd_tracer.writer.pop_traces()
+        eq_(100, len(traces))
+        eq_(1, len(traces[0]))
+        eq_('greenlet', traces[0][0].name)

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,8 @@ envlist =
     {py27,py34,py35,py36}-opentracer
     {py34,py35,py36}-opentracer_asyncio
     {py34,py35,py36}-opentracer_tornado-tornado{40,41,42,43,44}
+    {py27}-opentracer_gevent-gevent{10}
+    {py27,py34,py35,py36}-opentracer_gevent-gevent{11,12}
     {py34,py35,py36}-asyncio
     {py27}-pylons{096,097,010,10}
     {py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
@@ -251,7 +253,7 @@ commands =
     opentracer: pytest {posargs} tests/opentracer/test_tracer.py tests/opentracer/test_span.py tests/opentracer/test_span_context.py
     opentracer_asyncio: pytest {posargs} tests/opentracer/test_tracer_asyncio.py
     opentracer_tornado-tornado{40,41,42,43,44}: pytest {posargs} tests/opentracer/test_tracer_tornado.py
-    opentracer-gevent: pytest {posargs} tests/opentracer-gevent/
+    opentracer_gevent: pytest {posargs} tests/opentracer/test_tracer_gevent.py
 # integration tests
     integration: nosetests {posargs} tests/test_integration.py
     asyncio: nosetests {posargs} tests/contrib/asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,8 @@ envlist =
     {py27,py34,py35,py36}-integration
     {py27,py34,py35,py36}-ddtracerun
     {py27,py34,py35,py36}-opentracer
+    {py34,py35,py36}-opentracer_asyncio
+    {py34,py35,py36}-opentracer_tornado-tornado{40,41,42,43,44}
     {py34,py35,py36}-asyncio
     {py27}-pylons{096,097,010,10}
     {py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
@@ -82,6 +84,10 @@ basepython =
     py36: python3.6
 
 deps =
+    pytest
+# TODO: force unreleased opentracing v2.0.0 for now
+# git+https://github.com/opentracing/opentracing-python.git@v2.0.0
+    git+https://github.com/carlosalberto/opentracing-python.git@scope_managers_integration
 # test dependencies installed in all envs
     mock
     nose
@@ -242,7 +248,10 @@ commands =
 # run only essential tests related to the tracing client
     tracer: nosetests {posargs} --exclude=".*(contrib|integration|commands).*" tests
 # run only the opentrace tests
-    opentracer: pytest {posargs} tests/opentracer/
+    opentracer: pytest {posargs} tests/opentracer/test_tracer.py tests/opentracer/test_span.py tests/opentracer/test_span_context.py
+    opentracer_asyncio: pytest {posargs} tests/opentracer/test_tracer_asyncio.py
+    opentracer_tornado-tornado{40,41,42,43,44}: pytest {posargs} tests/opentracer/test_tracer_tornado.py
+    opentracer-gevent: pytest {posargs} tests/opentracer-gevent/
 # integration tests
     integration: nosetests {posargs} tests/test_integration.py
     asyncio: nosetests {posargs} tests/contrib/asyncio
@@ -309,28 +318,6 @@ ignore_outcome=true
 deps=flake8==3.2.0
 commands=flake8 ddtrace
 basepython=python2
-
-# TODO: force unreleased v2.0.0 for now
-# git+https://github.com/opentracing/opentracing-python.git@v2.0.0
-[opentracer]
-deps=
-  pytest
-  nose
-  git+https://github.com/carlosalberto/opentracing-python.git@scope_managers_integration
-
-[testenv:py27-opentracer]
-deps=
-    {[opentracer]deps}
-[testenv:py34-opentracer]
-deps=
-    {[opentracer]deps}
-[testenv:py35-opentracer]
-deps=
-    {[opentracer]deps}
-[testenv:py36-opentracer]
-deps=
-    {[opentracer]deps}
-
 
 [falcon_autopatch]
 setenv =


### PR DESCRIPTION
This PR adds the remaining opentracing tracer functionality along with more extensive test coverage.

Particularly:
- `start_active_span`
- support for references
- tests for the above
- tests for:
  - asyncio
  - gevent
  - threading