### PR TITLE
[elasticsearch] Make constant organization consistent with other integrations

### DIFF
--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -2,17 +2,12 @@ import elasticsearch
 import wrapt
 from elasticsearch.exceptions import TransportError
 
-from . import metadata
 from .quantize import quantize
 
-from ...utils.wrappers import unwrap
 from ...compat import urlencode
+from ...ext import elasticsearch as elasticsearchx, http, AppTypes
 from ...pin import Pin
-from ...ext import http
-
-
-DEFAULT_SERVICE = 'elasticsearch'
-SPAN_TYPE = 'elasticsearch'
+from ...utils.wrappers import unwrap
 
 
 # NB: We are patching the default elasticsearch.transport module
@@ -22,7 +17,7 @@ def patch():
         return
     setattr(elasticsearch, '_datadog_patch', True)
     wrapt.wrap_function_wrapper('elasticsearch.transport', 'Transport.perform_request', _perform_request)
-    Pin(service=DEFAULT_SERVICE, app="elasticsearch", app_type="db").onto(elasticsearch.transport.Transport)
+    Pin(service=elasticsearchx.SERVICE, app=elasticsearchx.APP, app_type=AppTypes.db).onto(elasticsearch.transport.Transport)
 
 
 def unpatch():
@@ -45,12 +40,12 @@ def _perform_request(func, instance, args, kwargs):
         body = kwargs.get('body')
 
         span.service = pin.service
-        span.span_type = SPAN_TYPE
-        span.set_tag(metadata.METHOD, method)
-        span.set_tag(metadata.URL, url)
-        span.set_tag(metadata.PARAMS, urlencode(params))
+        span.span_type = elasticsearchx.TYPE
+        span.set_tag(elasticsearchx.METHOD, method)
+        span.set_tag(elasticsearchx.URL, url)
+        span.set_tag(elasticsearchx.PARAMS, urlencode(params))
         if method == "GET":
-            span.set_tag(metadata.BODY, instance.serializer.dumps(body))
+            span.set_tag(elasticsearchx.BODY, instance.serializer.dumps(body))
         status = None
 
         span = quantize(span)
@@ -73,7 +68,7 @@ def _perform_request(func, instance, args, kwargs):
 
             took = data.get("took")
             if took:
-                span.set_metric(metadata.TOOK, int(took))
+                span.set_metric(elasticsearchx.TOOK, int(took))
         except Exception:
             pass
 

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -17,7 +17,11 @@ def patch():
         return
     setattr(elasticsearch, '_datadog_patch', True)
     wrapt.wrap_function_wrapper('elasticsearch.transport', 'Transport.perform_request', _perform_request)
-    Pin(service=elasticsearchx.SERVICE, app=elasticsearchx.APP, app_type=AppTypes.db).onto(elasticsearch.transport.Transport)
+    Pin(
+        service=elasticsearchx.SERVICE,
+        app=elasticsearchx.APP,
+        app_type=AppTypes.db
+    ).onto(elasticsearch.transport.Transport)
 
 
 def unpatch():

--- a/ddtrace/contrib/elasticsearch/quantize.py
+++ b/ddtrace/contrib/elasticsearch/quantize.py
@@ -1,5 +1,6 @@
 import re
-from . import metadata
+
+from ...ext import elasticsearch as metadata
 
 # Replace any ID
 ID_REGEXP = re.compile(r'/([0-9]+)([/\?]|$)')

--- a/ddtrace/contrib/elasticsearch/transport.py
+++ b/ddtrace/contrib/elasticsearch/transport.py
@@ -1,12 +1,11 @@
 from elasticsearch import Transport
 from elasticsearch.exceptions import TransportError
 
-from . import metadata
 from .quantize import quantize
 
 from ...utils.deprecation import deprecated
 from ...compat import urlencode
-from ...ext import AppTypes, http
+from ...ext import AppTypes, http, elasticsearch as metadata
 
 DEFAULT_SERVICE = 'elasticsearch'
 SPAN_TYPE = 'elasticsearch'

--- a/ddtrace/ext/elasticsearch.py
+++ b/ddtrace/ext/elasticsearch.py
@@ -1,3 +1,8 @@
+TYPE = 'elasticsearch'
+SERVICE = 'elasticsearch'
+APP = 'elasticsearch'
+
+# standard tags
 URL = 'elasticsearch.url'
 METHOD = 'elasticsearch.method'
 TOOK = 'elasticsearch.took'

--- a/tests/contrib/elasticsearch/test.py
+++ b/tests/contrib/elasticsearch/test.py
@@ -9,7 +9,7 @@ from nose.tools import eq_
 # project
 from ddtrace import Pin
 from ddtrace.ext import http
-from ddtrace.contrib.elasticsearch import get_traced_transport, metadata
+from ddtrace.contrib.elasticsearch import get_traced_transport
 from ddtrace.contrib.elasticsearch.patch import patch, unpatch
 
 # testing
@@ -64,8 +64,8 @@ class ElasticsearchTest(unittest.TestCase):
         eq_(span.name, "elasticsearch.query")
         eq_(span.span_type, "elasticsearch")
         eq_(span.error, 0)
-        eq_(span.get_tag(metadata.METHOD), "PUT")
-        eq_(span.get_tag(metadata.URL), "/%s" % self.ES_INDEX)
+        eq_(span.get_tag('elasticsearch.method'), "PUT")
+        eq_(span.get_tag('elasticsearch.url'), "/%s" % self.ES_INDEX)
         eq_(span.resource, "PUT /%s" % self.ES_INDEX)
 
         # Put data
@@ -79,8 +79,8 @@ class ElasticsearchTest(unittest.TestCase):
         eq_(len(spans), 3)
         span = spans[0]
         eq_(span.error, 0)
-        eq_(span.get_tag(metadata.METHOD), "PUT")
-        eq_(span.get_tag(metadata.URL), "/%s/%s/%s" % (self.ES_INDEX, self.ES_TYPE, 10))
+        eq_(span.get_tag('elasticsearch.method'), "PUT")
+        eq_(span.get_tag('elasticsearch.url'), "/%s/%s/%s" % (self.ES_INDEX, self.ES_TYPE, 10))
         eq_(span.resource, "PUT /%s/%s/?" % (self.ES_INDEX, self.ES_TYPE))
 
         # Make the data available
@@ -91,8 +91,8 @@ class ElasticsearchTest(unittest.TestCase):
         eq_(len(spans), 1)
         span = spans[0]
         eq_(span.resource, "POST /%s/_refresh" % self.ES_INDEX)
-        eq_(span.get_tag(metadata.METHOD), "POST")
-        eq_(span.get_tag(metadata.URL), "/%s/_refresh" % self.ES_INDEX)
+        eq_(span.get_tag('elasticsearch.method'), "POST")
+        eq_(span.get_tag('elasticsearch.url'), "/%s/_refresh" % self.ES_INDEX)
 
         # Search data
         result = es.search(sort=['name:desc'], size=100,
@@ -106,13 +106,13 @@ class ElasticsearchTest(unittest.TestCase):
         span = spans[0]
         eq_(span.resource,
                 "GET /%s/%s/_search" % (self.ES_INDEX, self.ES_TYPE))
-        eq_(span.get_tag(metadata.METHOD), "GET")
-        eq_(span.get_tag(metadata.URL),
+        eq_(span.get_tag('elasticsearch.method'), "GET")
+        eq_(span.get_tag('elasticsearch.url'),
                 "/%s/%s/_search" % (self.ES_INDEX, self.ES_TYPE))
-        eq_(span.get_tag(metadata.BODY).replace(" ", ""), '{"query":{"match_all":{}}}')
-        eq_(set(span.get_tag(metadata.PARAMS).split('&')), {'sort=name%3Adesc', 'size=100'})
+        eq_(span.get_tag('elasticsearch.body').replace(" ", ""), '{"query":{"match_all":{}}}')
+        eq_(set(span.get_tag('elasticsearch.params').split('&')), {'sort=name%3Adesc', 'size=100'})
 
-        self.assertTrue(span.get_metric(metadata.TOOK) > 0)
+        self.assertTrue(span.get_metric('elasticsearch.took') > 0)
 
         # Search by type not supported by default json encoder
         query = {"range": {"created": {"gte": datetime.date(2016, 2, 1)}}}
@@ -180,8 +180,8 @@ class ElasticsearchTest(unittest.TestCase):
         eq_(dd_span.name, "elasticsearch.query")
         eq_(dd_span.span_type, "elasticsearch")
         eq_(dd_span.error, 0)
-        eq_(dd_span.get_tag(metadata.METHOD), "PUT")
-        eq_(dd_span.get_tag(metadata.URL), "/%s" % self.ES_INDEX)
+        eq_(dd_span.get_tag('elasticsearch.method'), "PUT")
+        eq_(dd_span.get_tag('elasticsearch.url'), "/%s" % self.ES_INDEX)
         eq_(dd_span.resource, "PUT /%s" % self.ES_INDEX)
 
 
@@ -237,8 +237,8 @@ class ElasticsearchPatchTest(unittest.TestCase):
         eq_(span.name, "elasticsearch.query")
         eq_(span.span_type, "elasticsearch")
         eq_(span.error, 0)
-        eq_(span.get_tag(metadata.METHOD), "PUT")
-        eq_(span.get_tag(metadata.URL), "/%s" % self.ES_INDEX)
+        eq_(span.get_tag('elasticsearch.method'), "PUT")
+        eq_(span.get_tag('elasticsearch.url'), "/%s" % self.ES_INDEX)
         eq_(span.resource, "PUT /%s" % self.ES_INDEX)
 
         # Put data
@@ -252,8 +252,8 @@ class ElasticsearchPatchTest(unittest.TestCase):
         eq_(len(spans), 3)
         span = spans[0]
         eq_(span.error, 0)
-        eq_(span.get_tag(metadata.METHOD), "PUT")
-        eq_(span.get_tag(metadata.URL), "/%s/%s/%s" % (self.ES_INDEX, self.ES_TYPE, 10))
+        eq_(span.get_tag('elasticsearch.method'), "PUT")
+        eq_(span.get_tag('elasticsearch.url'), "/%s/%s/%s" % (self.ES_INDEX, self.ES_TYPE, 10))
         eq_(span.resource, "PUT /%s/%s/?" % (self.ES_INDEX, self.ES_TYPE))
 
         # Make the data available
@@ -264,8 +264,8 @@ class ElasticsearchPatchTest(unittest.TestCase):
         eq_(len(spans), 1)
         span = spans[0]
         eq_(span.resource, "POST /%s/_refresh" % self.ES_INDEX)
-        eq_(span.get_tag(metadata.METHOD), "POST")
-        eq_(span.get_tag(metadata.URL), "/%s/_refresh" % self.ES_INDEX)
+        eq_(span.get_tag('elasticsearch.method'), "POST")
+        eq_(span.get_tag('elasticsearch.url'), "/%s/_refresh" % self.ES_INDEX)
 
         # Search data
         result = es.search(sort=['name:desc'], size=100,
@@ -279,13 +279,13 @@ class ElasticsearchPatchTest(unittest.TestCase):
         span = spans[0]
         eq_(span.resource,
             "GET /%s/%s/_search" % (self.ES_INDEX, self.ES_TYPE))
-        eq_(span.get_tag(metadata.METHOD), "GET")
-        eq_(span.get_tag(metadata.URL),
+        eq_(span.get_tag('elasticsearch.method'), "GET")
+        eq_(span.get_tag('elasticsearch.url'),
             "/%s/%s/_search" % (self.ES_INDEX, self.ES_TYPE))
-        eq_(span.get_tag(metadata.BODY).replace(" ", ""), '{"query":{"match_all":{}}}')
-        eq_(set(span.get_tag(metadata.PARAMS).split('&')), {'sort=name%3Adesc', 'size=100'})
+        eq_(span.get_tag('elasticsearch.body').replace(" ", ""), '{"query":{"match_all":{}}}')
+        eq_(set(span.get_tag('elasticsearch.params').split('&')), {'sort=name%3Adesc', 'size=100'})
 
-        self.assertTrue(span.get_metric(metadata.TOOK) > 0)
+        self.assertTrue(span.get_metric('elasticsearch.took') > 0)
 
         # Search by type not supported by default json encoder
         query = {"range": {"created": {"gte": datetime.date(2016, 2, 1)}}}


### PR DESCRIPTION
The PR adjusts the elasticsearch integration to use constants defined in `ext/elasticsearch.py`. It also changes over the tests to use string literals instead of the constants.