### PR TITLE
Use new name for msgpack-python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['tests*']),
     install_requires=[
-        'msgpack-python',
+        'msgpack',
         'six',
         'wrapt',
     ],


### PR DESCRIPTION
More Info
https://github.com/msgpack/msgpack-python/blob/8f513af999d4abd39d632fcc8732225a658268ee/README.rst#pypi-package-name

Right now when you pip install ddtrace it is installing msgpack-python==0.5.6

With this change it will install the latest which is currently msgpack==0.6.1