### PR TITLE
Revert "[cassandra] Fix batched query leak"

### DIFF
--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -253,7 +253,9 @@ def _sanitize_query(span, query):
         # reset query if a string is available
         resource = getattr(query, "query_string", query)
     elif t == 'BatchStatement':
-        resource = '; '.join(q[1] for q in query._statements_and_parameters[:2])
+        resource = 'BatchStatement'
+        q = "; ".join(q[1] for q in query._statements_and_parameters[:2])
+        span.set_tag("cassandra.query", q)
         span.set_metric("cassandra.batch_size", len(query._statements_and_parameters))
     elif t == 'BoundStatement':
         ps = getattr(query, 'prepared_statement', None)

--- a/tests/contrib/cassandra/test.py
+++ b/tests/contrib/cassandra/test.py
@@ -264,15 +264,9 @@ class CassandraBase(object):
         spans = writer.pop()
         eq_(len(spans), 1)
         s = spans[0]
-        eq_(
-            s.resource,
-            (
-                'INSERT INTO test.person_write (name, age, description) VALUES (\'Joe\', 1, \'a\'); '
-                'INSERT INTO test.person_write (name, age, description) VALUES (\'Jane\', 2, \'b\')'
-            )
-        )
+        eq_(s.resource, 'BatchStatement')
         eq_(s.get_metric('cassandra.batch_size'), 2)
-        assert s.get_tag('cassandra.query') is None
+        assert 'test.person' in s.get_tag('cassandra.query')
 
 
 class TestCassPatchDefault(CassandraBase):


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#714.

We ran into an issue when testing on our staging environment described in the comment below.