### PR TITLE
[tests] upgrade flake8 to 3.5.0

### DIFF
--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -106,7 +106,7 @@ def traced_start_fetching_next_page(func, instance, args, kwargs):
     setattr(instance, CURRENT_SPAN, span)
     try:
         return func(*args, **kwargs)
-    except:
+    except Exception:
         with span:
             span.set_exc_info(*sys.exc_info())
         raise
@@ -161,7 +161,7 @@ def traced_execute_async(func, instance, args, kwargs):
         )
         result.clear_callbacks()
         return result
-    except:
+    except Exception:
         with span:
             span.set_exc_info(*sys.exc_info())
         raise

--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -34,7 +34,7 @@ class GrpcClientInterceptor(
             new_details = inject_span(span, client_call_details)
             try:
                 return continuation(new_details, request)
-            except:
+            except Exception:
                 span.set_traceback()
                 raise
 
@@ -48,6 +48,6 @@ class GrpcClientInterceptor(
             new_details = inject_span(span, client_call_details)
             try:
                 return continuation(new_details, request_iterator)
-            except:
+            except Exception:
                 span.set_traceback()
                 raise

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -73,7 +73,7 @@ class PylonsTraceMiddleware(object):
                     code = int(code)
                     if not 100 <= code < 600:
                         code = 500
-                except:
+                except Exception:
                     code = 500
                 span.set_tag(http.STATUS_CODE, code)
                 span.error = 1

--- a/tox.ini
+++ b/tox.ini
@@ -372,7 +372,7 @@ deps=
 ignore_outcome=true
 
 [testenv:flake8]
-deps=flake8==3.2.0
+deps=flake8==3.5.0
 commands=flake8 ddtrace
 basepython=python2
 


### PR DESCRIPTION
We cannot upgrade to `3.6.0` since there is a bug that alerts on invalid escape sequences in docstrings.

For us this causes an issue with sphinx docstring `:param \**kwargs:`