### PR TITLE
[core] Allow futures to skip creating new context if one doesn't exist

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -242,9 +242,9 @@ class ThreadLocalContext(object):
     def set(self, ctx):
         setattr(self._locals, 'context', ctx)
 
-    def get(self):
+    def get(self, create_if_missing=True):
         ctx = getattr(self._locals, 'context', None)
-        if not ctx:
+        if not ctx and create_if_missing:
             # create a new Context if it's not available
             ctx = Context()
             self._locals.context = ctx

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -239,12 +239,22 @@ class ThreadLocalContext(object):
     def __init__(self):
         self._locals = threading.local()
 
+    def _has_active_context(self):
+        """
+        Determine whether we have a currently active context for this thread
+
+        :returns: Whether an active context exists
+        :rtype: bool
+        """
+        ctx = getattr(self._locals, 'context', None)
+        return ctx is not None
+
     def set(self, ctx):
         setattr(self._locals, 'context', ctx)
 
-    def get(self, create_if_missing=True):
+    def get(self):
         ctx = getattr(self._locals, 'context', None)
-        if not ctx and create_if_missing:
+        if not ctx:
             # create a new Context if it's not available
             ctx = Context()
             self._locals.context = ctx

--- a/ddtrace/contrib/asyncio/provider.py
+++ b/ddtrace/contrib/asyncio/provider.py
@@ -35,7 +35,7 @@ class AsyncioContextProvider(DefaultContextProvider):
         setattr(task, CONTEXT_ATTR, context)
         return context
 
-    def active(self, loop=None):
+    def active(self, loop=None, create_if_missing=True):
         """
         Returns the scoped Context for this execution flow. The ``Context`` uses
         the current task as a carrier so if a single task is used for the entire application,
@@ -48,7 +48,7 @@ class AsyncioContextProvider(DefaultContextProvider):
             # it happens when it's not possible to get the current event loop.
             # It's possible that a different Executor is handling a different Thread that
             # works with blocking code. In that case, we fallback to a thread-local Context.
-            return self._local.get()
+            return self._local.get(create_if_missing=True)
 
         # the current unit of work (if tasks are used)
         task = asyncio.Task.current_task(loop=loop)

--- a/ddtrace/contrib/asyncio/provider.py
+++ b/ddtrace/contrib/asyncio/provider.py
@@ -21,12 +21,8 @@ class AsyncioContextProvider(DefaultContextProvider):
     def activate(self, context, loop=None):
         """Sets the scoped ``Context`` for the current running ``Task``.
         """
-        try:
-            loop = loop or asyncio.get_event_loop()
-        except RuntimeError:
-            # detects if a loop is available in the current thread;
-            # This happens when a new thread is created from the one that is running
-            # the async loop
+        loop = self._get_loop(loop)
+        if not loop:
             self._local.set(context)
             return context
 
@@ -35,20 +31,41 @@ class AsyncioContextProvider(DefaultContextProvider):
         setattr(task, CONTEXT_ATTR, context)
         return context
 
-    def active(self, loop=None, create_if_missing=True):
+    def _get_loop(self, loop=None):
+        """Helper to try and resolve the current loop"""
+        try:
+            return loop or asyncio.get_event_loop()
+        except RuntimeError:
+            # Detects if a loop is available in the current thread;
+            # DEV: This happens when a new thread is created from the out that is running the async loop
+            # DEV: It's possible that a different Executor is handling a different Thread that
+            #      works with blocking code. In that case, we fallback to a thread-local Context.
+            pass
+        return None
+
+    def _has_active_context(self, loop=None):
+        """Helper to determine if we have a currently active context"""
+        loop = self._get_loop(loop=loop)
+        if loop is None:
+            return self._local._has_active_context()
+
+        # the current unit of work (if tasks are used)
+        task = asyncio.Task.current_task(loop=loop)
+        if task is None:
+            return False
+
+        ctx = getattr(task, CONTEXT_ATTR, None)
+        return ctx is not None
+
+    def active(self, loop=None):
         """
         Returns the scoped Context for this execution flow. The ``Context`` uses
         the current task as a carrier so if a single task is used for the entire application,
         the context must be handled separately.
         """
-        try:
-            loop = loop or asyncio.get_event_loop()
-        except RuntimeError:
-            # handles RuntimeError: There is no current event loop in thread 'MainThread'
-            # it happens when it's not possible to get the current event loop.
-            # It's possible that a different Executor is handling a different Thread that
-            # works with blocking code. In that case, we fallback to a thread-local Context.
-            return self._local.get(create_if_missing=True)
+        loop = self._get_loop(loop=loop)
+        if not loop:
+            return self._local.get()
 
         # the current unit of work (if tasks are used)
         task = asyncio.Task.current_task(loop=loop)

--- a/ddtrace/contrib/futures/threading.py
+++ b/ddtrace/contrib/futures/threading.py
@@ -1,4 +1,5 @@
 import ddtrace
+from ...provider import DefaultContextProvider
 
 
 def _wrap_submit(func, instance, args, kwargs):
@@ -7,8 +8,27 @@ def _wrap_submit(func, instance, args, kwargs):
     thread. This wrapper ensures that a new `Context` is created and
     properly propagated using an intermediate function.
     """
-    # propagate the same Context in the new thread
-    current_ctx = ddtrace.tracer.context_provider.active()
+    # If they are using the default context provider make sure we don't create a context if one doesn't exist
+    # DEV: We need to do this in case they are either:
+    #        - Starting nested futures
+    #        - Starting futures from outside of an existing context
+    #
+    #      In either of these cases we essentially will propagate the wrong context between futures
+    #
+    #      The resolution is to not create/propagate a new context if one does not exist, but let the
+    #      future's thread create the context instead.
+    # DEV: The `create_if_missing` param is currently only available on `DefaultContextProvider` do not
+    #      try to use if they are using another context provider.
+    if isinstance(ddtrace.tracer.context_provider, DefaultContextProvider):
+        current_ctx = ddtrace.tracer.context_provider.active(create_if_missing=False)
+    else:
+        current_ctx = ddtrace.tracer.context_provider.active()
+
+    # If we have a context then make sure we clone it
+    # DEV: We don't know if the future will finish executing before the parent span finishes
+    #      so we clone to ensure we properly collect/report the future's spans
+    if current_ctx is not None:
+        current_ctx = current_ctx.clone()
 
     # extract the target function that must be executed in
     # a new thread and the `target` arguments
@@ -25,5 +45,6 @@ def _wrap_execution(ctx, fn, args, kwargs):
     provider sets the Active context in a thread local storage
     variable because it's outside the asynchronous loop.
     """
-    ddtrace.tracer.context_provider.activate(ctx)
+    if ctx is not None:
+        ddtrace.tracer.context_provider.activate(ctx)
     return fn(*args, **kwargs)

--- a/ddtrace/contrib/gevent/provider.py
+++ b/ddtrace/contrib/gevent/provider.py
@@ -24,7 +24,7 @@ class GeventContextProvider(BaseContextProvider):
 
     def _has_active_context(self):
         """Helper to determine if we have a currently active context"""
-        return self._get_current_context() it not None
+        return self._get_current_context() is not None
 
     def activate(self, context):
         """Sets the scoped ``Context`` for the current running ``Greenlet``.

--- a/ddtrace/contrib/gevent/provider.py
+++ b/ddtrace/contrib/gevent/provider.py
@@ -15,6 +15,17 @@ class GeventContextProvider(BaseContextProvider):
     in the ``gevent`` library. Framework instrumentation that uses the
     gevent WSGI server (or gevent in general), can use this provider.
     """
+    def _get_current_context(self):
+        """Helper to get the current context from the current greenlet"""
+        current_g = gevent.getcurrent()
+        if current_g is not None:
+            return getattr(current_g, CONTEXT_ATTR, None)
+        return None
+
+    def _has_active_context(self):
+        """Helper to determine if we have a currently active context"""
+        return self._get_current_context() it not None
+
     def activate(self, context):
         """Sets the scoped ``Context`` for the current running ``Greenlet``.
         """
@@ -29,8 +40,7 @@ class GeventContextProvider(BaseContextProvider):
         uses the ``Greenlet`` class as a carrier, and everytime a greenlet
         is created it receives the "parent" context.
         """
-        current_g = gevent.getcurrent()
-        ctx = getattr(current_g, CONTEXT_ATTR, None)
+        ctx = self._get_current_context()
         if ctx is not None:
             # return the active Context for this greenlet (if any)
             return ctx
@@ -38,6 +48,7 @@ class GeventContextProvider(BaseContextProvider):
         # the Greenlet doesn't have a Context so it's created and attached
         # even to the main greenlet. This is required in Distributed Tracing
         # when a new arbitrary Context is provided.
+        current_g = gevent.getcurrent()
         if current_g:
             ctx = Context()
             setattr(current_g, CONTEXT_ATTR, ctx)

--- a/ddtrace/contrib/tornado/stack_context.py
+++ b/ddtrace/contrib/tornado/stack_context.py
@@ -57,24 +57,41 @@ class TracerStackContext(DefaultContextProvider):
     def deactivate(self):
         self._active = False
 
-    def active(self, create_if_missing=True):
+    def _has_io_loop(self):
+        """Helper to determine if we are currently in an IO loop"""
+        return getattr(IOLoop._current, 'instance', None) is not None
+
+    def _has_active_context(self):
+        """Helper to determine if we have an active context or not"""
+        if not self._has_io_loop():
+            return self._local._has_active_context()
+        else:
+            # we're inside a Tornado loop so the TracerStackContext is used
+            return self._get_state_active_context() is not None
+
+    def _get_state_active_context(self):
+        """Helper to get the currently active context from the TracerStackContext"""
+        # we're inside a Tornado loop so the TracerStackContext is used
+        for stack in reversed(_state.contexts[0]):
+            if isinstance(stack, self.__class__) and stack._active:
+                return stack._context
+        return None
+
+    def active(self):
         """
         Return the ``Context`` from the current execution flow. This method can be
         used inside a Tornado coroutine to retrieve and use the current tracing context.
         If used in a separated Thread, the `_state` thread-local storage is used to
         propagate the current Active context from the `MainThread`.
         """
-        io_loop = getattr(IOLoop._current, 'instance', None)
-        if io_loop is None:
+        if not self._has_io_loop():
             # if a Tornado loop is not available, it means that this method
             # has been called from a synchronous code, so we can rely in a
             # thread-local storage
-            return self._local.get(create_if_missing=create_if_missing)
+            return self._local.get()
         else:
             # we're inside a Tornado loop so the TracerStackContext is used
-            for stack in reversed(_state.contexts[0]):
-                if isinstance(stack, self.__class__) and stack._active:
-                    return stack._context
+            return self._get_state_active_context()
 
     def activate(self, ctx):
         """
@@ -83,8 +100,7 @@ class TracerStackContext(DefaultContextProvider):
         If used in a separated Thread, the `_state` thread-local storage is used to
         propagate the current Active context from the `MainThread`.
         """
-        io_loop = getattr(IOLoop._current, 'instance', None)
-        if io_loop is None:
+        if not self._has_io_loop():
             # because we're outside of an asynchronous execution, we store
             # the current context in a thread-local storage
             self._local.set(ctx)

--- a/ddtrace/contrib/tornado/stack_context.py
+++ b/ddtrace/contrib/tornado/stack_context.py
@@ -57,7 +57,7 @@ class TracerStackContext(DefaultContextProvider):
     def deactivate(self):
         self._active = False
 
-    def active(self):
+    def active(self, create_if_missing=True):
         """
         Return the ``Context`` from the current execution flow. This method can be
         used inside a Tornado coroutine to retrieve and use the current tracing context.
@@ -69,7 +69,7 @@ class TracerStackContext(DefaultContextProvider):
             # if a Tornado loop is not available, it means that this method
             # has been called from a synchronous code, so we can rely in a
             # thread-local storage
-            return self._local.get()
+            return self._local.get(create_if_missing=create_if_missing)
         else:
             # we're inside a Tornado loop so the TracerStackContext is used
             for stack in reversed(_state.contexts[0]):

--- a/ddtrace/provider.py
+++ b/ddtrace/provider.py
@@ -10,6 +10,9 @@ class BaseContextProvider(object):
         * the ``active`` method, that returns the current active ``Context``
         * the ``activate`` method, that sets the current active ``Context``
     """
+    def _has_active_context(self):
+        raise NotImplementedError
+
     def activate(self, context):
         raise NotImplementedError
 
@@ -32,15 +35,24 @@ class DefaultContextProvider(BaseContextProvider):
     def __init__(self):
         self._local = ThreadLocalContext()
 
+    def _has_active_context(self):
+        """
+        Check whether we have a currently active context.
+
+        :returns: Whether we have an active context
+        :rtype: bool
+        """
+        return self._local._has_active_context()
+
     def activate(self, context):
         """Makes the given ``context`` active, so that the provider calls
         the thread-local storage implementation.
         """
         return self._local.set(context)
 
-    def active(self, create_if_missing=True):
+    def active(self):
         """Returns the current active ``Context`` for this tracer. Returned
         ``Context`` must be thread-safe or thread-local for this specific
         implementation.
         """
-        return self._local.get(create_if_missing=True)
+        return self._local.get()

--- a/ddtrace/provider.py
+++ b/ddtrace/provider.py
@@ -38,9 +38,9 @@ class DefaultContextProvider(BaseContextProvider):
         """
         return self._local.set(context)
 
-    def active(self):
+    def active(self, create_if_missing=True):
         """Returns the current active ``Context`` for this tracer. Returned
         ``Context`` must be thread-safe or thread-local for this specific
         implementation.
         """
-        return self._local.get()
+        return self._local.get(create_if_missing=True)

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -1,7 +1,7 @@
 import contextlib
 import unittest
 
-from ddtrace import config
+import ddtrace
 
 from ..utils.tracer import DummyTracer
 from ..utils.span import TestSpanContainer, TestSpan, NO_CHILDREN
@@ -30,7 +30,7 @@ class BaseTestCase(unittest.TestCase):
         >>> with self.override_config('flask', dict(service_name='test-service')):
             # Your test
         """
-        options = getattr(config, integration)
+        options = getattr(ddtrace.config, integration)
 
         original = dict(
             (key, options.get(key))
@@ -81,3 +81,13 @@ class BaseTracerTestCase(TestSpanContainer, BaseTestCase):
         """Helper to call TestSpanNode.assert_structure on the current root span"""
         root_span = self.get_root_span()
         root_span.assert_structure(root, children)
+
+    @contextlib.contextmanager
+    def override_global_tracer(self, tracer=None):
+        original = ddtrace.tracer
+        tracer = tracer or self.tracer
+        setattr(ddtrace, 'tracer', tracer)
+        try:
+            yield
+        finally:
+            setattr(ddtrace, 'tracer', original)

--- a/tests/contrib/futures/test_propagation.py
+++ b/tests/contrib/futures/test_propagation.py
@@ -29,7 +29,7 @@ class PropagationTestCase(BaseTracerTestCase):
 
         def fn():
             # an active context must be available
-            # DEV: With `ThreadLocalContext` `.active()` will never been `None`
+            # DEV: With `ThreadLocalContext` `.active()` will never be `None`
             self.assertIsNotNone(self.tracer.context_provider.active())
             with self.tracer.trace('executor.thread'):
                 return 42
@@ -55,7 +55,7 @@ class PropagationTestCase(BaseTracerTestCase):
 
         def fn(value, key=None):
             # an active context must be available
-            # DEV: With `ThreadLocalContext` `.active()` will never been `None`
+            # DEV: With `ThreadLocalContext` `.active()` will never be `None`
             self.assertIsNotNone(self.tracer.context_provider.active())
             with self.tracer.trace('executor.thread'):
                 return value, key
@@ -83,7 +83,7 @@ class PropagationTestCase(BaseTracerTestCase):
 
         def fn():
             # an active context must be available
-            # DEV: With `ThreadLocalContext` `.active()` will never been `None`
+            # DEV: With `ThreadLocalContext` `.active()` will never be `None`
             self.assertIsNotNone(self.tracer.context_provider.active())
             with self.tracer.trace('executor.thread'):
                 return 42

--- a/tests/contrib/futures/test_propagation.py
+++ b/tests/contrib/futures/test_propagation.py
@@ -1,86 +1,81 @@
 import time
 import concurrent
 
-from unittest import TestCase
-from nose.tools import eq_, ok_
-
 from ddtrace.contrib.futures import patch, unpatch
 
 from tests.opentracer.utils import init_tracer
-from ...util import override_global_tracer
-from ...test_tracer import get_dummy_tracer
+from ...base import BaseTracerTestCase
 
 
-class PropagationTestCase(TestCase):
+class PropagationTestCase(BaseTracerTestCase):
     """Ensures the Context Propagation works between threads
     when the ``futures`` library is used, or when the
     ``concurrent`` module is available (Python 3 only)
     """
     def setUp(self):
+        super(PropagationTestCase, self).setUp()
+
         # instrument ``concurrent``
         patch()
-        self.tracer = get_dummy_tracer()
 
     def tearDown(self):
         # remove instrumentation
         unpatch()
+
+        super(PropagationTestCase, self).tearDown()
 
     def test_propagation(self):
         # it must propagate the tracing context if available
 
         def fn():
             # an active context must be available
-            ok_(self.tracer.context_provider.active() is not None)
+            # DEV: With `ThreadLocalContext` `.active()` will never been `None`
+            self.assertIsNotNone(self.tracer.context_provider.active())
             with self.tracer.trace('executor.thread'):
                 return 42
 
-        with override_global_tracer(self.tracer):
+        with self.override_global_tracer():
             with self.tracer.trace('main.thread'):
                 with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                     future = executor.submit(fn)
                     result = future.result()
                     # assert the right result
-                    eq_(result, 42)
+                    self.assertEqual(result, 42)
 
         # the trace must be completed
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 2)
-        main = traces[0][0]
-        executor = traces[0][1]
-
-        eq_(main.name, 'main.thread')
-        eq_(executor.name, 'executor.thread')
-        ok_(executor._parent is main)
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                dict(name='executor.thread'),
+            ),
+        )
 
     def test_propagation_with_params(self):
         # instrumentation must proxy arguments if available
 
         def fn(value, key=None):
             # an active context must be available
-            ok_(self.tracer.context_provider.active() is not None)
+            # DEV: With `ThreadLocalContext` `.active()` will never been `None`
+            self.assertIsNotNone(self.tracer.context_provider.active())
             with self.tracer.trace('executor.thread'):
                 return value, key
 
-        with override_global_tracer(self.tracer):
+        with self.override_global_tracer():
             with self.tracer.trace('main.thread'):
                 with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                     future = executor.submit(fn, 42, 'CheeseShop')
                     value, key = future.result()
                     # assert the right result
-                    eq_(value, 42)
-                    eq_(key, 'CheeseShop')
+                    self.assertEqual(value, 42)
+                    self.assertEqual(key, 'CheeseShop')
 
         # the trace must be completed
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 2)
-        main = traces[0][0]
-        executor = traces[0][1]
-
-        eq_(main.name, 'main.thread')
-        eq_(executor.name, 'executor.thread')
-        ok_(executor._parent is main)
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                dict(name='executor.thread'),
+            ),
+        )
 
     def test_disabled_instrumentation(self):
         # it must not propagate if the module is disabled
@@ -88,30 +83,29 @@ class PropagationTestCase(TestCase):
 
         def fn():
             # an active context must be available
-            ok_(self.tracer.context_provider.active() is not None)
+            # DEV: With `ThreadLocalContext` `.active()` will never been `None`
+            self.assertIsNotNone(self.tracer.context_provider.active())
             with self.tracer.trace('executor.thread'):
                 return 42
 
-        with override_global_tracer(self.tracer):
+        with self.override_global_tracer():
             with self.tracer.trace('main.thread'):
                 with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                     future = executor.submit(fn)
                     result = future.result()
                     # assert the right result
-                    eq_(result, 42)
+                    self.assertEqual(result, 42)
 
         # we provide two different traces
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 2)
-        eq_(len(traces[0]), 1)
-        eq_(len(traces[1]), 1)
-        executor = traces[0][0]
-        main = traces[1][0]
+        self.assert_span_count(2)
 
-        eq_(main.name, 'main.thread')
-        eq_(executor.name, 'executor.thread')
-        ok_(main.parent_id is None)
-        ok_(executor.parent_id is None)
+        # Retrieve the root spans (no parents)
+        # DEV: Results are sorted based on root span start time
+        traces = self.get_root_spans()
+        self.assertEqual(len(traces), 2)
+
+        traces[0].assert_structure(dict(name='main.thread'))
+        traces[1].assert_structure(dict(name='executor.thread'))
 
     def test_double_instrumentation(self):
         # double instrumentation must not happen
@@ -121,18 +115,186 @@ class PropagationTestCase(TestCase):
             with self.tracer.trace('executor.thread'):
                 return 42
 
-        with override_global_tracer(self.tracer):
+        with self.override_global_tracer():
             with self.tracer.trace('main.thread'):
                 with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                     future = executor.submit(fn)
                     result = future.result()
                     # assert the right result
-                    eq_(result, 42)
+                    self.assertEqual(result, 42)
 
         # the trace must be completed
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 2)
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                dict(name='executor.thread'),
+            ),
+        )
+
+    def test_no_parent_span(self):
+        def fn():
+            with self.tracer.trace('executor.thread'):
+                return 42
+
+        with self.override_global_tracer():
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                future = executor.submit(fn)
+                result = future.result()
+                # assert the right result
+                self.assertEqual(result, 42)
+
+        # the trace must be completed
+        self.assert_structure(dict(name='executor.thread'))
+
+    def test_multiple_futures(self):
+        def fn():
+            with self.tracer.trace('executor.thread'):
+                return 42
+
+        with self.override_global_tracer():
+            with self.tracer.trace('main.thread'):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+                    futures = [executor.submit(fn) for _ in range(4)]
+                    for future in futures:
+                        result = future.result()
+                        # assert the right result
+                        self.assertEqual(result, 42)
+
+        # the trace must be completed
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                dict(name='executor.thread'),
+                dict(name='executor.thread'),
+                dict(name='executor.thread'),
+                dict(name='executor.thread'),
+            ),
+        )
+
+    def test_multiple_futures_no_parent(self):
+        def fn():
+            with self.tracer.trace('executor.thread'):
+                return 42
+
+        with self.override_global_tracer():
+            with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+                futures = [executor.submit(fn) for _ in range(4)]
+                for future in futures:
+                    result = future.result()
+                    # assert the right result
+                    self.assertEqual(result, 42)
+
+        # the trace must be completed
+        self.assert_span_count(4)
+        traces = self.get_root_spans()
+        self.assertEqual(len(traces), 4)
+        for trace in traces:
+            trace.assert_structure(dict(name='executor.thread'))
+
+    def test_nested_futures(self):
+        def fn2():
+            with self.tracer.trace('nested.thread'):
+                return 42
+
+        def fn():
+            with self.tracer.trace('executor.thread'):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                    future = executor.submit(fn2)
+                    result = future.result()
+                    self.assertEqual(result, 42)
+                    return result
+
+        with self.override_global_tracer():
+            with self.tracer.trace('main.thread'):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                    future = executor.submit(fn)
+                    result = future.result()
+                    # assert the right result
+                    self.assertEqual(result, 42)
+
+        # the trace must be completed
+        self.assert_span_count(3)
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                (
+                    dict(name='executor.thread'),
+                    (
+                        dict(name='nested.thread'),
+                    ),
+                ),
+            ),
+        )
+
+    def test_multiple_nested_futures(self):
+        def fn2():
+            with self.tracer.trace('nested.thread'):
+                return 42
+
+        def fn():
+            with self.tracer.trace('executor.thread'):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                    futures = [executor.submit(fn2) for _ in range(4)]
+                    for future in futures:
+                        result = future.result()
+                        self.assertEqual(result, 42)
+                        return result
+
+        with self.override_global_tracer():
+            with self.tracer.trace('main.thread'):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                    futures = [executor.submit(fn) for _ in range(4)]
+                    for future in futures:
+                        result = future.result()
+                        # assert the right result
+                        self.assertEqual(result, 42)
+
+        # the trace must be completed
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                (
+                    dict(name='executor.thread'),
+                    (
+                        dict(name='nested.thread'),
+                    ) * 4,
+                ),
+            ) * 4,
+        )
+
+    def test_multiple_nested_futures_no_parent(self):
+        def fn2():
+            with self.tracer.trace('nested.thread'):
+                return 42
+
+        def fn():
+            with self.tracer.trace('executor.thread'):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                    futures = [executor.submit(fn2) for _ in range(4)]
+                    for future in futures:
+                        result = future.result()
+                        self.assertEqual(result, 42)
+                        return result
+
+        with self.override_global_tracer():
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                futures = [executor.submit(fn) for _ in range(4)]
+                for future in futures:
+                    result = future.result()
+                    # assert the right result
+                    self.assertEqual(result, 42)
+
+        # the trace must be completed
+        traces = self.get_root_spans()
+        self.assertEqual(len(traces), 4)
+
+        for trace in traces:
+            trace.assert_structure(
+                dict(name='executor.thread'),
+                (
+                    dict(name='nested.thread'),
+                ) * 4,
+            )
 
     def test_send_trace_when_finished(self):
         # it must send the trace only when all threads are finished
@@ -143,24 +305,28 @@ class PropagationTestCase(TestCase):
                 time.sleep(0.05)
                 return 42
 
-        with override_global_tracer(self.tracer):
+        with self.override_global_tracer():
             with self.tracer.trace('main.thread'):
                 # don't wait for the execution
                 executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
                 future = executor.submit(fn)
                 time.sleep(0.01)
 
-        # assert the trace is not sent because the secondary thread
-        # didn't finish the processing
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 0)
+        # assert main thread span is fniished first
+        self.assert_span_count(1)
+        self.assert_structure(dict(name='main.thread'))
 
         # then wait for the second thread and send the trace
         result = future.result()
-        eq_(result, 42)
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 2)
+        self.assertEqual(result, 42)
+
+        self.assert_span_count(2)
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                dict(name='executor.thread'),
+            ),
+        )
 
     def test_propagation_ot(self):
         """OpenTracing version of test_propagation."""
@@ -169,25 +335,22 @@ class PropagationTestCase(TestCase):
 
         def fn():
             # an active context must be available
-            ok_(self.tracer.context_provider.active() is not None)
+            self.assertTrue(self.tracer.context_provider.active() is not None)
             with self.tracer.trace('executor.thread'):
                 return 42
 
-        with override_global_tracer(self.tracer):
+        with self.override_global_tracer():
             with ot_tracer.start_active_span('main.thread'):
                 with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                     future = executor.submit(fn)
                     result = future.result()
                     # assert the right result
-                    eq_(result, 42)
+                    self.assertEqual(result, 42)
 
         # the trace must be completed
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 2)
-        main = traces[0][0]
-        executor = traces[0][1]
-
-        eq_(main.name, 'main.thread')
-        eq_(executor.name, 'executor.thread')
-        ok_(executor._parent is main)
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                dict(name='executor.thread'),
+            ),
+        )

--- a/tests/contrib/tornado/test_executor_decorator.py
+++ b/tests/contrib/tornado/test_executor_decorator.py
@@ -19,11 +19,12 @@ class TestTornadoExecutor(TornadoTestCase):
         eq_(200, response.code)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        eq_(2, len(traces))
+        eq_(1, len(traces[0]))
+        eq_(1, len(traces[1]))
 
         # this trace yields the execution of the thread
-        request_span = traces[0][0]
+        request_span = traces[1][0]
         eq_('tornado-web', request_span.service)
         eq_('tornado.request', request_span.name)
         eq_('http', request_span.span_type)
@@ -35,7 +36,7 @@ class TestTornadoExecutor(TornadoTestCase):
         ok_(request_span.duration >= 0.05)
 
         # this trace is executed in a different thread
-        executor_span = traces[0][1]
+        executor_span = traces[0][0]
         eq_('tornado-web', executor_span.service)
         eq_('tornado.executor.with', executor_span.name)
         eq_(executor_span.parent_id, request_span.span_id)
@@ -49,11 +50,12 @@ class TestTornadoExecutor(TornadoTestCase):
         eq_(200, response.code)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        eq_(2, len(traces))
+        eq_(1, len(traces[0]))
+        eq_(1, len(traces[1]))
 
         # this trace yields the execution of the thread
-        request_span = traces[0][0]
+        request_span = traces[1][0]
         eq_('tornado-web', request_span.service)
         eq_('tornado.request', request_span.name)
         eq_('http', request_span.span_type)
@@ -65,7 +67,7 @@ class TestTornadoExecutor(TornadoTestCase):
         ok_(request_span.duration >= 0.05)
 
         # this trace is executed in a different thread
-        executor_span = traces[0][1]
+        executor_span = traces[0][0]
         eq_('tornado-web', executor_span.service)
         eq_('tornado.executor.query', executor_span.name)
         eq_(executor_span.parent_id, request_span.span_id)
@@ -78,11 +80,12 @@ class TestTornadoExecutor(TornadoTestCase):
         eq_(500, response.code)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        eq_(2, len(traces))
+        eq_(1, len(traces[0]))
+        eq_(1, len(traces[1]))
 
         # this trace yields the execution of the thread
-        request_span = traces[0][0]
+        request_span = traces[1][0]
         eq_('tornado-web', request_span.service)
         eq_('tornado.request', request_span.name)
         eq_('http', request_span.span_type)
@@ -95,7 +98,7 @@ class TestTornadoExecutor(TornadoTestCase):
         ok_('Exception: Ouch!' in request_span.get_tag('error.stack'))
 
         # this trace is executed in a different thread
-        executor_span = traces[0][1]
+        executor_span = traces[0][0]
         eq_('tornado-web', executor_span.service)
         eq_('tornado.executor.with', executor_span.name)
         eq_(executor_span.parent_id, request_span.span_id)
@@ -114,11 +117,12 @@ class TestTornadoExecutor(TornadoTestCase):
         eq_(200, response.code)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        eq_(2, len(traces))
+        eq_(1, len(traces[0]))
+        eq_(1, len(traces[1]))
 
         # this trace yields the execution of the thread
-        request_span = traces[0][0]
+        request_span = traces[1][0]
         eq_('tornado-web', request_span.service)
         eq_('tornado.request', request_span.name)
         eq_('http', request_span.span_type)
@@ -130,7 +134,7 @@ class TestTornadoExecutor(TornadoTestCase):
         ok_(request_span.duration >= 0.05)
 
         # this trace is executed in a different thread
-        executor_span = traces[0][1]
+        executor_span = traces[0][0]
         eq_('tornado-web', executor_span.service)
         eq_('tornado.executor.with', executor_span.name)
         eq_(executor_span.parent_id, request_span.span_id)


### PR DESCRIPTION
This PR addresses an issue we had when using `gunicorn` sync workers with endpoints that use `futures`.

The bug is caused by the fact that when submitting a new future, if a context does not already exist in the current thread then we will create and propagate that context through to the future.

This is usually not a big deal, but with `gunicorn` it means the main `gunicorn` thread will have a single context created for it and then propagated to all requests that are handled via futures from that thread.

This is issue is very evident when calling creating nested futures.

The following basic example reproduces the issue:

```python
from ddtrace import tracer

import concurrent.futures
import time
import random


@tracer.wrap(service='task')
def task(w, i):
    time.sleep(random.random())
    print('task', w, ':', i, 'completed')


@tracer.wrap(service='worker')
def worker(w):
    time.sleep(random.random())
    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
        tasks = {executor.submit(task, w, i): i for i in range(2)}
        [future.result() for future in concurrent.futures.as_completed(tasks)]


def main():
    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
        workers = {executor.submit(worker, i): i for i in range(2)}
        [future.result() for future in concurrent.futures.as_completed(workers)]


if __name__ == '__main__':
    main()
```