### PR TITLE
[core] Allow DD_AGENT_HOST and DD_TRACE_AGENT_PORT env variables

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -51,7 +51,7 @@ try:
     # TODO: these variables are deprecated; use utils method and update our documentation
     # correct prefix should be DD_*
     enabled = os.environ.get("DATADOG_TRACE_ENABLED")
-    hostname = os.environ.get("DATADOG_TRACE_AGENT_HOSTNAME")
+    hostname = os.environ.get('DD_AGENT_HOST', os.environ.get('DATADOG_TRACE_AGENT_HOSTNAME'))
     port = os.environ.get("DATADOG_TRACE_AGENT_PORT")
     priority_sampling = os.environ.get("DATADOG_PRIORITY_SAMPLING")
 

--- a/ddtrace/contrib/django/conf.py
+++ b/ddtrace/contrib/django/conf.py
@@ -87,15 +87,19 @@ class DatadogSettings(object):
             self.defaults['TAGS'].update({'env': os.environ.get('DATADOG_ENV')})
         if os.environ.get('DATADOG_SERVICE_NAME'):
             self.defaults['DEFAULT_SERVICE'] = os.environ.get('DATADOG_SERVICE_NAME')
-        if os.environ.get('DATADOG_TRACE_AGENT_HOSTNAME'):
-            self.defaults['AGENT_HOSTNAME'] = os.environ.get('DATADOG_TRACE_AGENT_HOSTNAME')
-        if os.environ.get('DATADOG_TRACE_AGENT_PORT'):
+
+        host = os.environ.get('DD_AGENT_HOST', os.environ.get('DATADOG_TRACE_AGENT_HOSTNAME'))
+        if host:
+            self.defaults['AGENT_HOSTNAME'] = host
+
+        port = os.environ.get('DD_TRACE_AGENT_PORT', os.environ.get('DATADOG_TRACE_AGENT_PORT'))
+        if port:
             # if the agent port is a string, the underlying library that creates the socket
             # stops working
             try:
-                port = int(os.environ.get('DATADOG_TRACE_AGENT_PORT'))
+                port = int(port)
             except ValueError:
-                log.warning('DATADOG_TRACE_AGENT_PORT is not an integer value; default to 8126')
+                log.warning('DD_TRACE_AGENT_PORT is not an integer value; default to 8126')
             else:
                 self.defaults['AGENT_PORT'] = port
 

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -27,8 +27,8 @@ class Tracer(object):
         from ddtrace import tracer
         trace = tracer.trace("app.request", "web-server").finish()
     """
-    DEFAULT_HOSTNAME = environ.get('DATADOG_TRACE_AGENT_HOSTNAME', 'localhost')
-    DEFAULT_PORT = 8126
+    DEFAULT_HOSTNAME = environ.get('DD_AGENT_HOST', environ.get('DATADOG_TRACE_AGENT_HOSTNAME', 'localhost'))
+    DEFAULT_PORT = int(environ.get('DD_TRACE_AGENT_PORT', 8126))
 
     def __init__(self):
         """

--- a/tests/commands/ddtrace_run_hostname.py
+++ b/tests/commands/ddtrace_run_hostname.py
@@ -6,5 +6,5 @@ from nose.tools import eq_
 
 if __name__ == '__main__':
     eq_(tracer.writer.api.hostname, "172.10.0.1")
-    eq_(tracer.writer.api.port, 8126)
+    eq_(tracer.writer.api.port, 8120)
     print("Test success")

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -99,6 +99,18 @@ class DdtraceRunTest(unittest.TestCase):
         )
         assert out.startswith(b"Test success")
 
+    def test_host_port_from_env_dd(self):
+        """
+        DD_AGENT_HOST|DD_TRACE_AGENT_PORT point to the tracer
+        to the correct host/port for submission
+        """
+        os.environ['DD_AGENT_HOST'] = '172.10.0.1'
+        os.environ['DD_TRACE_AGENT_PORT'] = '8126'
+        out = subprocess.check_output(
+            ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_hostname.py']
+        )
+        assert out.startswith(b'Test success')
+
     def test_priority_sampling_from_env(self):
         """
         DATADOG_PRIORITY_SAMPLING enables Distributed Sampling

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -93,7 +93,7 @@ class DdtraceRunTest(unittest.TestCase):
         to the correct host/port for submission
         """
         os.environ["DATADOG_TRACE_AGENT_HOSTNAME"] = "172.10.0.1"
-        os.environ["DATADOG_TRACE_AGENT_PORT"] = "8126"
+        os.environ["DATADOG_TRACE_AGENT_PORT"] = "8120"
         out = subprocess.check_output(
             ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_hostname.py']
         )
@@ -105,9 +105,15 @@ class DdtraceRunTest(unittest.TestCase):
         to the correct host/port for submission
         """
         os.environ['DD_AGENT_HOST'] = '172.10.0.1'
-        os.environ['DD_TRACE_AGENT_PORT'] = '8126'
+        os.environ['DD_TRACE_AGENT_PORT'] = '8120'
         out = subprocess.check_output(
             ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_hostname.py']
+        )
+        assert out.startswith(b'Test success')
+
+        # Do we get the same results without `ddtrace-run`?
+        out = subprocess.check_output(
+            ['python', 'tests/commands/ddtrace_run_hostname.py']
         )
         assert out.startswith(b'Test success')
 


### PR DESCRIPTION
To help support desired containerization onboarding improvements we need to support `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` environment variables for configuration.

These changes are the minimal viable changes needed to support these variables. It isn't the most clean, using something like `get_env()` would be better, but we decided to get this out the door since @Kyle-Verhoog has a task to work on standardizing our `DD_*` variables.