### PR TITLE
[dbapi] return values for commit/rollback

### DIFF
--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -147,11 +147,11 @@ class TracedConnection(wrapt.ObjectProxy):
 
     def commit(self, *args, **kwargs):
         span_name = '{}.{}'.format(self._self_datadog_name, 'commit')
-        self._trace_method(self.__wrapped__.commit, span_name, {}, *args, **kwargs)
+        return self._trace_method(self.__wrapped__.commit, span_name, {}, *args, **kwargs)
 
     def rollback(self, *args, **kwargs):
         span_name = '{}.{}'.format(self._self_datadog_name, 'rollback')
-        self._trace_method(self.__wrapped__.rollback, span_name, {}, *args, **kwargs)
+        return self._trace_method(self.__wrapped__.rollback, span_name, {}, *args, **kwargs)
 
 def _get_vendor(conn):
     """ Return the vendor (e.g postgres, mysql) of the given


### PR DESCRIPTION
This change shouldn't make much of a difference since it seems `commit()` and `rollback()` typically just return `None`, but we want to make this change just in case one of our integrations (or one in the future) does not break if they would have returned something other than `None`