### PR TITLE
[futures] Enabled by default

### DIFF
--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -25,7 +25,7 @@ PATCH_MODULES = {
     'cassandra': True,
     'celery': True,
     'elasticsearch': True,
-    'futures': False,  # experimental propagation
+    'futures': True,
     'grpc': True,
     'mongoengine': True,
     'mysql': True,


### PR DESCRIPTION
This PR continues on from #658, enabling the futures integration by default.

The futures integration was previously marked as experimental.

@palazzem can you look over the futures integration and give the 👍 / 👎  for if this change is safe to make?