### PR TITLE
[tests] Skip flaky TestWorkers.test_worker_multiple_traces test case

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -114,6 +114,8 @@ class TestWorkers(TestCase):
         eq_(len(payload[0]), 1)
         eq_(payload[0][0]['name'], 'client.testing')
 
+    # DEV: If we can make the writer flushing deterministic for the case of tests, then we can re-enable this
+    @skip('Writer flush intervals are impossible to time correctly to make this test not flaky')
     def test_worker_multiple_traces(self):
         # make a single send() if multiple traces are created before the flush interval
         tracer = self.tracer


### PR DESCRIPTION
This test is non-deterministic and will fail for no reason and so should be skipped.

The problem we are having is that this test relies on us being able to correctly time the flush intervals from the writer, which we are unable to do at this time.

If we can tweak the writer internals in a way where we can make it deterministic then we should revive this test case.