### PR TITLE
[celery] refactor tests execution; change the patched Task() method

### DIFF
--- a/ddtrace/contrib/celery/app.py
+++ b/ddtrace/contrib/celery/app.py
@@ -30,9 +30,6 @@ def patch_app(app, pin=None):
         # Patch method
         setattr(app, method_name, wrapt.FunctionWrapper(method, wrapper))
 
-    # patch the Task class if available
-    setattr(app, 'Task', patch_task(app.Task))
-
     # Attach our pin to the app
     pin.onto(app)
     return app

--- a/ddtrace/contrib/celery/patch.py
+++ b/ddtrace/contrib/celery/patch.py
@@ -1,8 +1,10 @@
 import celery
+import celery.app.task
 
 from wrapt import wrap_function_wrapper as _w
 
 from .app import patch_app, unpatch_app
+from .task import patch_task, unpatch_task
 from .task import _wrap_shared_task
 from .registry import _wrap_register
 from ...utils.wrappers import unwrap as _u
@@ -14,7 +16,11 @@ def patch():
     case of Django-Celery integration, also the `@shared_task` decorator
     must be instrumented because Django doesn't use the Celery registry.
     """
+    # instrument the main Celery application constructor
     setattr(celery, 'Celery', patch_app(celery.Celery))
+    # `app.Task` is a `cached_property` so we need to patch the base class
+    # that is used to create this one.
+    patch_task(celery.app.task.Task)
     _w('celery.app.registry', 'TaskRegistry.register', _wrap_register)
     _w('celery', 'shared_task', _wrap_shared_task)
 
@@ -22,5 +28,6 @@ def patch():
 def unpatch():
     """Removes instrumentation from Celery"""
     setattr(celery, 'Celery', unpatch_app(celery.Celery))
+    unpatch_task(celery.app.task.Task)
     _u(celery.app.registry.TaskRegistry, 'register')
     _u(celery, 'shared_task')

--- a/ddtrace/contrib/celery/task.py
+++ b/ddtrace/contrib/celery/task.py
@@ -9,6 +9,7 @@ from ddtrace.ext import AppTypes
 from ...ext import errors
 from .util import APP, PRODUCER_SERVICE, WORKER_SERVICE, meta_from_context, require_pin
 
+
 PRODUCER_ROOT_SPAN = 'celery.apply'
 WORKER_ROOT_SPAN = 'celery.run'
 # Task operations

--- a/tests/contrib/celery/base.py
+++ b/tests/contrib/celery/base.py
@@ -1,0 +1,33 @@
+import unittest
+
+import celery
+
+from ddtrace import Pin
+from ddtrace.compat import PY2
+from ddtrace.contrib.celery.app import patch_app, unpatch_app
+from ddtrace.contrib.celery.task import patch_task, unpatch_task
+
+from ..config import REDIS_CONFIG
+from ...test_tracer import get_dummy_tracer
+
+
+class CeleryBaseTestCase(unittest.TestCase):
+    """Celery base test class. It patches Celery main class and task before
+    initializing a Celery app.
+    """
+
+    def setUp(self):
+        self.broker_url = 'redis://127.0.0.1:{port}/0'.format(port=REDIS_CONFIG['port'])
+        self.tracer = get_dummy_tracer()
+        self.pin = Pin(service='celery-ignored', tracer=self.tracer)
+        patch_app(celery.Celery, pin=self.pin)
+        patch_task(celery.Task, pin=self.pin)
+
+    def tearDown(self):
+        unpatch_app(celery.Celery)
+        unpatch_task(celery.Task)
+
+    def assert_items_equal(self, a, b):
+        if PY2:
+            return self.assertItemsEqual(a, b)
+        return self.assertCountEqual(a, b)

--- a/tests/contrib/celery/base.py
+++ b/tests/contrib/celery/base.py
@@ -1,31 +1,39 @@
 import unittest
 
-import celery
+from celery import Celery
 
 from ddtrace import Pin
 from ddtrace.compat import PY2
-from ddtrace.contrib.celery.app import patch_app, unpatch_app
-from ddtrace.contrib.celery.task import patch_task, unpatch_task
+from ddtrace.contrib.celery import patch, unpatch
 
 from ..config import REDIS_CONFIG
 from ...test_tracer import get_dummy_tracer
 
 
+REDIS_URL = 'redis://127.0.0.1:{port}'.format(port=REDIS_CONFIG['port'])
+BROKER_URL = '{redis}/{db}'.format(redis=REDIS_URL, db=0)
+BACKEND_URL = '{redis}/{db}'.format(redis=REDIS_URL, db=1)
+
+
 class CeleryBaseTestCase(unittest.TestCase):
-    """Celery base test class. It patches Celery main class and task before
-    initializing a Celery app.
+    """Test case that handles a full fledged Celery application with a
+    custom tracer. It patches the new Celery application.
     """
 
     def setUp(self):
-        self.broker_url = 'redis://127.0.0.1:{port}/0'.format(port=REDIS_CONFIG['port'])
+        # instrument Celery and create an app with Broker and Result backends
+        patch()
         self.tracer = get_dummy_tracer()
-        self.pin = Pin(service='celery-ignored', tracer=self.tracer)
-        patch_app(celery.Celery, pin=self.pin)
-        patch_task(celery.Task, pin=self.pin)
+        self.pin = Pin(service='celery-unittest', tracer=self.tracer)
+        self.app = Celery('celery.test_app', broker=BROKER_URL, backend=BACKEND_URL)
+        # override pins to use our Dummy Tracer
+        Pin.override(self.app, tracer=self.tracer)
+        Pin.override(self.app.task, tracer=self.tracer)
+        Pin.override(self.app.Task, tracer=self.tracer)
 
     def tearDown(self):
-        unpatch_app(celery.Celery)
-        unpatch_task(celery.Task)
+        unpatch()
+        self.app = None
 
     def assert_items_equal(self, a, b):
         if PY2:

--- a/tests/contrib/celery/test_app.py
+++ b/tests/contrib/celery/test_app.py
@@ -1,44 +1,23 @@
-import unittest
-
 import celery
 import wrapt
 
-from ddtrace.contrib.celery.app import patch_app, unpatch_app
+from ddtrace.contrib.celery import unpatch_app
+
+from .base import CeleryBaseTestCase
 
 
-class CeleryAppTest(unittest.TestCase):
-    def setUp(self):
-        patch_app(celery.Celery)
-
-    def tearDown(self):
-        unpatch_app(celery.Celery)
+class CeleryAppTest(CeleryBaseTestCase):
+    """Ensures the default application is properly instrumented"""
 
     def test_patch_app(self):
-        """
-        When celery.App is patched
-            the task() method will return a patched task
-        """
-        # Assert the base class has the wrapped function
-        self.assertIsInstance(celery.Celery.task, wrapt.BoundFunctionWrapper)
-        self.assertIsInstance(celery.Celery.Task.__init__, wrapt.BoundFunctionWrapper)
-
-        # Create an instance of `celery.Celery`
+        # When celery.App is patched the task() method will return a patched task
         app = celery.Celery()
-
-        # Assert the instance method is the wrapped function
+        self.assertIsInstance(celery.Celery.task, wrapt.BoundFunctionWrapper)
         self.assertIsInstance(app.task, wrapt.BoundFunctionWrapper)
 
     def test_unpatch_app(self):
-        """
-        When unpatch_app is called on a patched app
-            we unpatch the `task()` method
-        """
-        # Assert it is patched before we start
-        self.assertIsInstance(celery.Celery.task, wrapt.BoundFunctionWrapper)
-
-        # Unpatch the app
+        # When unpatch_app is called on a patched app we unpatch the `task()` method
         unpatch_app(celery.Celery)
-
-        # Assert the method is not patched
+        app = celery.Celery()
         self.assertFalse(isinstance(celery.Celery.task, wrapt.BoundFunctionWrapper))
-        self.assertFalse(isinstance(celery.Celery.Task.__init__, wrapt.BoundFunctionWrapper))
+        self.assertFalse(isinstance(app.task, wrapt.BoundFunctionWrapper))

--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -1,11 +1,10 @@
 from nose.tools import eq_, ok_
 
-from .utils import CeleryTestCase
+from .base import CeleryBaseTestCase
 
 
-class CeleryIntegrationTask(CeleryTestCase):
-    """
-    Ensures that the tracer works properly with a real Celery application
+class CeleryIntegrationTask(CeleryBaseTestCase):
+    """Ensures that the tracer works properly with a real Celery application
     without breaking the Application or Task APIs.
     """
     def test_concurrent_delays(self):

--- a/tests/contrib/celery/test_old_style_task.py
+++ b/tests/contrib/celery/test_old_style_task.py
@@ -12,9 +12,6 @@ class CeleryOldStyleTaskTest(CeleryBaseTestCase):
         # are used even in newer versions. This should extend support to
         # previous versions of Celery.
         # Regression test: https://github.com/DataDog/dd-trace-py/pull/449
-        app = celery.Celery('test_task_delay_eager', broker=self.broker_url)
-        app.conf['CELERY_ALWAYS_EAGER'] = True
-
         class CelerySuperClass(celery.task.Task):
             abstract = True
 
@@ -35,4 +32,4 @@ class CeleryOldStyleTaskTest(CeleryBaseTestCase):
         t = CelerySubClass()
         t.run()
         spans = self.tracer.writer.pop()
-        self.assertEqual(len(spans), 4)
+        self.assertEqual(len(spans), 2)

--- a/tests/contrib/celery/test_old_style_task.py
+++ b/tests/contrib/celery/test_old_style_task.py
@@ -1,0 +1,38 @@
+import celery
+
+from .base import CeleryBaseTestCase
+from .utils import patch_task_with_pin
+
+
+class CeleryOldStyleTaskTest(CeleryBaseTestCase):
+    """Ensure Old Style Tasks are properly instrumented"""
+
+    def test_apply_async_previous_style_tasks(self):
+        # ensures apply_async is properly patched if Celery 1.0 style tasks
+        # are used even in newer versions. This should extend support to
+        # previous versions of Celery.
+        # Regression test: https://github.com/DataDog/dd-trace-py/pull/449
+        app = celery.Celery('test_task_delay_eager', broker=self.broker_url)
+        app.conf['CELERY_ALWAYS_EAGER'] = True
+
+        class CelerySuperClass(celery.task.Task):
+            abstract = True
+
+            @classmethod
+            def apply_async(cls, args=None, kwargs=None, **kwargs_):
+                return super(CelerySuperClass, cls).apply_async(args=args, kwargs=kwargs, **kwargs_)
+
+            def run(self, *args, **kwargs):
+                if 'stop' in kwargs:
+                    # avoid call loop
+                    return
+                CelerySubClass.apply_async(args=[], kwargs={"stop": True})
+
+        @patch_task_with_pin(pin=self.pin)
+        class CelerySubClass(CelerySuperClass):
+            pass
+
+        t = CelerySubClass()
+        t.run()
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 4)

--- a/tests/contrib/celery/test_task.py
+++ b/tests/contrib/celery/test_task.py
@@ -1,41 +1,20 @@
-import unittest
-
 import celery
 import mock
 import wrapt
 
-from ddtrace import Pin
-from ddtrace.compat import PY2
-from ddtrace.contrib.celery.app import patch_app, unpatch_app
-from ddtrace.contrib.celery.task import patch_task, unpatch_task
-from .utils import patch_task_with_pin
+from ddtrace.contrib.celery.task import unpatch_task
 
-from ..config import REDIS_CONFIG
-from ...test_tracer import get_dummy_tracer
+from .base import CeleryBaseTestCase
 from ...util import assert_list_issuperset
+
 
 EXPECTED_KEYS = ['service', 'resource', 'meta', 'name',
                  'parent_id', 'trace_id', 'span_id',
                  'duration', 'error', 'start',
 ]
 
-class CeleryTaskTest(unittest.TestCase):
-    def assert_items_equal(self, a, b):
-        if PY2:
-            return self.assertItemsEqual(a, b)
-        return self.assertCountEqual(a, b)
 
-    def setUp(self):
-        self.broker_url = 'redis://127.0.0.1:{port}/0'.format(port=REDIS_CONFIG['port'])
-        self.tracer = get_dummy_tracer()
-        self.pin = Pin(service='celery-ignored', tracer=self.tracer)
-        patch_app(celery.Celery, pin=self.pin)
-        patch_task(celery.Task, pin=self.pin)
-
-    def tearDown(self):
-        unpatch_app(celery.Celery)
-        unpatch_task(celery.Task)
-
+class CeleryTaskTest(CeleryBaseTestCase):
     def test_patch_task(self):
         """
         When celery.Task is patched
@@ -459,37 +438,8 @@ class CeleryTaskTest(unittest.TestCase):
         # DEV: Assert as endswith, since PY3 gives us `u'is_eager` and PY2 gives us `'is_eager'`
         self.assertTrue(meta['celery.delivery_info'].endswith('\'is_eager\': True}'))
 
-    def test_apply_async_previous_style_tasks(self):
-        # ensures apply_async is properly patched if Celery 1.0 style tasks
-        # are used even in newer versions. This should extend support to
-        # previous versions of Celery.
-        # Regression test: https://github.com/DataDog/dd-trace-py/pull/449
-        app = celery.Celery('test_task_delay_eager', broker=self.broker_url)
-        app.conf['CELERY_ALWAYS_EAGER'] = True
-
-        class CelerySuperClass(celery.task.Task):
-            abstract = True
-
-            @classmethod
-            def apply_async(cls, args=None, kwargs=None, **kwargs_):
-                return super(CelerySuperClass, cls).apply_async(args=args, kwargs=kwargs, **kwargs_)
-
-            def run(self, *args, **kwargs):
-                if 'stop' in kwargs:
-                    # avoid call loop
-                    return
-                CelerySubClass.apply_async(args=[], kwargs={"stop": True})
-
-        @patch_task_with_pin(pin=self.pin)
-        class CelerySubClass(CelerySuperClass):
-            pass
-
-        t = CelerySubClass()
-        t.run()
-        spans = self.tracer.writer.pop()
-        self.assertEqual(len(spans), 4)
-
     def test_celery_shared_task(self):
+        # Ensure Django Shared Task are supported
         @celery.shared_task
         def add(x ,y):
             return x + y

--- a/tests/contrib/celery/utils.py
+++ b/tests/contrib/celery/utils.py
@@ -1,33 +1,7 @@
-import ddtrace
-
 import wrapt
-from unittest import TestCase
-from celery import Celery
 
-from ddtrace.contrib.celery import patch_app, patch_task
+from ddtrace.contrib.celery import patch_task
 
-from ..config import REDIS_CONFIG
-from ...test_tracer import get_dummy_tracer
-
-
-REDIS_URL = 'redis://127.0.0.1:{port}'.format(port=REDIS_CONFIG['port'])
-BROKER_URL = '{redis}/{db}'.format(redis=REDIS_URL, db=0)
-BACKEND_URL = '{redis}/{db}'.format(redis=REDIS_URL, db=1)
-
-
-class CeleryTestCase(TestCase):
-    """
-    Test case that handles a full fledged Celery application
-    with a custom tracer. It automatically patches the new
-    Celery application.
-    """
-    def setUp(self):
-        # use a dummy tracer
-        self.tracer = get_dummy_tracer()
-        self._original_tracer = ddtrace.tracer
-        ddtrace.tracer = self.tracer
-        # create and patch a new application
-        self.app = patch_app(Celery('celery.test_app', broker=BROKER_URL, backend=BACKEND_URL))
 
 def patch_task_with_pin(pin=None):
     """ patch_task_with_pin can be used as a decorator for v1 Celery tasks when specifying a pin is needed"""


### PR DESCRIPTION
### Overview

This PR changes how we execute our tests. It ensures `patch()` and `unpatch()` are used in tests, so we can double check if the integration works.

It introduces also a change that was needed to make the `patch()` work. It's a bug in the underlying instrumentation that wasn't reported before.

### Follow-up

This PR is the first of a series of PRs to address all problems related to our Celery integrations.