### PR TITLE
Release 0.20.2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -117,6 +117,31 @@ end
 namespace :pypi do
   RELEASE_DIR = '/tmp/dd-trace-py-release'
 
+  def get_version()
+    return `python setup.py --version`.strip
+  end
+
+  def get_branch()
+    return `git name-rev --name-only HEAD`.strip
+  end
+
+  task :confirm do
+    ddtrace_version = get_version
+
+    if get_branch.downcase != 'tags/v#{ddtrace_version}'
+      print "WARNING: Expected current commit to be tagged as 'tags/v#{ddtrace_version}, instead we are on '#{get_branch}', proceed anyways [y|N]? "
+      $stdout.flush
+
+      abort if $stdin.gets.to_s.strip.downcase != 'y'
+    end
+
+    puts "WARNING: This task will build and release a new wheel to https://pypi.org/project/ddtrace/, this action cannot be undone"
+    print "         To proceed please type the version '#{ddtrace_version}': "
+    $stdout.flush
+
+    abort if $stdin.gets.to_s.strip.downcase != ddtrace_version
+  end
+
   task :clean do
     FileUtils.rm_rf(RELEASE_DIR)
   end
@@ -130,7 +155,7 @@ namespace :pypi do
     sh "python setup.py -q sdist -d #{RELEASE_DIR}"
   end
 
-  task :release => [:install, :build] do
+  task :release => [:confirm, :install, :build] do
     builds = Dir.entries(RELEASE_DIR).reject {|f| f == '.' || f == '..'}
     if builds.length == 0
         fail "no build found in #{RELEASE_DIR}"

--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -4,7 +4,7 @@ from .span import Span
 from .tracer import Tracer
 from .settings import config
 
-__version__ = '0.20.1'
+__version__ = '0.20.2'
 
 # a global tracer instance with integration settings
 tracer = Tracer()

--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -27,27 +27,71 @@ _VERSIONS = {'v0.4': {'traces': '/v0.4/traces',
                       'fallback': None}}
 
 
-def _parse_response_json(response):
+class Response(object):
     """
-    Parse the content of a response object, and return the right type,
-    can be a string if the output was plain text, or a dictionnary if
-    the output was a JSON.
+    Custom API Response object to represent a response from calling the API.
+
+    We do this to ensure we know expected properties will exist, and so we
+    can call `resp.read()` and load the body once into an instance before we
+    close the HTTPConnection used for the request.
     """
-    if hasattr(response, 'read'):
-        body = response.read()
+    __slots__ = ['status', 'body', 'reason', 'msg']
+
+    def __init__(self, status=None, body=None, reason=None, msg=None):
+        self.status = status
+        self.body = body
+        self.reason = reason
+        self.msg = msg
+
+    @classmethod
+    def from_http_response(cls, resp):
+        """
+        Build a ``Response`` from the provided ``HTTPResponse`` object.
+
+        This function will call `.read()` to consume the body of the ``HTTPResponse`` object.
+
+        :param resp: ``HTTPResponse`` object to build the ``Response`` from
+        :type resp: ``HTTPResponse``
+        :rtype: ``Response``
+        :returns: A new ``Response``
+        """
+        return cls(
+            status=resp.status,
+            body=resp.read(),
+            reason=getattr(resp, 'reason', None),
+            msg=getattr(resp, 'msg', None),
+        )
+
+    def get_json(self):
+        """Helper to parse the body of this request as JSON"""
         try:
+            body = self.body
+            if not body:
+                log.debug('Empty reply from Datadog Agent, %r', self)
+                return
+
             if not isinstance(body, str) and hasattr(body, 'decode'):
                 body = body.decode('utf-8')
+
             if hasattr(body, 'startswith') and body.startswith('OK'):
                 # This typically happens when using a priority-sampling enabled
                 # library with an outdated agent. It still works, but priority sampling
                 # will probably send too many traces, so the next step is to upgrade agent.
-                log.debug("'OK' is not a valid JSON, please make sure trace-agent is up to date")
+                log.debug('Cannot parse Datadog Agent response, please make sure your Datadog Agent is up to date')
                 return
-            content = loads(body)
-            return content
+
+            return loads(body)
         except (ValueError, TypeError) as err:
-            log.debug("unable to load JSON '%s': %s" % (body, err))
+            log.debug('Unable to parse Datadog Agent JSON response: %s %r', err, body)
+
+    def __repr__(self):
+        return '{0}(status={1!r}, body={2!r}, reason={3!r}, msg={4!r})'.format(
+            self.__class__.__name__,
+            self.status,
+            self.body,
+            self.reason,
+            self.msg,
+        )
 
 
 class API(object):
@@ -142,6 +186,11 @@ class API(object):
                 headers[TRACE_COUNT_HEADER] = str(count)
 
             conn.request("PUT", endpoint, data, headers)
-            return get_connection_response(conn)
+
+            # Parse the HTTPResponse into an API.Response
+            # DEV: This will call `resp.read()` which must happen before the `conn.close()` below,
+            #      if we call `.close()` then all future `.read()` calls will return `b''`
+            resp = get_connection_response(conn)
+            return Response.from_http_response(resp)
         finally:
             conn.close()

--- a/ddtrace/writer.py
+++ b/ddtrace/writer.py
@@ -8,8 +8,6 @@ import time
 
 from ddtrace import api
 
-from .api import _parse_response_json
-
 log = logging.getLogger(__name__)
 
 
@@ -126,8 +124,8 @@ class AsyncWorker(object):
                     time.sleep(0.05)
 
     def _target(self):
-        result_traces = None
-        result_services = None
+        traces_response = None
+        services_response = None
 
         while True:
             traces = self._trace_queue.pop()
@@ -141,14 +139,14 @@ class AsyncWorker(object):
             if traces:
                 # If we have data, let's try to send it.
                 try:
-                    result_traces = self.api.send_traces(traces)
+                    traces_response = self.api.send_traces(traces)
                 except Exception as err:
                     log.error("cannot send spans to {1}:{2}: {0}".format(err, self.api.hostname, self.api.port))
 
             services = self._service_queue.pop()
             if services:
                 try:
-                    result_services = self.api.send_services(services)
+                    services_response = self.api.send_services(services)
                 except Exception as err:
                     log.error("cannot send services to {1}:{2}: {0}".format(err, self.api.hostname, self.api.port))
 
@@ -156,28 +154,35 @@ class AsyncWorker(object):
                 # no traces and the queue is closed. our work is done
                 return
 
-            if self._priority_sampler:
-                result_traces_json = _parse_response_json(result_traces)
+            if self._priority_sampler and traces_response:
+                result_traces_json = traces_response.get_json()
                 if result_traces_json and 'rate_by_service' in result_traces_json:
                     self._priority_sampler.set_sample_rate_by_service(result_traces_json['rate_by_service'])
 
-            self._log_error_status(result_traces, "traces")
-            result_traces = None
-            self._log_error_status(result_services, "services")
-            result_services = None
+            self._log_error_status(traces_response, "traces")
+            traces_response = None
+            self._log_error_status(services_response, "services")
+            services_response = None
 
             time.sleep(1)  # replace with a blocking pop.
 
-    def _log_error_status(self, result, result_name):
+    def _log_error_status(self, response, response_name):
+        if not isinstance(response, api.Response):
+            return
+
         log_level = log.debug
-        if result and getattr(result, "status", None) >= 400:
+        if response.status >= 400:
             now = time.time()
             if now > self._last_error_ts + LOG_ERR_INTERVAL:
                 log_level = log.error
                 self._last_error_ts = now
-            log_level("failed_to_send %s to Agent: HTTP error status %s, reason %s, message %s", result_name,
-                      getattr(result, "status", None), getattr(result, "reason", None),
-                      getattr(result, "msg", None))
+            log_level(
+                'failed_to_send %s to Datadog Agent: HTTP error status %s, reason %s, message %s',
+                response_name,
+                response.status,
+                response.reason,
+                response.msg,
+            )
 
     def _apply_filters(self, traces):
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,16 +1,18 @@
 import mock
+import re
 import warnings
 
 from unittest import TestCase
 from nose.tools import eq_, ok_
 
 from tests.test_tracer import get_dummy_tracer
-from ddtrace.api import _parse_response_json, API
+from ddtrace.api import API, Response
 from ddtrace.compat import iteritems, httplib
 
 
 class ResponseMock:
-    def __init__(self, content):
+    def __init__(self, content, status=200):
+        self.status = status
         self.content = content
 
     def read(self):
@@ -34,36 +36,49 @@ class APITests(TestCase):
         tracer.debug_logging = True
 
         test_cases = {
-            'OK': {'js': None, 'log': "please make sure trace-agent is up to date"},
-            'OK\n': {'js': None, 'log': "please make sure trace-agent is up to date"},
-            'error:unsupported-endpoint': {'js': None, 'log': "unable to load JSON 'error:unsupported-endpoint'"},
-            42: {'js': None, 'log': "unable to load JSON '42'"},  # int as key to trigger TypeError
-            '{}': {'js': {}},
-            '[]': {'js': []},
-            '{"rate_by_service": {"service:,env:":0.5, "service:mcnulty,env:test":0.9, "service:postgres,env:test":0.6}}': {  # noqa
-                'js': {
-                    'rate_by_service': {
+            'OK': dict(
+                js=None,
+                log='Cannot parse Datadog Agent response, please make sure your Datadog Agent is up to date',
+            ),
+            'OK\n': dict(
+                js=None,
+                log='Cannot parse Datadog Agent response, please make sure your Datadog Agent is up to date',
+            ),
+            'error:unsupported-endpoint': dict(
+                js=None,
+                log='Unable to parse Datadog Agent JSON response: .*? \'error:unsupported-endpoint\'',
+            ),
+            42: dict(  # int as key to trigger TypeError
+                js=None,
+                log='Unable to parse Datadog Agent JSON response: .*? 42',
+            ),
+            '{}': dict(js={}),
+            '[]': dict(js=[]),
+
+            # Priority sampling "rate_by_service" response
+            ('{"rate_by_service": '
+             '{"service:,env:":0.5, "service:mcnulty,env:test":0.9, "service:postgres,env:test":0.6}}'): dict(
+                js=dict(
+                    rate_by_service={
                         'service:,env:': 0.5,
                         'service:mcnulty,env:test': 0.9,
                         'service:postgres,env:test': 0.6,
                     },
-                },
-            },
-            ' [4,2,1] ': {'js': [4, 2, 1]},
+                ),
+            ),
+            ' [4,2,1] ': dict(js=[4, 2, 1]),
         }
 
         for k, v in iteritems(test_cases):
-            r = ResponseMock(k)
-            js = _parse_response_json(r)
+            log.reset_mock()
+
+            r = Response.from_http_response(ResponseMock(k))
+            js = r.get_json()
             eq_(v['js'], js)
             if 'log' in v:
-                ok_(
-                    1 <= len(log.call_args_list),
-                    'not enough elements in call_args_list: {}'.format(log.call_args_list),
-                )
-                print(log.call_args_list)
-                args = log.call_args_list[-1][0][0]
-                ok_(v['log'] in args, 'unable to find {} in {}'.format(v['log'], args))
+                log.assert_called_once()
+                msg = log.call_args[0][0] % log.call_args[0][1:]
+                ok_(re.match(v['log'], msg), msg)
 
     @mock.patch('ddtrace.compat.httplib.HTTPConnection')
     def test_put_connection_close(self, HTTPConnection):

--- a/tox.ini
+++ b/tox.ini
@@ -202,7 +202,7 @@ deps =
     gevent11: gevent>=1.1,<1.2
     gevent12: gevent>=1.2,<1.3
     gevent13: gevent>=1.3,<1.4
-    grpc: grpcio>=1.8.0
+    grpc: grpcio>=1.8.0,<1.18.0
     grpc: googleapis-common-protos
     jinja27: jinja2>=2.7,<2.8
     jinja28: jinja2>=2.8,<2.9


### PR DESCRIPTION
## Upgrading to 0.20.2

No changes are needed to upgrade to `0.20.2`.

This big fix release includes changes to ensure we properly read the HTTP response body from the trace agent before we close the HTTP connection.

## Changes
### Bug fixes

- [core] Call HTTPResponse.read() before HTTPConnection.close() (#800)

### Improvements
- [tests] limit grpcio version to >=1.8.0,<1.18.0 (#802)
- [tools] Add confirmation to 'rake pypi:release' task (#791 )

Read the [full changeset](https://github.com/DataDog/dd-trace-py/compare/v0.20.1...v0.20.2) and the [release milestone](https://github.com/DataDog/dd-trace-py/milestone/36?closed=1).