### PR TITLE
[opentracer] Integration with Datadog tracer

### DIFF
--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -149,8 +149,8 @@ class Span(OpenTracingSpan):
         self._dd_span.__exit__(exc_type, exc_val, exc_tb)
         self.finish()
 
-    def _add_dd_span(self, ddspan):
-        """Associates a datadog span with this span."""
+    def _associate_dd_span(self, ddspan):
+        """Associates a DD span with this span."""
         # get the datadog span context
         self._dd_span = ddspan
         self.context._dd_context = ddspan.context

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -5,7 +5,6 @@ from opentracing.scope_managers import ThreadLocalScopeManager
 
 from ddtrace import Tracer as DatadogTracer
 from ddtrace.constants import FILTERS_KEY
-from ddtrace.context import Context
 from ddtrace.settings import ConfigException
 from ddtrace.utils import merge_dicts
 from ddtrace.utils.config import get_application_name

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -252,7 +252,7 @@ class Tracer(opentracing.Tracer):
 
         otspan = Span(self, ot_parent_context, operation_name)
         # sync up the OT span with the DD span
-        otspan._add_dd_span(ddspan)
+        otspan._associate_dd_span(ddspan)
 
         return otspan
 

--- a/ddtrace/opentracer/utils.py
+++ b/ddtrace/opentracer/utils.py
@@ -1,0 +1,18 @@
+import ddtrace
+
+
+def get_context_provider_for_scope_manager(scope_manager):
+    """Returns the context_provider to use with a given scope_manager."""
+
+    scope_manager_type = type(scope_manager).__name__
+
+    # avoid having to import scope managers which may not be compatible
+    # with the version of python being used
+    if scope_manager_type == "AsyncioScopeManager":
+        dd_context_provider = ddtrace.contrib.asyncio.context_provider
+    elif scope_manager_type == "GeventScopeManager":
+        dd_context_provider = ddtrace.contrib.gevent.context_provider
+    else:
+        dd_context_provider = ddtrace.provider.DefaultContextProvider()
+
+    return dd_context_provider

--- a/tests/opentracer/test_dd_compatibility.py
+++ b/tests/opentracer/test_dd_compatibility.py
@@ -3,7 +3,7 @@ from tests.opentracer.utils import opentracer_init
 
 
 class TestTracerCompatibility(object):
-    """Ensure that our OT tracer produces results in the underlying DD tracer."""
+    """Ensure that our opentracer produces results in the underlying ddtracer."""
 
     def test_ot_dd_nested_trace(self):
         """Ensure intertwined usage of the opentracer and ddtracer."""
@@ -33,3 +33,44 @@ class TestTracerCompatibility(object):
         # check the parenting
         assert spans[1].parent_id == spans[0].span_id
 
+    def test_ot_dd_ot_dd_nested_trace(self):
+        """Ensure intertwined usage of the opentracer and ddtracer."""
+        ot_tracer, dd_tracer = opentracer_init()
+        writer = dd_tracer.writer
+
+        with opentracing.tracer.start_span('my_ot_span'):
+            with dd_tracer.trace('my_dd_span'):
+                with opentracing.tracer.start_span('my_ot_span'):
+                    with dd_tracer.trace('my_dd_span'):
+                        pass
+
+        spans = writer.pop()
+        assert len(spans) == 4
+
+        # check the parenting
+        assert spans[0].parent_id is None
+        assert spans[1].parent_id == spans[0].span_id
+        assert spans[2].parent_id == spans[1].span_id
+        assert spans[3].parent_id == spans[2].span_id
+
+    def test_ot_ot_dd_ot_dd_nested_trace_active(self):
+        """Ensure intertwined usage of the opentracer and ddtracer."""
+        ot_tracer, dd_tracer = opentracer_init()
+        writer = dd_tracer.writer
+
+        with opentracing.tracer.start_active_span('my_ot_span'):
+            with opentracing.tracer.start_active_span('my_ot_span'):
+                with dd_tracer.trace('my_dd_span'):
+                    with opentracing.tracer.start_active_span('my_ot_span'):
+                        with dd_tracer.trace('my_dd_span'):
+                            pass
+
+        spans = writer.pop()
+        assert len(spans) == 5
+
+        # check the parenting
+        assert spans[0].parent_id is None
+        assert spans[1].parent_id == spans[0].span_id
+        assert spans[2].parent_id == spans[1].span_id
+        assert spans[3].parent_id == spans[2].span_id
+        assert spans[4].parent_id == spans[3].span_id

--- a/tests/opentracer/test_dd_compatibility.py
+++ b/tests/opentracer/test_dd_compatibility.py
@@ -15,11 +15,9 @@ class TestTracerCompatibility(object):
         """Ensure intertwined usage of the opentracer and ddtracer."""
         ot_tracer, dd_tracer = opentracer_init()
 
-
         writer = dd_tracer.writer
 
         with opentracing.tracer.start_span("my_ot_span"):
-            print(opentracing.tracer._dd_tracer.context_provider)
             with dd_tracer.trace("my_dd_span"):
                 pass
         spans = writer.pop()
@@ -29,14 +27,13 @@ class TestTracerCompatibility(object):
         assert spans[0].parent_id is None
         assert spans[1].parent_id == spans[0].span_id
 
-
     def test_dd_ot_nested_trace(self):
         """Ensure intertwined usage of the opentracer and ddtracer."""
         ot_tracer, dd_tracer = opentracer_init()
         writer = dd_tracer.writer
 
-        with dd_tracer.trace('my_dd_span'):
-            with opentracing.tracer.start_span('my_ot_span'):
+        with dd_tracer.trace("my_dd_span"):
+            with opentracing.tracer.start_span("my_ot_span"):
                 pass
         spans = writer.pop()
         assert len(spans) == 2
@@ -50,10 +47,10 @@ class TestTracerCompatibility(object):
         ot_tracer, dd_tracer = opentracer_init()
         writer = dd_tracer.writer
 
-        with opentracing.tracer.start_span('my_ot_span'):
-            with dd_tracer.trace('my_dd_span'):
-                with opentracing.tracer.start_span('my_ot_span'):
-                    with dd_tracer.trace('my_dd_span'):
+        with opentracing.tracer.start_span("my_ot_span"):
+            with dd_tracer.trace("my_dd_span"):
+                with opentracing.tracer.start_span("my_ot_span"):
+                    with dd_tracer.trace("my_dd_span"):
                         pass
 
         spans = writer.pop()
@@ -70,11 +67,11 @@ class TestTracerCompatibility(object):
         ot_tracer, dd_tracer = opentracer_init()
         writer = dd_tracer.writer
 
-        with opentracing.tracer.start_active_span('my_ot_span'):
-            with opentracing.tracer.start_active_span('my_ot_span'):
-                with dd_tracer.trace('my_dd_span'):
-                    with opentracing.tracer.start_active_span('my_ot_span'):
-                        with dd_tracer.trace('my_dd_span'):
+        with opentracing.tracer.start_active_span("my_ot_span"):
+            with opentracing.tracer.start_active_span("my_ot_span"):
+                with dd_tracer.trace("my_dd_span"):
+                    with opentracing.tracer.start_active_span("my_ot_span"):
+                        with dd_tracer.trace("my_dd_span"):
                             pass
 
         spans = writer.pop()

--- a/tests/opentracer/test_dd_compatibility.py
+++ b/tests/opentracer/test_dd_compatibility.py
@@ -1,0 +1,35 @@
+import opentracing
+from tests.opentracer.utils import opentracer_init
+
+
+class TestTracerCompatibility(object):
+    """Ensure that our OT tracer produces results in the underlying DD tracer."""
+
+    def test_ot_dd_nested_trace(self):
+        """Ensure intertwined usage of the opentracer and ddtracer."""
+        ot_tracer, dd_tracer = opentracer_init()
+        writer = dd_tracer.writer
+
+        with opentracing.tracer.start_span('my_ot_span'):
+            with dd_tracer.trace('my_dd_span'):
+                pass
+        spans = writer.pop()
+        assert len(spans) == 2
+
+        # check the parenting
+        assert spans[1].parent_id == spans[0].span_id
+
+    def test_dd_ot_nested_trace(self):
+        """Ensure intertwined usage of the opentracer and ddtracer."""
+        ot_tracer, dd_tracer = opentracer_init()
+        writer = dd_tracer.writer
+
+        with dd_tracer.trace('my_dd_span'):
+            with opentracing.tracer.start_span('my_ot_span'):
+                pass
+        spans = writer.pop()
+        assert len(spans) == 2
+
+        # check the parenting
+        assert spans[1].parent_id == spans[0].span_id
+

--- a/tests/opentracer/test_dd_compatibility.py
+++ b/tests/opentracer/test_dd_compatibility.py
@@ -5,19 +5,30 @@ from tests.opentracer.utils import opentracer_init
 class TestTracerCompatibility(object):
     """Ensure that our opentracer produces results in the underlying ddtracer."""
 
+    def test_ot_dd_global_tracers(self):
+        """Ensure our test function opentracer_init() prep"""
+        ot_tracer, dd_tracer = opentracer_init()
+        assert ot_tracer is opentracing.tracer
+        assert ot_tracer._dd_tracer is dd_tracer
+
     def test_ot_dd_nested_trace(self):
         """Ensure intertwined usage of the opentracer and ddtracer."""
         ot_tracer, dd_tracer = opentracer_init()
+
+
         writer = dd_tracer.writer
 
-        with opentracing.tracer.start_span('my_ot_span'):
-            with dd_tracer.trace('my_dd_span'):
+        with opentracing.tracer.start_span("my_ot_span"):
+            print(opentracing.tracer._dd_tracer.context_provider)
+            with dd_tracer.trace("my_dd_span"):
                 pass
         spans = writer.pop()
         assert len(spans) == 2
 
         # check the parenting
+        assert spans[0].parent_id is None
         assert spans[1].parent_id == spans[0].span_id
+
 
     def test_dd_ot_nested_trace(self):
         """Ensure intertwined usage of the opentracer and ddtracer."""
@@ -31,7 +42,8 @@ class TestTracerCompatibility(object):
         assert len(spans) == 2
 
         # check the parenting
-        assert spans[1].parent_id == spans[0].span_id
+        assert spans[0].parent_id is None
+        assert spans[1].parent_id is spans[0].span_id
 
     def test_ot_dd_ot_dd_nested_trace(self):
         """Ensure intertwined usage of the opentracer and ddtracer."""
@@ -49,9 +61,9 @@ class TestTracerCompatibility(object):
 
         # check the parenting
         assert spans[0].parent_id is None
-        assert spans[1].parent_id == spans[0].span_id
-        assert spans[2].parent_id == spans[1].span_id
-        assert spans[3].parent_id == spans[2].span_id
+        assert spans[1].parent_id is spans[0].span_id
+        assert spans[2].parent_id is spans[1].span_id
+        assert spans[3].parent_id is spans[2].span_id
 
     def test_ot_ot_dd_ot_dd_nested_trace_active(self):
         """Ensure intertwined usage of the opentracer and ddtracer."""

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -1,22 +1,7 @@
 import pytest
 
 from ddtrace.opentracer import Tracer
-
-
-def get_dummy_ot_tracer(service_name='', config=None, scope_manager=None, context_provider=None):
-    from ..test_tracer import get_dummy_tracer
-    config = config or {}
-    tracer = Tracer(service_name=service_name, config=config, scope_manager=scope_manager)
-
-    # similar to how we test the ddtracer, use a dummy tracer
-    dd_tracer = get_dummy_tracer()
-    if context_provider:
-        dd_tracer.configure(context_provider=context_provider)
-
-    # attach the dummy tracer to the opentracer
-    tracer._dd_tracer = dd_tracer
-    return tracer
-
+from .utils import get_dummy_ot_tracer
 
 @pytest.fixture
 def nop_tracer():

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -3,11 +3,18 @@ import pytest
 from ddtrace.opentracer import Tracer
 
 
-def get_dummy_ot_tracer(service_name='', config=None, scope_manager=None):
+def get_dummy_ot_tracer(service_name='', config=None, scope_manager=None, context_provider=None):
     from ..test_tracer import get_dummy_tracer
     config = config or {}
     tracer = Tracer(service_name=service_name, config=config, scope_manager=scope_manager)
-    tracer._dd_tracer = get_dummy_tracer()
+
+    # similar to how we test the ddtracer, use a dummy tracer
+    dd_tracer = get_dummy_tracer()
+    if context_provider:
+        dd_tracer.configure(context_provider=context_provider)
+
+    # attach the dummy tracer to the opentracer
+    tracer._dd_tracer = dd_tracer
     return tracer
 
 

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -1,164 +1,152 @@
 import pytest
 
 from ddtrace.opentracer import Tracer
-from .utils import get_dummy_ot_tracer
 
-@pytest.fixture
-def nop_tracer():
-    return get_dummy_ot_tracer(service_name='mysvc')
-
-
-# helper to get the spans from a nop_tracer
-def get_spans(tracer):
-    return tracer._dd_tracer.writer.pop()
+from .utils import ot_tracer_factory, ot_tracer, writer
 
 
 class TestTracerConfig(object):
     def test_config(self):
         """Test the configuration of the tracer"""
-        config = {
-            'enabled': True,
-        }
-        tracer = Tracer(service_name='myservice', config=config)
+        config = {"enabled": True}
+        tracer = Tracer(service_name="myservice", config=config)
 
-        assert tracer._service_name == 'myservice'
+        assert tracer._service_name == "myservice"
         assert tracer._enabled is True
 
     def test_no_service_name(self):
         """A service_name should be generated if one is not provided."""
         tracer = Tracer()
-        assert tracer._service_name == 'pytest'
+        assert tracer._service_name == "pytest"
 
     def test_multiple_tracer_configs(self):
         """Ensure that a tracer config is a copy of the passed config."""
-        config = {
-            'enabled': True
-        }
+        config = {"enabled": True}
 
-        tracer1 = Tracer(service_name='serv1', config=config)
-        assert tracer1._service_name == 'serv1'
+        tracer1 = Tracer(service_name="serv1", config=config)
+        assert tracer1._service_name == "serv1"
 
-        config['enabled'] = False
-        tracer2 = Tracer(service_name='serv2', config=config)
+        config["enabled"] = False
+        tracer2 = Tracer(service_name="serv2", config=config)
 
         # Ensure tracer1's config was not mutated
-        assert tracer1._service_name == 'serv1'
+        assert tracer1._service_name == "serv1"
         assert tracer1._enabled is True
 
-        assert tracer2._service_name == 'serv2'
+        assert tracer2._service_name == "serv2"
         assert tracer2._enabled is False
 
     def test_invalid_config_key(self):
         """A config with an invalid key should raise a ConfigException."""
         from ddtrace.settings import ConfigException
-        config = {
-            'enabeld': False,
-        }
+
+        config = {"enabeld": False}
 
         # No debug flag should not raise an error
-        tracer = Tracer(service_name='mysvc', config=config)
+        tracer = Tracer(service_name="mysvc", config=config)
 
         # With debug flag should raise an error
-        config['debug'] = True
+        config["debug"] = True
         with pytest.raises(ConfigException) as ce_info:
             tracer = Tracer(config=config)
-            assert 'enabeld' in str(ce_info)
+            assert "enabeld" in str(ce_info)
             assert tracer is not None
 
         # Test with multiple incorrect keys
-        config['setttings'] = {}
+        config["setttings"] = {}
         with pytest.raises(ConfigException) as ce_info:
-            tracer = Tracer(service_name='mysvc', config=config)
-            assert ['enabeld', 'setttings'] in str(ce_info)
+            tracer = Tracer(service_name="mysvc", config=config)
+            assert ["enabeld", "setttings"] in str(ce_info)
             assert tracer is not None
 
 
 class TestTracer(object):
-    def test_start_span(self, nop_tracer):
+    def test_start_span(self, ot_tracer, writer):
         """Start and finish a span."""
         import time
-        with nop_tracer.start_span('myop') as span:
+
+        with ot_tracer.start_span("myop") as span:
             time.sleep(0.005)
 
         # span should be finished when the context manager exits
         assert span._finished
 
-        spans = get_spans(nop_tracer)
+        spans = writer.pop()
         assert len(spans) == 1
 
-    def test_start_span_references(self, nop_tracer):
+    def test_start_span_references(self, ot_tracer, writer):
         """Start a span using references."""
         from opentracing import child_of
 
-        with nop_tracer.start_span('one', references=[child_of()]):
+        with ot_tracer.start_span("one", references=[child_of()]):
             pass
 
-        spans = get_spans(nop_tracer)
+        spans = writer.pop()
         assert spans[0].parent_id is None
 
-        root = nop_tracer.start_active_span('root')
+        root = ot_tracer.start_active_span("root")
         # create a child using a parent reference that is not the context parent
-        with nop_tracer.start_active_span('one'):
-            with nop_tracer.start_active_span('two', references=[child_of(root.span)]):
+        with ot_tracer.start_active_span("one"):
+            with ot_tracer.start_active_span("two", references=[child_of(root.span)]):
                 pass
         root.close()
 
-        spans = get_spans(nop_tracer)
+        spans = writer.pop()
         assert spans[2].parent_id is spans[0].span_id
 
-    def test_start_span_custom_start_time(self, nop_tracer):
+    def test_start_span_custom_start_time(self, ot_tracer):
         """Start a span with a custom start time."""
         import time
+
         t = time.time() + 0.002
-        with nop_tracer.start_span('myop', start_time=t) as span:
+        with ot_tracer.start_span("myop", start_time=t) as span:
             time.sleep(0.005)
 
         # it should be certain that the span duration is strictly less than
         # the amount of time we sleep for
         assert span._dd_span.duration < 0.005
 
-    def test_start_span_with_spancontext(self, nop_tracer):
+    def test_start_span_with_spancontext(self, ot_tracer, writer):
         """Start and finish a span using a span context as the child_of
         reference.
         """
         import time
-        with nop_tracer.start_span('myop') as span:
+
+        with ot_tracer.start_span("myop") as span:
             time.sleep(0.005)
-            with nop_tracer.start_span('myop', child_of=span.context) as span2:
+            with ot_tracer.start_span("myop", child_of=span.context) as span2:
                 time.sleep(0.008)
 
         # span should be finished when the context manager exits
         assert span._finished
         assert span2._finished
 
-        spans = get_spans(nop_tracer)
+        spans = writer.pop()
         assert len(spans) == 2
 
         # ensure proper parenting
         assert spans[1].parent_id is spans[0].span_id
 
-    def test_start_span_with_tags(self, nop_tracer):
+    def test_start_span_with_tags(self, ot_tracer):
         """Create a span with initial tags."""
-        tags = {
-            'key': 'value',
-            'key2': 'value2',
-        }
-        with nop_tracer.start_span('myop', tags=tags) as span:
+        tags = {"key": "value", "key2": "value2"}
+        with ot_tracer.start_span("myop", tags=tags) as span:
             pass
 
-        assert span._dd_span.get_tag('key') == 'value'
-        assert span._dd_span.get_tag('key2') == 'value2'
+        assert span._dd_span.get_tag("key") == "value"
+        assert span._dd_span.get_tag("key2") == "value2"
 
-    def test_start_active_span_multi_child(self, nop_tracer):
+    def test_start_active_span_multi_child(self, ot_tracer, writer):
         """Start and finish multiple child spans.
         This should ensure that child spans can be created 2 levels deep.
         """
         import time
-        with nop_tracer.start_active_span('myfirstop') as scope1:
+
+        with ot_tracer.start_active_span("myfirstop") as scope1:
             time.sleep(0.009)
-            with nop_tracer.start_active_span('mysecondop') as scope2:
+            with ot_tracer.start_active_span("mysecondop") as scope2:
                 time.sleep(0.007)
-                with nop_tracer.start_active_span('mythirdop') as scope3:
+                with ot_tracer.start_active_span("mythirdop") as scope3:
                     time.sleep(0.005)
 
         # spans should be finished when the context manager exits
@@ -166,7 +154,7 @@ class TestTracer(object):
         assert scope2.span._finished
         assert scope3.span._finished
 
-        spans = get_spans(nop_tracer)
+        spans = writer.pop()
 
         # check spans are captured in the trace
         assert scope1.span._dd_span is spans[0]
@@ -182,17 +170,18 @@ class TestTracer(object):
         assert spans[1].duration >= 0.007 + 0.005
         assert spans[2].duration >= 0.005
 
-    def test_start_active_span_multi_child_siblings(self, nop_tracer):
+    def test_start_active_span_multi_child_siblings(self, ot_tracer, writer):
         """Start and finish multiple span at the same level.
         This should test to ensure a parent can have multiple child spans at the
         same level.
         """
         import time
-        with nop_tracer.start_active_span('myfirstop') as scope1:
+
+        with ot_tracer.start_active_span("myfirstop") as scope1:
             time.sleep(0.009)
-            with nop_tracer.start_active_span('mysecondop') as scope2:
+            with ot_tracer.start_active_span("mysecondop") as scope2:
                 time.sleep(0.007)
-            with nop_tracer.start_active_span('mythirdop') as scope3:
+            with ot_tracer.start_active_span("mythirdop") as scope3:
                 time.sleep(0.005)
 
         # spans should be finished when the context manager exits
@@ -200,7 +189,7 @@ class TestTracer(object):
         assert scope2.span._finished
         assert scope3.span._finished
 
-        spans = get_spans(nop_tracer)
+        spans = writer.pop()
 
         # check spans are captured in the trace
         assert scope1.span._dd_span is spans[0]
@@ -216,74 +205,79 @@ class TestTracer(object):
         assert spans[1].duration >= 0.007
         assert spans[2].duration >= 0.005
 
-    def test_start_span_manual_child_of(self, nop_tracer):
+    def test_start_span_manual_child_of(self, ot_tracer, writer):
         """Start spans without using a scope manager.
         Spans should be created without parents since there will be no call
         for the active span.
         """
         import time
 
-        root = nop_tracer.start_span('zero')
+        root = ot_tracer.start_span("zero")
 
-        with nop_tracer.start_span('one', child_of=root):
+        with ot_tracer.start_span("one", child_of=root):
             time.sleep(0.009)
-            with nop_tracer.start_span('two', child_of=root):
+            with ot_tracer.start_span("two", child_of=root):
                 time.sleep(0.007)
-                with nop_tracer.start_span('three', child_of=root):
+                with ot_tracer.start_span("three", child_of=root):
                     time.sleep(0.005)
         root.finish()
 
-        spans = get_spans(nop_tracer)
+        spans = writer.pop()
 
         assert spans[0].parent_id is None
         # ensure each child span is a child of root
         assert spans[1].parent_id is root._dd_span.span_id
         assert spans[2].parent_id is root._dd_span.span_id
         assert spans[3].parent_id is root._dd_span.span_id
-        assert spans[0].trace_id == spans[1].trace_id and \
-            spans[1].trace_id == spans[2].trace_id
+        assert (
+            spans[0].trace_id == spans[1].trace_id
+            and spans[1].trace_id == spans[2].trace_id
+        )
 
-    def test_start_span_no_active_span(self, nop_tracer):
+    def test_start_span_no_active_span(self, ot_tracer, writer):
         """Start spans without using a scope manager.
         Spans should be created without parents since there will be no call
         for the active span.
         """
         import time
-        with nop_tracer.start_span('one', ignore_active_span=True) as span1:
+
+        with ot_tracer.start_span("one", ignore_active_span=True):
             time.sleep(0.009)
-            with nop_tracer.start_span('two', ignore_active_span=True) as span2:
+            with ot_tracer.start_span("two", ignore_active_span=True):
                 time.sleep(0.007)
-            with nop_tracer.start_span('three', ignore_active_span=True) as span3:
+            with ot_tracer.start_span("three", ignore_active_span=True):
                 time.sleep(0.005)
 
-        spans = get_spans(nop_tracer)
+        spans = writer.pop()
 
         # ensure each span does not have a parent
         assert spans[0].parent_id is None
         assert spans[1].parent_id is None
         assert spans[2].parent_id is None
         # and that each span is a new trace
-        assert spans[0].trace_id != spans[1].trace_id and \
-               spans[1].trace_id != spans[2].trace_id and \
-               spans[0].trace_id != spans[2].trace_id
+        assert (
+            spans[0].trace_id != spans[1].trace_id
+            and spans[1].trace_id != spans[2].trace_id
+            and spans[0].trace_id != spans[2].trace_id
+        )
 
-    def test_start_active_span_child_finish_after_parent(self, nop_tracer):
+    def test_start_active_span_child_finish_after_parent(self, ot_tracer, writer):
         """Start a child span and finish it after its parent."""
         import time
 
-        span1 = nop_tracer.start_active_span('one').span
-        span2 = nop_tracer.start_active_span('two').span
+        span1 = ot_tracer.start_active_span("one").span
+        span2 = ot_tracer.start_active_span("two").span
         span1.finish()
         time.sleep(0.005)
         span2.finish()
 
-        spans = get_spans(nop_tracer)
+        spans = writer.pop()
         assert len(spans) is 2
         assert spans[0].parent_id is None
         assert spans[1].parent_id is span1._dd_span.span_id
         assert spans[1].duration > spans[0].duration
 
-    def test_start_span_multi_intertwined(self, nop_tracer):
+    def test_start_span_multi_intertwined(self, ot_tracer, writer):
         """Start multiple spans at the top level intertwined.
         Alternate calling between two traces.
         """
@@ -292,24 +286,24 @@ class TestTracer(object):
 
         def trace_one():
             id = 11
-            with nop_tracer.start_active_span(str(id)):
+            with ot_tracer.start_active_span(str(id)):
                 id += 1
                 time.sleep(0.009)
-                with nop_tracer.start_active_span(str(id)):
+                with ot_tracer.start_active_span(str(id)):
                     id += 1
                     time.sleep(0.001)
-                    with nop_tracer.start_active_span(str(id)):
+                    with ot_tracer.start_active_span(str(id)):
                         pass
 
         def trace_two():
             id = 21
-            with nop_tracer.start_active_span(str(id)):
+            with ot_tracer.start_active_span(str(id)):
                 id += 1
                 time.sleep(0.006)
-                with nop_tracer.start_active_span(str(id)):
+                with ot_tracer.start_active_span(str(id)):
                     id += 1
                     time.sleep(0.009)
-                with nop_tracer.start_active_span(str(id)):
+                with ot_tracer.start_active_span(str(id)):
                     pass
 
         # the ordering should be
@@ -324,16 +318,16 @@ class TestTracer(object):
         # wait for threads to finish
         time.sleep(0.018)
 
-        spans = get_spans(nop_tracer)
+        spans = writer.pop()
 
         # trace_one will finish before trace_two so its spans should be written
         # before the spans from trace_two, let's confirm this
-        assert spans[0].name == '11'
-        assert spans[1].name == '12'
-        assert spans[2].name == '13'
-        assert spans[3].name == '21'
-        assert spans[4].name == '22'
-        assert spans[5].name == '23'
+        assert spans[0].name == "11"
+        assert spans[1].name == "12"
+        assert spans[2].name == "13"
+        assert spans[3].name == "21"
+        assert spans[4].name == "22"
+        assert spans[5].name == "23"
 
         # next let's ensure that each span has the correct parent:
         # trace_one
@@ -347,166 +341,172 @@ class TestTracer(object):
 
         # finally we should ensure that the trace_ids are reasonable
         # trace_one
-        assert spans[0].trace_id == spans[1].trace_id and \
-            spans[1].trace_id == spans[2].trace_id
+        assert (
+            spans[0].trace_id == spans[1].trace_id
+            and spans[1].trace_id == spans[2].trace_id
+        )
         # traces should be independent
         assert spans[2].trace_id != spans[3].trace_id
         # trace_two
-        assert spans[3].trace_id == spans[4].trace_id and \
-            spans[4].trace_id == spans[5].trace_id
+        assert (
+            spans[3].trace_id == spans[4].trace_id
+            and spans[4].trace_id == spans[5].trace_id
+        )
 
-    def test_start_active_span(self, nop_tracer):
-        with nop_tracer.start_active_span('one') as scope:
+    def test_start_active_span(self, ot_tracer, writer):
+        with ot_tracer.start_active_span("one") as scope:
             pass
 
-        assert scope.span._dd_span.name == 'one'
+        assert scope.span._dd_span.name == "one"
         assert scope.span._finished
-        spans = get_spans(nop_tracer)
+        spans = writer.pop()
         assert spans
 
-    def test_start_active_span_finish_on_close(self, nop_tracer):
-        with nop_tracer.start_active_span('one', finish_on_close=False) as scope:
+    def test_start_active_span_finish_on_close(self, ot_tracer, writer):
+        with ot_tracer.start_active_span("one", finish_on_close=False) as scope:
             pass
 
-        assert scope.span._dd_span.name == 'one'
+        assert scope.span._dd_span.name == "one"
         assert not scope.span._finished
-        spans = get_spans(nop_tracer)
+        spans = writer.pop()
         assert not spans
 
-    def test_start_active_span_nested(self, nop_tracer):
+    def test_start_active_span_nested(self, ot_tracer):
         """Test the active span of multiple nested calls of start_active_span."""
-        with nop_tracer.start_active_span('one') as outer_scope:
-            assert nop_tracer.active_span == outer_scope.span
-            with nop_tracer.start_active_span('two') as inner_scope:
-                assert nop_tracer.active_span == inner_scope.span
-                with nop_tracer.start_active_span('three') as innest_scope: # why isn't it innest? innermost so verbose
-                    assert nop_tracer.active_span == innest_scope.span
-            with nop_tracer.start_active_span('two') as inner_scope:
-                assert nop_tracer.active_span == inner_scope.span
-            assert nop_tracer.active_span == outer_scope.span
-        assert nop_tracer.active_span is None
+        with ot_tracer.start_active_span("one") as outer_scope:
+            assert ot_tracer.active_span == outer_scope.span
+            with ot_tracer.start_active_span("two") as inner_scope:
+                assert ot_tracer.active_span == inner_scope.span
+                with ot_tracer.start_active_span(
+                    "three"
+                ) as innest_scope:  # why isn't it innest? innermost so verbose
+                    assert ot_tracer.active_span == innest_scope.span
+            with ot_tracer.start_active_span("two") as inner_scope:
+                assert ot_tracer.active_span == inner_scope.span
+            assert ot_tracer.active_span == outer_scope.span
+        assert ot_tracer.active_span is None
 
-    def test_start_active_span_trace(self, nop_tracer):
+    def test_start_active_span_trace(self, ot_tracer, writer):
         """Test the active span of multiple nested calls of start_active_span."""
-        with nop_tracer.start_active_span('one') as outer_scope:
-            outer_scope.span.set_tag('outer', 2)
-            with nop_tracer.start_active_span('two') as inner_scope:
-                inner_scope.span.set_tag('inner', 3)
-            with nop_tracer.start_active_span('two') as inner_scope:
-                inner_scope.span.set_tag('inner', 3)
-                with nop_tracer.start_active_span('three') as innest_scope:
-                    innest_scope.span.set_tag('innerest', 4)
+        with ot_tracer.start_active_span("one") as outer_scope:
+            outer_scope.span.set_tag("outer", 2)
+            with ot_tracer.start_active_span("two") as inner_scope:
+                inner_scope.span.set_tag("inner", 3)
+            with ot_tracer.start_active_span("two") as inner_scope:
+                inner_scope.span.set_tag("inner", 3)
+                with ot_tracer.start_active_span("three") as innest_scope:
+                    innest_scope.span.set_tag("innerest", 4)
 
-        spans = get_spans(nop_tracer)
+        spans = writer.pop()
 
         assert spans[0].parent_id is None
         assert spans[1].parent_id is spans[0].span_id
         assert spans[2].parent_id is spans[0].span_id
         assert spans[3].parent_id is spans[2].span_id
+
+
 @pytest.fixture
 def nop_span_ctx():
     from ddtrace.ext.priority import AUTO_KEEP
     from ddtrace.opentracer.span_context import SpanContext
+
     return SpanContext(sampling_priority=AUTO_KEEP, sampled=True)
 
 
 class TestTracerSpanContextPropagation(object):
     """Test the injection and extration of a span context from a tracer."""
 
-    def test_invalid_format(self, nop_tracer, nop_span_ctx):
+    def test_invalid_format(self, ot_tracer, nop_span_ctx):
         """An invalid format should raise an UnsupportedFormatException."""
         from opentracing import UnsupportedFormatException
 
         # test inject
         with pytest.raises(UnsupportedFormatException):
-            nop_tracer.inject(nop_span_ctx, None, {})
+            ot_tracer.inject(nop_span_ctx, None, {})
 
         # test extract
         with pytest.raises(UnsupportedFormatException):
-            nop_tracer.extract(None, {})
+            ot_tracer.extract(None, {})
 
-    def test_inject_invalid_carrier(self, nop_tracer, nop_span_ctx):
+    def test_inject_invalid_carrier(self, ot_tracer, nop_span_ctx):
         """Only dicts should be supported as a carrier."""
         from opentracing import InvalidCarrierException
         from opentracing import Format
 
         with pytest.raises(InvalidCarrierException):
-            nop_tracer.inject(nop_span_ctx, Format.HTTP_HEADERS, None)
+            ot_tracer.inject(nop_span_ctx, Format.HTTP_HEADERS, None)
 
-    def test_extract_invalid_carrier(self, nop_tracer):
+    def test_extract_invalid_carrier(self, ot_tracer):
         """Only dicts should be supported as a carrier."""
         from opentracing import InvalidCarrierException
         from opentracing import Format
 
         with pytest.raises(InvalidCarrierException):
-            nop_tracer.extract(Format.HTTP_HEADERS, None)
+            ot_tracer.extract(Format.HTTP_HEADERS, None)
 
-    def test_http_headers_base(self, nop_tracer):
+    def test_http_headers_base(self, ot_tracer):
         """extract should undo inject for http headers."""
         from opentracing import Format
         from ddtrace.opentracer.span_context import SpanContext
 
-        span_ctx = SpanContext(trace_id=123, span_id=456,)
+        span_ctx = SpanContext(trace_id=123, span_id=456)
         carrier = {}
 
-        nop_tracer.inject(span_ctx, Format.HTTP_HEADERS, carrier)
+        ot_tracer.inject(span_ctx, Format.HTTP_HEADERS, carrier)
         assert len(carrier.keys()) > 0
 
-        ext_span_ctx = nop_tracer.extract(Format.HTTP_HEADERS, carrier)
+        ext_span_ctx = ot_tracer.extract(Format.HTTP_HEADERS, carrier)
         assert ext_span_ctx._dd_context.trace_id == 123
         assert ext_span_ctx._dd_context.span_id == 456
 
-    def test_http_headers_baggage(self, nop_tracer):
+    def test_http_headers_baggage(self, ot_tracer):
         """extract should undo inject for http headers."""
         from opentracing import Format
         from ddtrace.opentracer.span_context import SpanContext
 
-        span_ctx = SpanContext(trace_id=123, span_id=456, baggage={
-            'test': 4,
-            'test2': 'string',
-        })
+        span_ctx = SpanContext(
+            trace_id=123, span_id=456, baggage={"test": 4, "test2": "string"}
+        )
         carrier = {}
 
-        nop_tracer.inject(span_ctx, Format.HTTP_HEADERS, carrier)
+        ot_tracer.inject(span_ctx, Format.HTTP_HEADERS, carrier)
         assert len(carrier.keys()) > 0
 
-        ext_span_ctx = nop_tracer.extract(Format.HTTP_HEADERS, carrier)
+        ext_span_ctx = ot_tracer.extract(Format.HTTP_HEADERS, carrier)
         assert ext_span_ctx._dd_context.trace_id == 123
         assert ext_span_ctx._dd_context.span_id == 456
         assert ext_span_ctx.baggage == span_ctx.baggage
 
-    def test_text(self, nop_tracer):
+    def test_text(self, ot_tracer):
         """extract should undo inject for http headers"""
         from opentracing import Format
         from ddtrace.opentracer.span_context import SpanContext
 
-        span_ctx = SpanContext(trace_id=123, span_id=456, baggage={
-            'test': 4,
-            'test2': 'string',
-        })
+        span_ctx = SpanContext(
+            trace_id=123, span_id=456, baggage={"test": 4, "test2": "string"}
+        )
         carrier = {}
 
-        nop_tracer.inject(span_ctx, Format.TEXT_MAP, carrier)
+        ot_tracer.inject(span_ctx, Format.TEXT_MAP, carrier)
         assert len(carrier.keys()) > 0
 
-        ext_span_ctx = nop_tracer.extract(Format.TEXT_MAP, carrier)
+        ext_span_ctx = ot_tracer.extract(Format.TEXT_MAP, carrier)
         assert ext_span_ctx._dd_context.trace_id == 123
         assert ext_span_ctx._dd_context.span_id == 456
         assert ext_span_ctx.baggage == span_ctx.baggage
 
-    def test_invalid_baggage_key(self, nop_tracer):
+    def test_invalid_baggage_key(self, ot_tracer):
         """Invaid baggage keys should be ignored."""
         from opentracing import Format
         from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
         from ddtrace.opentracer.span_context import SpanContext
 
-        span_ctx = SpanContext(trace_id=123, span_id=456, baggage={
-            'test': 4,
-            'test2': 'string',
-        })
+        span_ctx = SpanContext(
+            trace_id=123, span_id=456, baggage={"test": 4, "test2": "string"}
+        )
         carrier = {}
 
-        nop_tracer.inject(span_ctx, Format.TEXT_MAP, carrier)
+        ot_tracer.inject(span_ctx, Format.TEXT_MAP, carrier)
         assert len(carrier.keys()) > 0
 
         # manually alter a key in the carrier baggage
@@ -514,45 +514,45 @@ class TestTracerSpanContextPropagation(object):
         corrupted_key = HTTP_HEADER_TRACE_ID[2:]
         carrier[corrupted_key] = 123
 
-        ext_span_ctx = nop_tracer.extract(Format.TEXT_MAP, carrier)
+        ext_span_ctx = ot_tracer.extract(Format.TEXT_MAP, carrier)
         assert ext_span_ctx.baggage == span_ctx.baggage
 
-    def test_immutable_span_context(self, nop_tracer):
+    def test_immutable_span_context(self, ot_tracer):
         """Span contexts should be immutable."""
-        with nop_tracer.start_span('root') as root:
+        with ot_tracer.start_span("root") as root:
             ctx_before = root.context
-            root.set_baggage_item('test', 2)
+            root.set_baggage_item("test", 2)
             assert ctx_before is not root.context
-            with nop_tracer.start_span('child') as level1:
-                with nop_tracer.start_span('child') as level2:
+            with ot_tracer.start_span("child") as level1:
+                with ot_tracer.start_span("child") as level2:
                     pass
         assert root.context is not level1.context
         assert level2.context is not level1.context
         assert level2.context is not root.context
 
-    def test_inherited_baggage(self, nop_tracer):
+    def test_inherited_baggage(self, ot_tracer):
         """Baggage should be inherited by child spans."""
-        with nop_tracer.start_active_span('root') as root:
+        with ot_tracer.start_active_span("root") as root:
             # this should be passed down to the child
-            root.span.set_baggage_item('root', 1)
-            root.span.set_baggage_item('root2', 1)
-            with nop_tracer.start_active_span('child') as level1:
-                level1.span.set_baggage_item('level1', 1)
-                with nop_tracer.start_active_span('child') as level2:
-                    level2.span.set_baggage_item('level2', 1)
+            root.span.set_baggage_item("root", 1)
+            root.span.set_baggage_item("root2", 1)
+            with ot_tracer.start_active_span("child") as level1:
+                level1.span.set_baggage_item("level1", 1)
+                with ot_tracer.start_active_span("child") as level2:
+                    level2.span.set_baggage_item("level2", 1)
         # ensure immutability
         assert level1.span.context is not root.span.context
         assert level2.span.context is not level1.span.context
 
         # level1 should have inherited the baggage of root
-        assert level1.span.get_baggage_item('root')
-        assert level1.span.get_baggage_item('root2')
+        assert level1.span.get_baggage_item("root")
+        assert level1.span.get_baggage_item("root2")
 
         # level2 should have inherited the baggage of both level1 and level2
-        assert level2.span.get_baggage_item('root')
-        assert level2.span.get_baggage_item('root2')
-        assert level2.span.get_baggage_item('level1')
-        assert level2.span.get_baggage_item('level2')
+        assert level2.span.get_baggage_item("root")
+        assert level2.span.get_baggage_item("root2")
+        assert level2.span.get_baggage_item("level1")
+        assert level2.span.get_baggage_item("level2")
 
 
 class TestTracerCompatibility(object):
@@ -563,8 +563,8 @@ class TestTracerCompatibility(object):
         by the underlying datadog tracer.
         """
         # a service name is required
-        tracer = Tracer('service')
-        with tracer.start_span('my_span') as span:
+        tracer = Tracer("service")
+        with tracer.start_span("my_span") as span:
             assert span._dd_span.service
 
 
@@ -574,7 +574,7 @@ def test_set_global_tracer():
     import ddtrace
     from ddtrace.opentracer import set_global_tracer
 
-    my_tracer = Tracer('service')
+    my_tracer = Tracer("service")
     set_global_tracer(my_tracer)
 
     assert opentracing.tracer is my_tracer

--- a/tests/opentracer/test_tracer_asyncio.py
+++ b/tests/opentracer/test_tracer_asyncio.py
@@ -7,7 +7,9 @@ from tests.contrib.asyncio.utils import AsyncioTestCase, mark_asyncio
 
 
 def get_dummy_asyncio_tracer():
-    return get_dummy_ot_tracer('asyncio_svc', {}, AsyncioScopeManager())
+    from ddtrace.contrib.asyncio import context_provider
+    return get_dummy_ot_tracer('asyncio_svc', {}, AsyncioScopeManager(),
+                               context_provider)
 
 
 class TestTracerAsyncio(AsyncioTestCase):

--- a/tests/opentracer/test_tracer_asyncio.py
+++ b/tests/opentracer/test_tracer_asyncio.py
@@ -102,7 +102,7 @@ class TestTracerAsyncio(AsyncioTestCase):
 
 
 class TestTracerAsyncioCompatibility(AsyncioTestCase):
-    """Ensure the opentracer plays well with the ddtracer and asyncio"""
+    """Ensure the opentracer works in tandem with the ddtracer and asyncio."""
 
     def setUp(self):
         super(TestTracerAsyncioCompatibility, self).setUp()

--- a/tests/opentracer/test_tracer_asyncio.py
+++ b/tests/opentracer/test_tracer_asyncio.py
@@ -7,7 +7,6 @@ from ddtrace.opentracer.utils import get_context_provider_for_scope_manager
 
 from tests.contrib.asyncio.utils import AsyncioTestCase, mark_asyncio
 from tests.opentracer.test_tracer import get_dummy_ot_tracer
-from tests.opentracer.utils import opentracer_init
 from tests.test_tracer import get_dummy_tracer
 
 
@@ -106,7 +105,8 @@ class TestTracerAsyncioCompatibility(AsyncioTestCase):
 
     def setUp(self):
         super(TestTracerAsyncioCompatibility, self).setUp()
-        self.ot_tracer, self.dd_tracer = opentracer_init(set_global=False)
+        self.ot_tracer = get_dummy_asyncio_tracer()
+        self.dd_tracer = self.ot_tracer._dd_tracer
         self.writer = self.dd_tracer.writer
 
     @mark_asyncio

--- a/tests/opentracer/test_tracer_asyncio.py
+++ b/tests/opentracer/test_tracer_asyncio.py
@@ -1,7 +1,10 @@
 import asyncio
 from nose.tools import eq_, ok_
-
 from opentracing.scope_managers.asyncio import AsyncioScopeManager
+
+import ddtrace
+from ddtrace.opentracer.utils import get_context_provider_for_scope_manager
+
 from tests.opentracer.test_tracer import get_dummy_ot_tracer
 from tests.contrib.asyncio.utils import AsyncioTestCase, mark_asyncio
 
@@ -94,3 +97,16 @@ class TestTracerAsyncio(AsyncioTestCase):
         eq_(1, len(traces[0]))
         eq_('coroutine', traces[0][0].name)
 
+
+class TestUtilsAsyncio(object):
+    """Test the util routines of the opentracer with asyncio specific
+    configuration.
+    """
+    def test_get_context_provider_for_scope_manager_asyncio(self):
+        scope_manager = AsyncioScopeManager()
+        ctx_prov = get_context_provider_for_scope_manager(scope_manager)
+        assert isinstance(ctx_prov, ddtrace.contrib.asyncio.provider.AsyncioContextProvider)
+
+    def test_tracer_context_provider_config(self):
+        tracer = ddtrace.opentracer.Tracer("mysvc", scope_manager=AsyncioScopeManager())
+        assert isinstance(tracer._dd_tracer.context_provider, ddtrace.contrib.asyncio.provider.AsyncioContextProvider)

--- a/tests/opentracer/test_tracer_gevent.py
+++ b/tests/opentracer/test_tracer_gevent.py
@@ -1,142 +1,120 @@
 import gevent
 import pytest
-import unittest
-from nose.tools import eq_
 from opentracing.scope_managers.gevent import GeventScopeManager
 
 import ddtrace
 from ddtrace.contrib.gevent import patch, unpatch
 from ddtrace.opentracer.utils import get_context_provider_for_scope_manager
 
-from tests.opentracer.test_tracer import get_dummy_ot_tracer
-
-
-def get_dummy_gevent_tracer():
-    from ddtrace.contrib.gevent import context_provider
-
-    return get_dummy_ot_tracer("gevent", {}, GeventScopeManager(), context_provider)
+from .utils import ot_tracer_factory, dd_tracer, writer
 
 
 @pytest.fixture()
-def nop_tracer():
-    return get_dummy_gevent_tracer()
+def ot_tracer(ot_tracer_factory):
+    """Fixture providing an opentracer configured for gevent usage."""
+    # patch gevent
+    patch()
+    yield ot_tracer_factory(
+        "gevent_svc", {}, GeventScopeManager(), ddtrace.contrib.gevent.context_provider
+    )
+    # unpatch gevent
+    unpatch()
 
 
-class TestTracerGevent(unittest.TestCase):
+class TestTracerGevent(object):
     """Converted Gevent tests for the regular tracer.
 
     Ensures that greenlets are properly traced when using
     the opentracer.
     """
-    def setUp(self):
-        # use a dummy tracer
-        self.tracer = get_dummy_gevent_tracer()
 
-        # patch gevent
-        patch()
-
-    def tearDown(self):
-        # unpatch gevent
-        unpatch()
-
-    def test_no_threading(self):
-        with self.tracer.start_span('span') as span:
-            span.set_tag('tag', 'value')
+    def test_no_threading(self, ot_tracer):
+        with ot_tracer.start_span("span") as span:
+            span.set_tag("tag", "value")
 
         assert span._finished
 
-    def test_greenlets(self):
+    def test_greenlets(self, ot_tracer, writer):
         def f():
-            with self.tracer.start_span('f') as span:
+            with ot_tracer.start_span("f") as span:
                 gevent.sleep(0.04)
-                span.set_tag('f', 'yes')
+                span.set_tag("f", "yes")
 
         def g():
-            with self.tracer.start_span('g') as span:
+            with ot_tracer.start_span("g") as span:
                 gevent.sleep(0.03)
-                span.set_tag('g', 'yes')
+                span.set_tag("g", "yes")
 
-        with self.tracer.start_span('root'):
-            gevent.joinall([
-                gevent.spawn(f),
-                gevent.spawn(g),
-            ])
+        with ot_tracer.start_span("root"):
+            gevent.joinall([gevent.spawn(f), gevent.spawn(g)])
 
-        traces = self.tracer._dd_tracer.writer.pop_traces()
+        traces = writer.pop_traces()
         assert len(traces) == 3
 
-    def test_trace_greenlet(self):
+    def test_trace_greenlet(self, ot_tracer, writer):
         # a greenlet can be traced using the trace API
         def greenlet():
-            with self.tracer.start_span('greenlet'):
+            with ot_tracer.start_span("greenlet"):
                 pass
 
         gevent.spawn(greenlet).join()
-        traces = self.tracer._dd_tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
-        eq_('greenlet', traces[0][0].name)
+        traces = writer.pop_traces()
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
+        assert traces[0][0].name == "greenlet"
 
-    def test_trace_later_greenlet(self):
+    def test_trace_later_greenlet(self, ot_tracer, writer):
         # a greenlet can be traced using the trace API
         def greenlet():
-            with self.tracer.start_span('greenlet'):
+            with ot_tracer.start_span("greenlet"):
                 pass
 
         gevent.spawn_later(0.01, greenlet).join()
-        traces = self.tracer._dd_tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
-        eq_('greenlet', traces[0][0].name)
+        traces = writer.pop_traces()
 
-    def test_trace_concurrent_calls(self):
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
+        assert traces[0][0].name == "greenlet"
+
+    def test_trace_concurrent_calls(self, ot_tracer, writer):
         # create multiple futures so that we expect multiple
         # traces instead of a single one
         def greenlet():
-            with self.tracer.start_span('greenlet'):
+            with ot_tracer.start_span("greenlet"):
                 gevent.sleep(0.01)
 
         jobs = [gevent.spawn(greenlet) for x in range(100)]
         gevent.joinall(jobs)
 
-        traces = self.tracer._dd_tracer.writer.pop_traces()
-        eq_(100, len(traces))
-        eq_(1, len(traces[0]))
-        eq_('greenlet', traces[0][0].name)
+        traces = writer.pop_traces()
 
-    def test_trace_concurrent_spawn_later_calls(self):
+        assert len(traces) == 100
+        assert len(traces[0]) == 1
+        assert traces[0][0].name == "greenlet"
+
+    def test_trace_concurrent_spawn_later_calls(self, ot_tracer, writer):
         # create multiple futures so that we expect multiple
         # traces instead of a single one, even if greenlets
         # are delayed
         def greenlet():
-            with self.tracer.start_span('greenlet'):
+            with ot_tracer.start_span("greenlet"):
                 gevent.sleep(0.01)
 
         jobs = [gevent.spawn_later(0.01, greenlet) for x in range(100)]
         gevent.joinall(jobs)
 
-        traces = self.tracer._dd_tracer.writer.pop_traces()
-        eq_(100, len(traces))
-        eq_(1, len(traces[0]))
-        eq_('greenlet', traces[0][0].name)
+        traces = writer.pop_traces()
+        assert len(traces) == 100
+        assert len(traces[0]) == 1
+        assert traces[0][0].name == "greenlet"
 
 
-class TestTracerGeventCompatibility(unittest.TestCase):
+class TestTracerGeventCompatibility(object):
     """Ensure the opentracer works in tandem with the ddtracer and gevent."""
 
-    def setUp(self):
-        self.ot_tracer = get_dummy_gevent_tracer()
-        self.dd_tracer = self.ot_tracer._dd_tracer
-        self.writer = self.dd_tracer.writer
-
-        # patch gevent
-        patch()
-
-    def tearDown(self):
-        # unpatch gevent
-        unpatch()
-
-    def test_trace_spawn_multiple_greenlets_multiple_traces_ot_parent(self):
+    def test_trace_spawn_multiple_greenlets_multiple_traces_ot_parent(
+        self, ot_tracer, dd_tracer, writer
+    ):
         """
         Copy of gevent test with the same name but testing with mixed usage of
         the opentracer and datadog tracers.
@@ -145,39 +123,41 @@ class TestTracerGeventCompatibility(unittest.TestCase):
         """
         # multiple greenlets must be part of the same trace
         def entrypoint():
-            with self.ot_tracer.start_active_span('greenlet.main'):
+            with ot_tracer.start_active_span("greenlet.main"):
                 jobs = [gevent.spawn(green_1), gevent.spawn(green_2)]
                 gevent.joinall(jobs)
 
         def green_1():
-            with self.dd_tracer.trace('greenlet.worker') as span:
-                span.set_tag('worker_id', '1')
+            with dd_tracer.trace("greenlet.worker") as span:
+                span.set_tag("worker_id", "1")
                 gevent.sleep(0.01)
 
         def green_2():
-            with self.ot_tracer.start_span('greenlet.worker') as span:
-                span.set_tag('worker_id', '2')
+            with ot_tracer.start_span("greenlet.worker") as span:
+                span.set_tag("worker_id", "2")
                 gevent.sleep(0.01)
 
         gevent.spawn(entrypoint).join()
-        traces = self.writer.pop_traces()
-        eq_(3, len(traces))
-        eq_(1, len(traces[0]))
+        traces = writer.pop_traces()
+        assert len(traces) == 3
+        assert len(traces[0]) == 1
         parent_span = traces[2][0]
         worker_1 = traces[0][0]
         worker_2 = traces[1][0]
         # check spans data and hierarchy
-        eq_(parent_span.name, 'greenlet.main')
-        eq_(worker_1.get_tag('worker_id'), '1')
-        eq_(worker_1.name, 'greenlet.worker')
-        eq_(worker_1.resource, 'greenlet.worker')
-        eq_(worker_1.parent_id, parent_span.span_id)
-        eq_(worker_2.get_tag('worker_id'), '2')
-        eq_(worker_2.name, 'greenlet.worker')
-        eq_(worker_2.resource, 'greenlet.worker')
-        eq_(worker_2.parent_id, parent_span.span_id)
+        assert parent_span.name == "greenlet.main"
+        assert worker_1.get_tag("worker_id") == "1"
+        assert worker_1.name == "greenlet.worker"
+        assert worker_1.resource == "greenlet.worker"
+        assert worker_1.parent_id == parent_span.span_id
+        assert worker_2.get_tag("worker_id") == "2"
+        assert worker_2.name == "greenlet.worker"
+        assert worker_2.resource == "greenlet.worker"
+        assert worker_2.parent_id == parent_span.span_id
 
-    def test_trace_spawn_multiple_greenlets_multiple_traces_dd_parent(self):
+    def test_trace_spawn_multiple_greenlets_multiple_traces_dd_parent(
+        self, ot_tracer, dd_tracer, writer
+    ):
         """
         Copy of gevent test with the same name but testing with mixed usage of
         the opentracer and datadog tracers.
@@ -186,49 +166,54 @@ class TestTracerGeventCompatibility(unittest.TestCase):
         """
         # multiple greenlets must be part of the same trace
         def entrypoint():
-            with self.dd_tracer.trace('greenlet.main'):
+            with dd_tracer.trace("greenlet.main"):
                 jobs = [gevent.spawn(green_1), gevent.spawn(green_2)]
                 gevent.joinall(jobs)
 
         def green_1():
-            with self.ot_tracer.start_span('greenlet.worker') as span:
-                span.set_tag('worker_id', '1')
+            with ot_tracer.start_span("greenlet.worker") as span:
+                span.set_tag("worker_id", "1")
                 gevent.sleep(0.01)
 
         def green_2():
-            with self.dd_tracer.trace('greenlet.worker') as span:
-                span.set_tag('worker_id', '2')
+            with dd_tracer.trace("greenlet.worker") as span:
+                span.set_tag("worker_id", "2")
                 gevent.sleep(0.01)
 
         gevent.spawn(entrypoint).join()
-        traces = self.writer.pop_traces()
-        eq_(3, len(traces))
-        eq_(1, len(traces[0]))
+        traces = writer.pop_traces()
+        assert len(traces) == 3
+        assert len(traces[0]) == 1
         parent_span = traces[2][0]
         worker_1 = traces[0][0]
         worker_2 = traces[1][0]
         # check spans data and hierarchy
-        eq_(parent_span.name, 'greenlet.main')
-        eq_(worker_1.get_tag('worker_id'), '1')
-        eq_(worker_1.name, 'greenlet.worker')
-        eq_(worker_1.resource, 'greenlet.worker')
-        eq_(worker_1.parent_id, parent_span.span_id)
-        eq_(worker_2.get_tag('worker_id'), '2')
-        eq_(worker_2.name, 'greenlet.worker')
-        eq_(worker_2.resource, 'greenlet.worker')
-        eq_(worker_2.parent_id, parent_span.span_id)
+        assert parent_span.name == "greenlet.main"
+        assert worker_1.get_tag("worker_id") == "1"
+        assert worker_1.name == "greenlet.worker"
+        assert worker_1.resource == "greenlet.worker"
+        assert worker_1.parent_id == parent_span.span_id
+        assert worker_2.get_tag("worker_id") == "2"
+        assert worker_2.name == "greenlet.worker"
+        assert worker_2.resource == "greenlet.worker"
+        assert worker_2.parent_id == parent_span.span_id
 
 
 class TestUtilsGevent(object):
     """Test the util routines of the opentracer with gevent specific
     configuration.
     """
+
     def test_get_context_provider_for_scope_manager_asyncio(self):
         scope_manager = GeventScopeManager()
         ctx_prov = get_context_provider_for_scope_manager(scope_manager)
-        assert isinstance(ctx_prov, ddtrace.contrib.gevent.provider.GeventContextProvider)
+        assert isinstance(
+            ctx_prov, ddtrace.contrib.gevent.provider.GeventContextProvider
+        )
 
     def test_tracer_context_provider_config(self):
         tracer = ddtrace.opentracer.Tracer("mysvc", scope_manager=GeventScopeManager())
-        assert isinstance(tracer._dd_tracer.context_provider,
-                          ddtrace.contrib.gevent.provider.GeventContextProvider)
+        assert isinstance(
+            tracer._dd_tracer.context_provider,
+            ddtrace.contrib.gevent.provider.GeventContextProvider,
+        )

--- a/tests/opentracer/test_tracer_gevent.py
+++ b/tests/opentracer/test_tracer_gevent.py
@@ -6,7 +6,9 @@ from tests.opentracer.test_tracer import get_dummy_ot_tracer
 
 
 def get_dummy_gevent_tracer():
-    return get_dummy_ot_tracer('gevent', {}, GeventScopeManager())
+    from ddtrace.contrib.gevent import context_provider
+
+    return get_dummy_ot_tracer("gevent", {}, GeventScopeManager(), context_provider)
 
 
 @pytest.fixture()

--- a/tests/opentracer/test_tracer_gevent.py
+++ b/tests/opentracer/test_tracer_gevent.py
@@ -1,7 +1,10 @@
 import pytest
 import gevent
-
 from opentracing.scope_managers.gevent import GeventScopeManager
+
+import ddtrace
+from ddtrace.opentracer.utils import get_context_provider_for_scope_manager
+
 from tests.opentracer.test_tracer import get_dummy_ot_tracer
 
 
@@ -114,3 +117,18 @@ class TestTracerGeventCompat(TestCase):
         eq_(100, len(traces))
         eq_(1, len(traces[0]))
         eq_('greenlet', traces[0][0].name)
+
+
+class TestUtilsGevent(object):
+    """Test the util routines of the opentracer with gevent specific
+    configuration.
+    """
+    def test_get_context_provider_for_scope_manager_asyncio(self):
+        scope_manager = GeventScopeManager()
+        ctx_prov = get_context_provider_for_scope_manager(scope_manager)
+        assert isinstance(ctx_prov, ddtrace.contrib.gevent.provider.GeventContextProvider)
+
+    def test_tracer_context_provider_config(self):
+        tracer = ddtrace.opentracer.Tracer("mysvc", scope_manager=GeventScopeManager())
+        assert isinstance(tracer._dd_tracer.context_provider,
+                          ddtrace.contrib.gevent.provider.GeventContextProvider)

--- a/tests/opentracer/test_tracer_gevent.py
+++ b/tests/opentracer/test_tracer_gevent.py
@@ -1,8 +1,11 @@
-import pytest
 import gevent
+import pytest
+import unittest
+from nose.tools import eq_
 from opentracing.scope_managers.gevent import GeventScopeManager
 
 import ddtrace
+from ddtrace.contrib.gevent import patch, unpatch
 from ddtrace.opentracer.utils import get_context_provider_for_scope_manager
 
 from tests.opentracer.test_tracer import get_dummy_ot_tracer
@@ -19,54 +22,53 @@ def nop_tracer():
     return get_dummy_gevent_tracer()
 
 
-class TestTracerGevent(object):
-    def test_no_threading(self, nop_tracer):
-        with nop_tracer.start_span('span') as span:
-            span.set_tag('tag', 'value')
-
-        assert span._finished
-
-    def test_greenlets(self, nop_tracer):
-        def f():
-            with nop_tracer.start_span('f') as span:
-                gevent.sleep(0.04)
-                span.set_tag('f', 'yes')
-
-        def g():
-            with nop_tracer.start_span('g') as span:
-                gevent.sleep(0.03)
-                span.set_tag('g', 'yes')
-
-        with nop_tracer.start_span('root'):
-            gevent.joinall([
-                gevent.spawn(f),
-                gevent.spawn(g),
-            ])
-
-        traces = nop_tracer._dd_tracer.writer.pop_traces()
-        assert len(traces) == 3
-
-
-from unittest import TestCase
-from nose.tools import eq_, ok_
-
-class TestTracerGeventCompat(TestCase):
+class TestTracerGevent(unittest.TestCase):
     """Converted Gevent tests for the regular tracer.
 
     Ensures that greenlets are properly traced when using
-    the default Tracer.
+    the opentracer.
     """
     def setUp(self):
         # use a dummy tracer
         self.tracer = get_dummy_gevent_tracer()
 
+        # patch gevent
+        patch()
+
     def tearDown(self):
-        pass
+        # unpatch gevent
+        unpatch()
+
+    def test_no_threading(self):
+        with self.tracer.start_span('span') as span:
+            span.set_tag('tag', 'value')
+
+        assert span._finished
+
+    def test_greenlets(self):
+        def f():
+            with self.tracer.start_span('f') as span:
+                gevent.sleep(0.04)
+                span.set_tag('f', 'yes')
+
+        def g():
+            with self.tracer.start_span('g') as span:
+                gevent.sleep(0.03)
+                span.set_tag('g', 'yes')
+
+        with self.tracer.start_span('root'):
+            gevent.joinall([
+                gevent.spawn(f),
+                gevent.spawn(g),
+            ])
+
+        traces = self.tracer._dd_tracer.writer.pop_traces()
+        assert len(traces) == 3
 
     def test_trace_greenlet(self):
         # a greenlet can be traced using the trace API
         def greenlet():
-            with self.tracer.start_span('greenlet') as span:
+            with self.tracer.start_span('greenlet'):
                 pass
 
         gevent.spawn(greenlet).join()
@@ -78,7 +80,7 @@ class TestTracerGeventCompat(TestCase):
     def test_trace_later_greenlet(self):
         # a greenlet can be traced using the trace API
         def greenlet():
-            with self.tracer.start_span('greenlet') as span:
+            with self.tracer.start_span('greenlet'):
                 pass
 
         gevent.spawn_later(0.01, greenlet).join()
@@ -117,6 +119,104 @@ class TestTracerGeventCompat(TestCase):
         eq_(100, len(traces))
         eq_(1, len(traces[0]))
         eq_('greenlet', traces[0][0].name)
+
+
+class TestTracerGeventCompatibility(unittest.TestCase):
+    """Ensure the opentracer works in tandem with the ddtracer and gevent."""
+
+    def setUp(self):
+        self.ot_tracer = get_dummy_gevent_tracer()
+        self.dd_tracer = self.ot_tracer._dd_tracer
+        self.writer = self.dd_tracer.writer
+
+        # patch gevent
+        patch()
+
+    def tearDown(self):
+        # unpatch gevent
+        unpatch()
+
+    def test_trace_spawn_multiple_greenlets_multiple_traces_ot_parent(self):
+        """
+        Copy of gevent test with the same name but testing with mixed usage of
+        the opentracer and datadog tracers.
+
+        Uses an opentracer span as the parent span.
+        """
+        # multiple greenlets must be part of the same trace
+        def entrypoint():
+            with self.ot_tracer.start_active_span('greenlet.main'):
+                jobs = [gevent.spawn(green_1), gevent.spawn(green_2)]
+                gevent.joinall(jobs)
+
+        def green_1():
+            with self.dd_tracer.trace('greenlet.worker') as span:
+                span.set_tag('worker_id', '1')
+                gevent.sleep(0.01)
+
+        def green_2():
+            with self.ot_tracer.start_span('greenlet.worker') as span:
+                span.set_tag('worker_id', '2')
+                gevent.sleep(0.01)
+
+        gevent.spawn(entrypoint).join()
+        traces = self.writer.pop_traces()
+        eq_(3, len(traces))
+        eq_(1, len(traces[0]))
+        parent_span = traces[2][0]
+        worker_1 = traces[0][0]
+        worker_2 = traces[1][0]
+        # check spans data and hierarchy
+        eq_(parent_span.name, 'greenlet.main')
+        eq_(worker_1.get_tag('worker_id'), '1')
+        eq_(worker_1.name, 'greenlet.worker')
+        eq_(worker_1.resource, 'greenlet.worker')
+        eq_(worker_1.parent_id, parent_span.span_id)
+        eq_(worker_2.get_tag('worker_id'), '2')
+        eq_(worker_2.name, 'greenlet.worker')
+        eq_(worker_2.resource, 'greenlet.worker')
+        eq_(worker_2.parent_id, parent_span.span_id)
+
+    def test_trace_spawn_multiple_greenlets_multiple_traces_dd_parent(self):
+        """
+        Copy of gevent test with the same name but testing with mixed usage of
+        the opentracer and datadog tracers.
+
+        Uses an opentracer span as the parent span.
+        """
+        # multiple greenlets must be part of the same trace
+        def entrypoint():
+            with self.dd_tracer.trace('greenlet.main'):
+                jobs = [gevent.spawn(green_1), gevent.spawn(green_2)]
+                gevent.joinall(jobs)
+
+        def green_1():
+            with self.ot_tracer.start_span('greenlet.worker') as span:
+                span.set_tag('worker_id', '1')
+                gevent.sleep(0.01)
+
+        def green_2():
+            with self.dd_tracer.trace('greenlet.worker') as span:
+                span.set_tag('worker_id', '2')
+                gevent.sleep(0.01)
+
+        gevent.spawn(entrypoint).join()
+        traces = self.writer.pop_traces()
+        eq_(3, len(traces))
+        eq_(1, len(traces[0]))
+        parent_span = traces[2][0]
+        worker_1 = traces[0][0]
+        worker_2 = traces[1][0]
+        # check spans data and hierarchy
+        eq_(parent_span.name, 'greenlet.main')
+        eq_(worker_1.get_tag('worker_id'), '1')
+        eq_(worker_1.name, 'greenlet.worker')
+        eq_(worker_1.resource, 'greenlet.worker')
+        eq_(worker_1.parent_id, parent_span.span_id)
+        eq_(worker_2.get_tag('worker_id'), '2')
+        eq_(worker_2.name, 'greenlet.worker')
+        eq_(worker_2.resource, 'greenlet.worker')
+        eq_(worker_2.parent_id, parent_span.span_id)
 
 
 class TestUtilsGevent(object):

--- a/tests/opentracer/test_tracer_tornado.py
+++ b/tests/opentracer/test_tracer_tornado.py
@@ -1,7 +1,7 @@
 import pytest
 from nose.tools import eq_
-
 from opentracing.scope_managers.tornado import TornadoScopeManager
+
 from tests.opentracer.test_tracer import get_dummy_ot_tracer
 
 

--- a/tests/opentracer/test_tracer_tornado.py
+++ b/tests/opentracer/test_tracer_tornado.py
@@ -6,7 +6,11 @@ from tests.opentracer.test_tracer import get_dummy_ot_tracer
 
 
 def get_dummy_tornado_tracer():
-    return get_dummy_ot_tracer('tornado_svc', {}, TornadoScopeManager())
+    from ddtrace.contrib.tornado import context_provider
+
+    return get_dummy_ot_tracer(
+        "tornado_svc", {}, TornadoScopeManager(), context_provider
+    )
 
 
 @pytest.fixture()

--- a/tests/opentracer/test_tracer_tornado.py
+++ b/tests/opentracer/test_tracer_tornado.py
@@ -1,39 +1,34 @@
 import pytest
-from nose.tools import eq_
 from opentracing.scope_managers.tornado import TornadoScopeManager
 
-from tests.opentracer.test_tracer import get_dummy_ot_tracer
+import ddtrace
 
-
-def get_dummy_tornado_tracer():
-    from ddtrace.contrib.tornado import context_provider
-
-    return get_dummy_ot_tracer(
-        "tornado_svc", {}, TornadoScopeManager(), context_provider
-    )
+from tests.opentracer.utils import ot_tracer_factory, ot_tracer, writer
 
 
 @pytest.fixture()
-def nop_tracer():
-    return get_dummy_tornado_tracer()
+def ot_tracer(ot_tracer_factory):
+    """Fixture providing an opentracer configured for tornado usage."""
+    yield ot_tracer_factory("tornado_svc", {}, TornadoScopeManager())
 
 
-class TestTracerTornado():
+class TestTracerTornado(object):
     """
     Since the ScopeManager is provided by OpenTracing we should simply test
     whether it exists and works for a very simple use-case.
     """
 
-    def test_sanity(self, nop_tracer):
-        with nop_tracer.start_active_span('one'):
-            with nop_tracer.start_active_span('two'):
+    def test_sanity(self, ot_tracer, writer):
+        with ot_tracer.start_active_span('one'):
+            with ot_tracer.start_active_span('two'):
                 pass
 
-        traces = nop_tracer._dd_tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
-        eq_('one', traces[0][0].name)
-        eq_('two', traces[0][1].name)
+        traces = writer.pop_traces()
+        assert len(traces) == 1
+        assert len(traces[0]) == 2
+        assert traces[0][0].name == 'one'
+        assert traces[0][1].name == 'two'
+
         # the parenting is correct
-        eq_(traces[0][0], traces[0][1]._parent)
-        eq_(traces[0][0].trace_id, traces[0][1].trace_id)
+        assert traces[0][0] == traces[0][1]._parent
+        assert traces[0][0].trace_id == traces[0][1].trace_id

--- a/tests/opentracer/test_utils.py
+++ b/tests/opentracer/test_utils.py
@@ -1,0 +1,12 @@
+from opentracing.scope_managers import ThreadLocalScopeManager
+
+import ddtrace
+from ddtrace.opentracer.utils import (
+    get_context_provider_for_scope_manager,
+)
+
+class TestOpentracerUtils(object):
+    def test_get_context_provider_for_scope_manager_thread(self):
+        scope_manager = ThreadLocalScopeManager()
+        ctx_prov = get_context_provider_for_scope_manager(scope_manager)
+        assert isinstance(ctx_prov, ddtrace.provider.DefaultContextProvider)

--- a/tests/opentracer/utils.py
+++ b/tests/opentracer/utils.py
@@ -2,15 +2,17 @@ from tests.test_tracer import get_dummy_tracer
 
 
 def opentracer_init(service_name="ot_svc", dummy_tracer=None):
+    """A function similar to one OpenTracing users would write to initialize
+    their OpenTracing tracer.
+    """
     import opentracing
-    from ddtrace.opentracer import Tracer  # , set_global_tracer
-    from ddtrace.opentracer.tracer import set_global_tracer
+    from ddtrace.opentracer import Tracer, set_global_tracer
 
     dummy_tracer = dummy_tracer or get_dummy_tracer()
 
     ot_tracer = Tracer(service_name)
-    set_global_tracer(ot_tracer)
-
     ot_tracer._dd_tracer = dummy_tracer
+
+    set_global_tracer(ot_tracer)
 
     return ot_tracer, dummy_tracer

--- a/tests/opentracer/utils.py
+++ b/tests/opentracer/utils.py
@@ -1,14 +1,16 @@
 from tests.test_tracer import get_dummy_tracer
 
-def opentracer_init(service_name='ot_svc', dummy_tracer=None):
+
+def opentracer_init(service_name="ot_svc", dummy_tracer=None):
     import opentracing
-    from ddtrace.opentracer import Tracer#, set_global_tracer
+    from ddtrace.opentracer import Tracer  # , set_global_tracer
     from ddtrace.opentracer.tracer import set_global_tracer
+
     dummy_tracer = dummy_tracer or get_dummy_tracer()
 
     ot_tracer = Tracer(service_name)
-    # set the dummy tracer
-    ot_tracer._dd_tracer = dummy_tracer
     set_global_tracer(ot_tracer)
+
+    ot_tracer._dd_tracer = dummy_tracer
 
     return ot_tracer, dummy_tracer

--- a/tests/opentracer/utils.py
+++ b/tests/opentracer/utils.py
@@ -1,18 +1,39 @@
+from ddtrace.opentracer import Tracer, set_global_tracer
+
 from tests.test_tracer import get_dummy_tracer
 
 
-def opentracer_init(service_name="ot_svc", set_global=True, dummy_tracer=None):
+def get_dummy_ot_tracer(
+    service_name="", config=None, scope_manager=None, context_provider=None
+):
+    """Returns a dummy tracer to use for testing.
+
+    This is similar to the dummy tracer usage in place for the datadog tracer.
+    """
+    config = config or {}
+    tracer = Tracer(
+        service_name=service_name, config=config, scope_manager=scope_manager
+    )
+
+    # similar to how we test the ddtracer, use a dummy tracer
+    dd_tracer = get_dummy_tracer()
+    if context_provider:
+        dd_tracer.configure(context_provider=context_provider)
+
+    # attach the dummy tracer to the opentracer
+    tracer._dd_tracer = dd_tracer
+    return tracer
+
+
+def opentracer_init(service_name="ot_svc", set_global=True):
     """A function similar to one OpenTracing users would write to initialize
     their OpenTracing tracer.
     """
-    from ddtrace.opentracer import Tracer, set_global_tracer
 
-    dummy_tracer = dummy_tracer or get_dummy_tracer()
-
-    ot_tracer = Tracer(service_name)
-    ot_tracer._dd_tracer = dummy_tracer
+    ot_tracer = get_dummy_ot_tracer(service_name)
+    dd_tracer = ot_tracer._dd_tracer
 
     if set_global:
         set_global_tracer(ot_tracer)
 
-    return ot_tracer, dummy_tracer
+    return ot_tracer, dd_tracer

--- a/tests/opentracer/utils.py
+++ b/tests/opentracer/utils.py
@@ -1,39 +1,54 @@
+import pytest
+
 from ddtrace.opentracer import Tracer, set_global_tracer
 
 from tests.test_tracer import get_dummy_tracer
 
 
-def get_dummy_ot_tracer(
-    service_name="", config=None, scope_manager=None, context_provider=None
-):
-    """Returns a dummy tracer to use for testing.
+@pytest.fixture()
+def ot_tracer_factory():
+    """Fixture which returns an opentracer ready to use for testing."""
+    def make_ot_tracer(
+        service_name="my_svc", config=None, scope_manager=None, context_provider=None
+    ):
+        config = config or {}
+        tracer = Tracer(
+            service_name=service_name, config=config, scope_manager=scope_manager
+        )
 
-    This is similar to the dummy tracer usage in place for the datadog tracer.
-    """
-    config = config or {}
-    tracer = Tracer(
-        service_name=service_name, config=config, scope_manager=scope_manager
-    )
+        # similar to how we test the ddtracer, use a dummy tracer
+        dd_tracer = get_dummy_tracer()
+        if context_provider:
+            dd_tracer.configure(context_provider=context_provider)
 
-    # similar to how we test the ddtracer, use a dummy tracer
-    dd_tracer = get_dummy_tracer()
-    if context_provider:
-        dd_tracer.configure(context_provider=context_provider)
+        # attach the dummy tracer to the opentracer
+        tracer._dd_tracer = dd_tracer
+        return tracer
 
-    # attach the dummy tracer to the opentracer
-    tracer._dd_tracer = dd_tracer
-    return tracer
+    return make_ot_tracer
 
 
-def opentracer_init(service_name="ot_svc", set_global=True):
+@pytest.fixture()
+def ot_tracer(ot_tracer_factory):
+    """Fixture for a default opentracer."""
+    return ot_tracer_factory()
+
+
+@pytest.fixture()
+def global_tracer(ot_tracer):
     """A function similar to one OpenTracing users would write to initialize
     their OpenTracing tracer.
     """
+    set_global_tracer(ot_tracer)
 
-    ot_tracer = get_dummy_ot_tracer(service_name)
-    dd_tracer = ot_tracer._dd_tracer
+    return ot_tracer
 
-    if set_global:
-        set_global_tracer(ot_tracer)
 
-    return ot_tracer, dd_tracer
+@pytest.fixture()
+def writer(ot_tracer):
+    return ot_tracer._dd_tracer.writer
+
+
+@pytest.fixture()
+def dd_tracer(ot_tracer):
+    return ot_tracer._dd_tracer

--- a/tests/opentracer/utils.py
+++ b/tests/opentracer/utils.py
@@ -1,0 +1,14 @@
+from tests.test_tracer import get_dummy_tracer
+
+def opentracer_init(service_name='ot_svc', dummy_tracer=None):
+    import opentracing
+    from ddtrace.opentracer import Tracer#, set_global_tracer
+    from ddtrace.opentracer.tracer import set_global_tracer
+    dummy_tracer = dummy_tracer or get_dummy_tracer()
+
+    ot_tracer = Tracer(service_name)
+    # set the dummy tracer
+    ot_tracer._dd_tracer = dummy_tracer
+    set_global_tracer(ot_tracer)
+
+    return ot_tracer, dummy_tracer

--- a/tests/opentracer/utils.py
+++ b/tests/opentracer/utils.py
@@ -5,7 +5,6 @@ def opentracer_init(service_name="ot_svc", dummy_tracer=None):
     """A function similar to one OpenTracing users would write to initialize
     their OpenTracing tracer.
     """
-    import opentracing
     from ddtrace.opentracer import Tracer, set_global_tracer
 
     dummy_tracer = dummy_tracer or get_dummy_tracer()

--- a/tests/opentracer/utils.py
+++ b/tests/opentracer/utils.py
@@ -1,7 +1,7 @@
 from tests.test_tracer import get_dummy_tracer
 
 
-def opentracer_init(service_name="ot_svc", dummy_tracer=None):
+def opentracer_init(service_name="ot_svc", set_global=True, dummy_tracer=None):
     """A function similar to one OpenTracing users would write to initialize
     their OpenTracing tracer.
     """
@@ -12,6 +12,7 @@ def opentracer_init(service_name="ot_svc", dummy_tracer=None):
     ot_tracer = Tracer(service_name)
     ot_tracer._dd_tracer = dummy_tracer
 
-    set_global_tracer(ot_tracer)
+    if set_global:
+        set_global_tracer(ot_tracer)
 
     return ot_tracer, dummy_tracer

--- a/tox.ini
+++ b/tox.ini
@@ -248,7 +248,7 @@ commands =
 # run only essential tests related to the tracing client
     tracer: nosetests {posargs} --exclude=".*(contrib|integration|commands|opentracer).*" tests
 # run only the opentrace tests
-    opentracer: pytest {posargs} tests/opentracer/test_tracer.py tests/opentracer/test_span.py tests/opentracer/test_span_context.py tests/opentracer/test_dd_compatibility.py
+    opentracer: pytest {posargs} tests/opentracer/test_tracer.py tests/opentracer/test_span.py tests/opentracer/test_span_context.py tests/opentracer/test_dd_compatibility.py tests/opentracer/test_utils.py
     opentracer_asyncio: pytest {posargs} tests/opentracer/test_tracer_asyncio.py
     opentracer_tornado-tornado{40,41,42,43,44}: pytest {posargs} tests/opentracer/test_tracer_tornado.py
     opentracer_gevent: pytest {posargs} tests/opentracer/test_tracer_gevent.py

--- a/tox.ini
+++ b/tox.ini
@@ -248,7 +248,7 @@ commands =
 # run only essential tests related to the tracing client
     tracer: nosetests {posargs} --exclude=".*(contrib|integration|commands|opentracer).*" tests
 # run only the opentrace tests
-    opentracer: pytest {posargs} tests/opentracer/test_tracer.py tests/opentracer/test_span.py tests/opentracer/test_span_context.py
+    opentracer: pytest {posargs} tests/opentracer/test_tracer.py tests/opentracer/test_span.py tests/opentracer/test_span_context.py tests/opentracer/test_dd_compatibility.py
     opentracer_asyncio: pytest {posargs} tests/opentracer/test_tracer_asyncio.py
     opentracer_tornado-tornado{40,41,42,43,44}: pytest {posargs} tests/opentracer/test_tracer_tornado.py
     opentracer_gevent: pytest {posargs} tests/opentracer/test_tracer_gevent.py


### PR DESCRIPTION
This PR aims to add support so that the opentracer can be used in tandem with the Datadog tracer. Traces started with an opentracer should be continued seamlessly with the Datadog tracer, and the other way around as well.

This should enable us to verify in subsequent PRs that the opentracer will work with each of our supported integrations.