### PR TITLE
Check if bootstrap dir is in path before removal

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -103,6 +103,10 @@ try:
         log.debug('sitecustomize from user found in: %s', path)
         imp.load_module('sitecustomize', f, path, description)
 
-
+    # Loading status used in tests to detect if the `sitecustomize` has been
+    # properly loaded without exceptions. This must be the last action in the module
+    # when the execution ends with a success.
+    loaded = True
 except Exception as e:
+    loaded = False
     log.warn("error configuring Datadog tracing", exc_info=True)

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -90,7 +90,9 @@ try:
     # * import that module via `imp`
     bootstrap_dir = os.path.dirname(__file__)
     path = list(sys.path)
-    path.remove(bootstrap_dir)
+
+    if bootstrap_dir in path:
+        path.remove(bootstrap_dir)
 
     try:
         (f, path, description) = imp.find_module('sitecustomize', path)

--- a/tests/commands/ddtrace_minimal.py
+++ b/tests/commands/ddtrace_minimal.py
@@ -1,0 +1,7 @@
+from __future__ import print_function
+
+import ddtrace.bootstrap.sitecustomize as module
+
+
+if __name__ == '__main__':
+    print(module.loaded)

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -5,6 +5,8 @@ import sys
 import subprocess
 import unittest
 
+from nose.tools import ok_
+
 from ..util import inject_sitecustomize
 
 
@@ -149,6 +151,20 @@ class DdtraceRunTest(unittest.TestCase):
         update_patched_modules()
         assert EXTRA_PATCHED_MODULES["boto"] == True
         assert EXTRA_PATCHED_MODULES["django"] == False
+
+    def test_sitecustomize_without_ddtrace_run_command(self):
+        # [Regression test]: ensure `sitecustomize` path is removed only if it's
+        # present otherwise it will cause:
+        #   ValueError: list.remove(x): x not in list
+        # as mentioned here: https://github.com/DataDog/dd-trace-py/pull/516
+        env = inject_sitecustomize('')
+        out = subprocess.check_output(
+            ['python', 'tests/commands/ddtrace_minimal.py'],
+            env=env,
+        )
+        # `out` contains the `loaded` status of the module
+        result = out[:-1] == b'True'
+        ok_(result)
 
     def test_sitecustomize_run(self):
         # [Regression test]: ensure users `sitecustomize.py` is properly loaded,


### PR DESCRIPTION
Module `ddtrace.bootstrap.sitecustomize` expect that the python application is started using the `ddtrace-run` command or that the bootstrap_dir is in `sys.path` see  https://github.com/DataDog/dd-trace-py/blob/master/ddtrace/bootstrap/sitecustomize.py#L93

This PR prevent failed tracing initialization by checking presence of bootstrap dir in path.

How to reproduce:

minimal.py
```
#!/bin/env python
import ddtrace.bootstrap.sitecustomize
```
```
» python minimal.py
WARNING:ddtrace.bootstrap.sitecustomize:error configuring Datadog tracing
Traceback (most recent call last):
  File "/home/mkuffa/src/dd-trace-py/ddtrace/bootstrap/sitecustomize.py", line 93, in <module>
    path.remove(bootstrap_dir)
ValueError: list.remove(x): x not in list
```

While `ddtrace-run minimal.py` works fine.
