### PR TITLE
fix all E302 flake8 errors

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -26,6 +26,7 @@ _VERSIONS = {'v0.4': {'traces': '/v0.4/traces',
                       'compatibility_mode': True,
                       'fallback': None}}
 
+
 def _parse_response_json(response):
     """
     Parse the content of a response object, and return the right type,
@@ -47,6 +48,7 @@ def _parse_response_json(response):
             return content
         except (ValueError, TypeError) as err:
             log.debug("unable to load JSON '%s': %s" % (body, err))
+
 
 class API(object):
     """

--- a/ddtrace/commands/ddtrace_run.py
+++ b/ddtrace/commands/ddtrace_run.py
@@ -33,6 +33,7 @@ Available environment variables:
     DATADOG_PRIORITY_SAMPLING=true|false : (default: false): enables Priority Sampling.
 """ # noqa
 
+
 def _ddtrace_root():
     from ddtrace import __file__
     return os.path.dirname(__file__)

--- a/ddtrace/contrib/bottle/patch.py
+++ b/ddtrace/contrib/bottle/patch.py
@@ -1,4 +1,3 @@
-
 import os
 
 from .trace import TracePlugin
@@ -6,6 +5,7 @@ from .trace import TracePlugin
 import bottle
 
 import wrapt
+
 
 def patch():
     """Patch the bottle.Bottle class
@@ -15,6 +15,7 @@ def patch():
 
     setattr(bottle, '_datadog_patch', True)
     wrapt.wrap_function_wrapper('bottle', 'Bottle.__init__', traced_init)
+
 
 def traced_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)

--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -10,6 +10,7 @@ from ...propagation.http import HTTPPropagator
 
 SPAN_TYPE = 'web'
 
+
 class TracePlugin(object):
     name = 'trace'
     api = 2

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -25,14 +25,17 @@ PAGE_NUMBER = '_ddtrace_page_number'
 # Original connect connect function
 _connect = cassandra.cluster.Cluster.connect
 
+
 def patch():
     """ patch will add tracing to the cassandra library. """
     setattr(cassandra.cluster.Cluster, 'connect',
             wrapt.FunctionWrapper(_connect, traced_connect))
     Pin(service=SERVICE, app=SERVICE, app_type="db").onto(cassandra.cluster.Cluster)
 
+
 def unpatch():
     cassandra.cluster.Cluster.connect = _connect
+
 
 def traced_connect(func, instance, args, kwargs):
     session = func(*args, **kwargs)
@@ -40,6 +43,7 @@ def traced_connect(func, instance, args, kwargs):
         # FIXME[matt] this should probably be private.
         setattr(session, 'execute_async', wrapt.FunctionWrapper(session.execute_async, traced_execute_async))
     return session
+
 
 def _close_span_on_success(result, future):
     span = getattr(future, CURRENT_SPAN, None)
@@ -54,10 +58,12 @@ def _close_span_on_success(result, future):
         span.finish()
         delattr(future, CURRENT_SPAN)
 
+
 def traced_set_final_result(func, instance, args, kwargs):
     result = args[0]
     _close_span_on_success(result, instance)
     return func(*args, **kwargs)
+
 
 def _close_span_on_error(exc, future):
     span = getattr(future, CURRENT_SPAN, None)
@@ -76,10 +82,12 @@ def _close_span_on_error(exc, future):
         span.finish()
         delattr(future, CURRENT_SPAN)
 
+
 def traced_set_final_exception(func, instance, args, kwargs):
     exc = args[0]
     _close_span_on_error(exc, instance)
     return func(*args, **kwargs)
+
 
 def traced_start_fetching_next_page(func, instance, args, kwargs):
     has_more_pages = getattr(instance, 'has_more_pages', True)
@@ -110,6 +118,7 @@ def traced_start_fetching_next_page(func, instance, args, kwargs):
         with span:
             span.set_exc_info(*sys.exc_info())
         raise
+
 
 def traced_execute_async(func, instance, args, kwargs):
     cluster = getattr(instance, 'cluster', None)
@@ -166,6 +175,7 @@ def traced_execute_async(func, instance, args, kwargs):
             span.set_exc_info(*sys.exc_info())
         raise
 
+
 def _start_span_and_set_tags(pin, query, session, cluster):
     service = pin.service
     tracer = pin.tracer
@@ -174,6 +184,7 @@ def _start_span_and_set_tags(pin, query, session, cluster):
     span.set_tags(_extract_session_metas(session))     # FIXME[matt] do once?
     span.set_tags(_extract_cluster_metas(cluster))
     return span
+
 
 def _extract_session_metas(session):
     metas = {}
@@ -185,6 +196,7 @@ def _extract_session_metas(session):
 
     return metas
 
+
 def _extract_cluster_metas(cluster):
     metas = {}
     if deep_getattr(cluster, "metadata.cluster_name"):
@@ -193,6 +205,7 @@ def _extract_cluster_metas(cluster):
         metas[net.TARGET_PORT] = cluster.port
 
     return metas
+
 
 def _extract_result_metas(result):
     metas = {}
@@ -229,6 +242,7 @@ def _extract_result_metas(result):
         metas[cassx.ROW_COUNT] = len(result_rows)
 
     return metas
+
 
 def _sanitize_query(span, query):
     # TODO (aaditya): fix this hacky type check. we need it to avoid circular imports

--- a/ddtrace/contrib/celery/signals.py
+++ b/ddtrace/contrib/celery/signals.py
@@ -13,9 +13,9 @@ from .utils import (
     retrieve_span,
 )
 
-
 log = logging.getLogger(__name__)
 SPAN_TYPE = 'worker'
+
 
 def trace_prerun(*args, **kwargs):
     # safe-guard to avoid crashes in case the signals API

--- a/ddtrace/contrib/celery/task.py
+++ b/ddtrace/contrib/celery/task.py
@@ -18,6 +18,7 @@ def patch_task(task, pin=None):
     patch_app(task.app)
     return task
 
+
 def unpatch_task(task):
     """Deprecated API. The new API uses signals that can be deactivated
     via unpatch() API. This API is now a no-op implementation so it doesn't

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -153,6 +153,7 @@ class TracedConnection(wrapt.ObjectProxy):
         span_name = '{}.{}'.format(self._self_datadog_name, 'rollback')
         return self._trace_method(self.__wrapped__.rollback, span_name, {}, *args, **kwargs)
 
+
 def _get_vendor(conn):
     """ Return the vendor (e.g postgres, mysql) of the given
         database.

--- a/ddtrace/contrib/django/cache.py
+++ b/ddtrace/contrib/django/cache.py
@@ -93,6 +93,7 @@ def patch_cache(tracer):
         for method in TRACED_METHODS:
             _wrap_method(cache, method)
 
+
 def unpatch_method(cls, method_name):
     method = getattr(cls, DATADOG_NAMESPACE.format(method=method_name), None)
     if method is None:
@@ -100,6 +101,7 @@ def unpatch_method(cls, method_name):
         return
     setattr(cls, method_name, method)
     delattr(cls, DATADOG_NAMESPACE.format(method=method_name))
+
 
 def unpatch_cache():
     cache_backends = set([cache['BACKEND'] for cache in django_settings.CACHES.values()])

--- a/ddtrace/contrib/django/middleware.py
+++ b/ddtrace/contrib/django/middleware.py
@@ -47,25 +47,30 @@ def get_middleware_insertion_point():
         return MIDDLEWARE, middleware
     return MIDDLEWARE_CLASSES, getattr(django_settings, MIDDLEWARE_CLASSES, None)
 
+
 def insert_trace_middleware():
     middleware_attribute, middleware = get_middleware_insertion_point()
     if middleware is not None and TRACE_MIDDLEWARE not in set(middleware):
         setattr(django_settings, middleware_attribute, type(middleware)((TRACE_MIDDLEWARE,)) + middleware)
+
 
 def remove_trace_middleware():
     _, middleware = get_middleware_insertion_point()
     if middleware and TRACE_MIDDLEWARE in set(middleware):
         middleware.remove(TRACE_MIDDLEWARE)
 
+
 def insert_exception_middleware():
     middleware_attribute, middleware = get_middleware_insertion_point()
     if middleware is not None and EXCEPTION_MIDDLEWARE not in set(middleware):
         setattr(django_settings, middleware_attribute, middleware + type(middleware)((EXCEPTION_MIDDLEWARE,)))
 
+
 def remove_exception_middleware():
     _, middleware = get_middleware_insertion_point()
     if middleware and EXCEPTION_MIDDLEWARE in set(middleware):
         middleware.remove(EXCEPTION_MIDDLEWARE)
+
 
 class InstrumentationMixin(MiddlewareClass):
     """
@@ -172,9 +177,11 @@ def _get_req_span(request):
     """ Return the datadog span from the given request. """
     return getattr(request, '_datadog_request_span', None)
 
+
 def _set_req_span(request, span):
     """ Set the datadog span on the given request. """
     return setattr(request, '_datadog_request_span', span)
+
 
 def _set_auth_tags(span, request):
     """ Patch any available auth tags from the request onto the span. """

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -2,6 +2,7 @@ import wrapt
 
 import django
 
+
 def patch():
     """Patch the instrumented methods
     """
@@ -11,6 +12,7 @@ def patch():
 
     _w = wrapt.wrap_function_wrapper
     _w('django', 'setup', traced_setup)
+
 
 def traced_setup(wrapped, instance, args, kwargs):
     from django.conf import settings

--- a/ddtrace/contrib/django/templates.py
+++ b/ddtrace/contrib/django/templates.py
@@ -12,10 +12,10 @@ from ...ext import http
 # 3p
 from django.template import Template
 
-
 log = logging.getLogger(__name__)
 
 RENDER_ATTR = '_datadog_original_render'
+
 
 def patch_template(tracer):
     """ will patch django's template rendering function to include timing
@@ -41,6 +41,7 @@ def patch_template(tracer):
                 span.set_tag('django.template_name', template_name)
 
     Template.render = traced_render
+
 
 def unpatch_template():
     render = getattr(Template, RENDER_ATTR, None)

--- a/ddtrace/contrib/elasticsearch/quantize.py
+++ b/ddtrace/contrib/elasticsearch/quantize.py
@@ -11,6 +11,7 @@ ID_PLACEHOLDER = r'/?\2'
 INDEX_REGEXP = re.compile(r'[0-9]{2,}')
 INDEX_PLACEHOLDER = r'?'
 
+
 def quantize(span):
     """Quantize an elasticsearch span
 

--- a/ddtrace/contrib/falcon/patch.py
+++ b/ddtrace/contrib/falcon/patch.py
@@ -19,6 +19,7 @@ def patch():
     setattr(falcon, '_datadog_patch', True)
     wrapt.wrap_function_wrapper('falcon', 'API.__init__', traced_init)
 
+
 def traced_init(wrapped, instance, args, kwargs):
     mw = kwargs.pop('middleware', [])
     service = os.environ.get('DATADOG_SERVICE_NAME') or 'falcon'

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -177,6 +177,7 @@ class TraceMiddleware(object):
         span.set_tag(http.METHOD, method)
         span.finish()
 
+
 def _set_error_on_span(span, exception):
     # The 3 next lines might not be strictly required, since `set_traceback`
     # also get the exception from the sys.exc_info (and fill the error meta).
@@ -187,6 +188,7 @@ def _set_error_on_span(span, exception):
     # The provided `exception` object doesn't have a stack trace attached,
     # so attach the stack trace with `set_traceback`.
     span.set_traceback()
+
 
 def _patch_render(tracer):
     """ patch flask's render template methods with the given tracer. """

--- a/ddtrace/contrib/flask_cache/utils.py
+++ b/ddtrace/contrib/flask_cache/utils.py
@@ -3,6 +3,7 @@ from ...ext import net
 from ..redis.util import _extract_conn_tags as extract_redis_tags
 from ..pylibmc.addrs import parse_addresses
 
+
 def _resource_from_cache_prefix(resource, cache):
     """
     Combine the resource name with the cache prefix (if any)

--- a/ddtrace/contrib/futures/threading.py
+++ b/ddtrace/contrib/futures/threading.py
@@ -16,6 +16,7 @@ def _wrap_submit(func, instance, args, kwargs):
     fn_args = args[1:]
     return func(_wrap_execution, current_ctx, fn, fn_args, kwargs)
 
+
 def _wrap_execution(ctx, fn, args, kwargs):
     """
     Intermediate target function that is executed in a new thread;

--- a/ddtrace/contrib/gevent/greenlet.py
+++ b/ddtrace/contrib/gevent/greenlet.py
@@ -5,6 +5,7 @@ from .provider import CONTEXT_ATTR
 
 GEVENT_VERSION = gevent.version_info[0:3]
 
+
 class TracingMixin(object):
     def __init__(self, *args, **kwargs):
         # get the current Context if available

--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -3,6 +3,7 @@ import grpc
 from ddtrace import Pin
 from .propagation import inject_span
 
+
 class GrpcClientInterceptor(
         grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamClientInterceptor,
         grpc.StreamUnaryClientInterceptor, grpc.StreamStreamClientInterceptor):

--- a/ddtrace/contrib/grpc/patch.py
+++ b/ddtrace/contrib/grpc/patch.py
@@ -6,6 +6,7 @@ from ...utils.wrappers import unwrap
 
 from .client_interceptor import GrpcClientInterceptor
 
+
 def patch():
     # patch only once
     if getattr(grpc, '__datadog_patch', False):
@@ -18,12 +19,14 @@ def patch():
     _w('grpc', 'insecure_channel', _insecure_channel_with_interceptor)
     _w('grpc', 'secure_channel', _secure_channel_with_interceptor)
 
+
 def unpatch():
     if not getattr(grpc, '__datadog_patch', False):
         return
     setattr(grpc, '__datadog_patch', False)
     unwrap(grpc, 'secure_channel')
     unwrap(grpc, 'insecure_channel')
+
 
 def _insecure_channel_with_interceptor(wrapped, instance, args, kwargs):
     channel = wrapped(*args, **kwargs)
@@ -32,6 +35,7 @@ def _insecure_channel_with_interceptor(wrapped, instance, args, kwargs):
     channel = _intercept_channel(channel, host, port)
     return channel
 
+
 def _secure_channel_with_interceptor(wrapped, instance, args, kwargs):
     channel = wrapped(*args, **kwargs)
     target = args[0]
@@ -39,8 +43,10 @@ def _secure_channel_with_interceptor(wrapped, instance, args, kwargs):
     channel = _intercept_channel(channel, host, port)
     return channel
 
+
 def _intercept_channel(channel, host, port):
     return grpc.intercept_channel(channel, GrpcClientInterceptor(host, port))
+
 
 def get_host_port(target):
     split = target.rsplit(':', 2)

--- a/ddtrace/contrib/grpc/propagation.py
+++ b/ddtrace/contrib/grpc/propagation.py
@@ -1,6 +1,7 @@
 import grpc
 import collections
 
+
 class ClientCallDetails(
         collections.namedtuple(
             '_ClientCallDetails',
@@ -9,6 +10,7 @@ class ClientCallDetails(
     """Copy/paste from https://github.com/grpc/grpc/blob/d0cb61eada9d270b9043ec866b55c88617d362be/examples/python/interceptors/headers/header_manipulator_client_interceptor.py#L22
     """  # noqa
     pass
+
 
 def inject_span(span, client_call_details):
     """Inject propagation headers in grpc call metadata.

--- a/ddtrace/contrib/mongoengine/patch.py
+++ b/ddtrace/contrib/mongoengine/patch.py
@@ -10,10 +10,11 @@ _connect = mongoengine.connect
 def patch():
     setattr(mongoengine, 'connect', WrappedConnect(_connect))
 
+
 def unpatch():
     setattr(mongoengine, 'connect', _connect)
+
 
 @deprecated(message='Use patching instead (see the docs).', version='1.0.0')
 def trace_mongoengine(*args, **kwargs):
     return _connect
-

--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -15,11 +15,13 @@ CONN_ATTR_BY_TAG = {
     db.NAME: 'database',
 }
 
+
 def patch():
     wrapt.wrap_function_wrapper('mysql.connector', 'connect', _connect)
     # `Connect` is an alias for `connect`, patch it too
     if hasattr(mysql.connector, 'Connect'):
         mysql.connector.Connect = mysql.connector.connect
+
 
 def unpatch():
     if isinstance(mysql.connector.connect, wrapt.ObjectProxy):
@@ -27,9 +29,11 @@ def unpatch():
         if hasattr(mysql.connector, 'Connect'):
             mysql.connector.Connect = mysql.connector.connect
 
+
 def _connect(func, instance, args, kwargs):
     conn = func(*args, **kwargs)
     return patch_conn(conn)
+
 
 def patch_conn(conn):
 

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -10,12 +10,12 @@ from ddtrace.contrib.dbapi import TracedConnection
 from ...ext import net, db, AppTypes
 from ...utils.wrappers import unwrap as _u
 
-
 KWPOS_BY_TAG = {
     net.TARGET_HOST: ('host', 0),
     db.USER: ('user', 1),
     db.NAME: ('db', 3),
 }
+
 
 def patch():
     # patch only once

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -93,6 +93,7 @@ def _extensions_register_type(func, _, args, kwargs):
 
     return func(obj, scope) if scope else func(obj)
 
+
 def _extensions_quote_ident(func, _, args, kwargs):
     def _unroll_args(obj, scope=None):
         return obj, scope
@@ -104,6 +105,7 @@ def _extensions_quote_ident(func, _, args, kwargs):
         scope = scope.__wrapped__
 
     return func(obj, scope) if scope else func(obj)
+
 
 def _extensions_adapt(func, _, args, kwargs):
     adapt = func(*args, **kwargs)

--- a/ddtrace/contrib/pylibmc/addrs.py
+++ b/ddtrace/contrib/pylibmc/addrs.py
@@ -1,5 +1,3 @@
-
-
 translate_server_specs = None
 
 try:
@@ -8,6 +6,7 @@ try:
     from pylibmc.client import translate_server_specs
 except ImportError:
     pass
+
 
 def parse_addresses(addrs):
     if not translate_server_specs:

--- a/ddtrace/contrib/pylibmc/patch.py
+++ b/ddtrace/contrib/pylibmc/patch.py
@@ -9,6 +9,6 @@ _Client = pylibmc.Client
 def patch():
     setattr(pylibmc, 'Client', TracedClient)
 
+
 def unpatch():
     setattr(pylibmc, 'Client', _Client)
-

--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -234,11 +234,13 @@ def normalize_filter(f=None):
         # least it won't crash.
         return {}
 
+
 def _set_address_tags(span, address):
     # the address is only set after the cursor is done.
     if address:
         span.set_tag(netx.TARGET_HOST, address[0])
         span.set_tag(netx.TARGET_PORT, address[1])
+
 
 def _set_query_metadata(span, cmd):
     """ Sets span `mongodb.query` tag and resource given command query """

--- a/ddtrace/contrib/pymongo/parse.py
+++ b/ddtrace/contrib/pymongo/parse.py
@@ -115,6 +115,7 @@ def parse_msg(msg_bytes):
     cmd.metrics[netx.BYTES_OUT] = msg_len
     return cmd
 
+
 def parse_query(query):
     """ Return a command parsed from the given mongo db query. """
     db, coll = None, None
@@ -131,6 +132,7 @@ def parse_query(query):
     cmd = Command(getattr(query, 'name', 'query'), db, coll)
     cmd.query = query.spec
     return cmd
+
 
 def parse_spec(spec, db=None):
     """ Return a Command that has parsed the relevant detail for the given
@@ -165,9 +167,11 @@ def parse_spec(spec, db=None):
 
     return cmd
 
+
 def _cstring(raw):
     """ Return the first null terminated cstring from the bufffer. """
     return ctypes.create_string_buffer(raw).value
+
 
 def _split_namespace(ns):
     """ Return a tuple of (db, collecton) from the "db.coll" string. """

--- a/ddtrace/contrib/pymongo/patch.py
+++ b/ddtrace/contrib/pymongo/patch.py
@@ -9,6 +9,6 @@ _MongoClient = pymongo.MongoClient
 def patch():
     setattr(pymongo, 'MongoClient', TracedMongoClient)
 
+
 def unpatch():
     setattr(pymongo, 'MongoClient', _MongoClient)
-

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -11,6 +11,7 @@ import wrapt
 
 DD_PATCH = '_datadog_patch'
 
+
 def patch():
     """
     Patch pyramid.config.Configurator
@@ -21,6 +22,7 @@ def patch():
     setattr(pyramid.config, DD_PATCH, True)
     _w = wrapt.wrap_function_wrapper
     _w('pyramid.config', 'Configurator.__init__', traced_init)
+
 
 def traced_init(wrapped, instance, args, kwargs):
     settings = kwargs.pop('settings', {})
@@ -44,6 +46,7 @@ def traced_init(wrapped, instance, args, kwargs):
 
     wrapped(*args, **kwargs)
     trace_pyramid(instance)
+
 
 def insert_tween_if_needed(settings):
     tweens = settings.get('pyramid.tweens')

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -1,4 +1,3 @@
-
 # 3p
 import logging
 import pyramid.renderers
@@ -27,6 +26,7 @@ DD_SPAN = '_datadog_span'
 def trace_pyramid(config):
     config.include('ddtrace.contrib.pyramid')
 
+
 def includeme(config):
     # Add our tween just before the default exception handler
     config.add_tween(DD_TWEEN_NAME, over=pyramid.tweens.EXCVIEW)
@@ -50,6 +50,7 @@ def trace_render(func, instance, args, kwargs):
     with tracer.trace('pyramid.render') as span:
         span.span_type = http.TEMPLATE
         return func(*args, **kwargs)
+
 
 def trace_tween_factory(handler, registry):
     # configuration

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -34,6 +34,7 @@ def patch():
         _w('redis.client', 'Pipeline.immediate_execute_command', traced_execute_command)
     Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP, app_type=AppTypes.db).onto(redis.StrictRedis)
 
+
 def unpatch():
     if getattr(redis, '_datadog_patch', False):
         setattr(redis, '_datadog_patch', False)
@@ -50,10 +51,10 @@ def unpatch():
             unwrap(redis.client.Pipeline, 'execute')
             unwrap(redis.client.Pipeline, 'immediate_execute_command')
 
+
 #
 # tracing functions
 #
-
 def traced_execute_command(func, instance, args, kwargs):
     pin = Pin.get_from(instance)
     if not pin or not pin.enabled():
@@ -70,12 +71,14 @@ def traced_execute_command(func, instance, args, kwargs):
         # run the command
         return func(*args, **kwargs)
 
+
 def traced_pipeline(func, instance, args, kwargs):
     pipeline = func(*args, **kwargs)
     pin = Pin.get_from(instance)
     if pin:
         pin.onto(pipeline)
     return pipeline
+
 
 def traced_execute_pipeline(func, instance, args, kwargs):
     pin = Pin.get_from(instance)
@@ -92,6 +95,7 @@ def traced_execute_pipeline(func, instance, args, kwargs):
         s.set_tags(_get_tags(instance))
         s.set_metric(redisx.PIPELINE_LEN, len(instance.command_stack))
         return func(*args, **kwargs)
+
 
 def _get_tags(conn):
     return _extract_conn_tags(conn.connection_pool.connection_kwargs)

--- a/ddtrace/contrib/sqlalchemy/engine.py
+++ b/ddtrace/contrib/sqlalchemy/engine.py
@@ -122,6 +122,7 @@ class EngineTracer(object):
         finally:
             span.finish()
 
+
 def _set_tags_from_url(span, url):
     """ set connection tags from the url. return true if successful. """
     if url.host:
@@ -133,6 +134,7 @@ def _set_tags_from_url(span, url):
 
     return bool(span.get_tag(netx.TARGET_HOST))
 
+
 def _set_tags_from_cursor(span, vendor, cursor):
     """ attempt to set db connection tags by introspecting the cursor. """
     if 'postgres' == vendor:
@@ -143,4 +145,3 @@ def _set_tags_from_cursor(span, vendor, cursor):
                 span.set_tag(sqlx.DB, d.get("dbname"))
                 span.set_tag(netx.TARGET_HOST, d.get("host"))
                 span.set_tag(netx.TARGET_PORT, d.get("port"))
-

--- a/ddtrace/contrib/sqlite3/patch.py
+++ b/ddtrace/contrib/sqlite3/patch.py
@@ -12,24 +12,29 @@ from ...ext import AppTypes
 # Original connect method
 _connect = sqlite3.connect
 
+
 def patch():
     wrapped = wrapt.FunctionWrapper(_connect, traced_connect)
 
     setattr(sqlite3, 'connect', wrapped)
     setattr(sqlite3.dbapi2, 'connect', wrapped)
 
+
 def unpatch():
     sqlite3.connect = _connect
     sqlite3.dbapi2.connect = _connect
+
 
 def traced_connect(func, _, args, kwargs):
     conn = func(*args, **kwargs)
     return patch_conn(conn)
 
+
 def patch_conn(conn):
     wrapped = TracedSQLite(conn)
     Pin(service="sqlite", app="sqlite", app_type=AppTypes.db).onto(wrapped)
     return wrapped
+
 
 class TracedSQLite(TracedConnection):
 

--- a/ddtrace/encoding.py
+++ b/ddtrace/encoding.py
@@ -80,6 +80,7 @@ class MsgpackEncoder(Encoder):
     def _encode(self, obj):
         return msgpack.packb(obj, **MSGPACK_PARAMS)
 
+
 def get_encoder():
     """
     Switching logic that choose the best encoder for the API transport.

--- a/ddtrace/ext/errors.py
+++ b/ddtrace/ext/errors.py
@@ -14,6 +14,7 @@ MSG = ERROR_MSG
 TYPE = ERROR_TYPE
 STACK = ERROR_STACK
 
+
 def get_traceback(tb=None, error=None):
     t = None
     if error:

--- a/ddtrace/ext/http.py
+++ b/ddtrace/ext/http.py
@@ -18,5 +18,6 @@ STATUS_CODE = "http.status_code"
 # template render span type
 TEMPLATE = 'template'
 
+
 def normalize_status_code(code):
     return code.split(' ')[0]

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -1,4 +1,3 @@
-
 from ddtrace.ext import AppTypes
 
 
@@ -22,6 +21,7 @@ def normalize_vendor(vendor):
         return "postgres"
     else:
         return vendor
+
 
 def parse_pg_dsn(dsn):
     """

--- a/ddtrace/filters.py
+++ b/ddtrace/filters.py
@@ -2,6 +2,7 @@ import re
 
 from .ext import http
 
+
 class FilterRequestsOnUrl(object):
     """Filter out traces from incoming http requests based on the request's url.
     This class takes as argument a list of regular expression patterns

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -99,6 +99,7 @@ def patch_all(**patch_modules):
 
     patch(raise_errors=False, **modules)
 
+
 def patch(raise_errors=True, **patch_modules):
     """Patch only a set of given modules.
 
@@ -144,10 +145,12 @@ def patch_module(module, raise_errors=True):
         log.debug("failed to patch %s: %s", module, exc)
         return False
 
+
 def get_patched_modules():
     """Get the list of patched modules"""
     with _LOCK:
         return sorted(_PATCHED_MODULES)
+
 
 def _patch_module(module):
     """_patch_module will attempt to monkey patch the module.

--- a/ddtrace/opentracer/helpers.py
+++ b/ddtrace/opentracer/helpers.py
@@ -5,6 +5,7 @@ import ddtrace
 Helper routines for Datadog OpenTracing.
 """
 
+
 def set_global_tracer(tracer):
     """Sets the global tracers to the given tracer."""
 

--- a/ddtrace/opentracer/propagation/propagator.py
+++ b/ddtrace/opentracer/propagation/propagator.py
@@ -3,6 +3,7 @@ from abc import ABCMeta, abstractmethod
 # ref: https://stackoverflow.com/a/38668373
 ABC = ABCMeta('ABC', (object,), {'__slots__': ()})
 
+
 class Propagator(ABC):
 
     @abstractmethod

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -15,6 +15,7 @@ MAX_TRACE_ID = 2 ** 64
 # Has to be the same factor and key as the Agent to allow chained sampling
 KNUTH_FACTOR = 1111111111111111111
 
+
 class AllSampler(object):
     """Sampler sampling all the traces"""
 
@@ -57,6 +58,7 @@ def _key(service=None, env=None):
 
 
 _default_key = _key()
+
 
 class RateByServiceSampler(object):
     """Sampler based on a rate, by service

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -311,6 +311,7 @@ class Span(object):
             self.name,
         )
 
+
 def _new_id():
     """Generate a random trace_id or span_id"""
     return random.getrandbits(64)

--- a/ddtrace/utils/__init__.py
+++ b/ddtrace/utils/__init__.py
@@ -1,4 +1,3 @@
-
 # https://stackoverflow.com/a/26853961
 def merge_dicts(x, y):
     """Returns a copy of y merged into x."""

--- a/tox.ini
+++ b/tox.ini
@@ -610,7 +610,7 @@ setenv =
 
 
 [flake8]
-ignore=W391,E231,E201,E202,E203,E261,E302,E128,E126,E124,W503
+ignore=W391,E231,E201,E202,E203,E261,E128,E126,E124,W503
 
 max-line-length=120
 exclude=tests


### PR DESCRIPTION
Slowly but surely we'll remove all the ignored flake8 error codes.

This PR removes ignoring the E302 check which is ensuring there are 2 blank lines between top level functions/classes/etc and one blank line between class methods.