### PR TITLE
Allow django cache to be seen as a different service.

### DIFF
--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -51,6 +51,8 @@ The available settings are:
   tracer. Usually this configuration must be updated with a meaningful name.
 * ``DEFAULT_DATABASE_PREFIX`` (default: ``''``): set a prefix value to database services,
   so that your service is listed such as `prefix-defaultdb`.
+* ``DEFAULT_CACHE_SERVICE`` (default: ``''``): set the django cache service name used
+  by the tracer. Change this name if you want to see django cache spans as a cache application.
 * ``TAGS`` (default: ``{}``): set global tags that should be applied to all
   spans.
 * ``TRACER`` (default: ``ddtrace.tracer``): set the default tracer

--- a/ddtrace/contrib/django/cache.py
+++ b/ddtrace/contrib/django/cache.py
@@ -47,12 +47,15 @@ def patch_cache(tracer):
         """
         Return a wrapped function that traces a cache operation
         """
+        cache_service_name = settings.DEFAULT_CACHE_SERVICE \
+            if settings.DEFAULT_CACHE_SERVICE else settings.DEFAULT_SERVICE
+
         @wraps(fn)
         def wrapped(self, *args, **kwargs):
             # get the original function method
             method = getattr(self, DATADOG_NAMESPACE.format(method=method_name))
             with tracer.trace('django.cache',
-                    span_type=TYPE, service=settings.DEFAULT_SERVICE) as span:
+                    span_type=TYPE, service=cache_service_name) as span:
                 # update the resource name and tag the cache backend
                 span.resource = _resource_from_cache_prefix(method_name, self)
                 cache_backend = '{}.{}'.format(self.__module__, self.__class__.__name__)

--- a/ddtrace/contrib/django/conf.py
+++ b/ddtrace/contrib/django/conf.py
@@ -31,6 +31,7 @@ DEFAULTS = {
     'INSTRUMENT_TEMPLATE': True,
     'DEFAULT_DATABASE_PREFIX': '',
     'DEFAULT_SERVICE': 'django',
+    'DEFAULT_CACHE_SERVICE': '',
     'ENABLED': True,
     'DISTRIBUTED_TRACING': False,
     'TAGS': {},

--- a/tests/contrib/django/test_cache_client.py
+++ b/tests/contrib/django/test_cache_client.py
@@ -42,6 +42,21 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
         assert_dict_issuperset(span.meta, expected_meta)
         assert start < span.start < span.start + span.duration < end
 
+    @override_ddtrace_settings(DEFAULT_CACHE_SERVICE='foo')
+    def test_cache_service_can_be_overriden(self):
+        # get the default cache
+        cache = caches['default']
+
+        # (trace) the cache miss
+        hit = cache.get('missing_key')
+
+        # tests
+        spans = self.tracer.writer.pop()
+        eq_(len(spans), 1)
+
+        span = spans[0]
+        eq_(span.service, 'foo')
+
     @override_ddtrace_settings(INSTRUMENT_CACHE=False)
     def test_cache_disabled(self):
         # get the default cache


### PR DESCRIPTION
DEFAULT_CACHE_SERVICE is introduced to override the service name used for the span dedicated to the cache.
If the value is set, the django.cache span will appear as a different service. If not set, the current
behavior is kept.

Fix #528 