### PR TITLE
[tests] Use spotify cassandra image for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,10 +298,10 @@ jobs:
         env:
           TOX_SKIP_DIST: True
           CASS_DRIVER_NO_EXTENSIONS: 1
-      - image: cassandra:3.11
+      - image: spotify/cassandra:latest
         env:
-          - MAX_HEAP_SIZE=1024M
-          - HEAP_NEWSIZE=400M
+          - MAX_HEAP_SIZE=512M
+          - HEAP_NEWSIZE=256M
     resource_class: *resource_class
     steps:
       - checkout

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,10 @@ services:
         ports:
             - "127.0.0.1:9200:9200"
     cassandra:
-        image: cassandra:3.11
+        image: spotify/cassandra:latest
+        environment:
+            - MAX_HEAP_SIZE=512M
+            - HEAP_NEWSIZE=256M
         ports:
             - "127.0.0.1:9042:9042"
     postgres:


### PR DESCRIPTION
The spotify cassandra image boots much faster than the official cassandra image.

Hoping this helps reduce the flakiness of this test (usually fails due to memory issues).