### PR TITLE
Improve performance of tests execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ jobs:
           keys:
               - tox-cache-bottle-{{ checksum "tox.ini" }}
       - run: tox -e '{py27,py34,py35,py36}-bottle{11,12}-webtest' --result-json /tmp/bottle.1.results
-      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-bottle-autopatch{11,12}-webtest' --result-json /tmp/bottle.2.results
+      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-bottle-autopatch{11,12}-webtest' --result-json /tmp/bottle.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -292,7 +292,7 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-celery-{{ checksum "tox.ini" }}
-      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-celery{31,40,41,42}-redis{210}' --result-json /tmp/celery.results
+      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-celery{31,40,41,42}-redis{210}' --result-json /tmp/celery.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -311,7 +311,7 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-elasticsearch-{{ checksum "tox.ini" }}
-      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54}' --result-json /tmp/elasticsearch.results
+      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54}' --result-json /tmp/elasticsearch.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -330,7 +330,7 @@ jobs:
           keys:
               - tox-cache-falcon-{{ checksum "tox.ini" }}
       - run: tox -e '{py27,py34,py35,py36}-falcon{10,11,12}' --result-json /tmp/falcon.1.results
-      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-falcon-autopatch{10,11,12}' --result-json /tmp/falcon.2.results
+      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-falcon-autopatch{10,11,12}' --result-json /tmp/falcon.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -357,10 +357,10 @@ jobs:
           keys:
               - tox-cache-django-{{ checksum "tox.ini" }}
       - run: tox -e '{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.1.results
-      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-django-autopatch{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.2.results
+      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-django-autopatch{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.2.results
       - run: tox -e '{py27,py34,py35,py36}-django-drf{111}-djangorestframework{34,37,38}' --result-json /tmp/django.3.results
       - run: tox -e '{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.4.results
-      - run: export TOX_SKIP_DIST=False; tox -e '{py34,py35,py36}-django-autopatch{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.5.results
+      - run: TOX_SKIP_DIST=False tox -e '{py34,py35,py36}-django-autopatch{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.5.results
       - run: tox -e '{py34,py35,py36}-django-drf{200}-djangorestframework{37}' --result-json /tmp/django.6.results
       - persist_to_workspace:
           root: /tmp
@@ -387,11 +387,11 @@ jobs:
           keys:
               - tox-cache-flask-{{ checksum "tox.ini" }}
       - run: tox -e '{py27,py34,py35,py36}-flask{010,011,012}-blinker' --result-json /tmp/flask.1.results
-      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-flask-autopatch{010,011,012}-blinker' --result-json /tmp/flask.2.results
+      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-flask-autopatch{010,011,012}-blinker' --result-json /tmp/flask.2.results
       - run: tox -e '{py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.3.results
-      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-flask-autopatch{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.4.results
+      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-flask-autopatch{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.4.results
       - run: tox -e '{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.5.results
-      - run: export TOX_SKIP_DIST=False; tox -e '{py27}-flask-autopatch{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.6.results
+      - run: TOX_SKIP_DIST=False tox -e '{py27}-flask-autopatch{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.6.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -573,7 +573,7 @@ jobs:
           keys:
               - tox-cache-pymemcache-{{ checksum "tox.ini" }}
       - run: tox -e '{py27,py34,py35,py36}-pymemcache{130,140}' --result-json /tmp/pymemcache.1.results
-      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-pymemcache-autopatch{130,140}' --result-json /tmp/pymemcache.2.results
+      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-pymemcache-autopatch{130,140}' --result-json /tmp/pymemcache.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -631,7 +631,7 @@ jobs:
           keys:
               - tox-cache-pyramid-{{ checksum "tox.ini" }}
       - run: tox -e '{py27,py34,py35,py36}-pyramid{17,18,19}-webtest' --result-json /tmp/pyramid.1.results
-      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-pyramid-autopatch{17,18,19}-webtest' --result-json /tmp/pyramid.2.results
+      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-pyramid-autopatch{17,18,19}-webtest' --result-json /tmp/pyramid.2.results
       - persist_to_workspace:
           root: /tmp
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,21 @@
 version: 2
 
+
+# Common configuration blocks as YAML anchors
+# See: https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
+httpbin_local: &httpbin_local
+  image: kennethreitz/httpbin@sha256:2c7abc4803080c22928265744410173b6fea3b898872c01c5fd0f0f9df4a59fb
+  name: httpbin.org
+test_runner: &test_runner
+  image: datadog/docker-library:dd_trace_py_1_1_0
+  env:
+    TOX_SKIP_DIST: True
+
+
 jobs:
   flake8:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
@@ -21,7 +33,7 @@ jobs:
 
   tracer:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
@@ -39,7 +51,7 @@ jobs:
 
   opentracer:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
@@ -65,8 +77,9 @@ jobs:
 
   integration:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - <<: *test_runner
         env:
+          TOX_SKIP_DIST: True
           TEST_DATADOG_INTEGRATION: 1
       - image: datadog/docker-dd-agent
         env:
@@ -91,7 +104,7 @@ jobs:
 
   futures:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
@@ -111,7 +124,7 @@ jobs:
 
   boto:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
@@ -131,8 +144,10 @@ jobs:
 
   ddtracerun:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: redis:3.2-alpine
+    environment:
+      TOX_SKIP_DIST: False
     steps:
       - checkout
       - restore_cache:
@@ -150,7 +165,7 @@ jobs:
 
   asyncio:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
@@ -168,7 +183,7 @@ jobs:
 
   pylons:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
@@ -186,7 +201,7 @@ jobs:
 
   aiohttp:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
@@ -204,7 +219,7 @@ jobs:
 
   tornado:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
@@ -224,14 +239,14 @@ jobs:
 
   bottle:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
           keys:
               - tox-cache-bottle-{{ checksum "tox.ini" }}
       - run: tox -e '{py27,py34,py35,py36}-bottle{11,12}-webtest' --result-json /tmp/bottle.1.results
-      - run: tox -e '{py27,py34,py35,py36}-bottle-autopatch{11,12}-webtest' --result-json /tmp/bottle.2.results
+      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-bottle-autopatch{11,12}-webtest' --result-json /tmp/bottle.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -244,9 +259,10 @@ jobs:
 
   cassandra:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - <<: *test_runner
         env:
-          - CASS_DRIVER_NO_EXTENSIONS=1
+          TOX_SKIP_DIST: True
+          CASS_DRIVER_NO_EXTENSIONS: 1
       - image: cassandra:3.11
         env:
           - MAX_HEAP_SIZE=1024M
@@ -269,14 +285,14 @@ jobs:
 
   celery:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: redis:3.2-alpine
     steps:
       - checkout
       - restore_cache:
           keys:
               - tox-cache-celery-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-celery{31,40,41,42}-redis{210}' --result-json /tmp/celery.results
+      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-celery{31,40,41,42}-redis{210}' --result-json /tmp/celery.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -288,14 +304,14 @@ jobs:
 
   elasticsearch:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: elasticsearch:2.3
     steps:
       - checkout
       - restore_cache:
           keys:
               - tox-cache-elasticsearch-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54}' --result-json /tmp/elasticsearch.results
+      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54}' --result-json /tmp/elasticsearch.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -307,14 +323,14 @@ jobs:
 
   falcon:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
           keys:
               - tox-cache-falcon-{{ checksum "tox.ini" }}
       - run: tox -e '{py27,py34,py35,py36}-falcon{10,11,12}' --result-json /tmp/falcon.1.results
-      - run: tox -e '{py27,py34,py35,py36}-falcon-autopatch{10,11,12}' --result-json /tmp/falcon.2.results
+      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-falcon-autopatch{10,11,12}' --result-json /tmp/falcon.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -327,7 +343,7 @@ jobs:
 
   django:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: redis:3.2-alpine
       - image: memcached:1.5-alpine
       - image: datadog/docker-dd-agent
@@ -341,10 +357,10 @@ jobs:
           keys:
               - tox-cache-django-{{ checksum "tox.ini" }}
       - run: tox -e '{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.1.results
-      - run: tox -e '{py27,py34,py35,py36}-django-autopatch{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.2.results
+      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-django-autopatch{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.2.results
       - run: tox -e '{py27,py34,py35,py36}-django-drf{111}-djangorestframework{34,37,38}' --result-json /tmp/django.3.results
       - run: tox -e '{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.4.results
-      - run: tox -e '{py34,py35,py36}-django-autopatch{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.5.results
+      - run: export TOX_SKIP_DIST=False; tox -e '{py34,py35,py36}-django-autopatch{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.5.results
       - run: tox -e '{py34,py35,py36}-django-drf{200}-djangorestframework{37}' --result-json /tmp/django.6.results
       - persist_to_workspace:
           root: /tmp
@@ -362,7 +378,7 @@ jobs:
 
   flask:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: redis:3.2-alpine
       - image: memcached:1.5-alpine
     steps:
@@ -371,11 +387,11 @@ jobs:
           keys:
               - tox-cache-flask-{{ checksum "tox.ini" }}
       - run: tox -e '{py27,py34,py35,py36}-flask{010,011,012}-blinker' --result-json /tmp/flask.1.results
-      - run: tox -e '{py27,py34,py35,py36}-flask-autopatch{010,011,012}-blinker' --result-json /tmp/flask.2.results
+      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-flask-autopatch{010,011,012}-blinker' --result-json /tmp/flask.2.results
       - run: tox -e '{py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.3.results
-      - run: tox -e '{py27,py34,py35,py36}-flask-autopatch{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.4.results
+      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-flask-autopatch{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.4.results
       - run: tox -e '{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.5.results
-      - run: tox -e '{py27}-flask-autopatch{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.6.results
+      - run: export TOX_SKIP_DIST=False; tox -e '{py27}-flask-autopatch{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.6.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -392,7 +408,7 @@ jobs:
 
   gevent:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
@@ -412,7 +428,7 @@ jobs:
 
   httplib:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
@@ -430,7 +446,7 @@ jobs:
 
   mysqlconnector:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: mysql:5.7
         env:
             - MYSQL_ROOT_PASSWORD=admin
@@ -455,7 +471,7 @@ jobs:
 
   mysqlpython:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: mysql:5.7
         env:
             - MYSQL_ROOT_PASSWORD=admin
@@ -480,7 +496,7 @@ jobs:
 
   mysqldb:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: mysql:5.7
         env:
             - MYSQL_ROOT_PASSWORD=admin
@@ -505,7 +521,7 @@ jobs:
 
   pymysql:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: mysql:5.7
         env:
             - MYSQL_ROOT_PASSWORD=admin
@@ -530,7 +546,7 @@ jobs:
 
   pylibmc:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: memcached:1.5-alpine
     steps:
       - checkout
@@ -549,7 +565,7 @@ jobs:
 
   pymemcache:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: memcached:1.5-alpine
     steps:
       - checkout
@@ -557,7 +573,7 @@ jobs:
           keys:
               - tox-cache-pymemcache-{{ checksum "tox.ini" }}
       - run: tox -e '{py27,py34,py35,py36}-pymemcache{130,140}' --result-json /tmp/pymemcache.1.results
-      - run: tox -e '{py27,py34,py35,py36}-pymemcache-autopatch{130,140}' --result-json /tmp/pymemcache.2.results
+      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-pymemcache-autopatch{130,140}' --result-json /tmp/pymemcache.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -570,7 +586,7 @@ jobs:
 
   mongoengine:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: mongo:3.6
     steps:
       - checkout
@@ -589,7 +605,7 @@ jobs:
 
   pymongo:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: mongo:3.6
     steps:
       - checkout
@@ -608,14 +624,14 @@ jobs:
 
   pyramid:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
           keys:
               - tox-cache-pyramid-{{ checksum "tox.ini" }}
       - run: tox -e '{py27,py34,py35,py36}-pyramid{17,18,19}-webtest' --result-json /tmp/pyramid.1.results
-      - run: tox -e '{py27,py34,py35,py36}-pyramid-autopatch{17,18,19}-webtest' --result-json /tmp/pyramid.2.results
+      - run: export TOX_SKIP_DIST=False; tox -e '{py27,py34,py35,py36}-pyramid-autopatch{17,18,19}-webtest' --result-json /tmp/pyramid.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -628,7 +644,8 @@ jobs:
 
   requests:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
+      - *httpbin_local
     steps:
       - checkout
       - restore_cache:
@@ -646,7 +663,7 @@ jobs:
 
   sqlalchemy:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: postgres:10.5-alpine
         env:
             - POSTGRES_PASSWORD=postgres
@@ -676,7 +693,7 @@ jobs:
 
   psycopg:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: postgres:10.5-alpine
         env:
             - POSTGRES_PASSWORD=postgres
@@ -700,7 +717,7 @@ jobs:
 
   aiobotocore:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: palazzem/moto:1.0.1
     steps:
       - checkout
@@ -719,7 +736,7 @@ jobs:
 
   aiopg:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: postgres:10.5-alpine
         env:
             - POSTGRES_PASSWORD=postgres
@@ -743,7 +760,7 @@ jobs:
 
   redis:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
       - image: redis:3.2-alpine
     steps:
       - checkout
@@ -762,7 +779,7 @@ jobs:
 
   sqlite3:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
@@ -780,7 +797,7 @@ jobs:
 
   msgpack:
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - checkout
       - restore_cache:
@@ -831,7 +848,7 @@ jobs:
   wait_all_tests:
     # this step ensures all `tox` environments are properly executed
     docker:
-      - image: datadog/docker-library:dd_trace_py_1_0_0
+      - *test_runner
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/.circleci/images/runner/Dockerfile
+++ b/.circleci/images/runner/Dockerfile
@@ -1,3 +1,4 @@
+# Latest image for this Dockerfile: datadog/docker-library:dd_trace_py_1_1_0
 FROM buildpack-deps:xenial
 
 # Install required packages
@@ -29,4 +30,4 @@ RUN pyenv global 2.7.12 3.4.4 3.5.2 3.6.1
 
 # Install tox
 RUN pip install --upgrade pip
-RUN pip install tox
+RUN pip install "tox>=3.3,<4.0"

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,15 @@
 # versions.
 
 [tox]
+# By default the tox process includes a 'dist'->'install'->'test' workflow.
+# Instead of creating a dist and install it at every step, some tests can directly use the source code to run
+# tests: `skipsdist=True`. This is much faster.
+# On the other hand, both autopatch tests and the ddtracerun test cannot use the source code as they required the
+# module to be installed.
+# This variable can be set to True in our circleci env to speed up the process, but still we default to false so
+# locally we can run `tox` without any further requirement.
+skipsdist={env:TOX_SKIP_DIST:False}
+
 # Our various test environments. The py*-all tasks will run the core
 # library tests and all contrib tests with the latest library versions.
 # The others will test specific versions of libraries.
@@ -16,7 +25,6 @@
 #
 #See related github topic:
 # - https://github.com/pypa/virtualenv/issues/596
-
 envlist =
     flake8
     wait
@@ -89,6 +97,10 @@ basepython =
     py36: python3.6
 
 deps =
+# Avoid installing wrapt and msgpack-python, our only packages declared, dependencies, when we are testing the real
+# distribution build.
+    !ddtracerun: wrapt
+    !msgpack03-!msgpack04-!msgpack05-!ddtracerun: msgpack-python
     pytest
     opentracing
 # test dependencies installed in all envs


### PR DESCRIPTION
1) Avoid dist->install->test at each run.
Our previous workflow was to make a "dist" and an "install" of ddtrace at each environment even if it was cached. This had the benefit of testing a real dist package, but was also extremely time consumig.
This change switch to using the source code during testing instead of the actual dist. Which is much more fast (~50%).
At the same time, when we test the ddtestrun command, we want to use the real distribution, so that we do not lose testing the actual build of our library.

2) Requests tests had 2 problems, thay failed often because of 503 and were slow. In order to fix both the issues, this commit uses a local docker container running the httpbin image provided by http://httpbin.org

3) Avoid cassandra failures due to auto_snapshot functionality during keyspace drop
