### PR TITLE
[tests] Update the integrations libraries versions to the latest possible.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,11 +207,13 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-aiohttp-{{ checksum "tox.ini" }}
-      - run: tox -e '{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl' --result-json /tmp/aiohttp.results
+      - run: tox -e '{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl' --result-json /tmp/aiohttp.1.results
+      - run: tox -e '{py34,py35,py36}-aiohttp{23}-aiohttp_jinja{015}-yarl10' --result-json /tmp/aiohttp.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
-            - aiohttp.results
+            - aiohttp.1.results
+            - aiohttp.2.results
       - save_cache:
           key: tox-cache-aiohttp-{{ checksum "tox.ini" }}
           paths:
@@ -225,8 +227,8 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-tornado-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-tornado{40,41,42,43,44}' --result-json /tmp/tornado.1.results
-      - run: tox -e '{py27}-tornado{40,41,42,43,44}-futures{30,31,32}' --result-json /tmp/tornado.2.results
+      - run: tox -e '{py27,py34,py35,py36}-tornado{40,41,42,43,44,45}' --result-json /tmp/tornado.1.results
+      - run: tox -e '{py27}-tornado{40,41,42,43,44,45}-futures{30,31,32}' --result-json /tmp/tornado.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -273,7 +275,7 @@ jobs:
           keys:
               - tox-cache-cassandra-{{ checksum "tox.ini" }}
       - run: tox -e wait cassandra
-      - run: tox -e '{py27,py34,py35,py36}-cassandra{35,36,37,38}' --result-json /tmp/cassandra.results
+      - run: tox -e '{py27,py34,py35,py36}-cassandra{35,36,37,38,315}' --result-json /tmp/cassandra.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -311,7 +313,7 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-elasticsearch-{{ checksum "tox.ini" }}
-      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54}' --result-json /tmp/elasticsearch.results
+      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63}' --result-json /tmp/elasticsearch.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -329,8 +331,8 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-falcon-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-falcon{10,11,12}' --result-json /tmp/falcon.1.results
-      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-falcon-autopatch{10,11,12}' --result-json /tmp/falcon.2.results
+      - run: tox -e '{py27,py34,py35,py36}-falcon{10,11,12,13,14}' --result-json /tmp/falcon.1.results
+      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-falcon-autopatch{10,11,12,13,14}' --result-json /tmp/falcon.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -386,8 +388,8 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-flask-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-flask{010,011,012}-blinker' --result-json /tmp/flask.1.results
-      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-flask-autopatch{010,011,012}-blinker' --result-json /tmp/flask.2.results
+      - run: tox -e '{py27,py34,py35,py36}-flask{010,011,012,10}-blinker' --result-json /tmp/flask.1.results
+      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-flask-autopatch{010,011,012,10}-blinker' --result-json /tmp/flask.2.results
       - run: tox -e '{py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.3.results
       - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-flask-autopatch{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.4.results
       - run: tox -e '{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.5.results
@@ -414,7 +416,7 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-gevent-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-gevent{11,12}' --result-json /tmp/gevent.1.results
+      - run: tox -e '{py27,py34,py35,py36}-gevent{11,12,13}' --result-json /tmp/gevent.1.results
       - run: tox -e '{py27}-gevent{10}' --result-json /tmp/gevent.2.results
       - persist_to_workspace:
           root: /tmp
@@ -534,7 +536,7 @@ jobs:
           keys:
               - tox-cache-pymysql-{{ checksum "tox.ini" }}
       - run: tox -e 'wait' mysql
-      - run: tox -e '{py27,py34,py35,py36}-pymysql{07,08}' --result-json /tmp/pymysql.results
+      - run: tox -e '{py27,py34,py35,py36}-pymysql{07,08,09}' --result-json /tmp/pymysql.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -593,7 +595,7 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-mongoengine-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-mongoengine{011}' --result-json /tmp/mongoengine.results
+      - run: tox -e '{py27,py34,py35,py36}-mongoengine{015}' --result-json /tmp/mongoengine.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -612,7 +614,7 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-pymongo-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-pymongo{30,31,32,33,34}-mongoengine{011}' --result-json /tmp/pymongo.results
+      - run: tox -e '{py27,py34,py35,py36}-pymongo{30,31,32,33,34,36}-mongoengine{015}' --result-json /tmp/pymongo.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -651,7 +653,7 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-requests-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-requests{208,209,210,211,212,213}' --result-json /tmp/requests.results
+      - run: tox -e '{py27,py34,py35,py36}-requests{208,209,210,211,212,213,219}' --result-json /tmp/requests.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -681,7 +683,7 @@ jobs:
           keys:
               - tox-cache-sqlalchemy-{{ checksum "tox.ini" }}
       - run: tox -e 'wait' postgres mysql
-      - run: tox -e '{py27,py34,py35,py36}-sqlalchemy{10,11}-psycopg2{27}-mysqlconnector{21}' --result-json /tmp/sqlalchemy.results
+      - run: tox -e '{py27,py34,py35,py36}-sqlalchemy{10,11,12}-psycopg2{27}-mysqlconnector{21}' --result-json /tmp/sqlalchemy.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -748,7 +750,7 @@ jobs:
           keys:
               - tox-cache-aiopg-{{ checksum "tox.ini" }}
       - run: tox -e 'wait' postgres
-      - run: tox -e '{py34,py35,py36}-aiopg{012,013}' --result-json /tmp/aiopg.results
+      - run: tox -e '{py34,py35,py36}-aiopg{012,015}' --result-json /tmp/aiopg.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -803,7 +805,7 @@ jobs:
       - restore_cache:
           keys:
               - tox-cache-msgpack-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34}-msgpack{03,04}' --result-json /tmp/msgpack.results
+      - run: tox -e '{py27,py34}-msgpack{03,04,05}' --result-json /tmp/msgpack.results
       - persist_to_workspace:
           root: /tmp
           paths:

--- a/tests/contrib/elasticsearch/test.py
+++ b/tests/contrib/elasticsearch/test.py
@@ -123,7 +123,7 @@ class ElasticsearchTest(unittest.TestCase):
         # Raise error 404 with a non existent index
         writer.pop()
         try:
-            es.get(index="non_existent_index", id=100)
+            es.get(index="non_existent_index", id=100, doc_type="_all")
             eq_("error_not_raised", "TransportError")
         except TransportError as e:
             spans = writer.pop()

--- a/tests/contrib/falcon/test_autopatch.py
+++ b/tests/contrib/falcon/test_autopatch.py
@@ -8,6 +8,13 @@ from .test_suite import FalconTestCase
 
 
 class AutoPatchTestCase(testing.TestCase, FalconTestCase):
+
+    # Added because falcon 1.3 and 1.4 test clients (falcon.testing.client.TestClient) expect this property to be
+    # defined. It would be initialized in the constructor, but we call it here like in 'TestClient.__init__(self, None)'
+    # because falcon 1.0.x does not have such module and would fail. Once we stop supporting falcon 1.0.x then we can
+    # use the cleaner __init__ invocation
+    _default_headers = None
+
     def setUp(self):
         self._service = 'my-falcon'
         self.tracer = tracer

--- a/tox.ini
+++ b/tox.ini
@@ -111,6 +111,10 @@ deps =
 # https://github.com/aio-libs/aiohttp/issues/2662
     yarl: yarl==0.18.0
     yarl10: yarl>=1.0,<1.1
+#   aiobotocore -> aiohttp -> multidict: our old dependency line is no compatible with recently released multidict 4.4.x
+#   watch this Issue and once fixed remove the following lines: https://github.com/aio-libs/aiohttp/issues/3277
+    py{35}-aiobotocore{02,03,04}: multidict>=4.3,<4.4
+    py{34,35}-aiohttp{12,13,20,21,22,23}: multidict>=4.3,<4.4
 # integrations
     aiobotocore04: aiobotocore>=0.4,<0.5
     aiobotocore03: aiobotocore>=0.3,<0.4

--- a/tox.ini
+++ b/tox.ini
@@ -43,49 +43,50 @@ envlist =
     {py34,py35,py36}-asyncio
     {py27}-pylons{096,097,010,10}
     {py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
-    {py27,py34,py35,py36}-tornado{40,41,42,43,44}
-    {py27}-tornado{40,41,42,43,44}-futures{30,31,32}
+    {py34,py35,py36}-aiohttp{23}-aiohttp_jinja{015}-yarl10
+    {py27,py34,py35,py36}-tornado{40,41,42,43,44,45}
+    {py27}-tornado{40,41,42,43,44,45}-futures{30,31,32}
     {py27,py34,py35,py36}-bottle{11,12}-webtest
     {py27,py34,py35,py36}-bottle-autopatch{11,12}-webtest
-    {py27,py34,py35,py36}-cassandra{35,36,37,38}
+    {py27,py34,py35,py36}-cassandra{35,36,37,38,315}
     {py27,py34,py35,py36}-celery{31,40,41,42}-redis{210}
-    {py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54}
-    {py27,py34,py35,py36}-falcon{10,11,12}
-    {py27,py34,py35,py36}-falcon-autopatch{10,11,12}
+    {py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63}
+    {py27,py34,py35,py36}-falcon{10,11,12,13,14}
+    {py27,py34,py35,py36}-falcon-autopatch{10,11,12,13,14}
     {py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     {py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     {py27,py34,py35,py36}-django-autopatch{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     {py34,py35,py36}-django-autopatch{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     {py27,py34,py35,py36}-django-drf{111}-djangorestframework{34,37,38}
     {py34,py35,py36}-django-drf{200}-djangorestframework{37}
-    {py27,py34,py35,py36}-flask{010,011,012}-blinker
-    {py27,py34,py35,py36}-flask-autopatch{010,011,012}-blinker
+    {py27,py34,py35,py36}-flask{010,011,012,10}-blinker
+    {py27,py34,py35,py36}-flask-autopatch{010,011,012,10}-blinker
     {py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker
     {py27,py34,py35,py36}-flask-autopatch{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker
 # flask_cache 0.12 is not python 3 compatible
     {py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker
     {py27}-flask-autopatch{010,011}-flaskcache{012}-memcached-redis{210}-blinker
-    {py27,py34,py35,py36}-gevent{11,12}
+    {py27,py34,py35,py36}-gevent{11,12,13}
 # gevent 1.0 is not python 3 compatible
     {py27}-gevent{10}
     {py27,py34,py35,py36}-httplib
     {py27,py34,py35,py36}-mysqlconnector{21}
     {py27}-mysqldb{12}
     {py27,py34,py35,py36}-mysqlclient{13}
-    {py27,py34,py35,py36}-pymysql{07,08}
+    {py27,py34,py35,py36}-pymysql{07,08,09}
     {py27,py34,py35,py36}-pylibmc{140,150}
-    {py27,py34,py35,py36}-pymongo{30,31,32,33,34}-mongoengine{011}
-    {py27,py34,py35,py36}-mongoengine{011}
+    {py27,py34,py35,py36}-pymongo{30,31,32,33,34,36}-mongoengine{015}
+    {py27,py34,py35,py36}-mongoengine{015}
     {py27,py34,py35,py36}-pyramid{17,18,19}-webtest
     {py27,py34,py35,py36}-pyramid-autopatch{17,18,19}-webtest
-    {py27,py34,py35,py36}-requests{208,209,210,211,212,213}
-    {py27,py34,py35,py36}-sqlalchemy{10,11}-psycopg2{27}-mysqlconnector{21}
+    {py27,py34,py35,py36}-requests{208,209,210,211,212,213,219}
+    {py27,py34,py35,py36}-sqlalchemy{10,11,12}-psycopg2{27}-mysqlconnector{21}
     {py27,py34,py35,py36}-psycopg2{24,25,26,27}
     {py34,py35,py36}-aiobotocore{02,03,04}
-    {py34,py35,py36}-aiopg{012,013}
+    {py34,py35,py36}-aiopg{012,015}
     {py27,py34,py35,py36}-redis{26,27,28,29,210}
     {py27,py34,py35,py36}-sqlite3
-    {py27,py34}-msgpack{03,04}
+    {py27,py34}-msgpack{03,04,05}
     {py27,py34,py35,py36}-pymemcache{130,140}
     {py27,py34,py35,py36}-pymemcache-autopatch{130,140}
 
@@ -109,13 +110,14 @@ deps =
 # force the downgrade as a workaround
 # https://github.com/aio-libs/aiohttp/issues/2662
     yarl: yarl==0.18.0
+    yarl10: yarl>=1.0,<1.1
 # integrations
     aiobotocore04: aiobotocore>=0.4,<0.5
     aiobotocore03: aiobotocore>=0.3,<0.4
     aiobotocore02: aiobotocore>=0.2,<0.3
-    py{34}-aiobotocore{03,04}: typing
+    py{34}-aiobotocore{02,03,04}: typing
     aiopg012: aiopg>=0.12,<0.13
-    aiopg013: aiopg>=0.13,<0.14
+    aiopg015: aiopg>=0.15,<0.16
     aiopg: sqlalchemy
     aiohttp12: aiohttp>=1.2,<1.3
     aiohttp13: aiohttp>=1.3,<1.4
@@ -128,12 +130,13 @@ deps =
     tornado42: tornado>=4.2,<4.3
     tornado43: tornado>=4.3,<4.4
     tornado44: tornado>=4.4,<4.5
+    tornado45: tornado>=4.5,<4.6
     futures30: futures>=3.0,<3.1
     futures31: futures>=3.1,<3.2
     futures32: futures>=3.2,<3.3
     aiohttp_jinja012: aiohttp_jinja2>=0.12,<0.13
     aiohttp_jinja013: aiohttp_jinja2>=0.13,<0.14
-    aiohttp_jinja014: aiohttp_jinja2>=0.14,<0.15
+    aiohttp_jinja015: aiohttp_jinja2>=0.15,<0.16
     blinker: blinker
     boto: boto
     boto: moto<1.0
@@ -147,6 +150,7 @@ deps =
     cassandra36: cassandra-driver>=3.6,<3.7
     cassandra37: cassandra-driver>=3.7,<3.8
     cassandra38: cassandra-driver>=3.8,<3.9
+    cassandra315: cassandra-driver>=3.15,<3.16
     celery31: celery>=3.1,<3.2
     celery40: celery>=4.0,<4.1
     celery41: celery>=4.1,<4.2
@@ -161,12 +165,17 @@ deps =
     elasticsearch52: elasticsearch>=5.2,<5.3
     elasticsearch53: elasticsearch>=5.3,<5.4
     elasticsearch54: elasticsearch>=5.4,<5.5
+    elasticsearch63: elasticsearch>=6.3,<6.4
     falcon10: falcon>=1.0,<1.1
     falcon11: falcon>=1.1,<1.2
     falcon12: falcon>=1.2,<1.3
+    falcon13: falcon>=1.3,<1.4
+    falcon14: falcon>=1.4,<1.5
     falcon-autopatch10: falcon>=1.0,<1.1
     falcon-autopatch11: falcon>=1.1,<1.2
     falcon-autopatch12: falcon>=1.2,<1.3
+    falcon-autopatch13: falcon>=1.3,<1.4
+    falcon-autopatch14: falcon>=1.4,<1.5
     django18: django>=1.8,<1.9
     django111: django>=1.11,<1.12
     django200: django>=2.0,<2.1
@@ -183,23 +192,28 @@ deps =
     flask010: flask>=0.10,<0.11
     flask011: flask>=0.11,<0.12
     flask012: flask>=0.12,<0.13
+    flask10: flask>=1.0,<1.1
     flask-autopatch010: flask>=0.10,<0.11
     flask-autopatch011: flask>=0.11,<0.12
     flask-autopatch012: flask>=0.12,<0.13
+    flask-autopatch10: flask>=1.0,<1.1
     gevent10: gevent>=1.0,<1.1
     gevent11: gevent>=1.1,<1.2
     gevent12: gevent>=1.2,<1.3
+    gevent13: gevent>=1.3,<1.4
     flaskcache012: flask_cache>=0.12,<0.13
     flaskcache013: flask_cache>=0.13,<0.14
     memcached: python-memcached
     msgpack03: msgpack-python>=0.3,<0.4
     msgpack04: msgpack-python>=0.4,<0.5
-    mongoengine011: mongoengine>=0.11,<0.12
+    msgpack05: msgpack-python>=0.5,<0.6
+    mongoengine015: mongoengine>=0.15<0.16
     mysqlconnector21: mysql-connector>=2.1,<2.2
     mysqldb12: mysql-python>=1.2,<1.3
     mysqlclient13: mysqlclient>=1.3,<1.4
     pymysql07: pymysql>=0.7,<0.8
     pymysql08: pymysql>=0.8,<0.9
+    pymysql09: pymysql>=0.9,<0.10
 # webob is required for Pylons < 1.0
     pylons096: pylons>=0.9.6,<0.9.7
     pylons096: webob<1.1
@@ -220,6 +234,7 @@ deps =
     pymongo32: pymongo>=3.2,<3.3
     pymongo33: pymongo>=3.3,<3.4
     pymongo34: pymongo>=3.4,<3.5
+    pymongo36: pymongo>=3.6,<3.7
     pyramid17: pyramid>=1.7,<1.8
     pyramid18: pyramid>=1.8,<1.9
     pyramid19: pyramid>=1.9,<1.10
@@ -249,8 +264,10 @@ deps =
     requests212: requests-mock>=1.3
     requests213: requests>=2.13,<2.14
     requests213: requests-mock>=1.3
-    requests218: requests>=2.18,<2.18
+    requests218: requests>=2.18,<2.19
     requests218: requests-mock>=1.4
+    requests219: requests>=2.19,<2.20
+    requests219: requests-mock>=1.4
     sqlalchemy10: sqlalchemy>=1.0,<1.1
     sqlalchemy11: sqlalchemy>=1.1,<1.2
     sqlalchemy12: sqlalchemy>=1.2,<1.3
@@ -270,8 +287,8 @@ commands =
 # integration tests
     integration: nosetests {posargs} tests/test_integration.py
     asyncio: nosetests {posargs} tests/contrib/asyncio
-    aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}: nosetests {posargs} tests/contrib/aiohttp
-    tornado{40,41,42,43,44}: nosetests {posargs} tests/contrib/tornado
+    aiohttp{12,13,20,21,22,23}-aiohttp_jinja{012,013,015}: nosetests {posargs} tests/contrib/aiohttp
+    tornado{40,41,42,43,44,45}: nosetests {posargs} tests/contrib/tornado
 # run subsets of the tests for particular library versions
     {py27}-pylons{096,097,010,10}: nosetests {posargs} tests/contrib/pylons
     {py27,py34}-boto: nosetests {posargs} tests/contrib/boto
@@ -280,39 +297,39 @@ commands =
     py{35,36}-aiobotocore{02,03,04}: nosetests {posargs} tests/contrib/aiobotocore
     bottle{11,12}: nosetests {posargs} tests/contrib/bottle/test.py
     bottle-autopatch{11,12}: ddtrace-run nosetests {posargs} tests/contrib/bottle/test_autopatch.py
-    cassandra{35,36,37,38}: nosetests {posargs} tests/contrib/cassandra
+    cassandra{35,36,37,38,315}: nosetests {posargs} tests/contrib/cassandra
     celery{31,40,41,42}: nosetests {posargs} tests/contrib/celery
-    elasticsearch{16,17,18,23,24,25,51,52,53,54}: nosetests {posargs} tests/contrib/elasticsearch
+    elasticsearch{16,17,18,23,24,25,51,52,53,54,63}: nosetests {posargs} tests/contrib/elasticsearch
     django{18,111,200}: python tests/contrib/django/runtests.py {posargs}
     django-autopatch{18,111,200}: ddtrace-run python tests/contrib/django/runtests.py {posargs}
     django-drf{111,200}: python tests/contrib/djangorestframework/runtests.py {posargs}
     flaskcache{012,013}: nosetests {posargs} tests/contrib/flask_cache
-    flask{010,011,012}: nosetests {posargs} tests/contrib/flask
-    flask-autopatch{010,011,012}: ddtrace-run nosetests {posargs} tests/contrib/flask_autopatch
-    falcon{10,11,12}: nosetests {posargs} tests/contrib/falcon/test_middleware.py tests/contrib/falcon/test_distributed_tracing.py
-    falcon-autopatch{10,11,12}: ddtrace-run nosetests {posargs} tests/contrib/falcon/test_autopatch.py
-    gevent{11,12}: nosetests {posargs} tests/contrib/gevent
+    flask{010,011,012,10}: nosetests {posargs} tests/contrib/flask
+    flask-autopatch{010,011,012,10}: ddtrace-run nosetests {posargs} tests/contrib/flask_autopatch
+    falcon{10,11,12,13,14}: nosetests {posargs} tests/contrib/falcon/test_middleware.py tests/contrib/falcon/test_distributed_tracing.py
+    falcon-autopatch{10,11,12,13,14}: ddtrace-run nosetests {posargs} tests/contrib/falcon/test_autopatch.py
+    gevent{11,12,13}: nosetests {posargs} tests/contrib/gevent
     gevent{10}: nosetests {posargs} tests/contrib/gevent
     httplib: nosetests {posargs} tests/contrib/httplib
     mysqlconnector21: nosetests {posargs} tests/contrib/mysql
     mysqldb{12}: nosetests {posargs} tests/contrib/mysqldb
     mysqlclient{13}: nosetests {posargs} tests/contrib/mysqldb
-    pymysql{07,08}: nosetests {posargs} tests/contrib/pymysql
+    pymysql{07,08,09}: nosetests {posargs} tests/contrib/pymysql
     pylibmc{140,150}: nosetests {posargs} tests/contrib/pylibmc
-    pymongo{30,31,32,33,34}: nosetests {posargs} tests/contrib/pymongo
+    pymongo{30,31,32,33,34,36}: nosetests {posargs} tests/contrib/pymongo
     pyramid{17,18,19}: nosetests {posargs} tests/contrib/pyramid/test_pyramid.py
     pyramid-autopatch{17,18,19}: ddtrace-run nosetests {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
-    mongoengine{011}: nosetests {posargs} tests/contrib/mongoengine
+    mongoengine{015}: nosetests {posargs} tests/contrib/mongoengine
     psycopg2{24,25,26,27}: nosetests {posargs} tests/contrib/psycopg
-    py{34}-aiopg{012,013}: nosetests {posargs} --exclude=".*(test_aiopg_35).*" tests/contrib/aiopg
-    py{35,36}-aiopg{012,013}: nosetests {posargs} tests/contrib/aiopg
+    py{34}-aiopg{012,015}: nosetests {posargs} --exclude=".*(test_aiopg_35).*" tests/contrib/aiopg
+    py{35,36}-aiopg{012,015}: nosetests {posargs} tests/contrib/aiopg
     redis{26,27,28,29,210}: nosetests {posargs} tests/contrib/redis
     sqlite3: nosetests {posargs} tests/contrib/sqlite3
-    requests{200,208,209,210,211,212,213}: nosetests {posargs} tests/contrib/requests
-    sqlalchemy{10,11}: nosetests {posargs} tests/contrib/sqlalchemy
+    requests{200,208,209,210,211,212,213,219}: nosetests {posargs} tests/contrib/requests
+    sqlalchemy{10,11,12}: nosetests {posargs} tests/contrib/sqlalchemy
     threading: nosetests {posargs} tests/contrib/futures
     ddtracerun: nosetests {posargs} tests/commands/test_runner.py
-    msgpack{03,04}: nosetests {posargs} tests/test_encoders.py
+    msgpack{03,04,05}: nosetests {posargs} tests/test_encoders.py
     test_utils: nosetests {posargs} tests/contrib/test_utils.py
     pymemcache{130,140}: nosetests {posargs} --exclude="test_autopatch.py" tests/contrib/pymemcache/
     pymemcache-autopatch{130,140}: ddtrace-run nosetests {posargs} tests/contrib/pymemcache/test_autopatch.py
@@ -349,6 +366,12 @@ setenv =
 [testenv:py27-falcon-autopatch12]
 setenv =
     {[falcon_autopatch]setenv}
+[testenv:py27-falcon-autopatch13]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:py27-falcon-autopatch14]
+setenv =
+    {[falcon_autopatch]setenv}
 [testenv:py34-falcon-autopatch10]
 setenv =
     {[falcon_autopatch]setenv}
@@ -356,6 +379,12 @@ setenv =
 setenv =
     {[falcon_autopatch]setenv}
 [testenv:py34-falcon-autopatch12]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:py34-falcon-autopatch13]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:py34-falcon-autopatch14]
 setenv =
     {[falcon_autopatch]setenv}
 [testenv:py35-falcon-autopatch10]
@@ -367,6 +396,12 @@ setenv =
 [testenv:py35-falcon-autopatch12]
 setenv =
     {[falcon_autopatch]setenv}
+[testenv:py35-falcon-autopatch13]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:py35-falcon-autopatch14]
+setenv =
+    {[falcon_autopatch]setenv}
 [testenv:py36-falcon-autopatch10]
 setenv =
     {[falcon_autopatch]setenv}
@@ -374,6 +409,12 @@ setenv =
 setenv =
     {[falcon_autopatch]setenv}
 [testenv:py36-falcon-autopatch12]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:py36-falcon-autopatch13]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:py36-falcon-autopatch14]
 setenv =
     {[falcon_autopatch]setenv}
 
@@ -509,6 +550,9 @@ setenv =
 [testenv:py27-flask-autopatch012-blinker]
 setenv =
     {[flask_autopatch]setenv}
+[testenv:py27-flask-autopatch10-blinker]
+setenv =
+    {[flask_autopatch]setenv}
 [testenv:py34-flask-autopatch010-blinker]
 setenv =
     {[flask_autopatch]setenv}
@@ -516,6 +560,9 @@ setenv =
 setenv =
     {[flask_autopatch]setenv}
 [testenv:py34-flask-autopatch012-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:py34-flask-autopatch10-blinker]
 setenv =
     {[flask_autopatch]setenv}
 [testenv:py35-flask-autopatch010-blinker]
@@ -527,6 +574,9 @@ setenv =
 [testenv:py35-flask-autopatch012-blinker]
 setenv =
     {[flask_autopatch]setenv}
+[testenv:py35-flask-autopatch10-blinker]
+setenv =
+    {[flask_autopatch]setenv}
 [testenv:py36-flask-autopatch010-blinker]
 setenv =
     {[flask_autopatch]setenv}
@@ -534,6 +584,9 @@ setenv =
 setenv =
     {[flask_autopatch]setenv}
 [testenv:py36-flask-autopatch012-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:py36-flask-autopatch10-blinker]
 setenv =
     {[flask_autopatch]setenv}
 [testenv:py27-flask-autopatch010-flaskcache013-memcached-redis210-blinker]


### PR DESCRIPTION
A few notes follow for specific libraries besides updates you can see in the code itself

```
*tornado*
 - not possible to udate to 5.x, postponing
*elasticsearch*
 - added 6.3
 - a test had to be updated because `doc_type` arg was optional before, it is not anymore.
*falcon*
 - added 1.3, 1.4
 - a small change to a test class was necessaries because of a new expected property that must exists in the TestCase class.
*flask*
 - added version 1.0
 - our integration flask_cache does not support flask 1.
*pymongo/mongoengine*
 - mongoengine: updated to latest
 - pymongo: added 3.6. Latest stable is 3.7, but our integration fails to trace at least inserts.
      Example:
        1) ['count here.are.songs', 'count here.are.songs', 'count here.are.songs', 'count here.are.songs', 'delete here.are.songs {"artist": "?"}', 'delete here.are.songs {"artist": "?"}', 'drop here.are.songs', 'insert here.are.songs']
        2) [u'count here.are.songs', u'count here.are.songs', u'count here.are.songs', u'count here.are.songs', u'delete here.are.songs {"artist": "?"}', u'delete here.are.songs {"artist": "?"}', u'drop here.are.songs']
```

Moreover, we recently discovered of a problem with `aiohttp` dependency tree and opened an GH issue about it: https://github.com/aio-libs/aiohttp/issues/3277