### PR TITLE
0.20.1

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -4,7 +4,7 @@ from .span import Span
 from .tracer import Tracer
 from .settings import config
 
-__version__ = '0.20.0'
+__version__ = '0.20.1'
 
 # a global tracer instance with integration settings
 tracer = Tracer()

--- a/ddtrace/contrib/celery/signals.py
+++ b/ddtrace/contrib/celery/signals.py
@@ -88,7 +88,7 @@ def trace_before_publish(*args, **kwargs):
     # Note: adding tags from `traceback` or `state` calls will make an
     # API call to the backend for the properties so we should rely
     # only on the given `Context`
-    attach_span(task, task_id, span)
+    attach_span(task, task_id, span, is_publish=True)
 
 
 def trace_after_publish(*args, **kwargs):
@@ -102,12 +102,12 @@ def trace_after_publish(*args, **kwargs):
         return
 
     # retrieve and finish the Span
-    span = retrieve_span(task, task_id)
+    span = retrieve_span(task, task_id, is_publish=True)
     if span is None:
         return
     else:
         span.finish()
-        detach_span(task, task_id)
+        detach_span(task, task_id, is_publish=True)
 
 
 def trace_failure(*args, **kwargs):

--- a/ddtrace/contrib/celery/utils.py
+++ b/ddtrace/contrib/celery/utils.py
@@ -39,21 +39,34 @@ def tags_from_context(context):
     return tags
 
 
-def attach_span(task, task_id, span):
+def attach_span(task, task_id, span, is_publish=False):
     """Helper to propagate a `Span` for the given `Task` instance. This
     function uses a `WeakValueDictionary` that stores a Datadog Span using
-    the `task_id` as a key. This is useful when information must be
+    the `(task_id, is_publish)` as a key. This is useful when information must be
     propagated from one Celery signal to another.
+
+    DEV: We use (task_id, is_publish) for the key to ensure that publishing a
+         task from within another task does not cause any conflicts.
+
+         This mostly happens when either a task fails and a retry policy is in place,
+         or when a task is manually retries (e.g. `task.retry()`), we end up trying
+         to publish a task with the same id as the task currently running.
+
+         Previously publishing the new task would overwrite the existing `celery.run` span
+         in the `weak_dict` causing that span to be forgotten and never finished.
+
+         NOTE: We cannot test for this well yet, because we do not run a celery worker,
+         and cannot run `task.apply_async()`
     """
     weak_dict = getattr(task, CTX_KEY, None)
     if weak_dict is None:
         weak_dict = WeakValueDictionary()
         setattr(task, CTX_KEY, weak_dict)
 
-    weak_dict[task_id] = span
+    weak_dict[(task_id, is_publish)] = span
 
 
-def detach_span(task, task_id):
+def detach_span(task, task_id, is_publish=False):
     """Helper to remove a `Span` in a Celery task when it's propagated.
     This function handles tasks where the `Span` is not attached.
     """
@@ -61,10 +74,11 @@ def detach_span(task, task_id):
     if weak_dict is None:
         return
 
-    weak_dict.pop(task_id, None)
+    # DEV: See note in `attach_span` for key info
+    weak_dict.pop((task_id, is_publish), None)
 
 
-def retrieve_span(task, task_id):
+def retrieve_span(task, task_id, is_publish=False):
     """Helper to retrieve an active `Span` stored in a `Task`
     instance
     """
@@ -72,7 +86,8 @@ def retrieve_span(task, task_id):
     if weak_dict is None:
         return
     else:
-        return weak_dict.get(task_id)
+        # DEV: See note in `attach_span` for key info
+        return weak_dict.get((task_id, is_publish))
 
 
 def retrieve_task_id(context):

--- a/tests/contrib/celery/test_utils.py
+++ b/tests/contrib/celery/test_utils.py
@@ -89,7 +89,7 @@ class CeleryTagsTest(CeleryBaseTestCase):
         # delete the Span
         weak_dict = getattr(fn_task, '__dd_task_span')
         detach_span(fn_task, task_id)
-        ok_(weak_dict.get(task_id) is None)
+        ok_(weak_dict.get((task_id, False)) is None)
 
     def test_span_delete_empty(self):
         # ensure the helper works even if the Task doesn't have
@@ -119,13 +119,14 @@ class CeleryTagsTest(CeleryBaseTestCase):
         task_id = '7c6731af-9533-40c3-83a9-25b58f0d837f'
         attach_span(fn_task, task_id, self.tracer.trace('celery.run'))
         weak_dict = getattr(fn_task, '__dd_task_span')
-        ok_(weak_dict.get(task_id))
+        key = (task_id, False)
+        ok_(weak_dict.get(key))
         # flush data and force the GC
-        weak_dict.get(task_id).finish()
+        weak_dict.get(key).finish()
         self.tracer.writer.pop()
         self.tracer.writer.pop_traces()
         gc.collect()
-        ok_(weak_dict.get(task_id) is None)
+        ok_(weak_dict.get(key) is None)
 
     def test_task_id_from_protocol_v1(self):
         # ensures a `task_id` is properly returned when Protocol v1 is used.


### PR DESCRIPTION
## Upgrading to 0.20.1

No changes are needed to upgrade

## Changes
### Bug fixes
[celery] Ensure `celery.run` span is closed when task is retried (#787)

Read the [full changeset](https://github.com/DataDog/dd-trace-py/compare/v0.20.0...v0.20.1) and the [release milestone](https://github.com/DataDog/dd-trace-py/milestone/36?closed=1).