### PR TITLE
[core] Remove pin.app and pin.app_type 

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -78,7 +78,6 @@ class API(object):
             return
         self._version = version
         self._traces = _VERSIONS[version]['traces']
-        self._services = _VERSIONS[version]['services']
         self._fallback = _VERSIONS[version]['fallback']
         self._compatibility_mode = _VERSIONS[version]['compatibility_mode']
         if self._compatibility_mode:
@@ -111,24 +110,6 @@ class API(object):
             return self.send_traces(traces)
 
         log.debug("reported %d traces in %.5fs", len(traces), time.time() - start)
-        return response
-
-    def send_services(self, services):
-        if not services:
-            return
-        s = {}
-        for service in services:
-            s.update(service)
-        data = self._encoder.encode_services(s)
-        response = self._put(self._services, data)
-
-        # the API endpoint is not available so we should downgrade the connection and re-try the call
-        if response.status in [404, 415] and self._fallback:
-            log.debug('calling endpoint "%s" but received %s; downgrading API', self._services, response.status)
-            self._downgrade()
-            return self.send_services(services)
-
-        log.debug("reported %d services", len(services))
         return response
 
     def _put(self, endpoint, data, count=0):

--- a/ddtrace/contrib/aiobotocore/patch.py
+++ b/ddtrace/contrib/aiobotocore/patch.py
@@ -21,7 +21,7 @@ def patch():
     setattr(aiobotocore.client, '_datadog_patch', True)
 
     wrapt.wrap_function_wrapper('aiobotocore.client', 'AioBaseClient._make_api_call', _wrapped_api_call)
-    Pin(service='aws', app='aws', app_type='web').onto(aiobotocore.client.AioBaseClient)
+    Pin(service='aws').onto(aiobotocore.client.AioBaseClient)
 
 
 def unpatch():

--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -1,9 +1,8 @@
 import asyncio
 
 from ..asyncio import context_provider
-from ...ext import AppTypes, http
+from ...ext import http
 from ...compat import stringify
-from ...context import Context
 from ...propagation.http import HTTPPropagator
 
 

--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -115,13 +115,6 @@ def trace_app(app, tracer, service='aiohttp-web'):
     # the tracer must work with asynchronous Context propagation
     tracer.configure(context_provider=context_provider)
 
-    # configure the current service
-    tracer.set_service_info(
-        service=service,
-        app='aiohttp',
-        app_type=AppTypes.web,
-    )
-
     # add the async tracer middleware as a first middleware
     # and be sure that the on_prepare signal is the last one
     app.middlewares.insert(0, trace_middleware)

--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -26,7 +26,7 @@ def patch():
 
         _w = wrapt.wrap_function_wrapper
         _w('aiohttp_jinja2', 'render_template', _trace_render_template)
-        Pin(app='aiohttp', service=None, app_type='web').onto(aiohttp_jinja2)
+        Pin(service=None).onto(aiohttp_jinja2)
 
 
 def unpatch():

--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -61,7 +61,7 @@ class AIOTracedCursor(wrapt.ObjectProxy):
 class AIOTracedConnection(wrapt.ObjectProxy):
     """ TracedConnection wraps a Connection with tracing code. """
 
-    def __init__(self, conn, pin=None):
+    def __init__(self, conn, pin=None, name=None):
         super(AIOTracedConnection, self).__init__(conn)
         name = dbapi._get_vendor(conn)
         db_pin = pin or Pin(service=name)

--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -14,7 +14,6 @@ class AIOTracedCursor(wrapt.ObjectProxy):
     def __init__(self, cursor, pin):
         super(AIOTracedCursor, self).__init__(cursor)
         pin.onto(self)
-        self._datadog_name = 'sql.query'
 
     @asyncio.coroutine
     def _trace_method(self, method, resource, extra_tags, *args, **kwargs):
@@ -24,7 +23,7 @@ class AIOTracedCursor(wrapt.ObjectProxy):
             return result
         service = pin.service
 
-        with pin.tracer.trace(self._datadog_name, service=service,
+        with pin.tracer.trace('postgres.query', service=service,
                               resource=resource) as s:
             s.span_type = sql.TYPE
             s.set_tag(sql.QUERY, resource)

--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -5,7 +5,7 @@ from aiopg.utils import _ContextManager
 
 from .. import dbapi
 from ...pin import Pin
-from ...ext import sql, AppTypes
+from ...ext import sql
 
 
 class AIOTracedCursor(wrapt.ObjectProxy):
@@ -14,8 +14,7 @@ class AIOTracedCursor(wrapt.ObjectProxy):
     def __init__(self, cursor, pin):
         super(AIOTracedCursor, self).__init__(cursor)
         pin.onto(self)
-        name = pin.app or 'sql'
-        self._datadog_name = '%s.query' % name
+        self._datadog_name = 'sql.query'
 
     @asyncio.coroutine
     def _trace_method(self, method, resource, extra_tags, *args, **kwargs):
@@ -66,7 +65,7 @@ class AIOTracedConnection(wrapt.ObjectProxy):
     def __init__(self, conn, pin=None):
         super(AIOTracedConnection, self).__init__(conn)
         name = dbapi._get_vendor(conn)
-        db_pin = pin or Pin(service=name, app=name, app_type=AppTypes.db)
+        db_pin = pin or Pin(service=name)
         db_pin.onto(self)
 
     def cursor(self, *args, **kwargs):

--- a/ddtrace/contrib/boto/patch.py
+++ b/ddtrace/contrib/boto/patch.py
@@ -41,10 +41,10 @@ def patch():
     wrapt.wrap_function_wrapper(
         "boto.connection", "AWSAuthConnection.make_request", patched_auth_request
     )
-    Pin(service="aws", app="aws", app_type="web").onto(
+    Pin(service="aws").onto(
         boto.connection.AWSQueryConnection
     )
-    Pin(service="aws", app="aws", app_type="web").onto(
+    Pin(service="aws").onto(
         boto.connection.AWSAuthConnection
     )
 

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -26,7 +26,7 @@ def patch():
     setattr(botocore.client, '_datadog_patch', True)
 
     wrapt.wrap_function_wrapper('botocore.client', 'BaseClient._make_api_call', patched_api_call)
-    Pin(service="aws", app="aws", app_type="web").onto(botocore.client.BaseClient)
+    Pin(service='aws').onto(botocore.client.BaseClient)
 
 
 def unpatch():

--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -18,11 +18,6 @@ class TracePlugin(object):
         self.service = service
         self.tracer = tracer or ddtrace.tracer
         self.distributed_tracing = distributed_tracing
-        self.tracer.set_service_info(
-            service=service,
-            app='bottle',
-            app_type=AppTypes.web,
-        )
 
     def apply(self, callback, route):
 

--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -3,7 +3,7 @@ from bottle import response, request
 
 # stdlib
 import ddtrace
-from ddtrace.ext import http, AppTypes
+from ddtrace.ext import http
 
 # project
 from ...propagation.http import HTTPPropagator

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -29,7 +29,7 @@ def patch():
     """ patch will add tracing to the cassandra library. """
     setattr(cassandra.cluster.Cluster, 'connect',
             wrapt.FunctionWrapper(_connect, traced_connect))
-    Pin(service=SERVICE, app=SERVICE, app_type="db").onto(cassandra.cluster.Cluster)
+    Pin(service=SERVICE).onto(cassandra.cluster.Cluster)
 
 def unpatch():
     cassandra.cluster.Cluster.connect = _connect

--- a/ddtrace/contrib/celery/app.py
+++ b/ddtrace/contrib/celery/app.py
@@ -2,9 +2,7 @@ from celery import signals
 
 from ddtrace import Pin, config
 from ddtrace.pin import _DD_PIN_NAME
-from ddtrace.ext import AppTypes
 
-from .constants import APP
 from .signals import (
     trace_prerun,
     trace_postrun,
@@ -26,8 +24,6 @@ def patch_app(app, pin=None):
     # attach the PIN object
     pin = pin or Pin(
         service=config.celery['worker_service_name'],
-        app=APP,
-        app_type=AppTypes.worker,
         _config=config.celery,
     )
     pin.onto(app)

--- a/ddtrace/contrib/celery/constants.py
+++ b/ddtrace/contrib/celery/constants.py
@@ -14,8 +14,6 @@ TASK_APPLY_ASYNC = 'apply_async'
 TASK_RUN = 'run'
 TASK_RETRY_REASON_KEY = 'celery.retry.reason'
 
-# Service info
-APP = 'celery'
 # `getenv()` call must be kept for backward compatibility; we may remove it
 # later when we do a full migration to the `Config` class
 PRODUCER_SERVICE = getenv('DATADOG_SERVICE_NAME') or 'celery-producer'

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -7,7 +7,7 @@ import logging
 import wrapt
 
 from ddtrace import Pin
-from ddtrace.ext import AppTypes, sql
+from ddtrace.ext import sql
 
 log = logging.getLogger(__name__)
 
@@ -15,10 +15,9 @@ log = logging.getLogger(__name__)
 class TracedCursor(wrapt.ObjectProxy):
     """ TracedCursor wraps a psql cursor and traces it's queries. """
 
-    def __init__(self, cursor, pin):
+    def __init__(self, cursor, pin, name='sql'):
         super(TracedCursor, self).__init__(cursor)
         pin.onto(self)
-        name = pin.app or 'sql'
         self._self_datadog_name = '{}.query'.format(name)
         self._self_last_execute_operation = None
 
@@ -123,7 +122,7 @@ class TracedConnection(wrapt.ObjectProxy):
         super(TracedConnection, self).__init__(conn)
         name = _get_vendor(conn)
         self._self_datadog_name = '{}.connection'.format(name)
-        db_pin = pin or Pin(service=name, app=name, app_type=AppTypes.db)
+        db_pin = pin or Pin(service=name)
         db_pin.onto(self)
 
     def _trace_method(self, method, name, extra_tags, *args, **kwargs):

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -120,8 +120,8 @@ class TracedConnection(wrapt.ObjectProxy):
 
     def __init__(self, conn, pin=None, name=None):
         super(TracedConnection, self).__init__(conn)
-        name = name if name is not None else _get_vendor(conn)
         self._self_name = name
+        name = _get_vendor(conn)
         self._self_datadog_name = '{}.connection'.format(name)
         db_pin = pin or Pin(service=name)
         db_pin.onto(self)
@@ -143,7 +143,7 @@ class TracedConnection(wrapt.ObjectProxy):
         pin = Pin.get_from(self)
         if not pin:
             return cursor
-        return TracedCursor(cursor, pin, self._self_name)
+        return TracedCursor(cursor, pin, name=self._self_name)
 
     def commit(self, *args, **kwargs):
         span_name = '{}.{}'.format(self._self_datadog_name, 'commit')

--- a/ddtrace/contrib/django/apps.py
+++ b/ddtrace/contrib/django/apps.py
@@ -7,10 +7,8 @@ from django.apps import AppConfig, apps
 from .db import patch_db
 from .conf import settings
 from .cache import patch_cache
-from .templates import patch_template
 from .middleware import insert_exception_middleware, insert_trace_middleware
-
-from ...ext import AppTypes
+from .templates import patch_template
 
 
 log = logging.getLogger(__name__)
@@ -38,13 +36,6 @@ class TracerConfig(AppConfig):
         tracer.enabled = settings.ENABLED
         tracer.writer.api.hostname = settings.AGENT_HOSTNAME
         tracer.writer.api.port = settings.AGENT_PORT
-
-        # define the service details
-        tracer.set_service_info(
-            app='django',
-            app_type=AppTypes.web,
-            service=settings.DEFAULT_SERVICE,
-        )
 
         if settings.AUTO_INSTRUMENT:
             # trace Django internals

--- a/ddtrace/contrib/django/db.py
+++ b/ddtrace/contrib/django/db.py
@@ -5,7 +5,6 @@ from django.db import connections
 
 # project
 from ...ext import sql as sqlx
-from ...ext import AppTypes
 
 from .conf import settings
 from ..dbapi import TracedCursor as DbApiTracedCursor
@@ -63,12 +62,6 @@ def patch_conn(tracer, conn):
             'django.db.vendor': vendor,
             'django.db.alias': alias,
         }
-        tracer.set_service_info(
-            service=service,
-            app=prefix,
-            app_type=AppTypes.db,
-        )
-
         pin = Pin(service, tags=tags, tracer=tracer, app=prefix)
         return DbApiTracedCursor(conn._datadog_original_cursor(), pin)
 

--- a/ddtrace/contrib/django/db.py
+++ b/ddtrace/contrib/django/db.py
@@ -3,6 +3,8 @@ import logging
 from django.db import connections
 
 from ddtrace import Pin
+from ...ext import sql as sqlx
+
 from .conf import settings
 from ..dbapi import TracedCursor as DbApiTracedCursor
 
@@ -53,6 +55,7 @@ def patch_conn(tracer, conn):
         alias = getattr(conn, 'alias', 'default')
         service = '{}{}{}'.format(database_prefix, alias, 'db')
         vendor = getattr(conn, 'vendor', 'db')
+        prefix = sqlx.normalize_vendor(vendor)
         tags = {
             'django.db.vendor': vendor,
             'django.db.alias': alias,

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -5,7 +5,7 @@ from wrapt import wrap_function_wrapper as _w
 from .quantize import quantize
 
 from ...compat import urlencode
-from ...ext import elasticsearch as metadata, http, AppTypes
+from ...ext import elasticsearch as metadata, http
 from ...pin import Pin
 from ...utils.wrappers import unwrap as _u
 
@@ -30,7 +30,7 @@ def _patch(elasticsearch):
         return
     setattr(elasticsearch, '_datadog_patch', True)
     _w(elasticsearch.transport, 'Transport.perform_request', _get_perform_request(elasticsearch))
-    Pin(service=metadata.SERVICE, app=metadata.APP, app_type=AppTypes.db).onto(elasticsearch.transport.Transport)
+    Pin(service=metadata.SERVICE).onto(elasticsearch.transport.Transport)
 
 
 def unpatch():

--- a/ddtrace/contrib/elasticsearch/transport.py
+++ b/ddtrace/contrib/elasticsearch/transport.py
@@ -6,7 +6,7 @@ from .quantize import quantize
 
 from ...utils.deprecation import deprecated
 from ...compat import urlencode
-from ...ext import AppTypes, http, elasticsearch as metadata
+from ...ext import http, elasticsearch as metadata
 
 DEFAULT_SERVICE = 'elasticsearch'
 SPAN_TYPE = 'elasticsearch'

--- a/ddtrace/contrib/elasticsearch/transport.py
+++ b/ddtrace/contrib/elasticsearch/transport.py
@@ -15,12 +15,6 @@ SPAN_TYPE = 'elasticsearch'
 @deprecated(message='Use patching instead (see the docs).', version='1.0.0')
 def get_traced_transport(datadog_tracer, datadog_service=DEFAULT_SERVICE):
 
-    datadog_tracer.set_service_info(
-        service=datadog_service,
-        app=SPAN_TYPE,
-        app_type=AppTypes.db,
-    )
-
     class TracedTransport(elasticsearch.Transport):
         """ Extend elasticseach transport layer to allow Datadog
             tracer to catch any performed request.

--- a/ddtrace/contrib/falcon/middleware.py
+++ b/ddtrace/contrib/falcon/middleware.py
@@ -3,8 +3,8 @@ import sys
 from ddtrace.ext import http as httpx
 from ddtrace.http import store_request_headers, store_response_headers
 from ddtrace.propagation.http import HTTPPropagator
+
 from ...compat import iteritems
-from ...ext import AppTypes
 from ...settings import config
 
 
@@ -15,13 +15,6 @@ class TraceMiddleware(object):
         self.tracer = tracer
         self.service = service
         self._distributed_tracing = distributed_tracing
-
-        # configure Falcon service
-        self.tracer.set_service_info(
-            app='falcon',
-            app_type=AppTypes.web,
-            service=service,
-        )
 
     def process_request(self, req, resp):
         if self._distributed_tracing:

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -1,7 +1,7 @@
 import logging
 
 from ... import compat
-from ...ext import http, errors, AppTypes
+from ...ext import http, errors
 from ...propagation.http import HTTPPropagator
 from ...utils.deprecation import deprecated
 

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -37,12 +37,6 @@ class TraceMiddleware(object):
             return
         setattr(app, '__dd_instrumentation', True)
 
-        self.app._tracer.set_service_info(
-            service=service,
-            app="flask",
-            app_type=AppTypes.web,
-        )
-
         # Install hooks which time requests.
         self.app.before_request(self._before_request)
         self.app.after_request(self._after_request)

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -7,7 +7,6 @@ from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config, Pin
 
-from ...ext import AppTypes
 from ...ext import http
 from ...propagation.http import HTTPPropagator
 from ...utils.wrappers import unwrap as _u
@@ -26,8 +25,6 @@ config._add('flask', dict(
     # Flask service configuration
     # DEV: Environment variable 'DATADOG_SERVICE_NAME' used for backwards compatibility
     service_name=os.environ.get('DATADOG_SERVICE_NAME') or 'flask',
-    app='flask',
-    app_type=AppTypes.web,
 
     collect_view_args=True,
     distributed_tracing_enabled=False,
@@ -66,11 +63,7 @@ def patch():
     setattr(flask, '_datadog_patch', True)
 
     # Attach service pin to `flask.app.Flask`
-    Pin(
-        service=config.flask['service_name'],
-        app=config.flask['app'],
-        app_type=config.flask['app_type'],
-    ).onto(flask.Flask)
+    Pin(service=config.flask['service_name']).onto(flask.Flask)
 
     # flask.app.Flask methods that have custom tracing (add metadata, wrap functions, etc)
     _w('flask', 'Flask.wsgi_app', traced_wsgi_app)

--- a/ddtrace/contrib/flask_cache/tracers.py
+++ b/ddtrace/contrib/flask_cache/tracers.py
@@ -29,13 +29,6 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
     Return a traced Cache object that behaves exactly as the ``flask.ext.cache.Cache class``
     """
 
-    # set the Tracer info
-    ddtracer.set_service_info(
-        app="flask",
-        app_type=AppTypes.cache,
-        service=service,
-    )
-
     class TracedCache(Cache):
         """
         Traced cache backend that monitors any operations done by flask_cache. Observed actions are:

--- a/ddtrace/contrib/flask_cache/tracers.py
+++ b/ddtrace/contrib/flask_cache/tracers.py
@@ -7,7 +7,6 @@ import logging
 
 # project
 from .utils import _extract_conn_tags, _resource_from_cache_prefix
-from ...ext import AppTypes
 
 # 3rd party
 from flask.ext.cache import Cache

--- a/ddtrace/contrib/grpc/patch.py
+++ b/ddtrace/contrib/grpc/patch.py
@@ -11,7 +11,7 @@ def patch():
     if getattr(grpc, '__datadog_patch', False):
         return
     setattr(grpc, '__datadog_patch', True)
-    Pin(service='grpc', app='grpc', app_type='grpc').onto(grpc)
+    Pin(service='grpc').onto(grpc)
 
     _w = wrapt.wrap_function_wrapper
 

--- a/ddtrace/contrib/httplib/patch.py
+++ b/ddtrace/contrib/httplib/patch.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 def _wrap_init(func, instance, args, kwargs):
-    Pin(app='httplib', service=None, app_type=ext_http.TYPE).onto(instance)
+    Pin(service=None).onto(instance)
     return func(*args, **kwargs)
 
 

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -9,7 +9,6 @@ from ...pin import Pin
 from ...utils.formats import get_env
 from .constants import DEFAULT_SERVICE
 from ...ext import kombu as kombux
-from ...ext import AppTypes
 from ...utils.wrappers import unwrap
 from ...propagation.http import HTTPPropagator
 from .utils import (
@@ -45,17 +44,9 @@ def patch():
     # *  extracts/normalizes things like exchange
     _w(kombux.TYPE, 'Producer._publish', traced_publish)
     _w(kombux.TYPE, 'Consumer.receive', traced_receive)
-    Pin(
-        service=config.kombu['service_name'],
-        app='kombu',
-        app_type=AppTypes.worker,
-    ).onto(kombu.messaging.Producer)
+    Pin(service=config.kombu['service_name']).onto(kombu.messaging.Producer)
 
-    Pin(
-        service=config.kombu['service_name'],
-        app='kombu',
-        app_type=AppTypes.worker,
-    ).onto(kombu.messaging.Consumer)
+    Pin(service=config.kombu['service_name']).onto(kombu.messaging.Consumer)
 
 
 def unpatch():

--- a/ddtrace/contrib/mongoengine/trace.py
+++ b/ddtrace/contrib/mongoengine/trace.py
@@ -4,7 +4,7 @@ import wrapt
 
 # project
 import ddtrace
-from ddtrace.ext import AppTypes, mongo as mongox
+from ddtrace.ext import mongo as mongox
 from ddtrace.contrib.pymongo.client import TracedMongoClient
 
 
@@ -27,11 +27,6 @@ class WrappedConnect(wrapt.ObjectProxy):
             # existing pymongo integration and make sure that the connections it
             # uses internally are traced.
 
-            pin.tracer.set_service_info(
-                service=pin.service,
-                app=mongox.TYPE,
-                app_type=AppTypes.db,
-            )
             client = TracedMongoClient(client)
             ddtrace.Pin(service=pin.service, tracer=pin.tracer).onto(client)
 

--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -37,6 +37,6 @@ def patch_conn(conn):
     pin = Pin(service="mysql", tags=tags)
 
     # grab the metadata from the conn
-    wrapped = TracedConnection(conn, pin=pin)
+    wrapped = TracedConnection(conn, pin=pin, name='mysql')
     pin.onto(wrapped)
     return wrapped

--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -5,7 +5,7 @@ import mysql.connector
 # project
 from ddtrace import Pin
 from ddtrace.contrib.dbapi import TracedConnection
-from ...ext import net, db, AppTypes
+from ...ext import net, db
 
 
 CONN_ATTR_BY_TAG = {
@@ -34,7 +34,7 @@ def _connect(func, instance, args, kwargs):
 def patch_conn(conn):
 
     tags = {t: getattr(conn, a) for t, a in CONN_ATTR_BY_TAG.items() if getattr(conn, a, '') != ''}
-    pin = Pin(service="mysql", app="mysql", app_type=AppTypes.db, tags=tags)
+    pin = Pin(service="mysql", tags=tags)
 
     # grab the metadata from the conn
     wrapped = TracedConnection(conn, pin=pin)

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -58,6 +58,6 @@ def patch_conn(conn, *args, **kwargs):
     pin = Pin(service='mysql', tags=tags)
 
     # grab the metadata from the conn
-    wrapped = TracedConnection(conn, pin=pin)
+    wrapped = TracedConnection(conn, pin=pin, name='mysql')
     pin.onto(wrapped)
     return wrapped

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -7,7 +7,7 @@ from wrapt import wrap_function_wrapper as _w
 from ddtrace import Pin
 from ddtrace.contrib.dbapi import TracedConnection
 
-from ...ext import net, db, AppTypes
+from ...ext import net, db
 from ...utils.wrappers import unwrap as _u
 
 
@@ -55,7 +55,7 @@ def patch_conn(conn, *args, **kwargs):
             for t, (k, p) in KWPOS_BY_TAG.items()
             if k in kwargs or len(args) > p}
     tags[net.TARGET_PORT] = conn.port
-    pin = Pin(service="mysql", app="mysql", app_type=AppTypes.db, tags=tags)
+    pin = Pin(service='mysql', tags=tags)
 
     # grab the metadata from the conn
     wrapped = TracedConnection(conn, pin=pin)

--- a/ddtrace/contrib/psycopg/connection.py
+++ b/ddtrace/contrib/psycopg/connection.py
@@ -8,7 +8,6 @@ import functools
 from ...ext import db
 from ...ext import net
 from ...ext import sql
-from ...ext import AppTypes
 from ...utils.deprecation import deprecated
 
 # 3p

--- a/ddtrace/contrib/psycopg/connection.py
+++ b/ddtrace/contrib/psycopg/connection.py
@@ -24,12 +24,6 @@ def connection_factory(tracer, service="postgres"):
         >>> conn = pyscopg2.connect(..., connection_factory=factory)
     """
 
-    tracer.set_service_info(
-        service=service,
-        app="postgres",
-        app_type=AppTypes.db,
-    )
-
     return functools.partial(TracedConnection,
         datadog_tracer=tracer,
         datadog_service=service)

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -35,7 +35,7 @@ def patch_conn(conn, traced_conn_cls=dbapi.TracedConnection):
     # case we're only tracing some connections.
     _patch_extensions(_psycopg2_extensions)
 
-    c = traced_conn_cls(conn)
+    c = traced_conn_cls(conn, name='postgres')
 
     # fetch tags from the dsn
     dsn = sql.parse_pg_dsn(conn.dsn)

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -47,11 +47,7 @@ def patch_conn(conn, traced_conn_cls=dbapi.TracedConnection):
         "db.application" : dsn.get("application_name"),
     }
 
-    Pin(
-        service="postgres",
-        app="postgres",
-        app_type="db",
-        tags=tags).onto(c)
+    Pin(service="postgres", tags=tags).onto(c)
 
     return c
 

--- a/ddtrace/contrib/pylibmc/client.py
+++ b/ddtrace/contrib/pylibmc/client.py
@@ -50,15 +50,6 @@ class TracedClient(ObjectProxy):
         except Exception:
             log.debug("error setting addresses", exc_info=True)
 
-        # attempt to set the service info
-        try:
-            pin.tracer.set_service_info(
-                service=service,
-                app=memcached.SERVICE,
-                app_type=memcached.TYPE)
-        except Exception:
-            log.debug("error setting service info", exc_info=True)
-
     def clone(self, *args, **kwargs):
         # rewrap new connections.
         cloned = self.__wrapped__.clone(*args, **kwargs)

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -8,7 +8,7 @@ from .renderer import trace_rendering
 from .constants import CONFIG_MIDDLEWARE
 
 from ...compat import reraise
-from ...ext import http, AppTypes
+from ...ext import http
 from ...propagation.http import HTTPPropagator
 
 log = logging.getLogger(__name__)

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -28,12 +28,6 @@ class PylonsTraceMiddleware(object):
         # add template tracing
         trace_rendering()
 
-        self._tracer.set_service_info(
-            service=service,
-            app="pylons",
-            app_type=AppTypes.web,
-        )
-
     def __call__(self, environ, start_response):
         if self._distributed_tracing:
             # retrieve distributed tracing headers

--- a/ddtrace/contrib/pymemcache/patch.py
+++ b/ddtrace/contrib/pymemcache/patch.py
@@ -15,9 +15,7 @@ def patch():
     setattr(pymemcache.client.base, "Client", WrappedClient)
 
     # Create a global pin with default configuration for our pymemcache clients
-    Pin(
-        app=memcachedx.SERVICE, service=memcachedx.SERVICE, app_type=memcachedx.TYPE
-    ).onto(pymemcache)
+    Pin(service=memcachedx.SERVICE).onto(pymemcache)
 
 
 def unpatch():

--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -11,7 +11,6 @@ from wrapt import ObjectProxy
 import ddtrace
 from ...utils.deprecation import deprecated
 from ...compat import iteritems
-from ...ext import AppTypes
 from ...ext import mongo as mongox
 from ...ext import net as netx
 from .parse import parse_spec, parse_query, parse_msg
@@ -60,7 +59,7 @@ class TracedMongoClient(ObjectProxy):
         client._topology = TracedTopology(client._topology)
 
         # Default Pin
-        ddtrace.Pin(service=mongox.TYPE, app=mongox.TYPE, app_type=AppTypes.db).onto(self)
+        ddtrace.Pin(service=mongox.TYPE).onto(self)
 
     def __setddpin__(self, pin):
         pin.onto(self._topology)

--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -24,11 +24,6 @@ log = logging.getLogger(__name__)
 
 @deprecated(message='Use patching instead (see the docs).', version='1.0.0')
 def trace_mongo_client(client, tracer, service=mongox.TYPE):
-    tracer.set_service_info(
-        service=service,
-        app=mongox.TYPE,
-        app_type=AppTypes.db,
-    )
     traced_client = TracedMongoClient(client)
     ddtrace.Pin(service=service, tracer=tracer).onto(traced_client)
     return traced_client

--- a/ddtrace/contrib/pymysql/patch.py
+++ b/ddtrace/contrib/pymysql/patch.py
@@ -5,7 +5,7 @@ import pymysql
 # project
 from ddtrace import Pin
 from ddtrace.contrib.dbapi import TracedConnection
-from ...ext import net, db, AppTypes
+from ...ext import net, db
 
 CONN_ATTR_BY_TAG = {
     net.TARGET_HOST: 'host',
@@ -31,7 +31,7 @@ def _connect(func, instance, args, kwargs):
 
 def patch_conn(conn):
     tags = {t: getattr(conn, a, '') for t, a in CONN_ATTR_BY_TAG.items()}
-    pin = Pin(service="pymysql", app="pymysql", app_type=AppTypes.db, tags=tags)
+    pin = Pin(service='pymysql', tags=tags)
 
     # grab the metadata from the conn
     wrapped = TracedConnection(conn, pin=pin)

--- a/ddtrace/contrib/pymysql/patch.py
+++ b/ddtrace/contrib/pymysql/patch.py
@@ -34,6 +34,6 @@ def patch_conn(conn):
     pin = Pin(service='pymysql', tags=tags)
 
     # grab the metadata from the conn
-    wrapped = TracedConnection(conn, pin=pin)
+    wrapped = TracedConnection(conn, pin=pin, name='pymysql')
     pin.onto(wrapped)
     return wrapped

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -8,7 +8,7 @@ import wrapt
 
 # project
 import ddtrace
-from ...ext import http, AppTypes
+from ...ext import http
 from ...propagation.http import HTTPPropagator
 from .constants import (
     SETTINGS_TRACER,

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -59,12 +59,6 @@ def trace_tween_factory(handler, registry):
     enabled = asbool(settings.get(SETTINGS_TRACE_ENABLED, tracer.enabled))
     distributed_tracing = asbool(settings.get(SETTINGS_DISTRIBUTED_TRACING, False))
 
-    # set the service info
-    tracer.set_service_info(
-        service=service,
-        app="pyramid",
-        app_type=AppTypes.web)
-
     if enabled:
         # make a request tracing function
         def trace_tween(request):

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -1,4 +1,3 @@
-
 # 3p
 import logging
 import pyramid.renderers

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -4,7 +4,7 @@ import wrapt
 
 # project
 from ...pin import Pin
-from ...ext import AppTypes, redis as redisx
+from ...ext import redis as redisx
 from ...utils.wrappers import unwrap
 from .util import format_command_args, _extract_conn_tags
 
@@ -32,7 +32,7 @@ def patch():
         _w('redis', 'Redis.pipeline', traced_pipeline)
         _w('redis.client', 'Pipeline.execute', traced_execute_pipeline)
         _w('redis.client', 'Pipeline.immediate_execute_command', traced_execute_command)
-    Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP, app_type=AppTypes.db).onto(redis.StrictRedis)
+    Pin(service=redisx.DEFAULT_SERVICE).onto(redis.StrictRedis)
 
 def unpatch():
     if getattr(redis, '_datadog_patch', False):

--- a/ddtrace/contrib/rediscluster/patch.py
+++ b/ddtrace/contrib/rediscluster/patch.py
@@ -4,7 +4,7 @@ import wrapt
 
 # project
 from ...pin import Pin
-from ...ext import AppTypes, redis as redisx
+from ...ext import redis as redisx
 from ...utils.wrappers import unwrap
 from ..redis.patch import traced_execute_command, traced_pipeline
 from ..redis.util import format_command_args
@@ -21,7 +21,7 @@ def patch():
     _w('rediscluster', 'StrictRedisCluster.execute_command', traced_execute_command)
     _w('rediscluster', 'StrictRedisCluster.pipeline', traced_pipeline)
     _w('rediscluster', 'StrictClusterPipeline.execute', traced_execute_pipeline)
-    Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP, app_type=AppTypes.db).onto(rediscluster.StrictRedisCluster)
+    Pin(service=redisx.DEFAULT_SERVICE).onto(rediscluster.StrictRedisCluster)
 
 
 def unpatch():

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -10,7 +10,6 @@ from ...utils.wrappers import unwrap as _u
 from .legacy import _distributed_tracing, _distributed_tracing_setter
 from .constants import DEFAULT_SERVICE
 from .connection import _wrap_send
-from ...ext import AppTypes
 
 # requests default settings
 config._add('requests',{
@@ -29,8 +28,6 @@ def patch():
     _w('requests', 'Session.send', _wrap_send)
     Pin(
         service=config.requests['service_name'],
-        app='requests',
-        app_type=AppTypes.web,
         _config=config.requests,
     ).onto(requests.Session)
 

--- a/ddtrace/contrib/sqlalchemy/engine.py
+++ b/ddtrace/contrib/sqlalchemy/engine.py
@@ -57,18 +57,10 @@ class EngineTracer(object):
         self.service = service or self.vendor
         self.name = "%s.query" % self.vendor
 
-        # set the service info.
-        self.tracer.set_service_info(
-            service=self.service,
-            app=self.vendor,
-            app_type=sqlx.APP_TYPE)
-
         # attach the PIN
         Pin(
-            app=self.vendor,
             tracer=tracer,
             service=self.service,
-            app_type=sqlx.APP_TYPE,
         ).onto(engine)
 
         listen(engine, 'before_cursor_execute', self._before_cur_exec)

--- a/ddtrace/contrib/sqlite3/patch.py
+++ b/ddtrace/contrib/sqlite3/patch.py
@@ -7,7 +7,6 @@ import wrapt
 from ddtrace import Pin
 from ddtrace.contrib.dbapi import TracedConnection
 
-from ...ext import AppTypes
 
 # Original connect method
 _connect = sqlite3.connect
@@ -28,7 +27,7 @@ def traced_connect(func, _, args, kwargs):
 
 def patch_conn(conn):
     wrapped = TracedSQLite(conn)
-    Pin(service="sqlite", app="sqlite", app_type=AppTypes.db).onto(wrapped)
+    Pin(service='sqlite').onto(wrapped)
     return wrapped
 
 class TracedSQLite(TracedConnection):

--- a/ddtrace/contrib/sqlite3/patch.py
+++ b/ddtrace/contrib/sqlite3/patch.py
@@ -26,7 +26,7 @@ def traced_connect(func, _, args, kwargs):
     return patch_conn(conn)
 
 def patch_conn(conn):
-    wrapped = TracedSQLite(conn)
+    wrapped = TracedSQLite(conn, name='sqlite')
     Pin(service='sqlite').onto(wrapped)
     return wrapped
 

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -53,12 +53,5 @@ def tracer_config(__init__, app, args, kwargs):
     if tags:
         tracer.set_tags(tags)
 
-    # configure the current service
-    tracer.set_service_info(
-        service=service,
-        app='tornado',
-        app_type=AppTypes.web,
-    )
-
     # configure the PIN object for template rendering
     ddtrace.Pin(app='tornado', service=service, app_type='web', tracer=tracer).onto(template)

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -52,4 +52,4 @@ def tracer_config(__init__, app, args, kwargs):
         tracer.set_tags(tags)
 
     # configure the PIN object for template rendering
-    ddtrace.Pin(app='tornado', service=service, app_type='web', tracer=tracer).onto(template)
+    ddtrace.Pin(service=service, tracer=tracer).onto(template)

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -5,8 +5,6 @@ from tornado import template
 from . import decorators, context_provider
 from .constants import CONFIG_KEY
 
-from ...ext import AppTypes
-
 
 def tracer_config(__init__, app, args, kwargs):
     """

--- a/ddtrace/contrib/vertica/constants.py
+++ b/ddtrace/contrib/vertica/constants.py
@@ -1,2 +1,0 @@
-# Service info
-APP = "vertica"

--- a/ddtrace/contrib/vertica/patch.py
+++ b/ddtrace/contrib/vertica/patch.py
@@ -5,10 +5,9 @@ import wrapt
 
 import ddtrace
 from ddtrace import config, Pin
-from ddtrace.ext import net, AppTypes
+from ddtrace.ext import net
 from ddtrace.utils.wrappers import unwrap
 
-from .constants import APP
 from ...ext import db as dbx, sql
 
 
@@ -44,8 +43,6 @@ def cursor_span_end(instance, cursor, _, conf, *args, **kwargs):
 
     pin = Pin(
         service=config.vertica["service_name"],
-        app=APP,
-        app_type=AppTypes.db,
         tags=tags,
         _config=config.vertica["patch"]["vertica_python.vertica.cursor.Cursor"],
     )
@@ -57,8 +54,6 @@ config._add(
     "vertica",
     {
         "service_name": "vertica",
-        "app": "vertica",
-        "app_type": "db",
         "patch": {
             "vertica_python.vertica.connection.Connection": {
                 "routines": {
@@ -166,8 +161,6 @@ def _install_init(patch_item, patch_class, patch_mod, config):
         # create and attach a pin with the defaults
         Pin(
             service=config["service_name"],
-            app=config["app"],
-            app_type=config["app_type"],
             tags=config.get("tags", {}),
             tracer=config.get("tracer", ddtrace.tracer),
             _config=config["patch"][patch_item],

--- a/ddtrace/encoding.py
+++ b/ddtrace/encoding.py
@@ -46,14 +46,6 @@ class Encoder(object):
         normalized_traces = [[span.to_dict() for span in trace] for trace in traces]
         return self._encode(normalized_traces)
 
-    def encode_services(self, services):
-        """
-        Encodes a dictionary of services.
-
-        :param services: A dictionary that contains one or more services
-        """
-        return self._encode(services)
-
     def _encode(self, obj):
         """
         Defines the underlying format used during traces or services encoding.

--- a/ddtrace/ext/__init__.py
+++ b/ddtrace/ext/__init__.py
@@ -1,5 +1,0 @@
-class AppTypes(object):
-    web = "web"
-    db = "db"
-    cache = "cache"
-    worker = "worker"

--- a/ddtrace/ext/elasticsearch.py
+++ b/ddtrace/ext/elasticsearch.py
@@ -1,6 +1,5 @@
 TYPE = 'elasticsearch'
 SERVICE = 'elasticsearch'
-APP = 'elasticsearch'
 
 # standard tags
 URL = 'elasticsearch.url'

--- a/ddtrace/ext/redis.py
+++ b/ddtrace/ext/redis.py
@@ -1,5 +1,4 @@
 # defaults
-APP = 'redis'
 DEFAULT_SERVICE = 'redis'
 
 # type of the spans

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -1,10 +1,5 @@
-
-from ddtrace.ext import AppTypes
-
-
 # the type of the spans
 TYPE = "sql"
-APP_TYPE = AppTypes.db
 
 # tags
 QUERY = "sql.query"   # the query text

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -134,15 +134,6 @@ class Pin(object):
         """Patch this pin onto the given object. If send is true, it will also
         queue the metadata to be sent to the server.
         """
-        # pinning will also queue the metadata for service submission. this
-        # feels a bit side-effecty, but bc it's async and pretty clearly
-        # communicates what we want, i think it makes sense.
-        if send:
-            try:
-                self._send()
-            except Exception:
-                log.debug("can't send pin info", exc_info=True)
-
         # Actually patch it on the object.
         try:
             if hasattr(obj, '__setddpin__'):
@@ -177,11 +168,4 @@ class Pin(object):
             tags=tags,
             tracer=tracer or self.tracer,  # do not clone the Tracer
             _config=config,
-        )
-
-    def _send(self):
-        self.tracer.set_service_info(
-            service=self.service,
-            app=self.app,
-            app_type=self.app_type,
         )

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -3,6 +3,8 @@ import logging
 import wrapt
 import ddtrace
 
+from ddtrace.utils.deprecation import deprecation
+
 
 log = logging.getLogger(__name__)
 
@@ -24,12 +26,13 @@ class Pin(object):
         >>> pin = Pin.override(conn, service="user-db")
         >>> conn = sqlite.connect("/tmp/image.db")
     """
-    __slots__ = ['app', 'app_type', 'tags', 'tracer', '_target', '_config', '_initialized']
+    __slots__ = ['tags', 'tracer', '_target', '_config', '_initialized']
 
     def __init__(self, service, app=None, app_type=None, tags=None, tracer=None, _config=None):
+        if app is not None or app_type is not None:
+            deprecation(message='app and app_type are deprecated in favour of '
+                                'using span_type on each span.')
         tracer = tracer or ddtrace.tracer
-        self.app = app
-        self.app_type = app_type
         self.tags = tags
         self.tracer = tracer
         self._target = None
@@ -53,8 +56,8 @@ class Pin(object):
         super(Pin, self).__setattr__(name, value)
 
     def __repr__(self):
-        return "Pin(service=%s, app=%s, app_type=%s, tags=%s, tracer=%s)" % (
-            self.service, self.app, self.app_type, self.tags, self.tracer)
+        return "Pin(service=%s, tags=%s, tracer=%s)" % (
+            self.service, self.tags, self.tracer)
 
     @staticmethod
     def _find(*objs):
@@ -113,6 +116,9 @@ class Pin(object):
         """
         if not obj:
             return
+        if app is not None or app_type is not None:
+            deprecation(message='app and app_type are deprecated in favour of '
+                                'using span_type on each span.')
 
         pin = cls.get_from(obj)
         if not pin:
@@ -120,8 +126,6 @@ class Pin(object):
 
         pin.clone(
             service=service,
-            app=app,
-            app_type=app_type,
             tags=tags,
             tracer=tracer,
         ).onto(obj)
@@ -163,8 +167,6 @@ class Pin(object):
 
         return Pin(
             service=service or self.service,
-            app=app or self.app,
-            app_type=app_type or self.app_type,
             tags=tags,
             tracer=tracer or self.tracer,  # do not clone the Tracer
             _config=config,

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -54,9 +54,6 @@ class Tracer(object):
         # globally set tags
         self.tags = {}
 
-        # a buffer for service info so we dont' perpetually send the same things
-        self._services = {}
-
     def get_call_context(self, *args, **kwargs):
         """
         Return the current active ``Context`` for this traced execution. This method is

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -11,6 +11,7 @@ from .span import Span
 from .constants import FILTERS_KEY, SAMPLE_RATE_METRIC_KEY
 from . import compat
 from .ext.priority import AUTO_REJECT, AUTO_KEEP
+from .utils.deprecation import deprecated
 
 
 log = logging.getLogger(__name__)
@@ -333,35 +334,19 @@ class Tracer(object):
             # only submit the spans if we're actually enabled (and don't crash :)
             self.writer.write(spans=spans)
 
+    @deprecated(message='Service info is now inferred from spans based upon span_type', version='1.0.0')
     def set_service_info(self, service, app, app_type):
         """Set the information about the given service.
+
+        Note: This method has been deprecated since the the app and service
+        info is now inferred from a span based upon the span_type and service
+        attributes, respectively.
 
         :param str service: the internal name of the service (e.g. acme_search, datadog_web)
         :param str app: the off the shelf name of the application (e.g. rails, postgres, custom-app)
         :param str app_type: the type of the application (e.g. db, web)
         """
-        try:
-            # don't bother sending the same services over and over.
-            info = (service, app, app_type)
-            if self._services.get(service, None) == info:
-                return
-            self._services[service] = info
-
-            if self.debug_logging:
-                log.debug("set_service_info: service:%s app:%s type:%s", service, app, app_type)
-
-            # If we had changes, send them to the writer.
-            if self.enabled and self.writer:
-
-                # translate to the form the server understands.
-                services = {}
-                for service, app, app_type in self._services.values():
-                    services[service] = {"app" : app, "app_type" : app_type}
-
-                # queue them for writes.
-                self.writer.write(services=services)
-        except Exception:
-            log.debug("error setting service info", exc_info=True)
+        pass
 
     def wrap(self, name=None, service=None, resource=None, span_type=None):
         """

--- a/ddtrace/utils/deprecation.py
+++ b/ddtrace/utils/deprecation.py
@@ -13,7 +13,7 @@ def format_message(name, message, version):
 
         'fn' is deprecated and will be remove in future versions (1.0).
     """
-    return "'{}' is deprecated and will be remove in future versions{}. {}".format(
+    return "'{}' is deprecated and will be removed in future versions{}. {}".format(
         name,
         ' ({})'.format(version) if version else '',
         message,
@@ -48,7 +48,7 @@ def deprecated(message='', version=None):
         $ python -Wall script.py
 
     This approach is used by most of the frameworks, including Django
-    (ref: https://docs.djangoproject.com/en/2.0/howto/upgrade-version/#resolving-deprecation-warnings)
+    (ref: https://docs.djangoproject.com/en/2.0/howto/upgrade-version/#resolving-eprecation-warnings)
     """
     def decorator(func):
         @wraps(func)

--- a/ddtrace/writer.py
+++ b/ddtrace/writer.py
@@ -1,4 +1,3 @@
-
 # stdlib
 import atexit
 import logging
@@ -10,6 +9,7 @@ import time
 from ddtrace import api
 
 from .api import _parse_response_json
+from .utils.deprecation import deprecation
 
 log = logging.getLogger(__name__)
 
@@ -32,12 +32,20 @@ class AgentWriter(object):
         priority_sampling = priority_sampler is not None
         self.api = api.API(hostname, port, priority_sampling=priority_sampling)
 
-    def write(self, spans=None):
+    def write(self, spans=None, services=None):
         # if the worker needs to be reset, do it.
         self._reset_worker()
 
         if spans:
             self._traces.add(spans)
+
+        if services is not None:
+            deprecation(
+                name='write(services)',
+                message='Writing services has been replaced with specifying the'
+                        'and span_type on each span. Services are no longer'
+                        'sent.',
+            )
 
     def _reset_worker(self):
         # if this queue was created in a different process (i.e. this was

--- a/tests/commands/ddtrace_run_integration.py
+++ b/tests/commands/ddtrace_run_integration.py
@@ -17,7 +17,6 @@ if __name__ == '__main__':
     r = redis.Redis(port=REDIS_CONFIG['port'])
     pin = Pin.get_from(r)
     ok_(pin)
-    eq_(pin.app, 'redis')
     eq_(pin.service, 'redis')
 
     pin.tracer.writer = DummyWriter()

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -23,16 +23,6 @@ class TestTraceMiddleware(TraceTestCase):
 
     @unittest_run_loop
     @asyncio.coroutine
-    def test_tracing_service(self):
-        # it should configure the aiohttp service
-        eq_(1, len(self.tracer._services))
-        service = self.tracer._services.get('aiohttp-web')
-        eq_('aiohttp-web', service[0])
-        eq_('aiohttp', service[1])
-        eq_('web', service[2])
-
-    @unittest_run_loop
-    @asyncio.coroutine
     def test_handler(self):
         # it should create a root span when there is a handler hit
         # with the proper tags

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -23,6 +23,17 @@ class TestTraceMiddleware(TraceTestCase):
 
     @unittest_run_loop
     @asyncio.coroutine
+    def test_tracing_metadata(self):
+        yield from self.client.request('GET', '/')
+        self.spans[0].assert_matches(
+            name='aiohttp.request',
+            service='aiohttp-web',
+            span_type='http',
+            resource='/',
+        )
+
+    @unittest_run_loop
+    @asyncio.coroutine
     def test_handler(self):
         # it should create a root span when there is a handler hit
         # with the proper tags

--- a/tests/contrib/aiohttp/utils.py
+++ b/tests/contrib/aiohttp/utils.py
@@ -2,11 +2,13 @@ import asyncio
 
 from aiohttp.test_utils import AioHTTPTestCase
 
+from tests.base import BaseTracerTestCase
+
 from .app.web import setup_app
 from ...test_tracer import get_dummy_tracer
 
 
-class TraceTestCase(AioHTTPTestCase):
+class TraceTestCase(BaseTracerTestCase, AioHTTPTestCase):
     """
     Base class that provides a valid ``aiohttp`` application with
     the async tracer.
@@ -32,7 +34,5 @@ class TraceTestCase(AioHTTPTestCase):
         # create the app with the testing loop
         self.app = setup_app(loop)
         asyncio.set_event_loop(loop)
-        # trace the app
-        self.tracer = get_dummy_tracer()
         self.enable_tracing()
         return self.app

--- a/tests/contrib/aiopg/test_aiopg.py
+++ b/tests/contrib/aiopg/test_aiopg.py
@@ -149,14 +149,6 @@ class TestPsycopgPatch(AsyncioTestCase):
             yield from self.assert_conn_is_traced(tracer, conn, service)
             conn.close()
 
-        # ensure we have the service types
-        service_meta = tracer.writer.pop_services()
-        expected = {
-            'db': {'app': 'postgres', 'app_type': 'db'},
-            'another': {'app': 'postgres', 'app_type': 'db'},
-        }
-        eq_(service_meta, expected)
-
     @mark_asyncio
     def test_patch_unpatch(self):
         tracer = get_dummy_tracer()

--- a/tests/contrib/bottle/test.py
+++ b/tests/contrib/bottle/test.py
@@ -56,13 +56,6 @@ class TraceBottleTest(TestCase):
         eq_(s.get_tag('http.status_code'), '200')
         eq_(s.get_tag('http.method'), 'GET')
 
-        services = self.tracer.writer.pop_services()
-        eq_(len(services), 1)
-        ok_(SERVICE in services)
-        s = services[SERVICE]
-        eq_(s['app_type'], 'web')
-        eq_(s['app'], 'bottle')
-
     def test_500(self):
         @self.app.route('/hi')
         def hi():
@@ -136,10 +129,3 @@ class TraceBottleTest(TestCase):
         eq_(dd_span.resource, 'GET /hi/<name>')
         eq_(dd_span.get_tag('http.status_code'), '200')
         eq_(dd_span.get_tag('http.method'), 'GET')
-
-        services = self.tracer.writer.pop_services()
-        eq_(len(services), 1)
-        ok_(SERVICE in services)
-        s = services[SERVICE]
-        eq_(s['app_type'], 'web')
-        eq_(s['app'], 'bottle')

--- a/tests/contrib/bottle/test.py
+++ b/tests/contrib/bottle/test.py
@@ -2,8 +2,8 @@ import bottle
 import ddtrace
 import webtest
 
-from unittest import TestCase
 from nose.tools import eq_, ok_
+from tests.base import BaseTracerTestCase
 from tests.opentracer.utils import init_tracer
 from tests.test_tracer import get_dummy_tracer
 
@@ -14,13 +14,13 @@ from ddtrace.contrib.bottle import TracePlugin
 SERVICE = 'bottle-app'
 
 
-class TraceBottleTest(TestCase):
+class TraceBottleTest(BaseTracerTestCase):
     """
     Ensures that Bottle is properly traced.
     """
     def setUp(self):
+        super(TraceBottleTest, self).setUp()
         # provide a dummy tracer
-        self.tracer = get_dummy_tracer()
         self._original_tracer = ddtrace.tracer
         ddtrace.tracer = self.tracer
         # provide a Bottle app

--- a/tests/contrib/bottle/test_autopatch.py
+++ b/tests/contrib/bottle/test_autopatch.py
@@ -53,13 +53,6 @@ class TraceBottleTest(TestCase):
         eq_(s.get_tag('http.status_code'), '200')
         eq_(s.get_tag('http.method'), 'GET')
 
-        services = self.tracer.writer.pop_services()
-        eq_(len(services), 1)
-        ok_(SERVICE in services)
-        s = services[SERVICE]
-        eq_(s['app_type'], 'web')
-        eq_(s['app'], 'bottle')
-
     def test_500(self):
         @self.app.route('/hi')
         def hi():

--- a/tests/contrib/dbapi/test_unit.py
+++ b/tests/contrib/dbapi/test_unit.py
@@ -1,9 +1,8 @@
-import unittest
 import mock
+import unittest
 
 from ddtrace import Pin, Span
 from ddtrace.contrib.dbapi import TracedCursor, TracedConnection
-from ddtrace.ext import AppTypes, sql
 from tests.test_tracer import get_dummy_tracer
 
 
@@ -86,7 +85,7 @@ class TestTracedCursor(unittest.TestCase):
         cursor = self.cursor
         tracer = self.tracer
         cursor.rowcount = 0
-        pin = Pin('pin_name', app='changed', tracer=tracer)
+        pin = Pin('pin_name', tracer=tracer)
         traced_cursor = TracedCursor(cursor, pin)
 
         traced_cursor.execute('arg_1', kwarg1='kwarg1')
@@ -141,7 +140,7 @@ class TestTracedCursor(unittest.TestCase):
         cursor = self.cursor
         tracer = self.tracer
         cursor.rowcount = 123
-        pin = Pin('my_service', app='my_app', tracer=tracer, tags={'pin1': 'value_pin1'})
+        pin = Pin('my_service', tracer=tracer, tags={'pin1': 'value_pin1'})
         traced_cursor = TracedCursor(cursor, pin)
 
         def method():
@@ -166,7 +165,7 @@ class TestTracedCursor(unittest.TestCase):
         # implementation with the generic dbapi traced cursor, we had to make sure to add the tag 'sql.rows' that was
         # set by the legacy replaced implementation.
         cursor.rowcount = 123
-        pin = Pin('my_service', app='my_app', tracer=tracer, tags={'pin1': 'value_pin1'})
+        pin = Pin('my_service', tracer=tracer, tags={'pin1': 'value_pin1'})
         traced_cursor = TracedCursor(cursor, pin)
 
         def method():

--- a/tests/contrib/dbapi/test_unit.py
+++ b/tests/contrib/dbapi/test_unit.py
@@ -81,12 +81,12 @@ class TestTracedCursor(unittest.TestCase):
         traced_cursor.fetchall('arg_1', kwarg1='kwarg1')
         assert tracer.writer.pop()[0].name == 'sql.query.fetchall'
 
-    def test_correct_span_names_can_be_overridden_by_pin(self):
+    def test_correct_span_names_can_be_overridden(self):
         cursor = self.cursor
         tracer = self.tracer
         cursor.rowcount = 0
         pin = Pin('pin_name', tracer=tracer)
-        traced_cursor = TracedCursor(cursor, pin)
+        traced_cursor = TracedCursor(cursor, pin, 'changed')
 
         traced_cursor.execute('arg_1', kwarg1='kwarg1')
         assert tracer.writer.pop()[0].name == 'changed.query'

--- a/tests/contrib/django/test_tracing_disabled.py
+++ b/tests/contrib/django/test_tracing_disabled.py
@@ -32,10 +32,6 @@ class DjangoTracingDisabledTest(TestCase):
         settings.TRACER = self.backupTracer
         self.app.ready()
 
-    def test_no_service_info_is_written(self):
-        services = self.tracer.writer.pop_services()
-        assert len(services) == 0
-
     def test_no_trace_is_written(self):
         settings.TRACER.trace("client.testing").finish()
         traces = self.tracer.writer.pop_traces()

--- a/tests/contrib/falcon/test_distributed_tracing.py
+++ b/tests/contrib/falcon/test_distributed_tracing.py
@@ -1,5 +1,3 @@
-from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.ext import errors as errx, http as httpx, AppTypes
 from falcon import testing
 from nose.tools import eq_, ok_
 from tests.test_tracer import get_dummy_tracer

--- a/tests/contrib/falcon/test_suite.py
+++ b/tests/contrib/falcon/test_suite.py
@@ -12,14 +12,6 @@ class FalconTestCase(object):
     to add new tests, add them here so that they're shared across manual
     and automatic instrumentation.
     """
-    def test_falcon_service(self):
-        services = self.tracer._services
-        expected_service = (self._service, 'falcon', 'web')
-
-        # ensure users set service name is in the services list
-        ok_(self._service in services.keys())
-        eq_(services[self._service], expected_service)
-
     def test_404(self):
         out = self.simulate_get('/fake_endpoint')
         eq_(out.status_code, 404)

--- a/tests/contrib/flask/test_middleware.py
+++ b/tests/contrib/flask/test_middleware.py
@@ -114,12 +114,6 @@ class TestFlask(TestCase):
         eq_(s.meta.get(http.STATUS_CODE), '200')
         eq_(s.meta.get(http.METHOD), 'GET')
 
-        services = self.tracer.writer.pop_services()
-        expected = {
-            "test.flask.service": {"app":"flask", "app_type":"web"}
-        }
-        eq_(services, expected)
-
     def test_template(self):
         start = time.time()
         rv = self.app.get('/tmpl')

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -195,14 +195,6 @@ class PsycopgCore(object):
             Pin.get_from(conn).clone(service=service, tracer=tracer).onto(conn)
             self.assert_conn_is_traced(tracer, conn, service)
 
-        # ensure we have the service types
-        service_meta = tracer.writer.pop_services()
-        expected = {
-            "db" : {"app":"postgres", "app_type":"db"},
-            "another" : {"app":"postgres", "app_type":"db"},
-        }
-        eq_(service_meta, expected)
-
     def test_commit(self):
         conn, tracer = self._get_conn_and_tracer()
         writer = tracer.writer

--- a/tests/contrib/pymongo/test.py
+++ b/tests/contrib/pymongo/test.py
@@ -332,16 +332,8 @@ class TestPymongoPatchDefault(PymongoCore):
 
     def test_service(self):
         tracer, client = self.get_tracer_and_client()
-        writer = tracer.writer
         db = client["testdb"]
         db.drop_collection("songs")
-
-        services = writer.pop_services()
-        eq_(len(services), 1)
-        assert self.TEST_SERVICE in services
-        s = services[self.TEST_SERVICE]
-        assert s['app_type'] == 'db'
-        assert s['app'] == 'mongodb'
 
     def test_host_kwarg(self):
         # simulate what celery and django do when instantiating a new client

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -59,13 +59,6 @@ class PyramidTestCase(PyramidBase):
         eq_(s.meta.get('http.url'), '/')
         eq_(s.meta.get('pyramid.route.name'), 'index')
 
-        # ensure services are set correctly
-        services = writer.pop_services()
-        expected = {
-            'foobar': {"app": "pyramid", "app_type": "web"}
-        }
-        eq_(services, expected)
-
     def test_404(self):
         self.app.get('/404', status=404)
 

--- a/tests/contrib/sqlalchemy/mixins.py
+++ b/tests/contrib/sqlalchemy/mixins.py
@@ -162,14 +162,6 @@ class SQLAlchemyTestMixin(object):
         eq_(span.error, 0)
         ok_(span.duration > 0)
 
-    def test_traced_service(self):
-        # ensures that the service is set as expected
-        services = self.tracer.writer.pop_services()
-        expected = {
-            self.SERVICE: {'app': self.VENDOR, 'app_type': 'db'}
-        }
-        eq_(services, expected)
-
     def test_opentracing(self):
         """Ensure that sqlalchemy works with the opentracer."""
         ot_tracer = init_tracer('sqlalch_svc', self.tracer)

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -6,7 +6,6 @@ import time
 from nose.tools import eq_, ok_
 
 # project
-import ddtrace
 from ddtrace import Pin
 from ddtrace.contrib.sqlite3 import connection_factory
 from ddtrace.contrib.sqlite3.patch import patch, unpatch
@@ -34,22 +33,6 @@ class TestSQLite(object):
 
     def tearDown(self):
         unpatch()
-
-    def test_service_info(self):
-        tracer = get_dummy_tracer()
-        backup_tracer = ddtrace.tracer
-        ddtrace.tracer = tracer
-
-        db = sqlite3.connect(':memory:')
-
-        services = tracer.writer.pop_services()
-        eq_(len(services), 1)
-        expected = {
-            'sqlite': {'app': 'sqlite', 'app_type': 'db'}
-        }
-        eq_(expected, services)
-
-        ddtrace.tracer = backup_tracer
 
     def test_sqlite(self):
         tracer = get_dummy_tracer()
@@ -259,7 +242,6 @@ class TestSQLite(object):
         span = spans[0]
         eq_(span.service, 'sqlite')
         eq_(span.name, 'sqlite.connection.rollback')
-
 
     def test_patch_unpatch(self):
         tracer = get_dummy_tracer()

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -44,7 +44,6 @@ class TestSQLite(object):
             db = sqlite3.connect(':memory:')
             pin = Pin.get_from(db)
             assert pin
-            eq_('db', pin.app_type)
             pin.clone(
                 service=service,
                 tracer=tracer).onto(db)
@@ -190,7 +189,6 @@ class TestSQLite(object):
             db = sqlite3.connect(':memory:')
             pin = Pin.get_from(db)
             assert pin
-            eq_('db', pin.app_type)
             pin.clone(tracer=tracer).onto(db)
             cursor = db.execute(q)
             rows = cursor.fetchall()

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -196,7 +196,6 @@ class TestSQLite(object):
         spans = tracer.writer.pop()
         assert spans
 
-        print(spans)
         eq_(len(spans), 3)
         ot_span, dd_span, fetchall_span = spans
 

--- a/tests/contrib/tornado/test_config.py
+++ b/tests/contrib/tornado/test_config.py
@@ -29,7 +29,6 @@ class TestTornadoSettings(TornadoTestCase):
 
     def test_tracer_is_properly_configured(self):
         # the tracer must be properly configured
-        eq_(self.tracer._services, {'custom-tornado': ('custom-tornado', 'tornado', 'web')})
         eq_(self.tracer.tags, {'env': 'production', 'debug': 'false'})
         eq_(self.tracer.enabled, False)
         eq_(self.tracer.writer.api.hostname, 'dd-agent.service.consul')

--- a/tests/test_pin.py
+++ b/tests/test_pin.py
@@ -75,7 +75,7 @@ class PinTestCase(TestCase):
 
     def test_copy(self):
         # ensure a Pin is copied when using the clone methods
-        p1 = Pin(service='metrics', app='flask', tags={'key': 'value'})
+        p1 = Pin(service='metrics', tags={'key': 'value'})
         p2 = p1.clone(service='intake')
         # values are the same
         eq_(p1.service, 'metrics')
@@ -100,9 +100,9 @@ class PinTestCase(TestCase):
         class A(object):
             pass
 
-        Pin(service='metrics', app='flask').onto(A)
+        Pin(service='metrics').onto(A)
         a = A()
-        Pin.override(a, app='django')
+        Pin.override(a)
         eq_(Pin.get_from(a).service, 'metrics')
 
         b = A()

--- a/tests/test_pin.py
+++ b/tests/test_pin.py
@@ -80,8 +80,6 @@ class PinTestCase(TestCase):
         # values are the same
         eq_(p1.service, 'metrics')
         eq_(p2.service, 'intake')
-        eq_(p1.app, 'flask')
-        eq_(p2.app, 'flask')
         # but it's a copy
         ok_(p1.tags is not p2.tags)
         ok_(p1._config is not p2._config)
@@ -105,11 +103,9 @@ class PinTestCase(TestCase):
         Pin(service='metrics', app='flask').onto(A)
         a = A()
         Pin.override(a, app='django')
-        eq_(Pin.get_from(a).app, 'django')
         eq_(Pin.get_from(a).service, 'metrics')
 
         b = A()
-        eq_(Pin.get_from(b).app, 'flask')
         eq_(Pin.get_from(b).service, 'metrics')
 
     def test_override_missing(self):

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -10,9 +10,7 @@ from ddtrace.ext import system
 from ddtrace.context import Context
 
 from .base import BaseTracerTestCase
-from .utils.span import TestSpan
 from .utils.tracer import DummyTracer
-from .utils.tracer import DummyWriter  # noqa
 
 
 def get_dummy_tracer():

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -11,6 +11,7 @@ from ddtrace.context import Context
 
 from .base import BaseTracerTestCase
 from .utils.tracer import DummyTracer
+from .utils.tracer import DummyWriter  # noqa
 
 
 def get_dummy_tracer():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,7 +61,7 @@ class TestUtilities(unittest.TestCase):
             'use something else instead',
             '1.0.0',
         )
-        expected = "'deprecated_function' is deprecated and will be remove in future versions (1.0.0). use something else instead"
+        expected = "'deprecated_function' is deprecated and will be removed in future versions (1.0.0). use something else instead"
         eq_(msg, expected)
 
     def test_deprecation(self):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -44,14 +44,13 @@ class AsyncWorkerTests(TestCase):
     def setUp(self):
         self.api = DummmyAPI()
         self.traces = Q()
-        self.services = Q()
         for i in range(N_TRACES):
             self.traces.add([Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j-1 or None) for j in range(7)])
 
     def test_filters_keep_all(self):
         filtr = KeepAllFilter()
         filters = [filtr]
-        worker = AsyncWorker(self.api, self.traces, self.services, filters=filters)
+        worker = AsyncWorker(self.api, self.traces, filters=filters)
         worker.stop()
         worker.join()
         self.assertEqual(len(self.api.traces), N_TRACES)
@@ -60,7 +59,7 @@ class AsyncWorkerTests(TestCase):
     def test_filters_remove_all(self):
         filtr = RemoveAllFilter()
         filters = [filtr]
-        worker = AsyncWorker(self.api, self.traces, self.services, filters=filters)
+        worker = AsyncWorker(self.api, self.traces, filters=filters)
         worker.stop()
         worker.join()
         self.assertEqual(len(self.api.traces), 0)
@@ -70,7 +69,7 @@ class AsyncWorkerTests(TestCase):
         tag_name = "Tag"
         filtr = AddTagFilter(tag_name)
         filters = [filtr]
-        worker = AsyncWorker(self.api, self.traces, self.services, filters=filters)
+        worker = AsyncWorker(self.api, self.traces, filters=filters)
         worker.stop()
         worker.join()
         self.assertEqual(len(self.api.traces), N_TRACES)
@@ -82,7 +81,7 @@ class AsyncWorkerTests(TestCase):
     def test_filters_short_circuit(self):
         filtr = KeepAllFilter()
         filters = [RemoveAllFilter(), filtr]
-        worker = AsyncWorker(self.api, self.traces, self.services, filters=filters)
+        worker = AsyncWorker(self.api, self.traces, filters=filters)
         worker.stop()
         worker.join()
         self.assertEqual(len(self.api.traces), 0)

--- a/tests/utils/tracer.py
+++ b/tests/utils/tracer.py
@@ -1,6 +1,7 @@
 from ddtrace.encoding import JSONEncoder, MsgpackEncoder
 from ddtrace.tracer import Tracer
 from ddtrace.writer import AgentWriter
+from ddtrace.utils.deprecation import deprecation
 
 
 class DummyWriter(AgentWriter):
@@ -16,7 +17,7 @@ class DummyWriter(AgentWriter):
         self.json_encoder = JSONEncoder()
         self.msgpack_encoder = MsgpackEncoder()
 
-    def write(self, spans=None):
+    def write(self, spans=None, services=None):
         if spans:
             # the traces encoding expect a list of traces so we
             # put spans in a list like we do in the real execution path
@@ -26,6 +27,14 @@ class DummyWriter(AgentWriter):
             self.msgpack_encoder.encode_traces(trace)
             self.spans += spans
             self.traces += trace
+
+        if services:
+            deprecation(
+                name='write(services)',
+                message='Writing services has been replaced with specifying the'
+                        'and span_type on each span. Services are no longer'
+                        'sent.',
+            )
 
     def pop(self):
         # dummy method

--- a/tests/utils/tracer.py
+++ b/tests/utils/tracer.py
@@ -2,8 +2,6 @@ from ddtrace.encoding import JSONEncoder, MsgpackEncoder
 from ddtrace.tracer import Tracer
 from ddtrace.writer import AgentWriter
 
-from .span import TestSpan
-
 
 class DummyWriter(AgentWriter):
     """DummyWriter is a small fake writer used for tests. not thread-safe."""
@@ -18,7 +16,7 @@ class DummyWriter(AgentWriter):
         self.json_encoder = JSONEncoder()
         self.msgpack_encoder = MsgpackEncoder()
 
-    def write(self, spans=None, services=None):
+    def write(self, spans=None):
         if spans:
             # the traces encoding expect a list of traces so we
             # put spans in a list like we do in the real execution path
@@ -28,11 +26,6 @@ class DummyWriter(AgentWriter):
             self.msgpack_encoder.encode_traces(trace)
             self.spans += spans
             self.traces += trace
-
-        if services:
-            self.json_encoder.encode_services(services)
-            self.msgpack_encoder.encode_services(services)
-            self.services.update(services)
 
     def pop(self):
         # dummy method
@@ -45,12 +38,6 @@ class DummyWriter(AgentWriter):
         traces = self.traces
         self.traces = []
         return traces
-
-    def pop_services(self):
-        # dummy method
-        s = self.services
-        self.services = {}
-        return s
 
 
 class DummyTracer(Tracer):


### PR DESCRIPTION
**Note:** this PR follows #717 and should be re-based against the dev branch once #717 is merged.

## Overview
With the deprecation/removal of sending services (#717), there is no longer a need to use `pin.app` and `pin.app_type`.

## Core Changes
The only winkle is that `pin.app` was used for implicitly overriding the default database name for integrations using the `dbapi`. This was solved by allowing the name to be explicitly provided by the integration to specify what database name to use when creating spans in the `dbapi`.

### Previously
In the integration:
```python
def patch_conn(conn):
    # ...
    pin = Pin(service="pymysql", app="pymysql", app_type=AppTypes.db)

    # grab the metadata from the conn
    wrapped = TracedConnection(conn, pin=pin)
    pin.onto(wrapped)
    return wrapped
```

### Now
In the integration:
```python
def patch_conn(conn):
    pin = Pin(service='pymysql')

    # grab the metadata from the conn
    wrapped = TracedConnection(conn, pin=pin, name='pymysql')
    pin.onto(wrapped)
    return wrapped
```