### PR TITLE
[tools] Add confirmation to 'rake pypi:release' task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -126,14 +126,15 @@ namespace :pypi do
   end
 
   task :confirm do
-    if get_branch.downcase != 'master'
-      print "WARNING: This task should only be run from 'master' branch, currently on '#{get_branch.downcase}', proceed anyways [y|N]? "
+    ddtrace_version = get_version
+
+    if get_branch.downcase != 'tags/v#{ddtrace_version}'
+      print "WARNING: Expected current commit to be tagged as 'tags/v#{ddtrace_version}, instead we are on '#{get_branch}', proceed anyways [y|N]? "
       $stdout.flush
 
       abort if $stdin.gets.to_s.strip.downcase != 'y'
     end
 
-    ddtrace_version = get_version
     puts "WARNING: This task will build and release a new wheel to https://pypi.org/project/ddtrace/, this action cannot be undone"
     print "         To proceed please type the version '#{ddtrace_version}': "
     $stdout.flush

--- a/Rakefile
+++ b/Rakefile
@@ -117,6 +117,30 @@ end
 namespace :pypi do
   RELEASE_DIR = '/tmp/dd-trace-py-release'
 
+  def get_version()
+    return `python setup.py --version`.strip
+  end
+
+  def get_branch()
+    return `git name-rev --name-only HEAD`.strip
+  end
+
+  task :confirm do
+    if get_branch.downcase != 'master'
+      print "WARNING: This task should only be run from 'master' branch, currently on '#{get_branch.downcase}', proceed anyways [y|N]? "
+      $stdout.flush
+
+      abort if $stdin.gets.to_s.strip.downcase != 'y'
+    end
+
+    ddtrace_version = get_version
+    puts "WARNING: This task will build and release a new wheel to https://pypi.org/project/ddtrace/, this action cannot be undone"
+    print "         To proceed please type the version '#{ddtrace_version}': "
+    $stdout.flush
+
+    abort if $stdin.gets.to_s.strip.downcase != ddtrace_version
+  end
+
   task :clean do
     FileUtils.rm_rf(RELEASE_DIR)
   end
@@ -130,7 +154,7 @@ namespace :pypi do
     sh "python setup.py -q sdist -d #{RELEASE_DIR}"
   end
 
-  task :release => [:install, :build] do
+  task :release => [:confirm, :install, :build] do
     builds = Dir.entries(RELEASE_DIR).reject {|f| f == '.' || f == '..'}
     if builds.length == 0
         fail "no build found in #{RELEASE_DIR}"


### PR DESCRIPTION
This PR adds in two quick checks/confirmations to the `rake pypi:release` task.

The first check looks to see if the current commit is associated with the tag for `v#{__version__}`, if not it asks the user to confirm that they want to proceed.

The second check will always show, warning the user that this action cannot be undone and asks them to confirm by typing in the current (should be released) version of `ddtrace`.

Example:

```
$ rake pypi:release
WARNING: Expected current commit to be tagged as 'tags/v0.19.0, instead we are on 'brettlangdon/pypi.confirm', proceed anyways [y|N]? y
WARNING: This task will build and release a new wheel to https://pypi.org/project/ddtrace/, this action cannot be undone
         To proceed please type the version '0.19.0': 0.19.0
```