### PR TITLE
[core] Add WSGI http header support to HTTP propagator

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -8,25 +8,22 @@ log = logging.getLogger(__name__)
 
 # HTTP headers one should set for distributed tracing.
 # These are cross-language (eg: Python, Go and other implementations should honor these)
-HTTP_HEADER_TRACE_ID = 'x-datadog-trace-id'
-HTTP_HEADER_PARENT_ID = 'x-datadog-parent-id'
-HTTP_HEADER_SAMPLING_PRIORITY = 'x-datadog-sampling-priority'
+HTTP_HEADER_TRACE_ID = "x-datadog-trace-id"
+HTTP_HEADER_PARENT_ID = "x-datadog-parent-id"
+HTTP_HEADER_SAMPLING_PRIORITY = "x-datadog-sampling-priority"
 
 
 # Note that due to WSGI spec we have to also check for uppercased and prefixed
 # versions of these headers
-POSSIBLE_HTTP_HEADER_TRACE_IDS = frozenset([
-    HTTP_HEADER_TRACE_ID,
-    get_wsgi_header(HTTP_HEADER_TRACE_ID),
-])
-POSSIBLE_HTTP_HEADER_PARENT_IDS = frozenset([
-    HTTP_HEADER_PARENT_ID,
-    get_wsgi_header(HTTP_HEADER_PARENT_ID),
-])
-POSSIBLE_HTTP_HEADER_SAMPLING_PRIORITIES = frozenset([
-    HTTP_HEADER_SAMPLING_PRIORITY,
-    get_wsgi_header(HTTP_HEADER_SAMPLING_PRIORITY),
-])
+POSSIBLE_HTTP_HEADER_TRACE_IDS = frozenset(
+    [HTTP_HEADER_TRACE_ID, get_wsgi_header(HTTP_HEADER_TRACE_ID)]
+)
+POSSIBLE_HTTP_HEADER_PARENT_IDS = frozenset(
+    [HTTP_HEADER_PARENT_ID, get_wsgi_header(HTTP_HEADER_PARENT_ID)]
+)
+POSSIBLE_HTTP_HEADER_SAMPLING_PRIORITIES = frozenset(
+    [HTTP_HEADER_SAMPLING_PRIORITY, get_wsgi_header(HTTP_HEADER_SAMPLING_PRIORITY)]
+)
 
 
 class HTTPPropagator(object):

--- a/ddtrace/propagation/utils.py
+++ b/ddtrace/propagation/utils.py
@@ -1,3 +1,7 @@
 
 def get_wsgi_header(header):
+    """Returns a WSGI compliant HTTP header.
+    See https://www.python.org/dev/peps/pep-3333/#environ-variables for
+    information from the spec.
+    """
     return "HTTP_{}".format(header.upper().replace("-", "_"))

--- a/ddtrace/propagation/utils.py
+++ b/ddtrace/propagation/utils.py
@@ -1,4 +1,3 @@
-
 def get_wsgi_header(header):
     """Returns a WSGI compliant HTTP header.
     See https://www.python.org/dev/peps/pep-3333/#environ-variables for

--- a/ddtrace/propagation/utils.py
+++ b/ddtrace/propagation/utils.py
@@ -1,0 +1,3 @@
+
+def get_wsgi_header(header):
+    return "HTTP_{}".format(header.upper().replace("-", "_"))

--- a/tests/propagation/test_http.py
+++ b/tests/propagation/test_http.py
@@ -9,7 +9,6 @@ from ddtrace.propagation.http import (
     HTTP_HEADER_SAMPLING_PRIORITY,
 )
 
-from ddtrace.propagation.utils import get_wsgi_header
 
 class TestHttpPropagation(TestCase):
     """
@@ -52,9 +51,9 @@ class TestHttpPropagation(TestCase):
         tracer = get_dummy_tracer()
 
         headers = {
-            get_wsgi_header(HTTP_HEADER_TRACE_ID): '1234',
-            get_wsgi_header(HTTP_HEADER_PARENT_ID): '5678',
-            get_wsgi_header(HTTP_HEADER_SAMPLING_PRIORITY): '1',
+            'HTTP_X_DATADOG_TRACE_ID': '1234',
+            'HTTP_X_DATADOG_PARENT_ID': '5678',
+            'HTTP_X_DATADOG_SAMPLING_PRIORITY': '1',
         }
 
         propagator = HTTPPropagator()

--- a/tests/propagation/test_http.py
+++ b/tests/propagation/test_http.py
@@ -11,6 +11,7 @@ from ddtrace.propagation.http import (
     HTTP_HEADER_PARENT_ID,
     HTTP_HEADER_SAMPLING_PRIORITY,
 )
+from ddtrace.propagation.utils import get_wsgi_header
 
 class TestHttpPropagation(TestCase):
     """
@@ -37,6 +38,25 @@ class TestHttpPropagation(TestCase):
             HTTP_HEADER_TRACE_ID: '1234',
             HTTP_HEADER_PARENT_ID: '5678',
             HTTP_HEADER_SAMPLING_PRIORITY: '1',
+        }
+
+        propagator = HTTPPropagator()
+        context = propagator.extract(headers)
+        tracer.context_provider.activate(context)
+
+        with tracer.trace("local_root_span") as span:
+            eq_(span.trace_id, 1234)
+            eq_(span.parent_id, 5678)
+            # TODO: do it for priority too
+
+    def test_WSGI_extract(self):
+        """Ensure we support the WSGI formatted headers as well."""
+        tracer = get_dummy_tracer()
+
+        headers = {
+            get_wsgi_header(HTTP_HEADER_TRACE_ID): '1234',
+            get_wsgi_header(HTTP_HEADER_PARENT_ID): '5678',
+            get_wsgi_header(HTTP_HEADER_SAMPLING_PRIORITY): '1',
         }
 
         propagator = HTTPPropagator()

--- a/tests/propagation/test_http.py
+++ b/tests/propagation/test_http.py
@@ -15,6 +15,7 @@ class TestHttpPropagation(TestCase):
     Tests related to the ``Context`` class that hosts the trace for the
     current execution flow.
     """
+
     def test_inject(self):
         tracer = get_dummy_tracer()
 
@@ -26,15 +27,18 @@ class TestHttpPropagation(TestCase):
 
             eq_(int(headers[HTTP_HEADER_TRACE_ID]), span.trace_id)
             eq_(int(headers[HTTP_HEADER_PARENT_ID]), span.span_id)
-            eq_(int(headers[HTTP_HEADER_SAMPLING_PRIORITY]), span.context.sampling_priority)
+            eq_(
+                int(headers[HTTP_HEADER_SAMPLING_PRIORITY]),
+                span.context.sampling_priority,
+            )
 
     def test_extract(self):
         tracer = get_dummy_tracer()
 
         headers = {
-            HTTP_HEADER_TRACE_ID: '1234',
-            HTTP_HEADER_PARENT_ID: '5678',
-            HTTP_HEADER_SAMPLING_PRIORITY: '1',
+            HTTP_HEADER_TRACE_ID: "1234",
+            HTTP_HEADER_PARENT_ID: "5678",
+            HTTP_HEADER_SAMPLING_PRIORITY: "1",
         }
 
         propagator = HTTPPropagator()
@@ -51,9 +55,9 @@ class TestHttpPropagation(TestCase):
         tracer = get_dummy_tracer()
 
         headers = {
-            'HTTP_X_DATADOG_TRACE_ID': '1234',
-            'HTTP_X_DATADOG_PARENT_ID': '5678',
-            'HTTP_X_DATADOG_SAMPLING_PRIORITY': '1',
+            "HTTP_X_DATADOG_TRACE_ID": "1234",
+            "HTTP_X_DATADOG_PARENT_ID": "5678",
+            "HTTP_X_DATADOG_SAMPLING_PRIORITY": "1",
         }
 
         propagator = HTTPPropagator()

--- a/tests/propagation/test_http.py
+++ b/tests/propagation/test_http.py
@@ -36,9 +36,9 @@ class TestHttpPropagation(TestCase):
         tracer = get_dummy_tracer()
 
         headers = {
-            HTTP_HEADER_TRACE_ID: "1234",
-            HTTP_HEADER_PARENT_ID: "5678",
-            HTTP_HEADER_SAMPLING_PRIORITY: "1",
+            "x-datadog-trace-id": "1234",
+            "x-datadog-parent-id": "5678",
+            "x-datadog-sampling-priority": "1",
         }
 
         propagator = HTTPPropagator()

--- a/tests/propagation/test_utils.py
+++ b/tests/propagation/test_utils.py
@@ -1,0 +1,6 @@
+from ddtrace.propagation.utils import get_wsgi_header
+
+
+class TestPropagationUtils(object):
+    def test_get_wsgi_header(self):
+        assert get_wsgi_header("x-datadog-trace-id") == "HTTP_X_DATADOG_TRACE_ID"


### PR DESCRIPTION
WSGI specification states for variable HTTP headers to be in a particular format stated [here](https://www.python.org/dev/peps/pep-3333/#environ-variables).

This PR adds support to the HTTP Propagator to support if and when the Datadog headers are converted to this format.

This should fix #456.