### PR TITLE
Remove mysql-connector 2.1 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -499,7 +499,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'wait' mysql
-      - run: tox -e 'mysql_contrib-{py27,py34,py35,py36}-mysqlconnector{21}' --result-json /tmp/mysqlconnector.results
+      - run: tox -e 'mysql_contrib-{py27,py34,py35,py36}-mysqlconnector' --result-json /tmp/mysqlconnector.results
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -691,7 +691,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'wait' postgres mysql
-      - run: tox -e 'sqlalchemy_contrib-{py27,py34,py35,py36}-sqlalchemy{10,11,12}-psycopg2{27}-mysqlconnector{21}' --result-json /tmp/sqlalchemy.results
+      - run: tox -e 'sqlalchemy_contrib-{py27,py34,py35,py36}-sqlalchemy{10,11,12}-psycopg2{27}-mysqlconnector' --result-json /tmp/sqlalchemy.results
       - persist_to_workspace:
           root: /tmp
           paths:

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ envlist =
     molten_contrib-{py36}-molten{070,072}
     mongoengine_contrib-{py27,py34,py35,py36}-mongoengine{015}
     msgpack_contrib-{py27,py34}-msgpack{03,04,05}
-    mysql_contrib-{py27,py34,py35,py36}-mysqlconnector{21}
+    mysql_contrib-{py27,py34,py35,py36}-mysqlconnector
     mysqldb_contrib-{py27}-mysqldb{12}
     mysqldb_contrib-{py27,py34,py35,py36}-mysqlclient{13}
     psycopg_contrib-{py27,py34,py35,py36}-psycopg2{24,25,26,27}
@@ -98,7 +98,7 @@ envlist =
 # DEV: This is a known issue for gevent 1.1, suggestion is to upgrade to gevent > 1.2
 #      https://github.com/gevent/gevent/issues/903
     requests_gevent_contrib-{py36}-requests{208,209,210,211,212,213,219}-gevent{12,13}
-    sqlalchemy_contrib-{py27,py34,py35,py36}-sqlalchemy{10,11,12}-psycopg2{27}-mysqlconnector{21}
+    sqlalchemy_contrib-{py27,py34,py35,py36}-sqlalchemy{10,11,12}-psycopg2{27}-mysqlconnector
     sqlite3_contrib-{py27,py34,py35,py36}-sqlite3
     tornado_contrib-{py27,py34,py35,py36}-tornado{40,41,42,43,44,45}
     tornado_contrib-{py27}-tornado{40,41,42,43,44,45}-futures{30,31,32}
@@ -226,7 +226,7 @@ deps =
     msgpack03: msgpack-python>=0.3,<0.4
     msgpack04: msgpack-python>=0.4,<0.5
     msgpack05: msgpack-python>=0.5,<0.6
-    mysqlconnector21: mysql-connector>=2.1,<2.2
+    mysqlconnector: mysql-connector-python
     mysqldb12: mysql-python>=1.2,<1.3
     mysqlclient13: mysqlclient>=1.3,<1.4
 # webob is required for Pylons < 1.0
@@ -384,7 +384,7 @@ basepython=python
 deps=
     cassandra-driver
     psycopg2
-    mysql-connector>=2.1,<2.2
+    mysql-connector-python
     redis-py-cluster>=1.3.6,<1.4.0
     vertica-python>=0.6.0,<0.7.0
     kombu>=4.2.0,<4.3.0


### PR DESCRIPTION
The package has been removed from PyPI entirely.