### PR TITLE
[tests] Pin pytest to 3.x.x and redis to 2.10.x for rediscluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -728,7 +728,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e wait rediscluster
-      - run: tox -e 'rediscluster_contrib-{py27,py34,py35,py36}-rediscluster{135}' --result-json /tmp/rediscluster.results
+      - run: tox -e 'rediscluster_contrib-{py27,py34,py35,py36}-rediscluster{135,136}-redis210' --result-json /tmp/rediscluster.results
       - persist_to_workspace:
           root: /tmp
           paths:

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ envlist =
     pymysql_contrib-{py27,py34,py35,py36}-pymysql{07,08,09}
     pyramid_contrib{,_autopatch}-{py27,py34,py35,py36}-pyramid{17,18,19}-webtest
     redis_contrib-{py27,py34,py35,py36}-redis{26,27,28,29,210,300}
-    rediscluster_contrib-{py27,py34,py35,py36}-rediscluster{135}
+    rediscluster_contrib-{py27,py34,py35,py36}-rediscluster{135,136}-redis210
     requests_contrib{,_autopatch}-{py27,py34,py35,py36}-requests{208,209,210,211,212,213,219}
     kombu_contrib-{py27,py34,py35,py36}-kombu{40,41,42}
 # python 3.6 requests + gevent regression test
@@ -249,6 +249,7 @@ deps =
     redis210: redis>=2.10,<2.11
     redis300: redis>=3.0.0,<3.1.0
     rediscluster135: redis-py-cluster>=1.3.5,<1.3.6
+    rediscluster136: redis-py-cluster>=1.3.6,<1.3.7
     kombu42:  kombu>=4.2,<4.3
     kombu41:  kombu>=4.1,<4.2
     kombu40:  kombu>=4.0,<4.1

--- a/tox.ini
+++ b/tox.ini
@@ -112,7 +112,7 @@ deps =
 # distribution build.
     !ddtracerun: wrapt
     !msgpack03-!msgpack04-!msgpack05-!ddtracerun: msgpack-python
-    pytest
+    pytest>=3.0.0,<4.0.0
     opentracing
 # test dependencies installed in all envs
     mock


### PR DESCRIPTION
New major releases are killing us this month...