### PR TITLE
[ci] Reduce django and djangorestframework test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,9 +314,9 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-django-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-django{18,19,110,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.1.results
-      - run: tox -e '{py27,py34,py35,py36}-django-autopatch{18,19,110,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.2.results
-      - run: tox -e '{py27,py34,py35,py36}-django-drf{110,111}-djangorestframework{34,35,36,37}' --result-json /tmp/django.3.results
+      - run: tox -e '{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.1.results
+      - run: tox -e '{py27,py34,py35,py36}-django-autopatch{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.2.results
+      - run: tox -e '{py27,py34,py35,py36}-django-drf{111}-djangorestframework{34,37,38}' --result-json /tmp/django.3.results
       - run: tox -e '{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.4.results
       - run: tox -e '{py34,py35,py36}-django-autopatch{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.5.results
       - run: tox -e '{py34,py35,py36}-django-drf{200}-djangorestframework{37}' --result-json /tmp/django.6.results

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ envlist =
     {py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     {py27,py34,py35,py36}-django-autopatch{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     {py34,py35,py36}-django-autopatch{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
-    {py27,py34,py35,py36}-django-drf{111}-djangorestframework{34,35,36,37}
+    {py27,py34,py35,py36}-django-drf{111}-djangorestframework{34,37,38}
     {py34,py35,py36}-django-drf{200}-djangorestframework{37}
     {py27,py34,py35,py36}-flask{010,011,012}-blinker
     {py27,py34,py35,py36}-flask-autopatch{010,011,012}-blinker
@@ -158,9 +158,8 @@ deps =
     djangopylibmc06: django-pylibmc>=0.6,<0.7
     djangoredis45: django-redis>=4.5,<4.6
     djangorestframework34: djangorestframework>=3.4,<3.5
-    djangorestframework35: djangorestframework>=3.5,<3.6
-    djangorestframework36: djangorestframework>=3.6,<3.7
     djangorestframework37: djangorestframework>=3.7,<3.8
+    djangorestframework38: djangorestframework>=3.8,<3.9
     flask010: flask>=0.10,<0.11
     flask011: flask>=0.11,<0.12
     flask012: flask>=0.12,<0.13

--- a/tox.ini
+++ b/tox.ini
@@ -39,11 +39,11 @@ envlist =
     {py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54}
     {py27,py34,py35,py36}-falcon{10,11,12}
     {py27,py34,py35,py36}-falcon-autopatch{10,11,12}
-    {py27,py34,py35,py36}-django{18,19,110,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
+    {py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     {py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
-    {py27,py34,py35,py36}-django-autopatch{18,19,110,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
+    {py27,py34,py35,py36}-django-autopatch{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     {py34,py35,py36}-django-autopatch{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
-    {py27,py34,py35,py36}-django-drf{110,111}-djangorestframework{34,35,36,37}
+    {py27,py34,py35,py36}-django-drf{111}-djangorestframework{34,35,36,37}
     {py34,py35,py36}-django-drf{200}-djangorestframework{37}
     {py27,py34,py35,py36}-flask{010,011,012}-blinker
     {py27,py34,py35,py36}-flask-autopatch{010,011,012}-blinker
@@ -148,16 +148,11 @@ deps =
     falcon-autopatch11: falcon>=1.1,<1.2
     falcon-autopatch12: falcon>=1.2,<1.3
     django18: django>=1.8,<1.9
-    django19: django>=1.9,<1.10
-    django110: django>=1.10,<1.11
     django111: django>=1.11,<1.12
     django200: django>=2.0,<2.1
     django-autopatch18: django>=1.8,<1.9
-    django-autopatch19: django>=1.9,<1.10
-    django-autopatch110: django>=1.10,<1.11
     django-autopatch111: django>=1.11,<1.12
     django-autopatch200: django>=2.0,<2.1
-    django-drf110: django>=1.10,<1.11
     django-drf111: django>=1.11,<1.12
     django-drf200: django>=2.0,<2.1
     djangopylibmc06: django-pylibmc>=0.6,<0.7
@@ -264,9 +259,9 @@ commands =
     cassandra{35,36,37,38}: nosetests {posargs} tests/contrib/cassandra
     celery{31,40,41,42}: nosetests {posargs} tests/contrib/celery
     elasticsearch{16,17,18,23,24,25,51,52,53,54}: nosetests {posargs} tests/contrib/elasticsearch
-    django{18,19,110,111,200}: python tests/contrib/django/runtests.py {posargs}
-    django-autopatch{18,19,110,111,200}: ddtrace-run python tests/contrib/django/runtests.py {posargs}
-    django-drf{110,111,200}: python tests/contrib/djangorestframework/runtests.py {posargs}
+    django{18,111,200}: python tests/contrib/django/runtests.py {posargs}
+    django-autopatch{18,111,200}: ddtrace-run python tests/contrib/django/runtests.py {posargs}
+    django-drf{111,200}: python tests/contrib/djangorestframework/runtests.py {posargs}
     flaskcache{012,013}: nosetests {posargs} tests/contrib/flask_cache
     flask{010,011,012}: nosetests {posargs} tests/contrib/flask
     flask-autopatch{010,011,012}: ddtrace-run nosetests {posargs} tests/contrib/flask_autopatch


### PR DESCRIPTION
### Django
For python 1.x we tested a few versions that are no longer supported based on https://www.djangoproject.com/download/#supported-versions

With this PR, we keep the oldest version that we were already testing among the not supported just to be aware of potential breaking changes we are introducing for older versions and remove all the others.

### Django rest framework
We keep the oldest version that we were already testing and the latest two stable releases, 3.7 and 3.8.
