### PR TITLE
Fix minimum Django version for user.is_authenticated property

### DIFF
--- a/ddtrace/contrib/django/compat.py
+++ b/ddtrace/contrib/django/compat.py
@@ -5,7 +5,7 @@ if django.VERSION >= (1, 10, 1):
     def user_is_authenticated(user):
         # Explicit comparision due to the following bug
         # https://code.djangoproject.com/ticket/26988
-        return user.is_authenticated == True
+        return user.is_authenticated == True  # noqa E712
 else:
     def user_is_authenticated(user):
         return user.is_authenticated()

--- a/ddtrace/contrib/django/compat.py
+++ b/ddtrace/contrib/django/compat.py
@@ -1,9 +1,11 @@
 import django
 
 
-if django.VERSION >= (1, 10):
+if django.VERSION >= (1, 10, 1):
     def user_is_authenticated(user):
-        return user.is_authenticated
+        # Explicit comparision due to the following bug
+        # https://code.djangoproject.com/ticket/26988
+        return user.is_authenticated == True
 else:
     def user_is_authenticated(user):
         return user.is_authenticated()

--- a/ddtrace/contrib/django/compat.py
+++ b/ddtrace/contrib/django/compat.py
@@ -1,7 +1,7 @@
 import django
 
 
-if django.VERSION >= (2,):
+if django.VERSION >= (1, 10):
     def user_is_authenticated(user):
         return user.is_authenticated
 else:


### PR DESCRIPTION
We are running on Django 1.11 and we see a lots of deprecation warning although there is no reason for that, as it's been a property since [Django 1.10](https://docs.djangoproject.com/en/1.10/ref/contrib/auth/#django.contrib.auth.models.User.is_authenticated).

The amount of warnings coming from dd-trace is making it difficult for us to see the other actual warnings, so it would be great if they could be silenced, that would help us tackle the Django upgrade more easily.