### PR TITLE
tracer needs the settings object to get filter configurations

### DIFF
--- a/ddtrace/contrib/tornado/__init__.py
+++ b/ddtrace/contrib/tornado/__init__.py
@@ -55,6 +55,11 @@ Tornado settings can be used to change some tracing configuration, like::
             'default_service': 'my-tornado-app',
             'tags': {'env': 'production'},
             'distributed_tracing': True,
+            'settings': {
+                'FILTERS':  [
+                    FilterRequestsOnUrl(r'http://test\.example\.com'),
+                ],
+            },
         },
     }
 
@@ -74,6 +79,7 @@ The available settings are:
   We suggest to enable it only for internal services where headers are under your control.
 * ``agent_hostname`` (default: `localhost`): define the hostname of the APM agent.
 * ``agent_port`` (default: `8126`): define the port of the APM agent.
+* ``settings`` (default: ``{}``): Tracer extra settings used to change, for instance, the filtering behavior.
 """
 from ...utils.importlib import require_modules
 

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -42,6 +42,7 @@ def tracer_config(__init__, app, args, kwargs):
         enabled=settings.get('enabled', None),
         hostname=settings.get('agent_hostname', None),
         port=settings.get('agent_port', None),
+        settings=settings
     )
 
     # set global tags if any

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -32,6 +32,9 @@ def tracer_config(__init__, app, args, kwargs):
     tracer = settings['tracer']
     service = settings['default_service']
 
+    # extract extra settings
+    extra_settings = settings.get('settings', {})
+
     # the tracer must use the right Context propagation and wrap executor;
     # this action is done twice because the patch() method uses the
     # global tracer while here we can have a different instance (even if
@@ -42,7 +45,7 @@ def tracer_config(__init__, app, args, kwargs):
         enabled=settings.get('enabled', None),
         hostname=settings.get('agent_hostname', None),
         port=settings.get('agent_port', None),
-        settings=settings
+        settings=extra_settings,
     )
 
     # set global tags if any

--- a/tests/contrib/tornado/test_config.py
+++ b/tests/contrib/tornado/test_config.py
@@ -1,4 +1,6 @@
-from nose.tools import eq_
+from nose.tools import eq_, ok_
+
+from ddtrace.filters import FilterRequestsOnUrl
 
 from .utils import TornadoTestCase
 
@@ -17,6 +19,11 @@ class TestTornadoSettings(TornadoTestCase):
                 'enabled': False,
                 'agent_hostname': 'dd-agent.service.consul',
                 'agent_port': 8126,
+                'settings': {
+                    'FILTERS':  [
+                        FilterRequestsOnUrl(r'http://test\.example\.com'),
+                    ],
+                },
             },
         }
 
@@ -27,3 +34,7 @@ class TestTornadoSettings(TornadoTestCase):
         eq_(self.tracer.enabled, False)
         eq_(self.tracer.writer.api.hostname, 'dd-agent.service.consul')
         eq_(self.tracer.writer.api.port, 8126)
+        # settings are properly passed
+        ok_(self.tracer.writer._filters is not None)
+        eq_(len(self.tracer.writer._filters), 1)
+        ok_(isinstance(self.tracer.writer._filters[0], FilterRequestsOnUrl))


### PR DESCRIPTION
Closes #499

Filter doesn't work with tornado trace configuration since it doesn't have access to the settings object during configuration. https://github.com/DataDog/dd-trace-py/blob/master/ddtrace/tracer.py#L108

```python
settings['datadog_trace'] = {
    'FILTERS': [FilterRequestsOnUrl([r'.*/test'])]
}
```