### PR TITLE
[pymongo] Fix multiple host kwarg

### DIFF
--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -45,12 +45,12 @@ class TracedMongoClient(ObjectProxy):
             # client is just the first arg which could be the host if it is
             # None, then it could be that the caller:
 
-            # if `client` is None then:
-            #   1) __init__ was invoked with host=None
-            #   2) __init__ was not given a first argument (client defaults to
-            #      None)
+            # if client is None then __init__ was:
+            #   1) invoked with host=None
+            #   2) not given a first argument (client defaults to None)
             # we cannot tell which case it is, but it should not matter since
-            # the default value for host is None.
+            # the default value for host is None, in either case we can simply
+            # not provide it as an argument
             if client is None:
                 client = _MongoClient(*args, **kwargs)
             # else client is a value for host so just pass it along

--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -40,7 +40,7 @@ class TracedMongoClient(ObjectProxy):
         # To support the former trace_mongo_client interface, we have to keep this old interface
         # TODO(Benjamin): drop it in a later version
         if not isinstance(client, _MongoClient):
-            # Patched interface, instanciate the client
+            # Patched interface, instantiate the client
             # Note that, in that case, the client argument isn't a client, it's just the first arg
             client = _MongoClient(client, *args, **kwargs)
 

--- a/tests/contrib/pymongo/test.py
+++ b/tests/contrib/pymongo/test.py
@@ -280,6 +280,15 @@ class TestPymongoPatchDefault(PymongoCore):
         assert s['app_type'] == 'db'
         assert s['app'] == 'mongodb'
 
+    def test_host_kwarg(self):
+        # simulate what celery and django do when instantiating a new client
+        conf = {
+            'host': 'localhost'
+        }
+        client = pymongo.MongoClient(**conf)
+
+        assert client
+
 
 class TestPymongoPatchConfigured(PymongoCore):
     """Test suite for pymongo with a configured patched library"""

--- a/tests/contrib/pymongo/test.py
+++ b/tests/contrib/pymongo/test.py
@@ -287,6 +287,11 @@ class TestPymongoPatchDefault(PymongoCore):
         }
         client = pymongo.MongoClient(**conf)
 
+        conf = {
+            'host': None
+        }
+        client = pymongo.MongoClient(**conf)
+
         assert client
 
 


### PR DESCRIPTION
## Overview

This PR adds a fix for the bug demonstrated in #369.

## Background

Due to supporting deprecated code, a hack existed that used the first argument passed to the `TracedMongoClient`. The first argument passed to `MongoClient` was `host`. This bug would occur when host was provided explicitly as a kwarg.