### PR TITLE
[docs] add Flask configuration documentation

### DIFF
--- a/ddtrace/contrib/flask/__init__.py
+++ b/ddtrace/contrib/flask/__init__.py
@@ -27,6 +27,64 @@ You may also enable Flask tracing automatically via ddtrace-run::
 
     ddtrace-run python app.py
 
+
+Configuration
+~~~~~~~~~~~~~
+
+.. py:data:: ddtrace.config.flask['distributed_tracing_enabled']
+
+   Whether to parse distributed tracing headers from requests received by your Flask app.
+
+   Default: ``False``
+
+.. py:data:: ddtrace.config.flask['service_name']
+
+   The service name reported for your Flask app.
+
+   Can also be configured via the ``DATADOG_SERVICE_NAME`` environment variable.
+
+   Default: ``'flask'``
+
+.. py:data:: ddtrace.config.flask['collect_view_args']
+
+   Whether to add request tags for view function argument values.
+
+   Default: ``True``
+
+.. py:data:: ddtrace.config.flask['template_default_name']
+
+   The default template name to use when one does not exist.
+
+   Default: ``<memory>``
+
+.. py:data:: ddtrace.config.flask['trace_signals']
+
+   Whether to trace Flask signals (``before_request``, ``after_request``, etc).
+
+   Default: ``True``
+
+.. py:data:: ddtrace.config.flask['extra_error_codes']
+
+   A list of response codes that should get marked as errors.
+
+   *5xx codes are always considered an error.*
+
+   Default: ``[]``
+
+
+Example::
+
+    from ddtrace import config
+
+    # Enable distributed tracing
+    config.flask['distributed_tracing_enabled'] = True
+
+    # Override service name
+    config.flask['service_name'] = 'custom-service-name'
+
+    # Report 401, and 403 responses as errors
+    config.flask['extra_error_codes'] = [401, 403]
+
 .. __: http://flask.pocoo.org/
 """
 


### PR DESCRIPTION
We are missing this in our documentation right now.