### PR TITLE
[docs] Fix docs deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,7 +758,7 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get -y install rake
-      - run: sudo pip install mkwheelhouse sphinx awscli
+      - run: sudo pip install mkwheelhouse sphinx awscli wrapt
       - run: S3_DIR=trace-dev rake release:docs
       - run: VERSION_SUFFIX=$CIRCLE_BRANCH$CIRCLE_BUILD_NUM S3_DIR=trace-dev rake release:wheel
 
@@ -769,7 +769,7 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get -y install rake
-      - run: sudo pip install mkwheelhouse sphinx awscli
+      - run: sudo pip install mkwheelhouse sphinx awscli wrapt
       - run: VERSION_SUFFIX=$CIRCLE_BRANCH$CIRCLE_BUILD_NUM S3_DIR=trace-dev rake release:wheel
 
   deploy_docs:

--- a/Rakefile
+++ b/Rakefile
@@ -88,7 +88,6 @@ end
 desc "build the docs"
 task :docs do
     sh "pip install sphinx"
-    sh "pip install ddtrace"
   Dir.chdir 'docs' do
     sh "make html"
   end

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,13 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 
+import os
+import sys
 from datetime import datetime
+
+
+# append the ddtrace path to syspath
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
The documentation deploy was broken due to this change: https://github.com/DataDog/dd-trace-py/commit/2071be204e21d7725399c62d420b8ff27633278d#diff-85987f48f1258d9ee486e3191495582dL20

This PR re-adds this logic and also installs `wrapt` before building the docs as it seems to be required as well.