### PR TITLE
Fix "does not provide the extra opentracing"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,10 +60,10 @@ setup(
         "wrapt",
         "msgpack-python",
     ],
-    extra_requires={
+    extras_require={
         # users can include opentracing by having:
         # install_requires=["ddtrace[opentracing]", ...]
-        "opentracing": ["opentracing"],
+        "opentracing": ["opentracing>=2.0.0"],
     },
     # plugin tox
     tests_require=['tox', 'flake8'],


### PR DESCRIPTION
As mentioned in #611:

```sh
> pip install 'ddtrace[opentracing] == 0.14.0'
Collecting ddtrace[opentracing]==0.14.0
  ddtrace 0.14.0 does not provide the extra 'opentracing'
Collecting msgpack-python (from ddtrace[opentracing]==0.14.0)
Collecting wrapt (from ddtrace[opentracing]==0.14.0)
Installing collected packages: msgpack-python, wrapt, ddtrace
Successfully installed ddtrace-0.14.0 msgpack-python-0.5.6 wrapt-1.10.11
```

notably:
```
  ddtrace 0.14.0 does not provide the extra 'opentracing'
```

This was due to a typo in setup.py.

This PR also explicitly defines the supported `opentracing` version.

Should fix #611.