### PR TITLE
Release 0.20.4

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -4,7 +4,7 @@ from .span import Span
 from .tracer import Tracer
 from .settings import config
 
-__version__ = '0.20.3'
+__version__ = '0.20.4'
 
 # a global tracer instance with integration settings
 tracer = Tracer()

--- a/ddtrace/utils/attrdict.py
+++ b/ddtrace/utils/attrdict.py
@@ -22,8 +22,15 @@ class AttrDict(dict):
         return object.__getattribute__(self, key)
 
     def __setattr__(self, key, value):
-        # Allow overwriting an existing attribute, e.g. `self.global_config = dict()`
-        if hasattr(self, key):
+        # 1) Ensure if the key exists from a dict key we always prefer that
+        # 2) If we do not have an existing key but we do have an attr, set that
+        # 3) No existing key or attr exists, so set a key
+        if key in self:
+            # Update any existing key
+            self[key] = value
+        elif hasattr(self, key):
+            # Allow overwriting an existing attribute, e.g. `self.global_config = dict()`
             object.__setattr__(self, key, value)
         else:
+            # Set a new key
             self[key] = value

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -4,6 +4,7 @@ from nose.tools import eq_, ok_
 
 from ddtrace import config
 from ddtrace.pin import Pin
+from ddtrace.settings import IntegrationConfig
 
 
 class InstanceConfigTestCase(TestCase):
@@ -100,3 +101,32 @@ class InstanceConfigTestCase(TestCase):
         cfg = config.get_from(instance)
         # it should have users updated value
         eq_(cfg['service_name'], 'metrics')
+
+    def test_config_attr_and_key(self):
+        """
+        This is a regression test for when mixing attr attribute and key
+        access we would set the value of the attribute but not the key
+        """
+        integration_config = IntegrationConfig(config)
+
+        # Our key and attribute do not exist
+        self.assertFalse(hasattr(integration_config, 'distributed_tracing'))
+        self.assertNotIn('distributed_tracing', integration_config)
+
+        # Initially set and access
+        integration_config['distributed_tracing'] = True
+        self.assertTrue(integration_config['distributed_tracing'])
+        self.assertTrue(integration_config.get('distributed_tracing'))
+        self.assertTrue(integration_config.distributed_tracing)
+
+        # Override by key and access
+        integration_config['distributed_tracing'] = False
+        self.assertFalse(integration_config['distributed_tracing'])
+        self.assertFalse(integration_config.get('distributed_tracing'))
+        self.assertFalse(integration_config.distributed_tracing)
+
+        # Override by attr and access
+        integration_config.distributed_tracing = None
+        self.assertIsNone(integration_config['distributed_tracing'])
+        self.assertIsNone(integration_config.get('distributed_tracing'))
+        self.assertIsNone(integration_config.distributed_tracing)


### PR DESCRIPTION
## Upgrading to 0.20.4

This is a bug fix release, no code changes are required.

In this release we have fixed a bug that caused some configuration values to not get updated when set.

## Changes
### Bug fixes
* [bug] Integration config keys not being updated (#816)

Read the [full changeset](https://github.com/DataDog/dd-trace-py/compare/v0.20.3...v0.20.4) and the [release milestone](https://github.com/DataDog/dd-trace-py/milestone/37?closed=1).
