### PR TITLE
Add testing for Celery 4.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,12 +327,14 @@ jobs:
       - run: tox -e 'celery_contrib-{py27,py34,py35,py36}-celery{31}-redis{210}' --result-json /tmp/celery31.results
       - run: tox -e 'celery_contrib-{py27,py34,py35,py36}-celery{40,41}-{redis210-kombu43,redis320-kombu44}' --result-json /tmp/celery40-41.results
       - run: tox -e 'celery_contrib-{py27,py34,py35,py36}-celery42-redis210-kombu43' --result-json /tmp/celery42.results
+      - run: tox -e 'celery_contrib-{py27,py34,py35,py36}-celery43-redis320-kombu44' --result-json /tmp/celery43.results
       - persist_to_workspace:
           root: /tmp
           paths:
             - celery31.results
             - celery40-41.results
             - celery42.results
+            - celery43.results
       - *save_cache_step
 
   elasticsearch:

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,8 @@ envlist =
 # Celery 4.2 is now limited to Kombu 4.3
 # https://github.com/celery/celery/commit/1571d414461f01ae55be63a03e2adaa94dbcb15d
     celery_contrib-{py27,py34,py35,py36}-celery42-redis210-kombu43
+# Celery 4.3 wants Kombu >= 4.4 and Redis >= 3.2
+    celery_contrib-{py27,py34,py35,py36}-celery43-redis320-kombu44
     dbapi_contrib-{py27,py34,py35,py36}
     django_contrib{,_autopatch}-{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     django_contrib{,_autopatch}-{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
@@ -173,6 +175,7 @@ deps =
     celery40: celery>=4.0,<4.1
     celery41: celery>=4.1,<4.2
     celery42: celery>=4.2,<4.3
+    celery43: celery>=4.3,<4.4
     ddtracerun: redis
     django18: django>=1.8,<1.9
     django111: django>=1.11,<1.12


### PR DESCRIPTION
This is a prerequisite for Python 3.7 support.