### PR TITLE
[bug] Integration config keys not being updated

### DIFF
--- a/ddtrace/utils/attrdict.py
+++ b/ddtrace/utils/attrdict.py
@@ -22,8 +22,15 @@ class AttrDict(dict):
         return object.__getattribute__(self, key)
 
     def __setattr__(self, key, value):
-        # Allow overwriting an existing attribute, e.g. `self.global_config = dict()`
-        if hasattr(self, key):
+        # 1) Ensure if the key exists from a dict key we always prefer that
+        # 2) If we do not have an existing key but we do have an attr, set that
+        # 3) No existing key or attr exists, so set a key
+        if key in self:
+            # Update any existing key
+            self[key] = value
+        elif hasattr(self, key):
+            # Allow overwriting an existing attribute, e.g. `self.global_config = dict()`
             object.__setattr__(self, key, value)
         else:
+            # Set a new key
             self[key] = value

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -4,6 +4,7 @@ from nose.tools import eq_, ok_
 
 from ddtrace import config
 from ddtrace.pin import Pin
+from ddtrace.settings import IntegrationConfig
 
 
 class InstanceConfigTestCase(TestCase):
@@ -100,3 +101,32 @@ class InstanceConfigTestCase(TestCase):
         cfg = config.get_from(instance)
         # it should have users updated value
         eq_(cfg['service_name'], 'metrics')
+
+    def test_config_attr_and_key(self):
+        """
+        This is a regression test for when mixing attr attribute and key
+        access we would set the value of the attribute but not the key
+        """
+        integration_config = IntegrationConfig(config)
+
+        # Our key and attribute do not exist
+        self.assertFalse(hasattr(integration_config, 'distributed_tracing'))
+        self.assertNotIn('distributed_tracing', integration_config)
+
+        # Initially set and access
+        integration_config['distributed_tracing'] = True
+        self.assertTrue(integration_config['distributed_tracing'])
+        self.assertTrue(integration_config.get('distributed_tracing'))
+        self.assertTrue(integration_config.distributed_tracing)
+
+        # Override by key and access
+        integration_config['distributed_tracing'] = False
+        self.assertFalse(integration_config['distributed_tracing'])
+        self.assertFalse(integration_config.get('distributed_tracing'))
+        self.assertFalse(integration_config.distributed_tracing)
+
+        # Override by attr and access
+        integration_config.distributed_tracing = None
+        self.assertIsNone(integration_config['distributed_tracing'])
+        self.assertIsNone(integration_config.get('distributed_tracing'))
+        self.assertIsNone(integration_config.distributed_tracing)


### PR DESCRIPTION
This PR fixes a `__setattr__` priority issue we found for `IntegrationConfig`.

The problem was:

```python
from ddtrace import config

config._add('flask', dict(distributed_tracing_enabled=False))

config.flask.distributed_tracing_enabled = True

# This is correct
assert config.flask.distributed_tracing_enabled is True

# This fails
assert config.flask['distributed_tracing_enabled'] is True
```

The reason this is an issue is because initial we set a config key which gets is accessible as an item and an attribute. When we go to update as an attribute we see that an attribute already exists so we use `object.__setattr__(self, key, value)` to update it instead of `self[key] = value` like we should.

The change here ensures we always consider items first when calling `__setattr__`.