### PR TITLE
[ci] reorganize CircleCI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -748,7 +748,7 @@ jobs:
       - run: VERSION_SUFFIX=$CIRCLE_BRANCH$CIRCLE_BUILD_NUM S3_DIR=trace-dev rake release:wheel
 
   deploy_experimental:
-    # build the develop branch releasing development docs
+    # build the *-dev branch releasing development docs
     docker:
       - image: circleci/python:3.6
     steps:
@@ -939,4 +939,4 @@ workflows:
             - wait_all_tests
           filters:
             branches:
-              only: /(develop)/
+              only: /(.*-dev)/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -837,96 +837,182 @@ workflows:
   test:
     jobs:
       - flake8
-      - tracer
-      - opentracer
-      - integration
-      - futures
-      - boto
-      - ddtracerun
-      - test_utils
-      - asyncio
-      - pylons
-      - aiohttp
-      - tornado
-      - bottle
-      - cassandra
-      - celery
-      - elasticsearch
-      - falcon
-      - django
-      - flask
-      - gevent
-      - httplib
-      - grpc
-      - mongoengine
-      - mysqlconnector
-      - mysqlpython
-      - mysqldb
-      - pymemcache
-      - pymysql
-      - pylibmc
-      - pymongo
-      - pyramid
-      - requests
-      - requestsgevent
-      - sqlalchemy
-      - psycopg
-      - aiobotocore
-      - aiopg
-      - redis
-      - rediscluster
-      - kombu
-      - sqlite3
-      - msgpack
-      - vertica
-      - jinja2
+      - aiobotocore:
+          requires:
+            - flake8
+      - aiohttp:
+          requires:
+            - flake8
+      - aiopg:
+          requires:
+            - flake8
+      - asyncio:
+          requires:
+            - flake8
+      - boto:
+          requires:
+            - flake8
+      - bottle:
+          requires:
+            - flake8
+      - cassandra:
+          requires:
+            - flake8
+      - celery:
+          requires:
+            - flake8
+      - ddtracerun:
+          requires:
+            - flake8
+      - django:
+          requires:
+            - flake8
+      - elasticsearch:
+          requires:
+            - flake8
+      - falcon:
+          requires:
+            - flake8
+      - flask:
+          requires:
+            - flake8
+      - futures:
+          requires:
+            - flake8
+      - gevent:
+          requires:
+            - flake8
+      - grpc:
+          requires:
+            - flake8
+      - httplib:
+          requires:
+            - flake8
+      - integration:
+          requires:
+            - flake8
+      - jinja2:
+          requires:
+            - flake8
+      - kombu:
+          requires:
+            - flake8
+      - mongoengine:
+          requires:
+            - flake8
+      - msgpack:
+          requires:
+            - flake8
+      - mysqlconnector:
+          requires:
+            - flake8
+      - mysqldb:
+          requires:
+            - flake8
+      - mysqlpython:
+          requires:
+            - flake8
+      - opentracer:
+          requires:
+            - flake8
+      - psycopg:
+          requires:
+            - flake8
+      - pylibmc:
+          requires:
+            - flake8
+      - pylons:
+          requires:
+            - flake8
+      - pymemcache:
+          requires:
+            - flake8
+      - pymongo:
+          requires:
+            - flake8
+      - pymysql:
+          requires:
+            - flake8
+      - pyramid:
+          requires:
+            - flake8
+      - redis:
+          requires:
+            - flake8
+      - rediscluster:
+          requires:
+            - flake8
+      - requests:
+          requires:
+            - flake8
+      - requestsgevent:
+          requires:
+            - flake8
+      - sqlalchemy:
+          requires:
+            - flake8
+      - sqlite3:
+          requires:
+            - flake8
+      - test_utils:
+          requires:
+            - flake8
+      - tornado:
+          requires:
+            - flake8
+      - tracer:
+          requires:
+            - flake8
+      - vertica:
+          requires:
+            - flake8
       - build_docs
       - wait_all_tests:
           requires:
             - flake8
-            - tracer
-            - opentracer
-            - integration
-            - futures
-            - boto
-            - ddtracerun
-            - test_utils
-            - asyncio
-            - pylons
+            - aiobotocore
             - aiohttp
-            - tornado
+            - aiopg
+            - asyncio
+            - boto
             - bottle
             - cassandra
             - celery
+            - ddtracerun
+            - django
             - elasticsearch
             - falcon
-            - django
             - flask
+            - futures
             - gevent
             - grpc
             - httplib
+            - integration
+            - jinja2
+            - kombu
             - mongoengine
+            - msgpack
             - mysqlconnector
-            - mysqlpython
             - mysqldb
-            - pymysql
+            - mysqlpython
+            - opentracer
+            - psycopg
             - pylibmc
+            - pylons
             - pymemcache
             - pymongo
+            - pymysql
             - pyramid
+            - redis
+            - rediscluster
             - requests
             - requestsgevent
             - sqlalchemy
-            - psycopg
-            - aiobotocore
-            - aiopg
-            - redis
-            - rediscluster
-            - kombu
             - sqlite3
-            - msgpack
+            - test_utils
+            - tornado
+            - tracer
             - vertica
-            - jinja2
             - build_docs
       - deploy_dev:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -836,6 +836,7 @@ workflows:
 
   test:
     jobs:
+      - build_docs
       - flake8
       - aiobotocore:
           requires:
@@ -966,9 +967,9 @@ workflows:
       - vertica:
           requires:
             - flake8
-      - build_docs
       - wait_all_tests:
           requires:
+            - build_docs
             - flake8
             - aiobotocore
             - aiohttp
@@ -1013,7 +1014,6 @@ workflows:
             - tornado
             - tracer
             - vertica
-            - build_docs
       - deploy_dev:
           requires:
             - wait_all_tests


### PR DESCRIPTION
In this PR:

- Run `deploy_experimental` on all `*-dev` branches
  -  This will deploy to the wheelhouse when we merge into branches like `0.16-dev` so we don't need to merge into `master` in order to deploy to staging
- Reorganize list of jobs to be in alphabetical order
- Make test suites dependent on `flake8` task
  - This means CI will fail fast if linting fails. Bit of a pain to manage the `requires: flake8` for each and every job, but will be nice to not destroy our parallelism if linting fails