### PR TITLE
Fix broken status code in Flask tracing middleware

### DIFF
--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -128,7 +128,7 @@ class TraceMiddleware(object):
             return
 
         code = response.status_code if response else ''
-        span.set_tag(http.STATUS_CODE, code)
+        span.set_tag(http.STATUS_CODE, int(code))
 
     def _request_exception(self, *args, **kwargs):
         exception = kwargs.get("exception", None)


### PR DESCRIPTION
HTTP status code isn't reported correctly in Flask middleware - response.status_code is an enum, but being tagged in the tracer as if it is an int. We need to wrap the code in int() in order to get the actual integer value of the status code.