### PR TITLE
[requests] [gevent] Patch modules on first import

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -784,6 +784,7 @@ workflows:
       - pymongo
       - pyramid
       - requests
+      - requestsgevent
       - sqlalchemy
       - psycopg
       - aiobotocore
@@ -824,6 +825,7 @@ workflows:
             - pymongo
             - pyramid
             - requests
+            - requestsgevent
             - sqlalchemy
             - psycopg
             - aiobotocore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -536,6 +536,20 @@ jobs:
             - requests.results
       - *save_cache_step
 
+  requestsgevent:
+    docker:
+      - *test_runner
+      - *httpbin_local
+    steps:
+      - checkout
+      - *restore_cache_step
+      - run: tox -e 'requests_gevent_contrib-{py36}-requests{208,209,210,211,212,213,219}-gevent{12,13}' --result-json /tmp/requestsgevent.results
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - requestsgevent.results
+      - *save_cache_step
+
   sqlalchemy:
     docker:
       - *test_runner

--- a/tests/contrib/requests_gevent/test_regression.py
+++ b/tests/contrib/requests_gevent/test_regression.py
@@ -1,0 +1,48 @@
+import sys
+import unittest
+import warnings
+
+
+class TestRequestsGeventRegression(unittest.TestCase):
+    def test_regression(self):
+        """
+        Patching `requests` before `gevent` monkeypatching
+
+        This is a regression test for https://github.com/DataDog/dd-trace-py/issues/506
+
+        When using `ddtrace-run` along with `requests` and `gevent` our patching causes
+        `requests` and `urllib3` to get loaded before `gevent` has a chance to monkey patch.
+
+        This causes `gevent` to show a warning and under certain versions cause
+        a maxiumum recursion exception to be raised.
+        """
+        # Assert none of our modules have been imported yet
+        # DEV: This regression test depends on being able to control import order of these modules
+        # DEV: This is not entirely necessary but is a nice safe guard
+        self.assertNotIn('ddtrace', sys.modules)
+        self.assertNotIn('gevent', sys.modules)
+        self.assertNotIn('requests', sys.modules)
+        self.assertNotIn('urllib3', sys.modules)
+
+        try:
+            # Import ddtrace and patch only `requests`
+            # DEV: We do not need to patch `gevent` for the exception to occur
+            from ddtrace import patch
+            patch(requests=True)
+
+            # Import gevent and monkeypatch
+            from gevent import monkey
+            monkey.patch_all()
+
+            # This is typically what will fail if `requests` (or `urllib3`)
+            # gets loaded before running `monkey.patch_all()`
+            # DEV: We are testing that no exception gets raised
+            import requests
+
+            # DEV: We **MUST** use an HTTPS request, that is what causes the issue
+            requests.get('https://icanhazip.com/')
+
+        finally:
+            # Ensure we always unpatch `requests` when we are done
+            from ddtrace.contrib.requests import unpatch
+            unpatch()

--- a/tests/contrib/requests_gevent/test_requests_gevent.py
+++ b/tests/contrib/requests_gevent/test_requests_gevent.py
@@ -1,10 +1,9 @@
 import sys
 import unittest
-import warnings
 
 
-class TestRequestsGeventRegression(unittest.TestCase):
-    def test_regression(self):
+class TestRequestsGevent(unittest.TestCase):
+    def test_patch(self):
         """
         Patching `requests` before `gevent` monkeypatching
 

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,10 @@ envlist =
     pyramid_contrib{,_autopatch}-{py27,py34,py35,py36}-pyramid{17,18,19}-webtest
     redis_contrib-{py27,py34,py35,py36}-redis{26,27,28,29,210}
     requests_contrib-{py27,py34,py35,py36}-requests{208,209,210,211,212,213,219}
+# python 3.6 requests + gevent regression test
+# DEV: This is a known issue for gevent 1.1, suggestion is to upgrade to gevent > 1.2
+#      https://github.com/gevent/gevent/issues/903
+    requests_gevent_contrib-{py36}-requests{208,209,210,211,212,213,219}-gevent{12,13}
     sqlalchemy_contrib-{py27,py34,py35,py36}-sqlalchemy{10,11,12}-psycopg2{27}-mysqlconnector{21}
     sqlite3_contrib-{py27,py34,py35,py36}-sqlite3
     tornado_contrib-{py27,py34,py35,py36}-tornado{40,41,42,43,44,45}
@@ -297,6 +301,7 @@ commands =
     pyramid_contrib_autopatch: ddtrace-run nosetests {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
     redis_contrib: nosetests {posargs} tests/contrib/redis
     requests: nosetests {posargs} tests/contrib/requests
+    requests_gevent_contrib: nosetests {posargs} tests/contrib/requests_gevent
     sqlalchemy_contrib: nosetests {posargs} tests/contrib/sqlalchemy
     sqlite3_contrib: nosetests {posargs} tests/contrib/sqlite3
     tornado_contrib: nosetests {posargs} tests/contrib/tornado

--- a/tox.ini
+++ b/tox.ini
@@ -300,7 +300,7 @@ commands =
     pyramid_contrib: nosetests {posargs} tests/contrib/pyramid/test_pyramid.py
     pyramid_contrib_autopatch: ddtrace-run nosetests {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
     redis_contrib: nosetests {posargs} tests/contrib/redis
-    requests: nosetests {posargs} tests/contrib/requests
+    requests_contrib: nosetests {posargs} tests/contrib/requests
     requests_gevent_contrib: nosetests {posargs} tests/contrib/requests_gevent
     sqlalchemy_contrib: nosetests {posargs} tests/contrib/sqlalchemy
     sqlite3_contrib: nosetests {posargs} tests/contrib/sqlite3


### PR DESCRIPTION
This PR adds `requests` and `gevent` to the list of modules that we will patch on first import instead of explicitly importing/patching for the user.

We have refactored code in `monkey.py` for how we define which modules support patching on import.

We also added in a check to see if the module is already imported, in which case we will patch immediately rather that adding a hook for it.

This PR also resolves https://github.com/DataDog/dd-trace-py/issues/506

The problem we were seeing in that issue is when using `ddtrace-run` we were importing and patching `requests` (which imports and uses `urllib3`) before the user could import `gevent` and call `gevent.monkey.patch_all()`.

This resolves that issue by only patching `requests` when the user first imports it into their code.

We have added a regression test for this exact case for the effected versions of python and `gevent` (all versions of `requests` that we test were effected).