### PR TITLE
[core] Call HTTPResponse.read() before HTTPConnection.close()

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -67,7 +67,7 @@ class Response(object):
         try:
             body = self.body
             if not body:
-                log.debug('Empty reply from Datadog agent, %r', self)
+                log.debug('Empty reply from Datadog Agent, %r', self)
                 return
 
             if not isinstance(body, str) and hasattr(body, 'decode'):

--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -27,33 +27,56 @@ _VERSIONS = {'v0.4': {'traces': '/v0.4/traces',
                       'fallback': None}}
 
 
-def _parse_response_json(response):
-    """
-    Parse the content of a response object, and return the right type,
-    can be a string if the output was plain text, or a dictionnary if
-    the output was a JSON.
-    """
-    if hasattr(response, 'read'):
-        body = response.read()
-        try:
-            if not isinstance(body, str) and hasattr(body, 'decode'):
-                body = body.decode('utf-8')
-            if hasattr(body, 'startswith') and body.startswith('OK'):
-                # This typically happens when using a priority-sampling enabled
-                # library with an outdated agent. It still works, but priority sampling
-                # will probably send too many traces, so the next step is to upgrade agent.
-                log.debug("'OK' is not a valid JSON, please make sure trace-agent is up to date")
-                return
-            content = loads(body)
-            return content
-        except (ValueError, TypeError) as err:
-            log.debug("unable to load JSON '%s': %s" % (body, err))
-
-
 class API(object):
     """
     Send data to the trace agent using the HTTP protocol and JSON format
     """
+    class Response(object):
+        """
+        Custom API Response object to represent a response from calling the API.
+
+        We do this to ensure we know expected properties will exist, and so we
+        can call `resp.read()` and load the body once into an instance before we
+        close the HTTPConnection used for the request.
+
+        DEV: Calling `HTTPConnection.close()` before `HTTPResponse.read()` will result in
+             `.read()` always returning back `b''`
+        """
+        __slots__ = ['status', 'body']
+
+        def __init__(self, status=None, body=None):
+            self.status = status
+            self.body = body
+
+        @classmethod
+        def from_http_response(cls, resp):
+            return cls(status=resp.status, body=resp.read())
+
+        def get_json(self):
+            """Helper to parse the body of this request as JSON"""
+            try:
+                body = self.body
+                if not body:
+                    log.debug('Empty reply from trace-agent, %r', self)
+                    return
+
+                if not isinstance(body, str) and hasattr(body, 'decode'):
+                    body = body.decode('utf-8')
+
+                if hasattr(body, 'startswith') and body.startswith('OK'):
+                    # This typically happens when using a priority-sampling enabled
+                    # library with an outdated agent. It still works, but priority sampling
+                    # will probably send too many traces, so the next step is to upgrade agent.
+                    log.debug("'OK' is not a valid JSON, please make sure trace-agent is up to date")
+                    return
+
+                return loads(body)
+            except (ValueError, TypeError) as err:
+                log.debug("unable to load JSON '%s': %s" % (body, err))
+
+        def __repr__(self):
+            return 'API.Response(status={0!r}, body={1!r})'.format(self.status, self.body)
+
     def __init__(self, hostname, port, headers=None, encoder=None, priority_sampling=False):
         self.hostname = hostname
         self.port = port
@@ -142,6 +165,11 @@ class API(object):
                 headers[TRACE_COUNT_HEADER] = str(count)
 
             conn.request("PUT", endpoint, data, headers)
-            return get_connection_response(conn)
+
+            # Parse the HTTPResponse into a API.Response
+            # DEV: This will call `resp.read()` which must happen `conn.close()` below,
+            #      otherwise the if we `.close()` then all `.read()` calls will return `b''`
+            resp = get_connection_response(conn)
+            return API.Response.from_http_response(resp)
         finally:
             conn.close()

--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -42,15 +42,22 @@ class API(object):
         DEV: Calling `HTTPConnection.close()` before `HTTPResponse.read()` will result in
              `.read()` always returning back `b''`
         """
-        __slots__ = ['status', 'body']
+        __slots__ = ['status', 'body', 'reason', 'msg']
 
-        def __init__(self, status=None, body=None):
+        def __init__(self, status=None, body=None, reason=None, msg=None):
             self.status = status
             self.body = body
+            self.reason = reason
+            self.msg = msg
 
         @classmethod
         def from_http_response(cls, resp):
-            return cls(status=resp.status, body=resp.read())
+            return cls(
+                status=resp.status,
+                body=resp.read(),
+                reason=getattr(resp, 'reason', None),
+                msg=getattr(resp, 'msg', None),
+            )
 
         def get_json(self):
             """Helper to parse the body of this request as JSON"""
@@ -75,7 +82,12 @@ class API(object):
                 log.debug("unable to load JSON '%s': %s" % (body, err))
 
         def __repr__(self):
-            return 'API.Response(status={0!r}, body={1!r})'.format(self.status, self.body)
+            return 'API.Response(status={0!r}, body={1!r}, reason={2!r}, msg={3!r})'.format(
+                self.status,
+                self.body,
+                self.reason,
+                self.msg,
+            )
 
     def __init__(self, hostname, port, headers=None, encoder=None, priority_sampling=False):
         self.hostname = hostname

--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -27,68 +27,77 @@ _VERSIONS = {'v0.4': {'traces': '/v0.4/traces',
                       'fallback': None}}
 
 
+class Response(object):
+    """
+    Custom API Response object to represent a response from calling the API.
+
+    We do this to ensure we know expected properties will exist, and so we
+    can call `resp.read()` and load the body once into an instance before we
+    close the HTTPConnection used for the request.
+    """
+    __slots__ = ['status', 'body', 'reason', 'msg']
+
+    def __init__(self, status=None, body=None, reason=None, msg=None):
+        self.status = status
+        self.body = body
+        self.reason = reason
+        self.msg = msg
+
+    @classmethod
+    def from_http_response(cls, resp):
+        """
+        Build a ``Response`` from the provided ``HTTPResponse`` object.
+
+        This function will call `.read()` to consume the body of the ``HTTPResponse`` object.
+
+        :param resp: ``HTTPResponse`` object to build the ``Response`` from
+        :type resp: ``HTTPResponse``
+        :rtype: ``Response``
+        :returns: A new ``Response``
+        """
+        return cls(
+            status=resp.status,
+            body=resp.read(),
+            reason=getattr(resp, 'reason', None),
+            msg=getattr(resp, 'msg', None),
+        )
+
+    def get_json(self):
+        """Helper to parse the body of this request as JSON"""
+        try:
+            body = self.body
+            if not body:
+                log.debug('Empty reply from Datadog agent, %r', self)
+                return
+
+            if not isinstance(body, str) and hasattr(body, 'decode'):
+                body = body.decode('utf-8')
+
+            if hasattr(body, 'startswith') and body.startswith('OK'):
+                # This typically happens when using a priority-sampling enabled
+                # library with an outdated agent. It still works, but priority sampling
+                # will probably send too many traces, so the next step is to upgrade agent.
+                log.debug('Cannot parse Datadog Agent response, please make sure your Datadog Agent is up to date')
+                return
+
+            return loads(body)
+        except (ValueError, TypeError) as err:
+            log.debug('Unable to parse Datadog Agent JSON response: %s %r', err, body)
+
+    def __repr__(self):
+        return '{0}(status={1!r}, body={2!r}, reason={3!r}, msg={4!r})'.format(
+            self.__class__.__name__,
+            self.status,
+            self.body,
+            self.reason,
+            self.msg,
+        )
+
+
 class API(object):
     """
     Send data to the trace agent using the HTTP protocol and JSON format
     """
-    class Response(object):
-        """
-        Custom API Response object to represent a response from calling the API.
-
-        We do this to ensure we know expected properties will exist, and so we
-        can call `resp.read()` and load the body once into an instance before we
-        close the HTTPConnection used for the request.
-
-        DEV: Calling `HTTPConnection.close()` before `HTTPResponse.read()` will result in
-             `.read()` always returning back `b''`
-        """
-        __slots__ = ['status', 'body', 'reason', 'msg']
-
-        def __init__(self, status=None, body=None, reason=None, msg=None):
-            self.status = status
-            self.body = body
-            self.reason = reason
-            self.msg = msg
-
-        @classmethod
-        def from_http_response(cls, resp):
-            return cls(
-                status=resp.status,
-                body=resp.read(),
-                reason=getattr(resp, 'reason', None),
-                msg=getattr(resp, 'msg', None),
-            )
-
-        def get_json(self):
-            """Helper to parse the body of this request as JSON"""
-            try:
-                body = self.body
-                if not body:
-                    log.debug('Empty reply from trace-agent, %r', self)
-                    return
-
-                if not isinstance(body, str) and hasattr(body, 'decode'):
-                    body = body.decode('utf-8')
-
-                if hasattr(body, 'startswith') and body.startswith('OK'):
-                    # This typically happens when using a priority-sampling enabled
-                    # library with an outdated agent. It still works, but priority sampling
-                    # will probably send too many traces, so the next step is to upgrade agent.
-                    log.debug("'OK' is not a valid JSON, please make sure trace-agent is up to date")
-                    return
-
-                return loads(body)
-            except (ValueError, TypeError) as err:
-                log.debug("unable to load JSON '%s': %s" % (body, err))
-
-        def __repr__(self):
-            return 'API.Response(status={0!r}, body={1!r}, reason={2!r}, msg={3!r})'.format(
-                self.status,
-                self.body,
-                self.reason,
-                self.msg,
-            )
-
     def __init__(self, hostname, port, headers=None, encoder=None, priority_sampling=False):
         self.hostname = hostname
         self.port = port
@@ -182,6 +191,6 @@ class API(object):
             # DEV: This will call `resp.read()` which must happen before the `conn.close()` below,
             #      if we call `.close()` then all future `.read()` calls will return `b''`
             resp = get_connection_response(conn)
-            return API.Response.from_http_response(resp)
+            return Response.from_http_response(resp)
         finally:
             conn.close()

--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -166,9 +166,9 @@ class API(object):
 
             conn.request("PUT", endpoint, data, headers)
 
-            # Parse the HTTPResponse into a API.Response
-            # DEV: This will call `resp.read()` which must happen `conn.close()` below,
-            #      otherwise the if we `.close()` then all `.read()` calls will return `b''`
+            # Parse the HTTPResponse into an API.Response
+            # DEV: This will call `resp.read()` which must happen before the `conn.close()` below,
+            #      if we call `.close()` then all future `.read()` calls will return `b''`
             resp = get_connection_response(conn)
             return API.Response.from_http_response(resp)
         finally:

--- a/ddtrace/writer.py
+++ b/ddtrace/writer.py
@@ -8,8 +8,6 @@ import time
 
 from ddtrace import api
 
-from .api import _parse_response_json
-
 log = logging.getLogger(__name__)
 
 
@@ -156,8 +154,8 @@ class AsyncWorker(object):
                 # no traces and the queue is closed. our work is done
                 return
 
-            if self._priority_sampler:
-                result_traces_json = _parse_response_json(result_traces)
+            if self._priority_sampler and result_traces:
+                result_traces_json = result_traces.get_json()
                 if result_traces_json and 'rate_by_service' in result_traces_json:
                     self._priority_sampler.set_sample_rate_by_service(result_traces_json['rate_by_service'])
 

--- a/ddtrace/writer.py
+++ b/ddtrace/writer.py
@@ -177,7 +177,7 @@ class AsyncWorker(object):
                 log_level = log.error
                 self._last_error_ts = now
             log_level(
-                'failed_to_send %s to Agent: HTTP error status %s, reason %s, message %s',
+                'failed_to_send %s to Datadog Agent: HTTP error status %s, reason %s, message %s',
                 response_name,
                 response.status,
                 response.reason,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,7 +50,7 @@ class APITests(TestCase):
             ),
             42: dict(  # int as key to trigger TypeError
                 js=None,
-                log='Unable to parse Datadog Agent JSON response: .*? not \'int\' 42',
+                log='Unable to parse Datadog Agent JSON response: .*? 42',
             ),
             '{}': dict(js={}),
             '[]': dict(js=[]),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,12 +5,13 @@ from unittest import TestCase
 from nose.tools import eq_, ok_
 
 from tests.test_tracer import get_dummy_tracer
-from ddtrace.api import _parse_response_json, API
+from ddtrace.api import API
 from ddtrace.compat import iteritems, httplib
 
 
 class ResponseMock:
-    def __init__(self, content):
+    def __init__(self, content, status=200):
+        self.status = status
         self.content = content
 
     def read(self):
@@ -53,8 +54,8 @@ class APITests(TestCase):
         }
 
         for k, v in iteritems(test_cases):
-            r = ResponseMock(k)
-            js = _parse_response_json(r)
+            r = API.Response.from_http_response(ResponseMock(k))
+            js = r.get_json()
             eq_(v['js'], js)
             if 'log' in v:
                 ok_(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,11 +1,12 @@
 import mock
+import re
 import warnings
 
 from unittest import TestCase
 from nose.tools import eq_, ok_
 
 from tests.test_tracer import get_dummy_tracer
-from ddtrace.api import API
+from ddtrace.api import API, Response
 from ddtrace.compat import iteritems, httplib
 
 
@@ -35,36 +36,49 @@ class APITests(TestCase):
         tracer.debug_logging = True
 
         test_cases = {
-            'OK': {'js': None, 'log': "please make sure trace-agent is up to date"},
-            'OK\n': {'js': None, 'log': "please make sure trace-agent is up to date"},
-            'error:unsupported-endpoint': {'js': None, 'log': "unable to load JSON 'error:unsupported-endpoint'"},
-            42: {'js': None, 'log': "unable to load JSON '42'"},  # int as key to trigger TypeError
-            '{}': {'js': {}},
-            '[]': {'js': []},
-            '{"rate_by_service": {"service:,env:":0.5, "service:mcnulty,env:test":0.9, "service:postgres,env:test":0.6}}': {  # noqa
-                'js': {
-                    'rate_by_service': {
+            'OK': dict(
+                js=None,
+                log='Cannot parse Datadog Agent response, please make sure your Datadog Agent is up to date',
+            ),
+            'OK\n': dict(
+                js=None,
+                log='Cannot parse Datadog Agent response, please make sure your Datadog Agent is up to date',
+            ),
+            'error:unsupported-endpoint': dict(
+                js=None,
+                log='Unable to parse Datadog Agent JSON response: .*? \'error:unsupported-endpoint\'',
+            ),
+            42: dict(  # int as key to trigger TypeError
+                js=None,
+                log='Unable to parse Datadog Agent JSON response: .*? not \'int\' 42',
+            ),
+            '{}': dict(js={}),
+            '[]': dict(js=[]),
+
+            # Priority sampling "rate_by_service" response
+            ('{"rate_by_service": '
+             '{"service:,env:":0.5, "service:mcnulty,env:test":0.9, "service:postgres,env:test":0.6}}'): dict(
+                js=dict(
+                    rate_by_service={
                         'service:,env:': 0.5,
                         'service:mcnulty,env:test': 0.9,
                         'service:postgres,env:test': 0.6,
                     },
-                },
-            },
-            ' [4,2,1] ': {'js': [4, 2, 1]},
+                ),
+            ),
+            ' [4,2,1] ': dict(js=[4, 2, 1]),
         }
 
         for k, v in iteritems(test_cases):
-            r = API.Response.from_http_response(ResponseMock(k))
+            log.reset_mock()
+
+            r = Response.from_http_response(ResponseMock(k))
             js = r.get_json()
             eq_(v['js'], js)
             if 'log' in v:
-                ok_(
-                    1 <= len(log.call_args_list),
-                    'not enough elements in call_args_list: {}'.format(log.call_args_list),
-                )
-                print(log.call_args_list)
-                args = log.call_args_list[-1][0][0]
-                ok_(v['log'] in args, 'unable to find {} in {}'.format(v['log'], args))
+                log.assert_called_once()
+                msg = log.call_args[0][0] % log.call_args[0][1:]
+                ok_(re.match(v['log'], msg), msg)
 
     @mock.patch('ddtrace.compat.httplib.HTTPConnection')
     def test_put_connection_close(self, HTTPConnection):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -188,7 +188,7 @@ class TestWorkers(TestCase):
 
         logged_errors = log_handler.messages['error']
         eq_(len(logged_errors), 1)
-        ok_('failed_to_send traces to Agent: HTTP error status 400, reason Bad Request, message Content-Type:'
+        ok_('failed_to_send traces to Datadog Agent: HTTP error status 400, reason Bad Request, message Content-Type:'
             in logged_errors[0])
 
     def test_worker_filter_request(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,7 +9,7 @@ import ddtrace
 from unittest import TestCase, skip, skipUnless
 from nose.tools import eq_, ok_
 
-from ddtrace.api import API
+from ddtrace.api import API, Response
 from ddtrace.ext import http
 from ddtrace.filters import FilterRequestsOnUrl
 from ddtrace.constants import FILTERS_KEY
@@ -41,7 +41,7 @@ class FlawedAPI(API):
     def _put(self, endpoint, data, count=0):
         conn = httplib.HTTPConnection(self.hostname, self.port)
         conn.request('HEAD', endpoint, data, self._headers)
-        return API.Response.from_http_response(conn.getresponse())
+        return Response.from_http_response(conn.getresponse())
 
 
 @skipUnless(
@@ -488,8 +488,8 @@ class TestRateByService(TestCase):
         """
         # create a new API object to test the transport using synchronous calls
         self.tracer = get_dummy_tracer()
-        self.api_json = API('localhost', 8126, encoder=JSONEncoder())
-        self.api_msgpack = API('localhost', 8126, encoder=MsgpackEncoder())
+        self.api_json = API('localhost', 8126, encoder=JSONEncoder(), priority_sampling=True)
+        self.api_msgpack = API('localhost', 8126, encoder=MsgpackEncoder(), priority_sampling=True)
 
     def test_send_single_trace(self):
         # register a single trace with a span and send them to the trace agent
@@ -506,11 +506,13 @@ class TestRateByService(TestCase):
         response = self.api_json.send_traces(traces)
         ok_(response)
         eq_(response.status, 200)
+        eq_(response.get_json(), dict(rate_by_service={'service:,env:': 1}))
 
         # test Msgpack encoder
         response = self.api_msgpack.send_traces(traces)
         ok_(response)
         eq_(response.status, 200)
+        eq_(response.get_json(), dict(rate_by_service={'service:,env:': 1}))
 
 
 @skipUnless(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,7 +41,7 @@ class FlawedAPI(API):
     def _put(self, endpoint, data, count=0):
         conn = httplib.HTTPConnection(self.hostname, self.port)
         conn.request('HEAD', endpoint, data, self._headers)
-        return conn.getresponse()
+        return API.Response.from_http_response(conn.getresponse())
 
 
 @skipUnless(

--- a/tox.ini
+++ b/tox.ini
@@ -202,7 +202,7 @@ deps =
     gevent11: gevent>=1.1,<1.2
     gevent12: gevent>=1.2,<1.3
     gevent13: gevent>=1.3,<1.4
-    grpc: grpcio>=1.8.0
+    grpc: grpcio>=1.8.0,<1.18.0
     grpc: googleapis-common-protos
     jinja27: jinja2>=2.7,<2.8
     jinja28: jinja2>=2.8,<2.9


### PR DESCRIPTION
When working on another feature I noticed that we kept getting errors saying we cannot parse JSON response from trace agent showing it as an empty string.

After diving further I noticed that the response showed a length, and a quick wiresharking showed a valid JSON response, but still the body was always none.

If you call `HTTPConnection.close()` before calling `HTTPResponse.read()` the result will always be `b''`.

This means we have not been parsing/updating the rate by service sample rates.