### PR TITLE
[celery] add Config object to change Worker/Producer service names

### DIFF
--- a/ddtrace/contrib/celery/__init__.py
+++ b/ddtrace/contrib/celery/__init__.py
@@ -2,7 +2,7 @@
 The Celery integration will trace all tasks that are executed in the
 background. Functions and class based tasks are traced only if the Celery API
 is used, so calling the function directly or via the ``run()`` method will not
-generate traces. On the other hand, calling ``apply()`` and ``apply_async()``
+generate traces. On the other hand, calling ``apply()``, ``apply_async()`` and ``delay()``
 will produce tracing data. To trace your Celery application, call the patch method::
 
     import celery
@@ -20,8 +20,7 @@ will produce tracing data. To trace your Celery application, call the patch meth
             pass
 
 
-To change Celery service name, you can update the attached ``Pin``
-instance::
+To change Celery service name, you can use the ``Config`` API as follows::
 
     from ddtrace import Pin
 
@@ -31,12 +30,9 @@ instance::
     def compute_stats():
         pass
 
-    # globally
-    Pin.override(app, service='background-jobs')
-
-    # by task
-    Pin.override(compute_stats, service='data-processing')
-
+    # change service names for producers and workers
+    config.celery['producer_service_name'] = 'task-queue'
+    config.celery['worker_service_name'] = 'worker-notify'
 
 By default, reported service names are:
     * ``celery-producer`` when tasks are enqueued for processing

--- a/ddtrace/contrib/celery/app.py
+++ b/ddtrace/contrib/celery/app.py
@@ -1,10 +1,10 @@
 from celery import signals
 
-from ddtrace import Pin
+from ddtrace import Pin, config
 from ddtrace.pin import _DD_PIN_NAME
 from ddtrace.ext import AppTypes
 
-from .constants import APP, WORKER_SERVICE
+from .constants import APP
 from .signals import (
     trace_prerun,
     trace_postrun,
@@ -23,7 +23,12 @@ def patch_app(app, pin=None):
     setattr(app, '__datadog_patch', True)
 
     # attach the PIN object
-    pin = pin or Pin(service=WORKER_SERVICE, app=APP, app_type=AppTypes.worker)
+    pin = pin or Pin(
+        service=config.celery['worker_service_name'],
+        app=APP,
+        app_type=AppTypes.worker,
+        _config=config.celery,
+    )
     pin.onto(app)
     # connect to the Signal framework
     signals.task_prerun.connect(trace_prerun)

--- a/ddtrace/contrib/celery/constants.py
+++ b/ddtrace/contrib/celery/constants.py
@@ -15,5 +15,7 @@ TASK_RUN = 'run'
 
 # Service info
 APP = 'celery'
+# `getenv()` call must be kept for backward compatibility; we may remove it
+# later when we do a full migration to the `Config` class
 PRODUCER_SERVICE = getenv('DATADOG_SERVICE_NAME') or 'celery-producer'
 WORKER_SERVICE = getenv('DATADOG_SERVICE_NAME') or 'celery-worker'

--- a/ddtrace/contrib/celery/patch.py
+++ b/ddtrace/contrib/celery/patch.py
@@ -1,6 +1,17 @@
 import celery
 
+from ddtrace import config
+
 from .app import patch_app, unpatch_app
+from .constants import PRODUCER_SERVICE, WORKER_SERVICE
+from ...utils.formats import get_env
+
+
+# Celery default settings
+config._add('celery', {
+    'producer_service_name': get_env('celery', 'producer_service_name', PRODUCER_SERVICE),
+    'worker_service_name': get_env('celery', 'worker_service_name', WORKER_SERVICE),
+})
 
 
 def patch():

--- a/ddtrace/contrib/celery/signals.py
+++ b/ddtrace/contrib/celery/signals.py
@@ -1,6 +1,6 @@
 import logging
 
-from ddtrace import Pin
+from ddtrace import Pin, config
 
 from celery import registry
 
@@ -32,7 +32,8 @@ def trace_prerun(*args, **kwargs):
         return
 
     # propagate the `Span` in the current task Context
-    span = pin.tracer.trace(c.WORKER_ROOT_SPAN, service=c.WORKER_SERVICE, resource=task.name)
+    service = config.celery['worker_service_name']
+    span = pin.tracer.trace(c.WORKER_ROOT_SPAN, service=service, resource=task.name)
     attach_span(task, task_id, span)
 
 
@@ -79,7 +80,8 @@ def trace_before_publish(*args, **kwargs):
 
     # apply some tags here because most of the data is not available
     # in the task_after_publish signal
-    span = pin.tracer.trace(c.PRODUCER_ROOT_SPAN, service=c.PRODUCER_SERVICE, resource=task_name)
+    service = config.celery['producer_service_name']
+    span = pin.tracer.trace(c.PRODUCER_ROOT_SPAN, service=service, resource=task_name)
     span.set_tag(c.TASK_TAG_KEY, c.TASK_APPLY_ASYNC)
     span.set_tag('celery.id', task_id)
     span.set_tags(tags_from_context(kwargs))

--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -2,6 +2,7 @@ import celery
 
 from nose.tools import eq_, ok_
 
+from ddtrace import config
 from ddtrace.contrib.celery import patch, unpatch
 
 from .base import CeleryBaseTestCase
@@ -272,3 +273,40 @@ class CeleryIntegrationTask(CeleryBaseTestCase):
         eq_(span.get_tag('celery.id'), res.task_id)
         eq_(span.get_tag('celery.action'), 'run')
         eq_(span.get_tag('celery.state'), 'SUCCESS')
+
+    def test_worker_service_name(self):
+        # Ensure worker service name can be changed via
+        # configuration object
+        config.celery['worker_service_name'] = 'worker-notify'
+
+        @self.app.task
+        def fn_task():
+            return 42
+
+        t = fn_task.apply()
+        ok_(t.successful())
+        eq_(42, t.result)
+
+        traces = self.tracer.writer.pop_traces()
+        eq_(1, len(traces))
+        eq_(1, len(traces[0]))
+        span = traces[0][0]
+        eq_(span.service, 'worker-notify')
+
+    def test_producer_service_name(self):
+        # Ensure producer service name can be changed via
+        # configuration object
+        config.celery['producer_service_name'] = 'task-queue'
+
+        @self.app.task
+        def fn_task():
+            return 42
+
+        t = fn_task.delay()
+        eq_('PENDING', t.status)
+
+        traces = self.tracer.writer.pop_traces()
+        eq_(1, len(traces))
+        eq_(1, len(traces[0]))
+        span = traces[0][0]
+        eq_(span.service, 'task-queue')


### PR DESCRIPTION
### Overview

Fixes #510

Adds the `Config` API to Celery integration so that service names can be set globally per application as follows:
```python
from ddtrace import config

config.celery['producer_service_name'] = 'task-queue'
config.celery['worker_service_name'] = 'worker-notify'
```

or via the following environment variables:
```
DD_CELERY_PRODUCER_SERVICE_NAME=task-queue
DD_CELERY_WORKER_SERVICE_NAME=worker-notify
```