### PR TITLE
[core] add Tracer API to retrieve the root Span

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -84,6 +84,12 @@ class Context(object):
             new_ctx._current_span = self._current_span
             return new_ctx
 
+    def get_current_root_span(self):
+        """
+        Return the root span of the context or None if it does not exist.
+        """
+        return self._trace[0] if len(self._trace) > 0 else None
+
     def get_current_span(self):
         """
         Return the last active span that corresponds to the last inserted

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -285,6 +285,9 @@ class Tracer(object):
             span_type=span_type,
         )
 
+    def current_root_span(self):
+        return self.get_call_context().get_current_root_span()
+
     def current_span(self):
         """
         Return the active span for the current call context or ``None``

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -286,6 +286,18 @@ class Tracer(object):
         )
 
     def current_root_span(self):
+        """Returns the root span of the current context.
+
+        This is useful for attaching information related to the trace as a
+        whole without needing to add to child spans.
+
+        Usage is simple, for example::
+
+            # get the root span
+            root_span = tracer.current_root_span()
+            # set the host just once on the root span
+            root_span.set_tag('host', '127.0.0.1')
+        """
         return self.get_call_context().get_current_root_span()
 
     def current_span(self):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -53,6 +53,18 @@ class TestTracingContext(TestCase):
         ctx.add_span(span)
         eq_(span, ctx.get_current_span())
 
+    def test_current_root_span_none(self):
+        # it should return none when there is no root span
+        ctx = Context()
+        eq_(None, ctx.get_current_root_span())
+
+    def test_current_root_span(self):
+        # it should return the current active root span
+        ctx = Context()
+        span = Span(tracer=None, name='fake_span')
+        ctx.add_span(span)
+        eq_(span, ctx.get_current_root_span())
+
     def test_close_span(self):
         # it should keep track of closed spans, moving
         # the current active to it's parent


### PR DESCRIPTION
## Overview

This new tracer API method provides access to the root span in a given context. This is useful for setting tags on the root span which provide general information about the trace instead of having to attach tags on each child span.


## Usage

```python
# get the root span
root_span = tracer.current_root_span()
# the host of the trace doesn't need to be set on each span
root_span.set_tag('host', '127.0.0.1')
```

