### PR TITLE
Make CI faster by disabling dist and install in autopatching tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,27 @@ jobs:
             - ddtracerun.results
       - *save_cache_step
 
+  ddtracerun_dist_install_execute:
+    docker:
+      - *test_runner
+      - image: redis:3.2-alpine
+      - image: memcached:1.5-alpine
+      - image: datadog/docker-dd-agent
+        env:
+            - DD_APM_ENABLED=true
+            - DD_BIND_HOST=0.0.0.0
+            - DD_API_KEY=invalid_key_but_this_is_fine
+    environment:
+      TOX_SKIP_DIST: False
+    steps:
+      # DO NOT CACHE THIS JOB
+      - checkout
+      - run: tox -e '{py27,py34,py35,py36}-ddtracerun_dist_install_execute-django{111}-djangopylibmc{06}-djangoredis{45}-pylibmc-redis{210}-memcached' --result-json /tmp/ddtracerun_dist_install_execute.results
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - ddtracerun_dist_install_execute.results
+
   asyncio:
     docker:
       - *test_runner
@@ -214,7 +235,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'bottle_contrib-{py27,py34,py35,py36}-bottle{11,12}-webtest' --result-json /tmp/bottle.1.results
-      - run: TOX_SKIP_DIST=False tox -e 'bottle_contrib_autopatch-{py27,py34,py35,py36}-bottle{11,12}-webtest' --result-json /tmp/bottle.2.results
+      - run: tox -e 'bottle_contrib_autopatch-{py27,py34,py35,py36}-bottle{11,12}-webtest' --result-json /tmp/bottle.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -245,12 +266,14 @@ jobs:
 
   celery:
     docker:
-      - *test_runner
+      - <<: *test_runner
+        env:
+          TOX_SKIP_DIST: False
       - image: redis:3.2-alpine
     steps:
       - checkout
       - *restore_cache_step
-      - run: TOX_SKIP_DIST=False tox -e 'celery_contrib-{py27,py34,py35,py36}-celery{31,40,41,42}-redis{210}' --result-json /tmp/celery.results
+      - run: tox -e 'celery_contrib-{py27,py34,py35,py36}-celery{31,40,41,42}-redis{210}' --result-json /tmp/celery.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -264,7 +287,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: TOX_SKIP_DIST=False tox -e 'elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63}' --result-json /tmp/elasticsearch.results
+      - run: tox -e 'elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63}' --result-json /tmp/elasticsearch.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -278,7 +301,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'falcon_contrib-{py27,py34,py35,py36}-falcon{10,11,12,13,14}' --result-json /tmp/falcon.1.results
-      - run: TOX_SKIP_DIST=False tox -e 'falcon_contrib_autopatch-{py27,py34,py35,py36}-falcon{10,11,12,13,14}' --result-json /tmp/falcon.2.results
+      - run: tox -e 'falcon_contrib_autopatch-{py27,py34,py35,py36}-falcon{10,11,12,13,14}' --result-json /tmp/falcon.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -300,10 +323,10 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'django_contrib-{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.1.results
-      - run: TOX_SKIP_DIST=False tox -e 'django_contrib_autopatch-{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.2.results
+      - run: tox -e 'django_contrib_autopatch-{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.2.results
       - run: tox -e 'django_drf_contrib-{py27,py34,py35,py36}-django{111}-djangorestframework{34,37,38}' --result-json /tmp/django.3.results
       - run: tox -e 'django_contrib-{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.4.results
-      - run: TOX_SKIP_DIST=False tox -e 'django_contrib_autopatch-{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.5.results
+      - run: tox -e 'django_contrib_autopatch-{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.5.results
       - run: tox -e 'django_drf_contrib-{py34,py35,py36}-django{200}-djangorestframework{37,38}' --result-json /tmp/django.6.results
       - persist_to_workspace:
           root: /tmp
@@ -325,11 +348,11 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'flask_contrib-{py27,py34,py35,py36}-flask{010,011,012,10}-blinker' --result-json /tmp/flask.1.results
-      - run: TOX_SKIP_DIST=False tox -e 'flask_contrib_autopatch-{py27,py34,py35,py36}-flask{010,011,012,10}-blinker' --result-json /tmp/flask.2.results
+      - run: tox -e 'flask_contrib_autopatch-{py27,py34,py35,py36}-flask{010,011,012,10}-blinker' --result-json /tmp/flask.2.results
       - run: tox -e 'flask_cache_contrib-{py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.3.results
-      - run: TOX_SKIP_DIST=False tox -e 'flask_cache_contrib_autopatch-{py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.4.results
+      - run: tox -e 'flask_cache_contrib_autopatch-{py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.4.results
       - run: tox -e 'flask_cache_contrib-{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.5.results
-      - run: TOX_SKIP_DIST=False tox -e 'flask_cache_contrib_autopatch-{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.6.results
+      - run: tox -e 'flask_cache_contrib_autopatch-{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.6.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -471,7 +494,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'pymemcache_contrib-{py27,py34,py35,py36}-pymemcache{130,140}' --result-json /tmp/pymemcache.1.results
-      - run: TOX_SKIP_DIST=False tox -e 'pymemcache_contrib_autopatch-{py27,py34,py35,py36}-pymemcache{130,140}' --result-json /tmp/pymemcache.2.results
+      - run: tox -e 'pymemcache_contrib_autopatch-{py27,py34,py35,py36}-pymemcache{130,140}' --result-json /tmp/pymemcache.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -514,7 +537,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'pyramid_contrib-{py27,py34,py35,py36}-pyramid{17,18,19}-webtest' --result-json /tmp/pyramid.1.results
-      - run: TOX_SKIP_DIST=False tox -e 'pyramid_contrib_autopatch-{py27,py34,py35,py36}-pyramid{17,18,19}-webtest' --result-json /tmp/pyramid.2.results
+      - run: tox -e 'pyramid_contrib_autopatch-{py27,py34,py35,py36}-pyramid{17,18,19}-webtest' --result-json /tmp/pyramid.2.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -797,6 +820,7 @@ workflows:
       - futures
       - boto
       - ddtracerun
+      - ddtracerun_dist_install_execute
       - asyncio
       - pylons
       - aiohttp
@@ -840,6 +864,7 @@ workflows:
             - futures
             - boto
             - ddtracerun
+            - ddtracerun_dist_install_execute
             - asyncio
             - pylons
             - aiohttp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,34 +143,11 @@ jobs:
       TOX_SKIP_DIST: False
     steps:
       - checkout
-      - *restore_cache_step
       - run: tox -e '{py27,py34,py35,py36}-ddtracerun' --result-json /tmp/ddtracerun.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - ddtracerun.results
-      - *save_cache_step
-
-  ddtracerun_dist_install_execute:
-    docker:
-      - *test_runner
-      - image: redis:3.2-alpine
-      - image: memcached:1.5-alpine
-      - image: datadog/docker-dd-agent
-        env:
-            - DD_APM_ENABLED=true
-            - DD_BIND_HOST=0.0.0.0
-            - DD_API_KEY=invalid_key_but_this_is_fine
-    environment:
-      TOX_SKIP_DIST: False
-    steps:
-      # DO NOT CACHE THIS JOB
-      - checkout
-      - run: tox -e '{py27,py34,py35,py36}-ddtracerun_dist_install_execute-django{111}-djangopylibmc{06}-djangoredis{45}-pylibmc-redis{210}-memcached' --result-json /tmp/ddtracerun_dist_install_execute.results
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - ddtracerun_dist_install_execute.results
 
   asyncio:
     docker:
@@ -820,7 +797,6 @@ workflows:
       - futures
       - boto
       - ddtracerun
-      - ddtracerun_dist_install_execute
       - asyncio
       - pylons
       - aiohttp
@@ -864,7 +840,6 @@ workflows:
             - futures
             - boto
             - ddtracerun
-            - ddtracerun_dist_install_execute
             - asyncio
             - pylons
             - aiohttp

--- a/tests/ddtrace_run.py
+++ b/tests/ddtrace_run.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+sys.path.append('.')
+from ddtrace.commands import ddtrace_run
+
+os.environ['PYTHONPATH'] = "{}:{}".format(os.getenv('PYTHONPATH'), os.path.abspath('.'))
+ddtrace_run.main()

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,9 @@ envlist =
     {py27,py34,py35,py36}-tracer
     {py27,py34,py35,py36}-integration
     {py27,py34,py35,py36}-ddtracerun
+# The purpose of this tox environment is to test the real world cycle of the library: dist -> install -> run
+# We use the django tests as an example
+    {py27,py34,py35,py36}-ddtracerun_dist_install_execute-django{111}-djangopylibmc{06}-djangoredis{45}-pylibmc-redis{210}-memcached
 # Integrations environments
     aiobotocore_contrib-{py34,py35,py36}-aiobotocore{02,03,04}
     aiohttp_contrib-{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
@@ -276,17 +279,17 @@ commands =
     boto_contrib: nosetests {posargs} tests/contrib/boto
     botocore_contrib: nosetests {posargs} tests/contrib/botocore
     bottle_contrib: nosetests {posargs} tests/contrib/bottle/test.py
-    bottle_contrib_autopatch: ddtrace-run nosetests {posargs} tests/contrib/bottle/test_autopatch.py
+    bottle_contrib_autopatch: python tests/ddtrace_run.py nosetests {posargs} tests/contrib/bottle/test_autopatch.py
     cassandra_contrib: nosetests {posargs} tests/contrib/cassandra
     celery_contrib: nosetests {posargs} tests/contrib/celery
     django_contrib: python tests/contrib/django/runtests.py {posargs}
-    django_contrib_autopatch: ddtrace-run python tests/contrib/django/runtests.py {posargs}
+    django_contrib_autopatch: python tests/ddtrace_run.py python tests/contrib/django/runtests.py {posargs}
     django_drf_contrib: python tests/contrib/djangorestframework/runtests.py {posargs}
     elasticsearch_contrib: nosetests {posargs} tests/contrib/elasticsearch
     falcon_contrib: nosetests {posargs} tests/contrib/falcon/test_middleware.py tests/contrib/falcon/test_distributed_tracing.py
-    falcon_contrib_autopatch: ddtrace-run nosetests {posargs} tests/contrib/falcon/test_autopatch.py
+    falcon_contrib_autopatch: python tests/ddtrace_run.py nosetests {posargs} tests/contrib/falcon/test_autopatch.py
     flask_contrib: nosetests {posargs} tests/contrib/flask
-    flask_contrib_autopatch: ddtrace-run nosetests {posargs} tests/contrib/flask_autopatch
+    flask_contrib_autopatch: python tests/ddtrace_run.py nosetests {posargs} tests/contrib/flask_autopatch
     flask_cache_contrib: nosetests {posargs} tests/contrib/flask_cache
     futures_contrib: nosetests {posargs} tests/contrib/futures
     gevent_contrib: nosetests {posargs} tests/contrib/gevent
@@ -299,11 +302,11 @@ commands =
     pylibmc_contrib: nosetests {posargs} tests/contrib/pylibmc
     pylons_contrib: nosetests {posargs} tests/contrib/pylons
     pymemcache_contrib: nosetests {posargs} --exclude="test_autopatch.py" tests/contrib/pymemcache/
-    pymemcache_contrib_autopatch: ddtrace-run nosetests {posargs} tests/contrib/pymemcache/test_autopatch.py
+    pymemcache_contrib_autopatch: python tests/ddtrace_run.py nosetests {posargs} tests/contrib/pymemcache/test_autopatch.py
     pymongo_contrib: nosetests {posargs} tests/contrib/pymongo
     pymysql_contrib: nosetests {posargs} tests/contrib/pymysql
     pyramid_contrib: nosetests {posargs} tests/contrib/pyramid/test_pyramid.py
-    pyramid_contrib_autopatch: ddtrace-run nosetests {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
+    pyramid_contrib_autopatch: python tests/ddtrace_run.py nosetests {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
     redis_contrib: nosetests {posargs} tests/contrib/redis
     rediscluster_contrib: nosetests {posargs} tests/contrib/rediscluster
     requests_contrib: nosetests {posargs} tests/contrib/requests
@@ -315,6 +318,9 @@ commands =
 # run subsets of the tests for particular library versions
     ddtracerun: nosetests {posargs} tests/commands/test_runner.py
     test_utils: nosetests {posargs} tests/contrib/test_utils.py
+# The purpose of this tox environment is to test the real world cycle of the library: dist -> install -> run
+# DO NOT optimize this env using the fake test runner
+    ddtracerun_dist_install_execute: ddtrace-run python tests/contrib/django/runtests.py {posargs}
 
 
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,6 @@ envlist =
     {py27,py34,py35,py36}-tracer
     {py27,py34,py35,py36}-integration
     {py27,py34,py35,py36}-ddtracerun
-# The purpose of this tox environment is to test the real world cycle of the library: dist -> install -> run
-# We use the django tests as an example
-    {py27,py34,py35,py36}-ddtracerun_dist_install_execute-django{111}-djangopylibmc{06}-djangoredis{45}-pylibmc-redis{210}-memcached
 # Integrations environments
     aiobotocore_contrib-{py34,py35,py36}-aiobotocore{02,03,04}
     aiohttp_contrib-{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
@@ -318,9 +315,6 @@ commands =
 # run subsets of the tests for particular library versions
     ddtracerun: nosetests {posargs} tests/commands/test_runner.py
     test_utils: nosetests {posargs} tests/contrib/test_utils.py
-# The purpose of this tox environment is to test the real world cycle of the library: dist -> install -> run
-# DO NOT optimize this env using the fake test runner
-    ddtracerun_dist_install_execute: ddtrace-run python tests/contrib/django/runtests.py {posargs}
 
 
 setenv =


### PR DESCRIPTION
Currently, for a number of integrations, we test the integration itself in two scenarios: in "manual" patch mode and in "auto" patch mode.

We optimized the "manual" patch mode (avoiding the dist -> install) of the ddtrace package and forcing tox to use the source code. Now it is time to make "auto" patch mode quicker.

Right now we do `TOX_SKIP_DIST=False` for auto patch tests because we need the cli executable `ddtrace-run` in path. The idea is to avoid it.

**What does this PR add?**
1- We create files `tests/ddtrace_run.py` that loads the bootstrap module and run the tests commands
2- We execute autopatch tests using, again, source code instead of the installed bin
3- We add one job `ddtracerun_dist_install_execute` because we still want to make sure that in a clean environment we are able to build and install ddtrace run and to autopatch customers' apps

