### PR TITLE
Update elasticsearch docker image from 2.3 to 2.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 
 services:
     elasticsearch:
-        image: elasticsearch:2.3-alpine
+        image: elasticsearch:2.4-alpine
         ports:
             - "127.0.0.1:9200:9200"
     cassandra:


### PR DESCRIPTION
Elastic search doker image version 2.3-alpine disappeared from the docker hub and it is no longer available for download.
We should update the image to version 2.4-alpine