### PR TITLE
[opentracer] Compatibility with Datadog

### DIFF
--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -22,7 +22,7 @@ class Span(OpenTracingSpan):
 
         super(Span, self).__init__(tracer, context)
 
-        self.finished = False
+        self._finished = False
         self._lock = threading.Lock()
         # use a datadog span
         self._dd_span = DatadogSpan(tracer._dd_tracer, operation_name,
@@ -37,12 +37,12 @@ class Span(OpenTracingSpan):
             per time.time()
         :type timestamp: float
         """
-        if self.finished:
+        if self._finished:
             return
 
         # finish the datadog span
         self._dd_span.finish(finish_time)
-        self.finished = True
+        self._finished = True
 
     def set_baggage_item(self, key, value):
         """Sets a baggage item in the span context of this span.

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -4,7 +4,7 @@ import threading
 from opentracing import Span as OpenTracingSpan
 from ddtrace.span import Span as DatadogSpan
 from ddtrace.ext import errors
-from .tags import OTTags
+from .tags import Tags
 
 from .span_context import SpanContext
 
@@ -116,11 +116,18 @@ class Span(OpenTracingSpan):
 
         This sets the tag on the underlying datadog span.
         """
-        if key == OTTags.SPAN_TYPE:
+        if key == Tags.SPAN_TYPE:
             self._dd_span.span_type = value
-        elif key == OTTags.HTTP_URL or key == OTTags.DB_STATEMENT:
-            # TODO: there may be cardinality issues with this?
+        elif key == Tags.SERVICE_NAME:
+            self._dd_span.service = value
+        elif key == Tags.RESOURCE_NAME or key == Tags.DB_STATEMENT:
             self._dd_span.resource = value
+        elif key == Tags.PEER_HOSTNAME:
+            self._dd_span.set_tag(Tags.TARGET_HOST, value)
+        elif key == Tags.PEER_PORT:
+            self._dd_span.set_tag(Tags.TARGET_PORT, value)
+        elif key == Tags.SAMPLING_PRIORITY:
+            self._dd_span.context.sampling_priority = value
         else:
             self._dd_span.set_tag(key, value)
 

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -2,6 +2,7 @@ import time
 import threading
 
 from opentracing import Span as OpenTracingSpan
+from opentracing.ext import tags as OTTags
 from ddtrace.span import Span as DatadogSpan
 from ddtrace.ext import errors
 from .tags import Tags
@@ -120,11 +121,11 @@ class Span(OpenTracingSpan):
             self._dd_span.span_type = value
         elif key == Tags.SERVICE_NAME:
             self._dd_span.service = value
-        elif key == Tags.RESOURCE_NAME or key == Tags.DB_STATEMENT:
+        elif key == Tags.RESOURCE_NAME or key == OTTags.DATABASE_STATEMENT:
             self._dd_span.resource = value
-        elif key == Tags.PEER_HOSTNAME:
+        elif key == OTTags.PEER_HOSTNAME:
             self._dd_span.set_tag(Tags.TARGET_HOST, value)
-        elif key == Tags.PEER_PORT:
+        elif key == OTTags.PEER_PORT:
             self._dd_span.set_tag(Tags.TARGET_PORT, value)
         elif key == Tags.SAMPLING_PRIORITY:
             self._dd_span.context.sampling_priority = value

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -23,7 +23,7 @@ class Span(OpenTracingSpan):
         super(Span, self).__init__(tracer, context)
 
         self.finished = False
-        self.lock = threading.Lock()
+        self._lock = threading.Lock()
         # use a datadog span
         self._dd_span = DatadogSpan(tracer._dd_tracer, operation_name,
                                     context=context._dd_context)
@@ -60,7 +60,7 @@ class Span(OpenTracingSpan):
         """
         new_ctx = self.context.with_baggage_item(key, value)
         self.set_tag(key, value)
-        with self.lock:
+        with self._lock:
             self._context = new_ctx
         return self
 

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -4,6 +4,7 @@ import threading
 from opentracing import Span as OpenTracingSpan
 from ddtrace.span import Span as DatadogSpan
 from ddtrace.ext import errors
+from .tags import OTTags
 
 from .span_context import SpanContext
 
@@ -151,7 +152,13 @@ class Span(OpenTracingSpan):
 
         This sets the tag on the underlying datadog span.
         """
-        return self._dd_span.set_tag(key, value)
+        if key == OTTags.SPAN_TYPE:
+            self._dd_span.span_type = value
+        elif key == OTTags.HTTP_URL or key == OTTags.DB_STATEMENT:
+            # TODO: there may be cardinality issues with this?
+            self._dd_span.resource = value
+        else:
+            self._dd_span.set_tag(key, value)
 
     def _get_tag(self, key):
         """Gets a tag from the span.

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -59,7 +59,6 @@ class Span(OpenTracingSpan):
         :return: itself for chaining calls
         """
         new_ctx = self.context.with_baggage_item(key, value)
-        self.set_tag(key, value)
         with self._lock:
             self._context = new_ctx
         return self
@@ -149,9 +148,6 @@ class Span(OpenTracingSpan):
         # get the datadog span context
         self._dd_span = ddspan
         self.context._dd_context = ddspan.context
-        # set any baggage tags in the ddspan
-        for key, val in self.context.baggage.items():
-            self.set_tag(key, val)
 
     @property
     def _dd_context(self):

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -9,36 +9,6 @@ from .tags import OTTags
 from .span_context import SpanContext
 
 
-class SpanLogRecord(object):
-    """A representation of a log record."""
-
-    slots = ['record', 'timestamp']
-
-    def __init__(self, key_values, timestamp=None):
-        self.timestamp = timestamp or time.time()
-        self.record = key_values
-
-
-class SpanLog(object):
-    """A collection of log records."""
-
-    slots = ['records']
-
-    def __init__(self):
-        self.records = []
-
-    def add_record(self, key_values, timestamp=None):
-        self.records.append(SpanLogRecord(key_values, timestamp))
-
-    def __len__(self):
-        return len(self.records)
-
-    def __getitem__(self, key):
-        if type(key) is int:
-            return self.records[key]
-        else:
-            raise TypeError('only indexing by int is currently supported')
-
 
 class Span(OpenTracingSpan):
     """Datadog implementation of :class:`opentracing.Span`"""
@@ -52,7 +22,6 @@ class Span(OpenTracingSpan):
 
         super(Span, self).__init__(tracer, context)
 
-        self.log = SpanLog()
         self.finished = False
         self.lock = threading.Lock()
         # use a datadog span
@@ -124,10 +93,6 @@ class Span(OpenTracingSpan):
         :return: the span itself, for call chaining
         :rtype: Span
         """
-        # add the record to the log
-        # TODO: there really isn't any functionality provided in ddtrace
-        #       (or even opentracing) for logging
-        self.log.add_record(key_values, timestamp)
 
         # match opentracing defined keys to datadog functionality
         # opentracing/specification/blob/1be630515dafd4d2a468d083300900f89f28e24d/semantic_conventions.md#log-fields-table

--- a/ddtrace/opentracer/span_context.py
+++ b/ddtrace/opentracer/span_context.py
@@ -42,7 +42,6 @@ class SpanContext(OpenTracingSpanContext):
 
         Useful for instantiating new child span contexts.
         """
-
         baggage = dict(self._baggage)
         baggage[key] = value
         return SpanContext(ddcontext=self._dd_context, baggage=baggage)

--- a/ddtrace/opentracer/tags.py
+++ b/ddtrace/opentracer/tags.py
@@ -1,0 +1,45 @@
+from collections import namedtuple
+
+OT_TAG_NAMES = [
+    'COMPONENT',
+    'DB_INSTANCE',
+    'DB_STATEMENT',
+    'DB_TYPE',
+    'DB_USER',
+    'ERROR',
+    'HTTP_METHOD',
+    'HTTP_STATUS_CODE',
+    'HTTP_URL',
+    'MSG_BUS_DEST',
+    'PEER_ADDRESS',
+    'PEER_HOSTNAME',
+    'PEER_IPV4',
+    'PEER_IPV6',
+    'PEER_PORT',
+    'PEER_SERVICE',
+    'SAMPLING_PRIORITY',
+    'SPAN_TYPE',
+]
+
+OTTagNames = namedtuple('OTTagNames', OT_TAG_NAMES)
+
+OTTags = OTTagNames(
+    COMPONENT='component',
+    DB_INSTANCE='db.instance',
+    DB_STATEMENT='db.statement',
+    DB_TYPE='db.type',
+    DB_USER='db.user',
+    ERROR='error',
+    HTTP_METHOD='http.method',
+    HTTP_STATUS_CODE='http.status_code',
+    HTTP_URL='http.url',
+    MSG_BUS_DEST='message_bus.destination',
+    PEER_ADDRESS='peer.address',
+    PEER_HOSTNAME='peer.hostname',
+    PEER_IPV4='peer.ipv4',
+    PEER_IPV6='peer.ipv6',
+    PEER_PORT='peer.port',
+    PEER_SERVICE='peer.service',
+    SAMPLING_PRIORITY='sampling.priority',
+    SPAN_TYPE='span.kind',
+)

--- a/ddtrace/opentracer/tags.py
+++ b/ddtrace/opentracer/tags.py
@@ -1,27 +1,8 @@
 from collections import namedtuple
 
 TAG_NAMES = [
-    # OpenTracing tags
-    'COMPONENT',
-    'DB_INSTANCE',
-    'DB_STATEMENT',
-    'DB_TYPE',
-    'DB_USER',
-    'ERROR',
-    'HTTP_METHOD',
-    'HTTP_STATUS_CODE',
-    'HTTP_URL',
-    'MSG_BUS_DEST',
-    'PEER_ADDRESS',
-    'PEER_HOSTNAME',
-    'PEER_IPV4',
-    'PEER_IPV6',
-    'PEER_PORT',
-    'PEER_SERVICE',
-    'SAMPLING_PRIORITY',
-    'SPAN_KIND',
-    # Datadog tags
     'RESOURCE_NAME',
+    'SAMPLING_PRIORITY',
     'SERVICE_NAME',
     'SPAN_TYPE',
     'TARGET_HOST',
@@ -31,27 +12,8 @@ TAG_NAMES = [
 TagNames = namedtuple('TagNames', TAG_NAMES)
 
 Tags = TagNames(
-    # OpenTracing tags
-    COMPONENT='component',
-    DB_INSTANCE='db.instance',
-    DB_STATEMENT='db.statement',
-    DB_TYPE='db.type',
-    DB_USER='db.user',
-    ERROR='error',
-    HTTP_METHOD='http.method',
-    HTTP_STATUS_CODE='http.status_code',
-    HTTP_URL='http.url',
-    MSG_BUS_DEST='message_bus.destination',
-    PEER_ADDRESS='peer.address',
-    PEER_HOSTNAME='peer.hostname',
-    PEER_IPV4='peer.ipv4',
-    PEER_IPV6='peer.ipv6',
-    PEER_PORT='peer.port',
-    PEER_SERVICE='peer.service',
-    SAMPLING_PRIORITY='sampling.priority',
-    SPAN_KIND='span.kind',
-    # Datadog tags
     RESOURCE_NAME='resource.name',
+    SAMPLING_PRIORITY='sampling.priority',
     SERVICE_NAME='service.name',
     TARGET_HOST='out.host',
     TARGET_PORT='out.port',

--- a/ddtrace/opentracer/tags.py
+++ b/ddtrace/opentracer/tags.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 
-OT_TAG_NAMES = [
+TAG_NAMES = [
+    # OpenTracing tags
     'COMPONENT',
     'DB_INSTANCE',
     'DB_STATEMENT',
@@ -18,12 +19,19 @@ OT_TAG_NAMES = [
     'PEER_PORT',
     'PEER_SERVICE',
     'SAMPLING_PRIORITY',
+    'SPAN_KIND',
+    # Datadog tags
+    'RESOURCE_NAME',
+    'SERVICE_NAME',
     'SPAN_TYPE',
+    'TARGET_HOST',
+    'TARGET_PORT',
 ]
 
-OTTagNames = namedtuple('OTTagNames', OT_TAG_NAMES)
+TagNames = namedtuple('TagNames', TAG_NAMES)
 
-OTTags = OTTagNames(
+Tags = TagNames(
+    # OpenTracing tags
     COMPONENT='component',
     DB_INSTANCE='db.instance',
     DB_STATEMENT='db.statement',
@@ -41,5 +49,11 @@ OTTags = OTTagNames(
     PEER_PORT='peer.port',
     PEER_SERVICE='peer.service',
     SAMPLING_PRIORITY='sampling.priority',
-    SPAN_TYPE='span.kind',
+    SPAN_KIND='span.kind',
+    # Datadog tags
+    RESOURCE_NAME='resource.name',
+    SERVICE_NAME='service.name',
+    TARGET_HOST='out.host',
+    TARGET_PORT='out.port',
+    SPAN_TYPE='span.type',
 )

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -210,7 +210,12 @@ class Tracer(opentracing.Tracer):
         # create a new otspan and ddspan using the ddtracer and associate it
         # with the new otspan
         otspan = Span(self, ot_parent_context, operation_name)
-        ddspan = self._dd_tracer.start_span(name=operation_name, child_of=dd_parent)
+        ddspan = self._dd_tracer.start_span(
+            name=operation_name,
+            child_of=dd_parent,
+            service=self._service_name,
+
+        )
         # set the start time if one is specified
         ddspan.start = start_time or ddspan.start
         if tags is not None:

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -214,7 +214,6 @@ class Tracer(opentracing.Tracer):
             name=operation_name,
             child_of=dd_parent,
             service=self._service_name,
-
         )
         # set the start time if one is specified
         ddspan.start = start_time or ddspan.start

--- a/tests/opentracer/test_span.py
+++ b/tests/opentracer/test_span.py
@@ -28,7 +28,7 @@ class TestSpan(object):
     def test_init(self, nop_tracer, nop_span_ctx):
         """Very basic test for skeleton code"""
         span = Span(nop_tracer, nop_span_ctx, 'my_op_name')
-        assert not span.finished
+        assert not span._finished
 
     def test_tags(self, nop_span):
         """Set a tag and get it back."""
@@ -93,14 +93,14 @@ class TestSpan(object):
         """Test the span context manager."""
         import time
 
-        assert not nop_span.finished
+        assert not nop_span._finished
         # run the context manager but since the span has not been added
         # to the span context, we will not get any traces
         with nop_span:
             time.sleep(0.005)
 
         # span should be finished when the context manager exits
-        assert nop_span.finished
+        assert nop_span._finished
 
         # there should be no traces (see above comment)
         spans = nop_span.tracer._tracer.writer.pop()

--- a/tests/opentracer/test_span.py
+++ b/tests/opentracer/test_span.py
@@ -106,8 +106,16 @@ class TestSpan(object):
         spans = nop_span.tracer._tracer.writer.pop()
         assert len(spans) == 0
 
+    def test_immutable_span_context(self, nop_span):
+        """Ensure span contexts are immutable."""
+        before_ctx = nop_span._context
+        nop_span.set_baggage_item('key', 'value')
+        after_ctx = nop_span._context
+        # should be different contexts
+        assert before_ctx is not after_ctx
 
-class TestSpanLog():
+
+class TestSpanLog(object):
     def test_init(self):
         log = SpanLog()
         assert len(log) == 0
@@ -126,3 +134,11 @@ class TestSpanLog():
         assert len(log) == 2
         assert log[0].record == record
         assert log[0].timestamp <= log[1].timestamp
+
+
+class TestSpanCompatibility(object):
+    """Ensure our opentracer spans features correspond to datadog span features.
+    """
+    def test_set_tag(self, nop_span):
+        nop_span.set_tag('test', 2)
+        assert nop_span._dd_span.get_tag('test') == str(2)

--- a/tests/opentracer/test_span.py
+++ b/tests/opentracer/test_span.py
@@ -1,5 +1,5 @@
 import pytest
-from ddtrace.opentracer.span import Span, SpanLog
+from ddtrace.opentracer.span import Span
 from ..test_tracer import get_dummy_tracer
 
 
@@ -113,27 +113,6 @@ class TestSpan(object):
         after_ctx = nop_span._context
         # should be different contexts
         assert before_ctx is not after_ctx
-
-
-class TestSpanLog(object):
-    def test_init(self):
-        log = SpanLog()
-        assert len(log) == 0
-
-    def test_add_record(self):
-        """Add new records to a log."""
-        import time
-        log = SpanLog()
-        # add a record without a timestamp
-        record = {'event': 'now'}
-        log.add_record(record)
-
-        # add a record with a timestamp
-        log.add_record({'event2': 'later'}, time.time())
-
-        assert len(log) == 2
-        assert log[0].record == record
-        assert log[0].timestamp <= log[1].timestamp
 
 
 class TestSpanCompatibility(object):

--- a/tests/opentracer/test_span.py
+++ b/tests/opentracer/test_span.py
@@ -121,3 +121,31 @@ class TestSpanCompatibility(object):
     def test_set_tag(self, nop_span):
         nop_span.set_tag('test', 2)
         assert nop_span._dd_span.get_tag('test') == str(2)
+
+    def test_tag_resource_name(self, nop_span):
+        nop_span.set_tag('resource.name', 'myresource')
+        assert nop_span._dd_span.resource == 'myresource'
+
+    def test_tag_span_type(self, nop_span):
+        nop_span.set_tag('span.type', 'db')
+        assert nop_span._dd_span.span_type == 'db'
+
+    def test_tag_service_name(self, nop_span):
+        nop_span.set_tag('service.name', 'mysvc234')
+        assert nop_span._dd_span.service == 'mysvc234'
+
+    def test_tag_db_statement(self, nop_span):
+        nop_span.set_tag('db.statement', 'SELECT * FROM USERS')
+        assert nop_span._dd_span.resource == 'SELECT * FROM USERS'
+
+    def test_tag_peer_hostname(self, nop_span):
+        nop_span.set_tag('peer.hostname', 'peername')
+        assert nop_span._dd_span.get_tag('out.host') == 'peername'
+
+    def test_tag_peer_port(self, nop_span):
+        nop_span.set_tag('peer.port', '55555')
+        assert nop_span._dd_span.get_tag('out.port') == '55555'
+
+    def test_tag_sampling_priority(self, nop_span):
+        nop_span.set_tag('sampling.priority', '2')
+        assert nop_span._dd_span.context._sampling_priority == '2'

--- a/tests/opentracer/test_span_context.py
+++ b/tests/opentracer/test_span_context.py
@@ -34,6 +34,6 @@ class TestSpanContext(object):
     def test_span_context_immutable_baggage(self):
         """Ensure that two different span contexts do not share baggage."""
         ctx1 = SpanContext()
-        ctx1._baggage['test'] = 3
+        ctx1.set_baggage_item('test', 3)
         ctx2 = SpanContext()
         assert 'test' not in ctx2._baggage

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -572,7 +572,8 @@ class TestTracerCompatibility(object):
         """Ensure required fields needed for successful tracing are possessed
         by the underlying datadog tracer.
         """
-        tracer = Tracer()
+        # a service name is required
+        tracer = Tracer('service')
         with tracer.start_span('my_span') as span:
             assert span._dd_span.service
 

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -91,7 +91,7 @@ class TestTracer(object):
             time.sleep(0.005)
 
         # span should be finished when the context manager exits
-        assert span.finished
+        assert span._finished
 
         spans = get_spans(nop_tracer)
         assert len(spans) == 1
@@ -138,8 +138,8 @@ class TestTracer(object):
                 time.sleep(0.008)
 
         # span should be finished when the context manager exits
-        assert span.finished
-        assert span2.finished
+        assert span._finished
+        assert span2._finished
 
         spans = get_spans(nop_tracer)
         assert len(spans) == 2
@@ -172,9 +172,9 @@ class TestTracer(object):
                     time.sleep(0.005)
 
         # spans should be finished when the context manager exits
-        assert scope1.span.finished
-        assert scope2.span.finished
-        assert scope3.span.finished
+        assert span1._finished
+        assert span2._finished
+        assert span3._finished
 
         spans = get_spans(nop_tracer)
 
@@ -206,9 +206,9 @@ class TestTracer(object):
                 time.sleep(0.005)
 
         # spans should be finished when the context manager exits
-        assert scope1.span.finished
-        assert scope2.span.finished
-        assert scope3.span.finished
+        assert span1._finished
+        assert span2._finished
+        assert span3._finished
 
         spans = get_spans(nop_tracer)
 
@@ -370,7 +370,7 @@ class TestTracer(object):
             pass
 
         assert scope.span._dd_span.name == 'one'
-        assert scope.span.finished
+        assert scope.span._finished
         spans = get_spans(nop_tracer)
         assert spans
 
@@ -379,7 +379,7 @@ class TestTracer(object):
             pass
 
         assert scope.span._dd_span.name == 'one'
-        assert not scope.span.finished
+        assert not scope.span._finished
         spans = get_spans(nop_tracer)
         assert not spans
 

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -542,27 +542,27 @@ class TestTracerSpanContextPropagation(object):
 
     def test_inherited_baggage(self, nop_tracer):
         """Baggage should be inherited by child spans."""
-        with nop_tracer.start_span('root') as root:
+        with nop_tracer.start_active_span('root') as root:
             # this should be passed down to the child
-            root.set_baggage_item('root', 1)
-            root.set_baggage_item('root2', 1)
-            with nop_tracer.start_span('child') as level1:
-                level1.set_baggage_item('level1', 1)
-                with nop_tracer.start_span('child') as level2:
-                    level2.set_baggage_item('level2', 1)
+            root.span.set_baggage_item('root', 1)
+            root.span.set_baggage_item('root2', 1)
+            with nop_tracer.start_active_span('child') as level1:
+                level1.span.set_baggage_item('level1', 1)
+                with nop_tracer.start_active_span('child') as level2:
+                    level2.span.set_baggage_item('level2', 1)
         # ensure immutability
-        assert level1.context is not root.context
-        assert level2.context is not level1.context
+        assert level1.span.context is not root.span.context
+        assert level2.span.context is not level1.span.context
 
         # level1 should have inherited the baggage of root
-        assert level1.get_baggage_item('root')
-        assert level1.get_baggage_item('root2')
+        assert level1.span.get_baggage_item('root')
+        assert level1.span.get_baggage_item('root2')
 
         # level2 should have inherited the baggage of both level1 and level2
-        assert level2.get_baggage_item('root')
-        assert level2.get_baggage_item('root2')
-        assert level2.get_baggage_item('level1')
-        assert level2.get_baggage_item('level2')
+        assert level2.span.get_baggage_item('root')
+        assert level2.span.get_baggage_item('root2')
+        assert level2.span.get_baggage_item('level1')
+        assert level2.span.get_baggage_item('level2')
 
 
 class TestTracerCompatibility(object):

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -172,9 +172,9 @@ class TestTracer(object):
                     time.sleep(0.005)
 
         # spans should be finished when the context manager exits
-        assert span1._finished
-        assert span2._finished
-        assert span3._finished
+        assert scope1.span._finished
+        assert scope2.span._finished
+        assert scope3.span._finished
 
         spans = get_spans(nop_tracer)
 
@@ -206,9 +206,9 @@ class TestTracer(object):
                 time.sleep(0.005)
 
         # spans should be finished when the context manager exits
-        assert span1._finished
-        assert span2._finished
-        assert span3._finished
+        assert scope1.span._finished
+        assert scope2.span._finished
+        assert scope3.span._finished
 
         spans = get_spans(nop_tracer)
 

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -576,22 +576,3 @@ class TestTracerCompatibility(object):
         with tracer.start_span('my_span') as span:
             assert span._dd_span.service
 
-    def test_baggage_tags(self, nop_tracer):
-        """Ensure setting baggage tags results in corresponding datadog span tags."""
-        with nop_tracer.start_span('my_span') as span:
-            span.set_baggage_item('tag', 'value')
-        assert span._dd_span.get_tag('tag')
-
-    def test_baggage_tags_propagated(self, nop_tracer):
-        """Ensure baggage tags are propagated to child spans and result in
-        corresponding datadog tags.
-        """
-        with nop_tracer.start_span('root') as root:
-            # this should be passed down to the child
-            root.set_baggage_item('root_tag', 1)
-            with nop_tracer.start_span('child') as child:
-                child.set_baggage_item('child_tag', 1)
-
-        # child should have tags from both the parent and itself
-        assert child._dd_span.get_tag('child_tag')
-        assert child._dd_span.get_tag('root_tag')


### PR DESCRIPTION
This PR aims to connect the added opentracing logic to our Datadog tracing so that the traces collected by the opentracer are successfully sent and displayed in the Datadog platform.

A dependent PR in the trace-examples repo will contain a few more concrete opentracing usage examples: https://github.com/DataDog/trace-examples/pull/33.

This PR makes the following changes:

- a service name is set which allows traces to be accepted by the trace agent
- make span context usage immutable
- set the tags related to baggage in the datadog span
- fixes to scope manager usage
- tests for all the above