### PR TITLE
[tests] Fix ddtrace sitecustomize negative test

### DIFF
--- a/tests/commands/ddtrace_run_sitecustomize.py
+++ b/tests/commands/ddtrace_run_sitecustomize.py
@@ -6,7 +6,7 @@ from nose.tools import ok_
 
 if __name__ == '__main__':
     # detect if `-S` is used
-    suppress = len(sys.argv) == 2 and sys.argv[1] is '-S'
+    suppress = len(sys.argv) == 2 and sys.argv[1] == '-S'
     if suppress:
         ok_('sitecustomize' not in sys.modules)
     else:

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -206,7 +206,7 @@ class DdtraceRunTest(unittest.TestCase):
         # ensure `sitecustomize.py` is not loaded if `-S` is used
         env = inject_sitecustomize('tests/commands/bootstrap')
         out = subprocess.check_output(
-            ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_sitecustomize.py', '-S'],
+            ['ddtrace-run', 'python', '-S', 'tests/commands/ddtrace_run_sitecustomize.py', '-S'],
             env=env,
         )
         assert out.startswith(b"Test success")


### PR DESCRIPTION
The current negative test is broken and is actually testing the same case
without `-S`.

That's because the condition `sys.argv[1] is '-S'` is always `False`; strings
must be compared with `==`, not `is`.