### PR TITLE
[aiohttp] Add HTTP method to the root span resource

### DIFF
--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -83,6 +83,9 @@ def on_prepare(request, response):
         elif res_info.get('prefix'):
             resource = res_info.get('prefix')
 
+        # prefix the resource name by the http method
+        resource = '{} {}'.format(request.method, resource)
+
     request_span.resource = resource
     request_span.set_tag('http.method', request.method)
     request_span.set_tag('http.status_code', response.status)

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -50,7 +50,7 @@ class TestTraceMiddleware(TraceTestCase):
         eq_('aiohttp.request', span.name)
         eq_('aiohttp-web', span.service)
         eq_('http', span.span_type)
-        eq_('/', span.resource)
+        eq_('GET /', span.resource)
         eq_('/', span.get_tag('http.url'))
         eq_('GET', span.get_tag('http.method'))
         eq_('200', span.get_tag('http.status_code'))
@@ -70,7 +70,7 @@ class TestTraceMiddleware(TraceTestCase):
         eq_(1, len(traces[0]))
         span = traces[0][0]
         # with the right fields
-        eq_('/echo/{name}', span.resource)
+        eq_('GET /echo/{name}', span.resource)
         eq_('/echo/team', span.get_tag('http.url'))
         eq_('200', span.get_tag('http.status_code'))
 
@@ -108,7 +108,7 @@ class TestTraceMiddleware(TraceTestCase):
         coroutine = traces[0][2]
         # root span created in the middleware
         eq_('aiohttp.request', root.name)
-        eq_('/chaining/', root.resource)
+        eq_('GET /chaining/', root.resource)
         eq_('/chaining/', root.get_tag('http.url'))
         eq_('GET', root.get_tag('http.method'))
         eq_('200', root.get_tag('http.status_code'))
@@ -136,7 +136,7 @@ class TestTraceMiddleware(TraceTestCase):
         span = traces[0][0]
         # root span created in the middleware
         eq_('aiohttp.request', span.name)
-        eq_('/statics', span.resource)
+        eq_('GET /statics', span.resource)
         eq_('/statics/empty.txt', span.get_tag('http.url'))
         eq_('GET', span.get_tag('http.method'))
         eq_('200', span.get_tag('http.status_code'))
@@ -172,7 +172,7 @@ class TestTraceMiddleware(TraceTestCase):
         eq_(1, len(spans))
         span = spans[0]
         eq_(1, span.error)
-        eq_('/exception', span.resource)
+        eq_('GET /exception', span.resource)
         eq_('error', span.get_tag('error.msg'))
         ok_('Exception: error' in span.get_tag('error.stack'))
 
@@ -189,7 +189,7 @@ class TestTraceMiddleware(TraceTestCase):
         eq_(1, len(spans))
         span = spans[0]
         eq_(1, span.error)
-        eq_('/async_exception', span.resource)
+        eq_('GET /async_exception', span.resource)
         eq_('error', span.get_tag('error.msg'))
         ok_('Exception: error' in span.get_tag('error.stack'))
 
@@ -206,7 +206,7 @@ class TestTraceMiddleware(TraceTestCase):
         spans = traces[0]
         eq_(2, len(spans))
         span = spans[0]
-        eq_('/wrapped_coroutine', span.resource)
+        eq_('GET /wrapped_coroutine', span.resource)
         span = spans[1]
         eq_('nested', span.name)
         ok_(span.duration > 0.25,
@@ -367,7 +367,7 @@ class TestTraceMiddleware(TraceTestCase):
         eq_('aiohttp.request', inner_span.name)
         eq_('aiohttp-web', inner_span.service)
         eq_('http', inner_span.span_type)
-        eq_('/', inner_span.resource)
+        eq_('GET /', inner_span.resource)
         eq_('/', inner_span.get_tag('http.url'))
         eq_('GET', inner_span.get_tag('http.method'))
         eq_('200', inner_span.get_tag('http.status_code'))

--- a/tests/contrib/aiohttp/test_request.py
+++ b/tests/contrib/aiohttp/test_request.py
@@ -46,7 +46,7 @@ class TestRequestTracing(TraceTestCase):
         # request
         eq_('aiohttp-web', request_span.service)
         eq_('aiohttp.request', request_span.name)
-        eq_('/template/', request_span.resource)
+        eq_('GET /template/', request_span.resource)
         # template
         eq_('aiohttp-web', template_span.service)
         eq_('aiohttp.template', template_span.name)

--- a/tests/contrib/aiohttp/test_request_safety.py
+++ b/tests/contrib/aiohttp/test_request_safety.py
@@ -48,7 +48,7 @@ class TestAiohttpSafety(TraceTestCase):
         # request
         eq_('aiohttp-web', request_span.service)
         eq_('aiohttp.request', request_span.name)
-        eq_('/template/', request_span.resource)
+        eq_('GET /template/', request_span.resource)
         # template
         eq_('aiohttp-web', template_span.service)
         eq_('aiohttp.template', template_span.name)


### PR DESCRIPTION
At PeopleDoc we are using Datadog to monitor REST APIs written with Aiohttp. With APIs, you often have the same URL (eg: `/documents`) used for different views according to the HTTP method (eg: `GET /documents` vs `POST /documents`). But In Datadog's APM those views will share the same dashboard, making it impossible to get sensitive information about the behavior of a specific view.

Unfortunately I've found no easy way to change the `resource` attribute of a span in our apps, because the attribute is overwritten right before the span is sent [in ddtrace-py](https://github.com/k4nar/dd-trace-py/blob/1a5f79bca1ae81f691e214e9db53865e4f4610e3/ddtrace/contrib/aiohttp/middlewares.py#L89-L93).

My contribution could have gone two ways:
1. Don't overwrite the `resource` of a span if it has already been set, making it possible to customize it
2. Add the HTTP method to the resource of Aiohttp spans

I've chosen to go with 2 as it's the one which will work out of the box for everyone. But it also introduce a breaking compat, as I guess people could have monitors set to a specific resource in their Aiohttp apps, but this will change their names.

So, let's open the discussion :) .