### PR TITLE
[opentracer] Activate span context on extract

### DIFF
--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -288,4 +288,9 @@ class Tracer(opentracing.Tracer):
         if propagator is None:
             raise opentracing.UnsupportedFormatException
 
-        return propagator.extract(carrier)
+        # we have to manually activate the returned context from a distributed
+        # trace
+        ot_span_ctx = propagator.extract(carrier)
+        dd_span_ctx = ot_span_ctx._dd_context
+        self._dd_tracer.context_provider.activate(dd_span_ctx)
+        return ot_span_ctx


### PR DESCRIPTION
Fixes an oversight on my part: when spans are propagated the datadog tracer expects the use of a propagator to manually call `tracer.context_provider.activate`. This is not done by the opentracer. As such the context is not activated and any subsequent spans created will not inherit from the propagated context.

I was able to replicate #606 and to create a test to cover this logic.

Fixes #606.