### PR TITLE
[docs] downgrade Sphinx to 1.7.5

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -87,7 +87,8 @@ end
 
 desc "build the docs"
 task :docs do
-  sh "pip install sphinx"
+    # Sphinx 1.7.5 is required otherwise docs are not properly built
+    sh "pip install sphinx==1.7.5"
   Dir.chdir 'docs' do
     sh "make html"
   end

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,7 +160,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
### Overview

With Sphinx > 1.7.5 the table of content is not built. Because we're moving to ReadTheDocs to keep our API documentation, we just downgrade the package to make it work again.