### PR TITLE
[tests] add pdbpp to common dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -103,6 +103,7 @@ deps =
     !ddtracerun: wrapt
     !msgpack03-!msgpack04-!msgpack05-!ddtracerun: msgpack-python
     pytest
+    pdbpp
     opentracing
 # test dependencies installed in all envs
     mock


### PR DESCRIPTION
This PR adds [pdbpp](https://github.com/antocuni/pdb) to the common dependencies we install for test environments.

I am 50/50 on whether this is worth adding. On one end I always install/use `pdbpp` whenever I use `import pdb; pdb.set_trace()` in testing/dev (which I do a lot), but maybe there is a better way?