### PR TITLE
[docs] Add priority sampling to ddtrace-run usage

### DIFF
--- a/ddtrace/commands/ddtrace_run.py
+++ b/ddtrace/commands/ddtrace_run.py
@@ -30,6 +30,7 @@ Available environment variables:
                            This value is passed through when setting up middleware for web framework integrations.
                            (e.g. pylons, flask, django)
                            For tracing without a web integration, prefer setting the service name in code.
+    DATADOG_PRIORITY_SAMPLING=true|false : (default: false): enables Priority Sampling.
 """ # noqa
 
 def _ddtrace_root():


### PR DESCRIPTION
This fixes the discrepancy between: 
https://github.com/DataDog/dd-trace-py/blob/57e99540f3b330dd0fd5bbfdb0269c740fa75e26/ddtrace/commands/ddtrace_run.py#L16-L32

and

https://github.com/DataDog/dd-trace-py/blame/master/docs/advanced_usage.rst#L374-L395

We should consider a better way of ensuring these stay synchronized (or if we even need to keep them separated).