### PR TITLE
[httplib] Enabled by default

### DIFF
--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -42,7 +42,7 @@ PATCH_MODULES = {
     'aiohttp': True,  # requires asyncio (Python 3.4+)
     'aiopg': True,
     'aiobotocore': False,
-    'httplib': False,
+    'httplib': True,
     'vertica': True,
     'jinja2': True,
 


### PR DESCRIPTION
This PR continues on from #658, enabling the httplib integration by default.

Good coverage was provided for patch/unpatch, two more tests added to assert idempotency.