### PR TITLE
[core] remove the root logger configuration within the library

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -1,4 +1,3 @@
-import logging
 from .monkey import patch, patch_all
 from .pin import Pin
 from .span import Span
@@ -6,10 +5,6 @@ from .tracer import Tracer
 from .settings import Config
 
 __version__ = '0.13.0'
-
-# configure the root logger
-logging.basicConfig()
-log = logging.getLogger(__name__)
 
 # a global tracer instance with integration settings
 tracer = Tracer()


### PR DESCRIPTION
### Overview

Configuring Python logging from a library/module (rather than the application) will cause a lot of problems. As mentioned in this [comment](https://github.com/DataDog/dd-trace-py/pull/536/files#r213843347), we must not do that.

This reverts PR #536.