### PR TITLE
[core/api] Enable buffering on getresponse

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -6,7 +6,7 @@ from json import loads
 
 # project
 from .encoding import get_encoder, JSONEncoder
-from .compat import httplib, PYTHON_VERSION, PYTHON_INTERPRETER
+from .compat import httplib, PYTHON_VERSION, PYTHON_INTERPRETER, get_connection_response
 
 
 log = logging.getLogger(__name__)
@@ -132,7 +132,7 @@ class API(object):
         return response
 
     def _put(self, endpoint, data, count=0):
-        conn = httplib.HTTPConnection(self.hostname, self.port, buffering=True)
+        conn = httplib.HTTPConnection(self.hostname, self.port)
 
         headers = self._headers
         if count:
@@ -140,4 +140,4 @@ class API(object):
             headers[TRACE_COUNT_HEADER] = str(count)
 
         conn.request("PUT", endpoint, data, headers)
-        return conn.getresponse()
+        return get_connection_response(conn)

--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -132,7 +132,7 @@ class API(object):
         return response
 
     def _put(self, endpoint, data, count=0):
-        conn = httplib.HTTPConnection(self.hostname, self.port)
+        conn = httplib.HTTPConnection(self.hostname, self.port, buffering=True)
 
         headers = self._headers
         if count:

--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -70,6 +70,24 @@ def to_unicode(s):
     return stringify(s)
 
 
+def get_connection_response(conn):
+    """Returns the response for a connection.
+
+    If using Python 2 enable buffering.
+
+    Python 2 does not enable buffering by default resulting in many recv
+    syscalls.
+
+    See:
+    https://bugs.python.org/issue4879
+    https://github.com/python/cpython/commit/3c43fcba8b67ea0cec4a443c755ce5f25990a6cf
+    """
+    if PY2:
+        return conn.getresponse(buffering=True)
+    else:
+        return conn.getresponse()
+
+
 if PY2:
     string_type = basestring
     msgpack_type = basestring

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,7 +13,6 @@ from ddtrace.api import API
 from ddtrace.ext import http
 from ddtrace.filters import FilterRequestsOnUrl
 from ddtrace.constants import FILTERS_KEY
-from ddtrace.span import Span
 from ddtrace.tracer import Tracer
 from ddtrace.encoding import JSONEncoder, MsgpackEncoder, get_encoder
 from ddtrace.compat import httplib, PYTHON_INTERPRETER, PYTHON_VERSION


### PR DESCRIPTION
This PR addresses an issue where an excessive number of syscalls are made when getting a response from the `httplib` library.

For more information about the issue see:
- https://bugs.python.org/issue4879
- https://github.com/python/cpython/commit/3c43fcba8b67ea0cec4a443c755ce5f25990a6cf

See #464 for the symptoms. This should fix #464.