### PR TITLE
Release 0.22.0

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -4,7 +4,7 @@ from .span import Span
 from .tracer import Tracer
 from .settings import config
 
-__version__ = '0.21.1'
+__version__ = '0.22.0'
 
 # a global tracer instance with integration settings
 tracer = Tracer()

--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -2,7 +2,7 @@ import platform
 import sys
 import textwrap
 
-import six
+from ddtrace.vendor import six
 
 __all__ = [
     'httplib',

--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -1,6 +1,7 @@
 FILTERS_KEY = 'FILTERS'
 SAMPLE_RATE_METRIC_KEY = '_sample_rate'
 SAMPLING_PRIORITY_KEY = '_sampling_priority_v1'
+ORIGIN_KEY = '_dd.origin'
 EVENT_SAMPLE_RATE_KEY = '_dd1.sr.eausr'
 
 NUMERIC_TAGS = (EVENT_SAMPLE_RATE_KEY, )

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 
-from .constants import SAMPLING_PRIORITY_KEY
+from .constants import SAMPLING_PRIORITY_KEY, ORIGIN_KEY
 from .utils.formats import asbool, get_env
 
 log = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class Context(object):
     _partial_flush_enabled = asbool(get_env('tracer', 'partial_flush_enabled', 'false'))
     _partial_flush_min_spans = int(get_env('tracer', 'partial_flush_min_spans', 500))
 
-    def __init__(self, trace_id=None, span_id=None, sampled=True, sampling_priority=None):
+    def __init__(self, trace_id=None, span_id=None, sampled=True, sampling_priority=None, _dd_origin=None):
         """
         Initialize a new thread-safe ``Context``.
 
@@ -41,6 +41,7 @@ class Context(object):
         self._parent_span_id = span_id
         self._sampled = sampled
         self._sampling_priority = sampling_priority
+        self._dd_origin = _dd_origin
 
     @property
     def trace_id(self):
@@ -184,6 +185,10 @@ class Context(object):
                 # attach the sampling priority to the context root span
                 if sampled and sampling_priority is not None and trace:
                     trace[0].set_metric(SAMPLING_PRIORITY_KEY, sampling_priority)
+                origin = self._dd_origin
+                # attach the origin to the root span tag
+                if sampled and origin is not None and trace:
+                    trace[0].set_tag(ORIGIN_KEY, origin)
 
                 # clean the current state
                 self._trace = []
@@ -202,6 +207,10 @@ class Context(object):
                 # attach the sampling priority to the context root span
                 if sampled and sampling_priority is not None and trace:
                     trace[0].set_metric(SAMPLING_PRIORITY_KEY, sampling_priority)
+                origin = self._dd_origin
+                # attach the origin to the root span tag
+                if sampled and origin is not None and trace:
+                    trace[0].set_tag(ORIGIN_KEY, origin)
 
                 # Any open spans will remain as `self._trace`
                 # Any finished spans will get returned to be flushed

--- a/ddtrace/contrib/aiobotocore/patch.py
+++ b/ddtrace/contrib/aiobotocore/patch.py
@@ -1,5 +1,5 @@
 import asyncio
-import wrapt
+from ddtrace.vendor import wrapt
 import aiobotocore.client
 
 from aiobotocore.endpoint import ClientResponseContentProxy

--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -1,4 +1,4 @@
-import wrapt
+from ddtrace.vendor import wrapt
 
 from ...pin import Pin
 from ...utils.wrappers import unwrap

--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -1,5 +1,5 @@
 import asyncio
-import wrapt
+from ddtrace.vendor import wrapt
 
 from aiopg.utils import _ContextManager
 

--- a/ddtrace/contrib/aiopg/patch.py
+++ b/ddtrace/contrib/aiopg/patch.py
@@ -3,7 +3,7 @@ import asyncio
 
 import aiopg.connection
 import psycopg2.extensions
-import wrapt
+from ddtrace.vendor import wrapt
 
 from .connection import AIOTracedConnection
 from ..psycopg.patch import _patch_extensions, \

--- a/ddtrace/contrib/asyncio/patch.py
+++ b/ddtrace/contrib/asyncio/patch.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from wrapt import wrap_function_wrapper as _w
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from .helpers import _wrapped_create_task
 from ...utils.wrappers import unwrap as _u

--- a/ddtrace/contrib/boto/patch.py
+++ b/ddtrace/contrib/boto/patch.py
@@ -1,5 +1,5 @@
 import boto.connection
-import wrapt
+from ddtrace.vendor import wrapt
 import inspect
 
 from ...pin import Pin
@@ -105,10 +105,15 @@ def patched_auth_request(original_func, instance, args, kwargs):
 
     # Catching the name of the operation that called make_request()
     operation_name = None
+
+    # Go up the stack until we get the first non-ddtrace module
+    # DEV: For `lambda.list_functions()` this should be:
+    #        - ddtrace.contrib.boto.patch
+    #        - ddtrace.vendor.wrapt.wrappers
+    #        - boto.awslambda.layer1 (make_request)
+    #        - boto.awslambda.layer1 (list_functions)
     frame = inspect.currentframe()
-    # go up the call stack twice to get into the boto frame
-    boto_frame = frame.f_back.f_back
-    operation_name = boto_frame.f_code.co_name
+    operation_name = frame.f_back.f_back.f_back.f_code.co_name
 
     pin = Pin.get_from(instance)
     if not pin or not pin.enabled():

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -2,7 +2,7 @@
 Trace queries to aws api done via botocore client
 """
 # 3p
-import wrapt
+from ddtrace.vendor import wrapt
 import botocore.client
 
 # project

--- a/ddtrace/contrib/bottle/patch.py
+++ b/ddtrace/contrib/bottle/patch.py
@@ -4,7 +4,7 @@ from .trace import TracePlugin
 
 import bottle
 
-import wrapt
+from ddtrace.vendor import wrapt
 
 
 def patch():

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -5,7 +5,7 @@ import sys
 import logging
 # 3p
 import cassandra.cluster
-import wrapt
+from ddtrace.vendor import wrapt
 
 # project
 from ddtrace import Pin

--- a/ddtrace/contrib/celery/signals.py
+++ b/ddtrace/contrib/celery/signals.py
@@ -5,13 +5,7 @@ from ddtrace import Pin, config
 from celery import registry
 
 from . import constants as c
-from .utils import (
-    tags_from_context,
-    retrieve_task_id,
-    attach_span,
-    detach_span,
-    retrieve_span,
-)
+from .utils import tags_from_context, retrieve_task_id, attach_span, detach_span, retrieve_span
 
 log = logging.getLogger(__name__)
 SPAN_TYPE = 'worker'
@@ -128,6 +122,8 @@ def trace_failure(*args, **kwargs):
         # so we don't need to attach other tags here
         ex = kwargs.get('einfo')
         if ex is None:
+            return
+        if hasattr(task, 'throws') and isinstance(ex.exception, task.throws):
             return
         span.set_exc_info(ex.type, ex.exception, ex.tb)
 

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -4,7 +4,7 @@ Generic dbapi tracing code.
 
 import logging
 
-import wrapt
+from ddtrace.vendor import wrapt
 
 from ddtrace import Pin
 from ddtrace.ext import AppTypes, sql

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -1,4 +1,4 @@
-import wrapt
+from ddtrace.vendor import wrapt
 
 import django
 

--- a/ddtrace/contrib/django/restframework.py
+++ b/ddtrace/contrib/django/restframework.py
@@ -1,4 +1,4 @@
-from wrapt import wrap_function_wrapper as wrap
+from ddtrace.vendor.wrapt import wrap_function_wrapper as wrap
 
 from rest_framework.views import APIView
 

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -1,6 +1,6 @@
 from importlib import import_module
 
-from wrapt import wrap_function_wrapper as _w
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from .quantize import quantize
 

--- a/ddtrace/contrib/falcon/patch.py
+++ b/ddtrace/contrib/falcon/patch.py
@@ -1,5 +1,5 @@
 import os
-import wrapt
+from ddtrace.vendor import wrapt
 import falcon
 
 from ddtrace import tracer

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -3,7 +3,7 @@ import os
 
 import flask
 import werkzeug
-from wrapt import wrap_function_wrapper as _w
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config, Pin
 

--- a/ddtrace/contrib/flask/wrappers.py
+++ b/ddtrace/contrib/flask/wrappers.py
@@ -1,4 +1,4 @@
-from wrapt import function_wrapper
+from ddtrace.vendor.wrapt import function_wrapper
 
 from ...pin import Pin
 from ...utils.importlib import func_name

--- a/ddtrace/contrib/futures/patch.py
+++ b/ddtrace/contrib/futures/patch.py
@@ -1,6 +1,6 @@
 from concurrent import futures
 
-from wrapt import wrap_function_wrapper as _w
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from .threading import _wrap_submit
 from ...utils.wrappers import unwrap as _u

--- a/ddtrace/contrib/grpc/patch.py
+++ b/ddtrace/contrib/grpc/patch.py
@@ -1,5 +1,5 @@
 import grpc
-import wrapt
+from ddtrace.vendor import wrapt
 
 from ddtrace import Pin
 from ...utils.wrappers import unwrap

--- a/ddtrace/contrib/httplib/patch.py
+++ b/ddtrace/contrib/httplib/patch.py
@@ -2,7 +2,7 @@
 import logging
 
 # Third party
-import wrapt
+from ddtrace.vendor import wrapt
 
 # Project
 from ...compat import PY2, httplib, parse

--- a/ddtrace/contrib/jinja2/patch.py
+++ b/ddtrace/contrib/jinja2/patch.py
@@ -1,5 +1,5 @@
 import jinja2
-from wrapt import wrap_function_wrapper as _w
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
 

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -1,6 +1,6 @@
 # 3p
 import kombu
-import wrapt
+from ddtrace.vendor import wrapt
 
 # project
 from ddtrace import config

--- a/ddtrace/contrib/logging/patch.py
+++ b/ddtrace/contrib/logging/patch.py
@@ -1,10 +1,10 @@
 import logging
-from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
 
 from ...helpers import get_correlation_ids
 from ...utils.wrappers import unwrap as _u
+from ...vendor.wrapt import wrap_function_wrapper as _w
 
 RECORD_ATTR_TRACE_ID = 'dd.trace_id'
 RECORD_ATTR_SPAN_ID = 'dd.span_id'

--- a/ddtrace/contrib/mako/patch.py
+++ b/ddtrace/contrib/mako/patch.py
@@ -1,11 +1,11 @@
 import mako
 from mako.template import Template
-from wrapt import wrap_function_wrapper as _w
 
 from ...ext import http
 from ...pin import Pin
 from ...utils.importlib import func_name
 from ...utils.wrappers import unwrap as _u
+from ...vendor.wrapt import wrap_function_wrapper as _w
 from .constants import DEFAULT_TEMPLATE_NAME
 
 

--- a/ddtrace/contrib/molten/patch.py
+++ b/ddtrace/contrib/molten/patch.py
@@ -1,5 +1,5 @@
-import wrapt
-from wrapt import wrap_function_wrapper as _w
+from ddtrace.vendor import wrapt
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 import molten
 

--- a/ddtrace/contrib/molten/wrappers.py
+++ b/ddtrace/contrib/molten/wrappers.py
@@ -1,4 +1,4 @@
-import wrapt
+from ddtrace.vendor import wrapt
 import molten
 
 from ... import Pin

--- a/ddtrace/contrib/mongoengine/trace.py
+++ b/ddtrace/contrib/mongoengine/trace.py
@@ -1,6 +1,6 @@
 
 # 3p
-import wrapt
+from ddtrace.vendor import wrapt
 
 # project
 import ddtrace

--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -1,5 +1,5 @@
 # 3p
-import wrapt
+from ddtrace.vendor import wrapt
 import mysql.connector
 
 # project

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -1,7 +1,7 @@
 # 3p
 import MySQLdb
 
-from wrapt import wrap_function_wrapper as _w
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 # project
 from ddtrace import Pin

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -1,6 +1,6 @@
 # 3p
 import psycopg2
-import wrapt
+from ddtrace.vendor import wrapt
 
 # project
 from ddtrace import Pin, config

--- a/ddtrace/contrib/pylibmc/client.py
+++ b/ddtrace/contrib/pylibmc/client.py
@@ -4,7 +4,7 @@ import logging
 import random
 
 # 3p
-from wrapt import ObjectProxy
+from ddtrace.vendor.wrapt import ObjectProxy
 import pylibmc
 
 # project

--- a/ddtrace/contrib/pylons/patch.py
+++ b/ddtrace/contrib/pylons/patch.py
@@ -1,5 +1,5 @@
 import os
-import wrapt
+from ddtrace.vendor import wrapt
 import pylons.wsgiapp
 
 from ddtrace import tracer, Pin

--- a/ddtrace/contrib/pylons/renderer.py
+++ b/ddtrace/contrib/pylons/renderer.py
@@ -2,7 +2,7 @@ import pylons
 
 from pylons import config
 
-from wrapt import wrap_function_wrapper as _w
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from .compat import legacy_pylons
 from .constants import CONFIG_MIDDLEWARE

--- a/ddtrace/contrib/pymemcache/client.py
+++ b/ddtrace/contrib/pymemcache/client.py
@@ -3,7 +3,7 @@ import logging
 import sys
 
 # 3p
-import wrapt
+from ddtrace.vendor import wrapt
 import pymemcache
 from pymemcache.client.base import Client
 from pymemcache.exceptions import (

--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -5,7 +5,7 @@ import json
 
 # 3p
 import pymongo
-from wrapt import ObjectProxy
+from ddtrace.vendor.wrapt import ObjectProxy
 
 # project
 import ddtrace

--- a/ddtrace/contrib/pymysql/patch.py
+++ b/ddtrace/contrib/pymysql/patch.py
@@ -1,5 +1,5 @@
 # 3p
-import wrapt
+from ddtrace.vendor import wrapt
 import pymysql
 
 # project

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -3,7 +3,7 @@ import logging
 import pyramid.renderers
 from pyramid.settings import asbool
 from pyramid.httpexceptions import HTTPException
-import wrapt
+from ddtrace.vendor import wrapt
 
 # project
 import ddtrace

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -1,6 +1,6 @@
 # 3p
 import redis
-import wrapt
+from ddtrace.vendor import wrapt
 
 # project
 from ...pin import Pin

--- a/ddtrace/contrib/rediscluster/patch.py
+++ b/ddtrace/contrib/rediscluster/patch.py
@@ -1,6 +1,6 @@
 # 3p
 import rediscluster
-import wrapt
+from ddtrace.vendor import wrapt
 
 # project
 from ...pin import Pin

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -1,6 +1,6 @@
 import requests
 
-from wrapt import wrap_function_wrapper as _w
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
 

--- a/ddtrace/contrib/requests/session.py
+++ b/ddtrace/contrib/requests/session.py
@@ -1,6 +1,6 @@
 import requests
 
-from wrapt import wrap_function_wrapper as _w
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from .connection import _wrap_send
 

--- a/ddtrace/contrib/sqlalchemy/patch.py
+++ b/ddtrace/contrib/sqlalchemy/patch.py
@@ -1,6 +1,6 @@
 import sqlalchemy
 
-from wrapt import wrap_function_wrapper as _w
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from .engine import _wrap_create_engine
 from ...utils.wrappers import unwrap

--- a/ddtrace/contrib/sqlite3/patch.py
+++ b/ddtrace/contrib/sqlite3/patch.py
@@ -1,7 +1,7 @@
 # 3p
 import sqlite3
 import sqlite3.dbapi2
-import wrapt
+from ddtrace.vendor import wrapt
 
 # project
 from ...contrib.dbapi import TracedConnection, TracedCursor, FetchTracedCursor

--- a/ddtrace/contrib/tornado/patch.py
+++ b/ddtrace/contrib/tornado/patch.py
@@ -1,7 +1,7 @@
 import ddtrace
 import tornado
 
-from wrapt import wrap_function_wrapper as _w
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from . import handlers, application, decorators, template, compat, context_provider
 from ...utils.wrappers import unwrap as _u

--- a/ddtrace/contrib/vertica/patch.py
+++ b/ddtrace/contrib/vertica/patch.py
@@ -1,7 +1,7 @@
 import importlib
 import logging
 
-import wrapt
+from ddtrace.vendor import wrapt
 
 import ddtrace
 from ddtrace import config, Pin

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -11,7 +11,7 @@ import logging
 import sys
 import threading
 
-from wrapt.importer import when_imported
+from ddtrace.vendor.wrapt.importer import when_imported
 
 
 log = logging.getLogger(__name__)

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -1,6 +1,6 @@
 import logging
 
-import wrapt
+from ddtrace.vendor import wrapt
 import ddtrace
 
 

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -11,6 +11,7 @@ log = logging.getLogger(__name__)
 HTTP_HEADER_TRACE_ID = "x-datadog-trace-id"
 HTTP_HEADER_PARENT_ID = "x-datadog-parent-id"
 HTTP_HEADER_SAMPLING_PRIORITY = "x-datadog-sampling-priority"
+HTTP_HEADER_ORIGIN = "x-datadog-origin"
 
 
 # Note that due to WSGI spec we have to also check for uppercased and prefixed
@@ -23,6 +24,9 @@ POSSIBLE_HTTP_HEADER_PARENT_IDS = frozenset(
 )
 POSSIBLE_HTTP_HEADER_SAMPLING_PRIORITIES = frozenset(
     [HTTP_HEADER_SAMPLING_PRIORITY, get_wsgi_header(HTTP_HEADER_SAMPLING_PRIORITY)]
+)
+POSSIBLE_HTTP_HEADER_ORIGIN = frozenset(
+    [HTTP_HEADER_ORIGIN, get_wsgi_header(HTTP_HEADER_ORIGIN)]
 )
 
 
@@ -54,6 +58,9 @@ class HTTPPropagator(object):
         # Propagate priority only if defined
         if sampling_priority is not None:
             headers[HTTP_HEADER_SAMPLING_PRIORITY] = str(span_context.sampling_priority)
+        # Propagate origin only if defined
+        if span_context._dd_origin is not None:
+            headers[HTTP_HEADER_ORIGIN] = str(span_context._dd_origin)
 
     @staticmethod
     def extract_header_value(possible_header_names, headers, default=None):
@@ -86,6 +93,12 @@ class HTTPPropagator(object):
             POSSIBLE_HTTP_HEADER_SAMPLING_PRIORITIES, headers,
         )
 
+    @staticmethod
+    def extract_origin(headers):
+        return HTTPPropagator.extract_header_value(
+            POSSIBLE_HTTP_HEADER_ORIGIN, headers,
+        )
+
     def extract(self, headers):
         """Extract a Context from HTTP headers into a new Context.
 
@@ -111,6 +124,7 @@ class HTTPPropagator(object):
             trace_id = HTTPPropagator.extract_trace_id(headers)
             parent_span_id = HTTPPropagator.extract_parent_span_id(headers)
             sampling_priority = HTTPPropagator.extract_sampling_priority(headers)
+            origin = HTTPPropagator.extract_origin(headers)
 
             if sampling_priority is not None:
                 sampling_priority = int(sampling_priority)
@@ -119,15 +133,17 @@ class HTTPPropagator(object):
                 trace_id=trace_id,
                 span_id=parent_span_id,
                 sampling_priority=sampling_priority,
+                _dd_origin=origin,
             )
         # If headers are invalid and cannot be parsed, return a new context and log the issue.
         except Exception as error:
             try:
                 log.debug(
-                    "invalid x-datadog-* headers, trace-id: %s, parent-id: %s, priority: %s, error: %s",
+                    "invalid x-datadog-* headers, trace-id: %s, parent-id: %s, priority: %s, origin: %s, error: %s",
                     headers.get(HTTP_HEADER_TRACE_ID, 0),
                     headers.get(HTTP_HEADER_PARENT_ID, 0),
                     headers.get(HTTP_HEADER_SAMPLING_PRIORITY),
+                    headers.get(HTTP_HEADER_ORIGIN, ''),
                     error,
                 )
             # We might fail on string formatting errors ; in that case only format the first error

--- a/ddtrace/utils/wrappers.py
+++ b/ddtrace/utils/wrappers.py
@@ -1,4 +1,4 @@
-import wrapt
+from ddtrace.vendor import wrapt
 import inspect
 
 from .deprecation import deprecated

--- a/ddtrace/vendor/__init__.py
+++ b/ddtrace/vendor/__init__.py
@@ -1,0 +1,36 @@
+"""
+ddtrace.vendor
+==============
+Install vendored dependencies under a different top level package to avoid importing `ddtrace/__init__.py`
+whenever a dependency is imported. Doing this allows us to have a little more control over import order.
+
+
+Dependencies
+============
+
+six
+---
+
+Website: https://six.readthedocs.io/
+Source: https://github.com/benjaminp/six
+Version: 1.11.0
+License: MIT
+
+Notes:
+  `six/__init__.py` is just the source code's `six.py`
+  `curl https://raw.githubusercontent.com/benjaminp/six/1.11.0/six.py > ddtrace/vendor/six/__init__.py`
+
+
+wrapt
+-----
+
+Website: https://wrapt.readthedocs.io/en/latest/
+Source: https://github.com/GrahamDumpleton/wrapt/
+Version: 1.11.1
+License: BSD 2-Clause "Simplified" License
+
+Notes:
+  `wrapt/__init__.py` was updated to include a copy of `wrapt`'s license: https://github.com/GrahamDumpleton/wrapt/blob/1.11.1/LICENSE
+
+  `setup.py` will attempt to build the `wrapt/_wrappers.c` C module
+"""

--- a/ddtrace/vendor/six/__init__.py
+++ b/ddtrace/vendor/six/__init__.py
@@ -1,0 +1,891 @@
+# Copyright (c) 2010-2017 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Utilities for writing code that runs on Python 2 and 3"""
+
+from __future__ import absolute_import
+
+import functools
+import itertools
+import operator
+import sys
+import types
+
+__author__ = "Benjamin Peterson <benjamin@python.org>"
+__version__ = "1.11.0"
+
+
+# Useful for very coarse version differentiation.
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+PY34 = sys.version_info[0:2] >= (3, 4)
+
+if PY3:
+    string_types = str,
+    integer_types = int,
+    class_types = type,
+    text_type = str
+    binary_type = bytes
+
+    MAXSIZE = sys.maxsize
+else:
+    string_types = basestring,
+    integer_types = (int, long)
+    class_types = (type, types.ClassType)
+    text_type = unicode
+    binary_type = str
+
+    if sys.platform.startswith("java"):
+        # Jython always uses 32 bits.
+        MAXSIZE = int((1 << 31) - 1)
+    else:
+        # It's possible to have sizeof(long) != sizeof(Py_ssize_t).
+        class X(object):
+
+            def __len__(self):
+                return 1 << 31
+        try:
+            len(X())
+        except OverflowError:
+            # 32-bit
+            MAXSIZE = int((1 << 31) - 1)
+        else:
+            # 64-bit
+            MAXSIZE = int((1 << 63) - 1)
+        del X
+
+
+def _add_doc(func, doc):
+    """Add documentation to a function."""
+    func.__doc__ = doc
+
+
+def _import_module(name):
+    """Import module, returning the module after the last dot."""
+    __import__(name)
+    return sys.modules[name]
+
+
+class _LazyDescr(object):
+
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, obj, tp):
+        result = self._resolve()
+        setattr(obj, self.name, result)  # Invokes __set__.
+        try:
+            # This is a bit ugly, but it avoids running this again by
+            # removing this descriptor.
+            delattr(obj.__class__, self.name)
+        except AttributeError:
+            pass
+        return result
+
+
+class MovedModule(_LazyDescr):
+
+    def __init__(self, name, old, new=None):
+        super(MovedModule, self).__init__(name)
+        if PY3:
+            if new is None:
+                new = name
+            self.mod = new
+        else:
+            self.mod = old
+
+    def _resolve(self):
+        return _import_module(self.mod)
+
+    def __getattr__(self, attr):
+        _module = self._resolve()
+        value = getattr(_module, attr)
+        setattr(self, attr, value)
+        return value
+
+
+class _LazyModule(types.ModuleType):
+
+    def __init__(self, name):
+        super(_LazyModule, self).__init__(name)
+        self.__doc__ = self.__class__.__doc__
+
+    def __dir__(self):
+        attrs = ["__doc__", "__name__"]
+        attrs += [attr.name for attr in self._moved_attributes]
+        return attrs
+
+    # Subclasses should override this
+    _moved_attributes = []
+
+
+class MovedAttribute(_LazyDescr):
+
+    def __init__(self, name, old_mod, new_mod, old_attr=None, new_attr=None):
+        super(MovedAttribute, self).__init__(name)
+        if PY3:
+            if new_mod is None:
+                new_mod = name
+            self.mod = new_mod
+            if new_attr is None:
+                if old_attr is None:
+                    new_attr = name
+                else:
+                    new_attr = old_attr
+            self.attr = new_attr
+        else:
+            self.mod = old_mod
+            if old_attr is None:
+                old_attr = name
+            self.attr = old_attr
+
+    def _resolve(self):
+        module = _import_module(self.mod)
+        return getattr(module, self.attr)
+
+
+class _SixMetaPathImporter(object):
+
+    """
+    A meta path importer to import six.moves and its submodules.
+
+    This class implements a PEP302 finder and loader. It should be compatible
+    with Python 2.5 and all existing versions of Python3
+    """
+
+    def __init__(self, six_module_name):
+        self.name = six_module_name
+        self.known_modules = {}
+
+    def _add_module(self, mod, *fullnames):
+        for fullname in fullnames:
+            self.known_modules[self.name + "." + fullname] = mod
+
+    def _get_module(self, fullname):
+        return self.known_modules[self.name + "." + fullname]
+
+    def find_module(self, fullname, path=None):
+        if fullname in self.known_modules:
+            return self
+        return None
+
+    def __get_module(self, fullname):
+        try:
+            return self.known_modules[fullname]
+        except KeyError:
+            raise ImportError("This loader does not know module " + fullname)
+
+    def load_module(self, fullname):
+        try:
+            # in case of a reload
+            return sys.modules[fullname]
+        except KeyError:
+            pass
+        mod = self.__get_module(fullname)
+        if isinstance(mod, MovedModule):
+            mod = mod._resolve()
+        else:
+            mod.__loader__ = self
+        sys.modules[fullname] = mod
+        return mod
+
+    def is_package(self, fullname):
+        """
+        Return true, if the named module is a package.
+
+        We need this method to get correct spec objects with
+        Python 3.4 (see PEP451)
+        """
+        return hasattr(self.__get_module(fullname), "__path__")
+
+    def get_code(self, fullname):
+        """Return None
+
+        Required, if is_package is implemented"""
+        self.__get_module(fullname)  # eventually raises ImportError
+        return None
+    get_source = get_code  # same as get_code
+
+_importer = _SixMetaPathImporter(__name__)
+
+
+class _MovedItems(_LazyModule):
+
+    """Lazy loading of moved objects"""
+    __path__ = []  # mark as package
+
+
+_moved_attributes = [
+    MovedAttribute("cStringIO", "cStringIO", "io", "StringIO"),
+    MovedAttribute("filter", "itertools", "builtins", "ifilter", "filter"),
+    MovedAttribute("filterfalse", "itertools", "itertools", "ifilterfalse", "filterfalse"),
+    MovedAttribute("input", "__builtin__", "builtins", "raw_input", "input"),
+    MovedAttribute("intern", "__builtin__", "sys"),
+    MovedAttribute("map", "itertools", "builtins", "imap", "map"),
+    MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
+    MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
+    MovedAttribute("getoutput", "commands", "subprocess"),
+    MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
+    MovedAttribute("reduce", "__builtin__", "functools"),
+    MovedAttribute("shlex_quote", "pipes", "shlex", "quote"),
+    MovedAttribute("StringIO", "StringIO", "io"),
+    MovedAttribute("UserDict", "UserDict", "collections"),
+    MovedAttribute("UserList", "UserList", "collections"),
+    MovedAttribute("UserString", "UserString", "collections"),
+    MovedAttribute("xrange", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("zip", "itertools", "builtins", "izip", "zip"),
+    MovedAttribute("zip_longest", "itertools", "itertools", "izip_longest", "zip_longest"),
+    MovedModule("builtins", "__builtin__"),
+    MovedModule("configparser", "ConfigParser"),
+    MovedModule("copyreg", "copy_reg"),
+    MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
+    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
+    MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
+    MovedModule("http_cookies", "Cookie", "http.cookies"),
+    MovedModule("html_entities", "htmlentitydefs", "html.entities"),
+    MovedModule("html_parser", "HTMLParser", "html.parser"),
+    MovedModule("http_client", "httplib", "http.client"),
+    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
+    MovedModule("email_mime_image", "email.MIMEImage", "email.mime.image"),
+    MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),
+    MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),
+    MovedModule("email_mime_text", "email.MIMEText", "email.mime.text"),
+    MovedModule("BaseHTTPServer", "BaseHTTPServer", "http.server"),
+    MovedModule("CGIHTTPServer", "CGIHTTPServer", "http.server"),
+    MovedModule("SimpleHTTPServer", "SimpleHTTPServer", "http.server"),
+    MovedModule("cPickle", "cPickle", "pickle"),
+    MovedModule("queue", "Queue"),
+    MovedModule("reprlib", "repr"),
+    MovedModule("socketserver", "SocketServer"),
+    MovedModule("_thread", "thread", "_thread"),
+    MovedModule("tkinter", "Tkinter"),
+    MovedModule("tkinter_dialog", "Dialog", "tkinter.dialog"),
+    MovedModule("tkinter_filedialog", "FileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_scrolledtext", "ScrolledText", "tkinter.scrolledtext"),
+    MovedModule("tkinter_simpledialog", "SimpleDialog", "tkinter.simpledialog"),
+    MovedModule("tkinter_tix", "Tix", "tkinter.tix"),
+    MovedModule("tkinter_ttk", "ttk", "tkinter.ttk"),
+    MovedModule("tkinter_constants", "Tkconstants", "tkinter.constants"),
+    MovedModule("tkinter_dnd", "Tkdnd", "tkinter.dnd"),
+    MovedModule("tkinter_colorchooser", "tkColorChooser",
+                "tkinter.colorchooser"),
+    MovedModule("tkinter_commondialog", "tkCommonDialog",
+                "tkinter.commondialog"),
+    MovedModule("tkinter_tkfiledialog", "tkFileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_font", "tkFont", "tkinter.font"),
+    MovedModule("tkinter_messagebox", "tkMessageBox", "tkinter.messagebox"),
+    MovedModule("tkinter_tksimpledialog", "tkSimpleDialog",
+                "tkinter.simpledialog"),
+    MovedModule("urllib_parse", __name__ + ".moves.urllib_parse", "urllib.parse"),
+    MovedModule("urllib_error", __name__ + ".moves.urllib_error", "urllib.error"),
+    MovedModule("urllib", __name__ + ".moves.urllib", __name__ + ".moves.urllib"),
+    MovedModule("urllib_robotparser", "robotparser", "urllib.robotparser"),
+    MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
+    MovedModule("xmlrpc_server", "SimpleXMLRPCServer", "xmlrpc.server"),
+]
+# Add windows specific modules.
+if sys.platform == "win32":
+    _moved_attributes += [
+        MovedModule("winreg", "_winreg"),
+    ]
+
+for attr in _moved_attributes:
+    setattr(_MovedItems, attr.name, attr)
+    if isinstance(attr, MovedModule):
+        _importer._add_module(attr, "moves." + attr.name)
+del attr
+
+_MovedItems._moved_attributes = _moved_attributes
+
+moves = _MovedItems(__name__ + ".moves")
+_importer._add_module(moves, "moves")
+
+
+class Module_six_moves_urllib_parse(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_parse"""
+
+
+_urllib_parse_moved_attributes = [
+    MovedAttribute("ParseResult", "urlparse", "urllib.parse"),
+    MovedAttribute("SplitResult", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qs", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qsl", "urlparse", "urllib.parse"),
+    MovedAttribute("urldefrag", "urlparse", "urllib.parse"),
+    MovedAttribute("urljoin", "urlparse", "urllib.parse"),
+    MovedAttribute("urlparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("quote", "urllib", "urllib.parse"),
+    MovedAttribute("quote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_to_bytes", "urllib", "urllib.parse", "unquote", "unquote_to_bytes"),
+    MovedAttribute("urlencode", "urllib", "urllib.parse"),
+    MovedAttribute("splitquery", "urllib", "urllib.parse"),
+    MovedAttribute("splittag", "urllib", "urllib.parse"),
+    MovedAttribute("splituser", "urllib", "urllib.parse"),
+    MovedAttribute("splitvalue", "urllib", "urllib.parse"),
+    MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_params", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_query", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_relative", "urlparse", "urllib.parse"),
+]
+for attr in _urllib_parse_moved_attributes:
+    setattr(Module_six_moves_urllib_parse, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_parse._moved_attributes = _urllib_parse_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_parse"),
+                      "moves.urllib_parse", "moves.urllib.parse")
+
+
+class Module_six_moves_urllib_error(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_error"""
+
+
+_urllib_error_moved_attributes = [
+    MovedAttribute("URLError", "urllib2", "urllib.error"),
+    MovedAttribute("HTTPError", "urllib2", "urllib.error"),
+    MovedAttribute("ContentTooShortError", "urllib", "urllib.error"),
+]
+for attr in _urllib_error_moved_attributes:
+    setattr(Module_six_moves_urllib_error, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_error._moved_attributes = _urllib_error_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.error"),
+                      "moves.urllib_error", "moves.urllib.error")
+
+
+class Module_six_moves_urllib_request(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_request"""
+
+
+_urllib_request_moved_attributes = [
+    MovedAttribute("urlopen", "urllib2", "urllib.request"),
+    MovedAttribute("install_opener", "urllib2", "urllib.request"),
+    MovedAttribute("build_opener", "urllib2", "urllib.request"),
+    MovedAttribute("pathname2url", "urllib", "urllib.request"),
+    MovedAttribute("url2pathname", "urllib", "urllib.request"),
+    MovedAttribute("getproxies", "urllib", "urllib.request"),
+    MovedAttribute("Request", "urllib2", "urllib.request"),
+    MovedAttribute("OpenerDirector", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDefaultErrorHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPRedirectHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPCookieProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyHandler", "urllib2", "urllib.request"),
+    MovedAttribute("BaseHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgr", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgrWithDefaultRealm", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPSHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FileHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("CacheFTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("UnknownHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPErrorProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("urlretrieve", "urllib", "urllib.request"),
+    MovedAttribute("urlcleanup", "urllib", "urllib.request"),
+    MovedAttribute("URLopener", "urllib", "urllib.request"),
+    MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
+    MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+    MovedAttribute("parse_http_list", "urllib2", "urllib.request"),
+    MovedAttribute("parse_keqv_list", "urllib2", "urllib.request"),
+]
+for attr in _urllib_request_moved_attributes:
+    setattr(Module_six_moves_urllib_request, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_request._moved_attributes = _urllib_request_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.request"),
+                      "moves.urllib_request", "moves.urllib.request")
+
+
+class Module_six_moves_urllib_response(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_response"""
+
+
+_urllib_response_moved_attributes = [
+    MovedAttribute("addbase", "urllib", "urllib.response"),
+    MovedAttribute("addclosehook", "urllib", "urllib.response"),
+    MovedAttribute("addinfo", "urllib", "urllib.response"),
+    MovedAttribute("addinfourl", "urllib", "urllib.response"),
+]
+for attr in _urllib_response_moved_attributes:
+    setattr(Module_six_moves_urllib_response, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_response._moved_attributes = _urllib_response_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib.response"),
+                      "moves.urllib_response", "moves.urllib.response")
+
+
+class Module_six_moves_urllib_robotparser(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_robotparser"""
+
+
+_urllib_robotparser_moved_attributes = [
+    MovedAttribute("RobotFileParser", "robotparser", "urllib.robotparser"),
+]
+for attr in _urllib_robotparser_moved_attributes:
+    setattr(Module_six_moves_urllib_robotparser, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_robotparser._moved_attributes = _urllib_robotparser_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.urllib.robotparser"),
+                      "moves.urllib_robotparser", "moves.urllib.robotparser")
+
+
+class Module_six_moves_urllib(types.ModuleType):
+
+    """Create a six.moves.urllib namespace that resembles the Python 3 namespace"""
+    __path__ = []  # mark as package
+    parse = _importer._get_module("moves.urllib_parse")
+    error = _importer._get_module("moves.urllib_error")
+    request = _importer._get_module("moves.urllib_request")
+    response = _importer._get_module("moves.urllib_response")
+    robotparser = _importer._get_module("moves.urllib_robotparser")
+
+    def __dir__(self):
+        return ['parse', 'error', 'request', 'response', 'robotparser']
+
+_importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
+                      "moves.urllib")
+
+
+def add_move(move):
+    """Add an item to six.moves."""
+    setattr(_MovedItems, move.name, move)
+
+
+def remove_move(name):
+    """Remove item from six.moves."""
+    try:
+        delattr(_MovedItems, name)
+    except AttributeError:
+        try:
+            del moves.__dict__[name]
+        except KeyError:
+            raise AttributeError("no such move, %r" % (name,))
+
+
+if PY3:
+    _meth_func = "__func__"
+    _meth_self = "__self__"
+
+    _func_closure = "__closure__"
+    _func_code = "__code__"
+    _func_defaults = "__defaults__"
+    _func_globals = "__globals__"
+else:
+    _meth_func = "im_func"
+    _meth_self = "im_self"
+
+    _func_closure = "func_closure"
+    _func_code = "func_code"
+    _func_defaults = "func_defaults"
+    _func_globals = "func_globals"
+
+
+try:
+    advance_iterator = next
+except NameError:
+    def advance_iterator(it):
+        return it.next()
+next = advance_iterator
+
+
+try:
+    callable = callable
+except NameError:
+    def callable(obj):
+        return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
+
+
+if PY3:
+    def get_unbound_function(unbound):
+        return unbound
+
+    create_bound_method = types.MethodType
+
+    def create_unbound_method(func, cls):
+        return func
+
+    Iterator = object
+else:
+    def get_unbound_function(unbound):
+        return unbound.im_func
+
+    def create_bound_method(func, obj):
+        return types.MethodType(func, obj, obj.__class__)
+
+    def create_unbound_method(func, cls):
+        return types.MethodType(func, None, cls)
+
+    class Iterator(object):
+
+        def next(self):
+            return type(self).__next__(self)
+
+    callable = callable
+_add_doc(get_unbound_function,
+         """Get the function out of a possibly unbound function""")
+
+
+get_method_function = operator.attrgetter(_meth_func)
+get_method_self = operator.attrgetter(_meth_self)
+get_function_closure = operator.attrgetter(_func_closure)
+get_function_code = operator.attrgetter(_func_code)
+get_function_defaults = operator.attrgetter(_func_defaults)
+get_function_globals = operator.attrgetter(_func_globals)
+
+
+if PY3:
+    def iterkeys(d, **kw):
+        return iter(d.keys(**kw))
+
+    def itervalues(d, **kw):
+        return iter(d.values(**kw))
+
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+    def iterlists(d, **kw):
+        return iter(d.lists(**kw))
+
+    viewkeys = operator.methodcaller("keys")
+
+    viewvalues = operator.methodcaller("values")
+
+    viewitems = operator.methodcaller("items")
+else:
+    def iterkeys(d, **kw):
+        return d.iterkeys(**kw)
+
+    def itervalues(d, **kw):
+        return d.itervalues(**kw)
+
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)
+
+    def iterlists(d, **kw):
+        return d.iterlists(**kw)
+
+    viewkeys = operator.methodcaller("viewkeys")
+
+    viewvalues = operator.methodcaller("viewvalues")
+
+    viewitems = operator.methodcaller("viewitems")
+
+_add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
+_add_doc(itervalues, "Return an iterator over the values of a dictionary.")
+_add_doc(iteritems,
+         "Return an iterator over the (key, value) pairs of a dictionary.")
+_add_doc(iterlists,
+         "Return an iterator over the (key, [values]) pairs of a dictionary.")
+
+
+if PY3:
+    def b(s):
+        return s.encode("latin-1")
+
+    def u(s):
+        return s
+    unichr = chr
+    import struct
+    int2byte = struct.Struct(">B").pack
+    del struct
+    byte2int = operator.itemgetter(0)
+    indexbytes = operator.getitem
+    iterbytes = iter
+    import io
+    StringIO = io.StringIO
+    BytesIO = io.BytesIO
+    _assertCountEqual = "assertCountEqual"
+    if sys.version_info[1] <= 1:
+        _assertRaisesRegex = "assertRaisesRegexp"
+        _assertRegex = "assertRegexpMatches"
+    else:
+        _assertRaisesRegex = "assertRaisesRegex"
+        _assertRegex = "assertRegex"
+else:
+    def b(s):
+        return s
+    # Workaround for standalone backslash
+
+    def u(s):
+        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+    unichr = unichr
+    int2byte = chr
+
+    def byte2int(bs):
+        return ord(bs[0])
+
+    def indexbytes(buf, i):
+        return ord(buf[i])
+    iterbytes = functools.partial(itertools.imap, ord)
+    import StringIO
+    StringIO = BytesIO = StringIO.StringIO
+    _assertCountEqual = "assertItemsEqual"
+    _assertRaisesRegex = "assertRaisesRegexp"
+    _assertRegex = "assertRegexpMatches"
+_add_doc(b, """Byte literal""")
+_add_doc(u, """Text literal""")
+
+
+def assertCountEqual(self, *args, **kwargs):
+    return getattr(self, _assertCountEqual)(*args, **kwargs)
+
+
+def assertRaisesRegex(self, *args, **kwargs):
+    return getattr(self, _assertRaisesRegex)(*args, **kwargs)
+
+
+def assertRegex(self, *args, **kwargs):
+    return getattr(self, _assertRegex)(*args, **kwargs)
+
+
+if PY3:
+    exec_ = getattr(moves.builtins, "exec")
+
+    def reraise(tp, value, tb=None):
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
+
+else:
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+    exec_("""def reraise(tp, value, tb=None):
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
+""")
+
+
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        if from_value is None:
+            raise value
+        raise value from from_value
+    finally:
+        value = None
+""")
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        raise value from from_value
+    finally:
+        value = None
+""")
+else:
+    def raise_from(value, from_value):
+        raise value
+
+
+print_ = getattr(moves.builtins, "print", None)
+if print_ is None:
+    def print_(*args, **kwargs):
+        """The new-style print function for Python 2.4 and 2.5."""
+        fp = kwargs.pop("file", sys.stdout)
+        if fp is None:
+            return
+
+        def write(data):
+            if not isinstance(data, basestring):
+                data = str(data)
+            # If the file has an encoding, encode unicode with it.
+            if (isinstance(fp, file) and
+                    isinstance(data, unicode) and
+                    fp.encoding is not None):
+                errors = getattr(fp, "errors", None)
+                if errors is None:
+                    errors = "strict"
+                data = data.encode(fp.encoding, errors)
+            fp.write(data)
+        want_unicode = False
+        sep = kwargs.pop("sep", None)
+        if sep is not None:
+            if isinstance(sep, unicode):
+                want_unicode = True
+            elif not isinstance(sep, str):
+                raise TypeError("sep must be None or a string")
+        end = kwargs.pop("end", None)
+        if end is not None:
+            if isinstance(end, unicode):
+                want_unicode = True
+            elif not isinstance(end, str):
+                raise TypeError("end must be None or a string")
+        if kwargs:
+            raise TypeError("invalid keyword arguments to print()")
+        if not want_unicode:
+            for arg in args:
+                if isinstance(arg, unicode):
+                    want_unicode = True
+                    break
+        if want_unicode:
+            newline = unicode("\n")
+            space = unicode(" ")
+        else:
+            newline = "\n"
+            space = " "
+        if sep is None:
+            sep = space
+        if end is None:
+            end = newline
+        for i, arg in enumerate(args):
+            if i:
+                write(sep)
+            write(arg)
+        write(end)
+if sys.version_info[:2] < (3, 3):
+    _print = print_
+
+    def print_(*args, **kwargs):
+        fp = kwargs.get("file", sys.stdout)
+        flush = kwargs.pop("flush", False)
+        _print(*args, **kwargs)
+        if flush and fp is not None:
+            fp.flush()
+
+_add_doc(reraise, """Reraise an exception.""")
+
+if sys.version_info[0:2] < (3, 4):
+    def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
+              updated=functools.WRAPPER_UPDATES):
+        def wrapper(f):
+            f = functools.wraps(wrapped, assigned, updated)(f)
+            f.__wrapped__ = wrapped
+            return f
+        return wrapper
+else:
+    wraps = functools.wraps
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(type):
+
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
+    return type.__new__(metaclass, 'temporary_class', (), {})
+
+
+def add_metaclass(metaclass):
+    """Class decorator for creating a class with a metaclass."""
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper
+
+
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if PY2:
+        if '__str__' not in klass.__dict__:
+            raise ValueError("@python_2_unicode_compatible cannot be applied "
+                             "to %s because it doesn't define __str__()." %
+                             klass.__name__)
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass
+
+
+# Complete the moves implementation.
+# This code is at the end of this module to speed up module loading.
+# Turn this module into a package.
+__path__ = []  # required for PEP 302 and PEP 451
+__package__ = __name__  # see PEP 366 @ReservedAssignment
+if globals().get("__spec__") is not None:
+    __spec__.submodule_search_locations = []  # PEP 451 @UndefinedVariable
+# Remove other six meta path importers, since they cause problems. This can
+# happen if six is removed from sys.modules and then reloaded. (Setuptools does
+# this for some reason.)
+if sys.meta_path:
+    for i, importer in enumerate(sys.meta_path):
+        # Here's some real nastiness: Another "instance" of the six module might
+        # be floating around. Therefore, we can't use isinstance() to check for
+        # the six meta path importer, since the other six instance will have
+        # inserted an importer with different class.
+        if (type(importer).__name__ == "_SixMetaPathImporter" and
+                importer.name == __name__):
+            del sys.meta_path[i]
+            break
+    del i, importer
+# Finally, add the importer to the meta path import hook.
+sys.meta_path.append(_importer)

--- a/ddtrace/vendor/wrapt/__init__.py
+++ b/ddtrace/vendor/wrapt/__init__.py
@@ -1,0 +1,42 @@
+"""
+Copyright (c) 2013-2019, Graham Dumpleton
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+"""
+__version_info__ = ('1', '11', '1')
+__version__ = '.'.join(__version_info__)
+
+from .wrappers import (ObjectProxy, CallableObjectProxy, FunctionWrapper,
+        BoundFunctionWrapper, WeakFunctionProxy, PartialCallableObjectProxy,
+        resolve_path, apply_patch, wrap_object, wrap_object_attribute,
+        function_wrapper, wrap_function_wrapper, patch_function_wrapper,
+        transient_function_wrapper)
+
+from .decorators import (adapter_factory, AdapterFactory, decorator,
+        synchronized)
+
+from .importer import (register_post_import_hook, when_imported,
+        notify_module_loaded, discover_post_import_hooks)
+
+from inspect import getcallargs

--- a/ddtrace/vendor/wrapt/_wrappers.c
+++ b/ddtrace/vendor/wrapt/_wrappers.c
@@ -1,0 +1,3066 @@
+/* ------------------------------------------------------------------------- */
+
+#include "Python.h"
+
+#include "structmember.h"
+
+#ifndef PyVarObject_HEAD_INIT
+#define PyVarObject_HEAD_INIT(type, size) PyObject_HEAD_INIT(type) size,
+#endif
+
+/* ------------------------------------------------------------------------- */
+
+typedef struct {
+    PyObject_HEAD
+
+    PyObject *dict;
+    PyObject *wrapped;
+    PyObject *weakreflist;
+} WraptObjectProxyObject;
+
+PyTypeObject WraptObjectProxy_Type;
+PyTypeObject WraptCallableObjectProxy_Type;
+
+typedef struct {
+    WraptObjectProxyObject object_proxy;
+
+    PyObject *args;
+    PyObject *kwargs;
+} WraptPartialCallableObjectProxyObject;
+
+PyTypeObject WraptPartialCallableObjectProxy_Type;
+
+typedef struct {
+    WraptObjectProxyObject object_proxy;
+
+    PyObject *instance;
+    PyObject *wrapper;
+    PyObject *enabled;
+    PyObject *binding;
+    PyObject *parent;
+} WraptFunctionWrapperObject;
+
+PyTypeObject WraptFunctionWrapperBase_Type;
+PyTypeObject WraptBoundFunctionWrapper_Type;
+PyTypeObject WraptFunctionWrapper_Type;
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_new(PyTypeObject *type,
+        PyObject *args, PyObject *kwds)
+{
+    WraptObjectProxyObject *self;
+
+    self = (WraptObjectProxyObject *)type->tp_alloc(type, 0);
+
+    if (!self)
+        return NULL;
+
+    self->dict = PyDict_New();
+    self->wrapped = NULL;
+    self->weakreflist = NULL;
+
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_raw_init(WraptObjectProxyObject *self,
+        PyObject *wrapped)
+{
+    static PyObject *module_str = NULL;
+    static PyObject *doc_str = NULL;
+
+    PyObject *object = NULL;
+
+    Py_INCREF(wrapped);
+    Py_XDECREF(self->wrapped);
+    self->wrapped = wrapped;
+
+    if (!module_str) {
+#if PY_MAJOR_VERSION >= 3
+        module_str = PyUnicode_InternFromString("__module__");
+#else
+        module_str = PyString_InternFromString("__module__");
+#endif
+    }
+
+    if (!doc_str) {
+#if PY_MAJOR_VERSION >= 3
+        doc_str = PyUnicode_InternFromString("__doc__");
+#else
+        doc_str = PyString_InternFromString("__doc__");
+#endif
+    }
+
+    object = PyObject_GetAttr(wrapped, module_str);
+
+    if (object) {
+        if (PyDict_SetItem(self->dict, module_str, object) == -1) {
+            Py_DECREF(object);
+            return -1;
+        }
+        Py_DECREF(object);
+    }
+    else
+        PyErr_Clear();
+
+    object = PyObject_GetAttr(wrapped, doc_str);
+
+    if (object) {
+        if (PyDict_SetItem(self->dict, doc_str, object) == -1) {
+            Py_DECREF(object);
+            return -1;
+        }
+        Py_DECREF(object);
+    }
+    else
+        PyErr_Clear();
+
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_init(WraptObjectProxyObject *self,
+        PyObject *args, PyObject *kwds)
+{
+    PyObject *wrapped = NULL;
+
+    static char *kwlist[] = { "wrapped", NULL };
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O:ObjectProxy",
+            kwlist, &wrapped)) {
+        return -1;
+    }
+
+    return WraptObjectProxy_raw_init(self, wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_traverse(WraptObjectProxyObject *self,
+        visitproc visit, void *arg)
+{
+    Py_VISIT(self->dict);
+    Py_VISIT(self->wrapped);
+
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_clear(WraptObjectProxyObject *self)
+{
+    Py_CLEAR(self->dict);
+    Py_CLEAR(self->wrapped);
+
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static void WraptObjectProxy_dealloc(WraptObjectProxyObject *self)
+{
+    PyObject_GC_UnTrack(self);
+
+    if (self->weakreflist != NULL)
+        PyObject_ClearWeakRefs((PyObject *)self);
+
+    WraptObjectProxy_clear(self);
+
+    Py_TYPE(self)->tp_free(self);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_repr(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+#if PY_MAJOR_VERSION >= 3
+    return PyUnicode_FromFormat("<%s at %p for %s at %p>",
+            Py_TYPE(self)->tp_name, self,
+            Py_TYPE(self->wrapped)->tp_name, self->wrapped);
+#else
+    return PyString_FromFormat("<%s at %p for %s at %p>",
+            Py_TYPE(self)->tp_name, self,
+            Py_TYPE(self->wrapped)->tp_name, self->wrapped);
+#endif
+}
+
+/* ------------------------------------------------------------------------- */
+
+#if PY_MAJOR_VERSION < 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 3)
+typedef long Py_hash_t;
+#endif
+
+static Py_hash_t WraptObjectProxy_hash(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return -1;
+    }
+
+    return PyObject_Hash(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_str(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_Str(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_add(PyObject *o1, PyObject *o2)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+    return PyNumber_Add(o1, o2);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_subtract(PyObject *o1, PyObject *o2)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+
+    return PyNumber_Subtract(o1, o2);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_multiply(PyObject *o1, PyObject *o2)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+    return PyNumber_Multiply(o1, o2);
+}
+
+/* ------------------------------------------------------------------------- */
+
+#if PY_MAJOR_VERSION < 3
+static PyObject *WraptObjectProxy_divide(PyObject *o1, PyObject *o2)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+    return PyNumber_Divide(o1, o2);
+}
+#endif
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_remainder(PyObject *o1, PyObject *o2)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+    return PyNumber_Remainder(o1, o2);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_divmod(PyObject *o1, PyObject *o2)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+    return PyNumber_Divmod(o1, o2);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_power(PyObject *o1, PyObject *o2,
+        PyObject *modulo)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+    return PyNumber_Power(o1, o2, modulo);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_negative(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyNumber_Negative(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_positive(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyNumber_Positive(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_absolute(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyNumber_Absolute(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_bool(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return -1;
+    }
+
+    return PyObject_IsTrue(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_invert(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyNumber_Invert(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_lshift(PyObject *o1, PyObject *o2)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+    return PyNumber_Lshift(o1, o2);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_rshift(PyObject *o1, PyObject *o2)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+    return PyNumber_Rshift(o1, o2);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_and(PyObject *o1, PyObject *o2)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+    return PyNumber_And(o1, o2);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_xor(PyObject *o1, PyObject *o2)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+    return PyNumber_Xor(o1, o2);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_or(PyObject *o1, PyObject *o2)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+    return PyNumber_Or(o1, o2);
+}
+
+/* ------------------------------------------------------------------------- */
+
+#if PY_MAJOR_VERSION < 3
+static PyObject *WraptObjectProxy_int(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyNumber_Int(self->wrapped);
+}
+#endif
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_long(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyNumber_Long(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_float(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyNumber_Float(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+#if PY_MAJOR_VERSION < 3
+static PyObject *WraptObjectProxy_oct(WraptObjectProxyObject *self)
+{
+    PyNumberMethods *nb;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if ((nb = self->wrapped->ob_type->tp_as_number) == NULL ||
+        nb->nb_oct == NULL) {
+        PyErr_SetString(PyExc_TypeError,
+                   "oct() argument can't be converted to oct");
+        return NULL;
+    }
+
+    return (*nb->nb_oct)(self->wrapped);
+}
+#endif
+
+/* ------------------------------------------------------------------------- */
+
+#if PY_MAJOR_VERSION < 3
+static PyObject *WraptObjectProxy_hex(WraptObjectProxyObject *self)
+{
+    PyNumberMethods *nb;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if ((nb = self->wrapped->ob_type->tp_as_number) == NULL ||
+        nb->nb_hex == NULL) {
+        PyErr_SetString(PyExc_TypeError,
+                   "hex() argument can't be converted to hex");
+        return NULL;
+    }
+
+    return (*nb->nb_hex)(self->wrapped);
+}
+#endif
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_inplace_add(WraptObjectProxyObject *self,
+        PyObject *other)
+{
+    PyObject *object = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if (PyObject_IsInstance(other, (PyObject *)&WraptObjectProxy_Type))
+        other = ((WraptObjectProxyObject *)other)->wrapped;
+
+    object = PyNumber_InPlaceAdd(self->wrapped, other);
+
+    if (!object)
+        return NULL;
+
+    Py_DECREF(self->wrapped);
+    self->wrapped = object;
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_inplace_subtract(
+        WraptObjectProxyObject *self, PyObject *other)
+{
+    PyObject *object = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if (PyObject_IsInstance(other, (PyObject *)&WraptObjectProxy_Type))
+        other = ((WraptObjectProxyObject *)other)->wrapped;
+
+    object = PyNumber_InPlaceSubtract(self->wrapped, other);
+
+    if (!object)
+        return NULL;
+
+    Py_DECREF(self->wrapped);
+    self->wrapped = object;
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_inplace_multiply(
+        WraptObjectProxyObject *self, PyObject *other)
+{
+    PyObject *object = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if (PyObject_IsInstance(other, (PyObject *)&WraptObjectProxy_Type))
+        other = ((WraptObjectProxyObject *)other)->wrapped;
+
+    object = PyNumber_InPlaceMultiply(self->wrapped, other);
+
+    if (!object)
+        return NULL;
+
+    Py_DECREF(self->wrapped);
+    self->wrapped = object;
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+#if PY_MAJOR_VERSION < 3
+static PyObject *WraptObjectProxy_inplace_divide(
+        WraptObjectProxyObject *self, PyObject *other)
+{
+    PyObject *object = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if (PyObject_IsInstance(other, (PyObject *)&WraptObjectProxy_Type))
+        other = ((WraptObjectProxyObject *)other)->wrapped;
+
+    object = PyNumber_InPlaceDivide(self->wrapped, other);
+
+    if (!object)
+        return NULL;
+
+    Py_DECREF(self->wrapped);
+    self->wrapped = object;
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+#endif
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_inplace_remainder(
+        WraptObjectProxyObject *self, PyObject *other)
+{
+    PyObject *object = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if (PyObject_IsInstance(other, (PyObject *)&WraptObjectProxy_Type))
+        other = ((WraptObjectProxyObject *)other)->wrapped;
+
+    object = PyNumber_InPlaceRemainder(self->wrapped, other);
+
+    if (!object)
+        return NULL;
+
+    Py_DECREF(self->wrapped);
+    self->wrapped = object;
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_inplace_power(WraptObjectProxyObject *self,
+        PyObject *other, PyObject *modulo)
+{
+    PyObject *object = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if (PyObject_IsInstance(other, (PyObject *)&WraptObjectProxy_Type))
+        other = ((WraptObjectProxyObject *)other)->wrapped;
+
+    object = PyNumber_InPlacePower(self->wrapped, other, modulo);
+
+    if (!object)
+        return NULL;
+
+    Py_DECREF(self->wrapped);
+    self->wrapped = object;
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_inplace_lshift(WraptObjectProxyObject *self,
+        PyObject *other)
+{
+    PyObject *object = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if (PyObject_IsInstance(other, (PyObject *)&WraptObjectProxy_Type))
+        other = ((WraptObjectProxyObject *)other)->wrapped;
+
+    object = PyNumber_InPlaceLshift(self->wrapped, other);
+
+    if (!object)
+        return NULL;
+
+    Py_DECREF(self->wrapped);
+    self->wrapped = object;
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_inplace_rshift(WraptObjectProxyObject *self,
+        PyObject *other)
+{
+    PyObject *object = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if (PyObject_IsInstance(other, (PyObject *)&WraptObjectProxy_Type))
+        other = ((WraptObjectProxyObject *)other)->wrapped;
+
+    object = PyNumber_InPlaceRshift(self->wrapped, other);
+
+    if (!object)
+        return NULL;
+
+    Py_DECREF(self->wrapped);
+    self->wrapped = object;
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_inplace_and(WraptObjectProxyObject *self,
+        PyObject *other)
+{
+    PyObject *object = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if (PyObject_IsInstance(other, (PyObject *)&WraptObjectProxy_Type))
+        other = ((WraptObjectProxyObject *)other)->wrapped;
+
+    object = PyNumber_InPlaceAnd(self->wrapped, other);
+
+    if (!object)
+        return NULL;
+
+    Py_DECREF(self->wrapped);
+    self->wrapped = object;
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_inplace_xor(WraptObjectProxyObject *self,
+        PyObject *other)
+{
+    PyObject *object = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if (PyObject_IsInstance(other, (PyObject *)&WraptObjectProxy_Type))
+        other = ((WraptObjectProxyObject *)other)->wrapped;
+
+    object = PyNumber_InPlaceXor(self->wrapped, other);
+
+    if (!object)
+        return NULL;
+
+    Py_DECREF(self->wrapped);
+    self->wrapped = object;
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_inplace_or(WraptObjectProxyObject *self,
+        PyObject *other)
+{
+    PyObject *object = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if (PyObject_IsInstance(other, (PyObject *)&WraptObjectProxy_Type))
+        other = ((WraptObjectProxyObject *)other)->wrapped;
+
+    object = PyNumber_InPlaceOr(self->wrapped, other);
+
+    if (!object)
+        return NULL;
+
+    Py_DECREF(self->wrapped);
+    self->wrapped = object;
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_floor_divide(PyObject *o1, PyObject *o2)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+    return PyNumber_FloorDivide(o1, o2);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_true_divide(PyObject *o1, PyObject *o2)
+{
+    if (PyObject_IsInstance(o1, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o1)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o1 = ((WraptObjectProxyObject *)o1)->wrapped;
+    }
+
+    if (PyObject_IsInstance(o2, (PyObject *)&WraptObjectProxy_Type)) {
+        if (!((WraptObjectProxyObject *)o2)->wrapped) {
+          PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+          return NULL;
+        }
+
+        o2 = ((WraptObjectProxyObject *)o2)->wrapped;
+    }
+
+    return PyNumber_TrueDivide(o1, o2);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_inplace_floor_divide(
+        WraptObjectProxyObject *self, PyObject *other)
+{
+    PyObject *object = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if (PyObject_IsInstance(other, (PyObject *)&WraptObjectProxy_Type))
+        other = ((WraptObjectProxyObject *)other)->wrapped;
+
+    object = PyNumber_InPlaceFloorDivide(self->wrapped, other);
+
+    if (!object)
+        return NULL;
+
+    Py_DECREF(self->wrapped);
+    self->wrapped = object;
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_inplace_true_divide(
+        WraptObjectProxyObject *self, PyObject *other)
+{
+    PyObject *object = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    if (PyObject_IsInstance(other, (PyObject *)&WraptObjectProxy_Type))
+        other = ((WraptObjectProxyObject *)other)->wrapped;
+
+    object = PyNumber_InPlaceTrueDivide(self->wrapped, other);
+
+    if (!object)
+        return NULL;
+
+    Py_DECREF(self->wrapped);
+    self->wrapped = object;
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_index(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyNumber_Index(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static Py_ssize_t WraptObjectProxy_length(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return -1;
+    }
+
+    return PyObject_Length(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_contains(WraptObjectProxyObject *self,
+        PyObject *value)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return -1;
+    }
+
+    return PySequence_Contains(self->wrapped, value);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_getitem(WraptObjectProxyObject *self,
+        PyObject *key)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_GetItem(self->wrapped, key);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_setitem(WraptObjectProxyObject *self,
+        PyObject *key, PyObject* value)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return -1;
+    }
+
+    if (value == NULL)
+        return PyObject_DelItem(self->wrapped, key);
+    else
+        return PyObject_SetItem(self->wrapped, key, value);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_dir(
+        WraptObjectProxyObject *self, PyObject *args)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_Dir(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_enter(
+        WraptObjectProxyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *method = NULL;
+    PyObject *result = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    method = PyObject_GetAttrString(self->wrapped, "__enter__");
+
+    if (!method)
+        return NULL;
+
+    result = PyObject_Call(method, args, kwds);
+
+    Py_DECREF(method);
+
+    return result;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_exit(
+        WraptObjectProxyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *method = NULL;
+    PyObject *result = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    method = PyObject_GetAttrString(self->wrapped, "__exit__");
+
+    if (!method)
+        return NULL;
+
+    result = PyObject_Call(method, args, kwds);
+
+    Py_DECREF(method);
+
+    return result;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_copy(
+        WraptObjectProxyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "object proxy must define __copy__()");
+
+    return NULL;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_deepcopy(
+        WraptObjectProxyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "object proxy must define __deepcopy__()");
+
+    return NULL;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_reduce(
+        WraptObjectProxyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "object proxy must define __reduce_ex__()");
+
+    return NULL;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_reduce_ex(
+        WraptObjectProxyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "object proxy must define __reduce_ex__()");
+
+    return NULL;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_bytes(
+        WraptObjectProxyObject *self, PyObject *args)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_Bytes(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_reversed(
+        WraptObjectProxyObject *self, PyObject *args)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_CallFunctionObjArgs((PyObject *)&PyReversed_Type,
+            self->wrapped, NULL);
+}
+
+/* ------------------------------------------------------------------------- */
+
+#if PY_MAJOR_VERSION >= 3
+static PyObject *WraptObjectProxy_round(
+        WraptObjectProxyObject *self, PyObject *args)
+{
+    PyObject *module = NULL;
+    PyObject *dict = NULL;
+    PyObject *round = NULL;
+
+    PyObject *result = NULL;
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    module = PyImport_ImportModule("builtins");
+
+    if (!module)
+        return NULL;
+
+    dict = PyModule_GetDict(module);
+    round = PyDict_GetItemString(dict, "round");
+
+    if (!round) {
+        Py_DECREF(module);
+        return NULL;
+    }
+
+    Py_INCREF(round);
+    Py_DECREF(module);
+
+    result = PyObject_CallFunctionObjArgs(round, self->wrapped, NULL);
+
+    Py_DECREF(round);
+
+    return result;
+}
+#endif
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_complex(
+        WraptObjectProxyObject *self, PyObject *args)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_CallFunctionObjArgs((PyObject *)&PyComplex_Type,
+            self->wrapped, NULL);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_get_name(
+        WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_GetAttrString(self->wrapped, "__name__");
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_set_name(WraptObjectProxyObject *self,
+        PyObject *value)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return -1;
+    }
+
+    return PyObject_SetAttrString(self->wrapped, "__name__", value);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_get_qualname(
+        WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_GetAttrString(self->wrapped, "__qualname__");
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_set_qualname(WraptObjectProxyObject *self,
+        PyObject *value)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return -1;
+    }
+
+    return PyObject_SetAttrString(self->wrapped, "__qualname__", value);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_get_module(
+        WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_GetAttrString(self->wrapped, "__module__");
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_set_module(WraptObjectProxyObject *self,
+        PyObject *value)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return -1;
+    }
+
+    if (PyObject_SetAttrString(self->wrapped, "__module__", value) == -1)
+        return -1;
+
+    return PyDict_SetItemString(self->dict, "__module__", value);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_get_doc(
+        WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_GetAttrString(self->wrapped, "__doc__");
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_set_doc(WraptObjectProxyObject *self,
+        PyObject *value)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return -1;
+    }
+
+    if (PyObject_SetAttrString(self->wrapped, "__doc__", value) == -1)
+        return -1;
+
+    return PyDict_SetItemString(self->dict, "__doc__", value);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_get_class(
+        WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_GetAttrString(self->wrapped, "__class__");
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_get_annotations(
+        WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_GetAttrString(self->wrapped, "__annotations__");
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_set_annotations(WraptObjectProxyObject *self,
+        PyObject *value)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return -1;
+    }
+
+    return PyObject_SetAttrString(self->wrapped, "__annotations__", value);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_get_wrapped(
+        WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    Py_INCREF(self->wrapped);
+    return self->wrapped;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_set_wrapped(WraptObjectProxyObject *self,
+        PyObject *value)
+{
+    if (!value) {
+        PyErr_SetString(PyExc_TypeError, "__wrapped__ must be an object");
+        return -1;
+    }
+
+    Py_INCREF(value);
+    Py_XDECREF(self->wrapped);
+
+    self->wrapped = value;
+
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_getattro(
+        WraptObjectProxyObject *self, PyObject *name)
+{
+    PyObject *object = NULL;
+    PyObject *result = NULL;
+
+    static PyObject *getattr_str = NULL;
+
+    object = PyObject_GenericGetAttr((PyObject *)self, name);
+
+    if (object)
+        return object;
+
+    PyErr_Clear();
+
+    if (!getattr_str) {
+#if PY_MAJOR_VERSION >= 3
+        getattr_str = PyUnicode_InternFromString("__getattr__");
+#else
+        getattr_str = PyString_InternFromString("__getattr__");
+#endif
+    }
+
+    object = PyObject_GenericGetAttr((PyObject *)self, getattr_str);
+
+    if (!object)
+        return NULL;
+
+    result = PyObject_CallFunctionObjArgs(object, name, NULL);
+
+    Py_DECREF(object);
+
+    return result;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_getattr(
+        WraptObjectProxyObject *self, PyObject *args)
+{
+    PyObject *name = NULL;
+
+#if PY_MAJOR_VERSION >= 3
+    if (!PyArg_ParseTuple(args, "U:__getattr__", &name))
+        return NULL;
+#else
+    if (!PyArg_ParseTuple(args, "S:__getattr__", &name))
+        return NULL;
+#endif
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_GetAttr(self->wrapped, name);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptObjectProxy_setattro(
+        WraptObjectProxyObject *self, PyObject *name, PyObject *value)
+{
+    static PyObject *self_str = NULL;
+    static PyObject *wrapped_str = NULL;
+    static PyObject *startswith_str = NULL;
+
+    PyObject *match = NULL;
+
+    if (!startswith_str) {
+#if PY_MAJOR_VERSION >= 3
+        startswith_str = PyUnicode_InternFromString("startswith");
+#else
+        startswith_str = PyString_InternFromString("startswith");
+#endif
+    }
+
+    if (!self_str) {
+#if PY_MAJOR_VERSION >= 3
+        self_str = PyUnicode_InternFromString("_self_");
+#else
+        self_str = PyString_InternFromString("_self_");
+#endif
+    }
+
+    match = PyObject_CallMethodObjArgs(name, startswith_str, self_str, NULL);
+
+    if (match == Py_True) {
+        Py_DECREF(match);
+
+        return PyObject_GenericSetAttr((PyObject *)self, name, value);
+    }
+    else if (!match)
+        PyErr_Clear();
+
+    Py_XDECREF(match);
+
+    if (!wrapped_str) {
+#if PY_MAJOR_VERSION >= 3
+        wrapped_str = PyUnicode_InternFromString("__wrapped__");
+#else
+        wrapped_str = PyString_InternFromString("__wrapped__");
+#endif
+    }
+
+    if (PyObject_HasAttr((PyObject *)Py_TYPE(self), name))
+        return PyObject_GenericSetAttr((PyObject *)self, name, value);
+
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return -1;
+    }
+
+    return PyObject_SetAttr(self->wrapped, name, value);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_richcompare(WraptObjectProxyObject *self,
+        PyObject *other, int opcode)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_RichCompare(self->wrapped, other, opcode);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptObjectProxy_iter(WraptObjectProxyObject *self)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_GetIter(self->wrapped);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyNumberMethods WraptObjectProxy_as_number = {
+    (binaryfunc)WraptObjectProxy_add, /*nb_add*/
+    (binaryfunc)WraptObjectProxy_subtract, /*nb_subtract*/
+    (binaryfunc)WraptObjectProxy_multiply, /*nb_multiply*/
+#if PY_MAJOR_VERSION < 3
+    (binaryfunc)WraptObjectProxy_divide, /*nb_divide*/
+#endif
+    (binaryfunc)WraptObjectProxy_remainder, /*nb_remainder*/
+    (binaryfunc)WraptObjectProxy_divmod, /*nb_divmod*/
+    (ternaryfunc)WraptObjectProxy_power, /*nb_power*/
+    (unaryfunc)WraptObjectProxy_negative, /*nb_negative*/
+    (unaryfunc)WraptObjectProxy_positive, /*nb_positive*/
+    (unaryfunc)WraptObjectProxy_absolute, /*nb_absolute*/
+    (inquiry)WraptObjectProxy_bool, /*nb_nonzero/nb_bool*/
+    (unaryfunc)WraptObjectProxy_invert, /*nb_invert*/
+    (binaryfunc)WraptObjectProxy_lshift, /*nb_lshift*/
+    (binaryfunc)WraptObjectProxy_rshift, /*nb_rshift*/
+    (binaryfunc)WraptObjectProxy_and, /*nb_and*/
+    (binaryfunc)WraptObjectProxy_xor, /*nb_xor*/
+    (binaryfunc)WraptObjectProxy_or, /*nb_or*/
+#if PY_MAJOR_VERSION < 3
+    0,                      /*nb_coerce*/
+#endif
+#if PY_MAJOR_VERSION < 3
+    (unaryfunc)WraptObjectProxy_int, /*nb_int*/
+    (unaryfunc)WraptObjectProxy_long, /*nb_long*/
+#else
+    (unaryfunc)WraptObjectProxy_long, /*nb_int*/
+    0,                      /*nb_long/nb_reserved*/
+#endif
+    (unaryfunc)WraptObjectProxy_float, /*nb_float*/
+#if PY_MAJOR_VERSION < 3
+    (unaryfunc)WraptObjectProxy_oct, /*nb_oct*/
+    (unaryfunc)WraptObjectProxy_hex, /*nb_hex*/
+#endif
+    (binaryfunc)WraptObjectProxy_inplace_add, /*nb_inplace_add*/
+    (binaryfunc)WraptObjectProxy_inplace_subtract, /*nb_inplace_subtract*/
+    (binaryfunc)WraptObjectProxy_inplace_multiply, /*nb_inplace_multiply*/
+#if PY_MAJOR_VERSION < 3
+    (binaryfunc)WraptObjectProxy_inplace_divide, /*nb_inplace_divide*/
+#endif
+    (binaryfunc)WraptObjectProxy_inplace_remainder, /*nb_inplace_remainder*/
+    (ternaryfunc)WraptObjectProxy_inplace_power, /*nb_inplace_power*/
+    (binaryfunc)WraptObjectProxy_inplace_lshift, /*nb_inplace_lshift*/
+    (binaryfunc)WraptObjectProxy_inplace_rshift, /*nb_inplace_rshift*/
+    (binaryfunc)WraptObjectProxy_inplace_and, /*nb_inplace_and*/
+    (binaryfunc)WraptObjectProxy_inplace_xor, /*nb_inplace_xor*/
+    (binaryfunc)WraptObjectProxy_inplace_or, /*nb_inplace_or*/
+    (binaryfunc)WraptObjectProxy_floor_divide, /*nb_floor_divide*/
+    (binaryfunc)WraptObjectProxy_true_divide, /*nb_true_divide*/
+    (binaryfunc)WraptObjectProxy_inplace_floor_divide, /*nb_inplace_floor_divide*/
+    (binaryfunc)WraptObjectProxy_inplace_true_divide, /*nb_inplace_true_divide*/
+    (unaryfunc)WraptObjectProxy_index, /*nb_index*/
+};
+
+static PySequenceMethods WraptObjectProxy_as_sequence = {
+    (lenfunc)WraptObjectProxy_length, /*sq_length*/
+    0,                          /*sq_concat*/
+    0,                          /*sq_repeat*/
+    0,                          /*sq_item*/
+    0,                          /*sq_slice*/
+    0,                          /*sq_ass_item*/
+    0,                          /*sq_ass_slice*/
+    (objobjproc)WraptObjectProxy_contains, /* sq_contains */
+};
+
+static PyMappingMethods WraptObjectProxy_as_mapping = {
+    (lenfunc)WraptObjectProxy_length, /*mp_length*/
+    (binaryfunc)WraptObjectProxy_getitem, /*mp_subscript*/
+    (objobjargproc)WraptObjectProxy_setitem, /*mp_ass_subscript*/
+};
+
+static PyMethodDef WraptObjectProxy_methods[] = {
+    { "__dir__",    (PyCFunction)WraptObjectProxy_dir, METH_NOARGS, 0 },
+    { "__enter__",  (PyCFunction)WraptObjectProxy_enter,
+                    METH_VARARGS | METH_KEYWORDS, 0 },
+    { "__exit__",   (PyCFunction)WraptObjectProxy_exit,
+                    METH_VARARGS | METH_KEYWORDS, 0 },
+    { "__copy__",   (PyCFunction)WraptObjectProxy_copy,
+                    METH_NOARGS, 0 },
+    { "__deepcopy__", (PyCFunction)WraptObjectProxy_deepcopy,
+                    METH_VARARGS | METH_KEYWORDS, 0 },
+    { "__reduce__", (PyCFunction)WraptObjectProxy_reduce,
+                    METH_NOARGS, 0 },
+    { "__reduce_ex__", (PyCFunction)WraptObjectProxy_reduce_ex,
+                    METH_VARARGS | METH_KEYWORDS, 0 },
+    { "__getattr__", (PyCFunction)WraptObjectProxy_getattr,
+                    METH_VARARGS , 0 },
+    { "__bytes__",  (PyCFunction)WraptObjectProxy_bytes, METH_NOARGS, 0 },
+    { "__reversed__", (PyCFunction)WraptObjectProxy_reversed, METH_NOARGS, 0 },
+#if PY_MAJOR_VERSION >= 3
+    { "__round__",  (PyCFunction)WraptObjectProxy_round, METH_NOARGS, 0 },
+#endif
+    { "__complex__",  (PyCFunction)WraptObjectProxy_complex, METH_NOARGS, 0 },
+    { NULL, NULL },
+};
+
+static PyGetSetDef WraptObjectProxy_getset[] = {
+    { "__name__",           (getter)WraptObjectProxy_get_name,
+                            (setter)WraptObjectProxy_set_name, 0 },
+    { "__qualname__",       (getter)WraptObjectProxy_get_qualname,
+                            (setter)WraptObjectProxy_set_qualname, 0 },
+    { "__module__",         (getter)WraptObjectProxy_get_module,
+                            (setter)WraptObjectProxy_set_module, 0 },
+    { "__doc__",            (getter)WraptObjectProxy_get_doc,
+                            (setter)WraptObjectProxy_set_doc, 0 },
+    { "__class__",          (getter)WraptObjectProxy_get_class,
+                            NULL, 0 },
+    { "__annotations__",    (getter)WraptObjectProxy_get_annotations,
+                            (setter)WraptObjectProxy_set_annotations, 0 },
+    { "__wrapped__",        (getter)WraptObjectProxy_get_wrapped,
+                            (setter)WraptObjectProxy_set_wrapped, 0 },
+    { NULL },
+};
+
+PyTypeObject WraptObjectProxy_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "ObjectProxy",          /*tp_name*/
+    sizeof(WraptObjectProxyObject), /*tp_basicsize*/
+    0,                      /*tp_itemsize*/
+    /* methods */
+    (destructor)WraptObjectProxy_dealloc, /*tp_dealloc*/
+    0,                      /*tp_print*/
+    0,                      /*tp_getattr*/
+    0,                      /*tp_setattr*/
+    0,                      /*tp_compare*/
+    (unaryfunc)WraptObjectProxy_repr, /*tp_repr*/
+    &WraptObjectProxy_as_number, /*tp_as_number*/
+    &WraptObjectProxy_as_sequence, /*tp_as_sequence*/
+    &WraptObjectProxy_as_mapping, /*tp_as_mapping*/
+    (hashfunc)WraptObjectProxy_hash, /*tp_hash*/
+    0,                      /*tp_call*/
+    (unaryfunc)WraptObjectProxy_str, /*tp_str*/
+    (getattrofunc)WraptObjectProxy_getattro, /*tp_getattro*/
+    (setattrofunc)WraptObjectProxy_setattro, /*tp_setattro*/
+    0,                      /*tp_as_buffer*/
+#if PY_MAJOR_VERSION < 3
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
+        Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_CHECKTYPES, /*tp_flags*/
+#else
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
+        Py_TPFLAGS_HAVE_GC, /*tp_flags*/
+#endif
+    0,                      /*tp_doc*/
+    (traverseproc)WraptObjectProxy_traverse, /*tp_traverse*/
+    (inquiry)WraptObjectProxy_clear, /*tp_clear*/
+    (richcmpfunc)WraptObjectProxy_richcompare, /*tp_richcompare*/
+    offsetof(WraptObjectProxyObject, weakreflist), /*tp_weaklistoffset*/
+    (getiterfunc)WraptObjectProxy_iter, /*tp_iter*/
+    0,                      /*tp_iternext*/
+    WraptObjectProxy_methods, /*tp_methods*/
+    0,                      /*tp_members*/
+    WraptObjectProxy_getset, /*tp_getset*/
+    0,                      /*tp_base*/
+    0,                      /*tp_dict*/
+    0,                      /*tp_descr_get*/
+    0,                      /*tp_descr_set*/
+    offsetof(WraptObjectProxyObject, dict), /*tp_dictoffset*/
+    (initproc)WraptObjectProxy_init, /*tp_init*/
+    PyType_GenericAlloc,    /*tp_alloc*/
+    WraptObjectProxy_new,   /*tp_new*/
+    PyObject_GC_Del,        /*tp_free*/
+    0,                      /*tp_is_gc*/
+};
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptCallableObjectProxy_call(
+        WraptObjectProxyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    return PyObject_Call(self->wrapped, args, kwds);
+}
+
+/* ------------------------------------------------------------------------- */;
+
+static PyGetSetDef WraptCallableObjectProxy_getset[] = {
+    { "__module__",         (getter)WraptObjectProxy_get_module,
+                            (setter)WraptObjectProxy_set_module, 0 },
+    { "__doc__",            (getter)WraptObjectProxy_get_doc,
+                            (setter)WraptObjectProxy_set_doc, 0 },
+    { NULL },
+};
+
+PyTypeObject WraptCallableObjectProxy_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "CallableObjectProxy",   /*tp_name*/
+    sizeof(WraptObjectProxyObject), /*tp_basicsize*/
+    0,                      /*tp_itemsize*/
+    /* methods */
+    0,                      /*tp_dealloc*/
+    0,                      /*tp_print*/
+    0,                      /*tp_getattr*/
+    0,                      /*tp_setattr*/
+    0,                      /*tp_compare*/
+    0,                      /*tp_repr*/
+    0,                      /*tp_as_number*/
+    0,                      /*tp_as_sequence*/
+    0,                      /*tp_as_mapping*/
+    0,                      /*tp_hash*/
+    (ternaryfunc)WraptCallableObjectProxy_call, /*tp_call*/
+    0,                      /*tp_str*/
+    0,                      /*tp_getattro*/
+    0,                      /*tp_setattro*/
+    0,                      /*tp_as_buffer*/
+#if PY_MAJOR_VERSION < 3
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_CHECKTYPES, /*tp_flags*/
+#else
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+#endif
+    0,                      /*tp_doc*/
+    0,                      /*tp_traverse*/
+    0,                      /*tp_clear*/
+    0,                      /*tp_richcompare*/
+    offsetof(WraptObjectProxyObject, weakreflist), /*tp_weaklistoffset*/
+    0,                      /*tp_iter*/
+    0,                      /*tp_iternext*/
+    0,                      /*tp_methods*/
+    0,                      /*tp_members*/
+    WraptCallableObjectProxy_getset, /*tp_getset*/
+    0,                      /*tp_base*/
+    0,                      /*tp_dict*/
+    0,                      /*tp_descr_get*/
+    0,                      /*tp_descr_set*/
+    0,                      /*tp_dictoffset*/
+    (initproc)WraptObjectProxy_init, /*tp_init*/
+    0,                      /*tp_alloc*/
+    0,                      /*tp_new*/
+    0,                      /*tp_free*/
+    0,                      /*tp_is_gc*/
+};
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptPartialCallableObjectProxy_new(PyTypeObject *type,
+        PyObject *args, PyObject *kwds)
+{
+    WraptPartialCallableObjectProxyObject *self;
+
+    self = (WraptPartialCallableObjectProxyObject *)WraptObjectProxy_new(type,
+            args, kwds);
+
+    if (!self)
+        return NULL;
+
+    self->args = NULL;
+    self->kwargs = NULL;
+
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptPartialCallableObjectProxy_raw_init(
+        WraptPartialCallableObjectProxyObject *self,
+        PyObject *wrapped, PyObject *args, PyObject *kwargs)
+{
+    int result = 0;
+
+    result = WraptObjectProxy_raw_init((WraptObjectProxyObject *)self,
+            wrapped);
+
+    if (result == 0) {
+        Py_INCREF(args);
+        Py_XDECREF(self->args);
+        self->args = args;
+
+        Py_XINCREF(kwargs);
+        Py_XDECREF(self->kwargs);
+        self->kwargs = kwargs;
+    }
+
+    return result;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptPartialCallableObjectProxy_init(
+        WraptPartialCallableObjectProxyObject *self, PyObject *args,
+        PyObject *kwds)
+{
+    PyObject *wrapped = NULL;
+    PyObject *fnargs = NULL;
+
+    int result = 0;
+
+    if (!PyObject_Length(args)) {
+        PyErr_SetString(PyExc_TypeError,
+		"__init__ of partial needs an argument");
+        return -1;
+    }
+
+    if (PyObject_Length(args) < 1) {
+        PyErr_SetString(PyExc_TypeError,
+		"partial type takes at least one argument");
+        return -1;
+    }
+
+    wrapped = PyTuple_GetItem(args, 0);
+
+    if (!PyCallable_Check(wrapped)) {
+        PyErr_SetString(PyExc_TypeError,
+		"the first argument must be callable");
+        return -1;
+    }
+
+    fnargs = PyTuple_GetSlice(args, 1, PyTuple_Size(args));
+
+    if (!fnargs)
+        return -1;
+
+    result = WraptPartialCallableObjectProxy_raw_init(self, wrapped,
+	    fnargs, kwds);
+
+    Py_DECREF(fnargs);
+
+    return result;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptPartialCallableObjectProxy_traverse(
+        WraptPartialCallableObjectProxyObject *self,
+        visitproc visit, void *arg)
+{
+    WraptObjectProxy_traverse((WraptObjectProxyObject *)self, visit, arg);
+
+    Py_VISIT(self->args);
+    Py_VISIT(self->kwargs);
+
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptPartialCallableObjectProxy_clear(
+        WraptPartialCallableObjectProxyObject *self)
+{
+    WraptObjectProxy_clear((WraptObjectProxyObject *)self);
+
+    Py_CLEAR(self->args);
+    Py_CLEAR(self->kwargs);
+
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static void WraptPartialCallableObjectProxy_dealloc(
+        WraptPartialCallableObjectProxyObject *self)
+{
+    WraptPartialCallableObjectProxy_clear(self);
+
+    WraptObjectProxy_dealloc((WraptObjectProxyObject *)self);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptPartialCallableObjectProxy_call(
+        WraptPartialCallableObjectProxyObject *self, PyObject *args,
+        PyObject *kwds)
+{
+    PyObject *fnargs = NULL;
+    PyObject *fnkwargs = NULL;
+
+    PyObject *result = NULL;
+
+    long i;
+    long offset;
+
+    if (!self->object_proxy.wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return NULL;
+    }
+
+    fnargs = PyTuple_New(PyTuple_Size(self->args)+PyTuple_Size(args));
+
+    for (i=0; i<PyTuple_Size(self->args); i++) {
+        PyObject *item;
+        item = PyTuple_GetItem(self->args, i);
+        Py_INCREF(item);
+        PyTuple_SetItem(fnargs, i, item);
+    }
+
+    offset = PyTuple_Size(self->args);
+
+    for (i=0; i<PyTuple_Size(args); i++) {
+        PyObject *item;
+        item = PyTuple_GetItem(args, i);
+        Py_INCREF(item);
+        PyTuple_SetItem(fnargs, offset+i, item);
+    }
+
+    fnkwargs = PyDict_New();
+
+    if (self->kwargs && PyDict_Update(fnkwargs, self->kwargs) == -1) {
+        Py_DECREF(fnargs);
+        Py_DECREF(fnkwargs);
+        return NULL;
+    }
+
+    if (kwds && PyDict_Update(fnkwargs, kwds) == -1) {
+        Py_DECREF(fnargs);
+        Py_DECREF(fnkwargs);
+        return NULL;
+    }
+
+    result = PyObject_Call(self->object_proxy.wrapped,
+           fnargs, fnkwargs);
+
+    Py_DECREF(fnargs);
+    Py_DECREF(fnkwargs);
+
+    return result;
+}
+
+/* ------------------------------------------------------------------------- */;
+
+static PyGetSetDef WraptPartialCallableObjectProxy_getset[] = {
+    { "__module__",         (getter)WraptObjectProxy_get_module,
+                            (setter)WraptObjectProxy_set_module, 0 },
+    { "__doc__",            (getter)WraptObjectProxy_get_doc,
+                            (setter)WraptObjectProxy_set_doc, 0 },
+    { NULL },
+};
+
+PyTypeObject WraptPartialCallableObjectProxy_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "PartialCallableObjectProxy",   /*tp_name*/
+    sizeof(WraptPartialCallableObjectProxyObject), /*tp_basicsize*/
+    0,                      /*tp_itemsize*/
+    /* methods */
+    (destructor)WraptPartialCallableObjectProxy_dealloc, /*tp_dealloc*/
+    0,                      /*tp_print*/
+    0,                      /*tp_getattr*/
+    0,                      /*tp_setattr*/
+    0,                      /*tp_compare*/
+    0,                      /*tp_repr*/
+    0,                      /*tp_as_number*/
+    0,                      /*tp_as_sequence*/
+    0,                      /*tp_as_mapping*/
+    0,                      /*tp_hash*/
+    (ternaryfunc)WraptPartialCallableObjectProxy_call, /*tp_call*/
+    0,                      /*tp_str*/
+    0,                      /*tp_getattro*/
+    0,                      /*tp_setattro*/
+    0,                      /*tp_as_buffer*/
+#if PY_MAJOR_VERSION < 3
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
+        Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_CHECKTYPES, /*tp_flags*/
+#else
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
+        Py_TPFLAGS_HAVE_GC, /*tp_flags*/
+#endif
+    0,                      /*tp_doc*/
+    (traverseproc)WraptPartialCallableObjectProxy_traverse, /*tp_traverse*/
+    (inquiry)WraptPartialCallableObjectProxy_clear, /*tp_clear*/
+    0,                      /*tp_richcompare*/
+    offsetof(WraptObjectProxyObject, weakreflist), /*tp_weaklistoffset*/
+    0,                      /*tp_iter*/
+    0,                      /*tp_iternext*/
+    0,                      /*tp_methods*/
+    0,                      /*tp_members*/
+    WraptPartialCallableObjectProxy_getset, /*tp_getset*/
+    0,                      /*tp_base*/
+    0,                      /*tp_dict*/
+    0,                      /*tp_descr_get*/
+    0,                      /*tp_descr_set*/
+    0,                      /*tp_dictoffset*/
+    (initproc)WraptPartialCallableObjectProxy_init, /*tp_init*/
+    0,                      /*tp_alloc*/
+    WraptPartialCallableObjectProxy_new, /*tp_new*/
+    0,                      /*tp_free*/
+    0,                      /*tp_is_gc*/
+};
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptFunctionWrapperBase_new(PyTypeObject *type,
+        PyObject *args, PyObject *kwds)
+{
+    WraptFunctionWrapperObject *self;
+
+    self = (WraptFunctionWrapperObject *)WraptObjectProxy_new(type,
+            args, kwds);
+
+    if (!self)
+        return NULL;
+
+    self->instance = NULL;
+    self->wrapper = NULL;
+    self->enabled = NULL;
+    self->binding = NULL;
+    self->parent = NULL;
+
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptFunctionWrapperBase_raw_init(WraptFunctionWrapperObject *self,
+        PyObject *wrapped, PyObject *instance, PyObject *wrapper,
+         PyObject *enabled, PyObject *binding, PyObject *parent)
+{
+    int result = 0;
+
+    result = WraptObjectProxy_raw_init((WraptObjectProxyObject *)self,
+            wrapped);
+
+    if (result == 0) {
+        Py_INCREF(instance);
+        Py_XDECREF(self->instance);
+        self->instance = instance;
+
+        Py_INCREF(wrapper);
+        Py_XDECREF(self->wrapper);
+        self->wrapper = wrapper;
+
+        Py_INCREF(enabled);
+        Py_XDECREF(self->enabled);
+        self->enabled = enabled;
+
+        Py_INCREF(binding);
+        Py_XDECREF(self->binding);
+        self->binding = binding;
+
+        Py_INCREF(parent);
+        Py_XDECREF(self->parent);
+        self->parent = parent;
+    }
+
+    return result;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptFunctionWrapperBase_init(WraptFunctionWrapperObject *self,
+        PyObject *args, PyObject *kwds)
+{
+    PyObject *wrapped = NULL;
+    PyObject *instance = NULL;
+    PyObject *wrapper = NULL;
+    PyObject *enabled = Py_None;
+    PyObject *binding = NULL;
+    PyObject *parent = Py_None;
+
+    static PyObject *function_str = NULL;
+
+    static char *kwlist[] = { "wrapped", "instance", "wrapper",
+            "enabled", "binding", "parent", NULL };
+
+    if (!function_str) {
+#if PY_MAJOR_VERSION >= 3
+        function_str = PyUnicode_InternFromString("function");
+#else
+        function_str = PyString_InternFromString("function");
+#endif
+    }
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds,
+            "OOO|OOO:FunctionWrapperBase", kwlist, &wrapped, &instance,
+            &wrapper, &enabled, &binding, &parent)) {
+        return -1;
+    }
+
+    if (!binding)
+        binding = function_str;
+
+    return WraptFunctionWrapperBase_raw_init(self, wrapped, instance, wrapper,
+            enabled, binding, parent);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptFunctionWrapperBase_traverse(WraptFunctionWrapperObject *self,
+        visitproc visit, void *arg)
+{
+    WraptObjectProxy_traverse((WraptObjectProxyObject *)self, visit, arg);
+
+    Py_VISIT(self->instance);
+    Py_VISIT(self->wrapper);
+    Py_VISIT(self->enabled);
+    Py_VISIT(self->binding);
+    Py_VISIT(self->parent);
+
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptFunctionWrapperBase_clear(WraptFunctionWrapperObject *self)
+{
+    WraptObjectProxy_clear((WraptObjectProxyObject *)self);
+
+    Py_CLEAR(self->instance);
+    Py_CLEAR(self->wrapper);
+    Py_CLEAR(self->enabled);
+    Py_CLEAR(self->binding);
+    Py_CLEAR(self->parent);
+
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static void WraptFunctionWrapperBase_dealloc(WraptFunctionWrapperObject *self)
+{
+    WraptFunctionWrapperBase_clear(self);
+
+    WraptObjectProxy_dealloc((WraptObjectProxyObject *)self);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptFunctionWrapperBase_call(
+        WraptFunctionWrapperObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *param_kwds = NULL;
+
+    PyObject *result = NULL;
+
+    static PyObject *function_str = NULL;
+
+    if (!function_str) {
+#if PY_MAJOR_VERSION >= 3
+        function_str = PyUnicode_InternFromString("function");
+#else
+        function_str = PyString_InternFromString("function");
+#endif
+    }
+
+    if (self->enabled != Py_None) {
+        if (PyCallable_Check(self->enabled)) {
+            PyObject *object = NULL;
+
+            object = PyObject_CallFunctionObjArgs(self->enabled, NULL);
+
+            if (!object)
+                return NULL;
+
+            if (PyObject_Not(object)) {
+                Py_DECREF(object);
+                return PyObject_Call(self->object_proxy.wrapped, args, kwds);
+            }
+
+            Py_DECREF(object);
+        }
+        else if (PyObject_Not(self->enabled)) {
+            return PyObject_Call(self->object_proxy.wrapped, args, kwds);
+        }
+    }
+
+    if (!kwds) {
+        param_kwds = PyDict_New();
+        kwds = param_kwds;
+    }
+
+    if (self->instance == Py_None && (self->binding == function_str ||
+            PyObject_RichCompareBool(self->binding, function_str,
+            Py_EQ) == 1)) {
+
+        PyObject *instance = NULL;
+
+        instance = PyObject_GetAttrString(self->object_proxy.wrapped,
+                "__self__");
+
+        if (instance) {
+            result = PyObject_CallFunctionObjArgs(self->wrapper,
+                    self->object_proxy.wrapped, instance, args, kwds, NULL);
+
+            Py_XDECREF(param_kwds);
+
+            Py_DECREF(instance);
+
+            return result;
+        }
+        else
+            PyErr_Clear();
+    }
+
+    result = PyObject_CallFunctionObjArgs(self->wrapper,
+            self->object_proxy.wrapped, self->instance, args, kwds, NULL);
+
+    Py_XDECREF(param_kwds);
+
+    return result;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptFunctionWrapperBase_descr_get(
+        WraptFunctionWrapperObject *self, PyObject *obj, PyObject *type)
+{
+    PyObject *bound_type = NULL;
+    PyObject *descriptor = NULL;
+    PyObject *result = NULL;
+
+    static PyObject *bound_type_str = NULL;
+    static PyObject *function_str = NULL;
+
+    if (!bound_type_str) {
+#if PY_MAJOR_VERSION >= 3
+        bound_type_str = PyUnicode_InternFromString(
+                "__bound_function_wrapper__");
+#else
+        bound_type_str = PyString_InternFromString(
+                "__bound_function_wrapper__");
+#endif
+    }
+
+    if (!function_str) {
+#if PY_MAJOR_VERSION >= 3
+        function_str = PyUnicode_InternFromString("function");
+#else
+        function_str = PyString_InternFromString("function");
+#endif
+    }
+
+    if (self->parent == Py_None) {
+#if PY_MAJOR_VERSION < 3
+        if (PyObject_IsInstance(self->object_proxy.wrapped,
+                (PyObject *)&PyClass_Type) || PyObject_IsInstance(
+                self->object_proxy.wrapped, (PyObject *)&PyType_Type)) {
+            Py_INCREF(self);
+            return (PyObject *)self;
+        }
+#else
+        if (PyObject_IsInstance(self->object_proxy.wrapped,
+                (PyObject *)&PyType_Type)) {
+            Py_INCREF(self);
+            return (PyObject *)self;
+        }
+#endif
+
+        if (Py_TYPE(self->object_proxy.wrapped)->tp_descr_get == NULL) {
+            PyErr_Format(PyExc_AttributeError,
+                    "'%s' object has no attribute '__get__'",
+                    Py_TYPE(self->object_proxy.wrapped)->tp_name);
+            return NULL;
+        }
+
+        descriptor = (Py_TYPE(self->object_proxy.wrapped)->tp_descr_get)(
+                self->object_proxy.wrapped, obj, type);
+
+        if (!descriptor)
+            return NULL;
+
+        if (Py_TYPE(self) != &WraptFunctionWrapper_Type) {
+            bound_type = PyObject_GenericGetAttr((PyObject *)self,
+                    bound_type_str);
+
+            if (!bound_type)
+                PyErr_Clear();
+        }
+
+        if (obj == NULL)
+            obj = Py_None;
+
+        result = PyObject_CallFunctionObjArgs(bound_type ? bound_type :
+                (PyObject *)&WraptBoundFunctionWrapper_Type, descriptor,
+                obj, self->wrapper, self->enabled, self->binding,
+                self, NULL);
+
+        Py_XDECREF(bound_type);
+        Py_DECREF(descriptor);
+
+        return result;
+    }
+
+    if (self->instance == Py_None && (self->binding == function_str ||
+            PyObject_RichCompareBool(self->binding, function_str,
+            Py_EQ) == 1)) {
+
+        PyObject *wrapped = NULL;
+
+        static PyObject *wrapped_str = NULL;
+
+        if (!wrapped_str) {
+#if PY_MAJOR_VERSION >= 3
+            wrapped_str = PyUnicode_InternFromString("__wrapped__");
+#else
+            wrapped_str = PyString_InternFromString("__wrapped__");
+#endif
+        }
+
+        wrapped = PyObject_GetAttr(self->parent, wrapped_str);
+
+        if (!wrapped)
+            return NULL;
+
+        if (Py_TYPE(wrapped)->tp_descr_get == NULL) {
+            PyErr_Format(PyExc_AttributeError,
+                    "'%s' object has no attribute '__get__'",
+                    Py_TYPE(wrapped)->tp_name);
+            Py_DECREF(wrapped);
+            return NULL;
+        }
+
+        descriptor = (Py_TYPE(wrapped)->tp_descr_get)(wrapped, obj, type);
+
+        Py_DECREF(wrapped);
+
+        if (!descriptor)
+            return NULL;
+
+        if (Py_TYPE(self->parent) != &WraptFunctionWrapper_Type) {
+            bound_type = PyObject_GenericGetAttr((PyObject *)self->parent,
+                    bound_type_str);
+
+            if (!bound_type)
+                PyErr_Clear();
+        }
+
+        if (obj == NULL)
+            obj = Py_None;
+
+        result = PyObject_CallFunctionObjArgs(bound_type ? bound_type :
+                (PyObject *)&WraptBoundFunctionWrapper_Type, descriptor,
+                obj, self->wrapper, self->enabled, self->binding,
+                self->parent, NULL);
+
+        Py_XDECREF(bound_type);
+        Py_DECREF(descriptor);
+
+        return result;
+    }
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptFunctionWrapperBase_get_self_instance(
+        WraptFunctionWrapperObject *self, void *closure)
+{
+    if (!self->instance) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+
+    Py_INCREF(self->instance);
+    return self->instance;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptFunctionWrapperBase_get_self_wrapper(
+        WraptFunctionWrapperObject *self, void *closure)
+{
+    if (!self->wrapper) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+
+    Py_INCREF(self->wrapper);
+    return self->wrapper;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptFunctionWrapperBase_get_self_enabled(
+        WraptFunctionWrapperObject *self, void *closure)
+{
+    if (!self->enabled) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+
+    Py_INCREF(self->enabled);
+    return self->enabled;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptFunctionWrapperBase_get_self_binding(
+        WraptFunctionWrapperObject *self, void *closure)
+{
+    if (!self->binding) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+
+    Py_INCREF(self->binding);
+    return self->binding;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptFunctionWrapperBase_get_self_parent(
+        WraptFunctionWrapperObject *self, void *closure)
+{
+    if (!self->parent) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+
+    Py_INCREF(self->parent);
+    return self->parent;
+}
+
+/* ------------------------------------------------------------------------- */;
+
+static PyGetSetDef WraptFunctionWrapperBase_getset[] = {
+    { "__module__",         (getter)WraptObjectProxy_get_module,
+                            (setter)WraptObjectProxy_set_module, 0 },
+    { "__doc__",            (getter)WraptObjectProxy_get_doc,
+                            (setter)WraptObjectProxy_set_doc, 0 },
+    { "_self_instance",     (getter)WraptFunctionWrapperBase_get_self_instance,
+                            NULL, 0 },
+    { "_self_wrapper",      (getter)WraptFunctionWrapperBase_get_self_wrapper,
+                            NULL, 0 },
+    { "_self_enabled",      (getter)WraptFunctionWrapperBase_get_self_enabled,
+                            NULL, 0 },
+    { "_self_binding",      (getter)WraptFunctionWrapperBase_get_self_binding,
+                            NULL, 0 },
+    { "_self_parent",       (getter)WraptFunctionWrapperBase_get_self_parent,
+                            NULL, 0 },
+    { NULL },
+};
+
+PyTypeObject WraptFunctionWrapperBase_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "_FunctionWrapperBase",      /*tp_name*/
+    sizeof(WraptFunctionWrapperObject), /*tp_basicsize*/
+    0,                      /*tp_itemsize*/
+    /* methods */
+    (destructor)WraptFunctionWrapperBase_dealloc, /*tp_dealloc*/
+    0,                      /*tp_print*/
+    0,                      /*tp_getattr*/
+    0,                      /*tp_setattr*/
+    0,                      /*tp_compare*/
+    0,                      /*tp_repr*/
+    0,                      /*tp_as_number*/
+    0,                      /*tp_as_sequence*/
+    0,                      /*tp_as_mapping*/
+    0,                      /*tp_hash*/
+    (ternaryfunc)WraptFunctionWrapperBase_call, /*tp_call*/
+    0,                      /*tp_str*/
+    0,                      /*tp_getattro*/
+    0,                      /*tp_setattro*/
+    0,                      /*tp_as_buffer*/
+#if PY_MAJOR_VERSION < 3
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
+        Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_CHECKTYPES, /*tp_flags*/
+#else
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
+        Py_TPFLAGS_HAVE_GC, /*tp_flags*/
+#endif
+    0,                      /*tp_doc*/
+    (traverseproc)WraptFunctionWrapperBase_traverse, /*tp_traverse*/
+    (inquiry)WraptFunctionWrapperBase_clear, /*tp_clear*/
+    0,                      /*tp_richcompare*/
+    offsetof(WraptObjectProxyObject, weakreflist), /*tp_weaklistoffset*/
+    0,                      /*tp_iter*/
+    0,                      /*tp_iternext*/
+    0,                      /*tp_methods*/
+    0,                      /*tp_members*/
+    WraptFunctionWrapperBase_getset, /*tp_getset*/
+    0,                      /*tp_base*/
+    0,                      /*tp_dict*/
+    (descrgetfunc)WraptFunctionWrapperBase_descr_get, /*tp_descr_get*/
+    0,                      /*tp_descr_set*/
+    0,                      /*tp_dictoffset*/
+    (initproc)WraptFunctionWrapperBase_init, /*tp_init*/
+    0,                      /*tp_alloc*/
+    WraptFunctionWrapperBase_new,  /*tp_new*/
+    0,                      /*tp_free*/
+    0,                      /*tp_is_gc*/
+};
+
+/* ------------------------------------------------------------------------- */
+
+static PyObject *WraptBoundFunctionWrapper_call(
+        WraptFunctionWrapperObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *param_args = NULL;
+    PyObject *param_kwds = NULL;
+
+    PyObject *wrapped = NULL;
+    PyObject *instance = NULL;
+
+    PyObject *result = NULL;
+
+    static PyObject *function_str = NULL;
+
+    if (self->enabled != Py_None) {
+        if (PyCallable_Check(self->enabled)) {
+            PyObject *object = NULL;
+
+            object = PyObject_CallFunctionObjArgs(self->enabled, NULL);
+
+            if (!object)
+                return NULL;
+
+            if (PyObject_Not(object)) {
+                Py_DECREF(object);
+                return PyObject_Call(self->object_proxy.wrapped, args, kwds);
+            }
+
+            Py_DECREF(object);
+        }
+        else if (PyObject_Not(self->enabled)) {
+            return PyObject_Call(self->object_proxy.wrapped, args, kwds);
+        }
+    }
+
+    if (!function_str) {
+#if PY_MAJOR_VERSION >= 3
+        function_str = PyUnicode_InternFromString("function");
+#else
+        function_str = PyString_InternFromString("function");
+#endif
+    }
+
+    /* 
+    * We need to do things different depending on whether we are likely
+    * wrapping an instance method vs a static method or class method.
+    */
+
+    if (self->binding == function_str || PyObject_RichCompareBool(
+                self->binding, function_str, Py_EQ) == 1) {
+
+        if (self->instance == Py_None) {
+            /*
+             * This situation can occur where someone is calling the
+             * instancemethod via the class type and passing the
+             * instance as the first argument. We need to shift the args
+             * before making the call to the wrapper and effectively
+             * bind the instance to the wrapped function using a partial
+             * so the wrapper doesn't see anything as being different.
+             */
+
+            if (PyTuple_Size(args) == 0) {
+                PyErr_SetString(PyExc_TypeError,
+                        "missing 1 required positional argument");
+                return NULL;
+            }
+
+            instance = PyTuple_GetItem(args, 0);
+
+            if (!instance)
+                return NULL;
+
+            wrapped = PyObject_CallFunctionObjArgs(
+                    (PyObject *)&WraptPartialCallableObjectProxy_Type,
+                    self->object_proxy.wrapped, instance, NULL);
+
+            if (!wrapped)
+                return NULL;
+
+            param_args = PyTuple_GetSlice(args, 1, PyTuple_Size(args));
+
+            if (!param_args) {
+                Py_DECREF(wrapped);
+                return NULL;
+            }
+
+            args = param_args;
+        }
+        else
+            instance = self->instance;
+
+        if (!wrapped) {
+            Py_INCREF(self->object_proxy.wrapped);
+            wrapped = self->object_proxy.wrapped;
+        }
+
+        if (!kwds) {
+            param_kwds = PyDict_New();
+            kwds = param_kwds;
+        }
+
+        result = PyObject_CallFunctionObjArgs(self->wrapper, wrapped,
+                instance, args, kwds, NULL);
+
+        Py_XDECREF(param_args);
+        Py_XDECREF(param_kwds);
+        Py_DECREF(wrapped);
+
+        return result;
+    }
+    else {
+        /*
+         * As in this case we would be dealing with a classmethod or
+         * staticmethod, then _self_instance will only tell us whether
+         * when calling the classmethod or staticmethod they did it via
+         * an instance of the class it is bound to and not the case
+         * where done by the class type itself. We thus ignore
+         * _self_instance and use the __self__ attribute of the bound
+         * function instead. For a classmethod, this means instance will
+         * be the class type and for a staticmethod it will be None.
+         * This is probably the more useful thing we can pass through
+         * even though we loose knowledge of whether they were called on
+         * the instance vs the class type, as it reflects what they have
+         * available in the decoratored function.
+         */
+
+        instance = PyObject_GetAttrString(self->object_proxy.wrapped,
+                "__self__");
+
+        if (!instance) {
+            PyErr_Clear();
+            Py_INCREF(Py_None);
+            instance = Py_None;
+        }
+
+        if (!kwds) {
+            param_kwds = PyDict_New();
+            kwds = param_kwds;
+        }
+
+        result = PyObject_CallFunctionObjArgs(self->wrapper,
+                self->object_proxy.wrapped, instance, args, kwds, NULL);
+
+        Py_XDECREF(param_kwds);
+
+        Py_DECREF(instance);
+
+        return result;
+    }
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyGetSetDef WraptBoundFunctionWrapper_getset[] = {
+    { "__module__",         (getter)WraptObjectProxy_get_module,
+                            (setter)WraptObjectProxy_set_module, 0 },
+    { "__doc__",            (getter)WraptObjectProxy_get_doc,
+                            (setter)WraptObjectProxy_set_doc, 0 },
+    { NULL },
+};
+
+PyTypeObject WraptBoundFunctionWrapper_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "BoundFunctionWrapper", /*tp_name*/
+    sizeof(WraptFunctionWrapperObject), /*tp_basicsize*/
+    0,                      /*tp_itemsize*/
+    /* methods */
+    0,                      /*tp_dealloc*/
+    0,                      /*tp_print*/
+    0,                      /*tp_getattr*/
+    0,                      /*tp_setattr*/
+    0,                      /*tp_compare*/
+    0,                      /*tp_repr*/
+    0,                      /*tp_as_number*/
+    0,                      /*tp_as_sequence*/
+    0,                      /*tp_as_mapping*/
+    0,                      /*tp_hash*/
+    (ternaryfunc)WraptBoundFunctionWrapper_call, /*tp_call*/
+    0,                      /*tp_str*/
+    0,                      /*tp_getattro*/
+    0,                      /*tp_setattro*/
+    0,                      /*tp_as_buffer*/
+#if PY_MAJOR_VERSION < 3
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_CHECKTYPES, /*tp_flags*/
+#else
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+#endif
+    0,                      /*tp_doc*/
+    0,                      /*tp_traverse*/
+    0,                      /*tp_clear*/
+    0,                      /*tp_richcompare*/
+    offsetof(WraptObjectProxyObject, weakreflist), /*tp_weaklistoffset*/
+    0,                      /*tp_iter*/
+    0,                      /*tp_iternext*/
+    0,                      /*tp_methods*/
+    0,                      /*tp_members*/
+    WraptBoundFunctionWrapper_getset, /*tp_getset*/
+    0,                      /*tp_base*/
+    0,                      /*tp_dict*/
+    0,                      /*tp_descr_get*/
+    0,                      /*tp_descr_set*/
+    0,                      /*tp_dictoffset*/
+    0,                      /*tp_init*/
+    0,                      /*tp_alloc*/
+    0,                      /*tp_new*/
+    0,                      /*tp_free*/
+    0,                      /*tp_is_gc*/
+};
+
+/* ------------------------------------------------------------------------- */
+
+static int WraptFunctionWrapper_init(WraptFunctionWrapperObject *self,
+        PyObject *args, PyObject *kwds)
+{
+    PyObject *wrapped = NULL;
+    PyObject *wrapper = NULL;
+    PyObject *enabled = Py_None;
+    PyObject *binding = NULL;
+    PyObject *instance = NULL;
+
+    static PyObject *classmethod_str = NULL;
+    static PyObject *staticmethod_str = NULL;
+    static PyObject *function_str = NULL;
+
+    int result = 0;
+
+    static char *kwlist[] = { "wrapped", "wrapper", "enabled", NULL };
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O:FunctionWrapper",
+            kwlist, &wrapped, &wrapper, &enabled)) {
+        return -1;
+    }
+
+    if (!classmethod_str) {
+#if PY_MAJOR_VERSION >= 3
+        classmethod_str = PyUnicode_InternFromString("classmethod");
+#else
+        classmethod_str = PyString_InternFromString("classmethod");
+#endif
+    }
+
+    if (!staticmethod_str) {
+#if PY_MAJOR_VERSION >= 3
+        staticmethod_str = PyUnicode_InternFromString("staticmethod");
+#else
+        staticmethod_str = PyString_InternFromString("staticmethod");
+#endif
+    }
+
+    if (!function_str) {
+#if PY_MAJOR_VERSION >= 3
+        function_str = PyUnicode_InternFromString("function");
+#else
+        function_str = PyString_InternFromString("function");
+#endif
+    }
+
+    if (PyObject_IsInstance(wrapped, (PyObject *)&PyClassMethod_Type)) {
+        binding = classmethod_str;
+    }
+    else if (PyObject_IsInstance(wrapped, (PyObject *)&PyStaticMethod_Type)) {
+        binding = staticmethod_str;
+    }
+    else if ((instance = PyObject_GetAttrString(wrapped, "__self__")) != 0) {
+#if PY_MAJOR_VERSION < 3
+        if (PyObject_IsInstance(instance, (PyObject *)&PyClass_Type) ||
+                PyObject_IsInstance(instance, (PyObject *)&PyType_Type)) {
+            binding = classmethod_str;
+        }
+#else
+        if (PyObject_IsInstance(instance, (PyObject *)&PyType_Type)) {
+            binding = classmethod_str;
+        }
+#endif
+        else
+            binding = function_str;
+
+        Py_DECREF(instance);
+    }
+    else {
+        PyErr_Clear();
+
+        binding = function_str;
+    }
+
+    result = WraptFunctionWrapperBase_raw_init(self, wrapped, Py_None,
+            wrapper, enabled, binding, Py_None);
+
+    return result;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static PyGetSetDef WraptFunctionWrapper_getset[] = {
+    { "__module__",         (getter)WraptObjectProxy_get_module,
+                            (setter)WraptObjectProxy_set_module, 0 },
+    { "__doc__",            (getter)WraptObjectProxy_get_doc,
+                            (setter)WraptObjectProxy_set_doc, 0 },
+    { NULL },
+};
+
+PyTypeObject WraptFunctionWrapper_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "FunctionWrapper",      /*tp_name*/
+    sizeof(WraptFunctionWrapperObject), /*tp_basicsize*/
+    0,                      /*tp_itemsize*/
+    /* methods */
+    0,                      /*tp_dealloc*/
+    0,                      /*tp_print*/
+    0,                      /*tp_getattr*/
+    0,                      /*tp_setattr*/
+    0,                      /*tp_compare*/
+    0,                      /*tp_repr*/
+    0,                      /*tp_as_number*/
+    0,                      /*tp_as_sequence*/
+    0,                      /*tp_as_mapping*/
+    0,                      /*tp_hash*/
+    0,                      /*tp_call*/
+    0,                      /*tp_str*/
+    0,                      /*tp_getattro*/
+    0,                      /*tp_setattro*/
+    0,                      /*tp_as_buffer*/
+#if PY_MAJOR_VERSION < 3
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_CHECKTYPES, /*tp_flags*/
+#else
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+#endif
+    0,                      /*tp_doc*/
+    0,                      /*tp_traverse*/
+    0,                      /*tp_clear*/
+    0,                      /*tp_richcompare*/
+    offsetof(WraptObjectProxyObject, weakreflist), /*tp_weaklistoffset*/
+    0,                      /*tp_iter*/
+    0,                      /*tp_iternext*/
+    0,                      /*tp_methods*/
+    0,                      /*tp_members*/
+    WraptFunctionWrapper_getset, /*tp_getset*/
+    0,                      /*tp_base*/
+    0,                      /*tp_dict*/
+    0,                      /*tp_descr_get*/
+    0,                      /*tp_descr_set*/
+    0,                      /*tp_dictoffset*/
+    (initproc)WraptFunctionWrapper_init, /*tp_init*/
+    0,                      /*tp_alloc*/
+    0,                      /*tp_new*/
+    0,                      /*tp_free*/
+    0,                      /*tp_is_gc*/
+};
+
+/* ------------------------------------------------------------------------- */
+
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "_wrappers",         /* m_name */
+    NULL,                /* m_doc */
+    -1,                  /* m_size */
+    NULL,                /* m_methods */
+    NULL,                /* m_reload */
+    NULL,                /* m_traverse */
+    NULL,                /* m_clear */
+    NULL,                /* m_free */
+};
+#endif
+
+static PyObject *
+moduleinit(void)
+{
+    PyObject *module;
+
+#if PY_MAJOR_VERSION >= 3
+    module = PyModule_Create(&moduledef);
+#else
+    module = Py_InitModule3("_wrappers", NULL, NULL);
+#endif
+
+    if (module == NULL)
+        return NULL;
+
+    if (PyType_Ready(&WraptObjectProxy_Type) < 0)
+        return NULL;
+
+    /* Ensure that inheritance relationships specified. */
+
+    WraptCallableObjectProxy_Type.tp_base = &WraptObjectProxy_Type;
+    WraptPartialCallableObjectProxy_Type.tp_base = &WraptObjectProxy_Type;
+    WraptFunctionWrapperBase_Type.tp_base = &WraptObjectProxy_Type;
+    WraptBoundFunctionWrapper_Type.tp_base = &WraptFunctionWrapperBase_Type;
+    WraptFunctionWrapper_Type.tp_base = &WraptFunctionWrapperBase_Type;
+
+    if (PyType_Ready(&WraptCallableObjectProxy_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&WraptPartialCallableObjectProxy_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&WraptFunctionWrapperBase_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&WraptBoundFunctionWrapper_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&WraptFunctionWrapper_Type) < 0)
+        return NULL;
+
+    Py_INCREF(&WraptObjectProxy_Type);
+    PyModule_AddObject(module, "ObjectProxy",
+            (PyObject *)&WraptObjectProxy_Type);
+    Py_INCREF(&WraptCallableObjectProxy_Type);
+    PyModule_AddObject(module, "CallableObjectProxy",
+            (PyObject *)&WraptCallableObjectProxy_Type);
+    PyModule_AddObject(module, "PartialCallableObjectProxy",
+            (PyObject *)&WraptPartialCallableObjectProxy_Type);
+    Py_INCREF(&WraptFunctionWrapper_Type);
+    PyModule_AddObject(module, "FunctionWrapper",
+            (PyObject *)&WraptFunctionWrapper_Type);
+
+    Py_INCREF(&WraptFunctionWrapperBase_Type);
+    PyModule_AddObject(module, "_FunctionWrapperBase",
+            (PyObject *)&WraptFunctionWrapperBase_Type);
+    Py_INCREF(&WraptBoundFunctionWrapper_Type);
+    PyModule_AddObject(module, "BoundFunctionWrapper",
+            (PyObject *)&WraptBoundFunctionWrapper_Type);
+
+    return module;
+}
+
+#if PY_MAJOR_VERSION < 3
+PyMODINIT_FUNC init_wrappers(void)
+{
+    moduleinit();
+}
+#else
+PyMODINIT_FUNC PyInit__wrappers(void)
+{
+    return moduleinit();
+}
+#endif
+
+/* ------------------------------------------------------------------------- */

--- a/ddtrace/vendor/wrapt/decorators.py
+++ b/ddtrace/vendor/wrapt/decorators.py
@@ -1,0 +1,511 @@
+"""This module implements decorators for implementing other decorators
+as well as some commonly used decorators.
+
+"""
+
+import sys
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    string_types = str,
+
+    import builtins
+    exec_ = getattr(builtins, "exec")
+    del builtins
+
+else:
+    string_types = basestring,
+
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+from functools import partial
+from inspect import ismethod, isclass, formatargspec
+from collections import namedtuple
+from threading import Lock, RLock
+
+try:
+    from inspect import signature
+except ImportError:
+    pass
+
+from .wrappers import (FunctionWrapper, BoundFunctionWrapper, ObjectProxy,
+    CallableObjectProxy)
+
+# Adapter wrapper for the wrapped function which will overlay certain
+# properties from the adapter function onto the wrapped function so that
+# functions such as inspect.getargspec(), inspect.getfullargspec(),
+# inspect.signature() and inspect.getsource() return the correct results
+# one would expect.
+
+class _AdapterFunctionCode(CallableObjectProxy):
+
+    def __init__(self, wrapped_code, adapter_code):
+        super(_AdapterFunctionCode, self).__init__(wrapped_code)
+        self._self_adapter_code = adapter_code
+
+    @property
+    def co_argcount(self):
+        return self._self_adapter_code.co_argcount
+
+    @property
+    def co_code(self):
+        return self._self_adapter_code.co_code
+
+    @property
+    def co_flags(self):
+        return self._self_adapter_code.co_flags
+
+    @property
+    def co_kwonlyargcount(self):
+        return self._self_adapter_code.co_kwonlyargcount
+
+    @property
+    def co_varnames(self):
+        return self._self_adapter_code.co_varnames
+
+class _AdapterFunctionSurrogate(CallableObjectProxy):
+
+    def __init__(self, wrapped, adapter):
+        super(_AdapterFunctionSurrogate, self).__init__(wrapped)
+        self._self_adapter = adapter
+
+    @property
+    def __code__(self):
+        return _AdapterFunctionCode(self.__wrapped__.__code__,
+                self._self_adapter.__code__)
+
+    @property
+    def __defaults__(self):
+        return self._self_adapter.__defaults__
+
+    @property
+    def __kwdefaults__(self):
+        return self._self_adapter.__kwdefaults__
+
+    @property
+    def __signature__(self):
+        if 'signature' not in globals():
+            return self._self_adapter.__signature__
+        else:
+            # Can't allow this to fail on Python 3 else it falls
+            # through to using __wrapped__, but that will be the
+            # wrong function we want to derive the signature
+            # from. Thus generate the signature ourselves.
+
+            return signature(self._self_adapter)
+
+    if PY2:
+        func_code = __code__
+        func_defaults = __defaults__
+
+class _BoundAdapterWrapper(BoundFunctionWrapper):
+
+    @property
+    def __func__(self):
+        return _AdapterFunctionSurrogate(self.__wrapped__.__func__,
+                self._self_parent._self_adapter)
+
+    if PY2:
+        im_func = __func__
+
+class AdapterWrapper(FunctionWrapper):
+
+    __bound_function_wrapper__ = _BoundAdapterWrapper
+
+    def __init__(self, *args, **kwargs):
+        adapter = kwargs.pop('adapter')
+        super(AdapterWrapper, self).__init__(*args, **kwargs)
+        self._self_surrogate = _AdapterFunctionSurrogate(
+                self.__wrapped__, adapter)
+        self._self_adapter = adapter
+
+    @property
+    def __code__(self):
+        return self._self_surrogate.__code__
+
+    @property
+    def __defaults__(self):
+        return self._self_surrogate.__defaults__
+
+    @property
+    def __kwdefaults__(self):
+        return self._self_surrogate.__kwdefaults__
+
+    if PY2:
+        func_code = __code__
+        func_defaults = __defaults__
+
+    @property
+    def __signature__(self):
+        return self._self_surrogate.__signature__
+
+class AdapterFactory(object):
+    def __call__(self, wrapped):
+        raise NotImplementedError()
+
+class DelegatedAdapterFactory(AdapterFactory):
+    def __init__(self, factory):
+        super(DelegatedAdapterFactory, self).__init__()
+        self.factory = factory
+    def __call__(self, wrapped):
+        return self.factory(wrapped)
+
+adapter_factory = DelegatedAdapterFactory
+
+# Decorator for creating other decorators. This decorator and the
+# wrappers which they use are designed to properly preserve any name
+# attributes, function signatures etc, in addition to the wrappers
+# themselves acting like a transparent proxy for the original wrapped
+# function so the wrapper is effectively indistinguishable from the
+# original wrapped function.
+
+def decorator(wrapper=None, enabled=None, adapter=None):
+    # The decorator should be supplied with a single positional argument
+    # which is the wrapper function to be used to implement the
+    # decorator. This may be preceded by a step whereby the keyword
+    # arguments are supplied to customise the behaviour of the
+    # decorator. The 'adapter' argument is used to optionally denote a
+    # separate function which is notionally used by an adapter
+    # decorator. In that case parts of the function '__code__' and
+    # '__defaults__' attributes are used from the adapter function
+    # rather than those of the wrapped function. This allows for the
+    # argument specification from inspect.getargspec() and similar
+    # functions to be overridden with a prototype for a different
+    # function than what was wrapped. The 'enabled' argument provides a
+    # way to enable/disable the use of the decorator. If the type of
+    # 'enabled' is a boolean, then it is evaluated immediately and the
+    # wrapper not even applied if it is False. If not a boolean, it will
+    # be evaluated when the wrapper is called for an unbound wrapper,
+    # and when binding occurs for a bound wrapper. When being evaluated,
+    # if 'enabled' is callable it will be called to obtain the value to
+    # be checked. If False, the wrapper will not be called and instead
+    # the original wrapped function will be called directly instead.
+
+    if wrapper is not None:
+        # Helper function for creating wrapper of the appropriate
+        # time when we need it down below.
+
+        def _build(wrapped, wrapper, enabled=None, adapter=None):
+            if adapter:
+                if isinstance(adapter, AdapterFactory):
+                    adapter = adapter(wrapped)
+
+                if not callable(adapter):
+                    ns = {}
+                    if not isinstance(adapter, string_types):
+                        adapter = formatargspec(*adapter)
+                    exec_('def adapter{}: pass'.format(adapter), ns, ns)
+                    adapter = ns['adapter']
+
+                return AdapterWrapper(wrapped=wrapped, wrapper=wrapper,
+                        enabled=enabled, adapter=adapter)
+
+            return FunctionWrapper(wrapped=wrapped, wrapper=wrapper,
+                    enabled=enabled)
+
+        # The wrapper has been provided so return the final decorator.
+        # The decorator is itself one of our function wrappers so we
+        # can determine when it is applied to functions, instance methods
+        # or class methods. This allows us to bind the instance or class
+        # method so the appropriate self or cls attribute is supplied
+        # when it is finally called.
+
+        def _wrapper(wrapped, instance, args, kwargs):
+            # We first check for the case where the decorator was applied
+            # to a class type.
+            #
+            #     @decorator
+            #     class mydecoratorclass(object):
+            #         def __init__(self, arg=None):
+            #             self.arg = arg
+            #         def __call__(self, wrapped, instance, args, kwargs):
+            #             return wrapped(*args, **kwargs)
+            #
+            #     @mydecoratorclass(arg=1)
+            #     def function():
+            #         pass
+            #
+            # In this case an instance of the class is to be used as the
+            # decorator wrapper function. If args was empty at this point,
+            # then it means that there were optional keyword arguments
+            # supplied to be used when creating an instance of the class
+            # to be used as the wrapper function.
+
+            if instance is None and isclass(wrapped) and not args:
+                # We still need to be passed the target function to be
+                # wrapped as yet, so we need to return a further function
+                # to be able to capture it.
+
+                def _capture(target_wrapped):
+                    # Now have the target function to be wrapped and need
+                    # to create an instance of the class which is to act
+                    # as the decorator wrapper function. Before we do that,
+                    # we need to first check that use of the decorator
+                    # hadn't been disabled by a simple boolean. If it was,
+                    # the target function to be wrapped is returned instead.
+
+                    _enabled = enabled
+                    if type(_enabled) is bool:
+                        if not _enabled:
+                            return target_wrapped
+                        _enabled = None
+
+                    # Now create an instance of the class which is to act
+                    # as the decorator wrapper function. Any arguments had
+                    # to be supplied as keyword only arguments so that is
+                    # all we pass when creating it.
+
+                    target_wrapper = wrapped(**kwargs)
+
+                    # Finally build the wrapper itself and return it.
+
+                    return _build(target_wrapped, target_wrapper,
+                            _enabled, adapter)
+
+                return _capture
+
+            # We should always have the target function to be wrapped at
+            # this point as the first (and only) value in args.
+
+            target_wrapped = args[0]
+
+            # Need to now check that use of the decorator hadn't been
+            # disabled by a simple boolean. If it was, then target
+            # function to be wrapped is returned instead.
+
+            _enabled = enabled
+            if type(_enabled) is bool:
+                if not _enabled:
+                    return target_wrapped
+                _enabled = None
+
+            # We now need to build the wrapper, but there are a couple of
+            # different cases we need to consider.
+
+            if instance is None:
+                if isclass(wrapped):
+                    # In this case the decorator was applied to a class
+                    # type but optional keyword arguments were not supplied
+                    # for initialising an instance of the class to be used
+                    # as the decorator wrapper function.
+                    #
+                    #     @decorator
+                    #     class mydecoratorclass(object):
+                    #         def __init__(self, arg=None):
+                    #             self.arg = arg
+                    #         def __call__(self, wrapped, instance,
+                    #                 args, kwargs):
+                    #             return wrapped(*args, **kwargs)
+                    #
+                    #     @mydecoratorclass
+                    #     def function():
+                    #         pass
+                    #
+                    # We still need to create an instance of the class to
+                    # be used as the decorator wrapper function, but no
+                    # arguments are pass.
+
+                    target_wrapper = wrapped()
+
+                else:
+                    # In this case the decorator was applied to a normal
+                    # function, or possibly a static method of a class.
+                    #
+                    #     @decorator
+                    #     def mydecoratorfuntion(wrapped, instance,
+                    #             args, kwargs):
+                    #         return wrapped(*args, **kwargs)
+                    #
+                    #     @mydecoratorfunction
+                    #     def function():
+                    #         pass
+                    #
+                    # That normal function becomes the decorator wrapper
+                    # function.
+
+                    target_wrapper = wrapper
+
+            else:
+                if isclass(instance):
+                    # In this case the decorator was applied to a class
+                    # method.
+                    #
+                    #     class myclass(object):
+                    #         @decorator
+                    #         @classmethod
+                    #         def decoratorclassmethod(cls, wrapped,
+                    #                 instance, args, kwargs):
+                    #             return wrapped(*args, **kwargs)
+                    #
+                    #     instance = myclass()
+                    #
+                    #     @instance.decoratorclassmethod
+                    #     def function():
+                    #         pass
+                    #
+                    # This one is a bit strange because binding was actually
+                    # performed on the wrapper created by our decorator
+                    # factory. We need to apply that binding to the decorator
+                    # wrapper function which which the decorator factory
+                    # was applied to.
+
+                    target_wrapper = wrapper.__get__(None, instance)
+
+                else:
+                    # In this case the decorator was applied to an instance
+                    # method.
+                    #
+                    #     class myclass(object):
+                    #         @decorator
+                    #         def decoratorclassmethod(self, wrapped,
+                    #                 instance, args, kwargs):
+                    #             return wrapped(*args, **kwargs)
+                    #
+                    #     instance = myclass()
+                    #
+                    #     @instance.decoratorclassmethod
+                    #     def function():
+                    #         pass
+                    #
+                    # This one is a bit strange because binding was actually
+                    # performed on the wrapper created by our decorator
+                    # factory. We need to apply that binding to the decorator
+                    # wrapper function which which the decorator factory
+                    # was applied to.
+
+                    target_wrapper = wrapper.__get__(instance, type(instance))
+
+            # Finally build the wrapper itself and return it.
+
+            return _build(target_wrapped, target_wrapper, _enabled, adapter)
+
+        # We first return our magic function wrapper here so we can
+        # determine in what context the decorator factory was used. In
+        # other words, it is itself a universal decorator.
+
+        return _build(wrapper, _wrapper)
+
+    else:
+        # The wrapper still has not been provided, so we are just
+        # collecting the optional keyword arguments. Return the
+        # decorator again wrapped in a partial using the collected
+        # arguments.
+
+        return partial(decorator, enabled=enabled, adapter=adapter)
+
+# Decorator for implementing thread synchronization. It can be used as a
+# decorator, in which case the synchronization context is determined by
+# what type of function is wrapped, or it can also be used as a context
+# manager, where the user needs to supply the correct synchronization
+# context. It is also possible to supply an object which appears to be a
+# synchronization primitive of some sort, by virtue of having release()
+# and acquire() methods. In that case that will be used directly as the
+# synchronization primitive without creating a separate lock against the
+# derived or supplied context.
+
+def synchronized(wrapped):
+    # Determine if being passed an object which is a synchronization
+    # primitive. We can't check by type for Lock, RLock, Semaphore etc,
+    # as the means of creating them isn't the type. Therefore use the
+    # existence of acquire() and release() methods. This is more
+    # extensible anyway as it allows custom synchronization mechanisms.
+
+    if hasattr(wrapped, 'acquire') and hasattr(wrapped, 'release'):
+        # We remember what the original lock is and then return a new
+        # decorator which accesses and locks it. When returning the new
+        # decorator we wrap it with an object proxy so we can override
+        # the context manager methods in case it is being used to wrap
+        # synchronized statements with a 'with' statement.
+
+        lock = wrapped
+
+        @decorator
+        def _synchronized(wrapped, instance, args, kwargs):
+            # Execute the wrapped function while the original supplied
+            # lock is held.
+
+            with lock:
+                return wrapped(*args, **kwargs)
+
+        class _PartialDecorator(CallableObjectProxy):
+
+            def __enter__(self):
+                lock.acquire()
+                return lock
+
+            def __exit__(self, *args):
+                lock.release()
+
+        return _PartialDecorator(wrapped=_synchronized)
+
+    # Following only apply when the lock is being created automatically
+    # based on the context of what was supplied. In this case we supply
+    # a final decorator, but need to use FunctionWrapper directly as we
+    # want to derive from it to add context manager methods in case it is
+    # being used to wrap synchronized statements with a 'with' statement.
+
+    def _synchronized_lock(context):
+        # Attempt to retrieve the lock for the specific context.
+
+        lock = vars(context).get('_synchronized_lock', None)
+
+        if lock is None:
+            # There is no existing lock defined for the context we
+            # are dealing with so we need to create one. This needs
+            # to be done in a way to guarantee there is only one
+            # created, even if multiple threads try and create it at
+            # the same time. We can't always use the setdefault()
+            # method on the __dict__ for the context. This is the
+            # case where the context is a class, as __dict__ is
+            # actually a dictproxy. What we therefore do is use a
+            # meta lock on this wrapper itself, to control the
+            # creation and assignment of the lock attribute against
+            # the context.
+
+            with synchronized._synchronized_meta_lock:
+                # We need to check again for whether the lock we want
+                # exists in case two threads were trying to create it
+                # at the same time and were competing to create the
+                # meta lock.
+
+                lock = vars(context).get('_synchronized_lock', None)
+
+                if lock is None:
+                    lock = RLock()
+                    setattr(context, '_synchronized_lock', lock)
+
+        return lock
+
+    def _synchronized_wrapper(wrapped, instance, args, kwargs):
+        # Execute the wrapped function while the lock for the
+        # desired context is held. If instance is None then the
+        # wrapped function is used as the context.
+
+        with _synchronized_lock(instance or wrapped):
+            return wrapped(*args, **kwargs)
+
+    class _FinalDecorator(FunctionWrapper):
+
+        def __enter__(self):
+            self._self_lock = _synchronized_lock(self.__wrapped__)
+            self._self_lock.acquire()
+            return self._self_lock
+
+        def __exit__(self, *args):
+            self._self_lock.release()
+
+    return _FinalDecorator(wrapped=wrapped, wrapper=_synchronized_wrapper)
+
+synchronized._synchronized_meta_lock = Lock()

--- a/ddtrace/vendor/wrapt/importer.py
+++ b/ddtrace/vendor/wrapt/importer.py
@@ -1,0 +1,230 @@
+"""This module implements a post import hook mechanism styled after what is
+described in PEP-369. Note that it doesn't cope with modules being reloaded.
+
+"""
+
+import sys
+import threading
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    import importlib
+    string_types = str,
+else:
+    string_types = basestring,
+
+from .decorators import synchronized
+
+# The dictionary registering any post import hooks to be triggered once
+# the target module has been imported. Once a module has been imported
+# and the hooks fired, the list of hooks recorded against the target
+# module will be truncacted but the list left in the dictionary. This
+# acts as a flag to indicate that the module had already been imported.
+
+_post_import_hooks = {}
+_post_import_hooks_init = False
+_post_import_hooks_lock = threading.RLock()
+
+# Register a new post import hook for the target module name. This
+# differs from the PEP-369 implementation in that it also allows the
+# hook function to be specified as a string consisting of the name of
+# the callback in the form 'module:function'. This will result in a
+# proxy callback being registered which will defer loading of the
+# specified module containing the callback function until required.
+
+def _create_import_hook_from_string(name):
+    def import_hook(module):
+        module_name, function = name.split(':')
+        attrs = function.split('.')
+        __import__(module_name)
+        callback = sys.modules[module_name]
+        for attr in attrs:
+            callback = getattr(callback, attr)
+        return callback(module)
+    return import_hook
+
+@synchronized(_post_import_hooks_lock)
+def register_post_import_hook(hook, name):
+    # Create a deferred import hook if hook is a string name rather than
+    # a callable function.
+
+    if isinstance(hook, string_types):
+        hook = _create_import_hook_from_string(hook)
+
+    # Automatically install the import hook finder if it has not already
+    # been installed.
+
+    global _post_import_hooks_init
+
+    if not _post_import_hooks_init:
+        _post_import_hooks_init = True
+        sys.meta_path.insert(0, ImportHookFinder())
+
+    # Determine if any prior registration of a post import hook for
+    # the target modules has occurred and act appropriately.
+
+    hooks = _post_import_hooks.get(name, None)
+
+    if hooks is None:
+        # No prior registration of post import hooks for the target
+        # module. We need to check whether the module has already been
+        # imported. If it has we fire the hook immediately and add an
+        # empty list to the registry to indicate that the module has
+        # already been imported and hooks have fired. Otherwise add
+        # the post import hook to the registry.
+
+        module = sys.modules.get(name, None)
+
+        if module is not None:
+            _post_import_hooks[name] = []
+            hook(module)
+
+        else:
+            _post_import_hooks[name] = [hook]
+
+    elif hooks == []:
+        # A prior registration of port import hooks for the target
+        # module was done and the hooks already fired. Fire the hook
+        # immediately.
+
+        module = sys.modules[name]
+        hook(module)
+
+    else:
+        # A prior registration of port import hooks for the target
+        # module was done but the module has not yet been imported.
+
+        _post_import_hooks[name].append(hook)
+
+# Register post import hooks defined as package entry points.
+
+def _create_import_hook_from_entrypoint(entrypoint):
+    def import_hook(module):
+        __import__(entrypoint.module_name)
+        callback = sys.modules[entrypoint.module_name]
+        for attr in entrypoint.attrs:
+            callback = getattr(callback, attr)
+        return callback(module)
+    return import_hook
+
+def discover_post_import_hooks(group):
+    try:
+        import pkg_resources
+    except ImportError:
+        return
+
+    for entrypoint in pkg_resources.iter_entry_points(group=group):
+        callback = _create_import_hook_from_entrypoint(entrypoint)
+        register_post_import_hook(callback, entrypoint.name)
+
+# Indicate that a module has been loaded. Any post import hooks which
+# were registered against the target module will be invoked. If an
+# exception is raised in any of the post import hooks, that will cause
+# the import of the target module to fail.
+
+@synchronized(_post_import_hooks_lock)
+def notify_module_loaded(module):
+    name = getattr(module, '__name__', None)
+    hooks = _post_import_hooks.get(name, None)
+
+    if hooks:
+        _post_import_hooks[name] = []
+
+        for hook in hooks:
+            hook(module)
+
+# A custom module import finder. This intercepts attempts to import
+# modules and watches out for attempts to import target modules of
+# interest. When a module of interest is imported, then any post import
+# hooks which are registered will be invoked.
+
+class _ImportHookLoader:
+
+    def load_module(self, fullname):
+        module = sys.modules[fullname]
+        notify_module_loaded(module)
+
+        return module
+
+class _ImportHookChainedLoader:
+
+    def __init__(self, loader):
+        self.loader = loader
+
+    def load_module(self, fullname):
+        module = self.loader.load_module(fullname)
+        notify_module_loaded(module)
+
+        return module
+
+class ImportHookFinder:
+
+    def __init__(self):
+        self.in_progress = {}
+
+    @synchronized(_post_import_hooks_lock)
+    def find_module(self, fullname, path=None):
+        # If the module being imported is not one we have registered
+        # post import hooks for, we can return immediately. We will
+        # take no further part in the importing of this module.
+
+        if not fullname in _post_import_hooks:
+            return None
+
+        # When we are interested in a specific module, we will call back
+        # into the import system a second time to defer to the import
+        # finder that is supposed to handle the importing of the module.
+        # We set an in progress flag for the target module so that on
+        # the second time through we don't trigger another call back
+        # into the import system and cause a infinite loop.
+
+        if fullname in self.in_progress:
+            return None
+
+        self.in_progress[fullname] = True
+
+        # Now call back into the import system again.
+
+        try:
+            if PY3:
+                # For Python 3 we need to use find_spec().loader
+                # from the importlib.util module. It doesn't actually
+                # import the target module and only finds the
+                # loader. If a loader is found, we need to return
+                # our own loader which will then in turn call the
+                # real loader to import the module and invoke the
+                # post import hooks.
+                try:
+                    import importlib.util
+                    loader = importlib.util.find_spec(fullname).loader
+                except (ImportError, AttributeError):
+                    loader = importlib.find_loader(fullname, path)
+                if loader:
+                    return _ImportHookChainedLoader(loader)
+
+            else:
+                # For Python 2 we don't have much choice but to
+                # call back in to __import__(). This will
+                # actually cause the module to be imported. If no
+                # module could be found then ImportError will be
+                # raised. Otherwise we return a loader which
+                # returns the already loaded module and invokes
+                # the post import hooks.
+
+                __import__(fullname)
+
+                return _ImportHookLoader()
+
+        finally:
+            del self.in_progress[fullname]
+
+# Decorator for marking that a function should be called as a post
+# import hook when the target module is imported.
+
+def when_imported(name):
+    def register(hook):
+        register_post_import_hook(hook, name)
+        return hook
+    return register

--- a/ddtrace/vendor/wrapt/wrappers.py
+++ b/ddtrace/vendor/wrapt/wrappers.py
@@ -1,0 +1,943 @@
+import os
+import sys
+import functools
+import operator
+import weakref
+import inspect
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    string_types = str,
+else:
+    string_types = basestring,
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    return meta("NewBase", bases, {})
+
+class _ObjectProxyMethods(object):
+
+    # We use properties to override the values of __module__ and
+    # __doc__. If we add these in ObjectProxy, the derived class
+    # __dict__ will still be setup to have string variants of these
+    # attributes and the rules of descriptors means that they appear to
+    # take precedence over the properties in the base class. To avoid
+    # that, we copy the properties into the derived class type itself
+    # via a meta class. In that way the properties will always take
+    # precedence.
+
+    @property
+    def __module__(self):
+        return self.__wrapped__.__module__
+
+    @__module__.setter
+    def __module__(self, value):
+        self.__wrapped__.__module__ = value
+
+    @property
+    def __doc__(self):
+        return self.__wrapped__.__doc__
+
+    @__doc__.setter
+    def __doc__(self, value):
+        self.__wrapped__.__doc__ = value
+
+    # We similar use a property for __dict__. We need __dict__ to be
+    # explicit to ensure that vars() works as expected.
+
+    @property
+    def __dict__(self):
+        return self.__wrapped__.__dict__
+
+    # Need to also propagate the special __weakref__ attribute for case
+    # where decorating classes which will define this. If do not define
+    # it and use a function like inspect.getmembers() on a decorator
+    # class it will fail. This can't be in the derived classes.
+
+    @property
+    def __weakref__(self):
+        return self.__wrapped__.__weakref__
+
+class _ObjectProxyMetaType(type):
+    def __new__(cls, name, bases, dictionary):
+        # Copy our special properties into the class so that they
+        # always take precedence over attributes of the same name added
+        # during construction of a derived class. This is to save
+        # duplicating the implementation for them in all derived classes.
+
+        dictionary.update(vars(_ObjectProxyMethods))
+
+        return type.__new__(cls, name, bases, dictionary)
+
+class ObjectProxy(with_metaclass(_ObjectProxyMetaType)):
+
+    __slots__ = '__wrapped__'
+
+    def __init__(self, wrapped):
+        object.__setattr__(self, '__wrapped__', wrapped)
+
+        # Python 3.2+ has the __qualname__ attribute, but it does not
+        # allow it to be overridden using a property and it must instead
+        # be an actual string object instead.
+
+        try:
+            object.__setattr__(self, '__qualname__', wrapped.__qualname__)
+        except AttributeError:
+            pass
+
+    @property
+    def __name__(self):
+        return self.__wrapped__.__name__
+
+    @__name__.setter
+    def __name__(self, value):
+        self.__wrapped__.__name__ = value
+
+    @property
+    def __class__(self):
+        return self.__wrapped__.__class__
+
+    @__class__.setter
+    def __class__(self, value):
+        self.__wrapped__.__class__ = value
+
+    @property
+    def __annotations__(self):
+        return self.__wrapped__.__annotations__
+
+    @__annotations__.setter
+    def __annotations__(self, value):
+        self.__wrapped__.__annotations__ = value
+
+    def __dir__(self):
+        return dir(self.__wrapped__)
+
+    def __str__(self):
+        return str(self.__wrapped__)
+
+    if PY3:
+        def __bytes__(self):
+            return bytes(self.__wrapped__)
+
+    def __repr__(self):
+        return '<{} at 0x{:x} for {} at 0x{:x}>'.format(
+                type(self).__name__, id(self),
+                type(self.__wrapped__).__name__,
+                id(self.__wrapped__))
+
+    def __reversed__(self):
+        return reversed(self.__wrapped__)
+
+    if PY3:
+        def __round__(self):
+            return round(self.__wrapped__)
+
+    def __lt__(self, other):
+        return self.__wrapped__ < other
+
+    def __le__(self, other):
+        return self.__wrapped__ <= other
+
+    def __eq__(self, other):
+        return self.__wrapped__ == other
+
+    def __ne__(self, other):
+        return self.__wrapped__ != other
+
+    def __gt__(self, other):
+        return self.__wrapped__ > other
+
+    def __ge__(self, other):
+        return self.__wrapped__ >= other
+
+    def __hash__(self):
+        return hash(self.__wrapped__)
+
+    def __nonzero__(self):
+        return bool(self.__wrapped__)
+
+    def __bool__(self):
+        return bool(self.__wrapped__)
+
+    def __setattr__(self, name, value):
+        if name.startswith('_self_'):
+            object.__setattr__(self, name, value)
+
+        elif name == '__wrapped__':
+            object.__setattr__(self, name, value)
+            try:
+                object.__delattr__(self, '__qualname__')
+            except AttributeError:
+                pass
+            try:
+                object.__setattr__(self, '__qualname__', value.__qualname__)
+            except AttributeError:
+                pass
+
+        elif name == '__qualname__':
+            setattr(self.__wrapped__, name, value)
+            object.__setattr__(self, name, value)
+
+        elif hasattr(type(self), name):
+            object.__setattr__(self, name, value)
+
+        else:
+            setattr(self.__wrapped__, name, value)
+
+    def __getattr__(self, name):
+        # If we are being to lookup '__wrapped__' then the
+        # '__init__()' method cannot have been called.
+
+        if name == '__wrapped__':
+            raise ValueError('wrapper has not been initialised')
+
+        return getattr(self.__wrapped__, name)
+
+    def __delattr__(self, name):
+        if name.startswith('_self_'):
+            object.__delattr__(self, name)
+
+        elif name == '__wrapped__':
+            raise TypeError('__wrapped__ must be an object')
+
+        elif name == '__qualname__':
+            object.__delattr__(self, name)
+            delattr(self.__wrapped__, name)
+
+        elif hasattr(type(self), name):
+            object.__delattr__(self, name)
+
+        else:
+            delattr(self.__wrapped__, name)
+
+    def __add__(self, other):
+        return self.__wrapped__ + other
+
+    def __sub__(self, other):
+        return self.__wrapped__ - other
+
+    def __mul__(self, other):
+        return self.__wrapped__ * other
+
+    def __div__(self, other):
+        return operator.div(self.__wrapped__, other)
+
+    def __truediv__(self, other):
+        return operator.truediv(self.__wrapped__, other)
+
+    def __floordiv__(self, other):
+        return self.__wrapped__ // other
+
+    def __mod__(self, other):
+        return self.__wrapped__ % other
+
+    def __divmod__(self, other):
+        return divmod(self.__wrapped__, other)
+
+    def __pow__(self, other, *args):
+        return pow(self.__wrapped__, other, *args)
+
+    def __lshift__(self, other):
+        return self.__wrapped__ << other
+
+    def __rshift__(self, other):
+        return self.__wrapped__ >> other
+
+    def __and__(self, other):
+        return self.__wrapped__ & other
+
+    def __xor__(self, other):
+        return self.__wrapped__ ^ other
+
+    def __or__(self, other):
+        return self.__wrapped__ | other
+
+    def __radd__(self, other):
+        return other + self.__wrapped__
+
+    def __rsub__(self, other):
+        return other - self.__wrapped__
+
+    def __rmul__(self, other):
+        return other * self.__wrapped__
+
+    def __rdiv__(self, other):
+        return operator.div(other, self.__wrapped__)
+
+    def __rtruediv__(self, other):
+        return operator.truediv(other, self.__wrapped__)
+
+    def __rfloordiv__(self, other):
+        return other // self.__wrapped__
+
+    def __rmod__(self, other):
+        return other % self.__wrapped__
+
+    def __rdivmod__(self, other):
+        return divmod(other, self.__wrapped__)
+
+    def __rpow__(self, other, *args):
+        return pow(other, self.__wrapped__, *args)
+
+    def __rlshift__(self, other):
+        return other << self.__wrapped__
+
+    def __rrshift__(self, other):
+        return other >> self.__wrapped__
+
+    def __rand__(self, other):
+        return other & self.__wrapped__
+
+    def __rxor__(self, other):
+        return other ^ self.__wrapped__
+
+    def __ror__(self, other):
+        return other | self.__wrapped__
+
+    def __iadd__(self, other):
+        self.__wrapped__ += other
+        return self
+
+    def __isub__(self, other):
+        self.__wrapped__ -= other
+        return self
+
+    def __imul__(self, other):
+        self.__wrapped__ *= other
+        return self
+
+    def __idiv__(self, other):
+        self.__wrapped__ = operator.idiv(self.__wrapped__, other)
+        return self
+
+    def __itruediv__(self, other):
+        self.__wrapped__ = operator.itruediv(self.__wrapped__, other)
+        return self
+
+    def __ifloordiv__(self, other):
+        self.__wrapped__ //= other
+        return self
+
+    def __imod__(self, other):
+        self.__wrapped__ %= other
+        return self
+
+    def __ipow__(self, other):
+        self.__wrapped__ **= other
+        return self
+
+    def __ilshift__(self, other):
+        self.__wrapped__ <<= other
+        return self
+
+    def __irshift__(self, other):
+        self.__wrapped__ >>= other
+        return self
+
+    def __iand__(self, other):
+        self.__wrapped__ &= other
+        return self
+
+    def __ixor__(self, other):
+        self.__wrapped__ ^= other
+        return self
+
+    def __ior__(self, other):
+        self.__wrapped__ |= other
+        return self
+
+    def __neg__(self):
+        return -self.__wrapped__
+
+    def __pos__(self):
+        return +self.__wrapped__
+
+    def __abs__(self):
+        return abs(self.__wrapped__)
+
+    def __invert__(self):
+        return ~self.__wrapped__
+
+    def __int__(self):
+        return int(self.__wrapped__)
+
+    def __long__(self):
+        return long(self.__wrapped__)
+
+    def __float__(self):
+        return float(self.__wrapped__)
+
+    def __complex__(self):
+        return complex(self.__wrapped__)
+
+    def __oct__(self):
+        return oct(self.__wrapped__)
+
+    def __hex__(self):
+        return hex(self.__wrapped__)
+
+    def __index__(self):
+        return operator.index(self.__wrapped__)
+
+    def __len__(self):
+        return len(self.__wrapped__)
+
+    def __contains__(self, value):
+        return value in self.__wrapped__
+
+    def __getitem__(self, key):
+        return self.__wrapped__[key]
+
+    def __setitem__(self, key, value):
+        self.__wrapped__[key] = value
+
+    def __delitem__(self, key):
+        del self.__wrapped__[key]
+
+    def __getslice__(self, i, j):
+        return self.__wrapped__[i:j]
+
+    def __setslice__(self, i, j, value):
+        self.__wrapped__[i:j] = value
+
+    def __delslice__(self, i, j):
+        del self.__wrapped__[i:j]
+
+    def __enter__(self):
+        return self.__wrapped__.__enter__()
+
+    def __exit__(self, *args, **kwargs):
+        return self.__wrapped__.__exit__(*args, **kwargs)
+
+    def __iter__(self):
+        return iter(self.__wrapped__)
+
+    def __copy__(self):
+        raise NotImplementedError('object proxy must define __copy__()')
+
+    def __deepcopy__(self, memo):
+        raise NotImplementedError('object proxy must define __deepcopy__()')
+
+    def __reduce__(self):
+        raise NotImplementedError(
+                'object proxy must define __reduce_ex__()')
+
+    def __reduce_ex__(self, protocol):
+        raise NotImplementedError(
+                'object proxy must define __reduce_ex__()')
+
+class CallableObjectProxy(ObjectProxy):
+
+    def __call__(self, *args, **kwargs):
+        return self.__wrapped__(*args, **kwargs)
+
+class PartialCallableObjectProxy(ObjectProxy):
+
+    def __init__(self, *args, **kwargs):
+        if len(args) < 1:
+            raise TypeError('partial type takes at least one argument')
+
+        wrapped, args = args[0], args[1:]
+
+        if not callable(wrapped):
+            raise TypeError('the first argument must be callable')
+
+        super(PartialCallableObjectProxy, self).__init__(wrapped)
+
+        self._self_args = args
+        self._self_kwargs = kwargs
+
+    def __call__(self, *args, **kwargs):
+        _args = self._self_args + args
+
+        _kwargs = dict(self._self_kwargs)
+        _kwargs.update(kwargs)
+
+        return self.__wrapped__(*_args, **_kwargs)
+
+class _FunctionWrapperBase(ObjectProxy):
+
+    __slots__ = ('_self_instance', '_self_wrapper', '_self_enabled',
+            '_self_binding', '_self_parent')
+
+    def __init__(self, wrapped, instance, wrapper, enabled=None,
+            binding='function', parent=None):
+
+        super(_FunctionWrapperBase, self).__init__(wrapped)
+
+        object.__setattr__(self, '_self_instance', instance)
+        object.__setattr__(self, '_self_wrapper', wrapper)
+        object.__setattr__(self, '_self_enabled', enabled)
+        object.__setattr__(self, '_self_binding', binding)
+        object.__setattr__(self, '_self_parent', parent)
+
+    def __get__(self, instance, owner):
+        # This method is actually doing double duty for both unbound and
+        # bound derived wrapper classes. It should possibly be broken up
+        # and the distinct functionality moved into the derived classes.
+        # Can't do that straight away due to some legacy code which is
+        # relying on it being here in this base class.
+        #
+        # The distinguishing attribute which determines whether we are
+        # being called in an unbound or bound wrapper is the parent
+        # attribute. If binding has never occurred, then the parent will
+        # be None.
+        #
+        # First therefore, is if we are called in an unbound wrapper. In
+        # this case we perform the binding.
+        #
+        # We have one special case to worry about here. This is where we
+        # are decorating a nested class. In this case the wrapped class
+        # would not have a __get__() method to call. In that case we
+        # simply return self.
+        #
+        # Note that we otherwise still do binding even if instance is
+        # None and accessing an unbound instance method from a class.
+        # This is because we need to be able to later detect that
+        # specific case as we will need to extract the instance from the
+        # first argument of those passed in.
+
+        if self._self_parent is None:
+            if not inspect.isclass(self.__wrapped__):
+                descriptor = self.__wrapped__.__get__(instance, owner)
+
+                return self.__bound_function_wrapper__(descriptor, instance,
+                        self._self_wrapper, self._self_enabled,
+                        self._self_binding, self)
+
+            return self
+
+        # Now we have the case of binding occurring a second time on what
+        # was already a bound function. In this case we would usually
+        # return ourselves again. This mirrors what Python does.
+        #
+        # The special case this time is where we were originally bound
+        # with an instance of None and we were likely an instance
+        # method. In that case we rebind against the original wrapped
+        # function from the parent again.
+
+        if self._self_instance is None and self._self_binding == 'function':
+            descriptor = self._self_parent.__wrapped__.__get__(
+                    instance, owner)
+
+            return self._self_parent.__bound_function_wrapper__(
+                    descriptor, instance, self._self_wrapper,
+                    self._self_enabled, self._self_binding,
+                    self._self_parent)
+
+        return self
+
+    def __call__(self, *args, **kwargs):
+        # If enabled has been specified, then evaluate it at this point
+        # and if the wrapper is not to be executed, then simply return
+        # the bound function rather than a bound wrapper for the bound
+        # function. When evaluating enabled, if it is callable we call
+        # it, otherwise we evaluate it as a boolean.
+
+        if self._self_enabled is not None:
+            if callable(self._self_enabled):
+                if not self._self_enabled():
+                    return self.__wrapped__(*args, **kwargs)
+            elif not self._self_enabled:
+                return self.__wrapped__(*args, **kwargs)
+
+        # This can occur where initial function wrapper was applied to
+        # a function that was already bound to an instance. In that case
+        # we want to extract the instance from the function and use it.
+
+        if self._self_binding == 'function':
+            if self._self_instance is None:
+                instance = getattr(self.__wrapped__, '__self__', None)
+                if instance is not None:
+                    return self._self_wrapper(self.__wrapped__, instance,
+                            args, kwargs)
+
+        # This is generally invoked when the wrapped function is being
+        # called as a normal function and is not bound to a class as an
+        # instance method. This is also invoked in the case where the
+        # wrapped function was a method, but this wrapper was in turn
+        # wrapped using the staticmethod decorator.
+
+        return self._self_wrapper(self.__wrapped__, self._self_instance,
+                args, kwargs)
+
+class BoundFunctionWrapper(_FunctionWrapperBase):
+
+    def __call__(self, *args, **kwargs):
+        # If enabled has been specified, then evaluate it at this point
+        # and if the wrapper is not to be executed, then simply return
+        # the bound function rather than a bound wrapper for the bound
+        # function. When evaluating enabled, if it is callable we call
+        # it, otherwise we evaluate it as a boolean.
+
+        if self._self_enabled is not None:
+            if callable(self._self_enabled):
+                if not self._self_enabled():
+                    return self.__wrapped__(*args, **kwargs)
+            elif not self._self_enabled:
+                return self.__wrapped__(*args, **kwargs)
+
+        # We need to do things different depending on whether we are
+        # likely wrapping an instance method vs a static method or class
+        # method.
+
+        if self._self_binding == 'function':
+            if self._self_instance is None:
+                # This situation can occur where someone is calling the
+                # instancemethod via the class type and passing the instance
+                # as the first argument. We need to shift the args before
+                # making the call to the wrapper and effectively bind the
+                # instance to the wrapped function using a partial so the
+                # wrapper doesn't see anything as being different.
+
+                if not args:
+                    raise TypeError('missing 1 required positional argument')
+
+                instance, args = args[0], args[1:]
+                wrapped = PartialCallableObjectProxy(self.__wrapped__, instance)
+                return self._self_wrapper(wrapped, instance, args, kwargs)
+
+            return self._self_wrapper(self.__wrapped__, self._self_instance,
+                    args, kwargs)
+
+        else:
+            # As in this case we would be dealing with a classmethod or
+            # staticmethod, then _self_instance will only tell us whether
+            # when calling the classmethod or staticmethod they did it via an
+            # instance of the class it is bound to and not the case where
+            # done by the class type itself. We thus ignore _self_instance
+            # and use the __self__ attribute of the bound function instead.
+            # For a classmethod, this means instance will be the class type
+            # and for a staticmethod it will be None. This is probably the
+            # more useful thing we can pass through even though we loose
+            # knowledge of whether they were called on the instance vs the
+            # class type, as it reflects what they have available in the
+            # decoratored function.
+
+            instance = getattr(self.__wrapped__, '__self__', None)
+
+            return self._self_wrapper(self.__wrapped__, instance, args,
+                    kwargs)
+
+class FunctionWrapper(_FunctionWrapperBase):
+
+    __bound_function_wrapper__ = BoundFunctionWrapper
+
+    def __init__(self, wrapped, wrapper, enabled=None):
+        # What it is we are wrapping here could be anything. We need to
+        # try and detect specific cases though. In particular, we need
+        # to detect when we are given something that is a method of a
+        # class. Further, we need to know when it is likely an instance
+        # method, as opposed to a class or static method. This can
+        # become problematic though as there isn't strictly a fool proof
+        # method of knowing.
+        #
+        # The situations we could encounter when wrapping a method are:
+        #
+        # 1. The wrapper is being applied as part of a decorator which
+        # is a part of the class definition. In this case what we are
+        # given is the raw unbound function, classmethod or staticmethod
+        # wrapper objects.
+        #
+        # The problem here is that we will not know we are being applied
+        # in the context of the class being set up. This becomes
+        # important later for the case of an instance method, because in
+        # that case we just see it as a raw function and can't
+        # distinguish it from wrapping a normal function outside of
+        # a class context.
+        #
+        # 2. The wrapper is being applied when performing monkey
+        # patching of the class type afterwards and the method to be
+        # wrapped was retrieved direct from the __dict__ of the class
+        # type. This is effectively the same as (1) above.
+        #
+        # 3. The wrapper is being applied when performing monkey
+        # patching of the class type afterwards and the method to be
+        # wrapped was retrieved from the class type. In this case
+        # binding will have been performed where the instance against
+        # which the method is bound will be None at that point.
+        #
+        # This case is a problem because we can no longer tell if the
+        # method was a static method, plus if using Python3, we cannot
+        # tell if it was an instance method as the concept of an
+        # unnbound method no longer exists.
+        #
+        # 4. The wrapper is being applied when performing monkey
+        # patching of an instance of a class. In this case binding will
+        # have been perfomed where the instance was not None.
+        #
+        # This case is a problem because we can no longer tell if the
+        # method was a static method.
+        #
+        # Overall, the best we can do is look at the original type of the
+        # object which was wrapped prior to any binding being done and
+        # see if it is an instance of classmethod or staticmethod. In
+        # the case where other decorators are between us and them, if
+        # they do not propagate the __class__  attribute so that the
+        # isinstance() checks works, then likely this will do the wrong
+        # thing where classmethod and staticmethod are used.
+        #
+        # Since it is likely to be very rare that anyone even puts
+        # decorators around classmethod and staticmethod, likelihood of
+        # that being an issue is very small, so we accept it and suggest
+        # that those other decorators be fixed. It is also only an issue
+        # if a decorator wants to actually do things with the arguments.
+        #
+        # As to not being able to identify static methods properly, we
+        # just hope that that isn't something people are going to want
+        # to wrap, or if they do suggest they do it the correct way by
+        # ensuring that it is decorated in the class definition itself,
+        # or patch it in the __dict__ of the class type.
+        #
+        # So to get the best outcome we can, whenever we aren't sure what
+        # it is, we label it as a 'function'. If it was already bound and
+        # that is rebound later, we assume that it will be an instance
+        # method and try an cope with the possibility that the 'self'
+        # argument it being passed as an explicit argument and shuffle
+        # the arguments around to extract 'self' for use as the instance.
+
+        if isinstance(wrapped, classmethod):
+            binding = 'classmethod'
+
+        elif isinstance(wrapped, staticmethod):
+            binding = 'staticmethod'
+
+        elif hasattr(wrapped, '__self__'):
+            if inspect.isclass(wrapped.__self__):
+                binding = 'classmethod'
+            else:
+                binding = 'function'
+
+        else:
+            binding = 'function'
+
+        super(FunctionWrapper, self).__init__(wrapped, None, wrapper,
+                enabled, binding)
+
+try:
+    if not os.environ.get('WRAPT_DISABLE_EXTENSIONS'):
+        from ._wrappers import (ObjectProxy, CallableObjectProxy,
+            PartialCallableObjectProxy, FunctionWrapper,
+            BoundFunctionWrapper, _FunctionWrapperBase)
+except ImportError:
+    pass
+
+# Helper functions for applying wrappers to existing functions.
+
+def resolve_path(module, name):
+    if isinstance(module, string_types):
+        __import__(module)
+        module = sys.modules[module]
+
+    parent = module
+
+    path = name.split('.')
+    attribute = path[0]
+
+    original = getattr(parent, attribute)
+    for attribute in path[1:]:
+        parent = original
+
+        # We can't just always use getattr() because in doing
+        # that on a class it will cause binding to occur which
+        # will complicate things later and cause some things not
+        # to work. For the case of a class we therefore access
+        # the __dict__ directly. To cope though with the wrong
+        # class being given to us, or a method being moved into
+        # a base class, we need to walk the class hierarchy to
+        # work out exactly which __dict__ the method was defined
+        # in, as accessing it from __dict__ will fail if it was
+        # not actually on the class given. Fallback to using
+        # getattr() if we can't find it. If it truly doesn't
+        # exist, then that will fail.
+
+        if inspect.isclass(original):
+            for cls in inspect.getmro(original):
+                if attribute in vars(cls):
+                    original = vars(cls)[attribute]
+                    break
+            else:
+                original = getattr(original, attribute)
+
+        else:
+            original = getattr(original, attribute)
+
+    return (parent, attribute, original)
+
+def apply_patch(parent, attribute, replacement):
+    setattr(parent, attribute, replacement)
+
+def wrap_object(module, name, factory, args=(), kwargs={}):
+    (parent, attribute, original) = resolve_path(module, name)
+    wrapper = factory(original, *args, **kwargs)
+    apply_patch(parent, attribute, wrapper)
+    return wrapper
+
+# Function for applying a proxy object to an attribute of a class
+# instance. The wrapper works by defining an attribute of the same name
+# on the class which is a descriptor and which intercepts access to the
+# instance attribute. Note that this cannot be used on attributes which
+# are themselves defined by a property object.
+
+class AttributeWrapper(object):
+
+    def __init__(self, attribute, factory, args, kwargs):
+        self.attribute = attribute
+        self.factory = factory
+        self.args = args
+        self.kwargs = kwargs
+
+    def __get__(self, instance, owner):
+        value = instance.__dict__[self.attribute]
+        return self.factory(value, *self.args, **self.kwargs)
+
+    def __set__(self, instance, value):
+        instance.__dict__[self.attribute] = value
+
+    def __delete__(self, instance):
+        del instance.__dict__[self.attribute]
+
+def wrap_object_attribute(module, name, factory, args=(), kwargs={}):
+    path, attribute = name.rsplit('.', 1)
+    parent = resolve_path(module, path)[2]
+    wrapper = AttributeWrapper(attribute, factory, args, kwargs)
+    apply_patch(parent, attribute, wrapper)
+    return wrapper
+
+# Functions for creating a simple decorator using a FunctionWrapper,
+# plus short cut functions for applying wrappers to functions. These are
+# for use when doing monkey patching. For a more featured way of
+# creating decorators see the decorator decorator instead.
+
+def function_wrapper(wrapper):
+    def _wrapper(wrapped, instance, args, kwargs):
+        target_wrapped = args[0]
+        if instance is None:
+            target_wrapper = wrapper
+        elif inspect.isclass(instance):
+            target_wrapper = wrapper.__get__(None, instance)
+        else:
+            target_wrapper = wrapper.__get__(instance, type(instance))
+        return FunctionWrapper(target_wrapped, target_wrapper)
+    return FunctionWrapper(wrapper, _wrapper)
+
+def wrap_function_wrapper(module, name, wrapper):
+    return wrap_object(module, name, FunctionWrapper, (wrapper,))
+
+def patch_function_wrapper(module, name):
+    def _wrapper(wrapper):
+        return wrap_object(module, name, FunctionWrapper, (wrapper,))
+    return _wrapper
+
+def transient_function_wrapper(module, name):
+    def _decorator(wrapper):
+        def _wrapper(wrapped, instance, args, kwargs):
+            target_wrapped = args[0]
+            if instance is None:
+                target_wrapper = wrapper
+            elif inspect.isclass(instance):
+                target_wrapper = wrapper.__get__(None, instance)
+            else:
+                target_wrapper = wrapper.__get__(instance, type(instance))
+            def _execute(wrapped, instance, args, kwargs):
+                (parent, attribute, original) = resolve_path(module, name)
+                replacement = FunctionWrapper(original, target_wrapper)
+                setattr(parent, attribute, replacement)
+                try:
+                    return wrapped(*args, **kwargs)
+                finally:
+                    setattr(parent, attribute, original)
+            return FunctionWrapper(target_wrapped, _execute)
+        return FunctionWrapper(wrapper, _wrapper)
+    return _decorator
+
+# A weak function proxy. This will work on instance methods, class
+# methods, static methods and regular functions. Special treatment is
+# needed for the method types because the bound method is effectively a
+# transient object and applying a weak reference to one will immediately
+# result in it being destroyed and the weakref callback called. The weak
+# reference is therefore applied to the instance the method is bound to
+# and the original function. The function is then rebound at the point
+# of a call via the weak function proxy.
+
+def _weak_function_proxy_callback(ref, proxy, callback):
+    if proxy._self_expired:
+        return
+
+    proxy._self_expired = True
+
+    # This could raise an exception. We let it propagate back and let
+    # the weakref.proxy() deal with it, at which point it generally
+    # prints out a short error message direct to stderr and keeps going.
+
+    if callback is not None:
+        callback(proxy)
+
+class WeakFunctionProxy(ObjectProxy):
+
+    __slots__ = ('_self_expired', '_self_instance')
+
+    def __init__(self, wrapped, callback=None):
+        # We need to determine if the wrapped function is actually a
+        # bound method. In the case of a bound method, we need to keep a
+        # reference to the original unbound function and the instance.
+        # This is necessary because if we hold a reference to the bound
+        # function, it will be the only reference and given it is a
+        # temporary object, it will almost immediately expire and
+        # the weakref callback triggered. So what is done is that we
+        # hold a reference to the instance and unbound function and
+        # when called bind the function to the instance once again and
+        # then call it. Note that we avoid using a nested function for
+        # the callback here so as not to cause any odd reference cycles.
+
+        _callback = callback and functools.partial(
+                _weak_function_proxy_callback, proxy=self,
+                callback=callback)
+
+        self._self_expired = False
+
+        if isinstance(wrapped, _FunctionWrapperBase):
+            self._self_instance = weakref.ref(wrapped._self_instance,
+                    _callback)
+
+            if wrapped._self_parent is not None:
+                super(WeakFunctionProxy, self).__init__(
+                        weakref.proxy(wrapped._self_parent, _callback))
+
+            else:
+                super(WeakFunctionProxy, self).__init__(
+                        weakref.proxy(wrapped, _callback))
+
+            return
+
+        try:
+            self._self_instance = weakref.ref(wrapped.__self__, _callback)
+
+            super(WeakFunctionProxy, self).__init__(
+                    weakref.proxy(wrapped.__func__, _callback))
+
+        except AttributeError:
+            self._self_instance = None
+
+            super(WeakFunctionProxy, self).__init__(
+                    weakref.proxy(wrapped, _callback))
+
+    def __call__(self, *args, **kwargs):
+        # We perform a boolean check here on the instance and wrapped
+        # function as that will trigger the reference error prior to
+        # calling if the reference had expired.
+
+        instance = self._self_instance and self._self_instance()
+        function = self.__wrapped__ and self.__wrapped__
+
+        # If the wrapped function was originally a bound function, for
+        # which we retained a reference to the instance and the unbound
+        # function we need to rebind the function and then call it. If
+        # not just called the wrapped function.
+
+        if instance is None:
+            return self.__wrapped__(*args, **kwargs)
+
+        return function.__get__(instance, type(instance))(*args, **kwargs)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
         working_dir: /src
         volumes:
             - ./ddtrace:/src/ddtrace:ro
+            - ./ddtrace_vendor:/src/ddtrace_vendor:ro
             - ./tests:/src/tests:ro
             - ./setup.cfg:/src/setup.cfg:ro
             - ./setup.py:/src/setup.py:ro

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,13 @@
+from __future__ import print_function
+
+import copy
 import os
 import sys
 import re
 
-from setuptools import setup, find_packages
+from distutils.command.build_ext import build_ext
+from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
+from setuptools import setup, find_packages, Extension
 from setuptools.command.test import test as TestCommand
 
 
@@ -17,7 +22,7 @@ def get_version(package):
 
 class Tox(TestCommand):
 
-    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
+    user_options = [('tox-args=', 'a', 'Arguments to pass to tox')]
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
@@ -70,7 +75,8 @@ documentation][visualization docs].
 [visualization docs]: https://docs.datadoghq.com/tracing/visualization/
 """
 
-setup(
+# Base `setup()` kwargs without any C-extension registering
+setup_kwargs = dict(
     name='ddtrace',
     version=version,
     description='Datadog tracing code',
@@ -83,8 +89,6 @@ setup(
     packages=find_packages(exclude=['tests*']),
     install_requires=[
         'msgpack-python',
-        'six',
-        'wrapt',
     ],
     extras_require={
         # users can include opentracing by having:
@@ -107,3 +111,47 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
 )
+
+
+# The following from here to the end of the file is borrowed from wrapt's `setup.py`:
+#   https://github.com/GrahamDumpleton/wrapt/blob/4ee35415a4b0d570ee6a9b3a14a6931441aeab4b/setup.py
+# These helpers are useful for attempting build a C-extension and then retrying without it if it fails
+
+if sys.platform == 'win32':
+    build_ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError, IOError, OSError)
+else:
+    build_ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
+
+
+class BuildExtFailed(Exception):
+    pass
+
+
+# Attempt to build a C-extension, catch and throw a common/custom error if there are any issues
+class optional_build_ext(build_ext):
+    def run(self):
+        try:
+            build_ext.run(self)
+        except DistutilsPlatformError:
+            raise BuildExtFailed()
+
+    def build_extension(self, ext):
+        try:
+            build_ext.build_extension(self, ext)
+        except build_ext_errors:
+            raise BuildExtFailed()
+
+
+# Try to build with C extensions first, fallback to only pure-Python if building fails
+try:
+    kwargs = copy.deepcopy(setup_kwargs)
+    kwargs['ext_modules'] = [
+        Extension('ddtrace.vendor.wrapt._wrappers', ['ddtrace.vendor/wrapt/_wrappers.c']),
+    ]
+    # DEV: Make sure `cmdclass` exists
+    kwargs.update(dict(cmdclass=dict()))
+    kwargs['cmdclass']['build_ext'] = optional_build_ext
+    setup(**kwargs)
+except BuildExtFailed:
+    print('WARNING: Failed to install wrapt C-extension, using pure-Python wrapt instead')
+    setup(**setup_kwargs)

--- a/tests/contrib/__init__.py
+++ b/tests/contrib/__init__.py
@@ -1,7 +1,5 @@
-from .patch import PatchMixin, PatchTestCase
-
-
-__all__ = [
-    'PatchMixin',
-    'PatchTestCase',
-]
+# Do *NOT* `import ddtrace` in here
+# DEV: Some tests rely on import order of modules
+#   in order to properly function. Importing `ddtrace`
+#   here would mess with those tests since everyone
+#   will load this file by default

--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -10,10 +10,15 @@ from .base import CeleryBaseTestCase
 from tests.opentracer.utils import init_tracer
 
 
+class MyException(Exception):
+    pass
+
+
 class CeleryIntegrationTask(CeleryBaseTestCase):
     """Ensures that the tracer works properly with a real Celery application
     without breaking the Application or Task API.
     """
+
     def test_concurrent_delays(self):
         # it should create one trace for each delayed execution
         @self.app.task
@@ -196,6 +201,28 @@ class CeleryIntegrationTask(CeleryBaseTestCase):
         ok_('Traceback (most recent call last)' in span.get_tag('error.stack'))
         ok_('Task class is failing' in span.get_tag('error.stack'))
 
+    def test_fn_exception_expected(self):
+        # it should catch exceptions in task functions
+        @self.app.task(throws=(MyException,))
+        def fn_exception():
+            raise MyException('Task class is failing')
+
+        t = fn_exception.apply()
+        ok_(t.failed())
+        ok_('Task class is failing' in t.traceback)
+
+        traces = self.tracer.writer.pop_traces()
+        eq_(1, len(traces))
+        eq_(1, len(traces[0]))
+        span = traces[0][0]
+        eq_(span.name, 'celery.run')
+        eq_(span.resource, 'tests.contrib.celery.test_integration.fn_exception')
+        eq_(span.service, 'celery-worker')
+        eq_(span.get_tag('celery.id'), t.task_id)
+        eq_(span.get_tag('celery.action'), 'run')
+        eq_(span.get_tag('celery.state'), 'FAILURE')
+        eq_(span.error, 0)
+
     def test_fn_retry_exception(self):
         # it should not catch retry exceptions in task functions
         @self.app.task
@@ -281,6 +308,36 @@ class CeleryIntegrationTask(CeleryBaseTestCase):
         eq_(span.get_tag('error.msg'), 'Task class is failing')
         ok_('Traceback (most recent call last)' in span.get_tag('error.stack'))
         ok_('Task class is failing' in span.get_tag('error.stack'))
+
+    def test_class_task_exception_expected(self):
+        # it should catch exceptions in class based tasks
+        class BaseTask(self.app.Task):
+            throws = (MyException,)
+
+            def run(self):
+                raise MyException('Task class is failing')
+
+        t = BaseTask()
+        # register the Task class if it's available (required in Celery 4.0+)
+        register_task = getattr(self.app, 'register_task', None)
+        if register_task is not None:
+            register_task(t)
+
+        r = t.apply()
+        ok_(r.failed())
+        ok_('Task class is failing' in r.traceback)
+
+        traces = self.tracer.writer.pop_traces()
+        eq_(1, len(traces))
+        eq_(1, len(traces[0]))
+        span = traces[0][0]
+        eq_(span.name, 'celery.run')
+        eq_(span.resource, 'tests.contrib.celery.test_integration.BaseTask')
+        eq_(span.service, 'celery-worker')
+        eq_(span.get_tag('celery.id'), r.task_id)
+        eq_(span.get_tag('celery.action'), 'run')
+        eq_(span.get_tag('celery.state'), 'FAILURE')
+        eq_(span.error, 0)
 
     def test_shared_task(self):
         # Ensure Django Shared Task are supported

--- a/tests/contrib/flask/__init__.py
+++ b/tests/contrib/flask/__init__.py
@@ -1,7 +1,7 @@
 from ddtrace import Pin
 from ddtrace.contrib.flask import patch, unpatch
 import flask
-import wrapt
+from ddtrace.vendor import wrapt
 
 from ...base import BaseTracerTestCase
 

--- a/tests/contrib/flask/test_idempotency.py
+++ b/tests/contrib/flask/test_idempotency.py
@@ -2,7 +2,7 @@ import mock
 import unittest
 
 import flask
-import wrapt
+from ddtrace.vendor import wrapt
 
 from ddtrace.contrib.flask import patch, unpatch
 from ddtrace.contrib.flask.patch import _w, _u

--- a/tests/contrib/flask_autopatch/test_flask_autopatch.py
+++ b/tests/contrib/flask_autopatch/test_flask_autopatch.py
@@ -2,7 +2,7 @@
 import unittest
 
 import flask
-import wrapt
+from ddtrace.vendor import wrapt
 
 from ddtrace import Pin
 

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -3,7 +3,7 @@ import contextlib
 import sys
 
 # Third party
-import wrapt
+from ddtrace.vendor import wrapt
 
 # Project
 from ddtrace import config

--- a/tests/contrib/logging/test_logging.py
+++ b/tests/contrib/logging/test_logging.py
@@ -1,9 +1,9 @@
 import logging
-import wrapt
 
 from ddtrace.helpers import get_correlation_ids
 from ddtrace.compat import StringIO
 from ddtrace.contrib.logging import patch, unpatch
+from ddtrace.vendor import wrapt
 
 from ...base import BaseTracerTestCase
 

--- a/tests/contrib/patch.py
+++ b/tests/contrib/patch.py
@@ -3,7 +3,7 @@ import importlib
 import sys
 import unittest
 
-import wrapt
+from ddtrace.vendor import wrapt
 
 from tests.subprocesstest import SubprocessTestCase, run_in_subprocess
 

--- a/tests/contrib/pymemcache/autopatch/test.py
+++ b/tests/contrib/pymemcache/autopatch/test.py
@@ -1,6 +1,6 @@
 import pymemcache
 import unittest
-import wrapt
+from ddtrace.vendor import wrapt
 
 
 class AutoPatchTestCase(unittest.TestCase):

--- a/tests/contrib/pymemcache/test_client.py
+++ b/tests/contrib/pymemcache/test_client.py
@@ -9,7 +9,7 @@ from pymemcache.exceptions import (
     MemcacheIllegalInputError,
 )
 import unittest
-import wrapt
+from ddtrace.vendor import wrapt
 
 # project
 from ddtrace import Pin

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -1,5 +1,7 @@
 from nose.tools import eq_, ok_
 
+from ddtrace.constants import SAMPLING_PRIORITY_KEY, ORIGIN_KEY
+
 from .utils import PyramidTestCase, PyramidBase
 
 
@@ -32,6 +34,7 @@ class TestPyramidDistributedTracingDefault(PyramidBase):
             'x-datadog-trace-id': '100',
             'x-datadog-parent-id': '42',
             'x-datadog-sampling-priority': '2',
+            'x-datadog-origin': 'synthetics',
         }
         self.app.get('/', headers=headers, status=200)
         writer = self.tracer.writer
@@ -41,7 +44,8 @@ class TestPyramidDistributedTracingDefault(PyramidBase):
         span = spans[0]
         eq_(span.trace_id, 100)
         eq_(span.parent_id, 42)
-        eq_(span.get_metric('_sampling_priority_v1'), 2)
+        eq_(span.get_metric(SAMPLING_PRIORITY_KEY), 2)
+        eq_(span.get_tag(ORIGIN_KEY), 'synthetics')
 
 
 class TestPyramidDistributedTracingDisabled(PyramidBase):
@@ -58,6 +62,7 @@ class TestPyramidDistributedTracingDisabled(PyramidBase):
             'x-datadog-trace-id': '100',
             'x-datadog-parent-id': '42',
             'x-datadog-sampling-priority': '2',
+            'x-datadog-origin': 'synthetics',
         }
         self.app.get('/', headers=headers, status=200)
         writer = self.tracer.writer
@@ -67,4 +72,5 @@ class TestPyramidDistributedTracingDisabled(PyramidBase):
         span = spans[0]
         ok_(span.trace_id != 100)
         ok_(span.parent_id != 42)
-        ok_(span.get_metric('_sampling_priority_v1') != 2)
+        ok_(span.get_metric(SAMPLING_PRIORITY_KEY) != 2)
+        ok_(span.get_tag(ORIGIN_KEY) != 'synthetics')

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -27,6 +27,7 @@ class TestPyramidDistributedTracing(PyramidBase):
             'x-datadog-trace-id': '100',
             'x-datadog-parent-id': '42',
             'x-datadog-sampling-priority': '2',
+            'x-datadog-origin': 'synthetics',
         }
         self.app.get('/', headers=headers, status=200)
         writer = self.tracer.writer

--- a/tests/contrib/tornado/test_executor_decorator.py
+++ b/tests/contrib/tornado/test_executor_decorator.py
@@ -173,7 +173,7 @@ class TestTornadoExecutor(TornadoTestCase):
         # `futures` is already instrumented
         from ddtrace import patch; patch(futures=True)  # noqa
         from concurrent.futures import ThreadPoolExecutor
-        from wrapt import BoundFunctionWrapper
+        from ddtrace.vendor.wrapt import BoundFunctionWrapper
 
         fn_wrapper = getattr(ThreadPoolExecutor.submit, '__wrapped__', None)
         ok_(not isinstance(fn_wrapper, BoundFunctionWrapper))

--- a/tests/contrib/tornado/test_tornado_web.py
+++ b/tests/contrib/tornado/test_tornado_web.py
@@ -3,7 +3,7 @@ from nose.tools import eq_, ok_
 from .web.app import CustomDefaultHandler
 from .utils import TornadoTestCase
 
-from ddtrace.constants import SAMPLING_PRIORITY_KEY, EVENT_SAMPLE_RATE_KEY
+from ddtrace.constants import SAMPLING_PRIORITY_KEY, ORIGIN_KEY, EVENT_SAMPLE_RATE_KEY
 
 from opentracing.scope_managers.tornado import TornadoScopeManager
 from tests.opentracer.utils import init_tracer
@@ -321,7 +321,8 @@ class TestNoPropagationTornadoWeb(TornadoTestCase):
         headers = {
             'x-datadog-trace-id': '1234',
             'x-datadog-parent-id': '4567',
-            'x-datadog-sampling-priority': '2'
+            'x-datadog-sampling-priority': '2',
+            'x-datadog-origin': 'synthetics',
         }
         response = self.fetch('/success/', headers=headers)
         eq_(200, response.code)
@@ -342,6 +343,7 @@ class TestNoPropagationTornadoWeb(TornadoTestCase):
         assert request_span.trace_id != 1234
         assert request_span.parent_id != 4567
         assert request_span.get_metric(SAMPLING_PRIORITY_KEY) != 2
+        assert request_span.get_tag(ORIGIN_KEY) != 'synthetics'
 
 
 class TestCustomTornadoWeb(TornadoTestCase):

--- a/tests/contrib/vertica/test_vertica.py
+++ b/tests/contrib/vertica/test_vertica.py
@@ -1,6 +1,6 @@
 # 3p
 import pytest
-import wrapt
+from ddtrace.vendor import wrapt
 
 # project
 import ddtrace

--- a/tests/propagation/test_http.py
+++ b/tests/propagation/test_http.py
@@ -7,6 +7,7 @@ from ddtrace.propagation.http import (
     HTTP_HEADER_TRACE_ID,
     HTTP_HEADER_PARENT_ID,
     HTTP_HEADER_SAMPLING_PRIORITY,
+    HTTP_HEADER_ORIGIN,
 )
 
 
@@ -21,6 +22,7 @@ class TestHttpPropagation(TestCase):
 
         with tracer.trace("global_root_span") as span:
             span.context.sampling_priority = 2
+            span.context._dd_origin = "synthetics"
             headers = {}
             propagator = HTTPPropagator()
             propagator.inject(span.context, headers)
@@ -31,6 +33,10 @@ class TestHttpPropagation(TestCase):
                 int(headers[HTTP_HEADER_SAMPLING_PRIORITY]),
                 span.context.sampling_priority,
             )
+            eq_(
+                headers[HTTP_HEADER_ORIGIN],
+                span.context._dd_origin,
+            )
 
     def test_extract(self):
         tracer = get_dummy_tracer()
@@ -39,6 +45,7 @@ class TestHttpPropagation(TestCase):
             "x-datadog-trace-id": "1234",
             "x-datadog-parent-id": "5678",
             "x-datadog-sampling-priority": "1",
+            "x-datadog-origin": "synthetics",
         }
 
         propagator = HTTPPropagator()
@@ -49,6 +56,7 @@ class TestHttpPropagation(TestCase):
             eq_(span.trace_id, 1234)
             eq_(span.parent_id, 5678)
             eq_(span.context.sampling_priority, 1)
+            eq_(span.context._dd_origin, "synthetics")
 
     def test_WSGI_extract(self):
         """Ensure we support the WSGI formatted headers as well."""
@@ -58,6 +66,7 @@ class TestHttpPropagation(TestCase):
             "HTTP_X_DATADOG_TRACE_ID": "1234",
             "HTTP_X_DATADOG_PARENT_ID": "5678",
             "HTTP_X_DATADOG_SAMPLING_PRIORITY": "1",
+            "HTTP_X_DATADOG_ORIGIN": "synthetics",
         }
 
         propagator = HTTPPropagator()
@@ -68,3 +77,4 @@ class TestHttpPropagation(TestCase):
             eq_(span.trace_id, 1234)
             eq_(span.parent_id, 5678)
             eq_(span.context.sampling_priority, 1)
+            eq_(span.context._dd_origin, "synthetics")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -388,6 +388,7 @@ class TestTracingContext(TestCase):
         eq_(cloned_ctx._parent_span_id, ctx._parent_span_id)
         eq_(cloned_ctx._sampled, ctx._sampled)
         eq_(cloned_ctx._sampling_priority, ctx._sampling_priority)
+        eq_(cloned_ctx._dd_origin, ctx._dd_origin)
         eq_(cloned_ctx._current_span, ctx._current_span)
         eq_(cloned_ctx._trace, [])
         eq_(cloned_ctx._finished_spans, 0)

--- a/tox.ini
+++ b/tox.ini
@@ -629,4 +629,6 @@ max-line-length=120
 exclude=
   .ddtox,.tox,
   .git,__pycache__,
-  .eggs,*.egg
+  .eggs,*.egg,
+  # We shouldn't lint our vendored dependencies
+  ddtrace/vendor/


### PR DESCRIPTION
## Upgrading to 0.22.0

This release contains a few improvements for not marking a Celery task as an error if it is an expected and allowed exception, for propagating synthetics origin header, and to vendor our `six` and `wrapt` dependencies.

## Changes
### Improvements
- [celery] Don't mark expected failures as errors (#820 -- thanks @sciyoshi)
- [core] Propagate x-datadog-origin (#821)
- [core] vendor wrapt and six dependencies (#755)
