### PR TITLE
[celery] Patch via post-import hooks

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -70,9 +70,6 @@ try:
     if opts:
         tracer.configure(**opts)
 
-    if not hasattr(sys, 'argv'):
-        sys.argv = ['']
-
     if patch:
         update_patched_modules()
         from ddtrace import patch_all; patch_all(**EXTRA_PATCHED_MODULES) # noqa

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -93,6 +93,7 @@ def patch(raise_errors=True, **patch_modules):
             # manually add celery to patched modules and increment count
             _PATCHED_MODULES.add(module)
             count += 1
+            patched = True
         else:
             patched = patch_module(module, raise_errors=raise_errors)
         if patched:

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -77,7 +77,6 @@ def patch(raise_errors=True, **patch_modules):
         >>> patch(psycopg=True, elasticsearch=True)
     """
     modules = [m for (m, should_patch) in patch_modules.items() if should_patch]
-    count = 0
     for module in modules:
         # TODO: this is a temporary hack until we shift to using
         # post-import hooks for everything.
@@ -90,19 +89,16 @@ def patch(raise_errors=True, **patch_modules):
                 from ddtrace.contrib.celery import patch
                 patch()
 
-            # manually add celery to patched modules and increment count
+            # manually add celery to patched modules
             _PATCHED_MODULES.add(module)
-            count += 1
-            patched = True
         else:
-            patched = patch_module(module, raise_errors=raise_errors)
-        if patched:
-            count += 1
+            patch_module(module, raise_errors=raise_errors)
 
+    patched_modules = get_patched_modules()
     log.info("patched %s/%s modules (%s)",
-        count,
+        len(patched_modules),
         len(modules),
-        ",".join(get_patched_modules()))
+        ",".join(patched_modules))
 
 
 def patch_module(module, raise_errors=True):

--- a/tests/commands/ddtrace_run_patched_modules.py
+++ b/tests/commands/ddtrace_run_patched_modules.py
@@ -6,5 +6,4 @@ from nose.tools import ok_
 
 if __name__ == '__main__':
     ok_('redis' in monkey.get_patched_modules())
-    ok_('celery' in monkey.get_patched_modules())
     print("Test success")

--- a/tests/contrib/celery/autopatch.py
+++ b/tests/contrib/celery/autopatch.py
@@ -1,0 +1,13 @@
+from __future__ import print_function
+
+from nose.tools import ok_
+
+from ddtrace import Pin
+
+if __name__ == '__main__':
+    # have to import celery in order to have the post-import hooks run
+    import celery
+
+    # now celery.Celery should be patched and should have a pin
+    ok_(Pin.get_from(celery.Celery))
+    print("Test success")

--- a/tests/contrib/celery/test_autopatch.py
+++ b/tests/contrib/celery/test_autopatch.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import subprocess
+import unittest
+
+
+class DdtraceRunTest(unittest.TestCase):
+    """Test that celery is patched successfully if run with ddtrace-run."""
+
+    def test_autopatch(self):
+        out = subprocess.check_output(
+            ['ddtrace-run', 'python', 'tests/contrib/celery/autopatch.py']
+        )
+        assert out.startswith(b"Test success")

--- a/tests/contrib/celery/test_patch.py
+++ b/tests/contrib/celery/test_patch.py
@@ -1,0 +1,22 @@
+import unittest
+from nose.tools import ok_
+from ddtrace import Pin
+
+
+class CeleryPatchTest(unittest.TestCase):
+    def test_patch_after_import(self):
+        import celery
+        from ddtrace import patch
+        patch(celery=True)
+
+        app = celery.Celery()
+        ok_(Pin.get_from(app) is not None)
+
+    def test_patch_before_import(self):
+        from ddtrace import patch
+        patch(celery=True)
+        import celery
+
+        app = celery.Celery()
+        ok_(Pin.get_from(app) is not None)
+

--- a/tox.ini
+++ b/tox.ini
@@ -130,7 +130,6 @@ deps =
     celery41: celery>=4.1,<4.2
     celery42: celery>=4.2,<4.3
     ddtracerun: redis
-    ddtracerun: celery
     elasticsearch16: elasticsearch>=1.6,<1.7
     elasticsearch17: elasticsearch>=1.7,<1.8
     elasticsearch18: elasticsearch>=1.8,<1.9


### PR DESCRIPTION
# Patching Celery via Post-import Hooks

## Background
Patching `celery` our usual way does not work for `celery` as `celery` [contains a reference to `sys.argv`](https://github.com/celery/celery/blob/8d2f93d303dee9b8620933b89dd38704aa697a8b/celery/__init__.py#L121). This is problematic as [`sys.argv` is not defined in `sitecustomize.py`](https://bugs.python.org/issue2972). 

## Overview
This PR introduces a fix for this by taking a completely different approach to patching by using post-import hooks as defined here: https://www.python.org/dev/peps/pep-0369.

## Caveats
For simplicity and proof of concept this approach is meant only to patch `celery` via post-import hooks. It is a bit hacky in that we check explicitly for `celery` and add in the normal patching side-effects.


## Take-aways

It turns out that patching this way is extremely easy. We should strongly consider moving to this strategy for patching all of our modules!
