### PR TITLE
[core] Lock required library versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,8 +82,8 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['tests*']),
     install_requires=[
-        "wrapt",
-        "msgpack-python",
+        "wrapt==1.10.11",
+        "msgpack-python==0.5.4",
     ],
     extras_require={
         # users can include opentracing by having:


### PR DESCRIPTION
If `wrapt` or `msgpack-python` were to introduce breaking changes then `ddtrace` would be at the mercy of those changes. We should instead lock the package versions to ones which we have tested and have verified to work with `ddtrace`.