### PR TITLE
Use DEBUG log level for RateSampler initialization

### DIFF
--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -38,7 +38,7 @@ class RateSampler(object):
 
         self.set_sample_rate(sample_rate)
 
-        log.info("initialized RateSampler, sample %s%% of traces", 100 * sample_rate)
+        log.debug("initialized RateSampler, sample %s%% of traces", 100 * sample_rate)
 
     def set_sample_rate(self, sample_rate):
         self.sample_rate = sample_rate


### PR DESCRIPTION
In reference to [this issue](https://github.com/DataDog/dd-trace-py/issues/860).

This way these logs can be seen when debugging is turned on, but otherwise left out.