### PR TITLE
[pylons] Add middleware exception/error handling tests

### DIFF
--- a/tests/contrib/pylons/app/middleware.py
+++ b/tests/contrib/pylons/app/middleware.py
@@ -1,0 +1,30 @@
+from webob import Request, Response
+
+class ExceptionToSuccessMiddleware(object):
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        req = Request(environ)
+        try:
+            response = req.get_response(self.app)
+        except Exception:
+            response = Response()
+            response.status_int = 200
+            response.body = 'An error has been handled appropriately'
+        return response(environ, start_response)
+
+
+class ExceptionToClientErrorMiddleware(object):
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        req = Request(environ)
+        try:
+            response = req.get_response(self.app)
+        except Exception:
+            response = Response()
+            response.status_int = 404
+            response.body = 'An error has occured with proper client error handling'
+        return response(environ, start_response)

--- a/tests/contrib/pylons/app/middleware.py
+++ b/tests/contrib/pylons/app/middleware.py
@@ -1,15 +1,17 @@
 from webob import Request, Response
 
 class ExceptionMiddleware(object):
+    """A middleware which raises an exception."""
     def __init__(self, app):
         self.app = app
 
     def __call__(self, environ, start_response):
-        # req = Request(environ)
-        # req.get_response(self.app)
         raise Exception('Middleware exception')
 
 class ExceptionToSuccessMiddleware(object):
+    """A middleware which catches any exceptions that occur in a later
+    middleware and returns a successful request.
+    """
     def __init__(self, app):
         self.app = app
 

--- a/tests/contrib/pylons/app/middleware.py
+++ b/tests/contrib/pylons/app/middleware.py
@@ -1,5 +1,14 @@
 from webob import Request, Response
 
+class ExceptionMiddleware(object):
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        # req = Request(environ)
+        # req.get_response(self.app)
+        raise Exception('Middleware exception')
+
 class ExceptionToSuccessMiddleware(object):
     def __init__(self, app):
         self.app = app

--- a/tests/contrib/pylons/test_pylons.py
+++ b/tests/contrib/pylons/test_pylons.py
@@ -29,13 +29,15 @@ class PylonsTestCase(TestCase):
         app = PylonsTraceMiddleware(wsgiapp, self.tracer, service='web')
         self.app = fixture.TestApp(app)
 
-    def test_typical_pylon_app(self):
+    def test_controller_exception(self):
+        """Ensure exceptions thrown in controllers can be handled.
+
+        No error tags should be set in the span.
+        """
         from .app.middleware import ExceptionToSuccessMiddleware
-        from pylons.middleware import ErrorHandler
         wsgiapp = ExceptionToSuccessMiddleware(self._wsgiapp)
         app = PylonsTraceMiddleware(wsgiapp, self.tracer, service='web')
 
-        app = ErrorHandler(app, {})
         app = fixture.TestApp(app)
         app.get(url_for(controller='root', action='raise_exception'))
 
@@ -54,6 +56,10 @@ class PylonsTestCase(TestCase):
         eq_(span.get_tag(errors.ERROR_STACK), None)
 
     def test_mw_exc_success(self):
+        """Ensure exceptions can be properly handled by other middleware.
+
+        No error should be reported in the span.
+        """
         from .app.middleware import ExceptionMiddleware, ExceptionToSuccessMiddleware
         wsgiapp = ExceptionMiddleware(self._wsgiapp)
         wsgiapp = ExceptionToSuccessMiddleware(wsgiapp)
@@ -75,6 +81,33 @@ class PylonsTestCase(TestCase):
         eq_(span.get_tag(errors.ERROR_MSG), None)
         eq_(span.get_tag(errors.ERROR_TYPE), None)
         eq_(span.get_tag(errors.ERROR_STACK), None)
+
+    def test_middleware_exception(self):
+        """Ensure exceptions raised in middleware are properly handled.
+
+        Uncaught exceptions should result in error tagged spans.
+        """
+        from .app.middleware import ExceptionMiddleware
+        wsgiapp = ExceptionMiddleware(self._wsgiapp)
+        app = PylonsTraceMiddleware(wsgiapp, self.tracer, service='web')
+        app = fixture.TestApp(app)
+
+        with assert_raises(Exception):
+            app.get(url_for(controller='root', action='index'))
+
+        spans = self.tracer.writer.pop()
+
+        ok_(spans, spans)
+        eq_(len(spans), 1)
+        span = spans[0]
+
+        eq_(span.service, 'web')
+        eq_(span.resource, 'None.None')
+        eq_(span.error, 1)
+        eq_(span.get_tag('http.status_code'), '500')
+        eq_(span.get_tag(errors.ERROR_MSG), 'Middleware exception')
+        eq_(span.get_tag(errors.ERROR_TYPE), 'exceptions.Exception')
+        ok_(span.get_tag(errors.ERROR_STACK))
 
     def test_exc_success(self):
         from .app.middleware import ExceptionToSuccessMiddleware
@@ -106,7 +139,6 @@ class PylonsTestCase(TestCase):
         app.get(url_for(controller='root', action='raise_exception'), status=404)
 
         spans = self.tracer.writer.pop()
-        print(spans)
         ok_(spans, spans)
         eq_(len(spans), 1)
         span = spans[0]


### PR DESCRIPTION
#463 raised concerns about properly handled exceptions causing spans to be incorrectly tagged with error information. While the issue could not be replicated, a bunch of tests were written to assert the logic of exception handling in middleware.

This PR adds these regression tests.