### PR TITLE
[dbapi2] disable fetchone/fetchmany/fetchall tracing by default

### DIFF
--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -9,11 +9,12 @@ import wrapt
 from ddtrace import Pin
 from ddtrace.ext import AppTypes, sql
 from ddtrace.settings import config
+from ddtrace.utils.formats import asbool, get_env
 
 log = logging.getLogger(__name__)
 
 config._add('dbapi2', dict(
-    trace_fetch_methods=False,
+    trace_fetch_methods=asbool(get_env('dbapi2', 'trace_fetch_methods', 'false')),
 ))
 
 

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -13,7 +13,7 @@ from ddtrace.settings import config
 log = logging.getLogger(__name__)
 
 config._add('dbapi2', dict(
-    cursor_trace_fetch=False,
+    trace_fetch_methods=False,
 ))
 
 
@@ -136,7 +136,7 @@ class TracedConnection(wrapt.ObjectProxy):
         if not cursor_cls:
             # Do not trace `fetch*` methods by default
             cursor_cls = TracedCursor
-            if config.dbapi2.cursor_trace_fetch:
+            if config.dbapi2.trace_fetch_methods:
                 cursor_cls = FetchTracedCursor
 
         super(TracedConnection, self).__init__(conn)

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -3,7 +3,7 @@ import psycopg2
 import wrapt
 
 # project
-from ddtrace import Pin
+from ddtrace import Pin, config
 from ddtrace.contrib import dbapi
 from ddtrace.ext import sql, net, db
 
@@ -51,14 +51,21 @@ class Psycopg2TracedCursor(dbapi.TracedCursor):
         return super(Psycopg2TracedCursor, self)._trace_method(method, name, resource, extra_tags, *args, **kwargs)
 
 
+class Psycopg2FetchTracedCursor(Psycopg2TracedCursor, dbapi.FetchTracedCursor):
+    """ FetchTracedCursor for psycopg2 """
+
+
 class Psycopg2TracedConnection(dbapi.TracedConnection):
     """ TracedConnection wraps a Connection with tracing code. """
 
-    def __init__(self, conn, pin=None, cursor_cls=Psycopg2TracedCursor):
-        super(Psycopg2TracedConnection, self).__init__(conn, pin)
-        # wrapt requires prefix of `_self` for attributes that are only in the
-        # proxy (since some of our source objects will use `__slots__`)
-        self._self_cursor_cls = cursor_cls
+    def __init__(self, conn, pin=None, cursor_cls=None):
+        if not cursor_cls:
+            # Do not trace `fetch*` methods by default
+            cursor_cls = Psycopg2TracedCursor
+            if config.dbapi2.trace_fetch_methods:
+                cursor_cls = Psycopg2FetchTracedCursor
+
+        super(Psycopg2TracedConnection, self).__init__(conn, pin, cursor_cls=cursor_cls)
 
 
 def patch_conn(conn, traced_conn_cls=Psycopg2TracedConnection):

--- a/tests/contrib/dbapi/test_unit.py
+++ b/tests/contrib/dbapi/test_unit.py
@@ -1,9 +1,7 @@
-import unittest
 import mock
 
 from ddtrace import Pin
 from ddtrace.contrib.dbapi import FetchTracedCursor, TracedCursor, TracedConnection
-from tests.test_tracer import get_dummy_tracer
 from ...base import BaseTracerTestCase
 
 

--- a/tests/contrib/django/test_cache_views.py
+++ b/tests/contrib/django/test_cache_views.py
@@ -18,12 +18,12 @@ class DjangoCacheViewTest(DjangoTraceTestCase):
 
         # check the first call for a non-cached view
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 7)
+        eq_(len(spans), 6)
         # the cache miss
         eq_(spans[1].resource, 'get')
         # store the result in the cache
+        eq_(spans[4].resource, 'set')
         eq_(spans[5].resource, 'set')
-        eq_(spans[6].resource, 'set')
 
         # check if the cache hit is traced
         response = self.client.get(url)
@@ -69,11 +69,11 @@ class DjangoCacheViewTest(DjangoTraceTestCase):
 
         # check the first call for a non-cached view
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 6)
+        eq_(len(spans), 5)
         # the cache miss
         eq_(spans[2].resource, 'get')
         # store the result in the cache
-        eq_(spans[5].resource, 'set')
+        eq_(spans[4].resource, 'set')
 
         # check if the cache hit is traced
         response = self.client.get(url)

--- a/tests/contrib/django/test_connection.py
+++ b/tests/contrib/django/test_connection.py
@@ -24,7 +24,7 @@ class DjangoConnectionTest(DjangoTraceTestCase):
         # tests
         spans = self.tracer.writer.pop()
         assert spans, spans
-        eq_(len(spans), 2)
+        eq_(len(spans), 1)
 
         span = spans[0]
         eq_(span.name, 'sqlite.query')
@@ -33,8 +33,6 @@ class DjangoConnectionTest(DjangoTraceTestCase):
         eq_(span.get_tag('django.db.vendor'), 'sqlite')
         eq_(span.get_tag('django.db.alias'), 'default')
         assert start < span.start < span.start + span.duration < end
-
-        eq_(spans[1].name, 'sqlite.query.fetchone')
 
     def test_django_db_query_in_resource_not_in_tags(self):
         User.objects.count()
@@ -60,7 +58,7 @@ class DjangoConnectionTest(DjangoTraceTestCase):
         User.objects.count()
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 2)
+        eq_(len(traces), 1)
         eq_(len(traces[0]), 1)
         span = traces[0][0]
         eq_(span.service, 'my_prefix_db-defaultdb')

--- a/tests/contrib/django/test_middleware.py
+++ b/tests/contrib/django/test_middleware.py
@@ -27,11 +27,10 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 4)
+        eq_(len(spans), 3)
         sp_request = spans[0]
         sp_template = spans[1]
         sp_database = spans[2]
-        sp_database_fetch = spans[3]
         eq_(sp_database.get_tag('django.db.vendor'), 'sqlite')
         eq_(sp_template.get_tag('django.template_name'), 'users_list.html')
         eq_(sp_request.get_tag('http.status_code'), '200')
@@ -40,7 +39,6 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         eq_(sp_request.get_tag('http.method'), 'GET')
         eq_(sp_request.span_type, 'http')
         eq_(sp_request.resource, 'tests.contrib.django.app.views.UserList')
-        eq_(sp_database_fetch.name, 'sqlite.query.fetchmany')
 
     def test_database_patch(self):
         # We want to test that a connection-recreation event causes connections
@@ -57,11 +55,10 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         # We would be missing span #3, the database span, if the connection
         # wasn't patched.
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 4)
+        eq_(len(spans), 3)
         eq_(spans[0].name, 'django.request')
         eq_(spans[1].name, 'django.template')
         eq_(spans[2].name, 'sqlite.query')
-        eq_(spans[3].name, 'sqlite.query.fetchmany')
 
     def test_middleware_trace_errors(self):
         # ensures that the internals are properly traced
@@ -166,7 +163,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 4)
+        eq_(len(spans), 3)
         sp_request = spans[0]
         eq_(sp_request.get_tag('http.status_code'), '200')
         eq_(sp_request.get_tag('django.user.is_authenticated'), None)
@@ -185,7 +182,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 4)
+        eq_(len(spans), 3)
         sp_request = spans[0]
 
         # Check for proper propagated attributes
@@ -206,7 +203,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 4)
+        eq_(len(spans), 3)
         sp_request = spans[0]
 
         # Check that propagation didn't happen
@@ -278,12 +275,11 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 5)
+        eq_(len(spans), 4)
         ot_span = spans[0]
         sp_request = spans[1]
         sp_template = spans[2]
         sp_database = spans[3]
-        sp_database_fetch = spans[4]
 
         # confirm parenting
         eq_(ot_span.parent_id, None)
@@ -298,7 +294,6 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         eq_(sp_request.get_tag('http.url'), '/users/')
         eq_(sp_request.get_tag('django.user.is_authenticated'), 'False')
         eq_(sp_request.get_tag('http.method'), 'GET')
-        eq_(sp_database_fetch.name, 'sqlite.query.fetchmany')
 
     def test_middleware_trace_request_404(self):
         """

--- a/tests/contrib/django/utils.py
+++ b/tests/contrib/django/utils.py
@@ -13,6 +13,7 @@ from ddtrace.contrib.django.templates import unpatch_template
 from ddtrace.contrib.django.middleware import remove_exception_middleware, remove_trace_middleware
 
 # testing
+from ...base import BaseTestCase
 from ...test_tracer import DummyWriter
 
 
@@ -21,7 +22,7 @@ tracer = Tracer()
 tracer.writer = DummyWriter()
 
 
-class DjangoTraceTestCase(TestCase):
+class DjangoTraceTestCase(BaseTestCase, TestCase):
     """
     Base class that provides an internal tracer according to given
     Datadog settings. This class ensures that the tracer spans are

--- a/tests/contrib/mysql/test_mysql.py
+++ b/tests/contrib/mysql/test_mysql.py
@@ -9,7 +9,7 @@ from ddtrace.contrib.mysql.patch import patch, unpatch
 # tests
 from tests.contrib.config import MYSQL_CONFIG
 from tests.opentracer.utils import init_tracer
-from tests.test_tracer import get_dummy_tracer
+from ...base import BaseTracerTestCase
 from ...util import assert_dict_issuperset
 
 
@@ -19,6 +19,8 @@ class MySQLCore(object):
     TEST_SERVICE = 'test-mysql'
 
     def tearDown(self):
+        super(MySQLCore, self).tearDown()
+
         # Reuse the connection across tests
         if self.conn:
             try:
@@ -41,7 +43,7 @@ class MySQLCore(object):
         rows = cursor.fetchall()
         eq_(len(rows), 1)
         spans = writer.pop()
-        eq_(len(spans), 2)
+        eq_(len(spans), 1)
 
         span = spans[0]
         eq_(span.service, self.TEST_SERVICE)
@@ -55,7 +57,30 @@ class MySQLCore(object):
             'db.user': u'test',
         })
 
-        eq_(spans[1].name, 'mysql.query.fetchall')
+    def test_simple_query_fetchll(self):
+        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+            conn, tracer = self._get_conn_tracer()
+            writer = tracer.writer
+            cursor = conn.cursor()
+            cursor.execute("SELECT 1")
+            rows = cursor.fetchall()
+            eq_(len(rows), 1)
+            spans = writer.pop()
+            eq_(len(spans), 2)
+
+            span = spans[0]
+            eq_(span.service, self.TEST_SERVICE)
+            eq_(span.name, 'mysql.query')
+            eq_(span.span_type, 'sql')
+            eq_(span.error, 0)
+            assert_dict_issuperset(span.meta, {
+                'out.host': u'127.0.0.1',
+                'out.port': u'3306',
+                'db.name': u'test',
+                'db.user': u'test',
+            })
+
+            eq_(spans[1].name, 'mysql.query.fetchall')
 
     def test_query_with_several_rows(self):
         conn, tracer = self._get_conn_tracer()
@@ -66,10 +91,24 @@ class MySQLCore(object):
         rows = cursor.fetchall()
         eq_(len(rows), 3)
         spans = writer.pop()
-        eq_(len(spans), 2)
+        eq_(len(spans), 1)
         span = spans[0]
         ok_(span.get_tag('sql.query') is None)
-        eq_(spans[1].name, 'mysql.query.fetchall')
+
+    def test_query_with_several_rows_fetchall(self):
+        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+            conn, tracer = self._get_conn_tracer()
+            writer = tracer.writer
+            cursor = conn.cursor()
+            query = "SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m"
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            eq_(len(rows), 3)
+            spans = writer.pop()
+            eq_(len(spans), 2)
+            span = spans[0]
+            ok_(span.get_tag('sql.query') is None)
+            eq_(spans[1].name, 'mysql.query.fetchall')
 
     def test_query_many(self):
         # tests that the executemany method is correctly wrapped.
@@ -100,12 +139,47 @@ class MySQLCore(object):
         eq_(rows[1][1], "this is foo")
 
         spans = writer.pop()
-        eq_(len(spans), 3)
+        eq_(len(spans), 2)
         span = spans[-1]
         ok_(span.get_tag('sql.query') is None)
         cursor.execute("drop table if exists dummy")
 
-        eq_(spans[2].name, 'mysql.query.fetchall')
+    def test_query_many_fetchall(self):
+        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+            # tests that the executemany method is correctly wrapped.
+            conn, tracer = self._get_conn_tracer()
+            writer = tracer.writer
+            tracer.enabled = False
+            cursor = conn.cursor()
+
+            cursor.execute("""
+                create table if not exists dummy (
+                    dummy_key VARCHAR(32) PRIMARY KEY,
+                    dummy_value TEXT NOT NULL)""")
+            tracer.enabled = True
+
+            stmt = "INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)"
+            data = [
+                ('foo', 'this is foo'),
+                ('bar', 'this is bar'),
+            ]
+            cursor.executemany(stmt, data)
+            query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            eq_(len(rows), 2)
+            eq_(rows[0][0], "bar")
+            eq_(rows[0][1], "this is bar")
+            eq_(rows[1][0], "foo")
+            eq_(rows[1][1], "this is foo")
+
+            spans = writer.pop()
+            eq_(len(spans), 3)
+            span = spans[-1]
+            ok_(span.get_tag('sql.query') is None)
+            cursor.execute("drop table if exists dummy")
+
+            eq_(spans[2].name, 'mysql.query.fetchall')
 
     def test_query_proc(self):
         conn, tracer = self._get_conn_tracer()
@@ -161,9 +235,9 @@ class MySQLCore(object):
             eq_(len(rows), 1)
 
         spans = writer.pop()
-        eq_(len(spans), 3)
+        eq_(len(spans), 2)
 
-        ot_span, dd_span, fetch_span = spans
+        ot_span, dd_span = spans
 
         # confirm parenting
         eq_(ot_span.parent_id, None)
@@ -183,7 +257,44 @@ class MySQLCore(object):
             'db.user': u'test',
         })
 
-        eq_(fetch_span.name, 'mysql.query.fetchall')
+    def test_simple_query_ot_fetchall(self):
+        """OpenTracing version of test_simple_query."""
+        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+            conn, tracer = self._get_conn_tracer()
+            writer = tracer.writer
+
+            ot_tracer = init_tracer('mysql_svc', tracer)
+
+            with ot_tracer.start_active_span('mysql_op'):
+                cursor = conn.cursor()
+                cursor.execute("SELECT 1")
+                rows = cursor.fetchall()
+                eq_(len(rows), 1)
+
+            spans = writer.pop()
+            eq_(len(spans), 3)
+
+            ot_span, dd_span, fetch_span = spans
+
+            # confirm parenting
+            eq_(ot_span.parent_id, None)
+            eq_(dd_span.parent_id, ot_span.span_id)
+
+            eq_(ot_span.service, 'mysql_svc')
+            eq_(ot_span.name, 'mysql_op')
+
+            eq_(dd_span.service, self.TEST_SERVICE)
+            eq_(dd_span.name, 'mysql.query')
+            eq_(dd_span.span_type, 'sql')
+            eq_(dd_span.error, 0)
+            assert_dict_issuperset(dd_span.meta, {
+                'out.host': u'127.0.0.1',
+                'out.port': u'3306',
+                'db.name': u'test',
+                'db.user': u'test',
+            })
+
+            eq_(fetch_span.name, 'mysql.query.fetchall')
 
     def test_commit(self):
         conn, tracer = self._get_conn_tracer()
@@ -206,18 +317,18 @@ class MySQLCore(object):
         eq_(span.name, 'mysql.connection.rollback')
 
 
-class TestMysqlPatch(MySQLCore):
+class TestMysqlPatch(MySQLCore, BaseTracerTestCase):
 
     def setUp(self):
+        super(TestMysqlPatch, self).setUp()
         patch()
 
     def tearDown(self):
+        super(TestMysqlPatch, self).tearDown()
         unpatch()
-        MySQLCore.tearDown(self)
 
     def _get_conn_tracer(self):
         if not self.conn:
-            tracer = get_dummy_tracer()
             self.conn = mysql.connector.connect(**MYSQL_CONFIG)
             assert self.conn.is_connected()
             # Ensure that the default pin is there, with its default value
@@ -227,9 +338,9 @@ class TestMysqlPatch(MySQLCore):
             # Customize the service
             # we have to apply it on the existing one since new one won't inherit `app`
             pin.clone(
-                service=self.TEST_SERVICE, tracer=tracer).onto(self.conn)
+                service=self.TEST_SERVICE, tracer=self.tracer).onto(self.conn)
 
-            return self.conn, tracer
+            return self.conn, self.tracer
 
     def test_patch_unpatch(self):
         unpatch()
@@ -240,13 +351,12 @@ class TestMysqlPatch(MySQLCore):
 
         patch()
         try:
-            tracer = get_dummy_tracer()
-            writer = tracer.writer
+            writer = self.tracer.writer
             conn = mysql.connector.connect(**MYSQL_CONFIG)
             pin = Pin.get_from(conn)
             assert pin
             pin.clone(
-                service=self.TEST_SERVICE, tracer=tracer).onto(conn)
+                service=self.TEST_SERVICE, tracer=self.tracer).onto(conn)
             assert conn.is_connected()
 
             cursor = conn.cursor()
@@ -254,7 +364,7 @@ class TestMysqlPatch(MySQLCore):
             rows = cursor.fetchall()
             eq_(len(rows), 1)
             spans = writer.pop()
-            eq_(len(spans), 2)
+            eq_(len(spans), 1)
 
             span = spans[0]
             eq_(span.service, self.TEST_SERVICE)
@@ -268,8 +378,6 @@ class TestMysqlPatch(MySQLCore):
                 'db.user': u'test',
             })
             ok_(span.get_tag('sql.query') is None)
-
-            eq_(spans[1].name, 'mysql.query.fetchall')
 
         finally:
             unpatch()

--- a/tests/contrib/mysqldb/test_mysql.py
+++ b/tests/contrib/mysqldb/test_mysql.py
@@ -308,7 +308,6 @@ class MySQLCore(object):
             'db.user': u'test',
         })
 
-
     def test_simple_query_ot_fetchall(self):
         """OpenTracing version of test_simple_query."""
         with self.override_config('dbapi2', dict(trace_fetch_methods=True)):

--- a/tests/contrib/mysqldb/test_mysql.py
+++ b/tests/contrib/mysqldb/test_mysql.py
@@ -7,8 +7,8 @@ from nose.tools import eq_, ok_
 
 from tests.opentracer.utils import init_tracer
 from ..config import MYSQL_CONFIG
+from ...base import BaseTracerTestCase
 from ...util import assert_dict_issuperset
-from ...test_tracer import get_dummy_tracer
 
 
 class MySQLCore(object):
@@ -17,9 +17,13 @@ class MySQLCore(object):
     TEST_SERVICE = 'test-mysql'
 
     def setUp(self):
+        super(MySQLCore, self).setUp()
+
         patch()
 
     def tearDown(self):
+        super(MySQLCore, self).tearDown()
+
         # Reuse the connection across tests
         if self.conn:
             try:
@@ -42,7 +46,7 @@ class MySQLCore(object):
         rows = cursor.fetchall()
         eq_(len(rows), 1)
         spans = writer.pop()
-        eq_(len(spans), 2)
+        eq_(len(spans), 1)
 
         span = spans[0]
         eq_(span.service, self.TEST_SERVICE)
@@ -55,8 +59,31 @@ class MySQLCore(object):
             'db.name': u'test',
             'db.user': u'test',
         })
-        fetch_span = spans[1]
-        eq_(fetch_span.name, 'mysql.query.fetchall')
+
+    def test_simple_query_fetchall(self):
+        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+            conn, tracer = self._get_conn_tracer()
+            writer = tracer.writer
+            cursor = conn.cursor()
+            cursor.execute("SELECT 1")
+            rows = cursor.fetchall()
+            eq_(len(rows), 1)
+            spans = writer.pop()
+            eq_(len(spans), 2)
+
+            span = spans[0]
+            eq_(span.service, self.TEST_SERVICE)
+            eq_(span.name, 'mysql.query')
+            eq_(span.span_type, 'sql')
+            eq_(span.error, 0)
+            assert_dict_issuperset(span.meta, {
+                'out.host': u'127.0.0.1',
+                'out.port': u'3306',
+                'db.name': u'test',
+                'db.user': u'test',
+            })
+            fetch_span = spans[1]
+            eq_(fetch_span.name, 'mysql.query.fetchall')
 
     def test_simple_query_with_positional_args(self):
         conn, tracer = self._get_conn_tracer_with_positional_args()
@@ -66,7 +93,7 @@ class MySQLCore(object):
         rows = cursor.fetchall()
         eq_(len(rows), 1)
         spans = writer.pop()
-        eq_(len(spans), 2)
+        eq_(len(spans), 1)
 
         span = spans[0]
         eq_(span.service, self.TEST_SERVICE)
@@ -79,8 +106,31 @@ class MySQLCore(object):
             'db.name': u'test',
             'db.user': u'test',
         })
-        fetch_span = spans[1]
-        eq_(fetch_span.name, 'mysql.query.fetchall')
+
+    def test_simple_query_with_positional_args_fetchall(self):
+        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+            conn, tracer = self._get_conn_tracer_with_positional_args()
+            writer = tracer.writer
+            cursor = conn.cursor()
+            cursor.execute("SELECT 1")
+            rows = cursor.fetchall()
+            eq_(len(rows), 1)
+            spans = writer.pop()
+            eq_(len(spans), 2)
+
+            span = spans[0]
+            eq_(span.service, self.TEST_SERVICE)
+            eq_(span.name, 'mysql.query')
+            eq_(span.span_type, 'sql')
+            eq_(span.error, 0)
+            assert_dict_issuperset(span.meta, {
+                'out.host': u'127.0.0.1',
+                'out.port': u'3306',
+                'db.name': u'test',
+                'db.user': u'test',
+            })
+            fetch_span = spans[1]
+            eq_(fetch_span.name, 'mysql.query.fetchall')
 
     def test_query_with_several_rows(self):
         conn, tracer = self._get_conn_tracer()
@@ -91,11 +141,25 @@ class MySQLCore(object):
         rows = cursor.fetchall()
         eq_(len(rows), 3)
         spans = writer.pop()
-        eq_(len(spans), 2)
+        eq_(len(spans), 1)
         span = spans[0]
         ok_(span.get_tag('sql.query') is None)
-        fetch_span = spans[1]
-        eq_(fetch_span.name, 'mysql.query.fetchall')
+
+    def test_query_with_several_rows_fetchall(self):
+        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+            conn, tracer = self._get_conn_tracer()
+            writer = tracer.writer
+            cursor = conn.cursor()
+            query = "SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m"
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            eq_(len(rows), 3)
+            spans = writer.pop()
+            eq_(len(spans), 2)
+            span = spans[0]
+            ok_(span.get_tag('sql.query') is None)
+            fetch_span = spans[1]
+            eq_(fetch_span.name, 'mysql.query.fetchall')
 
     def test_query_many(self):
         # tests that the executemany method is correctly wrapped.
@@ -126,12 +190,47 @@ class MySQLCore(object):
         eq_(rows[1][1], "this is foo")
 
         spans = writer.pop()
-        eq_(len(spans), 3)
+        eq_(len(spans), 2)
         span = spans[1]
         ok_(span.get_tag('sql.query') is None)
         cursor.execute("drop table if exists dummy")
-        fetch_span = spans[2]
-        eq_(fetch_span.name, 'mysql.query.fetchall')
+
+    def test_query_many_fetchall(self):
+        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+            # tests that the executemany method is correctly wrapped.
+            conn, tracer = self._get_conn_tracer()
+            writer = tracer.writer
+            tracer.enabled = False
+            cursor = conn.cursor()
+
+            cursor.execute("""
+                create table if not exists dummy (
+                    dummy_key VARCHAR(32) PRIMARY KEY,
+                    dummy_value TEXT NOT NULL)""")
+            tracer.enabled = True
+
+            stmt = "INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)"
+            data = [
+                ('foo', 'this is foo'),
+                ('bar', 'this is bar'),
+            ]
+            cursor.executemany(stmt, data)
+            query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            eq_(len(rows), 2)
+            eq_(rows[0][0], "bar")
+            eq_(rows[0][1], "this is bar")
+            eq_(rows[1][0], "foo")
+            eq_(rows[1][1], "this is foo")
+
+            spans = writer.pop()
+            eq_(len(spans), 3)
+            span = spans[1]
+            ok_(span.get_tag('sql.query') is None)
+            cursor.execute("drop table if exists dummy")
+            fetch_span = spans[2]
+            eq_(fetch_span.name, 'mysql.query.fetchall')
 
     def test_query_proc(self):
         conn, tracer = self._get_conn_tracer()
@@ -188,8 +287,8 @@ class MySQLCore(object):
             eq_(len(rows), 1)
 
         spans = writer.pop()
-        eq_(len(spans), 3)
-        ot_span, dd_span, fetch_span = spans
+        eq_(len(spans), 2)
+        ot_span, dd_span = spans
 
         # confirm parenting
         eq_(ot_span.parent_id, None)
@@ -209,7 +308,42 @@ class MySQLCore(object):
             'db.user': u'test',
         })
 
-        eq_(fetch_span.name, 'mysql.query.fetchall')
+
+    def test_simple_query_ot_fetchall(self):
+        """OpenTracing version of test_simple_query."""
+        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+            conn, tracer = self._get_conn_tracer()
+            writer = tracer.writer
+            ot_tracer = init_tracer('mysql_svc', tracer)
+            with ot_tracer.start_active_span('mysql_op'):
+                cursor = conn.cursor()
+                cursor.execute("SELECT 1")
+                rows = cursor.fetchall()
+                eq_(len(rows), 1)
+
+            spans = writer.pop()
+            eq_(len(spans), 3)
+            ot_span, dd_span, fetch_span = spans
+
+            # confirm parenting
+            eq_(ot_span.parent_id, None)
+            eq_(dd_span.parent_id, ot_span.span_id)
+
+            eq_(ot_span.service, 'mysql_svc')
+            eq_(ot_span.name, 'mysql_op')
+
+            eq_(dd_span.service, self.TEST_SERVICE)
+            eq_(dd_span.name, 'mysql.query')
+            eq_(dd_span.span_type, 'sql')
+            eq_(dd_span.error, 0)
+            assert_dict_issuperset(dd_span.meta, {
+                'out.host': u'127.0.0.1',
+                'out.port': u'3306',
+                'db.name': u'test',
+                'db.user': u'test',
+            })
+
+            eq_(fetch_span.name, 'mysql.query.fetchall')
 
     def test_commit(self):
         conn, tracer = self._get_conn_tracer()
@@ -232,7 +366,7 @@ class MySQLCore(object):
         eq_(span.name, 'MySQLdb.connection.rollback')
 
 
-class TestMysqlPatch(MySQLCore):
+class TestMysqlPatch(MySQLCore, BaseTracerTestCase):
     """Ensures MysqlDB is properly patched"""
 
     def _connect_with_kwargs(self):
@@ -246,7 +380,6 @@ class TestMysqlPatch(MySQLCore):
 
     def _get_conn_tracer(self):
         if not self.conn:
-            tracer = get_dummy_tracer()
             self.conn = self._connect_with_kwargs()
             self.conn.ping()
             # Ensure that the default pin is there, with its default value
@@ -255,13 +388,12 @@ class TestMysqlPatch(MySQLCore):
             assert pin.service == 'mysql'
             # Customize the service
             # we have to apply it on the existing one since new one won't inherit `app`
-            pin.clone(service=self.TEST_SERVICE, tracer=tracer).onto(self.conn)
+            pin.clone(service=self.TEST_SERVICE, tracer=self.tracer).onto(self.conn)
 
-            return self.conn, tracer
+            return self.conn, self.tracer
 
     def _get_conn_tracer_with_positional_args(self):
         if not self.conn:
-            tracer = get_dummy_tracer()
             self.conn = MySQLdb.Connect(
                 MYSQL_CONFIG['host'],
                 MYSQL_CONFIG['user'],
@@ -276,9 +408,9 @@ class TestMysqlPatch(MySQLCore):
             assert pin.service == 'mysql'
             # Customize the service
             # we have to apply it on the existing one since new one won't inherit `app`
-            pin.clone(service=self.TEST_SERVICE, tracer=tracer).onto(self.conn)
+            pin.clone(service=self.TEST_SERVICE, tracer=self.tracer).onto(self.conn)
 
-            return self.conn, tracer
+            return self.conn, self.tracer
 
     def test_patch_unpatch(self):
         unpatch()
@@ -289,12 +421,11 @@ class TestMysqlPatch(MySQLCore):
 
         patch()
         try:
-            tracer = get_dummy_tracer()
-            writer = tracer.writer
+            writer = self.tracer.writer
             conn = self._connect_with_kwargs()
             pin = Pin.get_from(conn)
             assert pin
-            pin.clone(service=self.TEST_SERVICE, tracer=tracer).onto(conn)
+            pin.clone(service=self.TEST_SERVICE, tracer=self.tracer).onto(conn)
             conn.ping()
 
             cursor = conn.cursor()
@@ -302,7 +433,7 @@ class TestMysqlPatch(MySQLCore):
             rows = cursor.fetchall()
             eq_(len(rows), 1)
             spans = writer.pop()
-            eq_(len(spans), 2)
+            eq_(len(spans), 1)
 
             span = spans[0]
             eq_(span.service, self.TEST_SERVICE)
@@ -316,8 +447,6 @@ class TestMysqlPatch(MySQLCore):
                 'db.user': u'test',
             })
             ok_(span.get_tag('sql.query') is None)
-            fetch_span = spans[1]
-            eq_(fetch_span.name, 'mysql.query.fetchall')
 
         finally:
             unpatch()

--- a/tests/contrib/pymysql/test_pymysql.py
+++ b/tests/contrib/pymysql/test_pymysql.py
@@ -1,7 +1,6 @@
 # 3p
 import pymysql
 
-from unittest import TestCase
 from nose.tools import eq_
 
 # project
@@ -12,8 +11,8 @@ from ddtrace.contrib.pymysql.patch import patch, unpatch
 
 # testing
 from tests.opentracer.utils import init_tracer
+from ...base import BaseTracerTestCase
 from ...util import assert_dict_issuperset
-from ...test_tracer import get_dummy_tracer
 from ...contrib.config import MYSQL_CONFIG
 
 
@@ -38,9 +37,11 @@ class PyMySQLCore(object):
         })
 
     def setUp(self):
+        super(PyMySQLCore, self).setUp()
         patch()
 
     def tearDown(self):
+        super(PyMySQLCore, self).tearDown()
         if self.conn and not self.conn._closed:
             self.conn.close()
         unpatch()
@@ -57,7 +58,7 @@ class PyMySQLCore(object):
         rows = cursor.fetchall()
         eq_(len(rows), 1)
         spans = writer.pop()
-        eq_(len(spans), 2)
+        eq_(len(spans), 1)
 
         span = spans[0]
         eq_(span.service, self.TEST_SERVICE)
@@ -68,8 +69,28 @@ class PyMySQLCore(object):
         meta.update(self.DB_INFO)
         assert_dict_issuperset(span.meta, meta)
 
-        fetch_span = spans[1]
-        eq_(fetch_span.name, 'pymysql.query.fetchall')
+    def test_simple_query_fetchall(self):
+        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+            conn, tracer = self._get_conn_tracer()
+            writer = tracer.writer
+            cursor = conn.cursor()
+            cursor.execute('SELECT 1')
+            rows = cursor.fetchall()
+            eq_(len(rows), 1)
+            spans = writer.pop()
+            eq_(len(spans), 2)
+
+            span = spans[0]
+            eq_(span.service, self.TEST_SERVICE)
+            eq_(span.name, 'pymysql.query')
+            eq_(span.span_type, 'sql')
+            eq_(span.error, 0)
+            meta = {}
+            meta.update(self.DB_INFO)
+            assert_dict_issuperset(span.meta, meta)
+
+            fetch_span = spans[1]
+            eq_(fetch_span.name, 'pymysql.query.fetchall')
 
     def test_query_with_several_rows(self):
         conn, tracer = self._get_conn_tracer()
@@ -80,10 +101,23 @@ class PyMySQLCore(object):
         rows = cursor.fetchall()
         eq_(len(rows), 3)
         spans = writer.pop()
-        eq_(len(spans), 2)
+        eq_(len(spans), 1)
+        self.assertEqual(spans[0].name, 'pymysql.query')
 
-        fetch_span = spans[1]
-        eq_(fetch_span.name, 'pymysql.query.fetchall')
+    def test_query_with_several_rows_fetchall(self):
+        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+            conn, tracer = self._get_conn_tracer()
+            writer = tracer.writer
+            cursor = conn.cursor()
+            query = 'SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m'
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            eq_(len(rows), 3)
+            spans = writer.pop()
+            eq_(len(spans), 2)
+
+            fetch_span = spans[1]
+            eq_(fetch_span.name, 'pymysql.query.fetchall')
 
     def test_query_many(self):
         # tests that the executemany method is correctly wrapped.
@@ -112,11 +146,42 @@ class PyMySQLCore(object):
         eq_(rows[1][1], "this is foo")
 
         spans = writer.pop()
-        eq_(len(spans), 3)
+        eq_(len(spans), 2)
         cursor.execute("drop table if exists dummy")
 
-        fetch_span = spans[2]
-        eq_(fetch_span.name, 'pymysql.query.fetchall')
+    def test_query_many_fetchall(self):
+        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+            # tests that the executemany method is correctly wrapped.
+            conn, tracer = self._get_conn_tracer()
+            writer = tracer.writer
+            tracer.enabled = False
+            cursor = conn.cursor()
+
+            cursor.execute("""
+                create table if not exists dummy (
+                    dummy_key VARCHAR(32) PRIMARY KEY,
+                    dummy_value TEXT NOT NULL)""")
+            tracer.enabled = True
+
+            stmt = "INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)"
+            data = [("foo", "this is foo"),
+                    ("bar", "this is bar")]
+            cursor.executemany(stmt, data)
+            query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            eq_(len(rows), 2)
+            eq_(rows[0][0], "bar")
+            eq_(rows[0][1], "this is bar")
+            eq_(rows[1][0], "foo")
+            eq_(rows[1][1], "this is foo")
+
+            spans = writer.pop()
+            eq_(len(spans), 3)
+            cursor.execute("drop table if exists dummy")
+
+            fetch_span = spans[2]
+            eq_(fetch_span.name, 'pymysql.query.fetchall')
 
     def test_query_proc(self):
         conn, tracer = self._get_conn_tracer()
@@ -174,8 +239,8 @@ class PyMySQLCore(object):
             eq_(len(rows), 1)
 
         spans = writer.pop()
-        eq_(len(spans), 3)
-        ot_span, dd_span, fetch_span = spans
+        eq_(len(spans), 2)
+        ot_span, dd_span = spans
 
         # confirm parenting
         eq_(ot_span.parent_id, None)
@@ -192,7 +257,38 @@ class PyMySQLCore(object):
         meta.update(self.DB_INFO)
         assert_dict_issuperset(dd_span.meta, meta)
 
-        eq_(fetch_span.name, 'pymysql.query.fetchall')
+    def test_simple_query_ot_fetchall(self):
+        """OpenTracing version of test_simple_query."""
+        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+            conn, tracer = self._get_conn_tracer()
+            writer = tracer.writer
+            ot_tracer = init_tracer('mysql_svc', tracer)
+            with ot_tracer.start_active_span('mysql_op'):
+                cursor = conn.cursor()
+                cursor.execute("SELECT 1")
+                rows = cursor.fetchall()
+                eq_(len(rows), 1)
+
+            spans = writer.pop()
+            eq_(len(spans), 3)
+            ot_span, dd_span, fetch_span = spans
+
+            # confirm parenting
+            eq_(ot_span.parent_id, None)
+            eq_(dd_span.parent_id, ot_span.span_id)
+
+            eq_(ot_span.service, 'mysql_svc')
+            eq_(ot_span.name, 'mysql_op')
+
+            eq_(dd_span.service, self.TEST_SERVICE)
+            eq_(dd_span.name, 'pymysql.query')
+            eq_(dd_span.span_type, 'sql')
+            eq_(dd_span.error, 0)
+            meta = {}
+            meta.update(self.DB_INFO)
+            assert_dict_issuperset(dd_span.meta, meta)
+
+            eq_(fetch_span.name, 'pymysql.query.fetchall')
 
     def test_commit(self):
         conn, tracer = self._get_conn_tracer()
@@ -215,10 +311,9 @@ class PyMySQLCore(object):
         eq_(span.name, 'pymysql.connection.rollback')
 
 
-class TestPyMysqlPatch(PyMySQLCore, TestCase):
+class TestPyMysqlPatch(PyMySQLCore, BaseTracerTestCase):
     def _get_conn_tracer(self):
         if not self.conn:
-            tracer = get_dummy_tracer()
             self.conn = pymysql.connect(**MYSQL_CONFIG)
             assert not self.conn._closed
             # Ensure that the default pin is there, with its default value
@@ -227,9 +322,9 @@ class TestPyMysqlPatch(PyMySQLCore, TestCase):
             assert pin.service == 'pymysql'
             # Customize the service
             # we have to apply it on the existing one since new one won't inherit `app`
-            pin.clone(service=self.TEST_SERVICE, tracer=tracer).onto(self.conn)
+            pin.clone(service=self.TEST_SERVICE, tracer=self.tracer).onto(self.conn)
 
-            return self.conn, tracer
+            return self.conn, self.tracer
 
     def test_patch_unpatch(self):
         unpatch()
@@ -240,12 +335,11 @@ class TestPyMysqlPatch(PyMySQLCore, TestCase):
 
         patch()
         try:
-            tracer = get_dummy_tracer()
-            writer = tracer.writer
+            writer = self.tracer.writer
             conn = pymysql.connect(**MYSQL_CONFIG)
             pin = Pin.get_from(conn)
             assert pin
-            pin.clone(service=self.TEST_SERVICE, tracer=tracer).onto(conn)
+            pin.clone(service=self.TEST_SERVICE, tracer=self.tracer).onto(conn)
             assert not conn._closed
 
             cursor = conn.cursor()
@@ -253,7 +347,7 @@ class TestPyMysqlPatch(PyMySQLCore, TestCase):
             rows = cursor.fetchall()
             eq_(len(rows), 1)
             spans = writer.pop()
-            eq_(len(spans), 2)
+            eq_(len(spans), 1)
 
             span = spans[0]
             eq_(span.service, self.TEST_SERVICE)
@@ -264,10 +358,6 @@ class TestPyMysqlPatch(PyMySQLCore, TestCase):
             meta = {}
             meta.update(self.DB_INFO)
             assert_dict_issuperset(span.meta, meta)
-
-            fetch_span = spans[1]
-            eq_(fetch_span.name, 'pymysql.query.fetchall')
-
         finally:
             unpatch()
 

--- a/tests/utils/span.py
+++ b/tests/utils/span.py
@@ -234,6 +234,20 @@ class TestSpanContainer(object):
 
         return self._build_tree(root)
 
+    def get_root_spans(self):
+        """
+        Helper to get all root spans from the list of spans in this container
+
+        :returns: The root spans if any were found, None if not
+        :rtype: list of :class:`tests.utils.span.TestSpanNode`, None
+        """
+        roots = []
+        for span in self.spans:
+            if span.parent_id is None:
+                roots.append(self._build_tree(span))
+
+        return sorted(roots, key=lambda s: s.start)
+
     def assert_span_count(self, count):
         """Assert this container has the expected number of spans"""
         assert len(self.spans) == count, 'Span count {0} != {1}'.format(len(self.spans), count)


### PR DESCRIPTION
In a release `0.17.0` we added instrumentation for `dbapi2` `fetchone`, `fetchmany`, and `fetchall` methods.

While we want to provide instrumentation for these methods tracing them by default has caused issues. The reason being that most database libraries will use `fetchone()` when iterating over a cursor. This will cause your application to create an unnecessarily large number of spans when returning back a large number of rows from the database.

With this change we are disabling this tracing by default but provide a configuration option for enabling:

```python
from ddtrace import config
config.dbapi2.trace_fetch_methods = True
```

It can also be enabled with the environment variable `DD_DBAPI2_TRACE_FETCH_METHODS=true`