### PR TITLE
[rediscluster] Add wait for services to start

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,6 +650,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
+      - run: tox -e wait rediscluster
       - run: tox -e 'rediscluster_contrib-{py27,py34,py35,py36}-rediscluster{135}' --result-json /tmp/rediscluster.results
       - persist_to_workspace:
           root: /tmp

--- a/tox.ini
+++ b/tox.ini
@@ -324,6 +324,7 @@ deps=
     psycopg2
     mysql-connector>=2.1,<2.2
     rediscluster
+    redis
 
 # this is somewhat flaky (can fail and still be up) so try the tests anyway
 ignore_outcome=true

--- a/tox.ini
+++ b/tox.ini
@@ -323,6 +323,7 @@ deps=
     cassandra-driver
     psycopg2
     mysql-connector>=2.1,<2.2
+    rediscluster
 
 # this is somewhat flaky (can fail and still be up) so try the tests anyway
 ignore_outcome=true

--- a/tox.ini
+++ b/tox.ini
@@ -323,8 +323,7 @@ deps=
     cassandra-driver
     psycopg2
     mysql-connector>=2.1,<2.2
-    rediscluster
-    redis
+    redis-py-cluster>=1.3.5,<1.3.6
 
 # this is somewhat flaky (can fail and still be up) so try the tests anyway
 ignore_outcome=true


### PR DESCRIPTION
## Overview

The `rediscluster` tests were flaky due to the instances not being ready before the tests started running causing the first few tests to fail. 

This PR adds a connection and query check to `wait-for-services.py` which will allow the test to proceed once the connection and query are successfully made. 

