### PR TITLE
[docs] fix pymemcache documentation build

### DIFF
--- a/ddtrace/contrib/pymemcache/__init__.py
+++ b/ddtrace/contrib/pymemcache/__init__.py
@@ -21,10 +21,18 @@
     # Use a pin to specify metadata related to this particular client
     Pin.override(client, service='my-memcached-service')
 
-Pymemcache's ``HashClient`` will also be indirectly patched as it uses
-``Client``s under the hood.
+Pymemcache ``HashClient`` will also be indirectly patched as it uses ``Client``
+under the hood.
 """
+from ...utils.importlib import require_modules
 
-from .patch import patch, unpatch
 
-__all__ = [patch, unpatch]
+required_modules = ['pymemcache']
+
+with require_modules(required_modules) as missing_modules:
+    if not missing_modules:
+        from .patch import patch, unpatch
+        __all__ = [
+            patch,
+            unpatch,
+        ]


### PR DESCRIPTION
### Overview

When building docs, `pymemcache` library was imported, crashing the build for this module. Using our `require_modules` helper solves the problem. It doesn't impact the way `pymemcache` works.