### PR TITLE
Changed msgpack dependency to point to the real package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['tests*']),
     install_requires=[
-        'msgpack-python',
+        'msgpack',
         'six',
         'wrapt',
     ],


### PR DESCRIPTION
The msgpack-python package is just a redirect to msgpack.