### PR TITLE
[django] Infer span resource name when internal error handler is used

### DIFF
--- a/ddtrace/contrib/django/compat.py
+++ b/ddtrace/contrib/django/compat.py
@@ -2,10 +2,26 @@ import django
 
 
 if django.VERSION >= (1, 10, 1):
+    from django.urls import get_resolver
+
     def user_is_authenticated(user):
         # Explicit comparision due to the following bug
         # https://code.djangoproject.com/ticket/26988
         return user.is_authenticated == True  # noqa E712
 else:
+    from django.conf import settings
+    from django.core import urlresolvers
+
     def user_is_authenticated(user):
         return user.is_authenticated()
+
+    if django.VERSION >= (1, 9, 0):
+        def get_resolver(urlconf=None):
+            urlconf = urlconf or settings.ROOT_URLCONF
+            urlresolvers.set_urlconf(urlconf)
+            return urlresolvers.get_resolver(urlconf)
+    else:
+        def get_resolver(urlconf=None):
+            urlconf = urlconf or settings.ROOT_URLCONF
+            urlresolvers.set_urlconf(urlconf)
+            return urlresolvers.RegexURLResolver(r'^/', urlconf)

--- a/ddtrace/contrib/django/compat.py
+++ b/ddtrace/contrib/django/compat.py
@@ -5,7 +5,7 @@ if django.VERSION >= (1, 10, 1):
     from django.urls import get_resolver
 
     def user_is_authenticated(user):
-        # Explicit comparision due to the following bug
+        # Explicit comparison due to the following bug
         # https://code.djangoproject.com/ticket/26988
         return user.is_authenticated == True  # noqa E712
 else:

--- a/ddtrace/contrib/django/middleware.py
+++ b/ddtrace/contrib/django/middleware.py
@@ -139,7 +139,7 @@ class TraceMiddleware(InstrumentationMixin):
                 if span.resource == 'unknown':
                     try:
                         # Attempt to lookup the view function from the url resolver
-                        #   https://github.com/django/django/blob/38e2fdadfd9952e751deed662edf4c496d238f28/django/core/handlers/base.py#L104-L113
+                        #   https://github.com/django/django/blob/38e2fdadfd9952e751deed662edf4c496d238f28/django/core/handlers/base.py#L104-L113  # noqa
                         urlconf = None
                         if hasattr(request, 'urlconf'):
                             urlconf = request.urlconf
@@ -155,7 +155,8 @@ class TraceMiddleware(InstrumentationMixin):
                     except Exception:
                         log.debug('error determining request view function', exc_info=True)
 
-                        # If the view could not be found, try to set from a static list of known internal error handler views
+                        # If the view could not be found, try to set from a static list of
+                        # known internal error handler views
                         span.resource = _django_default_views.get(response.status_code, 'unknown')
 
                 span.set_tag(http.STATUS_CODE, response.status_code)

--- a/tests/contrib/django/test_middleware.py
+++ b/tests/contrib/django/test_middleware.py
@@ -299,7 +299,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         """
         When making a request to an unknown url in django
             when we do not have a 404 view handler set
-                the default view handler is used
+                we set a resource name for the default view handler
         """
         response = self.client.get('/unknown-url')
         eq_(response.status_code, 404)
@@ -310,10 +310,12 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         sp_request = spans[0]
         sp_template = spans[1]
 
+        # Template
         # DEV: The template name is `unknown` because unless they define a `404.html`
         #   django generates the template from a string, which will not have a `Template.name` set
         eq_(sp_template.get_tag('django.template_name'), 'unknown')
 
+        # Request
         eq_(sp_request.get_tag('http.status_code'), '404')
         eq_(sp_request.get_tag('http.url'), '/unknown-url')
         eq_(sp_request.get_tag('django.user.is_authenticated'), 'False')

--- a/tests/contrib/django/test_middleware.py
+++ b/tests/contrib/django/test_middleware.py
@@ -38,6 +38,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         eq_(sp_request.get_tag('django.user.is_authenticated'), 'False')
         eq_(sp_request.get_tag('http.method'), 'GET')
         eq_(sp_request.span_type, 'http')
+        eq_(sp_request.resource, 'tests.contrib.django.app.views.UserList')
 
     def test_database_patch(self):
         # We want to test that a connection-recreation event causes connections
@@ -164,8 +165,6 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         spans = self.tracer.writer.pop()
         eq_(len(spans), 3)
         sp_request = spans[0]
-        sp_template = spans[1]
-        sp_database = spans[2]
         eq_(sp_request.get_tag('http.status_code'), '200')
         eq_(sp_request.get_tag('django.user.is_authenticated'), None)
 
@@ -185,8 +184,6 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         spans = self.tracer.writer.pop()
         eq_(len(spans), 3)
         sp_request = spans[0]
-        sp_template = spans[1]
-        sp_database = spans[2]
 
         # Check for proper propagated attributes
         eq_(sp_request.trace_id, 100)
@@ -208,8 +205,6 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         spans = self.tracer.writer.pop()
         eq_(len(spans), 3)
         sp_request = spans[0]
-        sp_template = spans[1]
-        sp_database = spans[2]
 
         # Check that propagation didn't happen
         assert sp_request.trace_id != 100
@@ -299,3 +294,29 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         eq_(sp_request.get_tag('http.url'), '/users/')
         eq_(sp_request.get_tag('django.user.is_authenticated'), 'False')
         eq_(sp_request.get_tag('http.method'), 'GET')
+
+    def test_middleware_trace_request_404(self):
+        """
+        When making a request to an unknown url in django
+            when we do not have a 404 view handler set
+                the default view handler is used
+        """
+        response = self.client.get('/unknown-url')
+        eq_(response.status_code, 404)
+
+        # check for spans
+        spans = self.tracer.writer.pop()
+        eq_(len(spans), 2)
+        sp_request = spans[0]
+        sp_template = spans[1]
+
+        # DEV: The template name is `unknown` because unless they define a `404.html`
+        #   django generates the template from a string, which will not have a `Template.name` set
+        eq_(sp_template.get_tag('django.template_name'), 'unknown')
+
+        eq_(sp_request.get_tag('http.status_code'), '404')
+        eq_(sp_request.get_tag('http.url'), '/unknown-url')
+        eq_(sp_request.get_tag('django.user.is_authenticated'), 'False')
+        eq_(sp_request.get_tag('http.method'), 'GET')
+        eq_(sp_request.span_type, 'http')
+        eq_(sp_request.resource, 'django.views.defaults.page_not_found')


### PR DESCRIPTION
Django has a set of internal error view handlers that it will fallback to if the user does not define one.

This is most clear with requests to unknown urls (404).

The problem we have when one of these view handlers is used is Django is not calling the `process_view` method from our middleware so we are unable to determine and set a proper view resource name for the request.

In this PR we are adding in a little logic to infer a resource name if we both have a span resource name of `unknown` (`process_view` was not called) and the response status code is for a known internal error handler.