### PR TITLE
[tests] pin version of redis-py-cluster for 'tox -e wait'

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -362,7 +362,7 @@ deps=
     cassandra-driver
     psycopg2
     mysql-connector>=2.1,<2.2
-    redis-py-cluster>=1.3.5,<1.3.6
+    redis-py-cluster>=1.3.6,<1.4.0
     vertica-python>=0.6.0,<0.7.0
     kombu>=4.2.0,<4.3.0
 


### PR DESCRIPTION
It seems `tox -e wait <service>` has been failing because `redis-py-cluster` does not support `redis>3.0.0` yet.

Previous versions used to install `redis`, `1.3.6` now pins `redis` to a specific version.