### PR TITLE
Fix Opentracing/DDTrace span parenting issues

### DIFF
--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -76,8 +76,8 @@ class Tracer(opentracing.Tracer):
                                   """)
 
         self._scope_manager = scope_manager or ThreadLocalScopeManager()
-
         dd_context_provider = get_context_provider_for_scope_manager(self._scope_manager)
+        _patch_scope_manager(self._scope_manager, dd_context_provider)
 
         self._dd_tracer = dd_tracer or ddtrace.tracer or DatadogTracer()
         self._dd_tracer.set_tags(self._config.get(keys.GLOBAL_TAGS))
@@ -151,7 +151,6 @@ class Tracer(opentracing.Tracer):
 
         # activate this new span
         scope = self._scope_manager.activate(otspan, finish_on_close)
-
         return scope
 
     def start_span(self, operation_name=None, child_of=None, references=None,
@@ -295,3 +294,29 @@ class Tracer(opentracing.Tracer):
         dd_span_ctx = ot_span_ctx._dd_context
         self._dd_tracer.context_provider.activate(dd_span_ctx)
         return ot_span_ctx
+
+
+def _patch_scope_manager(scope_manager, context_provider):
+    """
+    Patches a scope manager so that any time a span is activated
+    it'll also activate the underlying ddcontext with the underlying
+    datadog context provider.
+
+    This allows opentracing users to rely on ddtrace.contrib patches and
+    have them parent correctly.
+
+    :param scope_manager: Something that implements `opentracing.ScopeManager`
+    :param context_provider: Something that implements `datadog.provider.BaseContextProvider`
+    """
+    if getattr(scope_manager, '_datadog_patch', False):
+        return
+    setattr(scope_manager, '_datadog_patch', True)
+
+    old_method = scope_manager.activate
+
+    def _patched_activate(*args, **kwargs):
+        otspan = kwargs.get('span', args[0])
+        context_provider.activate(otspan._dd_context)
+        return old_method(*args, **kwargs)
+
+    scope_manager.activate = _patched_activate


### PR DESCRIPTION
Spans were only synchronized between the two libraries if the first
point of ingestion starts with a ddtrace, and then remains with
opentracing through the stack. If someone using opentracing depends on
datadog's patches, spans may not be parented properly.

This commit patches the opentracing scope manager so that datadog's
context manager is notified whenever a new scope is activated. This
keeps datadog's context stack in sync with opentracing's scope stack,
allowing opentracing users to rely on datadog's patches.