### PR TITLE
[core] Update config to allow configuration before patching 

### DIFF
--- a/ddtrace/utils/merge.py
+++ b/ddtrace/utils/merge.py
@@ -1,0 +1,19 @@
+# Borrowed from: https://stackoverflow.com/questions/20656135/python-deep-merge-dictionary-data#20666342
+def deepmerge(source, destination):
+    """
+    Merge the first provided ``dict`` into the second.
+
+    :param dict source: The ``dict`` to merge into ``destination``
+    :param dict destination: The ``dict`` that should get updated
+    :rtype: dict
+    :returns: ``destination`` modified
+    """
+    for key, value in source.items():
+        if isinstance(value, dict):
+            # get node or create one
+            node = destination.setdefault(key, {})
+            deepmerge(value, node)
+        else:
+            destination[key] = value
+
+    return destination

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -48,3 +48,45 @@ class GlobalConfigTestCase(TestCase):
     def test_global_configuration(self):
         # ensure a global configuration is available in the `ddtrace` module
         ok_(isinstance(global_config, Config))
+
+    def test_settings_merge(self):
+        """
+        When caling `config._add()`
+            when existing settings exist
+                we do not overwrite the existing settings
+        """
+        self.config.requests['split_by_domain'] = True
+        self.config._add('requests', dict(split_by_domain=False))
+        eq_(self.config.requests['split_by_domain'], True)
+
+    def test_settings_overwrite(self):
+        """
+        When caling `config._add(..., merge=False)`
+            when existing settings exist
+                we overwrite the existing settings
+        """
+        self.config.requests['split_by_domain'] = True
+        self.config._add('requests', dict(split_by_domain=False), merge=False)
+        eq_(self.config.requests['split_by_domain'], False)
+
+    def test_settings_merge_deep(self):
+        """
+        When caling `config._add()`
+            when existing "deep" settings exist
+                we do not overwrite the existing settings
+        """
+        self.config.requests['a'] = dict(
+            b=dict(
+                c=True,
+            ),
+        )
+        self.config._add('requests', dict(
+            a=dict(
+                b=dict(
+                    c=False,
+                    d=True,
+                ),
+            ),
+        ))
+        eq_(self.config.requests['a']['b']['c'], True)
+        eq_(self.config.requests['a']['b']['d'], True)

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -51,7 +51,7 @@ class GlobalConfigTestCase(TestCase):
 
     def test_settings_merge(self):
         """
-        When caling `config._add()`
+        When calling `config._add()`
             when existing settings exist
                 we do not overwrite the existing settings
         """
@@ -61,7 +61,7 @@ class GlobalConfigTestCase(TestCase):
 
     def test_settings_overwrite(self):
         """
-        When caling `config._add(..., merge=False)`
+        When calling `config._add(..., merge=False)`
             when existing settings exist
                 we overwrite the existing settings
         """
@@ -71,7 +71,7 @@ class GlobalConfigTestCase(TestCase):
 
     def test_settings_merge_deep(self):
         """
-        When caling `config._add()`
+        When calling `config._add()`
             when existing "deep" settings exist
                 we do not overwrite the existing settings
         """


### PR DESCRIPTION
Previously if we tried to set a config setting before the contrib module was imported
we would receive an error that the integration key did not exist.

With this new approach we are allowing any integration setting to be configured by
the user, whenever they want and then when we call `config._add()` in the contrib
module, we will merge the settings with any existing settings, keeping those that
already exist.

We have also added a `Config.__repr__`