### PR TITLE
[tests] Fix requests gevent tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -659,7 +659,6 @@ jobs:
   requestsgevent:
     docker:
       - *test_runner
-      - *httpbin_local
     resource_class: *resource_class
     steps:
       - checkout

--- a/tests/contrib/requests_gevent/test_requests_gevent.py
+++ b/tests/contrib/requests_gevent/test_requests_gevent.py
@@ -39,7 +39,7 @@ class TestRequestsGevent(unittest.TestCase):
             import requests
 
             # DEV: We **MUST** use an HTTPS request, that is what causes the issue
-            requests.get('https://icanhazip.com/')
+            requests.get('https://httpbin.org/get')
 
         finally:
             # Ensure we always unpatch `requests` when we are done

--- a/tests/contrib/requests_gevent/test_requests_gevent.py
+++ b/tests/contrib/requests_gevent/test_requests_gevent.py
@@ -39,7 +39,7 @@ class TestRequestsGevent(unittest.TestCase):
             import requests
 
             # DEV: We **MUST** use an HTTPS request, that is what causes the issue
-            requests.get('https://httpbin.org/get')
+            requests.get('https://icanhazdadjoke.com/')
 
         finally:
             # Ensure we always unpatch `requests` when we are done

--- a/tests/contrib/requests_gevent/test_requests_gevent.py
+++ b/tests/contrib/requests_gevent/test_requests_gevent.py
@@ -39,7 +39,7 @@ class TestRequestsGevent(unittest.TestCase):
             import requests
 
             # DEV: We **MUST** use an HTTPS request, that is what causes the issue
-            requests.get('https://icanhazdadjoke.com/')
+            requests.get('https://httpbin.org/get')
 
         finally:
             # Ensure we always unpatch `requests` when we are done


### PR DESCRIPTION
We were getting connection issues with `https://icanhazip.com/` moved to `https://httpbin.org/get`

Also had to remove the `httpbin_local` container since we would try to hit that instead of the real server, and we need https for the tests to work.