### PR TITLE
[docs] Clarify debug mode

### DIFF
--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -2,6 +2,10 @@
 The Django integration will trace users requests, template renderers, database and cache
 calls.
 
+**Note:** by default the tracer is **disabled** (will not send spans) when
+``Debug=True``. This can be overridden by explicitly enabling the tracer with
+``DATADOG_TRACE['ENABLED'] = True``, as described below.
+
 To enable the Django integration, add the application to your installed
 apps, as follows::
 

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -407,9 +407,6 @@ Pass along command-line arguments as your program would normally expect them::
 
 $ ddtrace-run gunicorn myapp.wsgi:application --max-requests 1000 --statsd-host localhost:8125
 
-*As long as your application isn't running in* ``DEBUG`` *mode, this should be
-enough to see your application traces in Datadog.*
-
 If you're running in a Kubernetes cluster and still don't see your traces, make
 sure your application has a route to the tracing Agent. An easy way to test
 this is with a::


### PR DESCRIPTION
We had a line in our documentation with regard to the tracer being disabled in "`DEBUG`" mode. However this only applies to the Django integration.