### PR TITLE
[tests] Refactor tox.ini file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,14 @@ test_runner: &test_runner
 restore_cache_step: &restore_cache_step
   restore_cache:
     keys:
+        # In the cache key:
+        #   - .Environment.CIRCLE_JOB: We do separate tox environments by job name, so caching and restoring is
+        #                              much faster.
+        #   - .Environment.CACHE_EXPIRE_HASH: Typically CircleCI discard caches every ~60days. If we see any strange
+        #                              behavior in tests and we want to run a build in a clean environment, we should
+        #                              still be able to do it. In order to achieve this we can change the value of the
+        #                              CACHE_EXPIRE_HASH in our CircleCI's repo settings. Please use the format
+        #                              'YYYY-MM-DD'. This way a new push on the branch is not required.
         - tox-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_EXPIRE_HASH }}
 save_cache_step: &save_cache_step
   save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,15 @@ test_runner: &test_runner
   image: datadog/docker-library:dd_trace_py_1_1_0
   env:
     TOX_SKIP_DIST: True
+restore_cache_step: &restore_cache_step
+  restore_cache:
+    keys:
+        - tox-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_EXPIRE_HASH }}
+save_cache_step: &save_cache_step
+  save_cache:
+    key: tox-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_EXPIRE_HASH }}
+    paths:
+      - .tox
 
 
 jobs:
@@ -18,45 +27,33 @@ jobs:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-flake8-{{ checksum "tox.ini" }}
+      - *restore_cache_step
       - run: tox -e 'flake8' --result-json /tmp/flake8.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - flake8.results
-      - save_cache:
-          key: tox-cache-flake8-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   tracer:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-tracer-{{ checksum "tox.ini" }}
+      - *restore_cache_step
       - run: tox -e '{py27,py34,py35,py36}-tracer' --result-json /tmp/tracer.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - tracer.results
-      - save_cache:
-          key: tox-cache-tracer-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   opentracer:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-opentracer-{{ checksum "tox.ini" }}
+      - *restore_cache_step
       - run: tox -e '{py27,py34,py35,py36}-opentracer' --result-json /tmp/opentracer.results
       - run: tox -e '{py34,py35,py36}-opentracer_asyncio' --result-json /tmp/opentracer-asyncio.results
       - run: tox -e '{py34,py35,py36}-opentracer_tornado-tornado{40,41,42,43,44}' --result-json /tmp/opentracer-tornado.results
@@ -70,10 +67,7 @@ jobs:
             - opentracer-tornado.results
             - opentracer-gevent.1.results
             - opentracer-gevent.2.results
-      - save_cache:
-          key: tox-cache-opentracer-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   integration:
     docker:
@@ -88,59 +82,44 @@ jobs:
             - DD_API_KEY=invalid_key_but_this_is_fine
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-integration-{{ checksum "tox.ini" }}
+      - *restore_cache_step
       - run: tox -e '{py27,py34,py35,py36}-integration' --result-json /tmp/integration.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - integration.results
 
-      - save_cache:
-          key: tox-cache-integration-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   futures:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-futures-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27}-threading-futures{30,31,32}' --result-json /tmp/futures.1.results
-      - run: tox -e '{py34,py35,py36}-threading' --result-json /tmp/futures.2.results
+      - *restore_cache_step
+      - run: tox -e 'futures_contrib-{py27}-futures{30,31,32}' --result-json /tmp/futures.1.results
+      - run: tox -e 'futures_contrib-{py34,py35,py36}' --result-json /tmp/futures.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - futures.1.results
             - futures.2.results
-      - save_cache:
-          key: tox-cache-futures-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   boto:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-boto-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34}-boto' --result-json /tmp/boto.1.results
-      - run: tox -e '{py27,py34}-botocore' --result-json /tmp/boto.2.results
+      - *restore_cache_step
+      - run: tox -e 'boto_contrib-{py27,py34}-boto' --result-json /tmp/boto.1.results
+      - run: tox -e 'botocore_contrib-{py27,py34}-botocore' --result-json /tmp/boto.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - boto.1.results
             - boto.2.results
-      - save_cache:
-          key: tox-cache-boto-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   ddtracerun:
     docker:
@@ -150,114 +129,84 @@ jobs:
       TOX_SKIP_DIST: False
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-ddtracerun-{{ checksum "tox.ini" }}
+      - *restore_cache_step
       - run: tox -e '{py27,py34,py35,py36}-ddtracerun' --result-json /tmp/ddtracerun.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - ddtracerun.results
-      - save_cache:
-          key: tox-cache-ddtracerun-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   asyncio:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-asyncio-{{ checksum "tox.ini" }}
-      - run: tox -e '{py34,py35,py36}-asyncio' --result-json /tmp/asyncio.results
+      - *restore_cache_step
+      - run: tox -e 'asyncio_contrib-{py34,py35,py36}' --result-json /tmp/asyncio.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - asyncio.results
-      - save_cache:
-          key: tox-cache-asyncio-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   pylons:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-pylons-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27}-pylons{096,097,010,10}' --result-json /tmp/pylons.results
+      - *restore_cache_step
+      - run: tox -e 'pylons_contrib-{py27}-pylons{096,097,010,10}' --result-json /tmp/pylons.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - pylons.results
-      - save_cache:
-          key: tox-cache-pylons-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   aiohttp:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-aiohttp-{{ checksum "tox.ini" }}
-      - run: tox -e '{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl' --result-json /tmp/aiohttp.1.results
-      - run: tox -e '{py34,py35,py36}-aiohttp{23}-aiohttp_jinja{015}-yarl10' --result-json /tmp/aiohttp.2.results
+      - *restore_cache_step
+      - run: tox -e 'aiohttp_contrib-{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl' --result-json /tmp/aiohttp.1.results
+      - run: tox -e 'aiohttp_contrib-{py34,py35,py36}-aiohttp{23}-aiohttp_jinja{015}-yarl10' --result-json /tmp/aiohttp.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - aiohttp.1.results
             - aiohttp.2.results
-      - save_cache:
-          key: tox-cache-aiohttp-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   tornado:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-tornado-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-tornado{40,41,42,43,44,45}' --result-json /tmp/tornado.1.results
-      - run: tox -e '{py27}-tornado{40,41,42,43,44,45}-futures{30,31,32}' --result-json /tmp/tornado.2.results
+      - *restore_cache_step
+      - run: tox -e 'tornado_contrib-{py27,py34,py35,py36}-tornado{40,41,42,43,44,45}' --result-json /tmp/tornado.1.results
+      - run: tox -e 'tornado_contrib-{py27}-tornado{40,41,42,43,44,45}-futures{30,31,32}' --result-json /tmp/tornado.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - tornado.1.results
             - tornado.2.results
-      - save_cache:
-          key: tox-cache-tornado-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   bottle:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-bottle-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-bottle{11,12}-webtest' --result-json /tmp/bottle.1.results
-      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-bottle-autopatch{11,12}-webtest' --result-json /tmp/bottle.2.results
+      - *restore_cache_step
+      - run: tox -e 'bottle_contrib-{py27,py34,py35,py36}-bottle{11,12}-webtest' --result-json /tmp/bottle.1.results
+      - run: TOX_SKIP_DIST=False tox -e 'bottle_contrib_autopatch-{py27,py34,py35,py36}-bottle{11,12}-webtest' --result-json /tmp/bottle.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - bottle.1.results
             - bottle.2.results
-      - save_cache:
-          key: tox-cache-bottle-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   cassandra:
     docker:
@@ -271,19 +220,14 @@ jobs:
           - HEAP_NEWSIZE=400M
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-cassandra-{{ checksum "tox.ini" }}
+      - *restore_cache_step
       - run: tox -e wait cassandra
-      - run: tox -e '{py27,py34,py35,py36}-cassandra{35,36,37,38,315}' --result-json /tmp/cassandra.results
+      - run: tox -e 'cassandra_contrib-{py27,py34,py35,py36}-cassandra{35,36,37,38,315}' --result-json /tmp/cassandra.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - cassandra.results
-      - save_cache:
-          key: tox-cache-cassandra-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   celery:
     docker:
@@ -291,18 +235,13 @@ jobs:
       - image: redis:3.2-alpine
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-celery-{{ checksum "tox.ini" }}
-      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-celery{31,40,41,42}-redis{210}' --result-json /tmp/celery.results
+      - *restore_cache_step
+      - run: TOX_SKIP_DIST=False tox -e 'celery_contrib-{py27,py34,py35,py36}-celery{31,40,41,42}-redis{210}' --result-json /tmp/celery.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - celery.results
-      - save_cache:
-          key: tox-cache-celery-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   elasticsearch:
     docker:
@@ -310,38 +249,28 @@ jobs:
       - image: elasticsearch:2.3
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-elasticsearch-{{ checksum "tox.ini" }}
-      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63}' --result-json /tmp/elasticsearch.results
+      - *restore_cache_step
+      - run: TOX_SKIP_DIST=False tox -e 'elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63}' --result-json /tmp/elasticsearch.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - elasticsearch.results
-      - save_cache:
-          key: tox-cache-elasticsearch-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   falcon:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-falcon-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-falcon{10,11,12,13,14}' --result-json /tmp/falcon.1.results
-      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-falcon-autopatch{10,11,12,13,14}' --result-json /tmp/falcon.2.results
+      - *restore_cache_step
+      - run: tox -e 'falcon_contrib-{py27,py34,py35,py36}-falcon{10,11,12,13,14}' --result-json /tmp/falcon.1.results
+      - run: TOX_SKIP_DIST=False tox -e 'falcon_contrib_autopatch-{py27,py34,py35,py36}-falcon{10,11,12,13,14}' --result-json /tmp/falcon.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - falcon.1.results
             - falcon.2.results
-      - save_cache:
-          key: tox-cache-falcon-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   django:
     docker:
@@ -355,15 +284,13 @@ jobs:
             - DD_API_KEY=invalid_key_but_this_is_fine
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-django-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.1.results
-      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-django-autopatch{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.2.results
-      - run: tox -e '{py27,py34,py35,py36}-django-drf{111}-djangorestframework{34,37,38}' --result-json /tmp/django.3.results
-      - run: tox -e '{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.4.results
-      - run: TOX_SKIP_DIST=False tox -e '{py34,py35,py36}-django-autopatch{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.5.results
-      - run: tox -e '{py34,py35,py36}-django-drf{200}-djangorestframework{37}' --result-json /tmp/django.6.results
+      - *restore_cache_step
+      - run: tox -e 'django_contrib-{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.1.results
+      - run: TOX_SKIP_DIST=False tox -e 'django_contrib_autopatch-{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.2.results
+      - run: tox -e 'django_drf_contrib-{py27,py34,py35,py36}-django{111}-djangorestframework{34,37,38}' --result-json /tmp/django.3.results
+      - run: tox -e 'django_contrib-{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.4.results
+      - run: TOX_SKIP_DIST=False tox -e 'django_contrib_autopatch-{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.5.results
+      - run: tox -e 'django_drf_contrib-{py34,py35,py36}-django{200}-djangorestframework{37,38}' --result-json /tmp/django.6.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -373,10 +300,7 @@ jobs:
             - django.4.results
             - django.5.results
             - django.6.results
-      - save_cache:
-          key: tox-cache-django-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   flask:
     docker:
@@ -385,15 +309,13 @@ jobs:
       - image: memcached:1.5-alpine
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-flask-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-flask{010,011,012,10}-blinker' --result-json /tmp/flask.1.results
-      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-flask-autopatch{010,011,012,10}-blinker' --result-json /tmp/flask.2.results
-      - run: tox -e '{py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.3.results
-      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-flask-autopatch{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.4.results
-      - run: tox -e '{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.5.results
-      - run: TOX_SKIP_DIST=False tox -e '{py27}-flask-autopatch{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.6.results
+      - *restore_cache_step
+      - run: tox -e 'flask_contrib-{py27,py34,py35,py36}-flask{010,011,012,10}-blinker' --result-json /tmp/flask.1.results
+      - run: TOX_SKIP_DIST=False tox -e 'flask_contrib_autopatch-{py27,py34,py35,py36}-flask{010,011,012,10}-blinker' --result-json /tmp/flask.2.results
+      - run: tox -e 'flask_cache_contrib-{py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.3.results
+      - run: TOX_SKIP_DIST=False tox -e 'flask_cache_contrib_autopatch-{py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.4.results
+      - run: tox -e 'flask_cache_contrib-{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.5.results
+      - run: TOX_SKIP_DIST=False tox -e 'flask_cache_contrib_autopatch-{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.6.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -403,48 +325,35 @@ jobs:
             - flask.4.results
             - flask.5.results
             - flask.6.results
-      - save_cache:
-          key: tox-cache-flask-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   gevent:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-gevent-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-gevent{11,12,13}' --result-json /tmp/gevent.1.results
-      - run: tox -e '{py27}-gevent{10}' --result-json /tmp/gevent.2.results
+      - *restore_cache_step
+      - run: tox -e 'gevent_contrib-{py27,py34,py35,py36}-gevent{11,12,13}' --result-json /tmp/gevent.1.results
+      - run: tox -e 'gevent_contrib-{py27}-gevent{10}' --result-json /tmp/gevent.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - gevent.1.results
             - gevent.2.results
-      - save_cache:
-          key: tox-cache-gevent-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   httplib:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-httplib-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-httplib' --result-json /tmp/httplib.results
+      - *restore_cache_step
+      - run: tox -e 'httplib_contrib-{py27,py34,py35,py36}' --result-json /tmp/httplib.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - httplib.results
-      - save_cache:
-          key: tox-cache-httplib-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   mysqlconnector:
     docker:
@@ -457,19 +366,14 @@ jobs:
             - MYSQL_DATABASE=test
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-mysqlconnector-{{ checksum "tox.ini" }}
+      - *restore_cache_step
       - run: tox -e 'wait' mysql
-      - run: tox -e '{py27,py34,py35,py36}-mysqlconnector{21}' --result-json /tmp/mysqlconnector.results
+      - run: tox -e 'mysql_contrib-{py27,py34,py35,py36}-mysqlconnector{21}' --result-json /tmp/mysqlconnector.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - mysqlconnector.results
-      - save_cache:
-          key: tox-cache-mysqlconnector-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   mysqlpython:
     docker:
@@ -482,19 +386,14 @@ jobs:
             - MYSQL_DATABASE=test
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-mysqlpython-{{ checksum "tox.ini" }}
+      - *restore_cache_step
       - run: tox -e 'wait' mysql
-      - run: tox -e '{py27,py34,py35,py36}-mysqlclient{13}' --result-json /tmp/mysqlpython.results
+      - run: tox -e 'mysqldb_contrib-{py27,py34,py35,py36}-mysqlclient{13}' --result-json /tmp/mysqlpython.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - mysqlpython.results
-      - save_cache:
-          key: tox-cache-mysqlpython-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   mysqldb:
     docker:
@@ -507,19 +406,14 @@ jobs:
             - MYSQL_DATABASE=test
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-mysqldb-{{ checksum "tox.ini" }}
+      - *restore_cache_step
       - run: tox -e 'wait' mysql
-      - run: tox -e '{py27}-mysqldb{12}' --result-json /tmp/mysqldb.results
+      - run: tox -e 'mysqldb_contrib-{py27}-mysqldb{12}' --result-json /tmp/mysqldb.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - mysqldb.results
-      - save_cache:
-          key: tox-cache-mysqldb-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   pymysql:
     docker:
@@ -532,19 +426,14 @@ jobs:
             - MYSQL_DATABASE=test
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-pymysql-{{ checksum "tox.ini" }}
+      - *restore_cache_step
       - run: tox -e 'wait' mysql
-      - run: tox -e '{py27,py34,py35,py36}-pymysql{07,08,09}' --result-json /tmp/pymysql.results
+      - run: tox -e 'pymysql_contrib-{py27,py34,py35,py36}-pymysql{07,08,09}' --result-json /tmp/pymysql.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - pymysql.results
-      - save_cache:
-          key: tox-cache-pymysql-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   pylibmc:
     docker:
@@ -552,18 +441,13 @@ jobs:
       - image: memcached:1.5-alpine
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-pylibmc-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-pylibmc{140,150}' --result-json /tmp/pylibmc.results
+      - *restore_cache_step
+      - run: tox -e 'pylibmc_contrib-{py27,py34,py35,py36}-pylibmc{140,150}' --result-json /tmp/pylibmc.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - pylibmc.results
-      - save_cache:
-          key: tox-cache-pylibmc-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   pymemcache:
     docker:
@@ -571,20 +455,15 @@ jobs:
       - image: memcached:1.5-alpine
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-pymemcache-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-pymemcache{130,140}' --result-json /tmp/pymemcache.1.results
-      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-pymemcache-autopatch{130,140}' --result-json /tmp/pymemcache.2.results
+      - *restore_cache_step
+      - run: tox -e 'pymemcache_contrib-{py27,py34,py35,py36}-pymemcache{130,140}' --result-json /tmp/pymemcache.1.results
+      - run: TOX_SKIP_DIST=False tox -e 'pymemcache_contrib_autopatch-{py27,py34,py35,py36}-pymemcache{130,140}' --result-json /tmp/pymemcache.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - pymemcache.1.results
             - pymemcache.2.results
-      - save_cache:
-          key: tox-cache-pymemcache-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   mongoengine:
     docker:
@@ -592,18 +471,13 @@ jobs:
       - image: mongo:3.6
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-mongoengine-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-mongoengine{015}' --result-json /tmp/mongoengine.results
+      - *restore_cache_step
+      - run: tox -e 'mongoengine_contrib-{py27,py34,py35,py36}-mongoengine{015}' --result-json /tmp/mongoengine.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - mongoengine.results
-      - save_cache:
-          key: tox-cache-mongoengine-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   pymongo:
     docker:
@@ -611,38 +485,28 @@ jobs:
       - image: mongo:3.6
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-pymongo-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-pymongo{30,31,32,33,34,36}-mongoengine{015}' --result-json /tmp/pymongo.results
+      - *restore_cache_step
+      - run: tox -e 'pymongo_contrib-{py27,py34,py35,py36}-pymongo{30,31,32,33,34,36}-mongoengine{015}' --result-json /tmp/pymongo.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - pymongo.results
-      - save_cache:
-          key: tox-cache-pymongo-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   pyramid:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-pyramid-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-pyramid{17,18,19}-webtest' --result-json /tmp/pyramid.1.results
-      - run: TOX_SKIP_DIST=False tox -e '{py27,py34,py35,py36}-pyramid-autopatch{17,18,19}-webtest' --result-json /tmp/pyramid.2.results
+      - *restore_cache_step
+      - run: tox -e 'pyramid_contrib-{py27,py34,py35,py36}-pyramid{17,18,19}-webtest' --result-json /tmp/pyramid.1.results
+      - run: TOX_SKIP_DIST=False tox -e 'pyramid_contrib_autopatch-{py27,py34,py35,py36}-pyramid{17,18,19}-webtest' --result-json /tmp/pyramid.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - pyramid.1.results
             - pyramid.2.results
-      - save_cache:
-          key: tox-cache-pyramid-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   requests:
     docker:
@@ -650,18 +514,13 @@ jobs:
       - *httpbin_local
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-requests-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-requests{208,209,210,211,212,213,219}' --result-json /tmp/requests.results
+      - *restore_cache_step
+      - run: tox -e 'requests_contrib-{py27,py34,py35,py36}-requests{208,209,210,211,212,213,219}' --result-json /tmp/requests.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - requests.results
-      - save_cache:
-          key: tox-cache-requests-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   sqlalchemy:
     docker:
@@ -679,19 +538,14 @@ jobs:
             - MYSQL_DATABASE=test
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-sqlalchemy-{{ checksum "tox.ini" }}
+      - *restore_cache_step
       - run: tox -e 'wait' postgres mysql
-      - run: tox -e '{py27,py34,py35,py36}-sqlalchemy{10,11,12}-psycopg2{27}-mysqlconnector{21}' --result-json /tmp/sqlalchemy.results
+      - run: tox -e 'sqlalchemy_contrib-{py27,py34,py35,py36}-sqlalchemy{10,11,12}-psycopg2{27}-mysqlconnector{21}' --result-json /tmp/sqlalchemy.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - sqlalchemy.results
-      - save_cache:
-          key: tox-cache-sqlalchemy-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   psycopg:
     docker:
@@ -703,19 +557,14 @@ jobs:
             - POSTGRES_DB=postgres
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-pycopg-{{ checksum "tox.ini" }}
+      - *restore_cache_step
       - run: tox -e 'wait' postgres
-      - run: tox -e '{py27,py34,py35,py36}-psycopg2{24,25,26,27}' --result-json /tmp/psycopg.results
+      - run: tox -e 'psycopg_contrib-{py27,py34,py35,py36}-psycopg2{24,25,26,27}' --result-json /tmp/psycopg.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - psycopg.results
-      - save_cache:
-          key: tox-cache-pycopg-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   aiobotocore:
     docker:
@@ -723,18 +572,13 @@ jobs:
       - image: palazzem/moto:1.0.1
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-aiobotocore-{{ checksum "tox.ini" }}
-      - run: tox -e '{py34,py35,py36}-aiobotocore{02,03,04}' --result-json /tmp/aiobotocore.results
+      - *restore_cache_step
+      - run: tox -e 'aiobotocore_contrib-{py34,py35,py36}-aiobotocore{02,03,04}' --result-json /tmp/aiobotocore.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - aiobotocore.results
-      - save_cache:
-          key: tox-cache-aiobotocore-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   aiopg:
     docker:
@@ -746,19 +590,14 @@ jobs:
             - POSTGRES_DB=postgres
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-aiopg-{{ checksum "tox.ini" }}
+      - *restore_cache_step
       - run: tox -e 'wait' postgres
-      - run: tox -e '{py34,py35,py36}-aiopg{012,015}' --result-json /tmp/aiopg.results
+      - run: tox -e 'aiopg_contrib-{py34,py35,py36}-aiopg{012,015}' --result-json /tmp/aiopg.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - aiopg.results
-      - save_cache:
-          key: tox-cache-aiopg-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   redis:
     docker:
@@ -766,54 +605,39 @@ jobs:
       - image: redis:3.2-alpine
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-redis-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-redis{26,27,28,29,210}' --result-json /tmp/redis.results
+      - *restore_cache_step
+      - run: tox -e 'redis_contrib-{py27,py34,py35,py36}-redis{26,27,28,29,210}' --result-json /tmp/redis.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - redis.results
-      - save_cache:
-          key: tox-cache-redis-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   sqlite3:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-sqlite3-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34,py35,py36}-sqlite3' --result-json /tmp/sqlite3.results
+      - *restore_cache_step
+      - run: tox -e 'sqlite3_contrib-{py27,py34,py35,py36}-sqlite3' --result-json /tmp/sqlite3.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - sqlite3.results
-      - save_cache:
-          key: tox-cache-sqlite3-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   msgpack:
     docker:
       - *test_runner
     steps:
       - checkout
-      - restore_cache:
-          keys:
-              - tox-cache-msgpack-{{ checksum "tox.ini" }}
-      - run: tox -e '{py27,py34}-msgpack{03,04,05}' --result-json /tmp/msgpack.results
+      - *restore_cache_step
+      - run: tox -e 'msgpack_contrib-{py27,py34}-msgpack{03,04,05}' --result-json /tmp/msgpack.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - msgpack.results
-      - save_cache:
-          key: tox-cache-msgpack-{{ checksum "tox.ini" }}
-          paths:
-            - .tox
+      - *save_cache_step
 
   deploy_dev:
     # build only the nightly package

--- a/tox.ini
+++ b/tox.ini
@@ -28,67 +28,59 @@ skipsdist={env:TOX_SKIP_DIST:False}
 envlist =
     flake8
     wait
-    {py27}-threading-futures{30,31,32}
-    {py34,py35,py36}-threading
-    {py27,py34}-boto
-    {py27,py34}-botocore
     {py27,py34,py35,py36}-tracer
     {py27,py34,py35,py36}-integration
     {py27,py34,py35,py36}-ddtracerun
+# Integrations environments
+    aiobotocore_contrib-{py34,py35,py36}-aiobotocore{02,03,04}
+    aiohttp_contrib-{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
+    aiohttp_contrib-{py34,py35,py36}-aiohttp{23}-aiohttp_jinja{015}-yarl10
+    aiopg_contrib-{py34,py35,py36}-aiopg{012,015}
+    asyncio_contrib-{py34,py35,py36}
+    boto_contrib-{py27,py34}-boto
+    botocore_contrib-{py27,py34}-botocore
+    bottle_contrib{,_autopatch}-{py27,py34,py35,py36}-bottle{11,12}-webtest
+    cassandra_contrib-{py27,py34,py35,py36}-cassandra{35,36,37,38,315}
+    celery_contrib-{py27,py34,py35,py36}-celery{31,40,41,42}-redis{210}
+    django_contrib{,_autopatch}-{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
+    django_contrib{,_autopatch}-{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
+    django_drf_contrib-{py27,py34,py35,py36}-django{111}-djangorestframework{34,37,38}
+    django_drf_contrib-{py34,py35,py36}-django{200}-djangorestframework{37,38}
+    elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63}
+    falcon_contrib{,_autopatch}-{py27,py34,py35,py36}-falcon{10,11,12,13,14}
+    flask_contrib{,_autopatch}-{py27,py34,py35,py36}-flask{010,011,012,10}-blinker
+    flask_cache_contrib{,_autopatch}-{py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker
+    flask_cache_contrib{,_autopatch}-{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker
+    futures_contrib-{py27}-futures{30,31,32}
+    futures_contrib-{py34,py35,py36}
+    gevent_contrib-{py27,py34,py35,py36}-gevent{11,12,13}
+# gevent 1.0 is not python 3 compatible
+    gevent_contrib-{py27}-gevent{10}
+    httplib_contrib-{py27,py34,py35,py36}
+    mongoengine_contrib-{py27,py34,py35,py36}-mongoengine{015}
+    msgpack_contrib-{py27,py34}-msgpack{03,04,05}
+    mysql_contrib-{py27,py34,py35,py36}-mysqlconnector{21}
+    mysqldb_contrib-{py27}-mysqldb{12}
+    mysqldb_contrib-{py27,py34,py35,py36}-mysqlclient{13}
+    psycopg_contrib-{py27,py34,py35,py36}-psycopg2{24,25,26,27}
+    pylibmc_contrib-{py27,py34,py35,py36}-pylibmc{140,150}
+    pylons_contrib-{py27}-pylons{096,097,010,10}
+    pymemcache_contrib{,_autopatch}-{py27,py34,py35,py36}-pymemcache{130,140}
+    pymongo_contrib-{py27,py34,py35,py36}-pymongo{30,31,32,33,34,36}-mongoengine{015}
+    pymysql_contrib-{py27,py34,py35,py36}-pymysql{07,08,09}
+    pyramid_contrib{,_autopatch}-{py27,py34,py35,py36}-pyramid{17,18,19}-webtest
+    redis_contrib-{py27,py34,py35,py36}-redis{26,27,28,29,210}
+    requests_contrib-{py27,py34,py35,py36}-requests{208,209,210,211,212,213,219}
+    sqlalchemy_contrib-{py27,py34,py35,py36}-sqlalchemy{10,11,12}-psycopg2{27}-mysqlconnector{21}
+    sqlite3_contrib-{py27,py34,py35,py36}-sqlite3
+    tornado_contrib-{py27,py34,py35,py36}-tornado{40,41,42,43,44,45}
+    tornado_contrib-{py27}-tornado{40,41,42,43,44,45}-futures{30,31,32}
+# Opentracer
     {py27,py34,py35,py36}-opentracer
     {py34,py35,py36}-opentracer_asyncio
     {py34,py35,py36}-opentracer_tornado-tornado{40,41,42,43,44}
     {py27}-opentracer_gevent-gevent{10}
     {py27,py34,py35,py36}-opentracer_gevent-gevent{11,12}
-    {py34,py35,py36}-asyncio
-    {py27}-pylons{096,097,010,10}
-    {py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
-    {py34,py35,py36}-aiohttp{23}-aiohttp_jinja{015}-yarl10
-    {py27,py34,py35,py36}-tornado{40,41,42,43,44,45}
-    {py27}-tornado{40,41,42,43,44,45}-futures{30,31,32}
-    {py27,py34,py35,py36}-bottle{11,12}-webtest
-    {py27,py34,py35,py36}-bottle-autopatch{11,12}-webtest
-    {py27,py34,py35,py36}-cassandra{35,36,37,38,315}
-    {py27,py34,py35,py36}-celery{31,40,41,42}-redis{210}
-    {py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63}
-    {py27,py34,py35,py36}-falcon{10,11,12,13,14}
-    {py27,py34,py35,py36}-falcon-autopatch{10,11,12,13,14}
-    {py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
-    {py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
-    {py27,py34,py35,py36}-django-autopatch{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
-    {py34,py35,py36}-django-autopatch{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
-    {py27,py34,py35,py36}-django-drf{111}-djangorestframework{34,37,38}
-    {py34,py35,py36}-django-drf{200}-djangorestframework{37}
-    {py27,py34,py35,py36}-flask{010,011,012,10}-blinker
-    {py27,py34,py35,py36}-flask-autopatch{010,011,012,10}-blinker
-    {py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker
-    {py27,py34,py35,py36}-flask-autopatch{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker
-# flask_cache 0.12 is not python 3 compatible
-    {py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker
-    {py27}-flask-autopatch{010,011}-flaskcache{012}-memcached-redis{210}-blinker
-    {py27,py34,py35,py36}-gevent{11,12,13}
-# gevent 1.0 is not python 3 compatible
-    {py27}-gevent{10}
-    {py27,py34,py35,py36}-httplib
-    {py27,py34,py35,py36}-mysqlconnector{21}
-    {py27}-mysqldb{12}
-    {py27,py34,py35,py36}-mysqlclient{13}
-    {py27,py34,py35,py36}-pymysql{07,08,09}
-    {py27,py34,py35,py36}-pylibmc{140,150}
-    {py27,py34,py35,py36}-pymongo{30,31,32,33,34,36}-mongoengine{015}
-    {py27,py34,py35,py36}-mongoengine{015}
-    {py27,py34,py35,py36}-pyramid{17,18,19}-webtest
-    {py27,py34,py35,py36}-pyramid-autopatch{17,18,19}-webtest
-    {py27,py34,py35,py36}-requests{208,209,210,211,212,213,219}
-    {py27,py34,py35,py36}-sqlalchemy{10,11,12}-psycopg2{27}-mysqlconnector{21}
-    {py27,py34,py35,py36}-psycopg2{24,25,26,27}
-    {py34,py35,py36}-aiobotocore{02,03,04}
-    {py34,py35,py36}-aiopg{012,015}
-    {py27,py34,py35,py36}-redis{26,27,28,29,210}
-    {py27,py34,py35,py36}-sqlite3
-    {py27,py34}-msgpack{03,04,05}
-    {py27,py34,py35,py36}-pymemcache{130,140}
-    {py27,py34,py35,py36}-pymemcache-autopatch{130,140}
 
 [testenv]
 basepython =
@@ -111,15 +103,11 @@ deps =
 # https://github.com/aio-libs/aiohttp/issues/2662
     yarl: yarl==0.18.0
     yarl10: yarl>=1.0,<1.1
-#   aiobotocore -> aiohttp -> multidict: our old dependency line is no compatible with recently released multidict 4.4.x
-#   watch this Issue and once fixed remove the following lines: https://github.com/aio-libs/aiohttp/issues/3277
-    py{35}-aiobotocore{02,03,04}: multidict>=4.3,<4.4
-    py{34,35}-aiohttp{12,13,20,21,22,23}: multidict>=4.3,<4.4
 # integrations
     aiobotocore04: aiobotocore>=0.4,<0.5
     aiobotocore03: aiobotocore>=0.3,<0.4
     aiobotocore02: aiobotocore>=0.2,<0.3
-    py{34}-aiobotocore{02,03,04}: typing
+    aiobotocore{02,03,04}-{py34}: typing
     aiopg012: aiopg>=0.12,<0.13
     aiopg015: aiopg>=0.15,<0.16
     aiopg: sqlalchemy
@@ -129,15 +117,6 @@ deps =
     aiohttp21: aiohttp>=2.1,<2.2
     aiohttp22: aiohttp>=2.2,<2.3
     aiohttp23: aiohttp>=2.3,<2.4
-    tornado40: tornado>=4.0,<4.1
-    tornado41: tornado>=4.1,<4.2
-    tornado42: tornado>=4.2,<4.3
-    tornado43: tornado>=4.3,<4.4
-    tornado44: tornado>=4.4,<4.5
-    tornado45: tornado>=4.5,<4.6
-    futures30: futures>=3.0,<3.1
-    futures31: futures>=3.1,<3.2
-    futures32: futures>=3.2,<3.3
     aiohttp_jinja012: aiohttp_jinja2>=0.12,<0.13
     aiohttp_jinja013: aiohttp_jinja2>=0.13,<0.14
     aiohttp_jinja015: aiohttp_jinja2>=0.15,<0.16
@@ -148,8 +127,6 @@ deps =
     botocore: moto<1.0
     bottle11: bottle>=0.11,<0.12
     bottle12: bottle>=0.12,<0.13
-    bottle-autopatch11: bottle>=0.11,<0.12
-    bottle-autopatch12: bottle>=0.12,<0.13
     cassandra35: cassandra-driver>=3.5,<3.6
     cassandra36: cassandra-driver>=3.6,<3.7
     cassandra37: cassandra-driver>=3.7,<3.8
@@ -160,6 +137,14 @@ deps =
     celery41: celery>=4.1,<4.2
     celery42: celery>=4.2,<4.3
     ddtracerun: redis
+    django18: django>=1.8,<1.9
+    django111: django>=1.11,<1.12
+    django200: django>=2.0,<2.1
+    djangopylibmc06: django-pylibmc>=0.6,<0.7
+    djangoredis45: django-redis>=4.5,<4.6
+    djangorestframework34: djangorestframework>=3.4,<3.5
+    djangorestframework37: djangorestframework>=3.7,<3.8
+    djangorestframework38: djangorestframework>=3.8,<3.9
     elasticsearch16: elasticsearch>=1.6,<1.7
     elasticsearch17: elasticsearch>=1.7,<1.8
     elasticsearch18: elasticsearch>=1.8,<1.9
@@ -175,49 +160,27 @@ deps =
     falcon12: falcon>=1.2,<1.3
     falcon13: falcon>=1.3,<1.4
     falcon14: falcon>=1.4,<1.5
-    falcon-autopatch10: falcon>=1.0,<1.1
-    falcon-autopatch11: falcon>=1.1,<1.2
-    falcon-autopatch12: falcon>=1.2,<1.3
-    falcon-autopatch13: falcon>=1.3,<1.4
-    falcon-autopatch14: falcon>=1.4,<1.5
-    django18: django>=1.8,<1.9
-    django111: django>=1.11,<1.12
-    django200: django>=2.0,<2.1
-    django-autopatch18: django>=1.8,<1.9
-    django-autopatch111: django>=1.11,<1.12
-    django-autopatch200: django>=2.0,<2.1
-    django-drf111: django>=1.11,<1.12
-    django-drf200: django>=2.0,<2.1
-    djangopylibmc06: django-pylibmc>=0.6,<0.7
-    djangoredis45: django-redis>=4.5,<4.6
-    djangorestframework34: djangorestframework>=3.4,<3.5
-    djangorestframework37: djangorestframework>=3.7,<3.8
-    djangorestframework38: djangorestframework>=3.8,<3.9
     flask010: flask>=0.10,<0.11
     flask011: flask>=0.11,<0.12
     flask012: flask>=0.12,<0.13
     flask10: flask>=1.0,<1.1
-    flask-autopatch010: flask>=0.10,<0.11
-    flask-autopatch011: flask>=0.11,<0.12
-    flask-autopatch012: flask>=0.12,<0.13
-    flask-autopatch10: flask>=1.0,<1.1
+    flaskcache012: flask_cache>=0.12,<0.13
+    flaskcache013: flask_cache>=0.13,<0.14
+    futures30: futures>=3.0,<3.1
+    futures31: futures>=3.1,<3.2
+    futures32: futures>=3.2,<3.3
     gevent10: gevent>=1.0,<1.1
     gevent11: gevent>=1.1,<1.2
     gevent12: gevent>=1.2,<1.3
     gevent13: gevent>=1.3,<1.4
-    flaskcache012: flask_cache>=0.12,<0.13
-    flaskcache013: flask_cache>=0.13,<0.14
     memcached: python-memcached
+    mongoengine015: mongoengine>=0.15<0.16
     msgpack03: msgpack-python>=0.3,<0.4
     msgpack04: msgpack-python>=0.4,<0.5
     msgpack05: msgpack-python>=0.5,<0.6
-    mongoengine015: mongoengine>=0.15<0.16
     mysqlconnector21: mysql-connector>=2.1,<2.2
     mysqldb12: mysql-python>=1.2,<1.3
     mysqlclient13: mysqlclient>=1.3,<1.4
-    pymysql07: pymysql>=0.7,<0.8
-    pymysql08: pymysql>=0.8,<0.9
-    pymysql09: pymysql>=0.9,<0.10
 # webob is required for Pylons < 1.0
     pylons096: pylons>=0.9.6,<0.9.7
     pylons096: webob<1.1
@@ -231,20 +194,18 @@ deps =
     pylibmc150: pylibmc>=1.5.0,<1.6.0
     pymemcache130: pymemcache>=1.3.0,<1.4.0
     pymemcache140: pymemcache>=1.4.0,<1.5.0
-    pymemcache-autopatch130: pymemcache>=1.3.0,<1.4.0
-    pymemcache-autopatch140: pymemcache>=1.4.0,<1.5.0
     pymongo30: pymongo>=3.0,<3.1
     pymongo31: pymongo>=3.1,<3.2
     pymongo32: pymongo>=3.2,<3.3
     pymongo33: pymongo>=3.3,<3.4
     pymongo34: pymongo>=3.4,<3.5
     pymongo36: pymongo>=3.6,<3.7
+    pymysql07: pymysql>=0.7,<0.8
+    pymysql08: pymysql>=0.8,<0.9
+    pymysql09: pymysql>=0.9,<0.10
     pyramid17: pyramid>=1.7,<1.8
     pyramid18: pyramid>=1.8,<1.9
     pyramid19: pyramid>=1.9,<1.10
-    pyramid-autopatch17: pyramid>=1.7,<1.8
-    pyramid-autopatch18: pyramid>=1.8,<1.9
-    pyramid-autopatch19: pyramid>=1.9,<1.10
     psycopg224: psycopg2>=2.4,<2.5
     psycopg225: psycopg2>=2.5,<2.6
     psycopg226: psycopg2>=2.6,<2.7
@@ -275,6 +236,12 @@ deps =
     sqlalchemy10: sqlalchemy>=1.0,<1.1
     sqlalchemy11: sqlalchemy>=1.1,<1.2
     sqlalchemy12: sqlalchemy>=1.2,<1.3
+    tornado40: tornado>=4.0,<4.1
+    tornado41: tornado>=4.1,<4.2
+    tornado42: tornado>=4.2,<4.3
+    tornado43: tornado>=4.3,<4.4
+    tornado44: tornado>=4.4,<4.5
+    tornado45: tornado>=4.5,<4.6
     webtest: WebTest
 
 # pass along test env variables
@@ -290,53 +257,53 @@ commands =
     opentracer_gevent: pytest {posargs} tests/opentracer/test_tracer_gevent.py
 # integration tests
     integration: nosetests {posargs} tests/test_integration.py
-    asyncio: nosetests {posargs} tests/contrib/asyncio
-    aiohttp{12,13,20,21,22,23}-aiohttp_jinja{012,013,015}: nosetests {posargs} tests/contrib/aiohttp
-    tornado{40,41,42,43,44,45}: nosetests {posargs} tests/contrib/tornado
+# Contribs
+    aiobotocore_contrib-{py34}: nosetests {posargs} --exclude=".*(test_35).*" tests/contrib/aiobotocore
+    aiobotocore_contrib-{py35,py36}: nosetests {posargs} tests/contrib/aiobotocore
+    aiopg_contrib-{py34}: nosetests {posargs} --exclude=".*(test_aiopg_35).*" tests/contrib/aiopg
+    aiopg_contrib-{py35,py36}: nosetests {posargs} tests/contrib/aiopg
+    aiohttp_contrib: nosetests {posargs} tests/contrib/aiohttp
+    asyncio_contrib: nosetests {posargs} tests/contrib/asyncio
+    boto_contrib: nosetests {posargs} tests/contrib/boto
+    botocore_contrib: nosetests {posargs} tests/contrib/botocore
+    bottle_contrib: nosetests {posargs} tests/contrib/bottle/test.py
+    bottle_contrib_autopatch: ddtrace-run nosetests {posargs} tests/contrib/bottle/test_autopatch.py
+    cassandra_contrib: nosetests {posargs} tests/contrib/cassandra
+    celery_contrib: nosetests {posargs} tests/contrib/celery
+    django_contrib: python tests/contrib/django/runtests.py {posargs}
+    django_contrib_autopatch: ddtrace-run python tests/contrib/django/runtests.py {posargs}
+    django_drf_contrib: python tests/contrib/djangorestframework/runtests.py {posargs}
+    elasticsearch_contrib: nosetests {posargs} tests/contrib/elasticsearch
+    falcon_contrib: nosetests {posargs} tests/contrib/falcon/test_middleware.py tests/contrib/falcon/test_distributed_tracing.py
+    falcon_contrib_autopatch: ddtrace-run nosetests {posargs} tests/contrib/falcon/test_autopatch.py
+    flask_contrib: nosetests {posargs} tests/contrib/flask
+    flask_contrib_autopatch: ddtrace-run nosetests {posargs} tests/contrib/flask_autopatch
+    flask_cache_contrib: nosetests {posargs} tests/contrib/flask_cache
+    futures_contrib: nosetests {posargs} tests/contrib/futures
+    gevent_contrib: nosetests {posargs} tests/contrib/gevent
+    httplib_contrib: nosetests {posargs} tests/contrib/httplib
+    mongoengine_contrib: nosetests {posargs} tests/contrib/mongoengine
+    msgpack_contrib: nosetests {posargs} tests/test_encoders.py
+    mysql_contrib: nosetests {posargs} tests/contrib/mysql
+    mysqldb_contrib: nosetests {posargs} tests/contrib/mysqldb
+    psycopg_contrib: nosetests {posargs} tests/contrib/psycopg
+    pylibmc_contrib: nosetests {posargs} tests/contrib/pylibmc
+    pylons_contrib: nosetests {posargs} tests/contrib/pylons
+    pymemcache_contrib: nosetests {posargs} --exclude="test_autopatch.py" tests/contrib/pymemcache/
+    pymemcache_contrib_autopatch: ddtrace-run nosetests {posargs} tests/contrib/pymemcache/test_autopatch.py
+    pymongo_contrib: nosetests {posargs} tests/contrib/pymongo
+    pymysql_contrib: nosetests {posargs} tests/contrib/pymysql
+    pyramid_contrib: nosetests {posargs} tests/contrib/pyramid/test_pyramid.py
+    pyramid_contrib_autopatch: ddtrace-run nosetests {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
+    redis_contrib: nosetests {posargs} tests/contrib/redis
+    requests: nosetests {posargs} tests/contrib/requests
+    sqlalchemy_contrib: nosetests {posargs} tests/contrib/sqlalchemy
+    sqlite3_contrib: nosetests {posargs} tests/contrib/sqlite3
+    tornado_contrib: nosetests {posargs} tests/contrib/tornado
 # run subsets of the tests for particular library versions
-    {py27}-pylons{096,097,010,10}: nosetests {posargs} tests/contrib/pylons
-    {py27,py34}-boto: nosetests {posargs} tests/contrib/boto
-    {py27,py34}-botocore: nosetests {posargs} tests/contrib/botocore
-    py{34}-aiobotocore{02,03,04}: nosetests {posargs} --exclude=".*(test_35).*" tests/contrib/aiobotocore
-    py{35,36}-aiobotocore{02,03,04}: nosetests {posargs} tests/contrib/aiobotocore
-    bottle{11,12}: nosetests {posargs} tests/contrib/bottle/test.py
-    bottle-autopatch{11,12}: ddtrace-run nosetests {posargs} tests/contrib/bottle/test_autopatch.py
-    cassandra{35,36,37,38,315}: nosetests {posargs} tests/contrib/cassandra
-    celery{31,40,41,42}: nosetests {posargs} tests/contrib/celery
-    elasticsearch{16,17,18,23,24,25,51,52,53,54,63}: nosetests {posargs} tests/contrib/elasticsearch
-    django{18,111,200}: python tests/contrib/django/runtests.py {posargs}
-    django-autopatch{18,111,200}: ddtrace-run python tests/contrib/django/runtests.py {posargs}
-    django-drf{111,200}: python tests/contrib/djangorestframework/runtests.py {posargs}
-    flaskcache{012,013}: nosetests {posargs} tests/contrib/flask_cache
-    flask{010,011,012,10}: nosetests {posargs} tests/contrib/flask
-    flask-autopatch{010,011,012,10}: ddtrace-run nosetests {posargs} tests/contrib/flask_autopatch
-    falcon{10,11,12,13,14}: nosetests {posargs} tests/contrib/falcon/test_middleware.py tests/contrib/falcon/test_distributed_tracing.py
-    falcon-autopatch{10,11,12,13,14}: ddtrace-run nosetests {posargs} tests/contrib/falcon/test_autopatch.py
-    gevent{11,12,13}: nosetests {posargs} tests/contrib/gevent
-    gevent{10}: nosetests {posargs} tests/contrib/gevent
-    httplib: nosetests {posargs} tests/contrib/httplib
-    mysqlconnector21: nosetests {posargs} tests/contrib/mysql
-    mysqldb{12}: nosetests {posargs} tests/contrib/mysqldb
-    mysqlclient{13}: nosetests {posargs} tests/contrib/mysqldb
-    pymysql{07,08,09}: nosetests {posargs} tests/contrib/pymysql
-    pylibmc{140,150}: nosetests {posargs} tests/contrib/pylibmc
-    pymongo{30,31,32,33,34,36}: nosetests {posargs} tests/contrib/pymongo
-    pyramid{17,18,19}: nosetests {posargs} tests/contrib/pyramid/test_pyramid.py
-    pyramid-autopatch{17,18,19}: ddtrace-run nosetests {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
-    mongoengine{015}: nosetests {posargs} tests/contrib/mongoengine
-    psycopg2{24,25,26,27}: nosetests {posargs} tests/contrib/psycopg
-    py{34}-aiopg{012,015}: nosetests {posargs} --exclude=".*(test_aiopg_35).*" tests/contrib/aiopg
-    py{35,36}-aiopg{012,015}: nosetests {posargs} tests/contrib/aiopg
-    redis{26,27,28,29,210}: nosetests {posargs} tests/contrib/redis
-    sqlite3: nosetests {posargs} tests/contrib/sqlite3
-    requests{200,208,209,210,211,212,213,219}: nosetests {posargs} tests/contrib/requests
-    sqlalchemy{10,11,12}: nosetests {posargs} tests/contrib/sqlalchemy
-    threading: nosetests {posargs} tests/contrib/futures
     ddtracerun: nosetests {posargs} tests/commands/test_runner.py
-    msgpack{03,04,05}: nosetests {posargs} tests/test_encoders.py
     test_utils: nosetests {posargs} tests/contrib/test_utils.py
-    pymemcache{130,140}: nosetests {posargs} --exclude="test_autopatch.py" tests/contrib/pymemcache/
-    pymemcache-autopatch{130,140}: ddtrace-run nosetests {posargs} tests/contrib/pymemcache/test_autopatch.py
+
 
 setenv =
     DJANGO_SETTINGS_MODULE = app.settings
@@ -360,65 +327,64 @@ basepython=python2
 [falcon_autopatch]
 setenv =
     DATADOG_SERVICE_NAME=my-falcon
-
-[testenv:py27-falcon-autopatch10]
+[testenv:falcon_contrib_autopatch-py27-falcon10]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py27-falcon-autopatch11]
+[testenv:falcon_contrib_autopatch-py27-falcon11]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py27-falcon-autopatch12]
+[testenv:falcon_contrib_autopatch-py27-falcon12]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py27-falcon-autopatch13]
+[testenv:falcon_contrib_autopatch-py27-falcon13]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py27-falcon-autopatch14]
+[testenv:falcon_contrib_autopatch-py27-falcon14]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py34-falcon-autopatch10]
+[testenv:falcon_contrib_autopatch-py34-falcon10]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py34-falcon-autopatch11]
+[testenv:falcon_contrib_autopatch-py34-falcon11]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py34-falcon-autopatch12]
+[testenv:falcon_contrib_autopatch-py34-falcon12]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py34-falcon-autopatch13]
+[testenv:falcon_contrib_autopatch-py34-falcon13]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py34-falcon-autopatch14]
+[testenv:falcon_contrib_autopatch-py34-falcon14]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py35-falcon-autopatch10]
+[testenv:falcon_contrib_autopatch-py35-falcon10]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py35-falcon-autopatch11]
+[testenv:falcon_contrib_autopatch-py35-falcon11]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py35-falcon-autopatch12]
+[testenv:falcon_contrib_autopatch-py35-falcon12]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py35-falcon-autopatch13]
+[testenv:falcon_contrib_autopatch-py35-falcon13]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py35-falcon-autopatch14]
+[testenv:falcon_contrib_autopatch-py35-falcon14]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py36-falcon-autopatch10]
+[testenv:falcon_contrib_autopatch-py36-falcon10]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py36-falcon-autopatch11]
+[testenv:falcon_contrib_autopatch-py36-falcon11]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py36-falcon-autopatch12]
+[testenv:falcon_contrib_autopatch-py36-falcon12]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py36-falcon-autopatch13]
+[testenv:falcon_contrib_autopatch-py36-falcon13]
 setenv =
     {[falcon_autopatch]setenv}
-[testenv:py36-falcon-autopatch14]
+[testenv:falcon_contrib_autopatch-py36-falcon14]
 setenv =
     {[falcon_autopatch]setenv}
 
@@ -427,240 +393,165 @@ setenv =
 setenv =
     DATADOG_SERVICE_NAME = foobar
     DATADOG_PYRAMID_DISTRIBUTED_TRACING = True
-
-[testenv:py27-pyramid-autopatch17-webtest]
+[testenv:pyramid_contrib_autopatch-py27-pyramid17-webtest]
 setenv =
     {[pyramid_autopatch]setenv}
 
-[testenv:py27-pyramid-autopatch18-webtest]
+[testenv:pyramid_contrib_autopatch-py27-pyramid18-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:pyramid_contrib_autopatch-py27-pyramid19-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:pyramid_contrib_autopatch-py34-pyramid17-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:pyramid_contrib_autopatch-py34-pyramid18-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:pyramid_contrib_autopatch-py34-pyramid19-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:pyramid_contrib_autopatch-py35-pyramid17-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:pyramid_contrib_autopatch-py35-pyramid18-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:pyramid_contrib_autopatch-py35-pyramid19-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:pyramid_contrib_autopatch-py36-pyramid17-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:pyramid_contrib_autopatch-py36-pyramid18-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:pyramid_contrib_autopatch-py36-pyramid19-webtest]
 setenv =
     {[pyramid_autopatch]setenv}
 
-[testenv:py27-pyramid-autopatch19-webtest]
-setenv =
-    {[pyramid_autopatch]setenv}
-
-[testenv:py34-pyramid-autopatch17-webtest]
-setenv =
-    {[pyramid_autopatch]setenv}
-
-[testenv:py34-pyramid-autopatch18-webtest]
-setenv =
-    {[pyramid_autopatch]setenv}
-
-[testenv:py34-pyramid-autopatch19-webtest]
-setenv =
-    {[pyramid_autopatch]setenv}
-
-[testenv:py35-pyramid-autopatch17-webtest]
-setenv =
-    {[pyramid_autopatch]setenv}
-
-[testenv:py35-pyramid-autopatch18-webtest]
-setenv =
-    {[pyramid_autopatch]setenv}
-
-[testenv:py35-pyramid-autopatch19-webtest]
-setenv =
-    {[pyramid_autopatch]setenv}
-
-[testenv:py36-pyramid-autopatch17-webtest]
-setenv =
-    {[pyramid_autopatch]setenv}
-
-[testenv:py36-pyramid-autopatch18-webtest]
-setenv =
-    {[pyramid_autopatch]setenv}
-
-[testenv:py36-pyramid-autopatch19-webtest]
-setenv =
-    {[pyramid_autopatch]setenv}
-
-
-[django_autopatch]
-setenv =
-    DATADOG_ENV = test
-    DJANGO_SETTINGS_MODULE = app.settings_untraced
-
-[testenv:py27-django-autopatch18-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-
-[testenv:py27-django-autopatch19-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py27-django-autopatch110-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py27-django-autopatch111-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py34-django-autopatch18-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py34-django-autopatch19-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py34-django-autopatch110-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py34-django-autopatch111-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py34-django-autopatch200-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py35-django-autopatch18-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py35-django-autopatch19-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py35-django-autopatch110-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py35-django-autopatch111-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py35-django-autopatch200-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py36-django-autopatch18-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py36-django-autopatch19-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py36-django-autopatch110-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py36-django-autopatch111-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
-[testenv:py36-django-autopatch200-djangopylibmc06-djangoredis45-pylibmc-redis-memcached]
-setenv =
-    {[django_autopatch]setenv}
 
 [flask_autopatch]
 setenv =
     DATADOG_SERVICE_NAME = test.flask.service
+[testenv:flask_contrib_autopatch-py27-flask010-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py27-flask011-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py27-flask012-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py27-flask10-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py34-flask010-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py34-flask011-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py34-flask012-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py34-flask10-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py35-flask010-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py35-flask011-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py35-flask012-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py35-flask10-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py36-flask010-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py36-flask011-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py36-flask012-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py36-flask10-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py27-flask010-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py27-flask011-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py27-flask012-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py34-flask010-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py34-flask011-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py34-flask012-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py35-flask010-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py35-flask011-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py35-flask012-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py36-flask010-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py36-flask011-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py36-flask012-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py27-flask010-flaskcache012-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py27-flask011-flaskcache012-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
 
-[testenv:py27-flask-autopatch010-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py27-flask-autopatch011-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py27-flask-autopatch012-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py27-flask-autopatch10-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py34-flask-autopatch010-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py34-flask-autopatch011-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py34-flask-autopatch012-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py34-flask-autopatch10-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py35-flask-autopatch010-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py35-flask-autopatch011-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py35-flask-autopatch012-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py35-flask-autopatch10-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py36-flask-autopatch010-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py36-flask-autopatch011-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py36-flask-autopatch012-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py36-flask-autopatch10-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py27-flask-autopatch010-flaskcache013-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py27-flask-autopatch011-flaskcache013-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py27-flask-autopatch012-flaskcache013-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py34-flask-autopatch010-flaskcache013-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py34-flask-autopatch011-flaskcache013-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py34-flask-autopatch012-flaskcache013-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py35-flask-autopatch010-flaskcache013-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py35-flask-autopatch011-flaskcache013-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py35-flask-autopatch012-flaskcache013-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py36-flask-autopatch010-flaskcache013-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py36-flask-autopatch011-flaskcache013-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py36-flask-autopatch012-flaskcache013-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py27-flask-autopatch010-flaskcache012-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
-[testenv:py27-flask-autopatch011-flaskcache012-memcached-redis210-blinker]
-setenv =
-    {[flask_autopatch]setenv}
 
 [bottle_autopatch]
 setenv =
     DATADOG_SERVICE_NAME = bottle-app
-[testenv:py27-bottle-autopatch11-webtest]
+[testenv:bottle_contrib_autopatch-py27-bottle11-webtest]
 setenv =
     {[bottle_autopatch]setenv}
-[testenv:py34-bottle-autopatch11-webtest]
+[testenv:bottle_contrib_autopatch-py34-bottle11-webtest]
 setenv =
     {[bottle_autopatch]setenv}
-[testenv:py35-bottle-autopatch11-webtest]
+[testenv:bottle_contrib_autopatch-py35-bottle11-webtest]
 setenv =
     {[bottle_autopatch]setenv}
-[testenv:py36-bottle-autopatch11-webtest]
+[testenv:bottle_contrib_autopatch-py36-bottle11-webtest]
 setenv =
     {[bottle_autopatch]setenv}
-[testenv:py27-bottle-autopatch12-webtest]
+[testenv:bottle_contrib_autopatch-py27-bottle12-webtest]
 setenv =
     {[bottle_autopatch]setenv}
-[testenv:py34-bottle-autopatch12-webtest]
+[testenv:bottle_contrib_autopatch-py34-bottle12-webtest]
 setenv =
     {[bottle_autopatch]setenv}
-[testenv:py35-bottle-autopatch12-webtest]
+[testenv:bottle_contrib_autopatch-py35-bottle12-webtest]
 setenv =
     {[bottle_autopatch]setenv}
-[testenv:py36-bottle-autopatch12-webtest]
+[testenv:bottle_contrib_autopatch-py36-bottle12-webtest]
 setenv =
     {[bottle_autopatch]setenv}
 


### PR DESCRIPTION
- We defined specific commands depending on the real command and not on
the dependency graph
- We removed django testenv special configurations that were no longer
used after we added redis{210} in place of redis to the dependency list
- We sorted alphabetically the various envs
- We do not rely anymore on checksum of tox.ini to invalidate cache