### PR TITLE
[requests] patch Session.send instead of Session.request

### DIFF
--- a/ddtrace/contrib/requests/connection.py
+++ b/ddtrace/contrib/requests/connection.py
@@ -37,8 +37,8 @@ def _extract_service_name(session, span, hostname=None):
     return service_name
 
 
-def _wrap_request(func, instance, args, kwargs):
-    """Trace the `Session.request` instance method"""
+def _wrap_send(func, instance, args, kwargs):
+    """Trace the `Session.send` instance method"""
     # TODO[manu]: we already offer a way to provide the Global Tracer
     # and is ddtrace.tracer; it's used only inside our tests and can
     # be easily changed by providing a TracingTestCase that sets common
@@ -49,11 +49,15 @@ def _wrap_request(func, instance, args, kwargs):
     if not tracer.enabled:
         return func(*args, **kwargs)
 
-    method = kwargs.get('method') or args[0]
-    url = kwargs.get('url') or args[1]
-    headers = kwargs.get('headers', {})
-    parsed_uri = parse.urlparse(url)
+    request = kwargs.get('request') or args[0]
+    if not request:
+        return func(*args, **kwargs)
+
     # sanitize url of query
+    parsed_uri = parse.urlparse(request.url)
+    hostname = parsed_uri.hostname
+    if parsed_uri.port:
+        hostname = '{}:{}'.format(hostname, parsed_uri.port)
     sanitized_url = parse.urlunparse((
         parsed_uri.scheme,
         parsed_uri.netloc,
@@ -63,18 +67,14 @@ def _wrap_request(func, instance, args, kwargs):
         parsed_uri.fragment
     ))
 
-    with tracer.trace("requests.request", span_type=http.TYPE) as span:
+    with tracer.trace('requests.request', span_type=http.TYPE) as span:
         # update the span service name before doing any action
-        hostname = parsed_uri.hostname
-        if parsed_uri.port:
-            hostname += ':{}'.format(parsed_uri.port)
         span.service = _extract_service_name(instance, span, hostname=hostname)
 
         # propagate distributed tracing headers
         if config.get_from(instance).get('distributed_tracing'):
             propagator = HTTPPropagator()
-            propagator.inject(span.context, headers)
-            kwargs['headers'] = headers
+            propagator.inject(span.context, request.headers)
 
         response = None
         try:
@@ -82,7 +82,7 @@ def _wrap_request(func, instance, args, kwargs):
             return response
         finally:
             try:
-                span.set_tag(http.METHOD, method.upper())
+                span.set_tag(http.METHOD, request.method.upper())
                 span.set_tag(http.URL, sanitized_url)
                 if response is not None:
                     span.set_tag(http.STATUS_CODE, response.status_code)

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -9,7 +9,7 @@ from ...utils.formats import asbool, get_env
 from ...utils.wrappers import unwrap as _u
 from .legacy import _distributed_tracing, _distributed_tracing_setter
 from .constants import DEFAULT_SERVICE
-from .connection import _wrap_request
+from .connection import _wrap_send
 from ...ext import AppTypes
 
 # requests default settings
@@ -26,7 +26,7 @@ def patch():
         return
     setattr(requests, '__datadog_patch', True)
 
-    _w('requests', 'Session.request', _wrap_request)
+    _w('requests', 'Session.send', _wrap_send)
     Pin(
         service=config.requests['service_name'],
         app='requests',
@@ -48,4 +48,4 @@ def unpatch():
         return
     setattr(requests, '__datadog_patch', False)
 
-    _u(requests.Session, 'request')
+    _u(requests.Session, 'send')

--- a/ddtrace/contrib/requests/session.py
+++ b/ddtrace/contrib/requests/session.py
@@ -2,7 +2,7 @@ import requests
 
 from wrapt import wrap_function_wrapper as _w
 
-from .connection import _wrap_request
+from .connection import _wrap_send
 
 
 class TracedSession(requests.Session):
@@ -14,4 +14,4 @@ class TracedSession(requests.Session):
 
 
 # always patch our `TracedSession` when imported
-_w(TracedSession, 'request', _wrap_request)
+_w(TracedSession, 'send', _wrap_send)

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -105,6 +105,22 @@ class TestRequests(BaseRequestTestCase):
         eq_(s.error, 0)
         eq_(s.span_type, http.TYPE)
 
+    def test_200_send(self):
+        # when calling send directly
+        req = requests.Request(url=URL_200, method='GET')
+        req = self.session.prepare_request(req)
+
+        out = self.session.send(req)
+        eq_(out.status_code, 200)
+        # validation
+        spans = self.tracer.writer.pop()
+        eq_(len(spans), 1)
+        s = spans[0]
+        eq_(s.get_tag(http.METHOD), 'GET')
+        eq_(s.get_tag(http.STATUS_CODE), '200')
+        eq_(s.error, 0)
+        eq_(s.span_type, http.TYPE)
+
     def test_200_query_string(self):
         # ensure query string is removed before adding url to metadata
         out = self.session.get(URL_200 + '?key=value&key2=value2')
@@ -272,17 +288,15 @@ class TestRequests(BaseRequestTestCase):
 
     def test_split_by_domain_wrong(self):
         # ensure the split by domain doesn't crash in case of a wrong URL;
-        # in that case, the default service name must be used
+        # in that case, no spans are created
         cfg = config.get_from(self.session)
         cfg['split_by_domain'] = True
         with assert_raises(MissingSchema):
             self.session.get('http:/some>thing')
 
+        # We are wrapping `requests.Session.send` and this error gets thrown before that function
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
-        s = spans[0]
-
-        eq_(s.service, 'requests')
+        eq_(len(spans), 0)
 
     def test_split_by_domain_remove_auth_in_url(self):
         # ensure that auth details are stripped from URL


### PR DESCRIPTION
This PR changes our `requests` instrumentation to patch `requests.Session.send` instead of `requests.Session.request`.

The problem we have is if someone is using `.send()` directly then we do not end up tracing their calls.

This change is safe to make since `.request()` calls `.send()`, and this is a change compatible with `>=2.0.0`.

If we wanted to support `<2.0.0` in the future we can add tracing back in `requests.Session.request`.