### PR TITLE
[testing] Ensure consistent use of override_config and override_env

### DIFF
--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 import unittest
 
 import ddtrace
@@ -22,6 +23,24 @@ class BaseTestCase(unittest.TestCase):
                 with self.override_config('flask', dict(distributed_tracing_enabled=True):
                     pass
     """
+
+    @contextlib.contextmanager
+    def override_env(self, env):
+        """
+        Temporarily override ``os.environ`` with provided values
+        >>> with self.override_env(dict(DATADOG_TRACE_DEBUG=True)):
+            # Your test
+        """
+        original = dict(
+            (key, os.environ.get(key))
+            for key in env.keys()
+        )
+
+        os.environ.update(env)
+        try:
+            yield
+        finally:
+            os.environ.update(original)
 
     @contextlib.contextmanager
     def override_config(self, integration, values):

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -31,15 +31,16 @@ class BaseTestCase(unittest.TestCase):
         >>> with self.override_env(dict(DATADOG_TRACE_DEBUG=True)):
             # Your test
         """
-        original = dict(
-            (key, os.environ.get(key))
-            for key in env.keys()
-        )
+        # Copy the full original environment
+        original = dict(os.environ)
 
+        # Update based on the passed in arguments
         os.environ.update(env)
         try:
             yield
         finally:
+            # Full clear the environment out and reset back to the original
+            os.environ.clear()
             os.environ.update(original)
 
     @contextlib.contextmanager

--- a/tests/contrib/celery/base.py
+++ b/tests/contrib/celery/base.py
@@ -1,6 +1,6 @@
 from celery import Celery
 
-from ddtrace import Pin, config
+from ddtrace import Pin
 from ddtrace.compat import PY2
 from ddtrace.contrib.celery import patch, unpatch
 
@@ -21,8 +21,6 @@ class CeleryBaseTestCase(BaseTracerTestCase):
     def setUp(self):
         super(CeleryBaseTestCase, self).setUp()
 
-        # keep track of original config
-        self._config = dict(config.celery)
         # instrument Celery and create an app with Broker and Result backends
         patch()
         self.pin = Pin(service='celery-unittest', tracer=self.tracer)
@@ -34,9 +32,6 @@ class CeleryBaseTestCase(BaseTracerTestCase):
         # remove instrumentation from Celery
         unpatch()
         self.app = None
-        # restore the global configuration
-        config.celery.update(self._config)
-        self._config = None
 
         super(CeleryBaseTestCase, self).tearDown()
 

--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -306,41 +306,39 @@ class CeleryIntegrationTask(CeleryBaseTestCase):
         eq_(span.get_tag('celery.state'), 'SUCCESS')
 
     def test_worker_service_name(self):
+        @self.app.task
+        def fn_task():
+            return 42
+
         # Ensure worker service name can be changed via
         # configuration object
-        config.celery['worker_service_name'] = 'worker-notify'
+        with self.override_config('celery', dict(worker_service_name='worker-notify')):
+            t = fn_task.apply()
+            self.assertTrue(t.successful())
+            self.assertEqual(42, t.result)
 
-        @self.app.task
-        def fn_task():
-            return 42
-
-        t = fn_task.apply()
-        ok_(t.successful())
-        eq_(42, t.result)
-
-        traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
-        span = traces[0][0]
-        eq_(span.service, 'worker-notify')
+            traces = self.tracer.writer.pop_traces()
+            self.assertEqual(1, len(traces))
+            self.assertEqual(1, len(traces[0]))
+            span = traces[0][0]
+            self.assertEqual(span.service, 'worker-notify')
 
     def test_producer_service_name(self):
-        # Ensure producer service name can be changed via
-        # configuration object
-        config.celery['producer_service_name'] = 'task-queue'
-
         @self.app.task
         def fn_task():
             return 42
 
-        t = fn_task.delay()
-        eq_('PENDING', t.status)
+        # Ensure producer service name can be changed via
+        # configuration object
+        with self.override_config('celery', dict(producer_service_name='task-queue')):
+            t = fn_task.delay()
+            self.assertEqual('PENDING', t.status)
 
-        traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
-        span = traces[0][0]
-        eq_(span.service, 'task-queue')
+            traces = self.tracer.writer.pop_traces()
+            self.assertEqual(1, len(traces))
+            self.assertEqual(1, len(traces[0]))
+            span = traces[0][0]
+            self.assertEqual(span.service, 'task-queue')
 
     def test_fn_task_apply_async_ot(self):
         """OpenTracing version of test_fn_task_apply_async."""

--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -3,7 +3,6 @@ from celery.exceptions import Retry
 
 from nose.tools import eq_, ok_
 
-from ddtrace import config
 from ddtrace.contrib.celery import patch, unpatch
 
 from .base import CeleryBaseTestCase

--- a/tests/contrib/django/test_instrumentation.py
+++ b/tests/contrib/django/test_instrumentation.py
@@ -6,7 +6,6 @@ from ddtrace.contrib.django.conf import DatadogSettings
 
 # testing
 from .utils import DjangoTraceTestCase
-from ...util import set_env
 
 
 class DjangoInstrumentationTest(DjangoTraceTestCase):
@@ -23,7 +22,7 @@ class DjangoInstrumentationTest(DjangoTraceTestCase):
     def test_environment_vars(self):
         # Django defaults can be overridden by env vars, ensuring that
         # environment strings are properly converted
-        with set_env(
+        with self.override_env(
             DATADOG_TRACE_AGENT_HOSTNAME='agent.consul.local',
             DATADOG_TRACE_AGENT_PORT='58126'
         ):
@@ -34,6 +33,6 @@ class DjangoInstrumentationTest(DjangoTraceTestCase):
     def test_environment_var_wrong_port(self):
         # ensures that a wrong Agent Port doesn't crash the system
         # and defaults to 8126
-        with set_env(DATADOG_TRACE_AGENT_PORT='something'):
+        with self.override_env(DATADOG_TRACE_AGENT_PORT='something'):
             settings = DatadogSettings()
             eq_(settings.AGENT_PORT, 8126)

--- a/tests/contrib/django/test_instrumentation.py
+++ b/tests/contrib/django/test_instrumentation.py
@@ -22,10 +22,10 @@ class DjangoInstrumentationTest(DjangoTraceTestCase):
     def test_environment_vars(self):
         # Django defaults can be overridden by env vars, ensuring that
         # environment strings are properly converted
-        with self.override_env(
+        with self.override_env(dict(
             DATADOG_TRACE_AGENT_HOSTNAME='agent.consul.local',
             DATADOG_TRACE_AGENT_PORT='58126'
-        ):
+        )):
             settings = DatadogSettings()
             eq_(settings.AGENT_HOSTNAME, 'agent.consul.local')
             eq_(settings.AGENT_PORT, 58126)
@@ -33,6 +33,6 @@ class DjangoInstrumentationTest(DjangoTraceTestCase):
     def test_environment_var_wrong_port(self):
         # ensures that a wrong Agent Port doesn't crash the system
         # and defaults to 8126
-        with self.override_env(DATADOG_TRACE_AGENT_PORT='something'):
+        with self.override_env(dict(DATADOG_TRACE_AGENT_PORT='something')):
             settings = DatadogSettings()
             eq_(settings.AGENT_PORT, 8126)

--- a/tests/contrib/falcon/test_suite.py
+++ b/tests/contrib/falcon/test_suite.py
@@ -5,7 +5,6 @@ from ddtrace.constants import EVENT_SAMPLE_RATE_KEY
 from ddtrace.ext import errors as errx, http as httpx
 
 from tests.opentracer.utils import init_tracer
-from ...util import override_config
 
 
 class FalconTestCase(object):
@@ -193,7 +192,7 @@ class FalconTestCase(object):
         eq_(span.get_tag('my.custom'), 'tag')
 
     def test_http_header_tracing(self):
-        with override_config('falcon', {}):
+        with self.override_config('falcon', {}):
             config.falcon.http.trace_headers(['my-header', 'my-response-header'])
             self.simulate_get('/200', headers={'my-header': 'my_value'})
             traces = self.tracer.writer.pop_traces()

--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -5,7 +5,6 @@ from ddtrace.contrib.flask.patch import flask_version
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID, HTTP_HEADER_PARENT_ID
 from flask import abort
 
-from ...util import override_config
 from . import BaseFlaskTestCase
 
 
@@ -117,7 +116,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
             return 'Hello Flask', 200
 
         # Enable distributed tracing
-        with override_config('flask', dict(distributed_tracing_enabled=True)):
+        with self.override_config('flask', dict(distributed_tracing_enabled=True)):
             res = self.client.get('/', headers={
                 HTTP_HEADER_PARENT_ID: '12345',
                 HTTP_HEADER_TRACE_ID: '678910',
@@ -131,7 +130,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(span.parent_id, 12345)
 
         # With distributed tracing disabled
-        with override_config('flask', dict(distributed_tracing_enabled=False)):
+        with self.override_config('flask', dict(distributed_tracing_enabled=False)):
             res = self.client.get('/', headers={
                 HTTP_HEADER_PARENT_ID: '12345',
                 HTTP_HEADER_TRACE_ID: '678910',

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -15,8 +15,8 @@ from ddtrace.pin import Pin
 
 from tests.opentracer.utils import init_tracer
 
-from ...test_tracer import get_dummy_tracer
-from ...util import assert_dict_issuperset, override_global_tracer, override_config
+from ...base import BaseTracerTestCase
+from ...util import assert_dict_issuperset, override_global_tracer
 
 if PY2:
     from urllib2 import urlopen, build_opener, Request
@@ -39,16 +39,19 @@ class HTTPLibBaseMixin(object):
         return value.decode('utf-8')
 
     def setUp(self):
+        super(HTTPLibBaseMixin, self).setUp()
+
         patch()
-        self.tracer = get_dummy_tracer()
         Pin.override(httplib, tracer=self.tracer)
 
     def tearDown(self):
         unpatch()
 
+        super(HTTPLibBaseMixin, self).tearDown()
+
 
 # Main test cases for httplib/http.client and urllib2/urllib.request
-class HTTPLibTestCase(HTTPLibBaseMixin, unittest.TestCase):
+class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
     SPAN_NAME = 'httplib.request' if PY2 else 'http.client.request'
 
     def to_str(self, value):
@@ -64,13 +67,6 @@ class HTTPLibTestCase(HTTPLibBaseMixin, unittest.TestCase):
         conn = httplib.HTTPSConnection(*args, **kwargs)
         Pin.override(conn, tracer=self.tracer)
         return conn
-
-    def setUp(self):
-        patch()
-        self.tracer = get_dummy_tracer()
-
-    def tearDown(self):
-        unpatch()
 
     def test_patch(self):
         """
@@ -354,7 +350,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, unittest.TestCase):
             self.assertEqual(s.get_tag('http.response.headers.access_control_allow_origin'), None)
 
         # Enabled when configured
-        with override_config('hhtplib', {}):
+        with self.override_config('hhtplib', {}):
             integration_config = config.httplib  # type: IntegrationConfig
             integration_config.http.trace_headers(['my-header', 'access-control-allow-origin'])
             conn = self.get_http_connection(SOCKET)
@@ -502,7 +498,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, unittest.TestCase):
 if PY2:
     import urllib
 
-    class HTTPLibPython2Test(HTTPLibBaseMixin, unittest.TestCase):
+    class HTTPLibPython2Test(HTTPLibBaseMixin, BaseTracerTestCase):
         def test_urllib_request(self):
             """
             When making a request via urllib.urlopen

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -1,7 +1,6 @@
 # Standard library
 import contextlib
 import sys
-import unittest
 
 # Third party
 import wrapt

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -11,7 +11,6 @@ from ddtrace.contrib.molten import patch, unpatch
 from ddtrace.contrib.molten.patch import MOLTEN_VERSION
 
 from ...base import BaseTracerTestCase
-from ...util import override_config
 
 
 # NOTE: Type annotations required by molten otherwise parameters cannot be coerced
@@ -158,7 +157,7 @@ class TestMolten(BaseTracerTestCase):
 
     def test_distributed_tracing(self):
         """ Tests whether span IDs are propogated when distributed tracing is on """
-        with override_config('molten', dict(distributed_tracing=True)):
+        with self.override_config('molten', dict(distributed_tracing=True)):
             response = molten_client(headers={
                 HTTP_HEADER_TRACE_ID: '100',
                 HTTP_HEADER_PARENT_ID: '42',
@@ -173,7 +172,7 @@ class TestMolten(BaseTracerTestCase):
         self.assertEqual(span.parent_id, 42)
 
         # Now without tracing on
-        with override_config('molten', dict(distributed_tracing=False)):
+        with self.override_config('molten', dict(distributed_tracing=False)):
             response = molten_client(headers={
                 HTTP_HEADER_TRACE_ID: '100',
                 HTTP_HEADER_PARENT_ID: '42',

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -11,8 +11,8 @@ from nose.tools import assert_raises, eq_
 
 from tests.opentracer.utils import init_tracer
 
-from ...test_tracer import get_dummy_tracer
-from ...util import override_global_tracer, override_config
+from ...base import BaseTracerTestCase
+from ...util import override_global_tracer
 
 # socket name comes from https://english.stackexchange.com/a/44048
 SOCKET = 'httpbin.org'
@@ -20,21 +20,24 @@ URL_200 = 'http://{}/status/200'.format(SOCKET)
 URL_500 = 'http://{}/status/500'.format(SOCKET)
 
 
-class BaseRequestTestCase(unittest.TestCase):
+class BaseRequestTestCase(object):
     """Create a traced Session, patching during the setUp and
     unpatching after the tearDown
     """
     def setUp(self):
+        super(BaseRequestTestCase, self).setUp()
+
         patch()
-        self.tracer = get_dummy_tracer()
         self.session = Session()
         setattr(self.session, 'datadog_tracer', self.tracer)
 
     def tearDown(self):
         unpatch()
 
+        super(BaseRequestTestCase, self).tearDown()
 
-class TestRequests(BaseRequestTestCase):
+
+class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
     def test_resource_path(self):
         out = self.session.get(URL_200)
         eq_(out.status_code, 200)
@@ -375,7 +378,7 @@ class TestRequests(BaseRequestTestCase):
         eq_(s.get_tag('http.response.headers.access-control-allow-origin'), None)
 
         # Enabled when explicitly configured
-        with override_config('requests', {}):
+        with self.override_config('requests', {}):
             config.requests.http.trace_headers(['my-header', 'access-control-allow-origin'])
             self.session.get(URL_200, headers={'my-header': 'my_value'})
             spans = self.tracer.writer.pop()

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -1,5 +1,3 @@
-import unittest
-
 import requests
 from requests import Session
 from requests.exceptions import MissingSchema

--- a/tests/contrib/requests/test_requests_distributed.py
+++ b/tests/contrib/requests/test_requests_distributed.py
@@ -3,10 +3,11 @@ from nose.tools import eq_, assert_in, assert_not_in
 
 from ddtrace import config
 
+from ...base import BaseTracerTestCase
 from .test_requests import BaseRequestTestCase
 
 
-class TestRequestsDistributed(BaseRequestTestCase):
+class TestRequestsDistributed(BaseRequestTestCase, BaseTracerTestCase):
     def headers_here(self, tracer, request, root_span):
         # Use an additional matcher to query the request headers.
         # This is because the parent_id can only been known within such a callback,

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,10 +1,9 @@
 import os
 import sys
 import mock
-import ddtrace
 
+import ddtrace
 from ddtrace import __file__ as root_file
-from ddtrace import config
 from nose.tools import ok_
 from contextlib import contextmanager
 
@@ -65,23 +64,6 @@ def override_global_tracer(tracer):
     ddtrace.tracer = tracer
     yield
     ddtrace.tracer = original_tracer
-
-
-@contextmanager
-def set_env(**environ):
-    """
-    Temporarily set the process environment variables.
-
-    >>> with set_env(DEFAULT_SERVICE='my-webapp'):
-            # your test
-    """
-    old_environ = dict(os.environ)
-    os.environ.update(environ)
-    try:
-        yield
-    finally:
-        os.environ.clear()
-        os.environ.update(old_environ)
 
 
 def inject_sitecustomize(path):

--- a/tests/util.py
+++ b/tests/util.py
@@ -68,27 +68,6 @@ def override_global_tracer(tracer):
 
 
 @contextmanager
-def override_config(integration, values):
-    """
-    Temporarily override an integration configuration value
-    >>> with override_config('flask', dict(service_name='test-service')):
-        # Your test
-    """
-    options = getattr(config, integration)
-
-    original = dict(
-        (key, options.get(key))
-        for key in values.keys()
-    )
-
-    options.update(values)
-    try:
-        yield
-    finally:
-        options.update(original)
-
-
-@contextmanager
 def set_env(**environ):
     """
     Temporarily set the process environment variables.


### PR DESCRIPTION
This PR ensures consistent use of our base `override_config` and `override_env` helpers from the `tests.base.BaseTestCase`