### PR TITLE
Add a split-by-host option to dbapi2

### DIFF
--- a/tests/contrib/dbapi/test_unit.py
+++ b/tests/contrib/dbapi/test_unit.py
@@ -386,6 +386,24 @@ class TestTracedConnection(BaseTracerTestCase):
         super(TestTracedConnection, self).setUp()
         self.connection = mock.Mock()
 
+    def test_split_by_host(self):
+        connection = self.connection
+        connection.host = 'hostname'
+
+        with self.override_config('dbapi2', {'split_by_host': True}):
+            pin = Pin('pin_name', tracer=self.tracer)
+            traced_connection = TracedConnection(connection, pin)
+
+            pin = Pin.get_from(traced_connection)
+            assert pin.service == 'hostname'
+
+        with self.override_config('dbapi2', {'split_by_host': False}):
+            pin = Pin('pin_name', tracer=self.tracer)
+            traced_connection = TracedConnection(connection, pin)
+
+            pin = Pin.get_from(traced_connection)
+            assert pin.service == 'pin_name'
+
     def test_cursor_class(self):
         pin = Pin('pin_name', tracer=self.tracer)
 


### PR DESCRIPTION
This is similar to the requests module's `split_by_domain`. This will be useful when multiple services talk to their own DB services that use similar drivers. In such a case, it's useful to split the services in APM to provide better scoped traces and service maps.