### PR TITLE
[tests] Add test cases for API._put

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -49,6 +49,7 @@ class APITests(TestCase):
             eq_(v['js'], js)
             if 'log' in v:
                 ok_(1<=len(log.call_args_list), "not enough elements in call_args_list: %s" % log.call_args_list)
+                print(log.call_args_list)
                 l = log.call_args_list[-1][0][0]
                 ok_(v['log'] in l, "unable to find %s in %s" % (v['log'], l))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,11 +1,12 @@
 import mock
+import warnings
 
 from unittest import TestCase
 from nose.tools import eq_, ok_
 
 from tests.test_tracer import get_dummy_tracer
-from ddtrace.api import _parse_response_json
-from ddtrace.compat import iteritems
+from ddtrace.api import _parse_response_json, API
+from ddtrace.compat import iteritems, httplib
 
 class ResponseMock:
     def __init__(self, content):
@@ -15,6 +16,16 @@ class ResponseMock:
         return self.content
 
 class APITests(TestCase):
+
+    def setUp(self):
+        # DEV: Mock here instead of in tests, before we have patched `httplib.HTTPConnection`
+        self.conn = mock.MagicMock(spec=httplib.HTTPConnection)
+        self.api = API('localhost', 8126)
+
+    def tearDown(self):
+        del self.api
+        del self.conn
+
     @mock.patch('logging.Logger.debug')
     def test_parse_response_json(self, log):
         tracer = get_dummy_tracer()
@@ -38,6 +49,40 @@ class APITests(TestCase):
             eq_(v['js'], js)
             if 'log' in v:
                 ok_(1<=len(log.call_args_list), "not enough elements in call_args_list: %s" % log.call_args_list)
-                print(log.call_args_list)
                 l = log.call_args_list[-1][0][0]
                 ok_(v['log'] in l, "unable to find %s in %s" % (v['log'], l))
+
+    @mock.patch('ddtrace.compat.httplib.HTTPConnection')
+    def test_put_connection_close(self, HTTPConnection):
+        """
+        When calling API._put
+            we close the HTTPConnection we create
+        """
+        HTTPConnection.return_value = self.conn
+
+        with warnings.catch_warnings(record=True) as w:
+            self.api._put('/test', '<test data>', 1)
+
+            self.assertEqual(len(w), 0, 'Test raised unexpected warnings: {0!r}'.format(w))
+
+        self.conn.request.assert_called_once()
+        self.conn.close.assert_called_once()
+
+    @mock.patch('ddtrace.compat.httplib.HTTPConnection')
+    def test_put_connection_close_exception(self, HTTPConnection):
+        """
+        When calling API._put raises an exception
+            we close the HTTPConnection we create
+        """
+        HTTPConnection.return_value = self.conn
+        # Ensure calling `request` raises an exception
+        self.conn.request.side_effect = Exception
+
+        with warnings.catch_warnings(record=True) as w:
+            with self.assertRaises(Exception):
+                self.api._put('/test', '<test data>', 1)
+
+            self.assertEqual(len(w), 0, 'Test raised unexpected warnings: {0!r}'.format(w))
+
+        self.conn.request.assert_called_once()
+        self.conn.close.assert_called_once()


### PR DESCRIPTION
#542 helped to fix an issue where we were leaking some `HTTPConnection`s.

This PR adds in two basic test cases to ensure that we are always calling `HTTPConnection.close()` on `API._put`.

Also added in checking to ensure we do not raise any `Warning`s