### PR TITLE
[tests] limit grpcio version to >=1.8.0,<1.18.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -202,7 +202,7 @@ deps =
     gevent11: gevent>=1.1,<1.2
     gevent12: gevent>=1.2,<1.3
     gevent13: gevent>=1.3,<1.4
-    grpc: grpcio>=1.8.0
+    grpc: grpcio>=1.8.0,<1.18.0
     grpc: googleapis-common-protos
     jinja27: jinja2>=2.7,<2.8
     jinja28: jinja2>=2.8,<2.9


### PR DESCRIPTION
`grpcio==1.18.0` was released recently and it changed how it raises exceptions so it is causing a test case to fail.

We should address the change, but this PR updates the tox version to be `>=0.8.0,<1.18.0` for now to ensure our tests pass.