### PR TITLE
[pyramid] Enabled by default

### DIFF
--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -1,15 +1,17 @@
 import os
 
+import pyramid.config
+from pyramid.path import caller_package
+import wrapt
+
 from .trace import trace_pyramid, DD_TWEEN_NAME
 from .constants import SETTINGS_SERVICE, SETTINGS_DISTRIBUTED_TRACING
 from ...utils.formats import asbool
+from ...utils.wrappers import unwrap as _u
 
-import pyramid.config
-from pyramid.path import caller_package
-
-import wrapt
 
 DD_PATCH = '_datadog_patch'
+
 
 def patch():
     """
@@ -21,6 +23,16 @@ def patch():
     setattr(pyramid.config, DD_PATCH, True)
     _w = wrapt.wrap_function_wrapper
     _w('pyramid.config', 'Configurator.__init__', traced_init)
+
+def unpatch():
+    """
+    Patch pyramid.config.Configurator
+    """
+    if not getattr(pyramid.config, DD_PATCH, False):
+        return
+
+    setattr(pyramid.config, DD_PATCH, False)
+    _u(pyramid.config.Configurator, '__init__')
 
 def traced_init(wrapped, instance, args, kwargs):
     settings = kwargs.pop('settings', {})

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -26,7 +26,7 @@ def patch():
 
 def unpatch():
     """
-    Patch pyramid.config.Configurator
+    Unpatch pyramid.config.Configurator if it has been patched.
     """
     if not getattr(pyramid.config, DD_PATCH, False):
         return

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -50,10 +50,10 @@ PATCH_MODULES = {
     # instrumenting should be done idempotently
     'django': True,
     'falcon': True,
+    'pyramid': True,
     # Ignore some web framework integrations that might be configured explicitly in code
     "flask": False,
     "pylons": False,
-    "pyramid": False,
 }
 
 _LOCK = threading.Lock()

--- a/tests/contrib/pyramid/app/web.py
+++ b/tests/contrib/pyramid/app/web.py
@@ -7,7 +7,6 @@ from pyramid.httpexceptions import (
     HTTPInternalServerError,
     HTTPFound,
     HTTPNotFound,
-    HTTPException,
     HTTPNoContent,
 )
 

--- a/tests/contrib/pyramid/app/web.py
+++ b/tests/contrib/pyramid/app/web.py
@@ -1,7 +1,7 @@
 from ddtrace.contrib.pyramid import trace_pyramid
 
+import pyramid
 from pyramid.response import Response
-from pyramid.config import Configurator
 from pyramid.renderers import render_to_response
 from pyramid.httpexceptions import (
     HTTPInternalServerError,
@@ -44,7 +44,7 @@ def create_app(settings, instrument):
         else:
             return HTTPNotFound()
 
-    config = Configurator(settings=settings)
+    config = pyramid.config.Configurator(settings=settings)
     config.add_route('index', '/')
     config.add_route('error', '/error')
     config.add_route('exception', '/exception')

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -116,6 +116,20 @@ class PyramidTestCase(PyramidBase):
         spans = writer.pop()
         eq_(len(spans), 1)
 
+    def test_double_unpatch(self):
+        # Make sure double unpatching is a no-op
+        with self.override_instrument(False):
+            patch()
+            unpatch()
+            unpatch()
+            self.create_app()
+
+        res = self.app.get('/', status=200)
+        assert b'idx' in res.body
+        writer = self.tracer.writer
+        spans = writer.pop()
+        eq_(len(spans), 0)
+
     def test_idempotence(self):
         # Ensure that patching is idempotent with manual instrumentation.
         patch()

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -52,6 +52,7 @@ class PyramidBase(object):
             self.instrument = old
 
 
+
 class PyramidTestCase(PyramidBase):
     """Pyramid TestCase that includes tests for automatic instrumentation"""
 
@@ -122,13 +123,14 @@ class PyramidTestCase(PyramidBase):
             patch()
             unpatch()
             unpatch()
+            patch()
             self.create_app()
 
         res = self.app.get('/', status=200)
         assert b'idx' in res.body
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 0)
+        eq_(len(spans), 1)
 
     def test_idempotence(self):
         # Ensure that patching is idempotent with manual instrumentation.

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -1,27 +1,28 @@
-# stdlib
-import sys
-import webtest
-import ddtrace
-
 from nose.tools import eq_
 from pyramid.config import Configurator
 
-# 3p
-from wsgiref.simple_server import make_server
-
-# project
-from ...test_tracer import get_dummy_tracer
-from ...util import override_global_tracer
-
 from .test_pyramid import PyramidTestCase, PyramidBase
+
+
+"""
+Note: we cannot unpatch when autopatching since the patch will only be
+performed once when the application starts up. So for each test case we have
+to override the tearDown method of the base class (which calls unpatch).
+"""
 
 
 class TestPyramidAutopatch(PyramidTestCase):
     instrument = False
 
+    def tearDown(self):
+        pass
+
 
 class TestPyramidExplicitTweens(PyramidTestCase):
     instrument = False
+
+    def tearDown(self):
+        pass
 
     def get_settings(self):
         return {
@@ -32,6 +33,9 @@ class TestPyramidExplicitTweens(PyramidTestCase):
 class TestPyramidDistributedTracing(PyramidBase):
     instrument = False
 
+    def tearDown(self):
+        pass
+
     def test_distributed_tracing(self):
         # ensure the Context is properly created
         # if distributed tracing is enabled
@@ -40,7 +44,7 @@ class TestPyramidDistributedTracing(PyramidBase):
             'x-datadog-parent-id': '42',
             'x-datadog-sampling-priority': '2',
         }
-        res = self.app.get('/', headers=headers, status=200)
+        self.app.get('/', headers=headers, status=200)
         writer = self.tracer.writer
         spans = writer.pop()
         eq_(len(spans), 1)


### PR DESCRIPTION
This PR continues on from #658, enabling the pyramid integration by default.

In order to properly test the change a test was added to test the idempotence of patching pyramid. To clean up the test an `unpatch` method was added. Tests are added for both `patch` and `unpatch`.