### PR TITLE
Release 0.20.3

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -4,7 +4,7 @@ from .span import Span
 from .tracer import Tracer
 from .settings import config
 
-__version__ = '0.20.2'
+__version__ = '0.20.3'
 
 # a global tracer instance with integration settings
 tracer = Tracer()

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -239,6 +239,16 @@ class ThreadLocalContext(object):
     def __init__(self):
         self._locals = threading.local()
 
+    def _has_active_context(self):
+        """
+        Determine whether we have a currently active context for this thread
+
+        :returns: Whether an active context exists
+        :rtype: bool
+        """
+        ctx = getattr(self._locals, 'context', None)
+        return ctx is not None
+
     def set(self, ctx):
         setattr(self._locals, 'context', ctx)
 

--- a/ddtrace/contrib/futures/threading.py
+++ b/ddtrace/contrib/futures/threading.py
@@ -7,8 +7,24 @@ def _wrap_submit(func, instance, args, kwargs):
     thread. This wrapper ensures that a new `Context` is created and
     properly propagated using an intermediate function.
     """
-    # propagate the same Context in the new thread
-    current_ctx = ddtrace.tracer.context_provider.active()
+    # If there isn't a currently active context, then do not create one
+    # DEV: Calling `.active()` when there isn't an active context will create a new context
+    # DEV: We need to do this in case they are either:
+    #        - Starting nested futures
+    #        - Starting futures from outside of an existing context
+    #
+    #      In either of these cases we essentially will propagate the wrong context between futures
+    #
+    #      The resolution is to not create/propagate a new context if one does not exist, but let the
+    #      future's thread create the context instead.
+    current_ctx = None
+    if ddtrace.tracer.context_provider._has_active_context():
+        current_ctx = ddtrace.tracer.context_provider.active()
+
+        # If we have a context then make sure we clone it
+        # DEV: We don't know if the future will finish executing before the parent span finishes
+        #      so we clone to ensure we properly collect/report the future's spans
+        current_ctx = current_ctx.clone()
 
     # extract the target function that must be executed in
     # a new thread and the `target` arguments
@@ -25,5 +41,6 @@ def _wrap_execution(ctx, fn, args, kwargs):
     provider sets the Active context in a thread local storage
     variable because it's outside the asynchronous loop.
     """
-    ddtrace.tracer.context_provider.activate(ctx)
+    if ctx is not None:
+        ddtrace.tracer.context_provider.activate(ctx)
     return fn(*args, **kwargs)

--- a/ddtrace/provider.py
+++ b/ddtrace/provider.py
@@ -10,6 +10,9 @@ class BaseContextProvider(object):
         * the ``active`` method, that returns the current active ``Context``
         * the ``activate`` method, that sets the current active ``Context``
     """
+    def _has_active_context(self):
+        raise NotImplementedError
+
     def activate(self, context):
         raise NotImplementedError
 
@@ -31,6 +34,15 @@ class DefaultContextProvider(BaseContextProvider):
     """
     def __init__(self):
         self._local = ThreadLocalContext()
+
+    def _has_active_context(self):
+        """
+        Check whether we have a currently active context.
+
+        :returns: Whether we have an active context
+        :rtype: bool
+        """
+        return self._local._has_active_context()
 
     def activate(self, context):
         """Makes the given ``context`` active, so that the provider calls

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -1,7 +1,7 @@
 import contextlib
 import unittest
 
-from ddtrace import config
+import ddtrace
 
 from ..utils.tracer import DummyTracer
 from ..utils.span import TestSpanContainer, TestSpan, NO_CHILDREN
@@ -30,7 +30,7 @@ class BaseTestCase(unittest.TestCase):
         >>> with self.override_config('flask', dict(service_name='test-service')):
             # Your test
         """
-        options = getattr(config, integration)
+        options = getattr(ddtrace.config, integration)
 
         original = dict(
             (key, options.get(key))
@@ -81,3 +81,13 @@ class BaseTracerTestCase(TestSpanContainer, BaseTestCase):
         """Helper to call TestSpanNode.assert_structure on the current root span"""
         root_span = self.get_root_span()
         root_span.assert_structure(root, children)
+
+    @contextlib.contextmanager
+    def override_global_tracer(self, tracer=None):
+        original = ddtrace.tracer
+        tracer = tracer or self.tracer
+        setattr(ddtrace, 'tracer', tracer)
+        try:
+            yield
+        finally:
+            setattr(ddtrace, 'tracer', original)

--- a/tests/contrib/futures/test_propagation.py
+++ b/tests/contrib/futures/test_propagation.py
@@ -1,86 +1,81 @@
 import time
 import concurrent
 
-from unittest import TestCase
-from nose.tools import eq_, ok_
-
 from ddtrace.contrib.futures import patch, unpatch
 
 from tests.opentracer.utils import init_tracer
-from ...util import override_global_tracer
-from ...test_tracer import get_dummy_tracer
+from ...base import BaseTracerTestCase
 
 
-class PropagationTestCase(TestCase):
+class PropagationTestCase(BaseTracerTestCase):
     """Ensures the Context Propagation works between threads
     when the ``futures`` library is used, or when the
     ``concurrent`` module is available (Python 3 only)
     """
     def setUp(self):
+        super(PropagationTestCase, self).setUp()
+
         # instrument ``concurrent``
         patch()
-        self.tracer = get_dummy_tracer()
 
     def tearDown(self):
         # remove instrumentation
         unpatch()
+
+        super(PropagationTestCase, self).tearDown()
 
     def test_propagation(self):
         # it must propagate the tracing context if available
 
         def fn():
             # an active context must be available
-            ok_(self.tracer.context_provider.active() is not None)
+            # DEV: With `ThreadLocalContext` `.active()` will never be `None`
+            self.assertIsNotNone(self.tracer.context_provider.active())
             with self.tracer.trace('executor.thread'):
                 return 42
 
-        with override_global_tracer(self.tracer):
+        with self.override_global_tracer():
             with self.tracer.trace('main.thread'):
                 with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                     future = executor.submit(fn)
                     result = future.result()
                     # assert the right result
-                    eq_(result, 42)
+                    self.assertEqual(result, 42)
 
         # the trace must be completed
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 2)
-        main = traces[0][0]
-        executor = traces[0][1]
-
-        eq_(main.name, 'main.thread')
-        eq_(executor.name, 'executor.thread')
-        ok_(executor._parent is main)
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                dict(name='executor.thread'),
+            ),
+        )
 
     def test_propagation_with_params(self):
         # instrumentation must proxy arguments if available
 
         def fn(value, key=None):
             # an active context must be available
-            ok_(self.tracer.context_provider.active() is not None)
+            # DEV: With `ThreadLocalContext` `.active()` will never be `None`
+            self.assertIsNotNone(self.tracer.context_provider.active())
             with self.tracer.trace('executor.thread'):
                 return value, key
 
-        with override_global_tracer(self.tracer):
+        with self.override_global_tracer():
             with self.tracer.trace('main.thread'):
                 with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                     future = executor.submit(fn, 42, 'CheeseShop')
                     value, key = future.result()
                     # assert the right result
-                    eq_(value, 42)
-                    eq_(key, 'CheeseShop')
+                    self.assertEqual(value, 42)
+                    self.assertEqual(key, 'CheeseShop')
 
         # the trace must be completed
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 2)
-        main = traces[0][0]
-        executor = traces[0][1]
-
-        eq_(main.name, 'main.thread')
-        eq_(executor.name, 'executor.thread')
-        ok_(executor._parent is main)
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                dict(name='executor.thread'),
+            ),
+        )
 
     def test_disabled_instrumentation(self):
         # it must not propagate if the module is disabled
@@ -88,30 +83,29 @@ class PropagationTestCase(TestCase):
 
         def fn():
             # an active context must be available
-            ok_(self.tracer.context_provider.active() is not None)
+            # DEV: With `ThreadLocalContext` `.active()` will never be `None`
+            self.assertIsNotNone(self.tracer.context_provider.active())
             with self.tracer.trace('executor.thread'):
                 return 42
 
-        with override_global_tracer(self.tracer):
+        with self.override_global_tracer():
             with self.tracer.trace('main.thread'):
                 with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                     future = executor.submit(fn)
                     result = future.result()
                     # assert the right result
-                    eq_(result, 42)
+                    self.assertEqual(result, 42)
 
         # we provide two different traces
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 2)
-        eq_(len(traces[0]), 1)
-        eq_(len(traces[1]), 1)
-        executor = traces[0][0]
-        main = traces[1][0]
+        self.assert_span_count(2)
 
-        eq_(main.name, 'main.thread')
-        eq_(executor.name, 'executor.thread')
-        ok_(main.parent_id is None)
-        ok_(executor.parent_id is None)
+        # Retrieve the root spans (no parents)
+        # DEV: Results are sorted based on root span start time
+        traces = self.get_root_spans()
+        self.assertEqual(len(traces), 2)
+
+        traces[0].assert_structure(dict(name='main.thread'))
+        traces[1].assert_structure(dict(name='executor.thread'))
 
     def test_double_instrumentation(self):
         # double instrumentation must not happen
@@ -121,18 +115,186 @@ class PropagationTestCase(TestCase):
             with self.tracer.trace('executor.thread'):
                 return 42
 
-        with override_global_tracer(self.tracer):
+        with self.override_global_tracer():
             with self.tracer.trace('main.thread'):
                 with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                     future = executor.submit(fn)
                     result = future.result()
                     # assert the right result
-                    eq_(result, 42)
+                    self.assertEqual(result, 42)
 
         # the trace must be completed
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 2)
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                dict(name='executor.thread'),
+            ),
+        )
+
+    def test_no_parent_span(self):
+        def fn():
+            with self.tracer.trace('executor.thread'):
+                return 42
+
+        with self.override_global_tracer():
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                future = executor.submit(fn)
+                result = future.result()
+                # assert the right result
+                self.assertEqual(result, 42)
+
+        # the trace must be completed
+        self.assert_structure(dict(name='executor.thread'))
+
+    def test_multiple_futures(self):
+        def fn():
+            with self.tracer.trace('executor.thread'):
+                return 42
+
+        with self.override_global_tracer():
+            with self.tracer.trace('main.thread'):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+                    futures = [executor.submit(fn) for _ in range(4)]
+                    for future in futures:
+                        result = future.result()
+                        # assert the right result
+                        self.assertEqual(result, 42)
+
+        # the trace must be completed
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                dict(name='executor.thread'),
+                dict(name='executor.thread'),
+                dict(name='executor.thread'),
+                dict(name='executor.thread'),
+            ),
+        )
+
+    def test_multiple_futures_no_parent(self):
+        def fn():
+            with self.tracer.trace('executor.thread'):
+                return 42
+
+        with self.override_global_tracer():
+            with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+                futures = [executor.submit(fn) for _ in range(4)]
+                for future in futures:
+                    result = future.result()
+                    # assert the right result
+                    self.assertEqual(result, 42)
+
+        # the trace must be completed
+        self.assert_span_count(4)
+        traces = self.get_root_spans()
+        self.assertEqual(len(traces), 4)
+        for trace in traces:
+            trace.assert_structure(dict(name='executor.thread'))
+
+    def test_nested_futures(self):
+        def fn2():
+            with self.tracer.trace('nested.thread'):
+                return 42
+
+        def fn():
+            with self.tracer.trace('executor.thread'):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                    future = executor.submit(fn2)
+                    result = future.result()
+                    self.assertEqual(result, 42)
+                    return result
+
+        with self.override_global_tracer():
+            with self.tracer.trace('main.thread'):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                    future = executor.submit(fn)
+                    result = future.result()
+                    # assert the right result
+                    self.assertEqual(result, 42)
+
+        # the trace must be completed
+        self.assert_span_count(3)
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                (
+                    dict(name='executor.thread'),
+                    (
+                        dict(name='nested.thread'),
+                    ),
+                ),
+            ),
+        )
+
+    def test_multiple_nested_futures(self):
+        def fn2():
+            with self.tracer.trace('nested.thread'):
+                return 42
+
+        def fn():
+            with self.tracer.trace('executor.thread'):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                    futures = [executor.submit(fn2) for _ in range(4)]
+                    for future in futures:
+                        result = future.result()
+                        self.assertEqual(result, 42)
+                        return result
+
+        with self.override_global_tracer():
+            with self.tracer.trace('main.thread'):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                    futures = [executor.submit(fn) for _ in range(4)]
+                    for future in futures:
+                        result = future.result()
+                        # assert the right result
+                        self.assertEqual(result, 42)
+
+        # the trace must be completed
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                (
+                    dict(name='executor.thread'),
+                    (
+                        dict(name='nested.thread'),
+                    ) * 4,
+                ),
+            ) * 4,
+        )
+
+    def test_multiple_nested_futures_no_parent(self):
+        def fn2():
+            with self.tracer.trace('nested.thread'):
+                return 42
+
+        def fn():
+            with self.tracer.trace('executor.thread'):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                    futures = [executor.submit(fn2) for _ in range(4)]
+                    for future in futures:
+                        result = future.result()
+                        self.assertEqual(result, 42)
+                        return result
+
+        with self.override_global_tracer():
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                futures = [executor.submit(fn) for _ in range(4)]
+                for future in futures:
+                    result = future.result()
+                    # assert the right result
+                    self.assertEqual(result, 42)
+
+        # the trace must be completed
+        traces = self.get_root_spans()
+        self.assertEqual(len(traces), 4)
+
+        for trace in traces:
+            trace.assert_structure(
+                dict(name='executor.thread'),
+                (
+                    dict(name='nested.thread'),
+                ) * 4,
+            )
 
     def test_send_trace_when_finished(self):
         # it must send the trace only when all threads are finished
@@ -143,24 +305,28 @@ class PropagationTestCase(TestCase):
                 time.sleep(0.05)
                 return 42
 
-        with override_global_tracer(self.tracer):
+        with self.override_global_tracer():
             with self.tracer.trace('main.thread'):
                 # don't wait for the execution
                 executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
                 future = executor.submit(fn)
                 time.sleep(0.01)
 
-        # assert the trace is not sent because the secondary thread
-        # didn't finish the processing
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 0)
+        # assert main thread span is fniished first
+        self.assert_span_count(1)
+        self.assert_structure(dict(name='main.thread'))
 
         # then wait for the second thread and send the trace
         result = future.result()
-        eq_(result, 42)
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 2)
+        self.assertEqual(result, 42)
+
+        self.assert_span_count(2)
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                dict(name='executor.thread'),
+            ),
+        )
 
     def test_propagation_ot(self):
         """OpenTracing version of test_propagation."""
@@ -169,25 +335,22 @@ class PropagationTestCase(TestCase):
 
         def fn():
             # an active context must be available
-            ok_(self.tracer.context_provider.active() is not None)
+            self.assertTrue(self.tracer.context_provider.active() is not None)
             with self.tracer.trace('executor.thread'):
                 return 42
 
-        with override_global_tracer(self.tracer):
+        with self.override_global_tracer():
             with ot_tracer.start_active_span('main.thread'):
                 with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                     future = executor.submit(fn)
                     result = future.result()
                     # assert the right result
-                    eq_(result, 42)
+                    self.assertEqual(result, 42)
 
         # the trace must be completed
-        traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 2)
-        main = traces[0][0]
-        executor = traces[0][1]
-
-        eq_(main.name, 'main.thread')
-        eq_(executor.name, 'executor.thread')
-        ok_(executor._parent is main)
+        self.assert_structure(
+            dict(name='main.thread'),
+            (
+                dict(name='executor.thread'),
+            ),
+        )

--- a/tests/contrib/tornado/test_executor_decorator.py
+++ b/tests/contrib/tornado/test_executor_decorator.py
@@ -19,11 +19,12 @@ class TestTornadoExecutor(TornadoTestCase):
         eq_(200, response.code)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        eq_(2, len(traces))
+        eq_(1, len(traces[0]))
+        eq_(1, len(traces[1]))
 
         # this trace yields the execution of the thread
-        request_span = traces[0][0]
+        request_span = traces[1][0]
         eq_('tornado-web', request_span.service)
         eq_('tornado.request', request_span.name)
         eq_('http', request_span.span_type)
@@ -35,7 +36,7 @@ class TestTornadoExecutor(TornadoTestCase):
         ok_(request_span.duration >= 0.05)
 
         # this trace is executed in a different thread
-        executor_span = traces[0][1]
+        executor_span = traces[0][0]
         eq_('tornado-web', executor_span.service)
         eq_('tornado.executor.with', executor_span.name)
         eq_(executor_span.parent_id, request_span.span_id)
@@ -49,11 +50,12 @@ class TestTornadoExecutor(TornadoTestCase):
         eq_(200, response.code)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        eq_(2, len(traces))
+        eq_(1, len(traces[0]))
+        eq_(1, len(traces[1]))
 
         # this trace yields the execution of the thread
-        request_span = traces[0][0]
+        request_span = traces[1][0]
         eq_('tornado-web', request_span.service)
         eq_('tornado.request', request_span.name)
         eq_('http', request_span.span_type)
@@ -65,7 +67,7 @@ class TestTornadoExecutor(TornadoTestCase):
         ok_(request_span.duration >= 0.05)
 
         # this trace is executed in a different thread
-        executor_span = traces[0][1]
+        executor_span = traces[0][0]
         eq_('tornado-web', executor_span.service)
         eq_('tornado.executor.query', executor_span.name)
         eq_(executor_span.parent_id, request_span.span_id)
@@ -78,11 +80,12 @@ class TestTornadoExecutor(TornadoTestCase):
         eq_(500, response.code)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        eq_(2, len(traces))
+        eq_(1, len(traces[0]))
+        eq_(1, len(traces[1]))
 
         # this trace yields the execution of the thread
-        request_span = traces[0][0]
+        request_span = traces[1][0]
         eq_('tornado-web', request_span.service)
         eq_('tornado.request', request_span.name)
         eq_('http', request_span.span_type)
@@ -95,7 +98,7 @@ class TestTornadoExecutor(TornadoTestCase):
         ok_('Exception: Ouch!' in request_span.get_tag('error.stack'))
 
         # this trace is executed in a different thread
-        executor_span = traces[0][1]
+        executor_span = traces[0][0]
         eq_('tornado-web', executor_span.service)
         eq_('tornado.executor.with', executor_span.name)
         eq_(executor_span.parent_id, request_span.span_id)
@@ -114,11 +117,12 @@ class TestTornadoExecutor(TornadoTestCase):
         eq_(200, response.code)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        eq_(2, len(traces))
+        eq_(1, len(traces[0]))
+        eq_(1, len(traces[1]))
 
         # this trace yields the execution of the thread
-        request_span = traces[0][0]
+        request_span = traces[1][0]
         eq_('tornado-web', request_span.service)
         eq_('tornado.request', request_span.name)
         eq_('http', request_span.span_type)
@@ -130,7 +134,7 @@ class TestTornadoExecutor(TornadoTestCase):
         ok_(request_span.duration >= 0.05)
 
         # this trace is executed in a different thread
-        executor_span = traces[0][1]
+        executor_span = traces[0][0]
         eq_('tornado-web', executor_span.service)
         eq_('tornado.executor.with', executor_span.name)
         eq_(executor_span.parent_id, request_span.span_id)


### PR DESCRIPTION
## Upgrading to 0.20.3

This is a bug fix release that requires no changes.

This release includes a fix for context propagation with `futures`. Under the right conditions we could incorrectly share a trace context between multiple `futures` threads which result in multiple traces being joined together in one.

## Changes
### Bug fixes
* [core] Allow futures to skip creating new context if one doesn't exist (#806)

Read the [full changeset](https://github.com/DataDog/dd-trace-py/compare/v0.20.2...v0.20.3) and the [release milestone](https://github.com/DataDog/dd-trace-py/milestone/37?closed=1).