### PR TITLE
[testing] Remove nose usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,6 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[nosetests]
-verbosity=1
-
 [bdist_wheel]
 universal=1

--- a/tests/commands/ddtrace_run_argv.py
+++ b/tests/commands/ddtrace_run_argv.py
@@ -1,6 +1,5 @@
-from nose.tools import eq_
 import sys
 
 if __name__ == '__main__':
-    eq_(sys.argv[1:], ['foo', 'bar'])
+    assert sys.argv[1:] == ['foo', 'bar']
     print('Test success')

--- a/tests/commands/ddtrace_run_debug.py
+++ b/tests/commands/ddtrace_run_debug.py
@@ -1,7 +1,5 @@
 from ddtrace import tracer
 
-from nose.tools import ok_
-
 if __name__ == '__main__':
-    ok_(tracer.debug_logging)
+    assert tracer.debug_logging
     print("Test success")

--- a/tests/commands/ddtrace_run_disabled.py
+++ b/tests/commands/ddtrace_run_disabled.py
@@ -1,8 +1,6 @@
 from ddtrace import tracer, monkey
 
-from nose.tools import ok_, eq_
-
 if __name__ == '__main__':
-    ok_(not tracer.enabled)
-    eq_(len(monkey.get_patched_modules()), 0)
+    assert not tracer.enabled
+    assert len(monkey.get_patched_modules()) == 0
     print("Test success")

--- a/tests/commands/ddtrace_run_enabled.py
+++ b/tests/commands/ddtrace_run_enabled.py
@@ -1,7 +1,5 @@
 from ddtrace import tracer
 
-from nose.tools import ok_
-
 if __name__ == '__main__':
-    ok_(tracer.enabled)
+    assert tracer.enabled
     print("Test success")

--- a/tests/commands/ddtrace_run_env.py
+++ b/tests/commands/ddtrace_run_env.py
@@ -1,7 +1,5 @@
 from ddtrace import tracer
 
-from nose.tools import eq_
-
 if __name__ == '__main__':
-    eq_(tracer.tags['env'], 'test')
+    assert tracer.tags['env'] == 'test'
     print('Test success')

--- a/tests/commands/ddtrace_run_hostname.py
+++ b/tests/commands/ddtrace_run_hostname.py
@@ -1,8 +1,6 @@
 from ddtrace import tracer
 
-from nose.tools import eq_
-
 if __name__ == '__main__':
-    eq_(tracer.writer.api.hostname, "172.10.0.1")
-    eq_(tracer.writer.api.port, 8120)
+    assert tracer.writer.api.hostname == "172.10.0.1"
+    assert tracer.writer.api.port == 8120
     print("Test success")

--- a/tests/commands/ddtrace_run_integration.py
+++ b/tests/commands/ddtrace_run_integration.py
@@ -9,40 +9,38 @@ from ddtrace import Pin
 from tests.contrib.config import REDIS_CONFIG
 from tests.test_tracer import DummyWriter
 
-from nose.tools import eq_, ok_
-
 if __name__ == '__main__':
     r = redis.Redis(port=REDIS_CONFIG['port'])
     pin = Pin.get_from(r)
-    ok_(pin)
-    eq_(pin.app, 'redis')
-    eq_(pin.service, 'redis')
+    assert pin
+    assert pin.app == 'redis'
+    assert pin.service == 'redis'
 
     pin.tracer.writer = DummyWriter()
     r.flushall()
     spans = pin.tracer.writer.pop()
 
-    eq_(len(spans), 1)
-    eq_(spans[0].service, 'redis')
-    eq_(spans[0].resource, 'FLUSHALL')
+    assert len(spans) == 1
+    assert spans[0].service == 'redis'
+    assert spans[0].resource == 'FLUSHALL'
 
     long_cmd = "mget %s" % " ".join(map(str, range(1000)))
     us = r.execute_command(long_cmd)
 
     spans = pin.tracer.writer.pop()
-    eq_(len(spans), 1)
+    assert len(spans) == 1
     span = spans[0]
-    eq_(span.service, 'redis')
-    eq_(span.name, 'redis.command')
-    eq_(span.span_type, 'redis')
-    eq_(span.error, 0)
+    assert span.service == 'redis'
+    assert span.name == 'redis.command'
+    assert span.span_type == 'redis'
+    assert span.error == 0
     meta = {
         'out.host': u'localhost',
         'out.port': str(REDIS_CONFIG['port']),
         'out.redis_db': u'0',
     }
     for k, v in meta.items():
-        eq_(span.get_tag(k), v)
+        assert span.get_tag(k) == v
 
     assert span.get_tag('redis.raw_command').startswith(u'mget 0 1 2 3')
     assert span.get_tag('redis.raw_command').endswith(u'...')

--- a/tests/commands/ddtrace_run_no_debug.py
+++ b/tests/commands/ddtrace_run_no_debug.py
@@ -1,7 +1,5 @@
 from ddtrace import tracer
 
-from nose.tools import ok_
-
 if __name__ == '__main__':
-    ok_(not tracer.debug_logging)
+    assert not tracer.debug_logging
     print("Test success")

--- a/tests/commands/ddtrace_run_patched_modules.py
+++ b/tests/commands/ddtrace_run_patched_modules.py
@@ -1,7 +1,5 @@
 from ddtrace import monkey
 
-from nose.tools import ok_
-
 if __name__ == '__main__':
-    ok_('redis' in monkey.get_patched_modules())
+    assert 'redis' in monkey.get_patched_modules()
     print("Test success")

--- a/tests/commands/ddtrace_run_priority_sampling.py
+++ b/tests/commands/ddtrace_run_priority_sampling.py
@@ -1,7 +1,5 @@
 from ddtrace import tracer
 
-from nose.tools import ok_
-
 if __name__ == '__main__':
-    ok_(tracer.priority_sampler is not None)
+    assert tracer.priority_sampler is not None
     print("Test success")

--- a/tests/commands/ddtrace_run_service.py
+++ b/tests/commands/ddtrace_run_service.py
@@ -1,7 +1,5 @@
 import os
 
-from nose.tools import eq_
-
 if __name__ == '__main__':
-    eq_(os.environ['DATADOG_SERVICE_NAME'], 'my_test_service')
+    assert os.environ['DATADOG_SERVICE_NAME'] == 'my_test_service'
     print('Test success')

--- a/tests/commands/ddtrace_run_sitecustomize.py
+++ b/tests/commands/ddtrace_run_sitecustomize.py
@@ -1,16 +1,15 @@
 import sys
-from nose.tools import ok_
 
 
 if __name__ == '__main__':
     # detect if `-S` is used
     suppress = len(sys.argv) == 2 and sys.argv[1] == '-S'
     if suppress:
-        ok_('sitecustomize' not in sys.modules)
+        assert 'sitecustomize' not in sys.modules
     else:
-        ok_('sitecustomize' in sys.modules)
+        assert 'sitecustomize' in sys.modules
 
     # ensure the right `sitecustomize` will be imported
     import sitecustomize
-    ok_(sitecustomize.CORRECT_IMPORT)
+    assert sitecustomize.CORRECT_IMPORT
     print('Test success')

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -4,8 +4,6 @@ import os
 import subprocess
 import unittest
 
-from nose.tools import ok_
-
 from ..util import inject_sitecustomize
 
 
@@ -189,7 +187,7 @@ class DdtraceRunTest(unittest.TestCase):
         )
         # `out` contains the `loaded` status of the module
         result = out[:-1] == b'True'
-        ok_(result)
+        assert result
 
     def test_sitecustomize_run(self):
         # [Regression test]: ensure users `sitecustomize.py` is properly loaded,

--- a/tests/contrib/aiobotocore/py35/test.py
+++ b/tests/contrib/aiobotocore/py35/test.py
@@ -1,7 +1,6 @@
 # flake8: noqa
 # DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from `async`
 import aiobotocore
-from nose.tools import eq_
 
 from ddtrace.contrib.aiobotocore.patch import patch, unpatch
 
@@ -42,32 +41,32 @@ class AIOBotocoreTest(AsyncioTestCase):
         pre_08 = int(version[0]) == 0 and int(version[1]) < 8
         # Version 0.8+ generates only one span for reading an object.
         if pre_08:
-            eq_(len(traces), 2)
-            eq_(len(traces[0]), 1)
-            eq_(len(traces[1]), 1)
+            assert len(traces) == 2
+            assert len(traces[0]) == 1
+            assert len(traces[1]) == 1
 
             span = traces[0][0]
-            eq_(span.get_tag('aws.operation'), 'GetObject')
-            eq_(span.get_tag('http.status_code'), '200')
-            eq_(span.service, 'aws.s3')
-            eq_(span.resource, 's3.getobject')
+            assert span.get_tag('aws.operation') == 'GetObject'
+            assert span.get_tag('http.status_code') == '200'
+            assert span.service == 'aws.s3'
+            assert span.resource == 's3.getobject'
 
             read_span = traces[1][0]
-            eq_(read_span.get_tag('aws.operation'), 'GetObject')
-            eq_(read_span.get_tag('http.status_code'), '200')
-            eq_(read_span.service, 'aws.s3')
-            eq_(read_span.resource, 's3.getobject')
-            eq_(read_span.name, 's3.command.read')
+            assert read_span.get_tag('aws.operation') == 'GetObject'
+            assert read_span.get_tag('http.status_code') == '200'
+            assert read_span.service == 'aws.s3'
+            assert read_span.resource == 's3.getobject'
+            assert read_span.name == 's3.command.read'
             # enforce parenting
-            eq_(read_span.parent_id, span.span_id)
-            eq_(read_span.trace_id, span.trace_id)
+            assert read_span.parent_id == span.span_id
+            assert read_span.trace_id == span.trace_id
         else:
-            eq_(len(traces[0]), 1)
-            eq_(len(traces[0]), 1)
+            assert len(traces[0]) == 1
+            assert len(traces[0]) == 1
 
             span = traces[0][0]
-            eq_(span.get_tag('aws.operation'), 'GetObject')
-            eq_(span.get_tag('http.status_code'), '200')
-            eq_(span.service, 'aws.s3')
-            eq_(span.resource, 's3.getobject')
-            eq_(span.name, 's3.command')
+            assert span.get_tag('aws.operation') == 'GetObject'
+            assert span.get_tag('http.status_code') == '200'
+            assert span.service == 'aws.s3'
+            assert span.resource == 's3.getobject'
+            assert span.name == 's3.command'

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -1,7 +1,6 @@
 # flake8: noqa
 import asyncio
 
-from nose.tools import eq_, ok_
 from aiohttp.test_utils import unittest_run_loop
 
 from ddtrace.contrib.aiohttp.middlewares import trace_app, trace_middleware
@@ -28,108 +27,108 @@ class TestTraceMiddleware(TraceTestCase):
         # it should create a root span when there is a handler hit
         # with the proper tags
         request = yield from self.client.request('GET', '/')
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_("What's tracing?", text)
+        assert "What's tracing?" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        eq_('aiohttp.request', span.name)
-        eq_('aiohttp-web', span.service)
-        eq_('http', span.span_type)
-        eq_('GET /', span.resource)
-        eq_('/', span.get_tag('http.url'))
-        eq_('GET', span.get_tag('http.method'))
-        eq_('200', span.get_tag('http.status_code'))
-        eq_(0, span.error)
+        assert 'aiohttp.request' == span.name
+        assert 'aiohttp-web' == span.service
+        assert 'http' == span.span_type
+        assert 'GET /' == span.resource
+        assert '/' == span.get_tag('http.url')
+        assert 'GET' == span.get_tag('http.method')
+        assert '200' == span.get_tag('http.status_code')
+        assert 0 == span.error
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_param_handler(self):
         # it should manage properly handlers with params
         request = yield from self.client.request('GET', '/echo/team')
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_('Hello team', text)
+        assert 'Hello team' == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        eq_('GET /echo/{name}', span.resource)
-        eq_('/echo/team', span.get_tag('http.url'))
-        eq_('200', span.get_tag('http.status_code'))
+        assert 'GET /echo/{name}' == span.resource
+        assert '/echo/team' == span.get_tag('http.url')
+        assert '200' == span.get_tag('http.status_code')
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_404_handler(self):
         # it should not pollute the resource space
         request = yield from self.client.request('GET', '/404/not_found')
-        eq_(404, request.status)
+        assert 404 == request.status
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        eq_('404', span.resource)
-        eq_('/404/not_found', span.get_tag('http.url'))
-        eq_('GET', span.get_tag('http.method'))
-        eq_('404', span.get_tag('http.status_code'))
+        assert '404' == span.resource
+        assert '/404/not_found' == span.get_tag('http.url')
+        assert 'GET' == span.get_tag('http.method')
+        assert '404' == span.get_tag('http.status_code')
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_coroutine_chaining(self):
         # it should create a trace with multiple spans
         request = yield from self.client.request('GET', '/chaining/')
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_('OK', text)
+        assert 'OK' == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(3, len(traces[0]))
+        assert 1 == len(traces)
+        assert 3 == len(traces[0])
         root = traces[0][0]
         handler = traces[0][1]
         coroutine = traces[0][2]
         # root span created in the middleware
-        eq_('aiohttp.request', root.name)
-        eq_('GET /chaining/', root.resource)
-        eq_('/chaining/', root.get_tag('http.url'))
-        eq_('GET', root.get_tag('http.method'))
-        eq_('200', root.get_tag('http.status_code'))
+        assert 'aiohttp.request' == root.name
+        assert 'GET /chaining/' == root.resource
+        assert '/chaining/' == root.get_tag('http.url')
+        assert 'GET' == root.get_tag('http.method')
+        assert '200' == root.get_tag('http.status_code')
         # span created in the coroutine_chaining handler
-        eq_('aiohttp.coro_1', handler.name)
-        eq_(root.span_id, handler.parent_id)
-        eq_(root.trace_id, handler.trace_id)
+        assert 'aiohttp.coro_1' == handler.name
+        assert root.span_id == handler.parent_id
+        assert root.trace_id == handler.trace_id
         # span created in the coro_2 handler
-        eq_('aiohttp.coro_2', coroutine.name)
-        eq_(handler.span_id, coroutine.parent_id)
-        eq_(root.trace_id, coroutine.trace_id)
+        assert 'aiohttp.coro_2' == coroutine.name
+        assert handler.span_id == coroutine.parent_id
+        assert root.trace_id == coroutine.trace_id
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_static_handler(self):
         # it should create a trace with multiple spans
         request = yield from self.client.request('GET', '/statics/empty.txt')
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_('Static file\n', text)
+        assert 'Static file\n' == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
         # root span created in the middleware
-        eq_('aiohttp.request', span.name)
-        eq_('GET /statics', span.resource)
-        eq_('/statics/empty.txt', span.get_tag('http.url'))
-        eq_('GET', span.get_tag('http.method'))
-        eq_('200', span.get_tag('http.status_code'))
+        assert 'aiohttp.request' == span.name
+        assert 'GET /statics' == span.resource
+        assert '/statics/empty.txt' == span.get_tag('http.url')
+        assert 'GET' == span.get_tag('http.method')
+        assert '200' == span.get_tag('http.status_code')
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -137,70 +136,69 @@ class TestTraceMiddleware(TraceTestCase):
         # it should be idempotent
         app = setup_app(self.app.loop)
         # the middleware is not present
-        eq_(1, len(app.middlewares))
-        eq_(noop_middleware, app.middlewares[0])
+        assert 1 == len(app.middlewares)
+        assert noop_middleware == app.middlewares[0]
         # the middleware is present (with the noop middleware)
         trace_app(app, self.tracer)
-        eq_(2, len(app.middlewares))
+        assert 2 == len(app.middlewares)
         # applying the middleware twice doesn't add it again
         trace_app(app, self.tracer)
-        eq_(2, len(app.middlewares))
+        assert 2 == len(app.middlewares)
         # and the middleware is always the first
-        eq_(trace_middleware, app.middlewares[0])
-        eq_(noop_middleware, app.middlewares[1])
+        assert trace_middleware == app.middlewares[0]
+        assert noop_middleware == app.middlewares[1]
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_exception(self):
         request = yield from self.client.request('GET', '/exception')
-        eq_(500, request.status)
+        assert 500 == request.status
         yield from request.text()
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
+        assert 1 == len(traces)
         spans = traces[0]
-        eq_(1, len(spans))
+        assert 1 == len(spans)
         span = spans[0]
-        eq_(1, span.error)
-        eq_('GET /exception', span.resource)
-        eq_('error', span.get_tag('error.msg'))
-        ok_('Exception: error' in span.get_tag('error.stack'))
+        assert 1 == span.error
+        assert 'GET /exception' == span.resource
+        assert 'error' == span.get_tag('error.msg')
+        assert 'Exception: error' in span.get_tag('error.stack')
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_async_exception(self):
         request = yield from self.client.request('GET', '/async_exception')
-        eq_(500, request.status)
+        assert 500 == request.status
         yield from request.text()
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
+        assert 1 == len(traces)
         spans = traces[0]
-        eq_(1, len(spans))
+        assert 1 == len(spans)
         span = spans[0]
-        eq_(1, span.error)
-        eq_('GET /async_exception', span.resource)
-        eq_('error', span.get_tag('error.msg'))
-        ok_('Exception: error' in span.get_tag('error.stack'))
+        assert 1 == span.error
+        assert 'GET /async_exception' == span.resource
+        assert 'error' == span.get_tag('error.msg')
+        assert 'Exception: error' in span.get_tag('error.stack')
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_wrapped_coroutine(self):
         request = yield from self.client.request('GET', '/wrapped_coroutine')
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_('OK', text)
+        assert 'OK' == text
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
+        assert 1 == len(traces)
         spans = traces[0]
-        eq_(2, len(spans))
+        assert 2 == len(spans)
         span = spans[0]
-        eq_('GET /wrapped_coroutine', span.resource)
+        assert 'GET /wrapped_coroutine' == span.resource
         span = spans[1]
-        eq_('nested', span.name)
-        ok_(span.duration > 0.25,
-            msg="span.duration={0}".format(span.duration))
+        assert 'nested' == span.name
+        assert span.duration > 0.25, "span.duration={0}".format(span.duration)
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -212,18 +210,18 @@ class TestTraceMiddleware(TraceTestCase):
         }
 
         request = yield from self.client.request('GET', '/', headers=tracing_headers)
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_("What's tracing?", text)
+        assert "What's tracing?" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right trace_id and parent_id
-        eq_(span.trace_id, 100)
-        eq_(span.parent_id, 42)
-        eq_(span.get_metric(SAMPLING_PRIORITY_KEY), None)
+        assert span.trace_id == 100
+        assert span.parent_id == 42
+        assert span.get_metric(SAMPLING_PRIORITY_KEY) == None
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -237,18 +235,18 @@ class TestTraceMiddleware(TraceTestCase):
         }
 
         request = yield from self.client.request('GET', '/', headers=tracing_headers)
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_("What's tracing?", text)
+        assert "What's tracing?" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right trace_id and parent_id
-        eq_(100, span.trace_id)
-        eq_(42, span.parent_id)
-        eq_(1, span.get_metric(SAMPLING_PRIORITY_KEY))
+        assert 100 == span.trace_id
+        assert 42 == span.parent_id
+        assert 1 == span.get_metric(SAMPLING_PRIORITY_KEY)
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -262,18 +260,18 @@ class TestTraceMiddleware(TraceTestCase):
         }
 
         request = yield from self.client.request('GET', '/', headers=tracing_headers)
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_("What's tracing?", text)
+        assert "What's tracing?" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right trace_id and parent_id
-        eq_(100, span.trace_id)
-        eq_(42, span.parent_id)
-        eq_(0, span.get_metric(SAMPLING_PRIORITY_KEY))
+        assert 100 == span.trace_id
+        assert 42 == span.parent_id
+        assert 0 == span.get_metric(SAMPLING_PRIORITY_KEY)
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -286,17 +284,17 @@ class TestTraceMiddleware(TraceTestCase):
         }
 
         request = yield from self.client.request('GET', '/', headers=tracing_headers)
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_("What's tracing?", text)
+        assert "What's tracing?" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
         # distributed tracing must be ignored by default
-        ok_(span.trace_id is not 100)
-        ok_(span.parent_id is not 42)
+        assert span.trace_id is not 100
+        assert span.parent_id is not 42
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -311,22 +309,22 @@ class TestTraceMiddleware(TraceTestCase):
         }
 
         request = yield from self.client.request('GET', '/sub_span', headers=tracing_headers)
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_("OK", text)
+        assert "OK" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
         span, sub_span = traces[0][0], traces[0][1]
         # with the right trace_id and parent_id
-        eq_(100, span.trace_id)
-        eq_(42, span.parent_id)
-        eq_(0, span.get_metric(SAMPLING_PRIORITY_KEY))
+        assert 100 == span.trace_id
+        assert 42 == span.parent_id
+        assert 0 == span.get_metric(SAMPLING_PRIORITY_KEY)
         # check parenting is OK with custom sub-span created within server code
-        eq_(100, sub_span.trace_id)
-        eq_(span.span_id, sub_span.parent_id)
-        eq_(None, sub_span.get_metric(SAMPLING_PRIORITY_KEY))
+        assert 100 == sub_span.trace_id
+        assert span.span_id == sub_span.parent_id
+        assert None == sub_span.get_metric(SAMPLING_PRIORITY_KEY)
 
     def _assert_200_parenting(self, traces):
         """Helper to assert parenting when handling aiohttp requests.
@@ -334,8 +332,8 @@ class TestTraceMiddleware(TraceTestCase):
         This is used to ensure that parenting is consistent between Datadog
         and OpenTracing implementations of tracing.
         """
-        eq_(2, len(traces))
-        eq_(1, len(traces[0]))
+        assert 2 == len(traces)
+        assert 1 == len(traces[0])
 
         # the inner span will be the first trace since it completes before the
         # outer span does
@@ -343,30 +341,30 @@ class TestTraceMiddleware(TraceTestCase):
         outer_span = traces[1][0]
 
         # confirm the parenting
-        eq_(outer_span.parent_id, None)
-        eq_(inner_span.parent_id, None)
+        assert outer_span.parent_id == None
+        assert inner_span.parent_id == None
 
-        eq_(outer_span.name, 'aiohttp_op')
+        assert outer_span.name == 'aiohttp_op'
 
         # with the right fields
-        eq_('aiohttp.request', inner_span.name)
-        eq_('aiohttp-web', inner_span.service)
-        eq_('http', inner_span.span_type)
-        eq_('GET /', inner_span.resource)
-        eq_('/', inner_span.get_tag('http.url'))
-        eq_('GET', inner_span.get_tag('http.method'))
-        eq_('200', inner_span.get_tag('http.status_code'))
-        eq_(0, inner_span.error)
+        assert 'aiohttp.request' == inner_span.name
+        assert 'aiohttp-web' == inner_span.service
+        assert 'http' == inner_span.span_type
+        assert 'GET /' == inner_span.resource
+        assert '/' == inner_span.get_tag('http.url')
+        assert 'GET' == inner_span.get_tag('http.method')
+        assert '200' == inner_span.get_tag('http.status_code')
+        assert 0 == inner_span.error
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_parenting_200_dd(self):
         with self.tracer.trace('aiohttp_op'):
             request = yield from self.client.request('GET', '/')
-            eq_(200, request.status)
+            assert 200 == request.status
             text = yield from request.text()
 
-        eq_("What's tracing?", text)
+        assert "What's tracing?" == text
         traces = self.tracer.writer.pop_traces()
         self._assert_200_parenting(traces)
 
@@ -378,10 +376,10 @@ class TestTraceMiddleware(TraceTestCase):
 
         with ot_tracer.start_active_span('aiohttp_op'):
             request = yield from self.client.request('GET', '/')
-            eq_(200, request.status)
+            assert 200 == request.status
             text = yield from request.text()
 
-        eq_("What's tracing?", text)
+        assert "What's tracing?" == text
         traces = self.tracer.writer.pop_traces()
         self._assert_200_parenting(traces)
 

--- a/tests/contrib/aiohttp/test_request.py
+++ b/tests/contrib/aiohttp/test_request.py
@@ -4,7 +4,6 @@ import asyncio
 import aiohttp_jinja2
 
 from urllib import request
-from nose.tools import eq_
 from aiohttp.test_utils import unittest_run_loop
 
 from ddtrace.pin import Pin
@@ -36,22 +35,22 @@ class TestRequestTracing(TraceTestCase):
         # it should create a root span when there is a handler hit
         # with the proper tags
         request = yield from self.client.request('GET', '/template/')
-        eq_(200, request.status)
+        assert 200 == request.status
         yield from request.text()
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
         request_span = traces[0][0]
         template_span = traces[0][1]
         # request
-        eq_('aiohttp-web', request_span.service)
-        eq_('aiohttp.request', request_span.name)
-        eq_('GET /template/', request_span.resource)
+        assert 'aiohttp-web' == request_span.service
+        assert 'aiohttp.request' == request_span.name
+        assert 'GET /template/' == request_span.resource
         # template
-        eq_('aiohttp-web', template_span.service)
-        eq_('aiohttp.template', template_span.name)
-        eq_('aiohttp.template', template_span.resource)
+        assert 'aiohttp-web' == template_span.service
+        assert 'aiohttp.template' == template_span.name
+        assert 'aiohttp.template' == template_span.resource
 
 
     @unittest_run_loop
@@ -61,7 +60,7 @@ class TestRequestTracing(TraceTestCase):
         def make_requests():
             url = self.client.make_url('/delayed/')
             response = request.urlopen(str(url)).read().decode('utf-8')
-            eq_('Done', response)
+            assert 'Done' == response
 
         # blocking call executed in different threads
         threads = [threading.Thread(target=make_requests) for _ in range(10)]
@@ -77,5 +76,5 @@ class TestRequestTracing(TraceTestCase):
 
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(10, len(traces))
-        eq_(1, len(traces[0]))
+        assert 10 == len(traces)
+        assert 1 == len(traces[0])

--- a/tests/contrib/aiohttp/test_request_safety.py
+++ b/tests/contrib/aiohttp/test_request_safety.py
@@ -4,7 +4,6 @@ import asyncio
 import aiohttp_jinja2
 
 from urllib import request
-from nose.tools import eq_
 from aiohttp.test_utils import unittest_run_loop
 
 from ddtrace.pin import Pin
@@ -37,22 +36,22 @@ class TestAiohttpSafety(TraceTestCase):
         # it should create a root span when there is a handler hit
         # with the proper tags
         request = yield from self.client.request('GET', '/template/')
-        eq_(200, request.status)
+        assert 200 == request.status
         yield from request.text()
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
         request_span = traces[0][0]
         template_span = traces[0][1]
         # request
-        eq_('aiohttp-web', request_span.service)
-        eq_('aiohttp.request', request_span.name)
-        eq_('GET /template/', request_span.resource)
+        assert 'aiohttp-web' == request_span.service
+        assert 'aiohttp.request' == request_span.name
+        assert 'GET /template/' == request_span.resource
         # template
-        eq_('aiohttp-web', template_span.service)
-        eq_('aiohttp.template', template_span.name)
-        eq_('aiohttp.template', template_span.resource)
+        assert 'aiohttp-web' == template_span.service
+        assert 'aiohttp.template' == template_span.name
+        assert 'aiohttp.template' == template_span.resource
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -62,7 +61,7 @@ class TestAiohttpSafety(TraceTestCase):
         def make_requests():
             url = self.client.make_url('/delayed/')
             response = request.urlopen(str(url)).read().decode('utf-8')
-            eq_('Done', response)
+            assert 'Done' == response
 
         # blocking call executed in different threads
         ctx = self.tracer.get_call_context()
@@ -79,6 +78,6 @@ class TestAiohttpSafety(TraceTestCase):
 
         # the trace is wrong but the Context is finished
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(10, len(traces[0]))
-        eq_(0, len(ctx._trace))
+        assert 1 == len(traces)
+        assert 10 == len(traces[0])
+        assert 0 == len(ctx._trace)

--- a/tests/contrib/aiohttp/test_templates.py
+++ b/tests/contrib/aiohttp/test_templates.py
@@ -2,7 +2,6 @@
 import asyncio
 import aiohttp_jinja2
 
-from nose.tools import eq_, ok_
 from aiohttp.test_utils import unittest_run_loop
 
 from ddtrace.pin import Pin
@@ -28,19 +27,19 @@ class TestTraceTemplate(TraceTestCase):
     def test_template_rendering(self):
         # it should trace a template rendering
         request = yield from self.client.request('GET', '/template/')
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_('OK', text)
+        assert 'OK' == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        eq_('aiohttp.template', span.name)
-        eq_('template', span.span_type)
-        eq_('/template.jinja2', span.get_tag('aiohttp.template'))
-        eq_(0, span.error)
+        assert 'aiohttp.template' == span.name
+        assert 'template' == span.span_type
+        assert '/template.jinja2' == span.get_tag('aiohttp.template')
+        assert 0 == span.error
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -48,19 +47,19 @@ class TestTraceTemplate(TraceTestCase):
         # it should trace a template rendering with a FileSystemLoader
         set_filesystem_loader(self.app)
         request = yield from self.client.request('GET', '/template/')
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_('OK', text)
+        assert 'OK' == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        eq_('aiohttp.template', span.name)
-        eq_('template', span.span_type)
-        eq_('/template.jinja2', span.get_tag('aiohttp.template'))
-        eq_(0, span.error)
+        assert 'aiohttp.template' == span.name
+        assert 'template' == span.span_type
+        assert '/template.jinja2' == span.get_tag('aiohttp.template')
+        assert 0 == span.error
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -68,55 +67,55 @@ class TestTraceTemplate(TraceTestCase):
         # it should trace a template rendering with a PackageLoader
         set_package_loader(self.app)
         request = yield from self.client.request('GET', '/template/')
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_('OK', text)
+        assert 'OK' == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        eq_('aiohttp.template', span.name)
-        eq_('template', span.span_type)
-        eq_('templates/template.jinja2', span.get_tag('aiohttp.template'))
-        eq_(0, span.error)
+        assert 'aiohttp.template' == span.name
+        assert 'template' == span.span_type
+        assert 'templates/template.jinja2' == span.get_tag('aiohttp.template')
+        assert 0 == span.error
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_template_decorator(self):
         # it should trace a template rendering
         request = yield from self.client.request('GET', '/template_decorator/')
-        eq_(200, request.status)
+        assert 200 == request.status
         text = yield from request.text()
-        eq_('OK', text)
+        assert 'OK' == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        eq_('aiohttp.template', span.name)
-        eq_('template', span.span_type)
-        eq_('/template.jinja2', span.get_tag('aiohttp.template'))
-        eq_(0, span.error)
+        assert 'aiohttp.template' == span.name
+        assert 'template' == span.span_type
+        assert '/template.jinja2' == span.get_tag('aiohttp.template')
+        assert 0 == span.error
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_template_error(self):
         # it should trace a template rendering
         request = yield from self.client.request('GET', '/template_error/')
-        eq_(500, request.status)
+        assert 500 == request.status
         yield from request.text()
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        eq_('aiohttp.template', span.name)
-        eq_('template', span.span_type)
-        eq_('/error.jinja2', span.get_tag('aiohttp.template'))
-        eq_(1, span.error)
-        eq_('division by zero', span.get_tag('error.msg'))
-        ok_('ZeroDivisionError: division by zero' in span.get_tag('error.stack'))
+        assert 'aiohttp.template' == span.name
+        assert 'template' == span.span_type
+        assert '/error.jinja2' == span.get_tag('aiohttp.template')
+        assert 1 == span.error
+        assert 'division by zero' == span.get_tag('error.msg')
+        assert 'ZeroDivisionError: division by zero' in span.get_tag('error.stack')

--- a/tests/contrib/aiopg/py35/test.py
+++ b/tests/contrib/aiopg/py35/test.py
@@ -5,7 +5,6 @@ import asyncio
 
 # 3p
 import aiopg
-from nose.tools import eq_
 
 # project
 from ddtrace.contrib.aiopg.patch import patch, unpatch
@@ -57,7 +56,7 @@ class TestPsycopgPatch(AsyncioTestCase):
         spans = tracer.writer.pop()
         assert len(spans) == 1
         span = spans[0]
-        eq_(span.name, 'postgres.query')
+        assert span.name == 'postgres.query'
 
     @mark_asyncio
     def test_cursor_ctx_manager(self):

--- a/tests/contrib/aiopg/test.py
+++ b/tests/contrib/aiopg/test.py
@@ -7,7 +7,6 @@ import asyncio
 # 3p
 import aiopg
 from psycopg2 import extras
-from nose.tools import eq_
 
 # project
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -65,18 +64,18 @@ class AiopgTestCase(AsyncioTestCase):
         yield from cursor.execute(q)
         rows = yield from cursor.fetchall()
         end = time.time()
-        eq_(rows, [('foobarblah',)])
+        assert rows == [('foobarblah',)]
         assert rows
         spans = writer.pop()
         assert spans
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.name, 'postgres.query')
-        eq_(span.resource, q)
-        eq_(span.service, service)
-        eq_(span.meta['sql.query'], q)
-        eq_(span.error, 0)
-        eq_(span.span_type, 'sql')
+        assert span.name == 'postgres.query'
+        assert span.resource == q
+        assert span.service == service
+        assert span.meta['sql.query'] == q
+        assert span.error == 0
+        assert span.span_type == 'sql'
         assert start <= span.start <= end
         assert span.duration <= end - start
 
@@ -86,21 +85,21 @@ class AiopgTestCase(AsyncioTestCase):
             cursor = yield from db.cursor()
             yield from cursor.execute(q)
             rows = yield from cursor.fetchall()
-            eq_(rows, [('foobarblah',)])
+            assert rows == [('foobarblah',)]
         spans = writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         ot_span, dd_span = spans
         # confirm the parenting
-        eq_(ot_span.parent_id, None)
-        eq_(dd_span.parent_id, ot_span.span_id)
-        eq_(ot_span.name, 'aiopg_op')
-        eq_(ot_span.service, 'aiopg_svc')
-        eq_(dd_span.name, 'postgres.query')
-        eq_(dd_span.resource, q)
-        eq_(dd_span.service, service)
-        eq_(dd_span.meta['sql.query'], q)
-        eq_(dd_span.error, 0)
-        eq_(dd_span.span_type, 'sql')
+        assert ot_span.parent_id == None
+        assert dd_span.parent_id == ot_span.span_id
+        assert ot_span.name == 'aiopg_op'
+        assert ot_span.service == 'aiopg_svc'
+        assert dd_span.name == 'postgres.query'
+        assert dd_span.resource == q
+        assert dd_span.service == service
+        assert dd_span.meta['sql.query'] == q
+        assert dd_span.error == 0
+        assert dd_span.span_type == 'sql'
 
         # run a query with an error and ensure all is well
         q = 'select * from some_non_existant_table'
@@ -113,16 +112,16 @@ class AiopgTestCase(AsyncioTestCase):
             assert 0, 'should have an error'
         spans = writer.pop()
         assert spans, spans
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.name, 'postgres.query')
-        eq_(span.resource, q)
-        eq_(span.service, service)
-        eq_(span.meta['sql.query'], q)
-        eq_(span.error, 1)
-        # eq_(span.meta['out.host'], 'localhost')
-        eq_(span.meta['out.port'], TEST_PORT)
-        eq_(span.span_type, 'sql')
+        assert span.name == 'postgres.query'
+        assert span.resource == q
+        assert span.service == service
+        assert span.meta['sql.query'] == q
+        assert span.error == 1
+        # assert span.meta['out.host'] == 'localhost'
+        assert span.meta['out.port'] == TEST_PORT
+        assert span.span_type == 'sql'
 
     @mark_asyncio
     def test_disabled_execute(self):
@@ -155,7 +154,7 @@ class AiopgTestCase(AsyncioTestCase):
         # ensure we have the service types
         service_meta = tracer.writer.pop_services()
         expected = {}
-        eq_(service_meta, expected)
+        assert service_meta == expected
 
     @mark_asyncio
     def test_patch_unpatch(self):
@@ -175,7 +174,7 @@ class AiopgTestCase(AsyncioTestCase):
 
         spans = writer.pop()
         assert spans, spans
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         # Test unpatch
         unpatch()
@@ -197,7 +196,7 @@ class AiopgTestCase(AsyncioTestCase):
 
         spans = writer.pop()
         assert spans, spans
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
 
 class AiopgAnalyticsTestCase(AiopgTestCase):

--- a/tests/contrib/asyncio/test_helpers.py
+++ b/tests/contrib/asyncio/test_helpers.py
@@ -2,8 +2,6 @@
 # DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from `yield from`
 import asyncio
 
-from nose.tools import eq_, ok_
-
 from ddtrace.context import Context
 from ddtrace.contrib.asyncio import helpers
 from .utils import AsyncioTestCase, mark_asyncio
@@ -20,7 +18,7 @@ class TestAsyncioHelpers(AsyncioTestCase):
         task = asyncio.Task.current_task()
         ctx = Context()
         helpers.set_call_context(task, ctx)
-        eq_(ctx, self.tracer.get_call_context())
+        assert ctx == self.tracer.get_call_context()
 
     @mark_asyncio
     def test_ensure_future(self):
@@ -29,27 +27,27 @@ class TestAsyncioHelpers(AsyncioTestCase):
         def future_work():
             # the ctx is available in this task
             ctx = self.tracer.get_call_context()
-            eq_(1, len(ctx._trace))
-            eq_('coroutine', ctx._trace[0].name)
+            assert 1 == len(ctx._trace)
+            assert 'coroutine' == ctx._trace[0].name
             return ctx._trace[0].name
 
         self.tracer.trace('coroutine')
         # schedule future work and wait for a result
         delayed_task = helpers.ensure_future(future_work(), tracer=self.tracer)
         result = yield from asyncio.wait_for(delayed_task, timeout=1)
-        eq_('coroutine', result)
+        assert 'coroutine' == result
 
     @mark_asyncio
     def test_run_in_executor_proxy(self):
         # the wrapper should pass arguments and results properly
         def future_work(number, name):
-            eq_(42, number)
-            eq_('john', name)
+            assert 42 == number
+            assert 'john' == name
             return True
 
         future = helpers.run_in_executor(self.loop, None, future_work, 42, 'john', tracer=self.tracer)
         result = yield from future
-        ok_(result)
+        assert result
 
     @mark_asyncio
     def test_run_in_executor_traces(self):
@@ -59,8 +57,8 @@ class TestAsyncioHelpers(AsyncioTestCase):
             # the Context is empty but the reference to the latest
             # span is here to keep the parenting
             ctx = self.tracer.get_call_context()
-            eq_(0, len(ctx._trace))
-            eq_('coroutine', ctx._current_span.name)
+            assert 0 == len(ctx._trace)
+            assert 'coroutine' == ctx._current_span.name
             return True
 
         span = self.tracer.trace('coroutine')
@@ -68,7 +66,7 @@ class TestAsyncioHelpers(AsyncioTestCase):
         # we close the Context
         span.finish()
         result = yield from future
-        ok_(result)
+        assert result
 
     @mark_asyncio
     def test_create_task(self):
@@ -77,7 +75,7 @@ class TestAsyncioHelpers(AsyncioTestCase):
         def future_work():
             # the ctx is available in this task
             ctx = self.tracer.get_call_context()
-            eq_(0, len(ctx._trace))
+            assert 0 == len(ctx._trace)
             child_span = self.tracer.trace('child_task')
             return child_span
 
@@ -85,5 +83,5 @@ class TestAsyncioHelpers(AsyncioTestCase):
         # schedule future work and wait for a result
         task = helpers.create_task(future_work())
         result = yield from task
-        eq_(root_span.trace_id, result.trace_id)
-        eq_(root_span.span_id, result.parent_id)
+        assert root_span.trace_id == result.trace_id
+        assert root_span.span_id == result.parent_id

--- a/tests/contrib/asyncio/test_tracer.py
+++ b/tests/contrib/asyncio/test_tracer.py
@@ -9,7 +9,6 @@ from ddtrace.provider import DefaultContextProvider
 from ddtrace.contrib.asyncio.patch import patch, unpatch
 from ddtrace.contrib.asyncio.helpers import set_call_context
 
-from nose.tools import eq_, ok_
 from tests.opentracer.utils import init_tracer
 from .utils import AsyncioTestCase, mark_asyncio
 
@@ -27,16 +26,16 @@ class TestAsyncioTracer(AsyncioTestCase):
         # or create a new one
         task = asyncio.Task.current_task()
         ctx = getattr(task, '__datadog_context', None)
-        ok_(ctx is None)
+        assert ctx is None
         # get the context from the loop creates a new one that
         # is attached to the Task object
         ctx = self.tracer.get_call_context()
-        eq_(ctx, getattr(task, '__datadog_context', None))
+        assert ctx == getattr(task, '__datadog_context', None)
 
     @mark_asyncio
     def test_get_call_context_twice(self):
         # it should return the same Context if called twice
-        eq_(self.tracer.get_call_context(), self.tracer.get_call_context())
+        assert self.tracer.get_call_context() == self.tracer.get_call_context()
 
     @mark_asyncio
     def test_trace_coroutine(self):
@@ -45,10 +44,10 @@ class TestAsyncioTracer(AsyncioTestCase):
             span.resource = 'base'
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
-        eq_('coroutine', traces[0][0].name)
-        eq_('base', traces[0][0].resource)
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+        assert 'coroutine' == traces[0][0].name
+        assert 'base' == traces[0][0].resource
 
     @mark_asyncio
     def test_trace_multiple_coroutines(self):
@@ -64,23 +63,23 @@ class TestAsyncioTracer(AsyncioTestCase):
             value = yield from coro()
 
         # the coroutine has been called correctly
-        eq_(42, value)
+        assert 42 == value
         # a single trace has been properly reported
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
-        eq_('coroutine_1', traces[0][0].name)
-        eq_('coroutine_2', traces[0][1].name)
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
+        assert 'coroutine_1' == traces[0][0].name
+        assert 'coroutine_2' == traces[0][1].name
         # the parenting is correct
-        eq_(traces[0][0], traces[0][1]._parent)
-        eq_(traces[0][0].trace_id, traces[0][1].trace_id)
+        assert traces[0][0] == traces[0][1]._parent
+        assert traces[0][0].trace_id == traces[0][1].trace_id
 
     @mark_asyncio
     def test_event_loop_exception(self):
         # it should handle a loop exception
         asyncio.set_event_loop(None)
         ctx = self.tracer.get_call_context()
-        ok_(ctx is not None)
+        assert ctx is not None
 
     def test_context_task_none(self):
         # it should handle the case where a Task is not available
@@ -88,10 +87,10 @@ class TestAsyncioTracer(AsyncioTestCase):
         # without a Task
         task = asyncio.Task.current_task()
         # the task is not available
-        ok_(task is None)
+        assert task is None
         # but a new Context is still created making the operation safe
         ctx = self.tracer.get_call_context()
-        ok_(ctx is not None)
+        assert ctx is not None
 
     @mark_asyncio
     def test_exception(self):
@@ -103,13 +102,13 @@ class TestAsyncioTracer(AsyncioTestCase):
         with self.assertRaises(Exception):
             yield from f1()
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
+        assert 1 == len(traces)
         spans = traces[0]
-        eq_(1, len(spans))
+        assert 1 == len(spans)
         span = spans[0]
-        eq_(1, span.error)
-        eq_('f1 error', span.get_tag('error.msg'))
-        ok_('Exception: f1 error' in span.get_tag('error.stack'))
+        assert 1 == span.error
+        assert 'f1 error' == span.get_tag('error.msg')
+        assert 'Exception: f1 error' in span.get_tag('error.stack')
 
     @mark_asyncio
     def test_nested_exceptions(self):
@@ -127,19 +126,19 @@ class TestAsyncioTracer(AsyncioTestCase):
             yield from f2()
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
+        assert 1 == len(traces)
         spans = traces[0]
-        eq_(2, len(spans))
+        assert 2 == len(spans)
         span = spans[0]
-        eq_('f2', span.name)
-        eq_(1, span.error) # f2 did not catch the exception
-        eq_('f1 error', span.get_tag('error.msg'))
-        ok_('Exception: f1 error' in span.get_tag('error.stack'))
+        assert 'f2' == span.name
+        assert 1 == span.error # f2 did not catch the exception
+        assert 'f1 error' == span.get_tag('error.msg')
+        assert 'Exception: f1 error' in span.get_tag('error.stack')
         span = spans[1]
-        eq_('f1', span.name)
-        eq_(1, span.error)
-        eq_('f1 error', span.get_tag('error.msg'))
-        ok_('Exception: f1 error' in span.get_tag('error.stack'))
+        assert 'f1' == span.name
+        assert 1 == span.error
+        assert 'f1 error' == span.get_tag('error.msg')
+        assert 'Exception: f1 error' in span.get_tag('error.stack')
 
     @mark_asyncio
     def test_handled_nested_exceptions(self):
@@ -159,17 +158,17 @@ class TestAsyncioTracer(AsyncioTestCase):
         yield from f2()
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
+        assert 1 == len(traces)
         spans = traces[0]
-        eq_(2, len(spans))
+        assert 2 == len(spans)
         span = spans[0]
-        eq_('f2', span.name)
-        eq_(0, span.error) # f2 caught the exception
+        assert 'f2' == span.name
+        assert 0 == span.error # f2 caught the exception
         span = spans[1]
-        eq_('f1', span.name)
-        eq_(1, span.error)
-        eq_('f1 error', span.get_tag('error.msg'))
-        ok_('Exception: f1 error' in span.get_tag('error.stack'))
+        assert 'f1' == span.name
+        assert 1 == span.error
+        assert 'f1 error' == span.get_tag('error.msg')
+        assert 'Exception: f1 error' in span.get_tag('error.stack')
 
     @mark_asyncio
     def test_trace_multiple_calls(self):
@@ -186,9 +185,9 @@ class TestAsyncioTracer(AsyncioTestCase):
             yield from future
 
         traces = self.tracer.writer.pop_traces()
-        eq_(10, len(traces))
-        eq_(1, len(traces[0]))
-        eq_('coroutine', traces[0][0].name)
+        assert 10 == len(traces)
+        assert 1 == len(traces[0])
+        assert 'coroutine' == traces[0][0].name
 
     @mark_asyncio
     def test_wrapped_coroutine(self):
@@ -200,11 +199,11 @@ class TestAsyncioTracer(AsyncioTestCase):
         yield from f1()
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
+        assert 1 == len(traces)
         spans = traces[0]
-        eq_(1, len(spans))
+        assert 1 == len(spans)
         span = spans[0]
-        ok_(span.duration > 0.25, msg='span.duration={}'.format(span.duration))
+        assert span.duration > 0.25, 'span.duration={}'.format(span.duration)
 
 
 class TestAsyncioPropagation(AsyncioTestCase):
@@ -235,14 +234,14 @@ class TestAsyncioPropagation(AsyncioTestCase):
         yield from coro_1()
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 2)
-        eq_(len(traces[0]), 1)
-        eq_(len(traces[1]), 1)
+        assert len(traces) == 2
+        assert len(traces[0]) == 1
+        assert len(traces[1]) == 1
         spawn_task = traces[0][0]
         main_task = traces[1][0]
         # check if the context has been correctly propagated
-        eq_(spawn_task.trace_id, main_task.trace_id)
-        eq_(spawn_task.parent_id, main_task.span_id)
+        assert spawn_task.trace_id == main_task.trace_id
+        assert spawn_task.parent_id == main_task.span_id
 
     @mark_asyncio
     def test_concurrent_chaining(self):
@@ -262,18 +261,18 @@ class TestAsyncioPropagation(AsyncioTestCase):
             yield from asyncio.gather(f1(), f2())
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 3)
-        eq_(len(traces[0]), 1)
-        eq_(len(traces[1]), 1)
-        eq_(len(traces[2]), 1)
+        assert len(traces) == 3
+        assert len(traces[0]) == 1
+        assert len(traces[1]) == 1
+        assert len(traces[2]) == 1
         child_1 = traces[0][0]
         child_2 = traces[1][0]
         main_task = traces[2][0]
         # check if the context has been correctly propagated
-        eq_(child_1.trace_id, main_task.trace_id)
-        eq_(child_1.parent_id, main_task.span_id)
-        eq_(child_2.trace_id, main_task.trace_id)
-        eq_(child_2.parent_id, main_task.span_id)
+        assert child_1.trace_id == main_task.trace_id
+        assert child_1.parent_id == main_task.span_id
+        assert child_2.trace_id == main_task.trace_id
+        assert child_2.parent_id == main_task.span_id
 
     @mark_asyncio
     def test_propagation_with_set_call_context(self):
@@ -287,11 +286,11 @@ class TestAsyncioPropagation(AsyncioTestCase):
             yield from asyncio.sleep(0.01)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
-        eq_(span.trace_id, 100)
-        eq_(span.parent_id, 101)
+        assert span.trace_id == 100
+        assert span.parent_id == 101
 
     @mark_asyncio
     def test_propagation_with_new_context(self):
@@ -305,18 +304,18 @@ class TestAsyncioPropagation(AsyncioTestCase):
             yield from asyncio.sleep(0.01)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
-        eq_(span.trace_id, 100)
-        eq_(span.parent_id, 101)
+        assert span.trace_id == 100
+        assert span.parent_id == 101
 
     @mark_asyncio
     def test_event_loop_unpatch(self):
         # ensures that the event loop can be unpatched
         unpatch()
-        ok_(isinstance(self.tracer._context_provider, DefaultContextProvider))
-        ok_(BaseEventLoop.create_task == _orig_create_task)
+        assert isinstance(self.tracer._context_provider, DefaultContextProvider)
+        assert BaseEventLoop.create_task == _orig_create_task
 
     def test_event_loop_double_patch(self):
         # ensures that double patching will not double instrument
@@ -340,16 +339,16 @@ class TestAsyncioPropagation(AsyncioTestCase):
             value = yield from coro()
 
         # the coroutine has been called correctly
-        eq_(42, value)
+        assert 42 == value
         # a single trace has been properly reported
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
-        eq_('coroutine_1', traces[0][0].name)
-        eq_('coroutine_2', traces[0][1].name)
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
+        assert 'coroutine_1' == traces[0][0].name
+        assert 'coroutine_2' == traces[0][1].name
         # the parenting is correct
-        eq_(traces[0][0], traces[0][1]._parent)
-        eq_(traces[0][0].trace_id, traces[0][1].trace_id)
+        assert traces[0][0] == traces[0][1]._parent
+        assert traces[0][0].trace_id == traces[0][1].trace_id
 
     @mark_asyncio
     def test_trace_multiple_coroutines_ot_inner(self):
@@ -367,13 +366,13 @@ class TestAsyncioPropagation(AsyncioTestCase):
             value = yield from coro()
 
         # the coroutine has been called correctly
-        eq_(42, value)
+        assert 42 == value
         # a single trace has been properly reported
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
-        eq_('coroutine_1', traces[0][0].name)
-        eq_('coroutine_2', traces[0][1].name)
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
+        assert 'coroutine_1' == traces[0][0].name
+        assert 'coroutine_2' == traces[0][1].name
         # the parenting is correct
-        eq_(traces[0][0], traces[0][1]._parent)
-        eq_(traces[0][0].trace_id, traces[0][1].trace_id)
+        assert traces[0][0] == traces[0][1]._parent
+        assert traces[0][0].trace_id == traces[0][1].trace_id

--- a/tests/contrib/asyncio/test_tracer_safety.py
+++ b/tests/contrib/asyncio/test_tracer_safety.py
@@ -2,8 +2,6 @@
 # DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from `yield from`
 import asyncio
 
-from nose.tools import eq_, ok_
-
 from ddtrace.provider import DefaultContextProvider
 from .utils import AsyncioTestCase, mark_asyncio
 
@@ -23,11 +21,11 @@ class TestAsyncioSafety(AsyncioTestCase):
     def test_get_call_context(self):
         # it should return a context even if not attached to the Task
         ctx = self.tracer.get_call_context()
-        ok_(ctx is not None)
+        assert ctx is not None
         # test that it behaves the wrong way
         task = asyncio.Task.current_task()
         task_ctx = getattr(task, '__datadog_context', None)
-        ok_(task_ctx is None)
+        assert task_ctx is None
 
     @mark_asyncio
     def test_trace_coroutine(self):
@@ -36,10 +34,10 @@ class TestAsyncioSafety(AsyncioTestCase):
             span.resource = 'base'
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
-        eq_('coroutine', traces[0][0].name)
-        eq_('base', traces[0][0].resource)
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+        assert 'coroutine' == traces[0][0].name
+        assert 'base' == traces[0][0].resource
 
     @mark_asyncio
     def test_trace_multiple_calls(self):
@@ -56,6 +54,6 @@ class TestAsyncioSafety(AsyncioTestCase):
 
         # the trace is wrong but the Context is finished
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1000, len(traces[0]))
-        eq_(0, len(ctx._trace))
+        assert 1 == len(traces)
+        assert 1000 == len(traces[0])
+        assert 0 == len(ctx._trace)

--- a/tests/contrib/bottle/test.py
+++ b/tests/contrib/bottle/test.py
@@ -2,7 +2,6 @@ import bottle
 import ddtrace
 import webtest
 
-from nose.tools import eq_
 from tests.opentracer.utils import init_tracer
 from ...base import BaseTracerTestCase
 
@@ -43,21 +42,21 @@ class TraceBottleTest(BaseTracerTestCase):
 
         # make a request
         resp = self.app.get('/hi/dougie')
-        eq_(resp.status_int, 200)
-        eq_(compat.to_unicode(resp.body), u'hi dougie')
+        assert resp.status_int == 200
+        assert compat.to_unicode(resp.body) == u'hi dougie'
         # validate it's traced
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.name, 'bottle.request')
-        eq_(s.service, 'bottle-app')
-        eq_(s.span_type, 'web')
-        eq_(s.resource, 'GET /hi/<name>')
-        eq_(s.get_tag('http.status_code'), '200')
-        eq_(s.get_tag('http.method'), 'GET')
+        assert s.name == 'bottle.request'
+        assert s.service == 'bottle-app'
+        assert s.span_type == 'web'
+        assert s.resource == 'GET /hi/<name>'
+        assert s.get_tag('http.status_code') == '200'
+        assert s.get_tag('http.method') == 'GET'
 
         services = self.tracer.writer.pop_services()
-        eq_(services, {})
+        assert services == {}
 
     def test_500(self):
         @self.app.route('/hi')
@@ -68,18 +67,18 @@ class TraceBottleTest(BaseTracerTestCase):
         # make a request
         try:
             resp = self.app.get('/hi')
-            eq_(resp.status_int, 500)
+            assert resp.status_int == 500
         except Exception:
             pass
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.name, 'bottle.request')
-        eq_(s.service, 'bottle-app')
-        eq_(s.resource, 'GET /hi')
-        eq_(s.get_tag('http.status_code'), '500')
-        eq_(s.get_tag('http.method'), 'GET')
+        assert s.name == 'bottle.request'
+        assert s.service == 'bottle-app'
+        assert s.resource == 'GET /hi'
+        assert s.get_tag('http.status_code') == '500'
+        assert s.get_tag('http.method') == 'GET'
 
     def test_bottle_global_tracer(self):
         # without providing a Tracer instance, it should work
@@ -90,16 +89,16 @@ class TraceBottleTest(BaseTracerTestCase):
 
         # make a request
         resp = self.app.get('/home/')
-        eq_(resp.status_int, 200)
+        assert resp.status_int == 200
         # validate it's traced
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.name, 'bottle.request')
-        eq_(s.service, 'bottle-app')
-        eq_(s.resource, 'GET /home/')
-        eq_(s.get_tag('http.status_code'), '200')
-        eq_(s.get_tag('http.method'), 'GET')
+        assert s.name == 'bottle.request'
+        assert s.service == 'bottle-app'
+        assert s.resource == 'GET /home/'
+        assert s.get_tag('http.status_code') == '200'
+        assert s.get_tag('http.method') == 'GET'
 
     def test_analytics_global_on_integration_default(self):
         """
@@ -115,8 +114,8 @@ class TraceBottleTest(BaseTracerTestCase):
 
         with self.override_global_config(dict(analytics_enabled=True)):
             resp = self.app.get('/hi/dougie')
-            eq_(resp.status_int, 200)
-            eq_(compat.to_unicode(resp.body), u'hi dougie')
+            assert resp.status_int == 200
+            assert compat.to_unicode(resp.body) == u'hi dougie'
 
         root = self.get_root_span()
         root.assert_matches(
@@ -146,8 +145,8 @@ class TraceBottleTest(BaseTracerTestCase):
         with self.override_global_config(dict(analytics_enabled=True)):
             with self.override_config('bottle', dict(analytics_enabled=True, analytics_sample_rate=0.5)):
                 resp = self.app.get('/hi/dougie')
-                eq_(resp.status_int, 200)
-                eq_(compat.to_unicode(resp.body), u'hi dougie')
+                assert resp.status_int == 200
+                assert compat.to_unicode(resp.body) == u'hi dougie'
 
         root = self.get_root_span()
         root.assert_matches(
@@ -176,8 +175,8 @@ class TraceBottleTest(BaseTracerTestCase):
 
         with self.override_global_config(dict(analytics_enabled=False)):
             resp = self.app.get('/hi/dougie')
-            eq_(resp.status_int, 200)
-            eq_(compat.to_unicode(resp.body), u'hi dougie')
+            assert resp.status_int == 200
+            assert compat.to_unicode(resp.body) == u'hi dougie'
 
         root = self.get_root_span()
         self.assertIsNone(root.get_metric(ANALYTICS_SAMPLE_RATE_KEY))
@@ -202,8 +201,8 @@ class TraceBottleTest(BaseTracerTestCase):
         with self.override_global_config(dict(analytics_enabled=False)):
             with self.override_config('bottle', dict(analytics_enabled=True, analytics_sample_rate=0.5)):
                 resp = self.app.get('/hi/dougie')
-                eq_(resp.status_int, 200)
-                eq_(compat.to_unicode(resp.body), u'hi dougie')
+                assert resp.status_int == 200
+                assert compat.to_unicode(resp.body) == u'hi dougie'
 
         root = self.get_root_span()
         root.assert_matches(
@@ -231,24 +230,24 @@ class TraceBottleTest(BaseTracerTestCase):
         with ot_tracer.start_active_span('ot_span'):
             resp = self.app.get('/hi/dougie')
 
-        eq_(resp.status_int, 200)
-        eq_(compat.to_unicode(resp.body), u'hi dougie')
+        assert resp.status_int == 200
+        assert compat.to_unicode(resp.body) == u'hi dougie'
         # validate it's traced
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         ot_span, dd_span = spans
 
         # confirm the parenting
-        eq_(ot_span.parent_id, None)
-        eq_(dd_span.parent_id, ot_span.span_id)
+        assert ot_span.parent_id is None
+        assert dd_span.parent_id == ot_span.span_id
 
-        eq_(ot_span.resource, 'ot_span')
+        assert ot_span.resource == 'ot_span'
 
-        eq_(dd_span.name, 'bottle.request')
-        eq_(dd_span.service, 'bottle-app')
-        eq_(dd_span.resource, 'GET /hi/<name>')
-        eq_(dd_span.get_tag('http.status_code'), '200')
-        eq_(dd_span.get_tag('http.method'), 'GET')
+        assert dd_span.name == 'bottle.request'
+        assert dd_span.service == 'bottle-app'
+        assert dd_span.resource == 'GET /hi/<name>'
+        assert dd_span.get_tag('http.status_code') == '200'
+        assert dd_span.get_tag('http.method') == 'GET'
 
         services = self.tracer.writer.pop_services()
-        eq_(services, {})
+        assert services == {}

--- a/tests/contrib/bottle/test_autopatch.py
+++ b/tests/contrib/bottle/test_autopatch.py
@@ -3,7 +3,6 @@ import ddtrace
 import webtest
 
 from unittest import TestCase
-from nose.tools import eq_
 from tests.test_tracer import get_dummy_tracer
 
 from ddtrace import compat
@@ -40,20 +39,20 @@ class TraceBottleTest(TestCase):
 
         # make a request
         resp = self.app.get('/hi/dougie')
-        eq_(resp.status_int, 200)
-        eq_(compat.to_unicode(resp.body), u'hi dougie')
+        assert resp.status_int == 200
+        assert compat.to_unicode(resp.body) == u'hi dougie'
         # validate it's traced
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.name, 'bottle.request')
-        eq_(s.service, 'bottle-app')
-        eq_(s.resource, 'GET /hi/<name>')
-        eq_(s.get_tag('http.status_code'), '200')
-        eq_(s.get_tag('http.method'), 'GET')
+        assert s.name == 'bottle.request'
+        assert s.service == 'bottle-app'
+        assert s.resource == 'GET /hi/<name>'
+        assert s.get_tag('http.status_code') == '200'
+        assert s.get_tag('http.method') == 'GET'
 
         services = self.tracer.writer.pop_services()
-        eq_(services, {})
+        assert services == {}
 
     def test_500(self):
         @self.app.route('/hi')
@@ -64,18 +63,18 @@ class TraceBottleTest(TestCase):
         # make a request
         try:
             resp = self.app.get('/hi')
-            eq_(resp.status_int, 500)
+            assert resp.status_int == 500
         except Exception:
             pass
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.name, 'bottle.request')
-        eq_(s.service, 'bottle-app')
-        eq_(s.resource, 'GET /hi')
-        eq_(s.get_tag('http.status_code'), '500')
-        eq_(s.get_tag('http.method'), 'GET')
+        assert s.name == 'bottle.request'
+        assert s.service == 'bottle-app'
+        assert s.resource == 'GET /hi'
+        assert s.get_tag('http.status_code') == '500'
+        assert s.get_tag('http.method') == 'GET'
 
     def test_bottle_global_tracer(self):
         # without providing a Tracer instance, it should work
@@ -86,13 +85,13 @@ class TraceBottleTest(TestCase):
 
         # make a request
         resp = self.app.get('/home/')
-        eq_(resp.status_int, 200)
+        assert resp.status_int == 200
         # validate it's traced
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.name, 'bottle.request')
-        eq_(s.service, 'bottle-app')
-        eq_(s.resource, 'GET /home/')
-        eq_(s.get_tag('http.status_code'), '200')
-        eq_(s.get_tag('http.method'), 'GET')
+        assert s.name == 'bottle.request'
+        assert s.service == 'bottle-app'
+        assert s.resource == 'GET /home/'
+        assert s.get_tag('http.status_code') == '200'
+        assert s.get_tag('http.method') == 'GET'

--- a/tests/contrib/bottle/test_distributed.py
+++ b/tests/contrib/bottle/test_distributed.py
@@ -1,8 +1,6 @@
 import bottle
 import webtest
 
-from nose.tools import eq_, assert_not_equal
-
 import ddtrace
 from ddtrace import compat
 from ddtrace.contrib.bottle import TracePlugin
@@ -48,21 +46,21 @@ class TraceBottleDistributedTest(BaseTracerTestCase):
         headers = {'x-datadog-trace-id': '123',
                    'x-datadog-parent-id': '456'}
         resp = self.app.get('/hi/dougie', headers=headers)
-        eq_(resp.status_int, 200)
-        eq_(compat.to_unicode(resp.body), u'hi dougie')
+        assert resp.status_int == 200
+        assert compat.to_unicode(resp.body) == u'hi dougie'
 
         # validate it's traced
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.name, 'bottle.request')
-        eq_(s.service, 'bottle-app')
-        eq_(s.resource, 'GET /hi/<name>')
-        eq_(s.get_tag('http.status_code'), '200')
-        eq_(s.get_tag('http.method'), 'GET')
+        assert s.name == 'bottle.request'
+        assert s.service == 'bottle-app'
+        assert s.resource == 'GET /hi/<name>'
+        assert s.get_tag('http.status_code') == '200'
+        assert s.get_tag('http.method') == 'GET'
         # check distributed headers
-        eq_(123, s.trace_id)
-        eq_(456, s.parent_id)
+        assert 123 == s.trace_id
+        assert 456 == s.parent_id
 
     def test_not_distributed(self):
         # setup our test app
@@ -75,18 +73,18 @@ class TraceBottleDistributedTest(BaseTracerTestCase):
         headers = {'x-datadog-trace-id': '123',
                    'x-datadog-parent-id': '456'}
         resp = self.app.get('/hi/dougie', headers=headers)
-        eq_(resp.status_int, 200)
-        eq_(compat.to_unicode(resp.body), u'hi dougie')
+        assert resp.status_int == 200
+        assert compat.to_unicode(resp.body) == u'hi dougie'
 
         # validate it's traced
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.name, 'bottle.request')
-        eq_(s.service, 'bottle-app')
-        eq_(s.resource, 'GET /hi/<name>')
-        eq_(s.get_tag('http.status_code'), '200')
-        eq_(s.get_tag('http.method'), 'GET')
+        assert s.name == 'bottle.request'
+        assert s.service == 'bottle-app'
+        assert s.resource == 'GET /hi/<name>'
+        assert s.get_tag('http.status_code') == '200'
+        assert s.get_tag('http.method') == 'GET'
         # check distributed headers
-        assert_not_equal(123, s.trace_id)
-        assert_not_equal(456, s.parent_id)
+        assert 123 != s.trace_id
+        assert 456 != s.parent_id

--- a/tests/contrib/celery/autopatch.py
+++ b/tests/contrib/celery/autopatch.py
@@ -1,5 +1,3 @@
-from nose.tools import ok_
-
 from ddtrace import Pin
 
 if __name__ == '__main__':
@@ -7,5 +5,5 @@ if __name__ == '__main__':
     import celery
 
     # now celery.Celery should be patched and should have a pin
-    ok_(Pin.get_from(celery.Celery))
+    assert Pin.get_from(celery.Celery)
     print("Test success")

--- a/tests/contrib/celery/test_app.py
+++ b/tests/contrib/celery/test_app.py
@@ -1,7 +1,5 @@
 import celery
 
-from nose.tools import ok_
-
 from ddtrace import Pin
 from ddtrace.contrib.celery import unpatch_app
 
@@ -14,10 +12,10 @@ class CeleryAppTest(CeleryBaseTestCase):
     def test_patch_app(self):
         # When celery.App is patched it must include a `Pin` instance
         app = celery.Celery()
-        ok_(Pin.get_from(app) is not None)
+        assert Pin.get_from(app) is not None
 
     def test_unpatch_app(self):
         # When celery.App is unpatched it must not include a `Pin` instance
         unpatch_app(celery.Celery)
         app = celery.Celery()
-        ok_(Pin.get_from(app) is None)
+        assert Pin.get_from(app) is None

--- a/tests/contrib/celery/test_old_style_task.py
+++ b/tests/contrib/celery/test_old_style_task.py
@@ -1,7 +1,5 @@
 import celery
 
-from nose.tools import eq_
-
 from .base import CeleryBaseTestCase
 
 
@@ -33,20 +31,20 @@ class CeleryOldStyleTaskTest(CeleryBaseTestCase):
         res = t.apply()
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
         run_span = traces[0][0]
-        eq_(run_span.error, 0)
-        eq_(run_span.name, 'celery.run')
-        eq_(run_span.resource, 'tests.contrib.celery.test_old_style_task.CelerySubClass')
-        eq_(run_span.service, 'celery-worker')
-        eq_(run_span.get_tag('celery.id'), res.task_id)
-        eq_(run_span.get_tag('celery.action'), 'run')
-        eq_(run_span.get_tag('celery.state'), 'SUCCESS')
+        assert run_span.error == 0
+        assert run_span.name == 'celery.run'
+        assert run_span.resource == 'tests.contrib.celery.test_old_style_task.CelerySubClass'
+        assert run_span.service == 'celery-worker'
+        assert run_span.get_tag('celery.id') == res.task_id
+        assert run_span.get_tag('celery.action') == 'run'
+        assert run_span.get_tag('celery.state') == 'SUCCESS'
         apply_span = traces[0][1]
-        eq_(apply_span.error, 0)
-        eq_(apply_span.name, 'celery.apply')
-        eq_(apply_span.resource, 'tests.contrib.celery.test_old_style_task.CelerySubClass')
-        eq_(apply_span.service, 'celery-producer')
-        eq_(apply_span.get_tag('celery.action'), 'apply_async')
-        eq_(apply_span.get_tag('celery.routing_key'), 'celery')
+        assert apply_span.error == 0
+        assert apply_span.name == 'celery.apply'
+        assert apply_span.resource == 'tests.contrib.celery.test_old_style_task.CelerySubClass'
+        assert apply_span.service == 'celery-producer'
+        assert apply_span.get_tag('celery.action') == 'apply_async'
+        assert apply_span.get_tag('celery.routing_key') == 'celery'

--- a/tests/contrib/celery/test_patch.py
+++ b/tests/contrib/celery/test_patch.py
@@ -1,5 +1,4 @@
 import unittest
-from nose.tools import ok_
 from ddtrace import Pin
 
 
@@ -10,7 +9,7 @@ class CeleryPatchTest(unittest.TestCase):
         patch(celery=True)
 
         app = celery.Celery()
-        ok_(Pin.get_from(app) is not None)
+        assert Pin.get_from(app) is not None
 
     def test_patch_before_import(self):
         from ddtrace import patch
@@ -18,4 +17,4 @@ class CeleryPatchTest(unittest.TestCase):
         import celery
 
         app = celery.Celery()
-        ok_(Pin.get_from(app) is not None)
+        assert Pin.get_from(app) is not None

--- a/tests/contrib/celery/test_task_deprecation.py
+++ b/tests/contrib/celery/test_task_deprecation.py
@@ -3,8 +3,6 @@ import unittest
 
 from celery import Celery
 
-from nose.tools import ok_
-
 from ddtrace.contrib.celery import patch_task, unpatch_task, unpatch
 
 
@@ -32,9 +30,9 @@ class CeleryDeprecatedTaskPatch(unittest.TestCase):
             def fn_task():
                 return 42
 
-            ok_(len(w) == 1)
-            ok_(issubclass(w[-1].category, DeprecationWarning))
-            ok_('patch(celery=True)' in str(w[-1].message))
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
+            assert 'patch(celery=True)' in str(w[-1].message)
 
     def test_unpatch_signals_diconnect(self):
         # calling `unpatch_task` is a no-op that raises a Deprecation
@@ -47,6 +45,6 @@ class CeleryDeprecatedTaskPatch(unittest.TestCase):
             def fn_task():
                 return 42
 
-            ok_(len(w) == 1)
-            ok_(issubclass(w[-1].category, DeprecationWarning))
-            ok_('unpatch()' in str(w[-1].message))
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
+            assert 'unpatch()' in str(w[-1].message)

--- a/tests/contrib/django/test_autopatching.py
+++ b/tests/contrib/django/test_autopatching.py
@@ -2,7 +2,6 @@ import django
 
 from ddtrace.monkey import patch
 from .utils import DjangoTraceTestCase
-from nose.tools import eq_, ok_
 from django.conf import settings
 from unittest import skipIf
 
@@ -15,61 +14,65 @@ class DjangoAutopatchTest(DjangoTraceTestCase):
 
     @skipIf(django.VERSION >= (1, 10), 'skip if version above 1.10')
     def test_autopatching_middleware_classes(self):
-        ok_(django._datadog_patch)
-        ok_('ddtrace.contrib.django' in settings.INSTALLED_APPS)
-        eq_(settings.MIDDLEWARE_CLASSES[0], 'ddtrace.contrib.django.TraceMiddleware')
-        eq_(settings.MIDDLEWARE_CLASSES[-1], 'ddtrace.contrib.django.TraceExceptionMiddleware')
+        assert django._datadog_patch
+        assert 'ddtrace.contrib.django' in settings.INSTALLED_APPS
+        assert settings.MIDDLEWARE_CLASSES[0] == 'ddtrace.contrib.django.TraceMiddleware'
+        assert settings.MIDDLEWARE_CLASSES[-1] == 'ddtrace.contrib.django.TraceExceptionMiddleware'
 
     @skipIf(django.VERSION >= (1, 10), 'skip if version above 1.10')
     def test_autopatching_twice_middleware_classes(self):
-        ok_(django._datadog_patch)
+        assert django._datadog_patch
         # Call django.setup() twice and ensure we don't add a duplicate tracer
         django.setup()
 
         found_app = settings.INSTALLED_APPS.count('ddtrace.contrib.django')
-        eq_(found_app, 1)
+        assert found_app == 1
 
-        eq_(settings.MIDDLEWARE_CLASSES[0], 'ddtrace.contrib.django.TraceMiddleware')
-        eq_(settings.MIDDLEWARE_CLASSES[-1], 'ddtrace.contrib.django.TraceExceptionMiddleware')
+        assert settings.MIDDLEWARE_CLASSES[0] == 'ddtrace.contrib.django.TraceMiddleware'
+        assert settings.MIDDLEWARE_CLASSES[-1] == 'ddtrace.contrib.django.TraceExceptionMiddleware'
 
         found_mw = settings.MIDDLEWARE_CLASSES.count('ddtrace.contrib.django.TraceMiddleware')
-        eq_(found_mw, 1)
+        assert found_mw == 1
         found_mw = settings.MIDDLEWARE_CLASSES.count('ddtrace.contrib.django.TraceExceptionMiddleware')
-        eq_(found_mw, 1)
+        assert found_mw == 1
 
     @skipIf(django.VERSION < (1, 10), 'skip if version is below 1.10')
     def test_autopatching_middleware(self):
-        ok_(django._datadog_patch)
-        ok_('ddtrace.contrib.django' in settings.INSTALLED_APPS)
-        eq_(settings.MIDDLEWARE[0], 'ddtrace.contrib.django.TraceMiddleware')
+        assert django._datadog_patch
+        assert 'ddtrace.contrib.django' in settings.INSTALLED_APPS
+        assert settings.MIDDLEWARE[0] == 'ddtrace.contrib.django.TraceMiddleware'
         # MIDDLEWARE_CLASSES gets created internally in django 1.10 & 1.11 but doesn't
         # exist at all in 2.0.
-        ok_(not getattr(settings, 'MIDDLEWARE_CLASSES', None) or
-            'ddtrace.contrib.django.TraceMiddleware' not in settings.MIDDLEWARE_CLASSES)
-        eq_(settings.MIDDLEWARE[-1], 'ddtrace.contrib.django.TraceExceptionMiddleware')
-        ok_(not getattr(settings, 'MIDDLEWARE_CLASSES', None) or
-            'ddtrace.contrib.django.TraceExceptionMiddleware' not in settings.MIDDLEWARE_CLASSES)
+        assert not getattr(settings, 'MIDDLEWARE_CLASSES', None) or \
+            'ddtrace.contrib.django.TraceMiddleware' \
+            not in settings.MIDDLEWARE_CLASSES
+        assert settings.MIDDLEWARE[-1] == 'ddtrace.contrib.django.TraceExceptionMiddleware'
+        assert not getattr(settings, 'MIDDLEWARE_CLASSES', None) or \
+            'ddtrace.contrib.django.TraceExceptionMiddleware' \
+            not in settings.MIDDLEWARE_CLASSES
 
     @skipIf(django.VERSION < (1, 10), 'skip if version is below 1.10')
     def test_autopatching_twice_middleware(self):
-        ok_(django._datadog_patch)
+        assert django._datadog_patch
         # Call django.setup() twice and ensure we don't add a duplicate tracer
         django.setup()
 
         found_app = settings.INSTALLED_APPS.count('ddtrace.contrib.django')
-        eq_(found_app, 1)
+        assert found_app == 1
 
-        eq_(settings.MIDDLEWARE[0], 'ddtrace.contrib.django.TraceMiddleware')
+        assert settings.MIDDLEWARE[0] == 'ddtrace.contrib.django.TraceMiddleware'
         # MIDDLEWARE_CLASSES gets created internally in django 1.10 & 1.11 but doesn't
         # exist at all in 2.0.
-        ok_(not getattr(settings, 'MIDDLEWARE_CLASSES', None) or
-            'ddtrace.contrib.django.TraceMiddleware' not in settings.MIDDLEWARE_CLASSES)
-        eq_(settings.MIDDLEWARE[-1], 'ddtrace.contrib.django.TraceExceptionMiddleware')
-        ok_(not getattr(settings, 'MIDDLEWARE_CLASSES', None) or
-            'ddtrace.contrib.django.TraceExceptionMiddleware' not in settings.MIDDLEWARE_CLASSES)
+        assert not getattr(settings, 'MIDDLEWARE_CLASSES', None) or \
+            'ddtrace.contrib.django.TraceMiddleware' \
+            not in settings.MIDDLEWARE_CLASSES
+        assert settings.MIDDLEWARE[-1] == 'ddtrace.contrib.django.TraceExceptionMiddleware'
+        assert not getattr(settings, 'MIDDLEWARE_CLASSES', None) or \
+            'ddtrace.contrib.django.TraceExceptionMiddleware' \
+            not in settings.MIDDLEWARE_CLASSES
 
         found_mw = settings.MIDDLEWARE.count('ddtrace.contrib.django.TraceMiddleware')
-        eq_(found_mw, 1)
+        assert found_mw == 1
 
         found_mw = settings.MIDDLEWARE.count('ddtrace.contrib.django.TraceExceptionMiddleware')
-        eq_(found_mw, 1)
+        assert found_mw == 1

--- a/tests/contrib/django/test_cache_backends.py
+++ b/tests/contrib/django/test_cache_backends.py
@@ -1,7 +1,6 @@
 import time
 
 # 3rd party
-from nose.tools import eq_
 from django.core.cache import caches
 
 # testing
@@ -25,14 +24,14 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, 'django')
-        eq_(span.resource, 'get')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 0)
+        assert span.service == 'django'
+        assert span.resource == 'get'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django_redis.cache.RedisCache',
@@ -54,14 +53,14 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, 'django')
-        eq_(span.resource, 'get_many')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 0)
+        assert span.service == 'django'
+        assert span.resource == 'get_many'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django_redis.cache.RedisCache',
@@ -83,14 +82,14 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, 'django')
-        eq_(span.resource, 'get')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 0)
+        assert span.service == 'django'
+        assert span.resource == 'get'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.memcached.PyLibMCCache',
@@ -112,14 +111,14 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, 'django')
-        eq_(span.resource, 'get_many')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 0)
+        assert span.service == 'django'
+        assert span.resource == 'get_many'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.memcached.PyLibMCCache',
@@ -141,14 +140,14 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, 'django')
-        eq_(span.resource, 'get')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 0)
+        assert span.service == 'django'
+        assert span.resource == 'get'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.memcached.MemcachedCache',
@@ -170,14 +169,14 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, 'django')
-        eq_(span.resource, 'get_many')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 0)
+        assert span.service == 'django'
+        assert span.resource == 'get_many'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.memcached.MemcachedCache',
@@ -199,14 +198,14 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, 'django')
-        eq_(span.resource, 'get')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 0)
+        assert span.service == 'django'
+        assert span.resource == 'get'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django_pylibmc.memcached.PyLibMCCache',
@@ -228,14 +227,14 @@ class DjangoCacheRedisTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, 'django')
-        eq_(span.resource, 'get_many')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 0)
+        assert span.service == 'django'
+        assert span.resource == 'get_many'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django_pylibmc.memcached.PyLibMCCache',

--- a/tests/contrib/django/test_cache_client.py
+++ b/tests/contrib/django/test_cache_client.py
@@ -1,7 +1,6 @@
 import time
 
 # 3rd party
-from nose.tools import eq_, ok_
 from django.core.cache import caches
 
 # testing
@@ -24,14 +23,14 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, 'django')
-        eq_(span.resource, 'get')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 0)
+        assert span.service == 'django'
+        assert span.resource == 'get'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
@@ -52,10 +51,10 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, 'foo')
+        assert span.service == 'foo'
 
     @override_ddtrace_settings(INSTRUMENT_CACHE=False)
     def test_cache_disabled(self):
@@ -67,7 +66,7 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 0)
+        assert len(spans) == 0
 
     def test_cache_set(self):
         # get the default cache
@@ -80,14 +79,14 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, 'django')
-        eq_(span.resource, 'set')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 0)
+        assert span.service == 'django'
+        assert span.resource == 'set'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
@@ -109,14 +108,14 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, 'django')
-        eq_(span.resource, 'add')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 0)
+        assert span.service == 'django'
+        assert span.resource == 'add'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
@@ -138,14 +137,14 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, 'django')
-        eq_(span.resource, 'delete')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 0)
+        assert span.service == 'django'
+        assert span.resource == 'delete'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
@@ -169,22 +168,22 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
 
         span_incr = spans[0]
         span_get = spans[1]
 
         # LocMemCache doesn't provide an atomic operation
-        eq_(span_get.service, 'django')
-        eq_(span_get.resource, 'get')
-        eq_(span_get.name, 'django.cache')
-        eq_(span_get.span_type, 'cache')
-        eq_(span_get.error, 0)
-        eq_(span_incr.service, 'django')
-        eq_(span_incr.resource, 'incr')
-        eq_(span_incr.name, 'django.cache')
-        eq_(span_incr.span_type, 'cache')
-        eq_(span_incr.error, 0)
+        assert span_get.service == 'django'
+        assert span_get.resource == 'get'
+        assert span_get.name == 'django.cache'
+        assert span_get.span_type == 'cache'
+        assert span_get.error == 0
+        assert span_incr.service == 'django'
+        assert span_incr.resource == 'incr'
+        assert span_incr.name == 'django.cache'
+        assert span_incr.span_type == 'cache'
+        assert span_incr.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
@@ -209,28 +208,28 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
 
         span_decr = spans[0]
         span_incr = spans[1]
         span_get = spans[2]
 
         # LocMemCache doesn't provide an atomic operation
-        eq_(span_get.service, 'django')
-        eq_(span_get.resource, 'get')
-        eq_(span_get.name, 'django.cache')
-        eq_(span_get.span_type, 'cache')
-        eq_(span_get.error, 0)
-        eq_(span_incr.service, 'django')
-        eq_(span_incr.resource, 'incr')
-        eq_(span_incr.name, 'django.cache')
-        eq_(span_incr.span_type, 'cache')
-        eq_(span_incr.error, 0)
-        eq_(span_decr.service, 'django')
-        eq_(span_decr.resource, 'decr')
-        eq_(span_decr.name, 'django.cache')
-        eq_(span_decr.span_type, 'cache')
-        eq_(span_decr.error, 0)
+        assert span_get.service == 'django'
+        assert span_get.resource == 'get'
+        assert span_get.name == 'django.cache'
+        assert span_get.span_type == 'cache'
+        assert span_get.error == 0
+        assert span_incr.service == 'django'
+        assert span_incr.resource == 'incr'
+        assert span_incr.name == 'django.cache'
+        assert span_incr.span_type == 'cache'
+        assert span_incr.error == 0
+        assert span_decr.service == 'django'
+        assert span_decr.resource == 'decr'
+        assert span_decr.name == 'django.cache'
+        assert span_decr.span_type == 'cache'
+        assert span_decr.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
@@ -254,28 +253,28 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
 
         span_get_many = spans[0]
         span_get_first = spans[1]
         span_get_second = spans[2]
 
         # LocMemCache doesn't provide an atomic operation
-        eq_(span_get_first.service, 'django')
-        eq_(span_get_first.resource, 'get')
-        eq_(span_get_first.name, 'django.cache')
-        eq_(span_get_first.span_type, 'cache')
-        eq_(span_get_first.error, 0)
-        eq_(span_get_second.service, 'django')
-        eq_(span_get_second.resource, 'get')
-        eq_(span_get_second.name, 'django.cache')
-        eq_(span_get_second.span_type, 'cache')
-        eq_(span_get_second.error, 0)
-        eq_(span_get_many.service, 'django')
-        eq_(span_get_many.resource, 'get_many')
-        eq_(span_get_many.name, 'django.cache')
-        eq_(span_get_many.span_type, 'cache')
-        eq_(span_get_many.error, 0)
+        assert span_get_first.service == 'django'
+        assert span_get_first.resource == 'get'
+        assert span_get_first.name == 'django.cache'
+        assert span_get_first.span_type == 'cache'
+        assert span_get_first.error == 0
+        assert span_get_second.service == 'django'
+        assert span_get_second.resource == 'get'
+        assert span_get_second.name == 'django.cache'
+        assert span_get_second.span_type == 'cache'
+        assert span_get_second.error == 0
+        assert span_get_many.service == 'django'
+        assert span_get_many.resource == 'get_many'
+        assert span_get_many.name == 'django.cache'
+        assert span_get_many.span_type == 'cache'
+        assert span_get_many.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
@@ -297,32 +296,32 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
 
         span_set_many = spans[0]
         span_set_first = spans[1]
         span_set_second = spans[2]
 
         # LocMemCache doesn't provide an atomic operation
-        eq_(span_set_first.service, 'django')
-        eq_(span_set_first.resource, 'set')
-        eq_(span_set_first.name, 'django.cache')
-        eq_(span_set_first.span_type, 'cache')
-        eq_(span_set_first.error, 0)
-        eq_(span_set_second.service, 'django')
-        eq_(span_set_second.resource, 'set')
-        eq_(span_set_second.name, 'django.cache')
-        eq_(span_set_second.span_type, 'cache')
-        eq_(span_set_second.error, 0)
-        eq_(span_set_many.service, 'django')
-        eq_(span_set_many.resource, 'set_many')
-        eq_(span_set_many.name, 'django.cache')
-        eq_(span_set_many.span_type, 'cache')
-        eq_(span_set_many.error, 0)
+        assert span_set_first.service == 'django'
+        assert span_set_first.resource == 'set'
+        assert span_set_first.name == 'django.cache'
+        assert span_set_first.span_type == 'cache'
+        assert span_set_first.error == 0
+        assert span_set_second.service == 'django'
+        assert span_set_second.resource == 'set'
+        assert span_set_second.name == 'django.cache'
+        assert span_set_second.span_type == 'cache'
+        assert span_set_second.error == 0
+        assert span_set_many.service == 'django'
+        assert span_set_many.resource == 'set_many'
+        assert span_set_many.name == 'django.cache'
+        assert span_set_many.span_type == 'cache'
+        assert span_set_many.error == 0
 
-        eq_(span_set_many.meta['django.cache.backend'], 'django.core.cache.backends.locmem.LocMemCache')
-        ok_('first_key' in span_set_many.meta['django.cache.key'])
-        ok_('second_key' in span_set_many.meta['django.cache.key'])
+        assert span_set_many.meta['django.cache.backend'] == 'django.core.cache.backends.locmem.LocMemCache'
+        assert 'first_key' in span_set_many.meta['django.cache.key']
+        assert 'second_key' in span_set_many.meta['django.cache.key']
         assert start < span_set_many.start < span_set_many.start + span_set_many.duration < end
 
     def test_cache_delete_many(self):
@@ -336,30 +335,30 @@ class DjangoCacheWrapperTest(DjangoTraceTestCase):
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
 
         span_delete_many = spans[0]
         span_delete_first = spans[1]
         span_delete_second = spans[2]
 
         # LocMemCache doesn't provide an atomic operation
-        eq_(span_delete_first.service, 'django')
-        eq_(span_delete_first.resource, 'delete')
-        eq_(span_delete_first.name, 'django.cache')
-        eq_(span_delete_first.span_type, 'cache')
-        eq_(span_delete_first.error, 0)
-        eq_(span_delete_second.service, 'django')
-        eq_(span_delete_second.resource, 'delete')
-        eq_(span_delete_second.name, 'django.cache')
-        eq_(span_delete_second.span_type, 'cache')
-        eq_(span_delete_second.error, 0)
-        eq_(span_delete_many.service, 'django')
-        eq_(span_delete_many.resource, 'delete_many')
-        eq_(span_delete_many.name, 'django.cache')
-        eq_(span_delete_many.span_type, 'cache')
-        eq_(span_delete_many.error, 0)
+        assert span_delete_first.service == 'django'
+        assert span_delete_first.resource == 'delete'
+        assert span_delete_first.name == 'django.cache'
+        assert span_delete_first.span_type == 'cache'
+        assert span_delete_first.error == 0
+        assert span_delete_second.service == 'django'
+        assert span_delete_second.resource == 'delete'
+        assert span_delete_second.name == 'django.cache'
+        assert span_delete_second.span_type == 'cache'
+        assert span_delete_second.error == 0
+        assert span_delete_many.service == 'django'
+        assert span_delete_many.resource == 'delete_many'
+        assert span_delete_many.name == 'django.cache'
+        assert span_delete_many.span_type == 'cache'
+        assert span_delete_many.error == 0
 
-        eq_(span_delete_many.meta['django.cache.backend'], 'django.core.cache.backends.locmem.LocMemCache')
-        ok_('missing_key' in span_delete_many.meta['django.cache.key'])
-        ok_('another_key' in span_delete_many.meta['django.cache.key'])
+        assert span_delete_many.meta['django.cache.backend'] == 'django.core.cache.backends.locmem.LocMemCache'
+        assert 'missing_key' in span_delete_many.meta['django.cache.key']
+        assert 'another_key' in span_delete_many.meta['django.cache.key']
         assert start < span_delete_many.start < span_delete_many.start + span_delete_many.duration < end

--- a/tests/contrib/django/test_cache_views.py
+++ b/tests/contrib/django/test_cache_views.py
@@ -1,6 +1,3 @@
-# 3rd party
-from nose.tools import eq_
-
 # testing
 from .compat import reverse
 from .utils import DjangoTraceTestCase
@@ -14,34 +11,34 @@ class DjangoCacheViewTest(DjangoTraceTestCase):
         # make the first request so that the view is cached
         url = reverse('cached-users-list')
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
         # check the first call for a non-cached view
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 6)
+        assert len(spans) == 6
         # the cache miss
-        eq_(spans[1].resource, 'get')
+        assert spans[1].resource == 'get'
         # store the result in the cache
-        eq_(spans[4].resource, 'set')
-        eq_(spans[5].resource, 'set')
+        assert spans[4].resource == 'set'
+        assert spans[5].resource == 'set'
 
         # check if the cache hit is traced
         response = self.client.get(url)
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
 
         span_header = spans[1]
         span_view = spans[2]
-        eq_(span_view.service, 'django')
-        eq_(span_view.resource, 'get')
-        eq_(span_view.name, 'django.cache')
-        eq_(span_view.span_type, 'cache')
-        eq_(span_view.error, 0)
-        eq_(span_header.service, 'django')
-        eq_(span_header.resource, 'get')
-        eq_(span_header.name, 'django.cache')
-        eq_(span_header.span_type, 'cache')
-        eq_(span_header.error, 0)
+        assert span_view.service == 'django'
+        assert span_view.resource == 'get'
+        assert span_view.name == 'django.cache'
+        assert span_view.span_type == 'cache'
+        assert span_view.error == 0
+        assert span_header.service == 'django'
+        assert span_header.resource == 'get'
+        assert span_header.name == 'django.cache'
+        assert span_header.span_type == 'cache'
+        assert span_header.error == 0
 
         expected_meta_view = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
@@ -58,34 +55,34 @@ class DjangoCacheViewTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span_view.meta, expected_meta_view)
-        eq_(span_header.meta, expected_meta_header)
+        assert span_view.meta == expected_meta_view
+        assert span_header.meta == expected_meta_header
 
     def test_cached_template(self):
         # make the first request so that the view is cached
         url = reverse('cached-template-list')
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
         # check the first call for a non-cached view
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 5)
+        assert len(spans) == 5
         # the cache miss
-        eq_(spans[2].resource, 'get')
+        assert spans[2].resource == 'get'
         # store the result in the cache
-        eq_(spans[4].resource, 'set')
+        assert spans[4].resource == 'set'
 
         # check if the cache hit is traced
         response = self.client.get(url)
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
 
         span_template_cache = spans[2]
-        eq_(span_template_cache.service, 'django')
-        eq_(span_template_cache.resource, 'get')
-        eq_(span_template_cache.name, 'django.cache')
-        eq_(span_template_cache.span_type, 'cache')
-        eq_(span_template_cache.error, 0)
+        assert span_template_cache.service == 'django'
+        assert span_template_cache.resource == 'get'
+        assert span_template_cache.name == 'django.cache'
+        assert span_template_cache.span_type == 'cache'
+        assert span_template_cache.error == 0
 
         expected_meta = {
             'django.cache.backend': 'django.core.cache.backends.locmem.LocMemCache',
@@ -93,4 +90,4 @@ class DjangoCacheViewTest(DjangoTraceTestCase):
             'env': 'test',
         }
 
-        eq_(span_template_cache.meta, expected_meta)
+        assert span_template_cache.meta == expected_meta

--- a/tests/contrib/django/test_cache_wrapper.py
+++ b/tests/contrib/django/test_cache_wrapper.py
@@ -1,6 +1,6 @@
 # 3rd party
-from nose.tools import eq_, ok_, assert_raises
 from django.core.cache import caches
+import pytest
 
 # testing
 from .utils import DjangoTraceTestCase
@@ -16,11 +16,11 @@ class DjangoCacheTest(DjangoTraceTestCase):
         cache = caches['default']
 
         value = cache.get('missing_key')
-        eq_(value, None)
+        assert value is None
 
         cache.set('a_key', 50)
         value = cache.get('a_key')
-        eq_(value, 50)
+        assert value == 50
 
     def test_wrapper_add(self):
         # get the default cache
@@ -28,12 +28,12 @@ class DjangoCacheTest(DjangoTraceTestCase):
 
         cache.add('a_key', 50)
         value = cache.get('a_key')
-        eq_(value, 50)
+        assert value == 50
 
         # add should not update a key if it's present
         cache.add('a_key', 40)
         value = cache.get('a_key')
-        eq_(value, 50)
+        assert value == 50
 
     def test_wrapper_delete(self):
         # get the default cache
@@ -42,26 +42,26 @@ class DjangoCacheTest(DjangoTraceTestCase):
         cache.set('a_key', 50)
         cache.delete('a_key')
         value = cache.get('a_key')
-        eq_(value, None)
+        assert value is None
 
     def test_wrapper_incr_safety(self):
         # get the default cache
         cache = caches['default']
 
         # it should fail not because of our wrapper
-        with assert_raises(ValueError) as ex:
+        with pytest.raises(ValueError) as ex:
             cache.incr('missing_key')
 
         # the error is not caused by our tracer
-        eq_(ex.exception.args[0], "Key 'missing_key' not found")
+        assert ex.value.args[0] == "Key 'missing_key' not found"
         # an error trace must be sent
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         span = spans[0]
-        eq_(span.resource, 'incr')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 1)
+        assert span.resource == 'incr'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 1
 
     def test_wrapper_incr(self):
         # get the default cache
@@ -69,28 +69,28 @@ class DjangoCacheTest(DjangoTraceTestCase):
 
         cache.set('value', 0)
         value = cache.incr('value')
-        eq_(value, 1)
+        assert value == 1
         value = cache.get('value')
-        eq_(value, 1)
+        assert value == 1
 
     def test_wrapper_decr_safety(self):
         # get the default cache
         cache = caches['default']
 
         # it should fail not because of our wrapper
-        with assert_raises(ValueError) as ex:
+        with pytest.raises(ValueError) as ex:
             cache.decr('missing_key')
 
         # the error is not caused by our tracer
-        eq_(ex.exception.args[0], "Key 'missing_key' not found")
+        assert ex.value.args[0] == "Key 'missing_key' not found"
         # an error trace must be sent
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
         span = spans[0]
-        eq_(span.resource, 'decr')
-        eq_(span.name, 'django.cache')
-        eq_(span.span_type, 'cache')
-        eq_(span.error, 1)
+        assert span.resource == 'decr'
+        assert span.name == 'django.cache'
+        assert span.span_type == 'cache'
+        assert span.error == 1
 
     def test_wrapper_decr(self):
         # get the default cache
@@ -98,9 +98,9 @@ class DjangoCacheTest(DjangoTraceTestCase):
 
         cache.set('value', 0)
         value = cache.decr('value')
-        eq_(value, -1)
+        assert value == -1
         value = cache.get('value')
-        eq_(value, -1)
+        assert value == -1
 
     def test_wrapper_get_many(self):
         # get the default cache
@@ -110,17 +110,17 @@ class DjangoCacheTest(DjangoTraceTestCase):
         cache.set('another_key', 60)
 
         values = cache.get_many(['a_key', 'another_key'])
-        ok_(isinstance(values, dict))
-        eq_(values['a_key'], 50)
-        eq_(values['another_key'], 60)
+        assert isinstance(values, dict)
+        assert values['a_key'] == 50
+        assert values['another_key'] == 60
 
     def test_wrapper_set_many(self):
         # get the default cache
         cache = caches['default']
 
         cache.set_many({'a_key': 50, 'another_key': 60})
-        eq_(cache.get('a_key'), 50)
-        eq_(cache.get('another_key'), 60)
+        assert cache.get('a_key') == 50
+        assert cache.get('another_key') == 60
 
     def test_wrapper_delete_many(self):
         # get the default cache
@@ -129,5 +129,5 @@ class DjangoCacheTest(DjangoTraceTestCase):
         cache.set('a_key', 50)
         cache.set('another_key', 60)
         cache.delete_many(['a_key', 'another_key'])
-        eq_(cache.get('a_key'), None)
-        eq_(cache.get('another_key'), None)
+        assert cache.get('a_key') is None
+        assert cache.get('another_key') is None

--- a/tests/contrib/django/test_connection.py
+++ b/tests/contrib/django/test_connection.py
@@ -1,7 +1,6 @@
 import time
 
 # 3rd party
-from nose.tools import eq_
 from django.contrib.auth.models import User
 
 from ddtrace.contrib.django.conf import settings
@@ -18,38 +17,38 @@ class DjangoConnectionTest(DjangoTraceTestCase):
         # trace a simple query
         start = time.time()
         users = User.objects.count()
-        eq_(users, 0)
+        assert users == 0
         end = time.time()
 
         # tests
         spans = self.tracer.writer.pop()
         assert spans, spans
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.name, 'sqlite.query')
-        eq_(span.service, 'defaultdb')
-        eq_(span.span_type, 'sql')
-        eq_(span.get_tag('django.db.vendor'), 'sqlite')
-        eq_(span.get_tag('django.db.alias'), 'default')
+        assert span.name == 'sqlite.query'
+        assert span.service == 'defaultdb'
+        assert span.span_type == 'sql'
+        assert span.get_tag('django.db.vendor') == 'sqlite'
+        assert span.get_tag('django.db.alias') == 'default'
         assert start < span.start < span.start + span.duration < end
 
     def test_django_db_query_in_resource_not_in_tags(self):
         User.objects.count()
         spans = self.tracer.writer.pop()
-        eq_(spans[0].name, 'sqlite.query')
-        eq_(spans[0].resource, 'SELECT COUNT(*) AS "__count" FROM "auth_user"')
-        eq_(spans[0].get_tag('sql.query'), None)
+        assert spans[0].name == 'sqlite.query'
+        assert spans[0].resource == 'SELECT COUNT(*) AS "__count" FROM "auth_user"'
+        assert spans[0].get_tag('sql.query') is None
 
     @override_ddtrace_settings(INSTRUMENT_DATABASE=False)
     def test_connection_disabled(self):
         # trace a simple query
         users = User.objects.count()
-        eq_(users, 0)
+        assert users == 0
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 0)
+        assert len(spans) == 0
 
     def test_should_append_database_prefix(self):
         # trace a simple query and check if the prefix is correctly
@@ -58,7 +57,7 @@ class DjangoConnectionTest(DjangoTraceTestCase):
         User.objects.count()
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
-        eq_(span.service, 'my_prefix_db-defaultdb')
+        assert span.service == 'my_prefix_db-defaultdb'

--- a/tests/contrib/django/test_instrumentation.py
+++ b/tests/contrib/django/test_instrumentation.py
@@ -1,6 +1,3 @@
-# 3rd party
-from nose.tools import eq_, ok_
-
 # project
 from ddtrace.contrib.django.conf import DatadogSettings
 
@@ -14,10 +11,10 @@ class DjangoInstrumentationTest(DjangoTraceTestCase):
     users settings
     """
     def test_tracer_flags(self):
-        ok_(self.tracer.enabled)
-        eq_(self.tracer.writer.api.hostname, 'localhost')
-        eq_(self.tracer.writer.api.port, 8126)
-        eq_(self.tracer.tags, {'env': 'test'})
+        assert self.tracer.enabled
+        assert self.tracer.writer.api.hostname == 'localhost'
+        assert self.tracer.writer.api.port == 8126
+        assert self.tracer.tags == {'env': 'test'}
 
     def test_environment_vars(self):
         # Django defaults can be overridden by env vars, ensuring that
@@ -27,12 +24,12 @@ class DjangoInstrumentationTest(DjangoTraceTestCase):
             DATADOG_TRACE_AGENT_PORT='58126'
         )):
             settings = DatadogSettings()
-            eq_(settings.AGENT_HOSTNAME, 'agent.consul.local')
-            eq_(settings.AGENT_PORT, 58126)
+            assert settings.AGENT_HOSTNAME == 'agent.consul.local'
+            assert settings.AGENT_PORT == 58126
 
     def test_environment_var_wrong_port(self):
         # ensures that a wrong Agent Port doesn't crash the system
         # and defaults to 8126
         with self.override_env(dict(DATADOG_TRACE_AGENT_PORT='something')):
             settings = DatadogSettings()
-            eq_(settings.AGENT_PORT, 8126)
+            assert settings.AGENT_PORT == 8126

--- a/tests/contrib/django/test_middleware.py
+++ b/tests/contrib/django/test_middleware.py
@@ -1,6 +1,4 @@
 # 3rd party
-from nose.tools import eq_
-
 from django.test import modify_settings
 from django.db import connections
 
@@ -23,22 +21,22 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         # ensures that the internals are properly traced
         url = reverse('users-list')
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
         sp_request = spans[0]
         sp_template = spans[1]
         sp_database = spans[2]
-        eq_(sp_database.get_tag('django.db.vendor'), 'sqlite')
-        eq_(sp_template.get_tag('django.template_name'), 'users_list.html')
-        eq_(sp_request.get_tag('http.status_code'), '200')
-        eq_(sp_request.get_tag('http.url'), '/users/')
-        eq_(sp_request.get_tag('django.user.is_authenticated'), 'False')
-        eq_(sp_request.get_tag('http.method'), 'GET')
-        eq_(sp_request.span_type, 'http')
-        eq_(sp_request.resource, 'tests.contrib.django.app.views.UserList')
+        assert sp_database.get_tag('django.db.vendor') == 'sqlite'
+        assert sp_template.get_tag('django.template_name') == 'users_list.html'
+        assert sp_request.get_tag('http.status_code') == '200'
+        assert sp_request.get_tag('http.url') == '/users/'
+        assert sp_request.get_tag('django.user.is_authenticated') == 'False'
+        assert sp_request.get_tag('http.method') == 'GET'
+        assert sp_request.span_type == 'http'
+        assert sp_request.resource == 'tests.contrib.django.app.views.UserList'
 
     def test_analytics_global_on_integration_default(self):
         """
@@ -52,7 +50,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
             self.assertEqual(response.status_code, 200)
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
         sp_request = spans[0]
         sp_template = spans[1]
         sp_database = spans[2]
@@ -74,7 +72,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
             self.assertEqual(response.status_code, 200)
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
         sp_request = spans[0]
         sp_template = spans[1]
         sp_database = spans[2]
@@ -95,7 +93,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
             self.assertEqual(response.status_code, 200)
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
         sp_request = spans[0]
         sp_template = spans[1]
         sp_database = spans[2]
@@ -117,7 +115,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
             self.assertEqual(response.status_code, 200)
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
         sp_request = spans[0]
         sp_template = spans[1]
         sp_database = spans[2]
@@ -136,101 +134,101 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         # ensures that the internals are properly traced
         url = reverse('users-list')
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
         # We would be missing span #3, the database span, if the connection
         # wasn't patched.
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
-        eq_(spans[0].name, 'django.request')
-        eq_(spans[1].name, 'django.template')
-        eq_(spans[2].name, 'sqlite.query')
+        assert len(spans) == 3
+        assert spans[0].name == 'django.request'
+        assert spans[1].name == 'django.template'
+        assert spans[2].name == 'sqlite.query'
 
     def test_middleware_trace_errors(self):
         # ensures that the internals are properly traced
         url = reverse('forbidden-view')
         response = self.client.get(url)
-        eq_(response.status_code, 403)
+        assert response.status_code == 403
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.get_tag('http.status_code'), '403')
-        eq_(span.get_tag('http.url'), '/fail-view/')
-        eq_(span.resource, 'tests.contrib.django.app.views.ForbiddenView')
+        assert span.get_tag('http.status_code') == '403'
+        assert span.get_tag('http.url') == '/fail-view/'
+        assert span.resource == 'tests.contrib.django.app.views.ForbiddenView'
 
     def test_middleware_trace_function_based_view(self):
         # ensures that the internals are properly traced when using a function views
         url = reverse('fn-view')
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.get_tag('http.status_code'), '200')
-        eq_(span.get_tag('http.url'), '/fn-view/')
-        eq_(span.resource, 'tests.contrib.django.app.views.function_view')
+        assert span.get_tag('http.status_code') == '200'
+        assert span.get_tag('http.url') == '/fn-view/'
+        assert span.resource == 'tests.contrib.django.app.views.function_view'
 
     def test_middleware_trace_error_500(self):
         # ensures we trace exceptions generated by views
         url = reverse('error-500')
         response = self.client.get(url)
-        eq_(response.status_code, 500)
+        assert response.status_code == 500
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.error, 1)
-        eq_(span.get_tag('http.status_code'), '500')
-        eq_(span.get_tag('http.url'), '/error-500/')
-        eq_(span.resource, 'tests.contrib.django.app.views.error_500')
+        assert span.error == 1
+        assert span.get_tag('http.status_code') == '500'
+        assert span.get_tag('http.url') == '/error-500/'
+        assert span.resource == 'tests.contrib.django.app.views.error_500'
         assert "Error 500" in span.get_tag('error.stack')
 
     def test_middleware_trace_callable_view(self):
         # ensures that the internals are properly traced when using callable views
         url = reverse('feed-view')
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.get_tag('http.status_code'), '200')
-        eq_(span.get_tag('http.url'), '/feed-view/')
-        eq_(span.resource, 'tests.contrib.django.app.views.FeedView')
+        assert span.get_tag('http.status_code') == '200'
+        assert span.get_tag('http.url') == '/feed-view/'
+        assert span.resource == 'tests.contrib.django.app.views.FeedView'
 
     def test_middleware_trace_partial_based_view(self):
         # ensures that the internals are properly traced when using a function views
         url = reverse('partial-view')
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.get_tag('http.status_code'), '200')
-        eq_(span.get_tag('http.url'), '/partial-view/')
-        eq_(span.resource, 'partial')
+        assert span.get_tag('http.status_code') == '200'
+        assert span.get_tag('http.url') == '/partial-view/'
+        assert span.resource == 'partial'
 
     def test_middleware_trace_lambda_based_view(self):
         # ensures that the internals are properly traced when using a function views
         url = reverse('lambda-view')
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.get_tag('http.status_code'), '200')
-        eq_(span.get_tag('http.url'), '/lambda-view/')
-        eq_(span.resource, 'tests.contrib.django.app.views.<lambda>')
+        assert span.get_tag('http.status_code') == '200'
+        assert span.get_tag('http.url') == '/lambda-view/'
+        assert span.resource == 'tests.contrib.django.app.views.<lambda>'
 
     @modify_settings(
         MIDDLEWARE={
@@ -245,14 +243,14 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         # object doesn't have the ``user`` field
         url = reverse('users-list')
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
         sp_request = spans[0]
-        eq_(sp_request.get_tag('http.status_code'), '200')
-        eq_(sp_request.get_tag('django.user.is_authenticated'), None)
+        assert sp_request.get_tag('http.status_code') == '200'
+        assert sp_request.get_tag('django.user.is_authenticated') is None
 
     @override_ddtrace_settings(DISTRIBUTED_TRACING=True)
     def test_middleware_propagation(self):
@@ -264,17 +262,17 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
             'x-datadog-sampling-priority': '2',
         }
         response = self.client.get(url, **headers)
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
         sp_request = spans[0]
 
         # Check for proper propagated attributes
-        eq_(sp_request.trace_id, 100)
-        eq_(sp_request.parent_id, 42)
-        eq_(sp_request.get_metric(SAMPLING_PRIORITY_KEY), 2)
+        assert sp_request.trace_id == 100
+        assert sp_request.parent_id == 42
+        assert sp_request.get_metric(SAMPLING_PRIORITY_KEY) == 2
 
     def test_middleware_no_propagation(self):
         # ensures that we properly propagate http context
@@ -285,11 +283,11 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
             'x-datadog-sampling-priority': '2',
         }
         response = self.client.get(url, **headers)
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 3)
+        assert len(spans) == 3
         sp_request = spans[0]
 
         # Check that propagation didn't happen
@@ -311,14 +309,14 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         """
         url = reverse('error-500')
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         sp_request = spans[0]
 
-        eq_(sp_request.error, 0)
+        assert sp_request.error == 0
         assert sp_request.get_tag(errors.ERROR_STACK) is None
         assert sp_request.get_tag(errors.ERROR_MSG) is None
         assert sp_request.get_tag(errors.ERROR_TYPE) is None
@@ -337,14 +335,14 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         """
         url = reverse('error-500')
         response = self.client.get(url)
-        eq_(response.status_code, 404)
+        assert response.status_code == 404
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         sp_request = spans[0]
 
-        eq_(sp_request.error, 0)
+        assert sp_request.error == 0
         assert sp_request.get_tag(errors.ERROR_STACK) is None
         assert sp_request.get_tag(errors.ERROR_MSG) is None
         assert sp_request.get_tag(errors.ERROR_TYPE) is None
@@ -357,29 +355,29 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         url = reverse('users-list')
         with ot_tracer.start_active_span('ot_span'):
             response = self.client.get(url)
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 4)
+        assert len(spans) == 4
         ot_span = spans[0]
         sp_request = spans[1]
         sp_template = spans[2]
         sp_database = spans[3]
 
         # confirm parenting
-        eq_(ot_span.parent_id, None)
-        eq_(sp_request.parent_id, ot_span.span_id)
+        assert ot_span.parent_id is None
+        assert sp_request.parent_id == ot_span.span_id
 
-        eq_(ot_span.resource, 'ot_span')
-        eq_(ot_span.service, 'my_svc')
+        assert ot_span.resource == 'ot_span'
+        assert ot_span.service == 'my_svc'
 
-        eq_(sp_database.get_tag('django.db.vendor'), 'sqlite')
-        eq_(sp_template.get_tag('django.template_name'), 'users_list.html')
-        eq_(sp_request.get_tag('http.status_code'), '200')
-        eq_(sp_request.get_tag('http.url'), '/users/')
-        eq_(sp_request.get_tag('django.user.is_authenticated'), 'False')
-        eq_(sp_request.get_tag('http.method'), 'GET')
+        assert sp_database.get_tag('django.db.vendor') == 'sqlite'
+        assert sp_template.get_tag('django.template_name') == 'users_list.html'
+        assert sp_request.get_tag('http.status_code') == '200'
+        assert sp_request.get_tag('http.url') == '/users/'
+        assert sp_request.get_tag('django.user.is_authenticated') == 'False'
+        assert sp_request.get_tag('http.method') == 'GET'
 
     def test_middleware_trace_request_404(self):
         """
@@ -388,23 +386,23 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
                 we set a resource name for the default view handler
         """
         response = self.client.get('/unknown-url')
-        eq_(response.status_code, 404)
+        assert response.status_code == 404
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         sp_request = spans[0]
         sp_template = spans[1]
 
         # Template
         # DEV: The template name is `unknown` because unless they define a `404.html`
         #   django generates the template from a string, which will not have a `Template.name` set
-        eq_(sp_template.get_tag('django.template_name'), 'unknown')
+        assert sp_template.get_tag('django.template_name') == 'unknown'
 
         # Request
-        eq_(sp_request.get_tag('http.status_code'), '404')
-        eq_(sp_request.get_tag('http.url'), '/unknown-url')
-        eq_(sp_request.get_tag('django.user.is_authenticated'), 'False')
-        eq_(sp_request.get_tag('http.method'), 'GET')
-        eq_(sp_request.span_type, 'http')
-        eq_(sp_request.resource, 'django.views.defaults.page_not_found')
+        assert sp_request.get_tag('http.status_code') == '404'
+        assert sp_request.get_tag('http.url') == '/unknown-url'
+        assert sp_request.get_tag('django.user.is_authenticated') == 'False'
+        assert sp_request.get_tag('http.method') == 'GET'
+        assert sp_request.span_type == 'http'
+        assert sp_request.resource == 'django.views.defaults.page_not_found'

--- a/tests/contrib/django/test_templates.py
+++ b/tests/contrib/django/test_templates.py
@@ -1,7 +1,6 @@
 import time
 
 # 3rd party
-from nose.tools import eq_
 from django.template import Context, Template
 
 # testing
@@ -19,18 +18,18 @@ class DjangoTemplateTest(DjangoTraceTestCase):
 
         # (trace) the template rendering
         start = time.time()
-        eq_(template.render(ctx), 'Hello Django!')
+        assert template.render(ctx) == 'Hello Django!'
         end = time.time()
 
         # tests
         spans = self.tracer.writer.pop()
         assert spans, spans
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.span_type, 'template')
-        eq_(span.name, 'django.template')
-        eq_(span.get_tag('django.template_name'), 'unknown')
+        assert span.span_type == 'template'
+        assert span.name == 'django.template'
+        assert span.get_tag('django.template_name') == 'unknown'
         assert start < span.start < span.start + span.duration < end
 
     @override_ddtrace_settings(INSTRUMENT_TEMPLATE=False)
@@ -40,8 +39,8 @@ class DjangoTemplateTest(DjangoTraceTestCase):
         ctx = Context({'name': 'Django'})
 
         # (trace) the template rendering
-        eq_(template.render(ctx), 'Hello Django!')
+        assert template.render(ctx) == 'Hello Django!'
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 0)
+        assert len(spans) == 0

--- a/tests/contrib/django/test_utils.py
+++ b/tests/contrib/django/test_utils.py
@@ -1,5 +1,4 @@
 # 3d party
-from nose.tools import eq_, ok_
 from django.test import TestCase
 
 # project
@@ -13,6 +12,6 @@ class DjangoUtilsTest(TestCase):
         """
         key = {'second_key': 2, 'first_key': 1}
         result = quantize_key_values(key)
-        eq_(len(result), 2)
-        ok_('first_key' in result)
-        ok_('second_key' in result)
+        assert len(result) == 2
+        assert 'first_key' in result
+        assert 'second_key' in result

--- a/tests/contrib/djangorestframework/test_djangorestframework.py
+++ b/tests/contrib/djangorestframework/test_djangorestframework.py
@@ -1,6 +1,5 @@
 import django
 from django.apps import apps
-from nose.tools import ok_, eq_
 from unittest import skipIf
 
 from tests.contrib.django.utils import DjangoTraceTestCase
@@ -19,44 +18,44 @@ class RestFrameworkTest(DjangoTraceTestCase):
         self.unpatch_restframework = unpatch_restframework
 
     def test_setup(self):
-        ok_(apps.is_installed('rest_framework'))
-        ok_(hasattr(self.APIView, '_datadog_patch'))
+        assert apps.is_installed('rest_framework')
+        assert hasattr(self.APIView, '_datadog_patch')
 
     def test_unpatch(self):
         self.unpatch_restframework()
-        ok_(not getattr(self.APIView, '_datadog_patch'))
+        assert not getattr(self.APIView, '_datadog_patch')
 
         response = self.client.get('/users/')
 
         # Our custom exception handler is setting the status code to 500
-        eq_(response.status_code, 500)
+        assert response.status_code == 500
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         sp = spans[0]
-        eq_(sp.name, 'django.request')
-        eq_(sp.resource, 'app.views.UserViewSet')
-        eq_(sp.error, 0)
-        eq_(sp.span_type, 'http')
-        eq_(sp.get_tag('http.status_code'), '500')
-        eq_(sp.get_tag('error.msg'), None)
+        assert sp.name == 'django.request'
+        assert sp.resource == 'app.views.UserViewSet'
+        assert sp.error == 0
+        assert sp.span_type == 'http'
+        assert sp.get_tag('http.status_code') == '500'
+        assert sp.get_tag('error.msg') is None
 
     def test_trace_exceptions(self):
         response = self.client.get('/users/')
 
         # Our custom exception handler is setting the status code to 500
-        eq_(response.status_code, 500)
+        assert response.status_code == 500
 
         # check for spans
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         sp = spans[0]
-        eq_(sp.name, 'django.request')
-        eq_(sp.resource, 'app.views.UserViewSet')
-        eq_(sp.error, 1)
-        eq_(sp.span_type, 'http')
-        eq_(sp.get_tag('http.method'), 'GET')
-        eq_(sp.get_tag('http.status_code'), '500')
-        eq_(sp.get_tag('error.msg'), 'Authentication credentials were not provided.')
-        ok_('NotAuthenticated' in sp.get_tag('error.stack'))
+        assert sp.name == 'django.request'
+        assert sp.resource == 'app.views.UserViewSet'
+        assert sp.error == 1
+        assert sp.span_type == 'http'
+        assert sp.get_tag('http.method') == 'GET'
+        assert sp.get_tag('http.status_code') == '500'
+        assert sp.get_tag('error.msg') == 'Authentication credentials were not provided.'
+        assert 'NotAuthenticated' in sp.get_tag('error.stack')

--- a/tests/contrib/falcon/test_distributed_tracing.py
+++ b/tests/contrib/falcon/test_distributed_tracing.py
@@ -1,5 +1,4 @@
 from falcon import testing
-from nose.tools import eq_, ok_
 from tests.test_tracer import get_dummy_tracer
 
 from .app import get_app
@@ -22,16 +21,16 @@ class DistributedTracingTestCase(testing.TestCase):
             'x-datadog-parent-id': '42',
         }
         out = self.simulate_get('/200', headers=headers)
-        eq_(out.status_code, 200)
-        eq_(out.content.decode('utf-8'), 'Success')
+        assert out.status_code == 200
+        assert out.content.decode('utf-8') == 'Success'
 
         traces = self.tracer.writer.pop_traces()
 
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
 
-        eq_(traces[0][0].parent_id, 42)
-        eq_(traces[0][0].trace_id, 100)
+        assert traces[0][0].parent_id == 42
+        assert traces[0][0].trace_id == 100
 
     def test_distributred_tracing_disabled(self):
         self.tracer = get_dummy_tracer()
@@ -41,13 +40,13 @@ class DistributedTracingTestCase(testing.TestCase):
             'x-datadog-parent-id': '42',
         }
         out = self.simulate_get('/200', headers=headers)
-        eq_(out.status_code, 200)
-        eq_(out.content.decode('utf-8'), 'Success')
+        assert out.status_code == 200
+        assert out.content.decode('utf-8') == 'Success'
 
         traces = self.tracer.writer.pop_traces()
 
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
 
-        ok_(traces[0][0].parent_id != 42)
-        ok_(traces[0][0].trace_id != 100)
+        assert traces[0][0].parent_id != 42
+        assert traces[0][0].trace_id != 100

--- a/tests/contrib/falcon/test_suite.py
+++ b/tests/contrib/falcon/test_suite.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_, ok_
-
 from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.ext import errors as errx, http as httpx
@@ -14,18 +12,18 @@ class FalconTestCase(object):
     """
     def test_404(self):
         out = self.simulate_get('/fake_endpoint')
-        eq_(out.status_code, 404)
+        assert out.status_code == 404
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
-        eq_(span.name, 'falcon.request')
-        eq_(span.service, self._service)
-        eq_(span.resource, 'GET 404')
-        eq_(span.get_tag(httpx.STATUS_CODE), '404')
-        eq_(span.get_tag(httpx.URL), 'http://falconframework.org/fake_endpoint')
-        eq_(span.parent_id, None)
+        assert span.name == 'falcon.request'
+        assert span.service == self._service
+        assert span.resource == 'GET 404'
+        assert span.get_tag(httpx.STATUS_CODE) == '404'
+        assert span.get_tag(httpx.URL) == 'http://falconframework.org/fake_endpoint'
+        assert span.parent_id is None
 
     def test_exception(self):
         try:
@@ -36,32 +34,32 @@ class FalconTestCase(object):
             assert 0
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
-        eq_(span.name, 'falcon.request')
-        eq_(span.service, self._service)
-        eq_(span.resource, 'GET tests.contrib.falcon.app.resources.ResourceException')
-        eq_(span.get_tag(httpx.STATUS_CODE), '500')
-        eq_(span.get_tag(httpx.URL), 'http://falconframework.org/exception')
-        eq_(span.parent_id, None)
+        assert span.name == 'falcon.request'
+        assert span.service == self._service
+        assert span.resource == 'GET tests.contrib.falcon.app.resources.ResourceException'
+        assert span.get_tag(httpx.STATUS_CODE) == '500'
+        assert span.get_tag(httpx.URL) == 'http://falconframework.org/exception'
+        assert span.parent_id is None
 
     def test_200(self):
         out = self.simulate_get('/200')
-        eq_(out.status_code, 200)
-        eq_(out.content.decode('utf-8'), 'Success')
+        assert out.status_code == 200
+        assert out.content.decode('utf-8') == 'Success'
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
-        eq_(span.name, 'falcon.request')
-        eq_(span.service, self._service)
-        eq_(span.resource, 'GET tests.contrib.falcon.app.resources.Resource200')
-        eq_(span.get_tag(httpx.STATUS_CODE), '200')
-        eq_(span.get_tag(httpx.URL), 'http://falconframework.org/200')
-        eq_(span.parent_id, None)
-        eq_(span.span_type, 'http')
+        assert span.name == 'falcon.request'
+        assert span.service == self._service
+        assert span.resource == 'GET tests.contrib.falcon.app.resources.Resource200'
+        assert span.get_tag(httpx.STATUS_CODE) == '200'
+        assert span.get_tag(httpx.URL) == 'http://falconframework.org/200'
+        assert span.parent_id is None
+        assert span.span_type == 'http'
 
     def test_analytics_global_on_integration_default(self):
         """
@@ -126,65 +124,65 @@ class FalconTestCase(object):
 
     def test_201(self):
         out = self.simulate_post('/201')
-        eq_(out.status_code, 201)
-        eq_(out.content.decode('utf-8'), 'Success')
+        assert out.status_code == 201
+        assert out.content.decode('utf-8') == 'Success'
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
-        eq_(span.name, 'falcon.request')
-        eq_(span.service, self._service)
-        eq_(span.resource, 'POST tests.contrib.falcon.app.resources.Resource201')
-        eq_(span.get_tag(httpx.STATUS_CODE), '201')
-        eq_(span.get_tag(httpx.URL), 'http://falconframework.org/201')
-        eq_(span.parent_id, None)
+        assert span.name == 'falcon.request'
+        assert span.service == self._service
+        assert span.resource == 'POST tests.contrib.falcon.app.resources.Resource201'
+        assert span.get_tag(httpx.STATUS_CODE) == '201'
+        assert span.get_tag(httpx.URL) == 'http://falconframework.org/201'
+        assert span.parent_id is None
 
     def test_500(self):
         out = self.simulate_get('/500')
-        eq_(out.status_code, 500)
-        eq_(out.content.decode('utf-8'), 'Failure')
+        assert out.status_code == 500
+        assert out.content.decode('utf-8') == 'Failure'
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
-        eq_(span.name, 'falcon.request')
-        eq_(span.service, self._service)
-        eq_(span.resource, 'GET tests.contrib.falcon.app.resources.Resource500')
-        eq_(span.get_tag(httpx.STATUS_CODE), '500')
-        eq_(span.get_tag(httpx.URL), 'http://falconframework.org/500')
-        eq_(span.parent_id, None)
+        assert span.name == 'falcon.request'
+        assert span.service == self._service
+        assert span.resource == 'GET tests.contrib.falcon.app.resources.Resource500'
+        assert span.get_tag(httpx.STATUS_CODE) == '500'
+        assert span.get_tag(httpx.URL) == 'http://falconframework.org/500'
+        assert span.parent_id is None
 
     def test_404_exception(self):
         out = self.simulate_get('/not_found')
-        eq_(out.status_code, 404)
+        assert out.status_code == 404
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
-        eq_(span.name, 'falcon.request')
-        eq_(span.service, self._service)
-        eq_(span.resource, 'GET tests.contrib.falcon.app.resources.ResourceNotFound')
-        eq_(span.get_tag(httpx.STATUS_CODE), '404')
-        eq_(span.get_tag(httpx.URL), 'http://falconframework.org/not_found')
-        eq_(span.parent_id, None)
+        assert span.name == 'falcon.request'
+        assert span.service == self._service
+        assert span.resource == 'GET tests.contrib.falcon.app.resources.ResourceNotFound'
+        assert span.get_tag(httpx.STATUS_CODE) == '404'
+        assert span.get_tag(httpx.URL) == 'http://falconframework.org/not_found'
+        assert span.parent_id is None
 
     def test_404_exception_no_stacktracer(self):
         # it should not have the stacktrace when a 404 exception is raised
         out = self.simulate_get('/not_found')
-        eq_(out.status_code, 404)
+        assert out.status_code == 404
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
-        eq_(span.name, 'falcon.request')
-        eq_(span.service, self._service)
-        eq_(span.get_tag(httpx.STATUS_CODE), '404')
-        ok_(span.get_tag(errx.ERROR_TYPE) is None)
-        eq_(span.parent_id, None)
+        assert span.name == 'falcon.request'
+        assert span.service == self._service
+        assert span.get_tag(httpx.STATUS_CODE) == '404'
+        assert span.get_tag(errx.ERROR_TYPE) is None
+        assert span.parent_id is None
 
     def test_200_ot(self):
         """OpenTracing version of test_200."""
@@ -193,26 +191,26 @@ class FalconTestCase(object):
         with ot_tracer.start_active_span('ot_span'):
             out = self.simulate_get('/200')
 
-        eq_(out.status_code, 200)
-        eq_(out.content.decode('utf-8'), 'Success')
+        assert out.status_code == 200
+        assert out.content.decode('utf-8') == 'Success'
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 2)
+        assert len(traces) == 1
+        assert len(traces[0]) == 2
         ot_span, dd_span = traces[0]
 
         # confirm the parenting
-        eq_(ot_span.parent_id, None)
-        eq_(dd_span.parent_id, ot_span.span_id)
+        assert ot_span.parent_id is None
+        assert dd_span.parent_id == ot_span.span_id
 
-        eq_(ot_span.service, 'my_svc')
-        eq_(ot_span.resource, 'ot_span')
+        assert ot_span.service == 'my_svc'
+        assert ot_span.resource == 'ot_span'
 
-        eq_(dd_span.name, 'falcon.request')
-        eq_(dd_span.service, self._service)
-        eq_(dd_span.resource, 'GET tests.contrib.falcon.app.resources.Resource200')
-        eq_(dd_span.get_tag(httpx.STATUS_CODE), '200')
-        eq_(dd_span.get_tag(httpx.URL), 'http://falconframework.org/200')
+        assert dd_span.name == 'falcon.request'
+        assert dd_span.service == self._service
+        assert dd_span.resource == 'GET tests.contrib.falcon.app.resources.Resource200'
+        assert dd_span.get_tag(httpx.STATUS_CODE) == '200'
+        assert dd_span.get_tag(httpx.URL) == 'http://falconframework.org/200'
 
     def test_falcon_request_hook(self):
         @config.falcon.hooks.on('request')
@@ -220,19 +218,19 @@ class FalconTestCase(object):
             span.set_tag('my.custom', 'tag')
 
         out = self.simulate_get('/200')
-        eq_(out.status_code, 200)
-        eq_(out.content.decode('utf-8'), 'Success')
+        assert out.status_code == 200
+        assert out.content.decode('utf-8') == 'Success'
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
-        eq_(span.get_tag('http.request.headers.my_header'), None)
-        eq_(span.get_tag('http.response.headers.my_response_header'), None)
+        assert span.get_tag('http.request.headers.my_header') is None
+        assert span.get_tag('http.response.headers.my_response_header') is None
 
-        eq_(span.name, 'falcon.request')
+        assert span.name == 'falcon.request'
 
-        eq_(span.get_tag('my.custom'), 'tag')
+        assert span.get_tag('my.custom') == 'tag'
 
     def test_http_header_tracing(self):
         with self.override_config('falcon', {}):
@@ -240,8 +238,8 @@ class FalconTestCase(object):
             self.simulate_get('/200', headers={'my-header': 'my_value'})
             traces = self.tracer.writer.pop_traces()
 
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
-        eq_(span.get_tag('http.request.headers.my-header'), 'my_value')
-        eq_(span.get_tag('http.response.headers.my-response-header'), 'my_response_value')
+        assert span.get_tag('http.request.headers.my-header') == 'my_value'
+        assert span.get_tag('http.response.headers.my-response-header') == 'my_response_value'

--- a/tests/contrib/flask/test_middleware.py
+++ b/tests/contrib/flask/test_middleware.py
@@ -2,7 +2,6 @@
 import time
 import re
 
-from nose.tools import eq_, ok_
 from unittest import TestCase
 
 from ddtrace.contrib.flask import TraceMiddleware
@@ -38,9 +37,9 @@ class TestFlask(TestCase):
         # problem (the test scope must keep a strong reference)
         traced_app = TraceMiddleware(self.flask_app, self.tracer)  # noqa
         rv = self.app.get('/child')
-        eq_(rv.status_code, 200)
+        assert rv.status_code == 200
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
 
     def test_double_instrumentation_config(self):
         # ensure Flask uses the last set configuration to be sure
@@ -52,23 +51,23 @@ class TestFlask(TestCase):
             service='new-intake',
             distributed_tracing=False,
         )
-        eq_(self.flask_app._service, 'new-intake')
-        ok_(self.flask_app._use_distributed_tracing is False)
+        assert self.flask_app._service == 'new-intake'
+        assert self.flask_app._use_distributed_tracing is False
         rv = self.app.get('/child')
-        eq_(rv.status_code, 200)
+        assert rv.status_code == 200
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
 
     def test_child(self):
         start = time.time()
         rv = self.app.get('/child')
         end = time.time()
         # ensure request worked
-        eq_(rv.status_code, 200)
-        eq_(rv.data, b'child')
+        assert rv.status_code == 200
+        assert rv.data == b'child'
         # ensure trace worked
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
 
         spans_by_name = {s.name: s for s in spans}
 
@@ -76,21 +75,21 @@ class TestFlask(TestCase):
         assert s.span_id
         assert s.trace_id
         assert not s.parent_id
-        eq_(s.service, 'test.flask.service')
-        eq_(s.resource, "child")
+        assert s.service == 'test.flask.service'
+        assert s.resource == "child"
         assert s.start >= start
         assert s.duration <= end - start
-        eq_(s.error, 0)
+        assert s.error == 0
 
         c = spans_by_name['child']
         assert c.span_id
-        eq_(c.trace_id, s.trace_id)
-        eq_(c.parent_id, s.span_id)
-        eq_(c.service, 'test.flask.service')
-        eq_(c.resource, 'child')
+        assert c.trace_id == s.trace_id
+        assert c.parent_id == s.span_id
+        assert c.service == 'test.flask.service'
+        assert c.resource == 'child'
         assert c.start >= start
         assert c.duration <= end - start
-        eq_(c.error, 0)
+        assert c.error == 0
 
     def test_success(self):
         start = time.time()
@@ -98,25 +97,25 @@ class TestFlask(TestCase):
         end = time.time()
 
         # ensure request worked
-        eq_(rv.status_code, 200)
-        eq_(rv.data, b'hello')
+        assert rv.status_code == 200
+        assert rv.data == b'hello'
 
         # ensure trace worked
         assert not self.tracer.current_span(), self.tracer.current_span().pprint()
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, 'test.flask.service')
-        eq_(s.resource, "index")
+        assert s.service == 'test.flask.service'
+        assert s.resource == "index"
         assert s.start >= start
         assert s.duration <= end - start
-        eq_(s.error, 0)
-        eq_(s.meta.get(http.STATUS_CODE), '200')
-        eq_(s.meta.get(http.METHOD), 'GET')
+        assert s.error == 0
+        assert s.meta.get(http.STATUS_CODE) == '200'
+        assert s.meta.get(http.METHOD) == 'GET'
 
         services = self.tracer.writer.pop_services()
         expected = {}
-        eq_(services, expected)
+        assert services == expected
 
     def test_template(self):
         start = time.time()
@@ -124,27 +123,27 @@ class TestFlask(TestCase):
         end = time.time()
 
         # ensure request worked
-        eq_(rv.status_code, 200)
-        eq_(rv.data, b'hello earth')
+        assert rv.status_code == 200
+        assert rv.data == b'hello earth'
 
         # ensure trace worked
         assert not self.tracer.current_span(), self.tracer.current_span().pprint()
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         by_name = {s.name: s for s in spans}
         s = by_name["flask.request"]
-        eq_(s.service, "test.flask.service")
-        eq_(s.resource, "tmpl")
+        assert s.service == "test.flask.service"
+        assert s.resource == "tmpl"
         assert s.start >= start
         assert s.duration <= end - start
-        eq_(s.error, 0)
-        eq_(s.meta.get(http.STATUS_CODE), '200')
-        eq_(s.meta.get(http.METHOD), 'GET')
+        assert s.error == 0
+        assert s.meta.get(http.STATUS_CODE) == '200'
+        assert s.meta.get(http.METHOD) == 'GET'
 
         t = by_name["flask.template"]
-        eq_(t.get_tag("flask.template"), "test.html")
-        eq_(t.parent_id, s.span_id)
-        eq_(t.trace_id, s.trace_id)
+        assert t.get_tag("flask.template") == "test.html"
+        assert t.parent_id == s.span_id
+        assert t.trace_id == s.trace_id
         assert s.start < t.start < t.start + t.duration < end
 
     def test_handleme(self):
@@ -153,21 +152,21 @@ class TestFlask(TestCase):
         end = time.time()
 
         # ensure request worked
-        eq_(rv.status_code, 202)
-        eq_(rv.data, b'handled')
+        assert rv.status_code == 202
+        assert rv.data == b'handled'
 
         # ensure trace worked
         assert not self.tracer.current_span(), self.tracer.current_span().pprint()
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, "test.flask.service")
-        eq_(s.resource, "handle_me")
+        assert s.service == "test.flask.service"
+        assert s.resource == "handle_me"
         assert s.start >= start
         assert s.duration <= end - start
-        eq_(s.error, 0)
-        eq_(s.meta.get(http.STATUS_CODE), '202')
-        eq_(s.meta.get(http.METHOD), 'GET')
+        assert s.error == 0
+        assert s.meta.get(http.STATUS_CODE) == '202'
+        assert s.meta.get(http.METHOD) == 'GET'
 
     def test_template_err(self):
         start = time.time()
@@ -182,16 +181,16 @@ class TestFlask(TestCase):
         # ensure trace worked
         assert not self.tracer.current_span(), self.tracer.current_span().pprint()
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         by_name = {s.name: s for s in spans}
         s = by_name["flask.request"]
-        eq_(s.service, "test.flask.service")
-        eq_(s.resource, "tmpl_err")
+        assert s.service == "test.flask.service"
+        assert s.resource == "tmpl_err"
         assert s.start >= start
         assert s.duration <= end - start
-        eq_(s.error, 1)
-        eq_(s.meta.get(http.STATUS_CODE), '500')
-        eq_(s.meta.get(http.METHOD), 'GET')
+        assert s.error == 1
+        assert s.meta.get(http.STATUS_CODE) == '500'
+        assert s.meta.get(http.METHOD) == 'GET'
 
     def test_template_render_err(self):
         self.tracer.debug_logging = True
@@ -207,21 +206,21 @@ class TestFlask(TestCase):
         # ensure trace worked
         assert not self.tracer.current_span(), self.tracer.current_span().pprint()
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         by_name = {s.name: s for s in spans}
         s = by_name["flask.request"]
-        eq_(s.service, "test.flask.service")
-        eq_(s.resource, "tmpl_render_err")
+        assert s.service == "test.flask.service"
+        assert s.resource == "tmpl_render_err"
         assert s.start >= start
         assert s.duration <= end - start
-        eq_(s.error, 1)
-        eq_(s.meta.get(http.STATUS_CODE), '500')
-        eq_(s.meta.get(http.METHOD), 'GET')
+        assert s.error == 1
+        assert s.meta.get(http.STATUS_CODE) == '500'
+        assert s.meta.get(http.METHOD) == 'GET'
         t = by_name["flask.template"]
-        eq_(t.get_tag("flask.template"), "render_err.html")
-        eq_(t.error, 1)
-        eq_(t.parent_id, s.span_id)
-        eq_(t.trace_id, s.trace_id)
+        assert t.get_tag("flask.template") == "render_err.html"
+        assert t.error == 1
+        assert t.parent_id == s.span_id
+        assert t.trace_id == s.trace_id
 
     def test_error(self):
         start = time.time()
@@ -229,20 +228,20 @@ class TestFlask(TestCase):
         end = time.time()
 
         # ensure the request itself worked
-        eq_(rv.status_code, 500)
-        eq_(rv.data, b'error')
+        assert rv.status_code == 500
+        assert rv.data == b'error'
 
         # ensure the request was traced.
         assert not self.tracer.current_span()
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, "test.flask.service")
-        eq_(s.resource, "error")
+        assert s.service == "test.flask.service"
+        assert s.resource == "error"
         assert s.start >= start
         assert s.duration <= end - start
-        eq_(s.meta.get(http.STATUS_CODE), '500')
-        eq_(s.meta.get(http.METHOD), 'GET')
+        assert s.meta.get(http.STATUS_CODE) == '500'
+        assert s.meta.get(http.METHOD) == 'GET'
 
     def test_fatal(self):
         if not self.traced_app.use_signals:
@@ -260,14 +259,14 @@ class TestFlask(TestCase):
         # ensure the request was traced.
         assert not self.tracer.current_span()
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, "test.flask.service")
-        eq_(s.resource, "fatal")
+        assert s.service == "test.flask.service"
+        assert s.resource == "fatal"
         assert s.start >= start
         assert s.duration <= end - start
-        eq_(s.meta.get(http.STATUS_CODE), '500')
-        eq_(s.meta.get(http.METHOD), 'GET')
+        assert s.meta.get(http.STATUS_CODE) == '500'
+        assert s.meta.get(http.METHOD) == 'GET'
         assert "ZeroDivisionError" in s.meta.get(errors.ERROR_TYPE), s.meta
         assert "by zero" in s.meta.get(errors.ERROR_MSG)
         assert re.search('File ".*/contrib/flask/web.py", line [0-9]+, in fatal', s.meta.get(errors.ERROR_STACK))
@@ -278,22 +277,22 @@ class TestFlask(TestCase):
         end = time.time()
 
         # ensure request worked
-        eq_(rv.status_code, 200)
-        eq_(rv.data, b'\xc3\xbc\xc5\x8b\xc3\xaf\xc4\x89\xc3\xb3\xc4\x91\xc4\x93')
+        assert rv.status_code == 200
+        assert rv.data == b'\xc3\xbc\xc5\x8b\xc3\xaf\xc4\x89\xc3\xb3\xc4\x91\xc4\x93'
 
         # ensure trace worked
         assert not self.tracer.current_span(), self.tracer.current_span().pprint()
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, "test.flask.service")
-        eq_(s.resource, u'üŋïĉóđē')
+        assert s.service == "test.flask.service"
+        assert s.resource == u'üŋïĉóđē'
         assert s.start >= start
         assert s.duration <= end - start
-        eq_(s.error, 0)
-        eq_(s.meta.get(http.STATUS_CODE), '200')
-        eq_(s.meta.get(http.METHOD), 'GET')
-        eq_(s.meta.get(http.URL), u'http://localhost/üŋïĉóđē')
+        assert s.error == 0
+        assert s.meta.get(http.STATUS_CODE) == '200'
+        assert s.meta.get(http.METHOD) == 'GET'
+        assert s.meta.get(http.URL) == u'http://localhost/üŋïĉóđē'
 
     def test_404(self):
         start = time.time()
@@ -301,21 +300,21 @@ class TestFlask(TestCase):
         end = time.time()
 
         # ensure that we hit a 404
-        eq_(rv.status_code, 404)
+        assert rv.status_code == 404
 
         # ensure trace worked
         assert not self.tracer.current_span(), self.tracer.current_span().pprint()
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, "test.flask.service")
-        eq_(s.resource, u'404')
+        assert s.service == "test.flask.service"
+        assert s.resource == u'404'
         assert s.start >= start
         assert s.duration <= end - start
-        eq_(s.error, 0)
-        eq_(s.meta.get(http.STATUS_CODE), '404')
-        eq_(s.meta.get(http.METHOD), 'GET')
-        eq_(s.meta.get(http.URL), u'http://localhost/404/üŋïĉóđē')
+        assert s.error == 0
+        assert s.meta.get(http.STATUS_CODE) == '404'
+        assert s.meta.get(http.METHOD) == 'GET'
+        assert s.meta.get(http.URL) == u'http://localhost/404/üŋïĉóđē'
 
     def test_propagation(self):
         rv = self.app.get('/', headers={
@@ -325,33 +324,33 @@ class TestFlask(TestCase):
         })
 
         # ensure request worked
-        eq_(rv.status_code, 200)
-        eq_(rv.data, b'hello')
+        assert rv.status_code == 200
+        assert rv.data == b'hello'
 
         # ensure trace worked
         assert not self.tracer.current_span(), self.tracer.current_span().pprint()
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
 
         # ensure the propagation worked well
-        eq_(s.trace_id, 1234)
-        eq_(s.parent_id, 4567)
-        eq_(s.get_metric(SAMPLING_PRIORITY_KEY), 2)
+        assert s.trace_id == 1234
+        assert s.parent_id == 4567
+        assert s.get_metric(SAMPLING_PRIORITY_KEY) == 2
 
     def test_custom_span(self):
         rv = self.app.get('/custom_span')
-        eq_(rv.status_code, 200)
+        assert rv.status_code == 200
         # ensure trace worked
         assert not self.tracer.current_span(), self.tracer.current_span().pprint()
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, "test.flask.service")
-        eq_(s.resource, "overridden")
-        eq_(s.error, 0)
-        eq_(s.meta.get(http.STATUS_CODE), '200')
-        eq_(s.meta.get(http.METHOD), 'GET')
+        assert s.service == "test.flask.service"
+        assert s.resource == "overridden"
+        assert s.error == 0
+        assert s.meta.get(http.STATUS_CODE) == '200'
+        assert s.meta.get(http.METHOD) == 'GET'
 
     def test_success_200_ot(self):
         """OpenTracing version of test_success_200."""
@@ -364,25 +363,25 @@ class TestFlask(TestCase):
             end = time.time()
 
         # ensure request worked
-        eq_(rv.status_code, 200)
-        eq_(rv.data, b'hello')
+        assert rv.status_code == 200
+        assert rv.data == b'hello'
 
         # ensure trace worked
         assert not self.tracer.current_span(), self.tracer.current_span().pprint()
         spans = writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         ot_span, dd_span = spans
 
         # confirm the parenting
-        eq_(ot_span.parent_id, None)
-        eq_(dd_span.parent_id, ot_span.span_id)
+        assert ot_span.parent_id is None
+        assert dd_span.parent_id == ot_span.span_id
 
-        eq_(ot_span.resource, 'ot_span')
-        eq_(ot_span.service, 'my_svc')
+        assert ot_span.resource == 'ot_span'
+        assert ot_span.service == 'my_svc'
 
-        eq_(dd_span.resource, "index")
+        assert dd_span.resource == "index"
         assert dd_span.start >= start
         assert dd_span.duration <= end - start
-        eq_(dd_span.error, 0)
-        eq_(dd_span.meta.get(http.STATUS_CODE), '200')
-        eq_(dd_span.meta.get(http.METHOD), 'GET')
+        assert dd_span.error == 0
+        assert dd_span.meta.get(http.STATUS_CODE) == '200'
+        assert dd_span.meta.get(http.METHOD) == 'GET'

--- a/tests/contrib/flask_cache/test_utils.py
+++ b/tests/contrib/flask_cache/test_utils.py
@@ -1,7 +1,5 @@
 import unittest
 
-from nose.tools import eq_
-
 # project
 from ddtrace.tracer import Tracer
 from ddtrace.contrib.flask_cache import get_traced_cache
@@ -30,7 +28,7 @@ class FlaskCacheUtilsTest(unittest.TestCase):
         # extract client data
         meta = _extract_conn_tags(traced_cache.cache._client)
         expected_meta = {'out.host': 'localhost', 'out.port': REDIS_CONFIG['port'], 'out.redis_db': 0}
-        eq_(meta, expected_meta)
+        assert meta == expected_meta
 
     def test_extract_memcached_connection_metadata(self):
         # create the TracedCache instance for a Flask app
@@ -45,7 +43,7 @@ class FlaskCacheUtilsTest(unittest.TestCase):
         # extract client data
         meta = _extract_conn_tags(traced_cache.cache._client)
         expected_meta = {'out.host': '127.0.0.1', 'out.port': MEMCACHED_CONFIG['port']}
-        eq_(meta, expected_meta)
+        assert meta == expected_meta
 
     def test_extract_memcached_multiple_connection_metadata(self):
         # create the TracedCache instance for a Flask app
@@ -66,7 +64,7 @@ class FlaskCacheUtilsTest(unittest.TestCase):
             'out.host': '127.0.0.1',
             'out.port': MEMCACHED_CONFIG['port'],
         }
-        eq_(meta, expected_meta)
+        assert meta == expected_meta
 
     def test_resource_from_cache_with_prefix(self):
         # create the TracedCache instance for a Flask app
@@ -82,7 +80,7 @@ class FlaskCacheUtilsTest(unittest.TestCase):
         # expect a resource with a prefix
         expected_resource = "get users"
         resource = _resource_from_cache_prefix("GET", traced_cache.cache)
-        eq_(resource, expected_resource)
+        assert resource == expected_resource
 
     def test_resource_from_cache_with_empty_prefix(self):
         # create the TracedCache instance for a Flask app
@@ -98,7 +96,7 @@ class FlaskCacheUtilsTest(unittest.TestCase):
         # expect a resource with a prefix
         expected_resource = "get"
         resource = _resource_from_cache_prefix("GET", traced_cache.cache)
-        eq_(resource, expected_resource)
+        assert resource == expected_resource
 
     def test_resource_from_cache_without_prefix(self):
         # create the TracedCache instance for a Flask app
@@ -109,4 +107,4 @@ class FlaskCacheUtilsTest(unittest.TestCase):
         # expect only the resource name
         expected_resource = "get"
         resource = _resource_from_cache_prefix("GET", traced_cache.config)
-        eq_(resource, expected_resource)
+        assert resource == expected_resource

--- a/tests/contrib/flask_cache/test_wrapper_safety.py
+++ b/tests/contrib/flask_cache/test_wrapper_safety.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from nose.tools import eq_, ok_, assert_raises
-
 # project
 from ddtrace.ext import net
 from ddtrace.tracer import Tracer
@@ -12,6 +10,7 @@ from ddtrace.contrib.flask_cache.tracers import CACHE_BACKEND
 # 3rd party
 from flask import Flask
 from redis.exceptions import ConnectionError
+import pytest
 
 # testing
 from ...test_tracer import DummyWriter
@@ -32,21 +31,21 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         cache = Cache(app, config={"CACHE_TYPE": "simple"})
 
         # make a wrong call
-        with assert_raises(TypeError) as ex:
+        with pytest.raises(TypeError) as ex:
             cache.get()
 
         # ensure that the error is not caused by our tracer
-        ok_("get()" in ex.exception.args[0])
-        ok_("argument" in ex.exception.args[0])
+        assert "get()" in ex.value.args[0]
+        assert "argument" in ex.value.args[0]
         spans = writer.pop()
         # an error trace must be sent
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.SERVICE)
-        eq_(span.resource, "get")
-        eq_(span.name, "flask_cache.cmd")
-        eq_(span.span_type, "cache")
-        eq_(span.error, 1)
+        assert span.service == self.SERVICE
+        assert span.resource == "get"
+        assert span.name == "flask_cache.cmd"
+        assert span.span_type == "cache"
+        assert span.error == 1
 
     def test_cache_set_without_arguments(self):
         # initialize the dummy writer
@@ -60,21 +59,21 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         cache = Cache(app, config={"CACHE_TYPE": "simple"})
 
         # make a wrong call
-        with assert_raises(TypeError) as ex:
+        with pytest.raises(TypeError) as ex:
             cache.set()
 
         # ensure that the error is not caused by our tracer
-        ok_("set()" in ex.exception.args[0])
-        ok_("argument" in ex.exception.args[0])
+        assert "set()" in ex.value.args[0]
+        assert "argument" in ex.value.args[0]
         spans = writer.pop()
         # an error trace must be sent
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.SERVICE)
-        eq_(span.resource, "set")
-        eq_(span.name, "flask_cache.cmd")
-        eq_(span.span_type, "cache")
-        eq_(span.error, 1)
+        assert span.service == self.SERVICE
+        assert span.resource == "set"
+        assert span.name == "flask_cache.cmd"
+        assert span.span_type == "cache"
+        assert span.error == 1
 
     def test_cache_add_without_arguments(self):
         # initialize the dummy writer
@@ -88,21 +87,21 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         cache = Cache(app, config={"CACHE_TYPE": "simple"})
 
         # make a wrong call
-        with assert_raises(TypeError) as ex:
+        with pytest.raises(TypeError) as ex:
             cache.add()
 
         # ensure that the error is not caused by our tracer
-        ok_("add()" in ex.exception.args[0])
-        ok_("argument" in ex.exception.args[0])
+        assert "add()" in ex.value.args[0]
+        assert "argument" in ex.value.args[0]
         spans = writer.pop()
         # an error trace must be sent
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.SERVICE)
-        eq_(span.resource, "add")
-        eq_(span.name, "flask_cache.cmd")
-        eq_(span.span_type, "cache")
-        eq_(span.error, 1)
+        assert span.service == self.SERVICE
+        assert span.resource == "add"
+        assert span.name == "flask_cache.cmd"
+        assert span.span_type == "cache"
+        assert span.error == 1
 
     def test_cache_delete_without_arguments(self):
         # initialize the dummy writer
@@ -116,21 +115,21 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         cache = Cache(app, config={"CACHE_TYPE": "simple"})
 
         # make a wrong call
-        with assert_raises(TypeError) as ex:
+        with pytest.raises(TypeError) as ex:
             cache.delete()
 
         # ensure that the error is not caused by our tracer
-        ok_("delete()" in ex.exception.args[0])
-        ok_("argument" in ex.exception.args[0])
+        assert "delete()" in ex.value.args[0]
+        assert "argument" in ex.value.args[0]
         spans = writer.pop()
         # an error trace must be sent
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.SERVICE)
-        eq_(span.resource, "delete")
-        eq_(span.name, "flask_cache.cmd")
-        eq_(span.span_type, "cache")
-        eq_(span.error, 1)
+        assert span.service == self.SERVICE
+        assert span.resource == "delete"
+        assert span.name == "flask_cache.cmd"
+        assert span.span_type == "cache"
+        assert span.error == 1
 
     def test_cache_set_many_without_arguments(self):
         # initialize the dummy writer
@@ -144,21 +143,21 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         cache = Cache(app, config={"CACHE_TYPE": "simple"})
 
         # make a wrong call
-        with assert_raises(TypeError) as ex:
+        with pytest.raises(TypeError) as ex:
             cache.set_many()
 
         # ensure that the error is not caused by our tracer
-        ok_("set_many()" in ex.exception.args[0])
-        ok_("argument" in ex.exception.args[0])
+        assert "set_many()" in ex.value.args[0]
+        assert "argument" in ex.value.args[0]
         spans = writer.pop()
         # an error trace must be sent
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.SERVICE)
-        eq_(span.resource, "set_many")
-        eq_(span.name, "flask_cache.cmd")
-        eq_(span.span_type, "cache")
-        eq_(span.error, 1)
+        assert span.service == self.SERVICE
+        assert span.resource == "set_many"
+        assert span.name == "flask_cache.cmd"
+        assert span.span_type == "cache"
+        assert span.error == 1
 
     def test_redis_cache_tracing_with_a_wrong_connection(self):
         # initialize the dummy writer
@@ -177,24 +176,23 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         cache = Cache(app, config=config)
 
         # use a wrong redis connection
-        with assert_raises(ConnectionError) as ex:
+        with pytest.raises(ConnectionError) as ex:
             cache.get(u"á_complex_operation")
 
-        print(ex.exception)
         # ensure that the error is not caused by our tracer
-        ok_("127.0.0.1:2230. Connection refused." in ex.exception.args[0])
+        assert "127.0.0.1:2230. Connection refused." in ex.value.args[0]
         spans = writer.pop()
         # an error trace must be sent
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.SERVICE)
-        eq_(span.resource, "get")
-        eq_(span.name, "flask_cache.cmd")
-        eq_(span.span_type, "cache")
-        eq_(span.meta[CACHE_BACKEND], "redis")
-        eq_(span.meta[net.TARGET_HOST], '127.0.0.1')
-        eq_(span.meta[net.TARGET_PORT], '2230')
-        eq_(span.error, 1)
+        assert span.service == self.SERVICE
+        assert span.resource == "get"
+        assert span.name == "flask_cache.cmd"
+        assert span.span_type == "cache"
+        assert span.meta[CACHE_BACKEND] == "redis"
+        assert span.meta[net.TARGET_HOST] == '127.0.0.1'
+        assert span.meta[net.TARGET_PORT] == '2230'
+        assert span.error == 1
 
     def test_memcached_cache_tracing_with_a_wrong_connection(self):
         # initialize the dummy writer
@@ -219,15 +217,15 @@ class FlaskCacheWrapperTest(unittest.TestCase):
 
         # ensure that the error is not caused by our tracer
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.SERVICE)
-        eq_(span.resource, "get")
-        eq_(span.name, "flask_cache.cmd")
-        eq_(span.span_type, "cache")
-        eq_(span.meta[CACHE_BACKEND], "memcached")
-        eq_(span.meta[net.TARGET_HOST], 'localhost')
-        eq_(span.meta[net.TARGET_PORT], '2230')
+        assert span.service == self.SERVICE
+        assert span.resource == "get"
+        assert span.name == "flask_cache.cmd"
+        assert span.span_type == "cache"
+        assert span.meta[CACHE_BACKEND] == "memcached"
+        assert span.meta[net.TARGET_HOST] == 'localhost'
+        assert span.meta[net.TARGET_PORT] == '2230'
 
         # the pylibmc backend raises an exception and memcached backend does
         # not, so don't test anything about the status.

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -8,7 +8,6 @@ from ddtrace.contrib.gevent import patch, unpatch
 from ddtrace.ext.priority import USER_KEEP
 
 from unittest import TestCase
-from nose.tools import eq_, ok_
 from opentracing.scope_managers.gevent import GeventScopeManager
 from tests.opentracer.utils import init_tracer
 from tests.test_tracer import get_dummy_tracer
@@ -41,15 +40,15 @@ class TestGeventTracer(TestCase):
         # the main greenlet must not be affected by the tracer
         main_greenlet = gevent.getcurrent()
         ctx = getattr(main_greenlet, '__datadog_context', None)
-        ok_(ctx is None)
+        assert ctx is None
 
     def test_main_greenlet_context(self):
         # the main greenlet must have a ``Context`` if called
         ctx_tracer = self.tracer.get_call_context()
         main_greenlet = gevent.getcurrent()
         ctx_greenlet = getattr(main_greenlet, '__datadog_context', None)
-        ok_(ctx_tracer is ctx_greenlet)
-        eq_(len(ctx_tracer._trace), 0)
+        assert ctx_tracer is ctx_greenlet
+        assert len(ctx_tracer._trace) == 0
 
     def test_get_call_context(self):
         # it should return the context attached to the provider
@@ -60,18 +59,18 @@ class TestGeventTracer(TestCase):
         g.join()
         ctx = g.value
         stored_ctx = getattr(g, '__datadog_context', None)
-        ok_(stored_ctx is not None)
-        eq_(ctx, stored_ctx)
+        assert stored_ctx is not None
+        assert ctx == stored_ctx
 
     def test_get_call_context_twice(self):
         # it should return the same Context if called twice
         def greenlet():
-            eq_(self.tracer.get_call_context(), self.tracer.get_call_context())
+            assert self.tracer.get_call_context() == self.tracer.get_call_context()
             return True
 
         g = gevent.spawn(greenlet)
         g.join()
-        ok_(g.value)
+        assert g.value
 
     def test_spawn_greenlet_no_context(self):
         # a greenlet will not have a context if the tracer is not used
@@ -81,7 +80,7 @@ class TestGeventTracer(TestCase):
         g = gevent.spawn(greenlet)
         g.join()
         ctx = getattr(g, '__datadog_context', None)
-        ok_(ctx is None)
+        assert ctx is None
 
     def test_spawn_greenlet(self):
         # a greenlet will have a context if the tracer is used
@@ -91,8 +90,8 @@ class TestGeventTracer(TestCase):
         g = gevent.spawn(greenlet)
         g.join()
         ctx = getattr(g, '__datadog_context', None)
-        ok_(ctx is not None)
-        eq_(0, len(ctx._trace))
+        assert ctx is not None
+        assert 0 == len(ctx._trace)
 
     def test_spawn_later_greenlet(self):
         # a greenlet will have a context if the tracer is used even
@@ -103,8 +102,8 @@ class TestGeventTracer(TestCase):
         g = gevent.spawn_later(0.01, greenlet)
         g.join()
         ctx = getattr(g, '__datadog_context', None)
-        ok_(ctx is not None)
-        eq_(0, len(ctx._trace))
+        assert ctx is not None
+        assert 0 == len(ctx._trace)
 
     def test_trace_greenlet(self):
         # a greenlet can be traced using the trace API
@@ -114,10 +113,10 @@ class TestGeventTracer(TestCase):
 
         gevent.spawn(greenlet).join()
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
-        eq_('greenlet', traces[0][0].name)
-        eq_('base', traces[0][0].resource)
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+        assert 'greenlet' == traces[0][0].name
+        assert 'base' == traces[0][0].resource
 
     def test_trace_map_greenlet(self):
         # a greenlet can be traced using the trace API
@@ -139,24 +138,24 @@ class TestGeventTracer(TestCase):
                 list(func(greenlet, [0, 1, 2]))
             traces = self.tracer.writer.pop_traces()
 
-            eq_(4, len(traces))
+            assert 4 == len(traces)
             spans = []
             outer_span = None
             for t in traces:
-                eq_(1, len(t))
+                assert 1 == len(t)
                 span = t[0]
                 spans.append(span)
                 if span.name == 'outer':
                     outer_span = span
 
-            ok_(outer_span is not None)
-            eq_('base', outer_span.resource)
+            assert outer_span is not None
+            assert 'base' == outer_span.resource
             inner_spans = [s for s in spans if s is not outer_span]
             for s in inner_spans:
-                eq_('greenlet', s.name)
-                eq_('base', s.resource)
-                eq_(outer_span.trace_id, s.trace_id)
-                eq_(outer_span.span_id, s.parent_id)
+                assert 'greenlet' == s.name
+                assert 'base' == s.resource
+                assert outer_span.trace_id == s.trace_id
+                assert outer_span.span_id == s.parent_id
 
     def test_trace_later_greenlet(self):
         # a greenlet can be traced using the trace API
@@ -166,10 +165,10 @@ class TestGeventTracer(TestCase):
 
         gevent.spawn_later(0.01, greenlet).join()
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
-        eq_('greenlet', traces[0][0].name)
-        eq_('base', traces[0][0].resource)
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+        assert 'greenlet' == traces[0][0].name
+        assert 'base' == traces[0][0].resource
 
     def test_trace_sampling_priority_spawn_multiple_greenlets_multiple_traces(self):
         # multiple greenlets must be part of the same trace
@@ -192,15 +191,15 @@ class TestGeventTracer(TestCase):
 
         gevent.spawn(entrypoint).join()
         traces = self.tracer.writer.pop_traces()
-        eq_(3, len(traces))
-        eq_(1, len(traces[0]))
+        assert 3 == len(traces)
+        assert 1 == len(traces[0])
         parent_span = traces[2][0]
         worker_1 = traces[0][0]
         worker_2 = traces[1][0]
         # check sampling priority
-        eq_(parent_span.get_metric(SAMPLING_PRIORITY_KEY), USER_KEEP)
-        eq_(worker_1.get_metric(SAMPLING_PRIORITY_KEY), USER_KEEP)
-        eq_(worker_2.get_metric(SAMPLING_PRIORITY_KEY), USER_KEEP)
+        assert parent_span.get_metric(SAMPLING_PRIORITY_KEY) == USER_KEEP
+        assert worker_1.get_metric(SAMPLING_PRIORITY_KEY) == USER_KEEP
+        assert worker_2.get_metric(SAMPLING_PRIORITY_KEY) == USER_KEEP
 
     def test_trace_spawn_multiple_greenlets_multiple_traces(self):
         # multiple greenlets must be part of the same trace
@@ -222,22 +221,22 @@ class TestGeventTracer(TestCase):
 
         gevent.spawn(entrypoint).join()
         traces = self.tracer.writer.pop_traces()
-        eq_(3, len(traces))
-        eq_(1, len(traces[0]))
+        assert 3 == len(traces)
+        assert 1 == len(traces[0])
         parent_span = traces[2][0]
         worker_1 = traces[0][0]
         worker_2 = traces[1][0]
         # check spans data and hierarchy
-        eq_(parent_span.name, 'greenlet.main')
-        eq_(parent_span.resource, 'base')
-        eq_(worker_1.get_tag('worker_id'), '1')
-        eq_(worker_1.name, 'greenlet.worker')
-        eq_(worker_1.resource, 'greenlet.worker')
-        eq_(worker_1.parent_id, parent_span.span_id)
-        eq_(worker_2.get_tag('worker_id'), '2')
-        eq_(worker_2.name, 'greenlet.worker')
-        eq_(worker_2.resource, 'greenlet.worker')
-        eq_(worker_2.parent_id, parent_span.span_id)
+        assert parent_span.name == 'greenlet.main'
+        assert parent_span.resource == 'base'
+        assert worker_1.get_tag('worker_id') == '1'
+        assert worker_1.name == 'greenlet.worker'
+        assert worker_1.resource == 'greenlet.worker'
+        assert worker_1.parent_id == parent_span.span_id
+        assert worker_2.get_tag('worker_id') == '2'
+        assert worker_2.name == 'greenlet.worker'
+        assert worker_2.resource == 'greenlet.worker'
+        assert worker_2.parent_id == parent_span.span_id
 
     def test_trace_spawn_later_multiple_greenlets_multiple_traces(self):
         # multiple greenlets must be part of the same trace
@@ -259,22 +258,22 @@ class TestGeventTracer(TestCase):
 
         gevent.spawn(entrypoint).join()
         traces = self.tracer.writer.pop_traces()
-        eq_(3, len(traces))
-        eq_(1, len(traces[0]))
+        assert 3 == len(traces)
+        assert 1 == len(traces[0])
         parent_span = traces[2][0]
         worker_1 = traces[0][0]
         worker_2 = traces[1][0]
         # check spans data and hierarchy
-        eq_(parent_span.name, 'greenlet.main')
-        eq_(parent_span.resource, 'base')
-        eq_(worker_1.get_tag('worker_id'), '1')
-        eq_(worker_1.name, 'greenlet.worker')
-        eq_(worker_1.resource, 'greenlet.worker')
-        eq_(worker_1.parent_id, parent_span.span_id)
-        eq_(worker_2.get_tag('worker_id'), '2')
-        eq_(worker_2.name, 'greenlet.worker')
-        eq_(worker_2.resource, 'greenlet.worker')
-        eq_(worker_2.parent_id, parent_span.span_id)
+        assert parent_span.name == 'greenlet.main'
+        assert parent_span.resource == 'base'
+        assert worker_1.get_tag('worker_id') == '1'
+        assert worker_1.name == 'greenlet.worker'
+        assert worker_1.resource == 'greenlet.worker'
+        assert worker_1.parent_id == parent_span.span_id
+        assert worker_2.get_tag('worker_id') == '2'
+        assert worker_2.name == 'greenlet.worker'
+        assert worker_2.resource == 'greenlet.worker'
+        assert worker_2.parent_id == parent_span.span_id
 
     def test_trace_concurrent_calls(self):
         # create multiple futures so that we expect multiple
@@ -287,9 +286,9 @@ class TestGeventTracer(TestCase):
         gevent.joinall(jobs)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(100, len(traces))
-        eq_(1, len(traces[0]))
-        eq_('greenlet', traces[0][0].name)
+        assert 100 == len(traces)
+        assert 1 == len(traces[0])
+        assert 'greenlet' == traces[0][0].name
 
     def test_propagation_with_new_context(self):
         # create multiple futures so that we expect multiple
@@ -305,10 +304,10 @@ class TestGeventTracer(TestCase):
         gevent.joinall(jobs)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
-        eq_(traces[0][0].trace_id, 100)
-        eq_(traces[0][0].parent_id, 101)
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+        assert traces[0][0].trace_id == 100
+        assert traces[0][0].parent_id == 101
 
     def test_trace_concurrent_spawn_later_calls(self):
         # create multiple futures so that we expect multiple
@@ -322,9 +321,9 @@ class TestGeventTracer(TestCase):
         gevent.joinall(jobs)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(100, len(traces))
-        eq_(1, len(traces[0]))
-        eq_('greenlet', traces[0][0].name)
+        assert 100 == len(traces)
+        assert 1 == len(traces[0])
+        assert 'greenlet' == traces[0][0].name
 
     @silence_errors
     def test_exception(self):
@@ -335,15 +334,15 @@ class TestGeventTracer(TestCase):
 
         g = gevent.spawn(greenlet)
         g.join()
-        ok_(isinstance(g.exception, Exception))
+        assert isinstance(g.exception, Exception)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
         span = traces[0][0]
-        eq_(1, span.error)
-        eq_('Custom exception', span.get_tag('error.msg'))
-        ok_('Traceback (most recent call last)' in span.get_tag('error.stack'))
+        assert 1 == span.error
+        assert 'Custom exception' == span.get_tag('error.msg')
+        assert 'Traceback (most recent call last)' in span.get_tag('error.stack')
 
     def _assert_spawn_multiple_greenlets(self, spans):
         """A helper to assert the parenting of a trace when greenlets are
@@ -356,7 +355,7 @@ class TestGeventTracer(TestCase):
         management so the traces are not identical in form. However, the
         parenting of the spans must remain the same.
         """
-        eq_(len(spans), 3)
+        assert len(spans) == 3
 
         parent = None
         worker_1 = None
@@ -369,22 +368,22 @@ class TestGeventTracer(TestCase):
                 worker_1 = span
             if span.name == 'greenlet.worker2':
                 worker_2 = span
-        ok_(parent)
-        ok_(worker_1)
-        ok_(worker_2)
+        assert parent
+        assert worker_1
+        assert worker_2
 
         # confirm the parenting
-        eq_(worker_1.parent_id, parent.span_id)
-        eq_(worker_2.parent_id, parent.span_id)
+        assert worker_1.parent_id == parent.span_id
+        assert worker_2.parent_id == parent.span_id
 
         # check spans data and hierarchy
-        eq_(parent.name, 'greenlet.main')
-        eq_(worker_1.get_tag('worker_id'), '1')
-        eq_(worker_1.name, 'greenlet.worker1')
-        eq_(worker_1.resource, 'greenlet.worker1')
-        eq_(worker_2.get_tag('worker_id'), '2')
-        eq_(worker_2.name, 'greenlet.worker2')
-        eq_(worker_2.resource, 'greenlet.worker2')
+        assert parent.name == 'greenlet.main'
+        assert worker_1.get_tag('worker_id') == '1'
+        assert worker_1.name == 'greenlet.worker1'
+        assert worker_1.resource == 'greenlet.worker1'
+        assert worker_2.get_tag('worker_id') == '2'
+        assert worker_2.name == 'greenlet.worker2'
+        assert worker_2.resource == 'greenlet.worker2'
 
     def test_trace_spawn_multiple_greenlets_multiple_traces_dd(self):
         """Datadog version of the same test."""

--- a/tests/contrib/jinja2/test_jinja2.py
+++ b/tests/contrib/jinja2/test_jinja2.py
@@ -2,7 +2,6 @@ import os.path
 import unittest
 
 # 3rd party
-from nose.tools import eq_
 import jinja2
 
 from ddtrace import Pin, config
@@ -28,69 +27,63 @@ class Jinja2Test(unittest.TestCase):
 
     def test_render_inline_template(self):
         t = jinja2.environment.Template("Hello {{name}}!")
-        eq_(t.render(name="Jinja"), "Hello Jinja!")
+        assert t.render(name="Jinja") == "Hello Jinja!"
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
 
         for span in spans:
-            eq_(span.service, None)
-            eq_(span.span_type, "template")
-            eq_(span.get_tag("jinja2.template_name"), "<memory>")
+            assert span.service is None
+            assert span.span_type == "template"
+            assert span.get_tag("jinja2.template_name") == "<memory>"
 
-        eq_(spans[0].name, "jinja2.compile")
-        eq_(spans[1].name, "jinja2.render")
+        assert spans[0].name == "jinja2.compile"
+        assert spans[1].name == "jinja2.render"
 
     def test_generate_inline_template(self):
         t = jinja2.environment.Template("Hello {{name}}!")
-        eq_("".join(t.generate(name="Jinja")), "Hello Jinja!")
+        assert "".join(t.generate(name="Jinja")) == "Hello Jinja!"
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
 
         for span in spans:
-            eq_(span.service, None)
-            eq_(span.span_type, "template")
-            eq_(span.get_tag("jinja2.template_name"), "<memory>")
+            assert span.service is None
+            assert span.span_type == "template"
+            assert span.get_tag("jinja2.template_name") == "<memory>"
 
-        eq_(spans[0].name, "jinja2.compile")
-        eq_(spans[1].name, "jinja2.render")
+        assert spans[0].name == "jinja2.compile"
+        assert spans[1].name == "jinja2.render"
 
     def test_file_template(self):
         loader = jinja2.loaders.FileSystemLoader(TMPL_DIR)
         env = jinja2.Environment(loader=loader)
         t = env.get_template("template.html")
-        eq_(t.render(name="Jinja"), "Message: Hello Jinja!")
+        assert t.render(name="Jinja") == "Message: Hello Jinja!"
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 5)
+        assert len(spans) == 5
 
         for span in spans:
-            eq_(span.span_type, "template")
-            eq_(span.service, None)
+            assert span.span_type == "template"
+            assert span.service is None
 
         # templates.html extends base.html
         def get_def(s):
             return s.name, s.get_tag("jinja2.template_name")
 
-        eq_(get_def(spans[0]), ("jinja2.load", "template.html"))
-        eq_(get_def(spans[1]), ("jinja2.compile", "template.html"))
-        eq_(get_def(spans[2]), ("jinja2.render", "template.html"))
-        eq_(get_def(spans[3]), ("jinja2.load", "base.html"))
-        eq_(get_def(spans[4]), ("jinja2.compile", "base.html"))
+        assert get_def(spans[0]) == ("jinja2.load", "template.html")
+        assert get_def(spans[1]) == ("jinja2.compile", "template.html")
+        assert get_def(spans[2]) == ("jinja2.render", "template.html")
+        assert get_def(spans[3]) == ("jinja2.load", "base.html")
+        assert get_def(spans[4]) == ("jinja2.compile", "base.html")
 
         # additionnal checks for jinja2.load
-        eq_(
-            spans[0].get_tag("jinja2.template_path"),
-            os.path.join(TMPL_DIR, "template.html"),
-        )
-        eq_(
-            spans[3].get_tag("jinja2.template_path"),
-            os.path.join(TMPL_DIR, "base.html"),
-        )
+        assert spans[0].get_tag("jinja2.template_path") == os.path.join(TMPL_DIR, "template.html")
+        assert spans[3].get_tag("jinja2.template_path") == os.path.join(TMPL_DIR, "base.html")
 
     def test_service_name(self):
         # don't inherit the service name from the parent span, but force the value.
@@ -101,14 +94,14 @@ class Jinja2Test(unittest.TestCase):
         cfg['service_name'] = 'renderer'
 
         t = env.get_template("template.html")
-        eq_(t.render(name="Jinja"), "Message: Hello Jinja!")
+        assert t.render(name="Jinja") == "Message: Hello Jinja!"
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 5)
+        assert len(spans) == 5
 
         for span in spans:
-            eq_(span.service, "renderer")
+            assert span.service == "renderer"
 
     def test_inherit_service(self):
         # When there is a parent span and no custom service_name, the service name is inherited
@@ -117,11 +110,11 @@ class Jinja2Test(unittest.TestCase):
 
         with self.tracer.trace('parent.span', service='web'):
             t = env.get_template("template.html")
-            eq_(t.render(name="Jinja"), "Message: Hello Jinja!")
+            assert t.render(name="Jinja") == "Message: Hello Jinja!"
 
         # tests
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 6)
+        assert len(spans) == 6
 
         for span in spans:
-            eq_(span.service, "web")
+            assert span.service == "web"

--- a/tests/contrib/mysql/test_mysql.py
+++ b/tests/contrib/mysql/test_mysql.py
@@ -1,6 +1,5 @@
 # 3p
 import mysql
-from nose.tools import eq_, ok_
 
 # project
 from ddtrace import Pin
@@ -42,15 +41,15 @@ class MySQLCore(object):
         cursor = conn.cursor()
         cursor.execute("SELECT 1")
         rows = cursor.fetchall()
-        eq_(len(rows), 1)
+        assert len(rows) == 1
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'mysql.query')
-        eq_(span.span_type, 'sql')
-        eq_(span.error, 0)
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'mysql.query'
+        assert span.span_type == 'sql'
+        assert span.error == 0
         assert_dict_issuperset(span.meta, {
             'out.host': u'127.0.0.1',
             'out.port': u'3306',
@@ -65,15 +64,15 @@ class MySQLCore(object):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
             spans = writer.pop()
-            eq_(len(spans), 2)
+            assert len(spans) == 2
 
             span = spans[0]
-            eq_(span.service, self.TEST_SERVICE)
-            eq_(span.name, 'mysql.query')
-            eq_(span.span_type, 'sql')
-            eq_(span.error, 0)
+            assert span.service == self.TEST_SERVICE
+            assert span.name == 'mysql.query'
+            assert span.span_type == 'sql'
+            assert span.error == 0
             assert_dict_issuperset(span.meta, {
                 'out.host': u'127.0.0.1',
                 'out.port': u'3306',
@@ -81,7 +80,7 @@ class MySQLCore(object):
                 'db.user': u'test',
             })
 
-            eq_(spans[1].name, 'mysql.query.fetchall')
+            assert spans[1].name == 'mysql.query.fetchall'
 
     def test_query_with_several_rows(self):
         conn, tracer = self._get_conn_tracer()
@@ -90,11 +89,11 @@ class MySQLCore(object):
         query = "SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m"
         cursor.execute(query)
         rows = cursor.fetchall()
-        eq_(len(rows), 3)
+        assert len(rows) == 3
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        ok_(span.get_tag('sql.query') is None)
+        assert span.get_tag('sql.query') is None
 
     def test_query_with_several_rows_fetchall(self):
         with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
@@ -104,12 +103,12 @@ class MySQLCore(object):
             query = "SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m"
             cursor.execute(query)
             rows = cursor.fetchall()
-            eq_(len(rows), 3)
+            assert len(rows) == 3
             spans = writer.pop()
-            eq_(len(spans), 2)
+            assert len(spans) == 2
             span = spans[0]
-            ok_(span.get_tag('sql.query') is None)
-            eq_(spans[1].name, 'mysql.query.fetchall')
+            assert span.get_tag('sql.query') is None
+            assert spans[1].name == 'mysql.query.fetchall'
 
     def test_query_many(self):
         # tests that the executemany method is correctly wrapped.
@@ -133,16 +132,16 @@ class MySQLCore(object):
         query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
         cursor.execute(query)
         rows = cursor.fetchall()
-        eq_(len(rows), 2)
-        eq_(rows[0][0], "bar")
-        eq_(rows[0][1], "this is bar")
-        eq_(rows[1][0], "foo")
-        eq_(rows[1][1], "this is foo")
+        assert len(rows) == 2
+        assert rows[0][0] == "bar"
+        assert rows[0][1] == "this is bar"
+        assert rows[1][0] == "foo"
+        assert rows[1][1] == "this is foo"
 
         spans = writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         span = spans[-1]
-        ok_(span.get_tag('sql.query') is None)
+        assert span.get_tag('sql.query') is None
         cursor.execute("drop table if exists dummy")
 
     def test_query_many_fetchall(self):
@@ -168,19 +167,19 @@ class MySQLCore(object):
             query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
             cursor.execute(query)
             rows = cursor.fetchall()
-            eq_(len(rows), 2)
-            eq_(rows[0][0], "bar")
-            eq_(rows[0][1], "this is bar")
-            eq_(rows[1][0], "foo")
-            eq_(rows[1][1], "this is foo")
+            assert len(rows) == 2
+            assert rows[0][0] == "bar"
+            assert rows[0][1] == "this is bar"
+            assert rows[1][0] == "foo"
+            assert rows[1][1] == "this is foo"
 
             spans = writer.pop()
-            eq_(len(spans), 3)
+            assert len(spans) == 3
             span = spans[-1]
-            ok_(span.get_tag('sql.query') is None)
+            assert span.get_tag('sql.query') is None
             cursor.execute("drop table if exists dummy")
 
-            eq_(spans[2].name, 'mysql.query.fetchall')
+            assert spans[2].name == 'mysql.query.fetchall'
 
     def test_query_proc(self):
         conn, tracer = self._get_conn_tracer()
@@ -200,8 +199,8 @@ class MySQLCore(object):
         proc = "sp_sum"
         data = (40, 2, None)
         output = cursor.callproc(proc, data)
-        eq_(len(output), 3)
-        eq_(output[2], 42)
+        assert len(output) == 3
+        assert output[2] == 42
 
         spans = writer.pop()
         assert spans, spans
@@ -210,17 +209,17 @@ class MySQLCore(object):
         # typically, internal calls to execute, but at least we
         # can expect the last closed span to be our proc.
         span = spans[len(spans) - 1]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'mysql.query')
-        eq_(span.span_type, 'sql')
-        eq_(span.error, 0)
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'mysql.query'
+        assert span.span_type == 'sql'
+        assert span.error == 0
         assert_dict_issuperset(span.meta, {
             'out.host': u'127.0.0.1',
             'out.port': u'3306',
             'db.name': u'test',
             'db.user': u'test',
         })
-        ok_(span.get_tag('sql.query') is None)
+        assert span.get_tag('sql.query') is None
 
     def test_simple_query_ot(self):
         """OpenTracing version of test_simple_query."""
@@ -233,24 +232,24 @@ class MySQLCore(object):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
 
         spans = writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
 
         ot_span, dd_span = spans
 
         # confirm parenting
-        eq_(ot_span.parent_id, None)
-        eq_(dd_span.parent_id, ot_span.span_id)
+        assert ot_span.parent_id is None
+        assert dd_span.parent_id == ot_span.span_id
 
-        eq_(ot_span.service, 'mysql_svc')
-        eq_(ot_span.name, 'mysql_op')
+        assert ot_span.service == 'mysql_svc'
+        assert ot_span.name == 'mysql_op'
 
-        eq_(dd_span.service, self.TEST_SERVICE)
-        eq_(dd_span.name, 'mysql.query')
-        eq_(dd_span.span_type, 'sql')
-        eq_(dd_span.error, 0)
+        assert dd_span.service == self.TEST_SERVICE
+        assert dd_span.name == 'mysql.query'
+        assert dd_span.span_type == 'sql'
+        assert dd_span.error == 0
         assert_dict_issuperset(dd_span.meta, {
             'out.host': u'127.0.0.1',
             'out.port': u'3306',
@@ -270,24 +269,24 @@ class MySQLCore(object):
                 cursor = conn.cursor()
                 cursor.execute("SELECT 1")
                 rows = cursor.fetchall()
-                eq_(len(rows), 1)
+                assert len(rows) == 1
 
             spans = writer.pop()
-            eq_(len(spans), 3)
+            assert len(spans) == 3
 
             ot_span, dd_span, fetch_span = spans
 
             # confirm parenting
-            eq_(ot_span.parent_id, None)
-            eq_(dd_span.parent_id, ot_span.span_id)
+            assert ot_span.parent_id is None
+            assert dd_span.parent_id == ot_span.span_id
 
-            eq_(ot_span.service, 'mysql_svc')
-            eq_(ot_span.name, 'mysql_op')
+            assert ot_span.service == 'mysql_svc'
+            assert ot_span.name == 'mysql_op'
 
-            eq_(dd_span.service, self.TEST_SERVICE)
-            eq_(dd_span.name, 'mysql.query')
-            eq_(dd_span.span_type, 'sql')
-            eq_(dd_span.error, 0)
+            assert dd_span.service == self.TEST_SERVICE
+            assert dd_span.name == 'mysql.query'
+            assert dd_span.span_type == 'sql'
+            assert dd_span.error == 0
             assert_dict_issuperset(dd_span.meta, {
                 'out.host': u'127.0.0.1',
                 'out.port': u'3306',
@@ -295,27 +294,27 @@ class MySQLCore(object):
                 'db.user': u'test',
             })
 
-            eq_(fetch_span.name, 'mysql.query.fetchall')
+            assert fetch_span.name == 'mysql.query.fetchall'
 
     def test_commit(self):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         conn.commit()
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'mysql.connection.commit')
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'mysql.connection.commit'
 
     def test_rollback(self):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         conn.rollback()
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'mysql.connection.rollback')
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'mysql.connection.rollback'
 
     def test_analytics_default(self):
         conn, tracer = self._get_conn_tracer()
@@ -323,7 +322,7 @@ class MySQLCore(object):
         cursor = conn.cursor()
         cursor.execute("SELECT 1")
         rows = cursor.fetchall()
-        eq_(len(rows), 1)
+        assert len(rows) == 1
         spans = writer.pop()
 
         self.assertEqual(len(spans), 1)
@@ -340,7 +339,7 @@ class MySQLCore(object):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
             spans = writer.pop()
 
             self.assertEqual(len(spans), 1)
@@ -357,7 +356,7 @@ class MySQLCore(object):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
             spans = writer.pop()
 
             self.assertEqual(len(spans), 1)
@@ -410,22 +409,22 @@ class TestMysqlPatch(MySQLCore, BaseTracerTestCase):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
             spans = writer.pop()
-            eq_(len(spans), 1)
+            assert len(spans) == 1
 
             span = spans[0]
-            eq_(span.service, self.TEST_SERVICE)
-            eq_(span.name, 'mysql.query')
-            eq_(span.span_type, 'sql')
-            eq_(span.error, 0)
+            assert span.service == self.TEST_SERVICE
+            assert span.name == 'mysql.query'
+            assert span.span_type == 'sql'
+            assert span.error == 0
             assert_dict_issuperset(span.meta, {
                 'out.host': u'127.0.0.1',
                 'out.port': u'3306',
                 'db.name': u'test',
                 'db.user': u'test',
             })
-            ok_(span.get_tag('sql.query') is None)
+            assert span.get_tag('sql.query') is None
 
         finally:
             unpatch()

--- a/tests/contrib/mysqldb/test_mysql.py
+++ b/tests/contrib/mysqldb/test_mysql.py
@@ -4,8 +4,6 @@ from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.mysqldb.patch import patch, unpatch
 
-from nose.tools import eq_, ok_
-
 from tests.opentracer.utils import init_tracer
 from ..config import MYSQL_CONFIG
 from ...base import BaseTracerTestCase
@@ -44,17 +42,17 @@ class MySQLCore(object):
         writer = tracer.writer
         cursor = conn.cursor()
         rowcount = cursor.execute("SELECT 1")
-        eq_(rowcount, 1)
+        assert rowcount == 1
         rows = cursor.fetchall()
-        eq_(len(rows), 1)
+        assert len(rows) == 1
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'mysql.query')
-        eq_(span.span_type, 'sql')
-        eq_(span.error, 0)
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'mysql.query'
+        assert span.span_type == 'sql'
+        assert span.error == 0
         assert_dict_issuperset(span.meta, {
             'out.host': u'127.0.0.1',
             'out.port': u'3306',
@@ -69,15 +67,15 @@ class MySQLCore(object):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
             spans = writer.pop()
-            eq_(len(spans), 2)
+            assert len(spans) == 2
 
             span = spans[0]
-            eq_(span.service, self.TEST_SERVICE)
-            eq_(span.name, 'mysql.query')
-            eq_(span.span_type, 'sql')
-            eq_(span.error, 0)
+            assert span.service == self.TEST_SERVICE
+            assert span.name == 'mysql.query'
+            assert span.span_type == 'sql'
+            assert span.error == 0
             assert_dict_issuperset(span.meta, {
                 'out.host': u'127.0.0.1',
                 'out.port': u'3306',
@@ -85,7 +83,7 @@ class MySQLCore(object):
                 'db.user': u'test',
             })
             fetch_span = spans[1]
-            eq_(fetch_span.name, 'mysql.query.fetchall')
+            assert fetch_span.name == 'mysql.query.fetchall'
 
     def test_simple_query_with_positional_args(self):
         conn, tracer = self._get_conn_tracer_with_positional_args()
@@ -93,15 +91,15 @@ class MySQLCore(object):
         cursor = conn.cursor()
         cursor.execute("SELECT 1")
         rows = cursor.fetchall()
-        eq_(len(rows), 1)
+        assert len(rows) == 1
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'mysql.query')
-        eq_(span.span_type, 'sql')
-        eq_(span.error, 0)
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'mysql.query'
+        assert span.span_type == 'sql'
+        assert span.error == 0
         assert_dict_issuperset(span.meta, {
             'out.host': u'127.0.0.1',
             'out.port': u'3306',
@@ -116,15 +114,15 @@ class MySQLCore(object):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
             spans = writer.pop()
-            eq_(len(spans), 2)
+            assert len(spans) == 2
 
             span = spans[0]
-            eq_(span.service, self.TEST_SERVICE)
-            eq_(span.name, 'mysql.query')
-            eq_(span.span_type, 'sql')
-            eq_(span.error, 0)
+            assert span.service == self.TEST_SERVICE
+            assert span.name == 'mysql.query'
+            assert span.span_type == 'sql'
+            assert span.error == 0
             assert_dict_issuperset(span.meta, {
                 'out.host': u'127.0.0.1',
                 'out.port': u'3306',
@@ -132,7 +130,7 @@ class MySQLCore(object):
                 'db.user': u'test',
             })
             fetch_span = spans[1]
-            eq_(fetch_span.name, 'mysql.query.fetchall')
+            assert fetch_span.name == 'mysql.query.fetchall'
 
     def test_query_with_several_rows(self):
         conn, tracer = self._get_conn_tracer()
@@ -141,11 +139,11 @@ class MySQLCore(object):
         query = "SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m"
         cursor.execute(query)
         rows = cursor.fetchall()
-        eq_(len(rows), 3)
+        assert len(rows) == 3
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        ok_(span.get_tag('sql.query') is None)
+        assert span.get_tag('sql.query') is None
 
     def test_query_with_several_rows_fetchall(self):
         with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
@@ -155,13 +153,13 @@ class MySQLCore(object):
             query = "SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m"
             cursor.execute(query)
             rows = cursor.fetchall()
-            eq_(len(rows), 3)
+            assert len(rows) == 3
             spans = writer.pop()
-            eq_(len(spans), 2)
+            assert len(spans) == 2
             span = spans[0]
-            ok_(span.get_tag('sql.query') is None)
+            assert span.get_tag('sql.query') is None
             fetch_span = spans[1]
-            eq_(fetch_span.name, 'mysql.query.fetchall')
+            assert fetch_span.name == 'mysql.query.fetchall'
 
     def test_query_many(self):
         # tests that the executemany method is correctly wrapped.
@@ -185,16 +183,16 @@ class MySQLCore(object):
         query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
         cursor.execute(query)
         rows = cursor.fetchall()
-        eq_(len(rows), 2)
-        eq_(rows[0][0], "bar")
-        eq_(rows[0][1], "this is bar")
-        eq_(rows[1][0], "foo")
-        eq_(rows[1][1], "this is foo")
+        assert len(rows) == 2
+        assert rows[0][0] == "bar"
+        assert rows[0][1] == "this is bar"
+        assert rows[1][0] == "foo"
+        assert rows[1][1] == "this is foo"
 
         spans = writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         span = spans[1]
-        ok_(span.get_tag('sql.query') is None)
+        assert span.get_tag('sql.query') is None
         cursor.execute("drop table if exists dummy")
 
     def test_query_many_fetchall(self):
@@ -220,19 +218,19 @@ class MySQLCore(object):
             query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
             cursor.execute(query)
             rows = cursor.fetchall()
-            eq_(len(rows), 2)
-            eq_(rows[0][0], "bar")
-            eq_(rows[0][1], "this is bar")
-            eq_(rows[1][0], "foo")
-            eq_(rows[1][1], "this is foo")
+            assert len(rows) == 2
+            assert rows[0][0] == "bar"
+            assert rows[0][1] == "this is bar"
+            assert rows[1][0] == "foo"
+            assert rows[1][1] == "this is foo"
 
             spans = writer.pop()
-            eq_(len(spans), 3)
+            assert len(spans) == 3
             span = spans[1]
-            ok_(span.get_tag('sql.query') is None)
+            assert span.get_tag('sql.query') is None
             cursor.execute("drop table if exists dummy")
             fetch_span = spans[2]
-            eq_(fetch_span.name, 'mysql.query.fetchall')
+            assert fetch_span.name == 'mysql.query.fetchall'
 
     def test_query_proc(self):
         conn, tracer = self._get_conn_tracer()
@@ -252,11 +250,11 @@ class MySQLCore(object):
         proc = "sp_sum"
         data = (40, 2, None)
         output = cursor.callproc(proc, data)
-        eq_(len(output), 3)
+        assert len(output) == 3
         # resulted p3 isn't stored on output[2], we need to fetch it with select
         # http://mysqlclient.readthedocs.io/user_guide.html#cursor-objects
         cursor.execute("SELECT @_sp_sum_2;")
-        eq_(cursor.fetchone()[0], 42)
+        assert cursor.fetchone()[0] == 42
 
         spans = writer.pop()
         assert spans, spans
@@ -265,17 +263,17 @@ class MySQLCore(object):
         # typically, internal calls to execute, but at least we
         # can expect the next to the last closed span to be our proc.
         span = spans[-2]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'mysql.query')
-        eq_(span.span_type, 'sql')
-        eq_(span.error, 0)
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'mysql.query'
+        assert span.span_type == 'sql'
+        assert span.error == 0
         assert_dict_issuperset(span.meta, {
             'out.host': u'127.0.0.1',
             'out.port': u'3306',
             'db.name': u'test',
             'db.user': u'test',
         })
-        ok_(span.get_tag('sql.query') is None)
+        assert span.get_tag('sql.query') is None
 
     def test_simple_query_ot(self):
         """OpenTracing version of test_simple_query."""
@@ -286,23 +284,23 @@ class MySQLCore(object):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
 
         spans = writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         ot_span, dd_span = spans
 
         # confirm parenting
-        eq_(ot_span.parent_id, None)
-        eq_(dd_span.parent_id, ot_span.span_id)
+        assert ot_span.parent_id is None
+        assert dd_span.parent_id == ot_span.span_id
 
-        eq_(ot_span.service, 'mysql_svc')
-        eq_(ot_span.name, 'mysql_op')
+        assert ot_span.service == 'mysql_svc'
+        assert ot_span.name == 'mysql_op'
 
-        eq_(dd_span.service, self.TEST_SERVICE)
-        eq_(dd_span.name, 'mysql.query')
-        eq_(dd_span.span_type, 'sql')
-        eq_(dd_span.error, 0)
+        assert dd_span.service == self.TEST_SERVICE
+        assert dd_span.name == 'mysql.query'
+        assert dd_span.span_type == 'sql'
+        assert dd_span.error == 0
         assert_dict_issuperset(dd_span.meta, {
             'out.host': u'127.0.0.1',
             'out.port': u'3306',
@@ -320,23 +318,23 @@ class MySQLCore(object):
                 cursor = conn.cursor()
                 cursor.execute("SELECT 1")
                 rows = cursor.fetchall()
-                eq_(len(rows), 1)
+                assert len(rows) == 1
 
             spans = writer.pop()
-            eq_(len(spans), 3)
+            assert len(spans) == 3
             ot_span, dd_span, fetch_span = spans
 
             # confirm parenting
-            eq_(ot_span.parent_id, None)
-            eq_(dd_span.parent_id, ot_span.span_id)
+            assert ot_span.parent_id is None
+            assert dd_span.parent_id == ot_span.span_id
 
-            eq_(ot_span.service, 'mysql_svc')
-            eq_(ot_span.name, 'mysql_op')
+            assert ot_span.service == 'mysql_svc'
+            assert ot_span.name == 'mysql_op'
 
-            eq_(dd_span.service, self.TEST_SERVICE)
-            eq_(dd_span.name, 'mysql.query')
-            eq_(dd_span.span_type, 'sql')
-            eq_(dd_span.error, 0)
+            assert dd_span.service == self.TEST_SERVICE
+            assert dd_span.name == 'mysql.query'
+            assert dd_span.span_type == 'sql'
+            assert dd_span.error == 0
             assert_dict_issuperset(dd_span.meta, {
                 'out.host': u'127.0.0.1',
                 'out.port': u'3306',
@@ -344,27 +342,27 @@ class MySQLCore(object):
                 'db.user': u'test',
             })
 
-            eq_(fetch_span.name, 'mysql.query.fetchall')
+            assert fetch_span.name == 'mysql.query.fetchall'
 
     def test_commit(self):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         conn.commit()
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'MySQLdb.connection.commit')
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'MySQLdb.connection.commit'
 
     def test_rollback(self):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         conn.rollback()
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'MySQLdb.connection.rollback')
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'MySQLdb.connection.rollback'
 
     def test_analytics_default(self):
         conn, tracer = self._get_conn_tracer()
@@ -372,7 +370,7 @@ class MySQLCore(object):
         cursor = conn.cursor()
         cursor.execute("SELECT 1")
         rows = cursor.fetchall()
-        eq_(len(rows), 1)
+        assert len(rows) == 1
         spans = writer.pop()
 
         self.assertEqual(len(spans), 1)
@@ -389,7 +387,7 @@ class MySQLCore(object):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
             spans = writer.pop()
 
             self.assertEqual(len(spans), 1)
@@ -406,7 +404,7 @@ class MySQLCore(object):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
             spans = writer.pop()
 
             self.assertEqual(len(spans), 1)
@@ -479,22 +477,22 @@ class TestMysqlPatch(MySQLCore, BaseTracerTestCase):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
             spans = writer.pop()
-            eq_(len(spans), 1)
+            assert len(spans) == 1
 
             span = spans[0]
-            eq_(span.service, self.TEST_SERVICE)
-            eq_(span.name, 'mysql.query')
-            eq_(span.span_type, 'sql')
-            eq_(span.error, 0)
+            assert span.service == self.TEST_SERVICE
+            assert span.name == 'mysql.query'
+            assert span.span_type == 'sql'
+            assert span.error == 0
             assert_dict_issuperset(span.meta, {
                 'out.host': u'127.0.0.1',
                 'out.port': u'3306',
                 'db.name': u'test',
                 'db.user': u'test',
             })
-            ok_(span.get_tag('sql.query') is None)
+            assert span.get_tag('sql.query') is None
 
         finally:
             unpatch()

--- a/tests/contrib/pylons/test_pylons.py
+++ b/tests/contrib/pylons/test_pylons.py
@@ -1,10 +1,9 @@
 import os
 
-from nose.tools import eq_, ok_, assert_raises
-
 from routes import url_for
 from paste import fixture
 from paste.deploy import loadapp
+import pytest
 
 from ddtrace.ext import http, errors
 from ddtrace.constants import SAMPLING_PRIORITY_KEY, ANALYTICS_SAMPLE_RATE_KEY
@@ -43,18 +42,18 @@ class PylonsTestCase(BaseTracerTestCase):
 
         spans = self.tracer.writer.pop()
 
-        ok_(spans, spans)
-        eq_(len(spans), 1)
+        assert spans, spans
+        assert len(spans) == 1
         span = spans[0]
 
-        eq_(span.service, 'web')
-        eq_(span.resource, 'root.raise_exception')
-        eq_(span.error, 0)
-        eq_(span.get_tag('http.status_code'), '200')
-        eq_(span.get_tag(errors.ERROR_MSG), None)
-        eq_(span.get_tag(errors.ERROR_TYPE), None)
-        eq_(span.get_tag(errors.ERROR_STACK), None)
-        eq_(span.span_type, 'http')
+        assert span.service == 'web'
+        assert span.resource == 'root.raise_exception'
+        assert span.error == 0
+        assert span.get_tag('http.status_code') == '200'
+        assert span.get_tag(errors.ERROR_MSG) is None
+        assert span.get_tag(errors.ERROR_TYPE) is None
+        assert span.get_tag(errors.ERROR_STACK) is None
+        assert span.span_type == 'http'
 
     def test_mw_exc_success(self):
         """Ensure exceptions can be properly handled by other middleware.
@@ -71,17 +70,17 @@ class PylonsTestCase(BaseTracerTestCase):
 
         spans = self.tracer.writer.pop()
 
-        ok_(spans, spans)
-        eq_(len(spans), 1)
+        assert spans, spans
+        assert len(spans) == 1
         span = spans[0]
 
-        eq_(span.service, 'web')
-        eq_(span.resource, 'None.None')
-        eq_(span.error, 0)
-        eq_(span.get_tag('http.status_code'), '200')
-        eq_(span.get_tag(errors.ERROR_MSG), None)
-        eq_(span.get_tag(errors.ERROR_TYPE), None)
-        eq_(span.get_tag(errors.ERROR_STACK), None)
+        assert span.service == 'web'
+        assert span.resource == 'None.None'
+        assert span.error == 0
+        assert span.get_tag('http.status_code') == '200'
+        assert span.get_tag(errors.ERROR_MSG) is None
+        assert span.get_tag(errors.ERROR_TYPE) is None
+        assert span.get_tag(errors.ERROR_STACK) is None
 
     def test_middleware_exception(self):
         """Ensure exceptions raised in middleware are properly handled.
@@ -93,22 +92,22 @@ class PylonsTestCase(BaseTracerTestCase):
         app = PylonsTraceMiddleware(wsgiapp, self.tracer, service='web')
         app = fixture.TestApp(app)
 
-        with assert_raises(Exception):
+        with pytest.raises(Exception):
             app.get(url_for(controller='root', action='index'))
 
         spans = self.tracer.writer.pop()
 
-        ok_(spans, spans)
-        eq_(len(spans), 1)
+        assert spans, spans
+        assert len(spans) == 1
         span = spans[0]
 
-        eq_(span.service, 'web')
-        eq_(span.resource, 'None.None')
-        eq_(span.error, 1)
-        eq_(span.get_tag('http.status_code'), '500')
-        eq_(span.get_tag(errors.ERROR_MSG), 'Middleware exception')
-        eq_(span.get_tag(errors.ERROR_TYPE), 'exceptions.Exception')
-        ok_(span.get_tag(errors.ERROR_STACK))
+        assert span.service == 'web'
+        assert span.resource == 'None.None'
+        assert span.error == 1
+        assert span.get_tag('http.status_code') == '500'
+        assert span.get_tag(errors.ERROR_MSG) == 'Middleware exception'
+        assert span.get_tag(errors.ERROR_TYPE) == 'exceptions.Exception'
+        assert span.get_tag(errors.ERROR_STACK)
 
     def test_exc_success(self):
         from .app.middleware import ExceptionToSuccessMiddleware
@@ -119,17 +118,17 @@ class PylonsTestCase(BaseTracerTestCase):
         app.get(url_for(controller='root', action='raise_exception'))
 
         spans = self.tracer.writer.pop()
-        ok_(spans, spans)
-        eq_(len(spans), 1)
+        assert spans, spans
+        assert len(spans) == 1
         span = spans[0]
 
-        eq_(span.service, 'web')
-        eq_(span.resource, 'root.raise_exception')
-        eq_(span.error, 0)
-        eq_(span.get_tag('http.status_code'), '200')
-        eq_(span.get_tag(errors.ERROR_MSG), None)
-        eq_(span.get_tag(errors.ERROR_TYPE), None)
-        eq_(span.get_tag(errors.ERROR_STACK), None)
+        assert span.service == 'web'
+        assert span.resource == 'root.raise_exception'
+        assert span.error == 0
+        assert span.get_tag('http.status_code') == '200'
+        assert span.get_tag(errors.ERROR_MSG) is None
+        assert span.get_tag(errors.ERROR_TYPE) is None
+        assert span.get_tag(errors.ERROR_STACK) is None
 
     def test_exc_client_failure(self):
         from .app.middleware import ExceptionToClientErrorMiddleware
@@ -140,31 +139,31 @@ class PylonsTestCase(BaseTracerTestCase):
         app.get(url_for(controller='root', action='raise_exception'), status=404)
 
         spans = self.tracer.writer.pop()
-        ok_(spans, spans)
-        eq_(len(spans), 1)
+        assert spans, spans
+        assert len(spans) == 1
         span = spans[0]
 
-        eq_(span.service, 'web')
-        eq_(span.resource, 'root.raise_exception')
-        eq_(span.error, 0)
-        eq_(span.get_tag('http.status_code'), '404')
-        eq_(span.get_tag(errors.ERROR_MSG), None)
-        eq_(span.get_tag(errors.ERROR_TYPE), None)
-        eq_(span.get_tag(errors.ERROR_STACK), None)
+        assert span.service == 'web'
+        assert span.resource == 'root.raise_exception'
+        assert span.error == 0
+        assert span.get_tag('http.status_code') == '404'
+        assert span.get_tag(errors.ERROR_MSG) is None
+        assert span.get_tag(errors.ERROR_TYPE) is None
+        assert span.get_tag(errors.ERROR_STACK) is None
 
     def test_success_200(self):
         res = self.app.get(url_for(controller='root', action='index'))
-        eq_(res.status, 200)
+        assert res.status == 200
 
         spans = self.tracer.writer.pop()
-        ok_(spans, spans)
-        eq_(len(spans), 1)
+        assert spans, spans
+        assert len(spans) == 1
         span = spans[0]
 
-        eq_(span.service, 'web')
-        eq_(span.resource, 'root.index')
-        eq_(span.meta.get(http.STATUS_CODE), '200')
-        eq_(span.error, 0)
+        assert span.service == 'web'
+        assert span.resource == 'root.index'
+        assert span.meta.get(http.STATUS_CODE) == '200'
+        assert span.error == 0
 
     def test_analytics_global_on_integration_default(self):
         """
@@ -225,108 +224,108 @@ class PylonsTestCase(BaseTracerTestCase):
 
     def test_template_render(self):
         res = self.app.get(url_for(controller='root', action='render'))
-        eq_(res.status, 200)
+        assert res.status == 200
 
         spans = self.tracer.writer.pop()
-        ok_(spans, spans)
-        eq_(len(spans), 2)
+        assert spans, spans
+        assert len(spans) == 2
         request = spans[0]
         template = spans[1]
 
-        eq_(request.service, 'web')
-        eq_(request.resource, 'root.render')
-        eq_(request.meta.get(http.STATUS_CODE), '200')
-        eq_(request.error, 0)
+        assert request.service == 'web'
+        assert request.resource == 'root.render'
+        assert request.meta.get(http.STATUS_CODE) == '200'
+        assert request.error == 0
 
-        eq_(template.service, 'web')
-        eq_(template.resource, 'pylons.render')
-        eq_(template.meta.get('template.name'), '/template.mako')
-        eq_(template.error, 0)
+        assert template.service == 'web'
+        assert template.resource == 'pylons.render'
+        assert template.meta.get('template.name') == '/template.mako'
+        assert template.error == 0
 
     def test_template_render_exception(self):
-        with assert_raises(Exception):
+        with pytest.raises(Exception):
             self.app.get(url_for(controller='root', action='render_exception'))
 
         spans = self.tracer.writer.pop()
-        ok_(spans, spans)
-        eq_(len(spans), 2)
+        assert spans, spans
+        assert len(spans) == 2
         request = spans[0]
         template = spans[1]
 
-        eq_(request.service, 'web')
-        eq_(request.resource, 'root.render_exception')
-        eq_(request.meta.get(http.STATUS_CODE), '500')
-        eq_(request.error, 1)
+        assert request.service == 'web'
+        assert request.resource == 'root.render_exception'
+        assert request.meta.get(http.STATUS_CODE) == '500'
+        assert request.error == 1
 
-        eq_(template.service, 'web')
-        eq_(template.resource, 'pylons.render')
-        eq_(template.meta.get('template.name'), '/exception.mako')
-        eq_(template.error, 1)
-        eq_(template.get_tag('error.msg'), 'integer division or modulo by zero')
-        ok_('ZeroDivisionError: integer division or modulo by zero' in template.get_tag('error.stack'))
+        assert template.service == 'web'
+        assert template.resource == 'pylons.render'
+        assert template.meta.get('template.name') == '/exception.mako'
+        assert template.error == 1
+        assert template.get_tag('error.msg') == 'integer division or modulo by zero'
+        assert 'ZeroDivisionError: integer division or modulo by zero' in template.get_tag('error.stack')
 
     def test_failure_500(self):
-        with assert_raises(Exception):
+        with pytest.raises(Exception):
             self.app.get(url_for(controller='root', action='raise_exception'))
 
         spans = self.tracer.writer.pop()
-        ok_(spans, spans)
-        eq_(len(spans), 1)
+        assert spans, spans
+        assert len(spans) == 1
         span = spans[0]
 
-        eq_(span.service, 'web')
-        eq_(span.resource, 'root.raise_exception')
-        eq_(span.error, 1)
-        eq_(span.get_tag('http.status_code'), '500')
-        eq_(span.get_tag('error.msg'), 'Ouch!')
-        ok_('Exception: Ouch!' in span.get_tag('error.stack'))
+        assert span.service == 'web'
+        assert span.resource == 'root.raise_exception'
+        assert span.error == 1
+        assert span.get_tag('http.status_code') == '500'
+        assert span.get_tag('error.msg') == 'Ouch!'
+        assert 'Exception: Ouch!' in span.get_tag('error.stack')
 
     def test_failure_500_with_wrong_code(self):
-        with assert_raises(Exception):
+        with pytest.raises(Exception):
             self.app.get(url_for(controller='root', action='raise_wrong_code'))
 
         spans = self.tracer.writer.pop()
-        ok_(spans, spans)
-        eq_(len(spans), 1)
+        assert spans, spans
+        assert len(spans) == 1
         span = spans[0]
 
-        eq_(span.service, 'web')
-        eq_(span.resource, 'root.raise_wrong_code')
-        eq_(span.error, 1)
-        eq_(span.get_tag('http.status_code'), '500')
-        eq_(span.get_tag('error.msg'), 'Ouch!')
-        ok_('Exception: Ouch!' in span.get_tag('error.stack'))
+        assert span.service == 'web'
+        assert span.resource == 'root.raise_wrong_code'
+        assert span.error == 1
+        assert span.get_tag('http.status_code') == '500'
+        assert span.get_tag('error.msg') == 'Ouch!'
+        assert 'Exception: Ouch!' in span.get_tag('error.stack')
 
     def test_failure_500_with_custom_code(self):
-        with assert_raises(Exception):
+        with pytest.raises(Exception):
             self.app.get(url_for(controller='root', action='raise_custom_code'))
 
         spans = self.tracer.writer.pop()
-        ok_(spans, spans)
-        eq_(len(spans), 1)
+        assert spans, spans
+        assert len(spans) == 1
         span = spans[0]
 
-        eq_(span.service, 'web')
-        eq_(span.resource, 'root.raise_custom_code')
-        eq_(span.error, 1)
-        eq_(span.get_tag('http.status_code'), '512')
-        eq_(span.get_tag('error.msg'), 'Ouch!')
-        ok_('Exception: Ouch!' in span.get_tag('error.stack'))
+        assert span.service == 'web'
+        assert span.resource == 'root.raise_custom_code'
+        assert span.error == 1
+        assert span.get_tag('http.status_code') == '512'
+        assert span.get_tag('error.msg') == 'Ouch!'
+        assert 'Exception: Ouch!' in span.get_tag('error.stack')
 
     def test_failure_500_with_code_method(self):
-        with assert_raises(Exception):
+        with pytest.raises(Exception):
             self.app.get(url_for(controller='root', action='raise_code_method'))
 
         spans = self.tracer.writer.pop()
-        ok_(spans, spans)
-        eq_(len(spans), 1)
+        assert spans, spans
+        assert len(spans) == 1
         span = spans[0]
 
-        eq_(span.service, 'web')
-        eq_(span.resource, 'root.raise_code_method')
-        eq_(span.error, 1)
-        eq_(span.get_tag('http.status_code'), '500')
-        eq_(span.get_tag('error.msg'), 'Ouch!')
+        assert span.service == 'web'
+        assert span.resource == 'root.raise_code_method'
+        assert span.error == 1
+        assert span.get_tag('http.status_code') == '500'
+        assert span.get_tag('error.msg') == 'Ouch!'
 
     def test_distributed_tracing_default(self):
         # ensure by default, distributed tracing is not enabled
@@ -336,16 +335,16 @@ class PylonsTestCase(BaseTracerTestCase):
             'x-datadog-sampling-priority': '2',
         }
         res = self.app.get(url_for(controller='root', action='index'), headers=headers)
-        eq_(res.status, 200)
+        assert res.status == 200
 
         spans = self.tracer.writer.pop()
-        ok_(spans, spans)
-        eq_(len(spans), 1)
+        assert spans, spans
+        assert len(spans) == 1
         span = spans[0]
 
-        eq_(span.trace_id, 100)
-        eq_(span.parent_id, 42)
-        eq_(span.get_metric(SAMPLING_PRIORITY_KEY), 2)
+        assert span.trace_id == 100
+        assert span.parent_id == 42
+        assert span.get_metric(SAMPLING_PRIORITY_KEY) == 2
 
     def test_distributed_tracing_disabled(self):
         # ensure distributed tracing propagator is working
@@ -358,16 +357,16 @@ class PylonsTestCase(BaseTracerTestCase):
         }
 
         res = self.app.get(url_for(controller='root', action='index'), headers=headers)
-        eq_(res.status, 200)
+        assert res.status == 200
 
         spans = self.tracer.writer.pop()
-        ok_(spans, spans)
-        eq_(len(spans), 1)
+        assert spans, spans
+        assert len(spans) == 1
         span = spans[0]
 
-        ok_(span.trace_id != 100)
-        ok_(span.parent_id != 42)
-        ok_(span.get_metric(SAMPLING_PRIORITY_KEY) != 2)
+        assert span.trace_id != 100
+        assert span.parent_id != 42
+        assert span.get_metric(SAMPLING_PRIORITY_KEY) != 2
 
     def test_success_200_ot(self):
         """OpenTracing version of test_success_200."""
@@ -375,21 +374,21 @@ class PylonsTestCase(BaseTracerTestCase):
 
         with ot_tracer.start_active_span('pylons_get'):
             res = self.app.get(url_for(controller='root', action='index'))
-            eq_(res.status, 200)
+            assert res.status == 200
 
         spans = self.tracer.writer.pop()
-        ok_(spans, spans)
-        eq_(len(spans), 2)
+        assert spans, spans
+        assert len(spans) == 2
         ot_span, dd_span = spans
 
         # confirm the parenting
-        eq_(ot_span.parent_id, None)
-        eq_(dd_span.parent_id, ot_span.span_id)
+        assert ot_span.parent_id is None
+        assert dd_span.parent_id == ot_span.span_id
 
-        eq_(ot_span.name, 'pylons_get')
-        eq_(ot_span.service, 'pylons_svc')
+        assert ot_span.name == 'pylons_get'
+        assert ot_span.service == 'pylons_svc'
 
-        eq_(dd_span.service, 'web')
-        eq_(dd_span.resource, 'root.index')
-        eq_(dd_span.meta.get(http.STATUS_CODE), '200')
-        eq_(dd_span.error, 0)
+        assert dd_span.service == 'web'
+        assert dd_span.resource == 'root.index'
+        assert dd_span.meta.get(http.STATUS_CODE) == '200'
+        assert dd_span.error == 0

--- a/tests/contrib/pymemcache/test_client.py
+++ b/tests/contrib/pymemcache/test_client.py
@@ -1,5 +1,4 @@
 # 3p
-from nose.tools import assert_raises
 import pymemcache
 from pymemcache.exceptions import (
     MemcacheClientError,
@@ -8,6 +7,7 @@ from pymemcache.exceptions import (
     MemcacheUnknownError,
     MemcacheIllegalInputError,
 )
+import pytest
 import unittest
 from ddtrace.vendor import wrapt
 
@@ -86,7 +86,7 @@ class PymemcacheClientTestCase(PymemcacheClientTestCaseMixin):
         def _delete():
             client.delete(b"key", noreply=False)
 
-        assert_raises(Exception, _delete)
+        pytest.raises(Exception, _delete)
 
         spans = self.check_spans(1, ["delete"], ["delete key"])
         self.assertEqual(spans[0].error, 1)
@@ -104,7 +104,7 @@ class PymemcacheClientTestCase(PymemcacheClientTestCaseMixin):
         def _incr():
             client.incr(b"key", 1)
 
-        assert_raises(Exception, _incr)
+        pytest.raises(Exception, _incr)
 
         spans = self.check_spans(1, ["incr"], ["incr key"])
         self.assertEqual(spans[0].error, 1)
@@ -115,7 +115,7 @@ class PymemcacheClientTestCase(PymemcacheClientTestCaseMixin):
         def _get():
             client.get(b"key")
 
-        assert_raises(MemcacheUnknownCommandError, _get)
+        pytest.raises(MemcacheUnknownCommandError, _get)
 
         spans = self.check_spans(1, ["get"], ["get key"])
         self.assertEqual(spans[0].error, 1)
@@ -126,7 +126,7 @@ class PymemcacheClientTestCase(PymemcacheClientTestCaseMixin):
         def _get():
             client.get(b"key")
 
-        assert_raises(MemcacheUnknownError, _get)
+        pytest.raises(MemcacheUnknownError, _get)
 
         self.check_spans(1, ["get"], ["get key"])
 
@@ -150,7 +150,7 @@ class PymemcacheClientTestCase(PymemcacheClientTestCaseMixin):
         def _set():
             client.set("key", "value", noreply=False)
 
-        assert_raises(MemcacheClientError, _set)
+        pytest.raises(MemcacheClientError, _set)
 
         spans = self.check_spans(1, ["set"], ["set key"])
         self.assertEqual(spans[0].error, 1)
@@ -161,7 +161,7 @@ class PymemcacheClientTestCase(PymemcacheClientTestCaseMixin):
         def _set():
             client.set(b"key", b"value", noreply=False)
 
-        assert_raises(MemcacheServerError, _set)
+        pytest.raises(MemcacheServerError, _set)
 
         spans = self.check_spans(1, ["set"], ["set key"])
         self.assertEqual(spans[0].error, 1)
@@ -172,7 +172,7 @@ class PymemcacheClientTestCase(PymemcacheClientTestCaseMixin):
         def _set():
             client.set(b"key has space", b"value", noreply=False)
 
-        assert_raises(MemcacheIllegalInputError, _set)
+        pytest.raises(MemcacheIllegalInputError, _set)
 
         spans = self.check_spans(1, ["set"], ["set key has space"])
         self.assertEqual(spans[0].error, 1)

--- a/tests/contrib/pymongo/test_spec.py
+++ b/tests/contrib/pymongo/test_spec.py
@@ -3,7 +3,6 @@ tests for parsing specs.
 """
 
 from bson.son import SON
-from nose.tools import eq_
 
 from ddtrace.contrib.pymongo.parse import parse_spec
 
@@ -15,10 +14,10 @@ def test_empty():
 
 def test_create():
     cmd = parse_spec(SON([('create', 'foo')]))
-    eq_(cmd.name, 'create')
-    eq_(cmd.coll, 'foo')
-    eq_(cmd.tags, {})
-    eq_(cmd.metrics, {})
+    assert cmd.name == 'create'
+    assert cmd.coll == 'foo'
+    assert cmd.tags == {}
+    assert cmd.metrics == {}
 
 
 def test_insert():
@@ -28,10 +27,10 @@ def test_insert():
         ('documents', ['a', 'b']),
     ])
     cmd = parse_spec(spec)
-    eq_(cmd.name, 'insert')
-    eq_(cmd.coll, 'bla')
-    eq_(cmd.tags, {'mongodb.ordered': True})
-    eq_(cmd.metrics, {'mongodb.documents': 2})
+    assert cmd.name == 'insert'
+    assert cmd.coll == 'bla'
+    assert cmd.tags == {'mongodb.ordered': True}
+    assert cmd.metrics == {'mongodb.documents': 2}
 
 
 def test_update():
@@ -48,6 +47,6 @@ def test_update():
         ])
     ])
     cmd = parse_spec(spec)
-    eq_(cmd.name, 'update')
-    eq_(cmd.coll, 'songs')
-    eq_(cmd.query, {'artist': 'Neil'})
+    assert cmd.name == 'update'
+    assert cmd.coll == 'songs'
+    assert cmd.query == {'artist': 'Neil'}

--- a/tests/contrib/pymysql/test_pymysql.py
+++ b/tests/contrib/pymysql/test_pymysql.py
@@ -1,8 +1,6 @@
 # 3p
 import pymysql
 
-from nose.tools import eq_
-
 # project
 from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -58,18 +56,18 @@ class PyMySQLCore(object):
 
         # PyMySQL returns back the rowcount instead of a cursor
         rowcount = cursor.execute('SELECT 1')
-        eq_(rowcount, 1)
+        assert rowcount == 1
 
         rows = cursor.fetchall()
-        eq_(len(rows), 1)
+        assert len(rows) == 1
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'pymysql.query')
-        eq_(span.span_type, 'sql')
-        eq_(span.error, 0)
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'pymysql.query'
+        assert span.span_type == 'sql'
+        assert span.error == 0
         meta = {}
         meta.update(self.DB_INFO)
         assert_dict_issuperset(span.meta, meta)
@@ -81,21 +79,21 @@ class PyMySQLCore(object):
             cursor = conn.cursor()
             cursor.execute('SELECT 1')
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
             spans = writer.pop()
-            eq_(len(spans), 2)
+            assert len(spans) == 2
 
             span = spans[0]
-            eq_(span.service, self.TEST_SERVICE)
-            eq_(span.name, 'pymysql.query')
-            eq_(span.span_type, 'sql')
-            eq_(span.error, 0)
+            assert span.service == self.TEST_SERVICE
+            assert span.name == 'pymysql.query'
+            assert span.span_type == 'sql'
+            assert span.error == 0
             meta = {}
             meta.update(self.DB_INFO)
             assert_dict_issuperset(span.meta, meta)
 
             fetch_span = spans[1]
-            eq_(fetch_span.name, 'pymysql.query.fetchall')
+            assert fetch_span.name == 'pymysql.query.fetchall'
 
     def test_query_with_several_rows(self):
         conn, tracer = self._get_conn_tracer()
@@ -104,9 +102,9 @@ class PyMySQLCore(object):
         query = 'SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m'
         cursor.execute(query)
         rows = cursor.fetchall()
-        eq_(len(rows), 3)
+        assert len(rows) == 3
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         self.assertEqual(spans[0].name, 'pymysql.query')
 
     def test_query_with_several_rows_fetchall(self):
@@ -117,12 +115,12 @@ class PyMySQLCore(object):
             query = 'SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m'
             cursor.execute(query)
             rows = cursor.fetchall()
-            eq_(len(rows), 3)
+            assert len(rows) == 3
             spans = writer.pop()
-            eq_(len(spans), 2)
+            assert len(spans) == 2
 
             fetch_span = spans[1]
-            eq_(fetch_span.name, 'pymysql.query.fetchall')
+            assert fetch_span.name == 'pymysql.query.fetchall'
 
     def test_query_many(self):
         # tests that the executemany method is correctly wrapped.
@@ -143,19 +141,19 @@ class PyMySQLCore(object):
 
         # PyMySQL `executemany()` returns the rowcount
         rowcount = cursor.executemany(stmt, data)
-        eq_(rowcount, 2)
+        assert rowcount == 2
 
         query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
         cursor.execute(query)
         rows = cursor.fetchall()
-        eq_(len(rows), 2)
-        eq_(rows[0][0], "bar")
-        eq_(rows[0][1], "this is bar")
-        eq_(rows[1][0], "foo")
-        eq_(rows[1][1], "this is foo")
+        assert len(rows) == 2
+        assert rows[0][0] == "bar"
+        assert rows[0][1] == "this is bar"
+        assert rows[1][0] == "foo"
+        assert rows[1][1] == "this is foo"
 
         spans = writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         cursor.execute("drop table if exists dummy")
 
     def test_query_many_fetchall(self):
@@ -179,18 +177,18 @@ class PyMySQLCore(object):
             query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
             cursor.execute(query)
             rows = cursor.fetchall()
-            eq_(len(rows), 2)
-            eq_(rows[0][0], "bar")
-            eq_(rows[0][1], "this is bar")
-            eq_(rows[1][0], "foo")
-            eq_(rows[1][1], "this is foo")
+            assert len(rows) == 2
+            assert rows[0][0] == "bar"
+            assert rows[0][1] == "this is bar"
+            assert rows[1][0] == "foo"
+            assert rows[1][1] == "this is foo"
 
             spans = writer.pop()
-            eq_(len(spans), 3)
+            assert len(spans) == 3
             cursor.execute("drop table if exists dummy")
 
             fetch_span = spans[2]
-            eq_(fetch_span.name, 'pymysql.query.fetchall')
+            assert fetch_span.name == 'pymysql.query.fetchall'
 
     def test_query_proc(self):
         conn, tracer = self._get_conn_tracer()
@@ -218,8 +216,8 @@ class PyMySQLCore(object):
                        SELECT @_sp_sum_0, @_sp_sum_1, @_sp_sum_2
                        """)
         output = cursor.fetchone()
-        eq_(len(output), 3)
-        eq_(output[2], 42)
+        assert len(output) == 3
+        assert output[2] == 42
 
         spans = writer.pop()
         assert spans, spans
@@ -228,10 +226,10 @@ class PyMySQLCore(object):
         # typically, internal calls to execute, but at least we
         # can expect the last closed span to be our proc.
         span = spans[len(spans) - 2]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'pymysql.query')
-        eq_(span.span_type, 'sql')
-        eq_(span.error, 0)
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'pymysql.query'
+        assert span.span_type == 'sql'
+        assert span.error == 0
         meta = {}
         meta.update(self.DB_INFO)
         assert_dict_issuperset(span.meta, meta)
@@ -245,23 +243,23 @@ class PyMySQLCore(object):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
 
         spans = writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         ot_span, dd_span = spans
 
         # confirm parenting
-        eq_(ot_span.parent_id, None)
-        eq_(dd_span.parent_id, ot_span.span_id)
+        assert ot_span.parent_id is None
+        assert dd_span.parent_id == ot_span.span_id
 
-        eq_(ot_span.service, 'mysql_svc')
-        eq_(ot_span.name, 'mysql_op')
+        assert ot_span.service == 'mysql_svc'
+        assert ot_span.name == 'mysql_op'
 
-        eq_(dd_span.service, self.TEST_SERVICE)
-        eq_(dd_span.name, 'pymysql.query')
-        eq_(dd_span.span_type, 'sql')
-        eq_(dd_span.error, 0)
+        assert dd_span.service == self.TEST_SERVICE
+        assert dd_span.name == 'pymysql.query'
+        assert dd_span.span_type == 'sql'
+        assert dd_span.error == 0
         meta = {}
         meta.update(self.DB_INFO)
         assert_dict_issuperset(dd_span.meta, meta)
@@ -276,48 +274,48 @@ class PyMySQLCore(object):
                 cursor = conn.cursor()
                 cursor.execute("SELECT 1")
                 rows = cursor.fetchall()
-                eq_(len(rows), 1)
+                assert len(rows) == 1
 
             spans = writer.pop()
-            eq_(len(spans), 3)
+            assert len(spans) == 3
             ot_span, dd_span, fetch_span = spans
 
             # confirm parenting
-            eq_(ot_span.parent_id, None)
-            eq_(dd_span.parent_id, ot_span.span_id)
+            assert ot_span.parent_id is None
+            assert dd_span.parent_id == ot_span.span_id
 
-            eq_(ot_span.service, 'mysql_svc')
-            eq_(ot_span.name, 'mysql_op')
+            assert ot_span.service == 'mysql_svc'
+            assert ot_span.name == 'mysql_op'
 
-            eq_(dd_span.service, self.TEST_SERVICE)
-            eq_(dd_span.name, 'pymysql.query')
-            eq_(dd_span.span_type, 'sql')
-            eq_(dd_span.error, 0)
+            assert dd_span.service == self.TEST_SERVICE
+            assert dd_span.name == 'pymysql.query'
+            assert dd_span.span_type == 'sql'
+            assert dd_span.error == 0
             meta = {}
             meta.update(self.DB_INFO)
             assert_dict_issuperset(dd_span.meta, meta)
 
-            eq_(fetch_span.name, 'pymysql.query.fetchall')
+            assert fetch_span.name == 'pymysql.query.fetchall'
 
     def test_commit(self):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         conn.commit()
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'pymysql.connection.commit')
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'pymysql.connection.commit'
 
     def test_rollback(self):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         conn.rollback()
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'pymysql.connection.rollback')
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'pymysql.connection.rollback'
 
     def test_analytics_default(self):
         conn, tracer = self._get_conn_tracer()
@@ -325,7 +323,7 @@ class PyMySQLCore(object):
         cursor = conn.cursor()
         cursor.execute("SELECT 1")
         rows = cursor.fetchall()
-        eq_(len(rows), 1)
+        assert len(rows) == 1
         spans = writer.pop()
 
         self.assertEqual(len(spans), 1)
@@ -342,7 +340,7 @@ class PyMySQLCore(object):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
             spans = writer.pop()
 
             self.assertEqual(len(spans), 1)
@@ -359,7 +357,7 @@ class PyMySQLCore(object):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
             spans = writer.pop()
 
             self.assertEqual(len(spans), 1)
@@ -401,15 +399,15 @@ class TestPyMysqlPatch(PyMySQLCore, BaseTracerTestCase):
             cursor = conn.cursor()
             cursor.execute("SELECT 1")
             rows = cursor.fetchall()
-            eq_(len(rows), 1)
+            assert len(rows) == 1
             spans = writer.pop()
-            eq_(len(spans), 1)
+            assert len(spans) == 1
 
             span = spans[0]
-            eq_(span.service, self.TEST_SERVICE)
-            eq_(span.name, 'pymysql.query')
-            eq_(span.span_type, 'sql')
-            eq_(span.error, 0)
+            assert span.service == self.TEST_SERVICE
+            assert span.name == 'pymysql.query'
+            assert span.span_type == 'sql'
+            assert span.error == 0
 
             meta = {}
             meta.update(self.DB_INFO)

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_, ok_
-
 from ddtrace.constants import SAMPLING_PRIORITY_KEY, ORIGIN_KEY
 
 from .utils import PyramidTestCase, PyramidBase
@@ -18,7 +16,7 @@ class TestPyramid(PyramidTestCase):
         self.override_settings({'pyramid.tweens': 'pyramid.tweens.excview_tween_factory'})
         self.app.get('/json', status=200)
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 0)
+        assert len(spans) == 0
 
 
 class TestPyramidDistributedTracingDefault(PyramidBase):
@@ -39,13 +37,13 @@ class TestPyramidDistributedTracingDefault(PyramidBase):
         self.app.get('/', headers=headers, status=200)
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         # check the propagated Context
         span = spans[0]
-        eq_(span.trace_id, 100)
-        eq_(span.parent_id, 42)
-        eq_(span.get_metric(SAMPLING_PRIORITY_KEY), 2)
-        eq_(span.get_tag(ORIGIN_KEY), 'synthetics')
+        assert span.trace_id == 100
+        assert span.parent_id == 42
+        assert span.get_metric(SAMPLING_PRIORITY_KEY) == 2
+        assert span.get_tag(ORIGIN_KEY) == 'synthetics'
 
 
 class TestPyramidDistributedTracingDisabled(PyramidBase):
@@ -67,10 +65,10 @@ class TestPyramidDistributedTracingDisabled(PyramidBase):
         self.app.get('/', headers=headers, status=200)
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         # check the propagated Context
         span = spans[0]
-        ok_(span.trace_id != 100)
-        ok_(span.parent_id != 42)
-        ok_(span.get_metric(SAMPLING_PRIORITY_KEY) != 2)
-        ok_(span.get_tag(ORIGIN_KEY) != 'synthetics')
+        assert span.trace_id != 100
+        assert span.parent_id != 42
+        assert span.get_metric(SAMPLING_PRIORITY_KEY) != 2
+        assert span.get_tag(ORIGIN_KEY) != 'synthetics'

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -1,4 +1,3 @@
-from nose.tools import eq_
 from pyramid.config import Configurator
 
 from .test_pyramid import PyramidTestCase, PyramidBase
@@ -32,12 +31,12 @@ class TestPyramidDistributedTracing(PyramidBase):
         self.app.get('/', headers=headers, status=200)
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         # check the propagated Context
         span = spans[0]
-        eq_(span.trace_id, 100)
-        eq_(span.parent_id, 42)
-        eq_(span.get_metric('_sampling_priority_v1'), 2)
+        assert span.trace_id == 100
+        assert span.parent_id == 42
+        assert span.get_metric('_sampling_priority_v1') == 2
 
 
 def _include_me(config):

--- a/tests/contrib/pyramid/utils.py
+++ b/tests/contrib/pyramid/utils.py
@@ -1,7 +1,7 @@
 import json
 
-from nose.tools import eq_, assert_raises
 from pyramid.httpexceptions import HTTPException
+import pytest
 import webtest
 
 from ddtrace import compat
@@ -52,21 +52,21 @@ class PyramidTestCase(PyramidBase):
 
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, 'foobar')
-        eq_(s.resource, 'GET index')
-        eq_(s.error, 0)
-        eq_(s.span_type, 'http')
-        eq_(s.meta.get('http.method'), 'GET')
-        eq_(s.meta.get('http.status_code'), '200')
-        eq_(s.meta.get('http.url'), '/')
-        eq_(s.meta.get('pyramid.route.name'), 'index')
+        assert s.service == 'foobar'
+        assert s.resource == 'GET index'
+        assert s.error == 0
+        assert s.span_type == 'http'
+        assert s.meta.get('http.method') == 'GET'
+        assert s.meta.get('http.status_code') == '200'
+        assert s.meta.get('http.url') == '/'
+        assert s.meta.get('pyramid.route.name') == 'index'
 
         # ensure services are set correctly
         services = writer.pop_services()
         expected = {}
-        eq_(services, expected)
+        assert services == expected
 
     def test_analytics_global_on_integration_default(self):
         """
@@ -130,45 +130,45 @@ class PyramidTestCase(PyramidBase):
 
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, 'foobar')
-        eq_(s.resource, '404')
-        eq_(s.error, 0)
-        eq_(s.span_type, 'http')
-        eq_(s.meta.get('http.method'), 'GET')
-        eq_(s.meta.get('http.status_code'), '404')
-        eq_(s.meta.get('http.url'), '/404')
+        assert s.service == 'foobar'
+        assert s.resource == '404'
+        assert s.error == 0
+        assert s.span_type == 'http'
+        assert s.meta.get('http.method') == 'GET'
+        assert s.meta.get('http.status_code') == '404'
+        assert s.meta.get('http.url') == '/404'
 
     def test_302(self):
         self.app.get('/redirect', status=302)
 
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, 'foobar')
-        eq_(s.resource, 'GET raise_redirect')
-        eq_(s.error, 0)
-        eq_(s.span_type, 'http')
-        eq_(s.meta.get('http.method'), 'GET')
-        eq_(s.meta.get('http.status_code'), '302')
-        eq_(s.meta.get('http.url'), '/redirect')
+        assert s.service == 'foobar'
+        assert s.resource == 'GET raise_redirect'
+        assert s.error == 0
+        assert s.span_type == 'http'
+        assert s.meta.get('http.method') == 'GET'
+        assert s.meta.get('http.status_code') == '302'
+        assert s.meta.get('http.url') == '/redirect'
 
     def test_204(self):
         self.app.get('/nocontent', status=204)
 
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, 'foobar')
-        eq_(s.resource, 'GET raise_no_content')
-        eq_(s.error, 0)
-        eq_(s.span_type, 'http')
-        eq_(s.meta.get('http.method'), 'GET')
-        eq_(s.meta.get('http.status_code'), '204')
-        eq_(s.meta.get('http.url'), '/nocontent')
+        assert s.service == 'foobar'
+        assert s.resource == 'GET raise_no_content'
+        assert s.error == 0
+        assert s.span_type == 'http'
+        assert s.meta.get('http.method') == 'GET'
+        assert s.meta.get('http.status_code') == '204'
+        assert s.meta.get('http.url') == '/nocontent'
 
     def test_exception(self):
         try:
@@ -178,57 +178,57 @@ class PyramidTestCase(PyramidBase):
 
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, 'foobar')
-        eq_(s.resource, 'GET exception')
-        eq_(s.error, 1)
-        eq_(s.span_type, 'http')
-        eq_(s.meta.get('http.method'), 'GET')
-        eq_(s.meta.get('http.status_code'), '500')
-        eq_(s.meta.get('http.url'), '/exception')
-        eq_(s.meta.get('pyramid.route.name'), 'exception')
+        assert s.service == 'foobar'
+        assert s.resource == 'GET exception'
+        assert s.error == 1
+        assert s.span_type == 'http'
+        assert s.meta.get('http.method') == 'GET'
+        assert s.meta.get('http.status_code') == '500'
+        assert s.meta.get('http.url') == '/exception'
+        assert s.meta.get('pyramid.route.name') == 'exception'
 
     def test_500(self):
         self.app.get('/error', status=500)
 
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, 'foobar')
-        eq_(s.resource, 'GET error')
-        eq_(s.error, 1)
-        eq_(s.span_type, 'http')
-        eq_(s.meta.get('http.method'), 'GET')
-        eq_(s.meta.get('http.status_code'), '500')
-        eq_(s.meta.get('http.url'), '/error')
-        eq_(s.meta.get('pyramid.route.name'), 'error')
+        assert s.service == 'foobar'
+        assert s.resource == 'GET error'
+        assert s.error == 1
+        assert s.span_type == 'http'
+        assert s.meta.get('http.method') == 'GET'
+        assert s.meta.get('http.status_code') == '500'
+        assert s.meta.get('http.url') == '/error'
+        assert s.meta.get('pyramid.route.name') == 'error'
         assert type(s.error) == int
 
     def test_json(self):
         res = self.app.get('/json', status=200)
         parsed = json.loads(compat.to_unicode(res.body))
-        eq_(parsed, {'a': 1})
+        assert parsed == {'a': 1}
 
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         spans_by_name = {s.name: s for s in spans}
         s = spans_by_name['pyramid.request']
-        eq_(s.service, 'foobar')
-        eq_(s.resource, 'GET json')
-        eq_(s.error, 0)
-        eq_(s.span_type, 'http')
-        eq_(s.meta.get('http.method'), 'GET')
-        eq_(s.meta.get('http.status_code'), '200')
-        eq_(s.meta.get('http.url'), '/json')
-        eq_(s.meta.get('pyramid.route.name'), 'json')
+        assert s.service == 'foobar'
+        assert s.resource == 'GET json'
+        assert s.error == 0
+        assert s.span_type == 'http'
+        assert s.meta.get('http.method') == 'GET'
+        assert s.meta.get('http.status_code') == '200'
+        assert s.meta.get('http.url') == '/json'
+        assert s.meta.get('pyramid.route.name') == 'json'
 
         s = spans_by_name['pyramid.render']
-        eq_(s.service, 'foobar')
-        eq_(s.error, 0)
-        eq_(s.span_type, 'template')
+        assert s.service == 'foobar'
+        assert s.error == 0
+        assert s.span_type == 'template'
 
     def test_renderer(self):
         self.app.get('/renderer', status=200)
@@ -237,61 +237,62 @@ class PyramidTestCase(PyramidBase):
         self.renderer.assert_(foo='bar')
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         spans_by_name = {s.name: s for s in spans}
         s = spans_by_name['pyramid.request']
-        eq_(s.service, 'foobar')
-        eq_(s.resource, 'GET renderer')
-        eq_(s.error, 0)
-        eq_(s.span_type, 'http')
-        eq_(s.meta.get('http.method'), 'GET')
-        eq_(s.meta.get('http.status_code'), '200')
-        eq_(s.meta.get('http.url'), '/renderer')
-        eq_(s.meta.get('pyramid.route.name'), 'renderer')
+        assert s.service == 'foobar'
+        assert s.resource == 'GET renderer'
+        assert s.error == 0
+        assert s.span_type == 'http'
+        assert s.meta.get('http.method') == 'GET'
+        assert s.meta.get('http.status_code') == '200'
+        assert s.meta.get('http.url') == '/renderer'
+        assert s.meta.get('pyramid.route.name') == 'renderer'
 
         s = spans_by_name['pyramid.render']
-        eq_(s.service, 'foobar')
-        eq_(s.error, 0)
-        eq_(s.span_type, 'template')
+        assert s.service == 'foobar'
+        assert s.error == 0
+        assert s.span_type == 'template'
 
     def test_http_exception_response(self):
-        with assert_raises(HTTPException):
+        with pytest.raises(HTTPException):
             self.app.get('/404/raise_exception', status=404)
 
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.service, 'foobar')
-        eq_(s.resource, '404')
-        eq_(s.error, 1)
-        eq_(s.span_type, 'http')
-        eq_(s.meta.get('http.method'), 'GET')
-        eq_(s.meta.get('http.status_code'), '404')
-        eq_(s.meta.get('http.url'), '/404/raise_exception')
+        assert s.service == 'foobar'
+        assert s.resource == '404'
+        assert s.error == 1
+        assert s.span_type == 'http'
+        assert s.meta.get('http.method') == 'GET'
+        assert s.meta.get('http.status_code') == '404'
+        assert s.meta.get('http.url') == '/404/raise_exception'
 
     def test_insert_tween_if_needed_already_set(self):
         settings = {'pyramid.tweens': 'ddtrace.contrib.pyramid:trace_tween_factory'}
         insert_tween_if_needed(settings)
-        eq_(settings['pyramid.tweens'], 'ddtrace.contrib.pyramid:trace_tween_factory')
+        assert settings['pyramid.tweens'] == 'ddtrace.contrib.pyramid:trace_tween_factory'
 
     def test_insert_tween_if_needed_none(self):
         settings = {'pyramid.tweens': ''}
         insert_tween_if_needed(settings)
-        eq_(settings['pyramid.tweens'], '')
+        assert settings['pyramid.tweens'] == ''
 
     def test_insert_tween_if_needed_excview(self):
         settings = {'pyramid.tweens': 'pyramid.tweens.excview_tween_factory'}
         insert_tween_if_needed(settings)
-        eq_(
-            settings['pyramid.tweens'],
-            'ddtrace.contrib.pyramid:trace_tween_factory\npyramid.tweens.excview_tween_factory',
+        assert (
+            settings['pyramid.tweens'] ==
+            'ddtrace.contrib.pyramid:trace_tween_factory\npyramid.tweens.excview_tween_factory'
         )
 
     def test_insert_tween_if_needed_excview_and_other(self):
         settings = {'pyramid.tweens': 'a.first.tween\npyramid.tweens.excview_tween_factory\na.last.tween\n'}
         insert_tween_if_needed(settings)
-        eq_(settings['pyramid.tweens'],
+        assert (
+            settings['pyramid.tweens'] ==
             'a.first.tween\n'
             'ddtrace.contrib.pyramid:trace_tween_factory\n'
             'pyramid.tweens.excview_tween_factory\n'
@@ -300,14 +301,17 @@ class PyramidTestCase(PyramidBase):
     def test_insert_tween_if_needed_others(self):
         settings = {'pyramid.tweens': 'a.random.tween\nand.another.one'}
         insert_tween_if_needed(settings)
-        eq_(settings['pyramid.tweens'], 'a.random.tween\nand.another.one\nddtrace.contrib.pyramid:trace_tween_factory')
+        assert (
+            settings['pyramid.tweens'] ==
+            'a.random.tween\nand.another.one\nddtrace.contrib.pyramid:trace_tween_factory'
+        )
 
     def test_include_conflicts(self):
         # test that includes do not create conflicts
         self.override_settings({'pyramid.includes': 'tests.contrib.pyramid.test_pyramid'})
         self.app.get('/404', status=404)
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
     def test_200_ot(self):
         """OpenTracing version of test_200."""
@@ -319,22 +323,22 @@ class PyramidTestCase(PyramidBase):
 
         writer = self.tracer.writer
         spans = writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
 
         ot_span, dd_span = spans
 
         # confirm the parenting
-        eq_(ot_span.parent_id, None)
-        eq_(dd_span.parent_id, ot_span.span_id)
+        assert ot_span.parent_id is None
+        assert dd_span.parent_id == ot_span.span_id
 
-        eq_(ot_span.name, 'pyramid_get')
-        eq_(ot_span.service, 'pyramid_svc')
+        assert ot_span.name == 'pyramid_get'
+        assert ot_span.service == 'pyramid_svc'
 
-        eq_(dd_span.service, 'foobar')
-        eq_(dd_span.resource, 'GET index')
-        eq_(dd_span.error, 0)
-        eq_(dd_span.span_type, 'http')
-        eq_(dd_span.meta.get('http.method'), 'GET')
-        eq_(dd_span.meta.get('http.status_code'), '200')
-        eq_(dd_span.meta.get('http.url'), '/')
-        eq_(dd_span.meta.get('pyramid.route.name'), 'index')
+        assert dd_span.service == 'foobar'
+        assert dd_span.resource == 'GET index'
+        assert dd_span.error == 0
+        assert dd_span.span_type == 'http'
+        assert dd_span.meta.get('http.method') == 'GET'
+        assert dd_span.meta.get('http.status_code') == '200'
+        assert dd_span.meta.get('http.url') == '/'
+        assert dd_span.meta.get('pyramid.route.name') == 'index'

--- a/tests/contrib/redis/test.py
+++ b/tests/contrib/redis/test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import redis
-from nose.tools import eq_, ok_
 
 from ddtrace import Pin, compat
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -20,7 +19,7 @@ def test_redis_legacy():
     r = TracedRedisCache(port=REDIS_CONFIG['port'])
     r.set("a", "b")
     got = r.get("a")
-    eq_(compat.to_unicode(got), "b")
+    assert compat.to_unicode(got) == "b"
     assert not tracer.writer.pop()
 
 
@@ -45,39 +44,39 @@ class TestRedisPatch(BaseTracerTestCase):
         self.r.mget(*range(1000))
 
         spans = self.get_spans()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'redis.command')
-        eq_(span.span_type, 'redis')
-        eq_(span.error, 0)
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'redis.command'
+        assert span.span_type == 'redis'
+        assert span.error == 0
         meta = {
             'out.host': u'localhost',
             'out.port': str(self.TEST_PORT),
             'out.redis_db': u'0',
         }
         for k, v in meta.items():
-            eq_(span.get_tag(k), v)
+            assert span.get_tag(k) == v
 
         assert span.get_tag('redis.raw_command').startswith(u'MGET 0 1 2 3')
         assert span.get_tag('redis.raw_command').endswith(u'...')
 
     def test_basics(self):
         us = self.r.get('cheese')
-        eq_(us, None)
+        assert us is None
         spans = self.get_spans()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'redis.command')
-        eq_(span.span_type, 'redis')
-        eq_(span.error, 0)
-        eq_(span.get_tag('out.redis_db'), '0')
-        eq_(span.get_tag('out.host'), 'localhost')
-        eq_(span.get_tag('redis.raw_command'), u'GET cheese')
-        eq_(span.get_metric('redis.args_length'), 2)
-        eq_(span.resource, 'GET cheese')
-        ok_(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY) is None)
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'redis.command'
+        assert span.span_type == 'redis'
+        assert span.error == 0
+        assert span.get_tag('out.redis_db') == '0'
+        assert span.get_tag('out.host') == 'localhost'
+        assert span.get_tag('redis.raw_command') == u'GET cheese'
+        assert span.get_metric('redis.args_length') == 2
+        assert span.resource == 'GET cheese'
+        assert span.get_metric(ANALYTICS_SAMPLE_RATE_KEY) is None
 
     def test_analytics_without_rate(self):
         with self.override_config(
@@ -85,11 +84,11 @@ class TestRedisPatch(BaseTracerTestCase):
             dict(analytics_enabled=True)
         ):
             us = self.r.get('cheese')
-            eq_(us, None)
+            assert us is None
             spans = self.get_spans()
-            eq_(len(spans), 1)
+            assert len(spans) == 1
             span = spans[0]
-            eq_(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
+            assert span.get_metric(ANALYTICS_SAMPLE_RATE_KEY) == 1.0
 
     def test_analytics_with_rate(self):
         with self.override_config(
@@ -97,11 +96,11 @@ class TestRedisPatch(BaseTracerTestCase):
             dict(analytics_enabled=True, analytics_sample_rate=0.5)
         ):
             us = self.r.get('cheese')
-            eq_(us, None)
+            assert us is None
             spans = self.get_spans()
-            eq_(len(spans), 1)
+            assert len(spans) == 1
             span = spans[0]
-            eq_(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 0.5)
+            assert span.get_metric(ANALYTICS_SAMPLE_RATE_KEY) == 0.5
 
     def test_pipeline_traced(self):
         with self.r.pipeline(transaction=False) as p:
@@ -111,19 +110,19 @@ class TestRedisPatch(BaseTracerTestCase):
             p.execute()
 
         spans = self.get_spans()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'redis.command')
-        eq_(span.resource, u'SET blah 32\nRPUSH foo éé\nHGETALL xxx')
-        eq_(span.span_type, 'redis')
-        eq_(span.error, 0)
-        eq_(span.get_tag('out.redis_db'), '0')
-        eq_(span.get_tag('out.host'), 'localhost')
-        eq_(span.get_tag('redis.raw_command'), u'SET blah 32\nRPUSH foo éé\nHGETALL xxx')
-        eq_(span.get_metric('redis.pipeline_length'), 3)
-        eq_(span.get_metric('redis.pipeline_length'), 3)
-        ok_(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY) is None)
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'redis.command'
+        assert span.resource == u'SET blah 32\nRPUSH foo éé\nHGETALL xxx'
+        assert span.span_type == 'redis'
+        assert span.error == 0
+        assert span.get_tag('out.redis_db') == '0'
+        assert span.get_tag('out.host') == 'localhost'
+        assert span.get_tag('redis.raw_command') == u'SET blah 32\nRPUSH foo éé\nHGETALL xxx'
+        assert span.get_metric('redis.pipeline_length') == 3
+        assert span.get_metric('redis.pipeline_length') == 3
+        assert span.get_metric(ANALYTICS_SAMPLE_RATE_KEY) is None
 
     def test_pipeline_immediate(self):
         with self.r.pipeline() as p:
@@ -132,15 +131,15 @@ class TestRedisPatch(BaseTracerTestCase):
             p.execute()
 
         spans = self.get_spans()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'redis.command')
-        eq_(span.resource, u'SET a 1')
-        eq_(span.span_type, 'redis')
-        eq_(span.error, 0)
-        eq_(span.get_tag('out.redis_db'), '0')
-        eq_(span.get_tag('out.host'), 'localhost')
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'redis.command'
+        assert span.resource == u'SET a 1'
+        assert span.span_type == 'redis'
+        assert span.error == 0
+        assert span.get_tag('out.redis_db') == '0'
+        assert span.get_tag('out.host') == 'localhost'
 
     def test_meta_override(self):
         r = self.r
@@ -150,10 +149,10 @@ class TestRedisPatch(BaseTracerTestCase):
 
         r.get('cheese')
         spans = self.get_spans()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        ok_('cheese' in span.meta and span.meta['cheese'] == 'camembert')
+        assert span.service == self.TEST_SERVICE
+        assert 'cheese' in span.meta and span.meta['cheese'] == 'camembert'
 
     def test_patch_unpatch(self):
         tracer = get_dummy_tracer()
@@ -169,7 +168,7 @@ class TestRedisPatch(BaseTracerTestCase):
 
         spans = writer.pop()
         assert spans, spans
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         # Test unpatch
         unpatch()
@@ -189,7 +188,7 @@ class TestRedisPatch(BaseTracerTestCase):
 
         spans = writer.pop()
         assert spans, spans
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
     def test_opentracing(self):
         """Ensure OpenTracing works with redis."""
@@ -197,25 +196,25 @@ class TestRedisPatch(BaseTracerTestCase):
 
         with ot_tracer.start_active_span('redis_get'):
             us = self.r.get('cheese')
-            eq_(us, None)
+            assert us is None
 
         spans = self.get_spans()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         ot_span, dd_span = spans
 
         # confirm the parenting
-        eq_(ot_span.parent_id, None)
-        eq_(dd_span.parent_id, ot_span.span_id)
+        assert ot_span.parent_id is None
+        assert dd_span.parent_id == ot_span.span_id
 
-        eq_(ot_span.name, 'redis_get')
-        eq_(ot_span.service, 'redis_svc')
+        assert ot_span.name == 'redis_get'
+        assert ot_span.service == 'redis_svc'
 
-        eq_(dd_span.service, self.TEST_SERVICE)
-        eq_(dd_span.name, 'redis.command')
-        eq_(dd_span.span_type, 'redis')
-        eq_(dd_span.error, 0)
-        eq_(dd_span.get_tag('out.redis_db'), '0')
-        eq_(dd_span.get_tag('out.host'), 'localhost')
-        eq_(dd_span.get_tag('redis.raw_command'), u'GET cheese')
-        eq_(dd_span.get_metric('redis.args_length'), 2)
-        eq_(dd_span.resource, 'GET cheese')
+        assert dd_span.service == self.TEST_SERVICE
+        assert dd_span.name == 'redis.command'
+        assert dd_span.span_type == 'redis'
+        assert dd_span.error == 0
+        assert dd_span.get_tag('out.redis_db') == '0'
+        assert dd_span.get_tag('out.host') == 'localhost'
+        assert dd_span.get_tag('redis.raw_command') == u'GET cheese'
+        assert dd_span.get_metric('redis.args_length') == 2
+        assert dd_span.resource == 'GET cheese'

--- a/tests/contrib/rediscluster/test.py
+++ b/tests/contrib/rediscluster/test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import rediscluster
-from nose.tools import eq_
 
 from ddtrace import Pin
 from ddtrace.contrib.rediscluster.patch import patch, unpatch
@@ -36,17 +35,17 @@ class TestRedisPatch(BaseTracerTestCase):
 
     def test_basics(self):
         us = self.r.get('cheese')
-        eq_(us, None)
+        assert us is None
         spans = self.get_spans()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'redis.command')
-        eq_(span.span_type, 'redis')
-        eq_(span.error, 0)
-        eq_(span.get_tag('redis.raw_command'), u'GET cheese')
-        eq_(span.get_metric('redis.args_length'), 2)
-        eq_(span.resource, 'GET cheese')
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'redis.command'
+        assert span.span_type == 'redis'
+        assert span.error == 0
+        assert span.get_tag('redis.raw_command') == u'GET cheese'
+        assert span.get_metric('redis.args_length') == 2
+        assert span.resource == 'GET cheese'
 
     def test_pipeline(self):
         with self.r.pipeline(transaction=False) as p:
@@ -56,15 +55,15 @@ class TestRedisPatch(BaseTracerTestCase):
             p.execute()
 
         spans = self.get_spans()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         span = spans[0]
-        eq_(span.service, self.TEST_SERVICE)
-        eq_(span.name, 'redis.command')
-        eq_(span.resource, u'SET blah 32\nRPUSH foo éé\nHGETALL xxx')
-        eq_(span.span_type, 'redis')
-        eq_(span.error, 0)
-        eq_(span.get_tag('redis.raw_command'), u'SET blah 32\nRPUSH foo éé\nHGETALL xxx')
-        eq_(span.get_metric('redis.pipeline_length'), 3)
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'redis.command'
+        assert span.resource == u'SET blah 32\nRPUSH foo éé\nHGETALL xxx'
+        assert span.span_type == 'redis'
+        assert span.error == 0
+        assert span.get_tag('redis.raw_command') == u'SET blah 32\nRPUSH foo éé\nHGETALL xxx'
+        assert span.get_metric('redis.pipeline_length') == 3
 
     def test_patch_unpatch(self):
         tracer = get_dummy_tracer()
@@ -80,7 +79,7 @@ class TestRedisPatch(BaseTracerTestCase):
 
         spans = writer.pop()
         assert spans, spans
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
         # Test unpatch
         unpatch()
@@ -100,4 +99,4 @@ class TestRedisPatch(BaseTracerTestCase):
 
         spans = writer.pop()
         assert spans, spans
-        eq_(len(spans), 1)
+        assert len(spans) == 1

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -1,3 +1,4 @@
+import pytest
 import requests
 from requests import Session
 from requests.exceptions import MissingSchema
@@ -7,7 +8,6 @@ from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.requests import patch, unpatch
 from ddtrace.ext import errors, http
-from nose.tools import assert_raises, eq_
 
 from tests.opentracer.utils import init_tracer
 
@@ -40,19 +40,19 @@ class BaseRequestTestCase(object):
 class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
     def test_resource_path(self):
         out = self.session.get(URL_200)
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.get_tag("http.url"), URL_200)
+        assert s.get_tag("http.url") == URL_200
 
     def test_tracer_disabled(self):
         # ensure all valid combinations of args / kwargs work
         self.tracer.enabled = False
         out = self.session.get(URL_200)
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 0)
+        assert len(spans) == 0
 
     def test_args_kwargs(self):
         # ensure all valid combinations of args / kwargs work
@@ -67,13 +67,13 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         for args, kwargs in inputs:
             # ensure a traced request works with these args
             out = self.session.request(*args, **kwargs)
-            eq_(out.status_code, 200)
+            assert out.status_code == 200
             # validation
             spans = self.tracer.writer.pop()
-            eq_(len(spans), 1)
+            assert len(spans) == 1
             s = spans[0]
-            eq_(s.get_tag(http.METHOD), 'GET')
-            eq_(s.get_tag(http.STATUS_CODE), '200')
+            assert s.get_tag(http.METHOD) == 'GET'
+            assert s.get_tag(http.STATUS_CODE) == '200'
 
     def test_untraced_request(self):
         # ensure the unpatch removes tracing
@@ -81,10 +81,10 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         untraced = Session()
 
         out = untraced.get(URL_200)
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
         # validation
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 0)
+        assert len(spans) == 0
 
     def test_double_patch(self):
         # ensure that double patch doesn't duplicate instrumentation
@@ -93,21 +93,21 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         setattr(session, 'datadog_tracer', self.tracer)
 
         out = session.get(URL_200)
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
 
     def test_200(self):
         out = self.session.get(URL_200)
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
         # validation
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.get_tag(http.METHOD), 'GET')
-        eq_(s.get_tag(http.STATUS_CODE), '200')
-        eq_(s.error, 0)
-        eq_(s.span_type, http.TYPE)
+        assert s.get_tag(http.METHOD) == 'GET'
+        assert s.get_tag(http.STATUS_CODE) == '200'
+        assert s.error == 0
+        assert s.span_type == http.TYPE
 
     def test_200_send(self):
         # when calling send directly
@@ -115,55 +115,55 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         req = self.session.prepare_request(req)
 
         out = self.session.send(req)
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
         # validation
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.get_tag(http.METHOD), 'GET')
-        eq_(s.get_tag(http.STATUS_CODE), '200')
-        eq_(s.error, 0)
-        eq_(s.span_type, http.TYPE)
+        assert s.get_tag(http.METHOD) == 'GET'
+        assert s.get_tag(http.STATUS_CODE) == '200'
+        assert s.error == 0
+        assert s.span_type == http.TYPE
 
     def test_200_query_string(self):
         # ensure query string is removed before adding url to metadata
         out = self.session.get(URL_200 + '?key=value&key2=value2')
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
         # validation
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.get_tag(http.METHOD), 'GET')
-        eq_(s.get_tag(http.STATUS_CODE), '200')
-        eq_(s.get_tag(http.URL), URL_200)
-        eq_(s.error, 0)
-        eq_(s.span_type, http.TYPE)
+        assert s.get_tag(http.METHOD) == 'GET'
+        assert s.get_tag(http.STATUS_CODE) == '200'
+        assert s.get_tag(http.URL) == URL_200
+        assert s.error == 0
+        assert s.span_type == http.TYPE
 
     def test_requests_module_200(self):
         # ensure the requests API is instrumented even without
         # using a `Session` directly
         with override_global_tracer(self.tracer):
             out = requests.get(URL_200)
-            eq_(out.status_code, 200)
+            assert out.status_code == 200
             # validation
             spans = self.tracer.writer.pop()
-            eq_(len(spans), 1)
+            assert len(spans) == 1
             s = spans[0]
-            eq_(s.get_tag(http.METHOD), 'GET')
-            eq_(s.get_tag(http.STATUS_CODE), '200')
-            eq_(s.error, 0)
-            eq_(s.span_type, http.TYPE)
+            assert s.get_tag(http.METHOD) == 'GET'
+            assert s.get_tag(http.STATUS_CODE) == '200'
+            assert s.error == 0
+            assert s.span_type == http.TYPE
 
     def test_post_500(self):
         out = self.session.post(URL_500)
         # validation
-        eq_(out.status_code, 500)
+        assert out.status_code == 500
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.get_tag(http.METHOD), 'POST')
-        eq_(s.get_tag(http.STATUS_CODE), '500')
-        eq_(s.error, 1)
+        assert s.get_tag(http.METHOD) == 'POST'
+        assert s.get_tag(http.STATUS_CODE) == '500'
+        assert s.error == 1
 
     def test_non_existant_url(self):
         try:
@@ -174,10 +174,10 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
             assert 0, "expected error"
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.get_tag(http.METHOD), 'GET')
-        eq_(s.error, 1)
+        assert s.get_tag(http.METHOD) == 'GET'
+        assert s.error == 1
         assert "Failed to establish a new connection" in s.get_tag(errors.MSG)
         assert "Failed to establish a new connection" in s.get_tag(errors.STACK)
         assert "Traceback (most recent call last)" in s.get_tag(errors.STACK)
@@ -185,66 +185,66 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
 
     def test_500(self):
         out = self.session.get(URL_500)
-        eq_(out.status_code, 500)
+        assert out.status_code == 500
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.get_tag(http.METHOD), 'GET')
-        eq_(s.get_tag(http.STATUS_CODE), '500')
-        eq_(s.error, 1)
+        assert s.get_tag(http.METHOD) == 'GET'
+        assert s.get_tag(http.STATUS_CODE) == '500'
+        assert s.error == 1
 
     def test_default_service_name(self):
         # ensure a default service name is set
         out = self.session.get(URL_200)
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
 
-        eq_(s.service, 'requests')
+        assert s.service == 'requests'
 
     def test_user_set_service_name(self):
         # ensure a service name set by the user has precedence
         cfg = config.get_from(self.session)
         cfg['service_name'] = 'clients'
         out = self.session.get(URL_200)
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
 
-        eq_(s.service, 'clients')
+        assert s.service == 'clients'
 
     def test_parent_service_name_precedence(self):
         # ensure the parent service name has precedence if the value
         # is not set by the user
         with self.tracer.trace('parent.span', service='web'):
             out = self.session.get(URL_200)
-            eq_(out.status_code, 200)
+            assert out.status_code == 200
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         s = spans[1]
 
-        eq_(s.name, 'requests.request')
-        eq_(s.service, 'web')
+        assert s.name == 'requests.request'
+        assert s.service == 'web'
 
     def test_parent_without_service_name(self):
         # ensure the default value is used if the parent
         # doesn't have a service
         with self.tracer.trace('parent.span'):
             out = self.session.get(URL_200)
-            eq_(out.status_code, 200)
+            assert out.status_code == 200
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         s = spans[1]
 
-        eq_(s.name, 'requests.request')
-        eq_(s.service, 'requests')
+        assert s.name == 'requests.request'
+        assert s.service == 'requests'
 
     def test_user_service_name_precedence(self):
         # ensure the user service name takes precedence over
@@ -253,14 +253,14 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         cfg['service_name'] = 'clients'
         with self.tracer.trace('parent.span', service='web'):
             out = self.session.get(URL_200)
-            eq_(out.status_code, 200)
+            assert out.status_code == 200
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
         s = spans[1]
 
-        eq_(s.name, 'requests.request')
-        eq_(s.service, 'clients')
+        assert s.name == 'requests.request'
+        assert s.service == 'clients'
 
     def test_split_by_domain(self):
         # ensure a service name is generated by the domain name
@@ -268,13 +268,13 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         cfg = config.get_from(self.session)
         cfg['split_by_domain'] = True
         out = self.session.get(URL_200)
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
 
-        eq_(s.service, 'httpbin.org')
+        assert s.service == 'httpbin.org'
 
     def test_split_by_domain_precedence(self):
         # ensure the split by domain has precedence all the time
@@ -282,64 +282,64 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         cfg['split_by_domain'] = True
         cfg['service_name'] = 'intake'
         out = self.session.get(URL_200)
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
 
-        eq_(s.service, 'httpbin.org')
+        assert s.service == 'httpbin.org'
 
     def test_split_by_domain_wrong(self):
         # ensure the split by domain doesn't crash in case of a wrong URL;
         # in that case, no spans are created
         cfg = config.get_from(self.session)
         cfg['split_by_domain'] = True
-        with assert_raises(MissingSchema):
+        with pytest.raises(MissingSchema):
             self.session.get('http:/some>thing')
 
         # We are wrapping `requests.Session.send` and this error gets thrown before that function
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 0)
+        assert len(spans) == 0
 
     def test_split_by_domain_remove_auth_in_url(self):
         # ensure that auth details are stripped from URL
         cfg = config.get_from(self.session)
         cfg['split_by_domain'] = True
         out = self.session.get('http://user:pass@httpbin.org')
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
 
-        eq_(s.service, 'httpbin.org')
+        assert s.service == 'httpbin.org'
 
     def test_split_by_domain_includes_port(self):
         # ensure that port is included if present in URL
         cfg = config.get_from(self.session)
         cfg['split_by_domain'] = True
         out = self.session.get('http://httpbin.org:80')
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
 
-        eq_(s.service, 'httpbin.org:80')
+        assert s.service == 'httpbin.org:80'
 
     def test_split_by_domain_includes_port_path(self):
         # ensure that port is included if present in URL but not path
         cfg = config.get_from(self.session)
         cfg['split_by_domain'] = True
         out = self.session.get('http://httpbin.org:80/anything/v1/foo')
-        eq_(out.status_code, 200)
+        assert out.status_code == 200
 
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
 
-        eq_(s.service, 'httpbin.org:80')
+        assert s.service == 'httpbin.org:80'
 
     def test_200_ot(self):
         """OpenTracing version of test_200."""
@@ -348,44 +348,44 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
 
         with ot_tracer.start_active_span('requests_get'):
             out = self.session.get(URL_200)
-            eq_(out.status_code, 200)
+            assert out.status_code == 200
 
         # validation
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 2)
+        assert len(spans) == 2
 
         ot_span, dd_span = spans
 
         # confirm the parenting
-        eq_(ot_span.parent_id, None)
-        eq_(dd_span.parent_id, ot_span.span_id)
+        assert ot_span.parent_id is None
+        assert dd_span.parent_id == ot_span.span_id
 
-        eq_(ot_span.name, 'requests_get')
-        eq_(ot_span.service, 'requests_svc')
+        assert ot_span.name == 'requests_get'
+        assert ot_span.service == 'requests_svc'
 
-        eq_(dd_span.get_tag(http.METHOD), 'GET')
-        eq_(dd_span.get_tag(http.STATUS_CODE), '200')
-        eq_(dd_span.error, 0)
-        eq_(dd_span.span_type, http.TYPE)
+        assert dd_span.get_tag(http.METHOD) == 'GET'
+        assert dd_span.get_tag(http.STATUS_CODE) == '200'
+        assert dd_span.error == 0
+        assert dd_span.span_type == http.TYPE
 
     def test_request_and_response_headers(self):
         # Disabled when not configured
         self.session.get(URL_200, headers={'my-header': 'my_value'})
         spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.get_tag('http.request.headers.my-header'), None)
-        eq_(s.get_tag('http.response.headers.access-control-allow-origin'), None)
+        assert s.get_tag('http.request.headers.my-header') is None
+        assert s.get_tag('http.response.headers.access-control-allow-origin') is None
 
         # Enabled when explicitly configured
         with self.override_config('requests', {}):
             config.requests.http.trace_headers(['my-header', 'access-control-allow-origin'])
             self.session.get(URL_200, headers={'my-header': 'my_value'})
             spans = self.tracer.writer.pop()
-        eq_(len(spans), 1)
+        assert len(spans) == 1
         s = spans[0]
-        eq_(s.get_tag('http.request.headers.my-header'), 'my_value')
-        eq_(s.get_tag('http.response.headers.access-control-allow-origin'), '*')
+        assert s.get_tag('http.request.headers.my-header') == 'my_value'
+        assert s.get_tag('http.response.headers.access-control-allow-origin') == '*'
 
     def test_analytics_integration_default(self):
         """

--- a/tests/contrib/requests/test_requests_distributed.py
+++ b/tests/contrib/requests/test_requests_distributed.py
@@ -1,5 +1,4 @@
 from requests_mock import Adapter
-from nose.tools import eq_, assert_in, assert_not_in
 
 from ddtrace import config
 
@@ -13,18 +12,18 @@ class TestRequestsDistributed(BaseRequestTestCase, BaseTracerTestCase):
         # This is because the parent_id can only been known within such a callback,
         # as it's defined on the requests span, which is not available when calling register_uri
         headers = request.headers
-        assert_in('x-datadog-trace-id', headers)
-        assert_in('x-datadog-parent-id', headers)
-        eq_(str(root_span.trace_id), headers['x-datadog-trace-id'])
+        assert 'x-datadog-trace-id' in headers
+        assert 'x-datadog-parent-id' in headers
+        assert str(root_span.trace_id) == headers['x-datadog-trace-id']
         req_span = root_span.context.get_current_span()
-        eq_('requests.request', req_span.name)
-        eq_(str(req_span.span_id), headers['x-datadog-parent-id'])
+        assert 'requests.request' == req_span.name
+        assert str(req_span.span_id) == headers['x-datadog-parent-id']
         return True
 
     def headers_not_here(self, tracer, request):
         headers = request.headers
-        assert_not_in('x-datadog-trace-id', headers)
-        assert_not_in('x-datadog-parent-id', headers)
+        assert 'x-datadog-trace-id' not in headers
+        assert 'x-datadog-parent-id' not in headers
         return True
 
     def test_propagation_default(self):
@@ -37,8 +36,8 @@ class TestRequestsDistributed(BaseRequestTestCase, BaseTracerTestCase):
                 return self.headers_here(self.tracer, request, root)
             adapter.register_uri('GET', 'mock://datadog/foo', additional_matcher=matcher, text='bar')
             resp = self.session.get('mock://datadog/foo')
-            eq_(200, resp.status_code)
-            eq_('bar', resp.text)
+            assert 200 == resp.status_code
+            assert 'bar' == resp.text
 
     def test_propagation_true_global(self):
         # distributed tracing can be enabled globally
@@ -51,8 +50,8 @@ class TestRequestsDistributed(BaseRequestTestCase, BaseTracerTestCase):
                     return self.headers_here(self.tracer, request, root)
                 adapter.register_uri('GET', 'mock://datadog/foo', additional_matcher=matcher, text='bar')
                 resp = self.session.get('mock://datadog/foo')
-                eq_(200, resp.status_code)
-                eq_('bar', resp.text)
+                assert 200 == resp.status_code
+                assert 'bar' == resp.text
 
     def test_propagation_false_global(self):
         # distributed tracing can be disabled globally
@@ -65,8 +64,8 @@ class TestRequestsDistributed(BaseRequestTestCase, BaseTracerTestCase):
                     return self.headers_not_here(self.tracer, request)
                 adapter.register_uri('GET', 'mock://datadog/foo', additional_matcher=matcher, text='bar')
                 resp = self.session.get('mock://datadog/foo')
-                eq_(200, resp.status_code)
-                eq_('bar', resp.text)
+                assert 200 == resp.status_code
+                assert 'bar' == resp.text
 
     def test_propagation_true(self):
         # ensure distributed tracing can be enabled manually
@@ -80,15 +79,15 @@ class TestRequestsDistributed(BaseRequestTestCase, BaseTracerTestCase):
                 return self.headers_here(self.tracer, request, root)
             adapter.register_uri('GET', 'mock://datadog/foo', additional_matcher=matcher, text='bar')
             resp = self.session.get('mock://datadog/foo')
-            eq_(200, resp.status_code)
-            eq_('bar', resp.text)
+            assert 200 == resp.status_code
+            assert 'bar' == resp.text
 
         spans = self.tracer.writer.spans
         root, req = spans
-        eq_('root', root.name)
-        eq_('requests.request', req.name)
-        eq_(root.trace_id, req.trace_id)
-        eq_(root.span_id, req.parent_id)
+        assert 'root' == root.name
+        assert 'requests.request' == req.name
+        assert root.trace_id == req.trace_id
+        assert root.span_id == req.parent_id
 
     def test_propagation_false(self):
         # ensure distributed tracing can be disabled manually
@@ -102,8 +101,8 @@ class TestRequestsDistributed(BaseRequestTestCase, BaseTracerTestCase):
                 return self.headers_not_here(self.tracer, request)
             adapter.register_uri('GET', 'mock://datadog/foo', additional_matcher=matcher, text='bar')
             resp = self.session.get('mock://datadog/foo')
-            eq_(200, resp.status_code)
-            eq_('bar', resp.text)
+            assert 200 == resp.status_code
+            assert 'bar' == resp.text
 
     def test_propagation_true_legacy_default(self):
         # [Backward compatibility]: ensure users can switch the distributed
@@ -116,15 +115,15 @@ class TestRequestsDistributed(BaseRequestTestCase, BaseTracerTestCase):
                 return self.headers_here(self.tracer, request, root)
             adapter.register_uri('GET', 'mock://datadog/foo', additional_matcher=matcher, text='bar')
             resp = self.session.get('mock://datadog/foo')
-            eq_(200, resp.status_code)
-            eq_('bar', resp.text)
+            assert 200 == resp.status_code
+            assert 'bar' == resp.text
 
         spans = self.tracer.writer.spans
         root, req = spans
-        eq_('root', root.name)
-        eq_('requests.request', req.name)
-        eq_(root.trace_id, req.trace_id)
-        eq_(root.span_id, req.parent_id)
+        assert 'root' == root.name
+        assert 'requests.request' == req.name
+        assert root.trace_id == req.trace_id
+        assert root.span_id == req.parent_id
 
     def test_propagation_true_legacy(self):
         # [Backward compatibility]: ensure users can switch the distributed
@@ -138,15 +137,15 @@ class TestRequestsDistributed(BaseRequestTestCase, BaseTracerTestCase):
                 return self.headers_here(self.tracer, request, root)
             adapter.register_uri('GET', 'mock://datadog/foo', additional_matcher=matcher, text='bar')
             resp = self.session.get('mock://datadog/foo')
-            eq_(200, resp.status_code)
-            eq_('bar', resp.text)
+            assert 200 == resp.status_code
+            assert 'bar' == resp.text
 
         spans = self.tracer.writer.spans
         root, req = spans
-        eq_('root', root.name)
-        eq_('requests.request', req.name)
-        eq_(root.trace_id, req.trace_id)
-        eq_(root.span_id, req.parent_id)
+        assert 'root' == root.name
+        assert 'requests.request' == req.name
+        assert root.trace_id == req.trace_id
+        assert root.span_id == req.parent_id
 
     def test_propagation_false_legacy(self):
         # [Backward compatibility]: ensure users can switch the distributed
@@ -160,5 +159,5 @@ class TestRequestsDistributed(BaseRequestTestCase, BaseTracerTestCase):
                 return self.headers_not_here(self.tracer, request)
             adapter.register_uri('GET', 'mock://datadog/foo', additional_matcher=matcher, text='bar')
             resp = self.session.get('mock://datadog/foo')
-            eq_(200, resp.status_code)
-            eq_('bar', resp.text)
+            assert 200 == resp.status_code
+            assert 'bar' == resp.text

--- a/tests/contrib/sqlalchemy/test_mysql.py
+++ b/tests/contrib/sqlalchemy/test_mysql.py
@@ -1,6 +1,5 @@
 from sqlalchemy.exc import ProgrammingError
-
-from nose.tools import assert_raises
+import pytest
 
 from .mixins import SQLAlchemyTestMixin
 from ..config import MYSQL_CONFIG
@@ -27,7 +26,7 @@ class MysqlConnectorTestCase(SQLAlchemyTestMixin, BaseTracerTestCase):
 
     def test_engine_execute_errors(self):
         # ensures that SQL errors are reported
-        with assert_raises(ProgrammingError):
+        with pytest.raises(ProgrammingError):
             with self.connection() as conn:
                 conn.execute('SELECT * FROM a_wrong_table').fetchall()
 

--- a/tests/contrib/sqlalchemy/test_patch.py
+++ b/tests/contrib/sqlalchemy/test_patch.py
@@ -1,7 +1,6 @@
 import sqlalchemy
 
 from unittest import TestCase
-from nose.tools import eq_, ok_
 
 from ddtrace import Pin
 from ddtrace.contrib.sqlalchemy import patch, unpatch
@@ -35,32 +34,32 @@ class SQLAlchemyPatchTestCase(TestCase):
     def test_engine_traced(self):
         # ensures that the engine is traced
         rows = self.conn.execute('SELECT 1').fetchall()
-        eq_(len(rows), 1)
+        assert len(rows) == 1
 
         traces = self.tracer.writer.pop_traces()
         # trace composition
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
         # check subset of span fields
-        eq_(span.name, 'postgres.query')
-        eq_(span.service, 'postgres')
-        eq_(span.error, 0)
-        ok_(span.duration > 0)
+        assert span.name == 'postgres.query'
+        assert span.service == 'postgres'
+        assert span.error == 0
+        assert span.duration > 0
 
     def test_engine_pin_service(self):
         # ensures that the engine service is updated with the PIN object
         Pin.override(self.engine, service='replica-db')
         rows = self.conn.execute('SELECT 1').fetchall()
-        eq_(len(rows), 1)
+        assert len(rows) == 1
 
         traces = self.tracer.writer.pop_traces()
         # trace composition
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
         span = traces[0][0]
         # check subset of span fields
-        eq_(span.name, 'postgres.query')
-        eq_(span.service, 'replica-db')
-        eq_(span.error, 0)
-        ok_(span.duration > 0)
+        assert span.name == 'postgres.query'
+        assert span.service == 'replica-db'
+        assert span.error == 0
+        assert span.duration > 0

--- a/tests/contrib/sqlalchemy/test_postgres.py
+++ b/tests/contrib/sqlalchemy/test_postgres.py
@@ -1,8 +1,8 @@
 import psycopg2
 
-from nose.tools import assert_raises
-
 from sqlalchemy.exc import ProgrammingError
+
+import pytest
 
 from .mixins import SQLAlchemyTestMixin
 from ..config import POSTGRES_CONFIG
@@ -29,7 +29,7 @@ class PostgresTestCase(SQLAlchemyTestMixin, BaseTracerTestCase):
 
     def test_engine_execute_errors(self):
         # ensures that SQL errors are reported
-        with assert_raises(ProgrammingError):
+        with pytest.raises(ProgrammingError):
             with self.connection() as conn:
                 conn.execute('SELECT * FROM a_wrong_table').fetchall()
 

--- a/tests/contrib/sqlalchemy/test_sqlite.py
+++ b/tests/contrib/sqlalchemy/test_sqlite.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_raises
+import pytest
 
 from sqlalchemy.exc import OperationalError
 
@@ -21,7 +21,7 @@ class SQLiteTestCase(SQLAlchemyTestMixin, BaseTracerTestCase):
 
     def test_engine_execute_errors(self):
         # ensures that SQL errors are reported
-        with assert_raises(OperationalError):
+        with pytest.raises(OperationalError):
             with self.connection() as conn:
                 conn.execute('SELECT * FROM a_wrong_table').fetchall()
 

--- a/tests/contrib/test_utils.py
+++ b/tests/contrib/test_utils.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_
-
 from functools import partial
 from ddtrace.utils.importlib import func_name
 
@@ -48,22 +46,22 @@ class TestContrib(object):
     """
     def test_func_name(self):
         # check that func_name works on anything callable, not only funcs.
-        eq_('nothing', some_function())
-        eq_('tests.contrib.test_utils.some_function', func_name(some_function))
+        assert 'nothing' == some_function()
+        assert 'tests.contrib.test_utils.some_function' == func_name(some_function)
 
         f = SomethingCallable()
-        eq_('something', f())
-        eq_('tests.contrib.test_utils.SomethingCallable', func_name(f))
+        assert 'something' == f()
+        assert 'tests.contrib.test_utils.SomethingCallable' == func_name(f)
 
-        eq_(f, f.me())
-        eq_('tests.contrib.test_utils.me', func_name(f.me))
-        eq_(3, f.add(1, 2))
-        eq_('tests.contrib.test_utils.add', func_name(f.add))
-        eq_(42, f.answer())
-        eq_('tests.contrib.test_utils.answer', func_name(f.answer))
+        assert f == f.me()
+        assert 'tests.contrib.test_utils.me' == func_name(f.me)
+        assert 3 == f.add(1, 2)
+        assert 'tests.contrib.test_utils.add' == func_name(f.add)
+        assert 42 == f.answer()
+        assert 'tests.contrib.test_utils.answer' == func_name(f.answer)
 
-        eq_('tests.contrib.test_utils.minus', func_name(minus))
-        eq_(5, minus_two(7))
-        eq_('partial', func_name(minus_two))
-        eq_(10, plus_three(7))
-        eq_('tests.contrib.test_utils.<lambda>', func_name(plus_three))
+        assert 'tests.contrib.test_utils.minus' == func_name(minus)
+        assert 5 == minus_two(7)
+        assert 'partial' == func_name(minus_two)
+        assert 10 == plus_three(7)
+        assert 'tests.contrib.test_utils.<lambda>' == func_name(plus_three)

--- a/tests/contrib/tornado/test_config.py
+++ b/tests/contrib/tornado/test_config.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_, ok_
-
 from ddtrace.filters import FilterRequestsOnUrl
 
 from .utils import TornadoTestCase
@@ -29,11 +27,11 @@ class TestTornadoSettings(TornadoTestCase):
 
     def test_tracer_is_properly_configured(self):
         # the tracer must be properly configured
-        eq_(self.tracer.tags, {'env': 'production', 'debug': 'false'})
-        eq_(self.tracer.enabled, False)
-        eq_(self.tracer.writer.api.hostname, 'dd-agent.service.consul')
-        eq_(self.tracer.writer.api.port, 8126)
+        assert self.tracer.tags == {'env': 'production', 'debug': 'false'}
+        assert self.tracer.enabled is False
+        assert self.tracer.writer.api.hostname == 'dd-agent.service.consul'
+        assert self.tracer.writer.api.port == 8126
         # settings are properly passed
-        ok_(self.tracer.writer._filters is not None)
-        eq_(len(self.tracer.writer._filters), 1)
-        ok_(isinstance(self.tracer.writer._filters[0], FilterRequestsOnUrl))
+        assert self.tracer.writer._filters is not None
+        assert len(self.tracer.writer._filters) == 1
+        assert isinstance(self.tracer.writer._filters[0], FilterRequestsOnUrl)

--- a/tests/contrib/tornado/test_executor_decorator.py
+++ b/tests/contrib/tornado/test_executor_decorator.py
@@ -1,6 +1,5 @@
 import unittest
 
-from nose.tools import eq_, ok_
 from ddtrace.contrib.tornado.compat import futures_available
 
 from tornado import version_info
@@ -16,95 +15,95 @@ class TestTornadoExecutor(TornadoTestCase):
     def test_on_executor_handler(self):
         # it should trace a handler that uses @run_on_executor
         response = self.fetch('/executor_handler/')
-        eq_(200, response.code)
+        assert 200 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(2, len(traces))
-        eq_(1, len(traces[0]))
-        eq_(1, len(traces[1]))
+        assert 2 == len(traces)
+        assert 1 == len(traces[0])
+        assert 1 == len(traces[1])
 
         # this trace yields the execution of the thread
         request_span = traces[1][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.ExecutorHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/executor_handler/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
-        ok_(request_span.duration >= 0.05)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.ExecutorHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/executor_handler/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
+        assert request_span.duration >= 0.05
 
         # this trace is executed in a different thread
         executor_span = traces[0][0]
-        eq_('tornado-web', executor_span.service)
-        eq_('tornado.executor.with', executor_span.name)
-        eq_(executor_span.parent_id, request_span.span_id)
-        eq_(0, executor_span.error)
-        ok_(executor_span.duration >= 0.05)
+        assert 'tornado-web' == executor_span.service
+        assert 'tornado.executor.with' == executor_span.name
+        assert executor_span.parent_id == request_span.span_id
+        assert 0 == executor_span.error
+        assert executor_span.duration >= 0.05
 
     @unittest.skipUnless(futures_available, 'Futures must be available to test direct submit')
     def test_on_executor_submit(self):
         # it should propagate the context when a handler uses directly the `executor.submit()`
         response = self.fetch('/executor_submit_handler/')
-        eq_(200, response.code)
+        assert 200 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(2, len(traces))
-        eq_(1, len(traces[0]))
-        eq_(1, len(traces[1]))
+        assert 2 == len(traces)
+        assert 1 == len(traces[0])
+        assert 1 == len(traces[1])
 
         # this trace yields the execution of the thread
         request_span = traces[1][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.ExecutorSubmitHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/executor_submit_handler/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
-        ok_(request_span.duration >= 0.05)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.ExecutorSubmitHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/executor_submit_handler/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
+        assert request_span.duration >= 0.05
 
         # this trace is executed in a different thread
         executor_span = traces[0][0]
-        eq_('tornado-web', executor_span.service)
-        eq_('tornado.executor.query', executor_span.name)
-        eq_(executor_span.parent_id, request_span.span_id)
-        eq_(0, executor_span.error)
-        ok_(executor_span.duration >= 0.05)
+        assert 'tornado-web' == executor_span.service
+        assert 'tornado.executor.query' == executor_span.name
+        assert executor_span.parent_id == request_span.span_id
+        assert 0 == executor_span.error
+        assert executor_span.duration >= 0.05
 
     def test_on_executor_exception_handler(self):
         # it should trace a handler that uses @run_on_executor
         response = self.fetch('/executor_exception/')
-        eq_(500, response.code)
+        assert 500 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(2, len(traces))
-        eq_(1, len(traces[0]))
-        eq_(1, len(traces[1]))
+        assert 2 == len(traces)
+        assert 1 == len(traces[0])
+        assert 1 == len(traces[1])
 
         # this trace yields the execution of the thread
         request_span = traces[1][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.ExecutorExceptionHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('500', request_span.get_tag('http.status_code'))
-        eq_('/executor_exception/', request_span.get_tag('http.url'))
-        eq_(1, request_span.error)
-        eq_('Ouch!', request_span.get_tag('error.msg'))
-        ok_('Exception: Ouch!' in request_span.get_tag('error.stack'))
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.ExecutorExceptionHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '500' == request_span.get_tag('http.status_code')
+        assert '/executor_exception/' == request_span.get_tag('http.url')
+        assert 1 == request_span.error
+        assert 'Ouch!' == request_span.get_tag('error.msg')
+        assert 'Exception: Ouch!' in request_span.get_tag('error.stack')
 
         # this trace is executed in a different thread
         executor_span = traces[0][0]
-        eq_('tornado-web', executor_span.service)
-        eq_('tornado.executor.with', executor_span.name)
-        eq_(executor_span.parent_id, request_span.span_id)
-        eq_(1, executor_span.error)
-        eq_('Ouch!', executor_span.get_tag('error.msg'))
-        ok_('Exception: Ouch!' in executor_span.get_tag('error.stack'))
+        assert 'tornado-web' == executor_span.service
+        assert 'tornado.executor.with' == executor_span.name
+        assert executor_span.parent_id == request_span.span_id
+        assert 1 == executor_span.error
+        assert 'Ouch!' == executor_span.get_tag('error.msg')
+        assert 'Exception: Ouch!' in executor_span.get_tag('error.stack')
 
     @unittest.skipIf(
         (version_info[0], version_info[1]) in [(4, 0), (4, 1)],
@@ -114,32 +113,32 @@ class TestTornadoExecutor(TornadoTestCase):
         # it should trace a handler that uses @run_on_executor
         # with the `executor` kwarg
         response = self.fetch('/executor_custom_handler/')
-        eq_(200, response.code)
+        assert 200 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(2, len(traces))
-        eq_(1, len(traces[0]))
-        eq_(1, len(traces[1]))
+        assert 2 == len(traces)
+        assert 1 == len(traces[0])
+        assert 1 == len(traces[1])
 
         # this trace yields the execution of the thread
         request_span = traces[1][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.ExecutorCustomHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/executor_custom_handler/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
-        ok_(request_span.duration >= 0.05)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.ExecutorCustomHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/executor_custom_handler/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
+        assert request_span.duration >= 0.05
 
         # this trace is executed in a different thread
         executor_span = traces[0][0]
-        eq_('tornado-web', executor_span.service)
-        eq_('tornado.executor.with', executor_span.name)
-        eq_(executor_span.parent_id, request_span.span_id)
-        eq_(0, executor_span.error)
-        ok_(executor_span.duration >= 0.05)
+        assert 'tornado-web' == executor_span.service
+        assert 'tornado.executor.with' == executor_span.name
+        assert executor_span.parent_id == request_span.span_id
+        assert 0 == executor_span.error
+        assert executor_span.duration >= 0.05
 
     @unittest.skipIf(
         (version_info[0], version_info[1]) in [(4, 0), (4, 1)],
@@ -148,24 +147,24 @@ class TestTornadoExecutor(TornadoTestCase):
     def test_on_executor_custom_args_kwarg(self):
         # it should raise an exception if the decorator is used improperly
         response = self.fetch('/executor_custom_args_handler/')
-        eq_(500, response.code)
+        assert 500 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         # this trace yields the execution of the thread
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.ExecutorCustomArgsHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('500', request_span.get_tag('http.status_code'))
-        eq_('/executor_custom_args_handler/', request_span.get_tag('http.url'))
-        eq_(1, request_span.error)
-        eq_('cannot combine positional and keyword args', request_span.get_tag('error.msg'))
-        ok_('ValueError' in request_span.get_tag('error.stack'))
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.ExecutorCustomArgsHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '500' == request_span.get_tag('http.status_code')
+        assert '/executor_custom_args_handler/' == request_span.get_tag('http.url')
+        assert 1 == request_span.error
+        assert 'cannot combine positional and keyword args' == request_span.get_tag('error.msg')
+        assert 'ValueError' in request_span.get_tag('error.stack')
 
     @unittest.skipUnless(futures_available, 'Futures must be available to test direct submit')
     def test_futures_double_instrumentation(self):
@@ -176,4 +175,4 @@ class TestTornadoExecutor(TornadoTestCase):
         from ddtrace.vendor.wrapt import BoundFunctionWrapper
 
         fn_wrapper = getattr(ThreadPoolExecutor.submit, '__wrapped__', None)
-        ok_(not isinstance(fn_wrapper, BoundFunctionWrapper))
+        assert not isinstance(fn_wrapper, BoundFunctionWrapper)

--- a/tests/contrib/tornado/test_safety.py
+++ b/tests/contrib/tornado/test_safety.py
@@ -1,7 +1,5 @@
 import threading
 
-from nose.tools import eq_
-
 from tornado import httpclient
 from tornado.testing import gen_test
 
@@ -24,8 +22,8 @@ class TestAsyncConcurrency(TornadoTestCase):
             http_client = httpclient.HTTPClient()
             url = self.get_url('/nested/')
             response = http_client.fetch(url)
-            eq_(200, response.code)
-            eq_('OK', response.body.decode('utf-8'))
+            assert 200 == response.code
+            assert 'OK' == response.body.decode('utf-8')
             # freeing file descriptors
             http_client.close()
 
@@ -40,8 +38,8 @@ class TestAsyncConcurrency(TornadoTestCase):
 
         # the trace is created
         traces = self.tracer.writer.pop_traces()
-        eq_(25, len(traces))
-        eq_(2, len(traces[0]))
+        assert 25 == len(traces)
+        assert 2 == len(traces[0])
 
 
 class TestAppSafety(TornadoTestCase):
@@ -55,10 +53,10 @@ class TestAppSafety(TornadoTestCase):
         unpatch()
 
         response = self.fetch('/success/')
-        eq_(200, response.code)
+        assert 200 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(0, len(traces))
+        assert 0 == len(traces)
 
     def test_trace_unpatch_not_traced(self):
         # the untrace must be safe if the app is not traced
@@ -66,10 +64,10 @@ class TestAppSafety(TornadoTestCase):
         unpatch()
 
         response = self.fetch('/success/')
-        eq_(200, response.code)
+        assert 200 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(0, len(traces))
+        assert 0 == len(traces)
 
     def test_trace_app_twice(self):
         # the application must not be traced multiple times
@@ -77,37 +75,37 @@ class TestAppSafety(TornadoTestCase):
         patch()
 
         response = self.fetch('/success/')
-        eq_(200, response.code)
+        assert 200 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
     def test_arbitrary_resource_querystring(self):
         # users inputs should not determine `span.resource` field
         response = self.fetch('/success/?magic_number=42')
-        eq_(200, response.code)
+        assert 200 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tests.contrib.tornado.web.app.SuccessHandler', request_span.resource)
-        eq_('/success/?magic_number=42', request_span.get_tag('http.url'))
+        assert 'tests.contrib.tornado.web.app.SuccessHandler' == request_span.resource
+        assert '/success/?magic_number=42' == request_span.get_tag('http.url')
 
     def test_arbitrary_resource_404(self):
         # users inputs should not determine `span.resource` field
         response = self.fetch('/does_not_exist/')
-        eq_(404, response.code)
+        assert 404 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tornado.web.ErrorHandler', request_span.resource)
-        eq_('/does_not_exist/', request_span.get_tag('http.url'))
+        assert 'tornado.web.ErrorHandler' == request_span.resource
+        assert '/does_not_exist/' == request_span.get_tag('http.url')
 
     @gen_test
     def test_futures_without_context(self):
@@ -123,12 +121,12 @@ class TestAppSafety(TornadoTestCase):
         yield executor.submit(job)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         # this trace yields the execution of the thread
         span = traces[0][0]
-        eq_('job', span.name)
+        assert 'job' == span.name
 
 
 class TestCustomAppSafety(TornadoTestCase):
@@ -147,7 +145,7 @@ class TestCustomAppSafety(TornadoTestCase):
         unpatch()
 
         response = self.fetch('/custom_handler/')
-        eq_(400, response.code)
+        assert 400 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(0, len(traces))
+        assert 0 == len(traces)

--- a/tests/contrib/tornado/test_stack_context.py
+++ b/tests/contrib/tornado/test_stack_context.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_, ok_
-
 from ddtrace.context import Context
 from ddtrace.contrib.tornado import TracerStackContext
 
@@ -11,14 +9,14 @@ class TestStackContext(TornadoTestCase):
     def test_without_stack_context(self):
         # without a TracerStackContext, propagation is not available
         ctx = self.tracer.context_provider.active()
-        ok_(ctx is None)
+        assert ctx is None
 
     def test_stack_context(self):
         # a TracerStackContext should automatically propagate a tracing context
         with TracerStackContext():
             ctx = self.tracer.context_provider.active()
 
-        ok_(ctx is not None)
+        assert ctx is not None
 
     def test_propagation_with_new_context(self):
         # inside a TracerStackContext it should be possible to set
@@ -30,10 +28,10 @@ class TestStackContext(TornadoTestCase):
                 sleep(0.01)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
-        eq_(traces[0][0].trace_id, 100)
-        eq_(traces[0][0].parent_id, 101)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
+        assert traces[0][0].trace_id == 100
+        assert traces[0][0].parent_id == 101
 
     def test_propagation_without_stack_context(self):
         # a Context is discarded if not set inside a TracerStackContext
@@ -43,7 +41,7 @@ class TestStackContext(TornadoTestCase):
             sleep(0.01)
 
         traces = self.tracer.writer.pop_traces()
-        eq_(len(traces), 1)
-        eq_(len(traces[0]), 1)
-        ok_(traces[0][0].trace_id != 100)
-        ok_(traces[0][0].parent_id != 101)
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
+        assert traces[0][0].trace_id != 100
+        assert traces[0][0].parent_id != 101

--- a/tests/contrib/tornado/test_tornado_template.py
+++ b/tests/contrib/tornado/test_tornado_template.py
@@ -1,6 +1,6 @@
 from tornado import template
 
-from nose.tools import eq_, ok_, assert_raises
+import pytest
 
 from .utils import TornadoTestCase
 
@@ -13,154 +13,154 @@ class TestTornadoTemplate(TornadoTestCase):
     def test_template_handler(self):
         # it should trace the template rendering
         response = self.fetch('/template/')
-        eq_(200, response.code)
-        eq_('This is a rendered page called "home"\n', response.body.decode('utf-8'))
+        assert 200 == response.code
+        assert 'This is a rendered page called "home"\n' == response.body.decode('utf-8')
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.TemplateHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/template/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.TemplateHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/template/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
 
         template_span = traces[0][1]
-        eq_('tornado-web', template_span.service)
-        eq_('tornado.template', template_span.name)
-        eq_('template', template_span.span_type)
-        eq_('templates/page.html', template_span.resource)
-        eq_('templates/page.html', template_span.get_tag('tornado.template_name'))
-        eq_(template_span.parent_id, request_span.span_id)
-        eq_(0, template_span.error)
+        assert 'tornado-web' == template_span.service
+        assert 'tornado.template' == template_span.name
+        assert 'template' == template_span.span_type
+        assert 'templates/page.html' == template_span.resource
+        assert 'templates/page.html' == template_span.get_tag('tornado.template_name')
+        assert template_span.parent_id == request_span.span_id
+        assert 0 == template_span.error
 
     def test_template_renderer(self):
         # it should trace the Template generation even outside web handlers
         t = template.Template('Hello {{ name }}!')
         value = t.generate(name='world')
-        eq_(value, b'Hello world!')
+        assert value == b'Hello world!'
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         template_span = traces[0][0]
-        eq_('tornado-web', template_span.service)
-        eq_('tornado.template', template_span.name)
-        eq_('template', template_span.span_type)
-        eq_('render_string', template_span.resource)
-        eq_('render_string', template_span.get_tag('tornado.template_name'))
-        eq_(0, template_span.error)
+        assert 'tornado-web' == template_span.service
+        assert 'tornado.template' == template_span.name
+        assert 'template' == template_span.span_type
+        assert 'render_string' == template_span.resource
+        assert 'render_string' == template_span.get_tag('tornado.template_name')
+        assert 0 == template_span.error
 
     def test_template_partials(self):
         # it should trace the template rendering when partials are used
         response = self.fetch('/template_partial/')
-        eq_(200, response.code)
-        eq_('This is a list:\n\n* python\n\n\n* go\n\n\n* ruby\n\n\n', response.body.decode('utf-8'))
+        assert 200 == response.code
+        assert 'This is a list:\n\n* python\n\n\n* go\n\n\n* ruby\n\n\n' == response.body.decode('utf-8')
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(5, len(traces[0]))
+        assert 1 == len(traces)
+        assert 5 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.TemplatePartialHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/template_partial/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.TemplatePartialHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/template_partial/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
 
         template_root = traces[0][1]
-        eq_('tornado-web', template_root.service)
-        eq_('tornado.template', template_root.name)
-        eq_('template', template_root.span_type)
-        eq_('templates/list.html', template_root.resource)
-        eq_('templates/list.html', template_root.get_tag('tornado.template_name'))
-        eq_(template_root.parent_id, request_span.span_id)
-        eq_(0, template_root.error)
+        assert 'tornado-web' == template_root.service
+        assert 'tornado.template' == template_root.name
+        assert 'template' == template_root.span_type
+        assert 'templates/list.html' == template_root.resource
+        assert 'templates/list.html' == template_root.get_tag('tornado.template_name')
+        assert template_root.parent_id == request_span.span_id
+        assert 0 == template_root.error
 
         template_span = traces[0][2]
-        eq_('tornado-web', template_span.service)
-        eq_('tornado.template', template_span.name)
-        eq_('template', template_span.span_type)
-        eq_('templates/item.html', template_span.resource)
-        eq_('templates/item.html', template_span.get_tag('tornado.template_name'))
-        eq_(template_span.parent_id, template_root.span_id)
-        eq_(0, template_span.error)
+        assert 'tornado-web' == template_span.service
+        assert 'tornado.template' == template_span.name
+        assert 'template' == template_span.span_type
+        assert 'templates/item.html' == template_span.resource
+        assert 'templates/item.html' == template_span.get_tag('tornado.template_name')
+        assert template_span.parent_id == template_root.span_id
+        assert 0 == template_span.error
 
         template_span = traces[0][3]
-        eq_('tornado-web', template_span.service)
-        eq_('tornado.template', template_span.name)
-        eq_('template', template_span.span_type)
-        eq_('templates/item.html', template_span.resource)
-        eq_('templates/item.html', template_span.get_tag('tornado.template_name'))
-        eq_(template_span.parent_id, template_root.span_id)
-        eq_(0, template_span.error)
+        assert 'tornado-web' == template_span.service
+        assert 'tornado.template' == template_span.name
+        assert 'template' == template_span.span_type
+        assert 'templates/item.html' == template_span.resource
+        assert 'templates/item.html' == template_span.get_tag('tornado.template_name')
+        assert template_span.parent_id == template_root.span_id
+        assert 0 == template_span.error
 
         template_span = traces[0][4]
-        eq_('tornado-web', template_span.service)
-        eq_('tornado.template', template_span.name)
-        eq_('template', template_span.span_type)
-        eq_('templates/item.html', template_span.resource)
-        eq_('templates/item.html', template_span.get_tag('tornado.template_name'))
-        eq_(template_span.parent_id, template_root.span_id)
-        eq_(0, template_span.error)
+        assert 'tornado-web' == template_span.service
+        assert 'tornado.template' == template_span.name
+        assert 'template' == template_span.span_type
+        assert 'templates/item.html' == template_span.resource
+        assert 'templates/item.html' == template_span.get_tag('tornado.template_name')
+        assert template_span.parent_id == template_root.span_id
+        assert 0 == template_span.error
 
     def test_template_exception_handler(self):
         # it should trace template rendering exceptions
         response = self.fetch('/template_exception/')
-        eq_(500, response.code)
+        assert 500 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.TemplateExceptionHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('500', request_span.get_tag('http.status_code'))
-        eq_('/template_exception/', request_span.get_tag('http.url'))
-        eq_(1, request_span.error)
-        ok_('ModuleThatDoesNotExist' in request_span.get_tag('error.msg'))
-        ok_('AttributeError' in request_span.get_tag('error.stack'))
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.TemplateExceptionHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '500' == request_span.get_tag('http.status_code')
+        assert '/template_exception/' == request_span.get_tag('http.url')
+        assert 1 == request_span.error
+        assert 'ModuleThatDoesNotExist' in request_span.get_tag('error.msg')
+        assert 'AttributeError' in request_span.get_tag('error.stack')
 
         template_span = traces[0][1]
-        eq_('tornado-web', template_span.service)
-        eq_('tornado.template', template_span.name)
-        eq_('template', template_span.span_type)
-        eq_('templates/exception.html', template_span.resource)
-        eq_('templates/exception.html', template_span.get_tag('tornado.template_name'))
-        eq_(template_span.parent_id, request_span.span_id)
-        eq_(1, template_span.error)
-        ok_('ModuleThatDoesNotExist' in template_span.get_tag('error.msg'))
-        ok_('AttributeError' in template_span.get_tag('error.stack'))
+        assert 'tornado-web' == template_span.service
+        assert 'tornado.template' == template_span.name
+        assert 'template' == template_span.span_type
+        assert 'templates/exception.html' == template_span.resource
+        assert 'templates/exception.html' == template_span.get_tag('tornado.template_name')
+        assert template_span.parent_id == request_span.span_id
+        assert 1 == template_span.error
+        assert 'ModuleThatDoesNotExist' in template_span.get_tag('error.msg')
+        assert 'AttributeError' in template_span.get_tag('error.stack')
 
     def test_template_renderer_exception(self):
         # it should trace the Template exceptions generation even outside web handlers
         t = template.Template('{% module ModuleThatDoesNotExist() %}')
-        with assert_raises(NameError):
+        with pytest.raises(NameError):
             t.generate()
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         template_span = traces[0][0]
-        eq_('tornado-web', template_span.service)
-        eq_('tornado.template', template_span.name)
-        eq_('template', template_span.span_type)
-        eq_('render_string', template_span.resource)
-        eq_('render_string', template_span.get_tag('tornado.template_name'))
-        eq_(1, template_span.error)
-        ok_('is not defined' in template_span.get_tag('error.msg'))
-        ok_('NameError' in template_span.get_tag('error.stack'))
+        assert 'tornado-web' == template_span.service
+        assert 'tornado.template' == template_span.name
+        assert 'template' == template_span.span_type
+        assert 'render_string' == template_span.resource
+        assert 'render_string' == template_span.get_tag('tornado.template_name')
+        assert 1 == template_span.error
+        assert 'is not defined' in template_span.get_tag('error.msg')
+        assert 'NameError' in template_span.get_tag('error.stack')

--- a/tests/contrib/tornado/test_tornado_web.py
+++ b/tests/contrib/tornado/test_tornado_web.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_, ok_
-
 from .web.app import CustomDefaultHandler
 from .utils import TornadoTestCase
 
@@ -16,221 +14,221 @@ class TestTornadoWeb(TornadoTestCase):
     def test_success_handler(self):
         # it should trace a handler that returns 200
         response = self.fetch('/success/')
-        eq_(200, response.code)
+        assert 200 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.SuccessHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/success/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.SuccessHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/success/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
 
     def test_nested_handler(self):
         # it should trace a handler that calls the tracer.trace() method
         # using the automatic Context retrieval
         response = self.fetch('/nested/')
-        eq_(200, response.code)
+        assert 200 == response.code
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
         # check request span
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.NestedHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/nested/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.NestedHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/nested/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
         # check nested span
         nested_span = traces[0][1]
-        eq_('tornado-web', nested_span.service)
-        eq_('tornado.sleep', nested_span.name)
-        eq_(0, nested_span.error)
+        assert 'tornado-web' == nested_span.service
+        assert 'tornado.sleep' == nested_span.name
+        assert 0 == nested_span.error
         # check durations because of the yield sleep
-        ok_(request_span.duration >= 0.05)
-        ok_(nested_span.duration >= 0.05)
+        assert request_span.duration >= 0.05
+        assert nested_span.duration >= 0.05
 
     def test_exception_handler(self):
         # it should trace a handler that raises an exception
         response = self.fetch('/exception/')
-        eq_(500, response.code)
+        assert 500 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.ExceptionHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('500', request_span.get_tag('http.status_code'))
-        eq_('/exception/', request_span.get_tag('http.url'))
-        eq_(1, request_span.error)
-        eq_('Ouch!', request_span.get_tag('error.msg'))
-        ok_('Exception: Ouch!' in request_span.get_tag('error.stack'))
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.ExceptionHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '500' == request_span.get_tag('http.status_code')
+        assert '/exception/' == request_span.get_tag('http.url')
+        assert 1 == request_span.error
+        assert 'Ouch!' == request_span.get_tag('error.msg')
+        assert 'Exception: Ouch!' in request_span.get_tag('error.stack')
 
     def test_http_exception_handler(self):
         # it should trace a handler that raises a Tornado HTTPError
         response = self.fetch('/http_exception/')
-        eq_(501, response.code)
+        assert 501 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.HTTPExceptionHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('501', request_span.get_tag('http.status_code'))
-        eq_('/http_exception/', request_span.get_tag('http.url'))
-        eq_(1, request_span.error)
-        eq_('HTTP 501: Not Implemented (unavailable)', request_span.get_tag('error.msg'))
-        ok_('HTTP 501: Not Implemented (unavailable)' in request_span.get_tag('error.stack'))
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.HTTPExceptionHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '501' == request_span.get_tag('http.status_code')
+        assert '/http_exception/' == request_span.get_tag('http.url')
+        assert 1 == request_span.error
+        assert 'HTTP 501: Not Implemented (unavailable)' == request_span.get_tag('error.msg')
+        assert 'HTTP 501: Not Implemented (unavailable)' in request_span.get_tag('error.stack')
 
     def test_http_exception_500_handler(self):
         # it should trace a handler that raises a Tornado HTTPError
         response = self.fetch('/http_exception_500/')
-        eq_(500, response.code)
+        assert 500 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.HTTPException500Handler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('500', request_span.get_tag('http.status_code'))
-        eq_('/http_exception_500/', request_span.get_tag('http.url'))
-        eq_(1, request_span.error)
-        eq_('HTTP 500: Server Error (server error)', request_span.get_tag('error.msg'))
-        ok_('HTTP 500: Server Error (server error)' in request_span.get_tag('error.stack'))
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.HTTPException500Handler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '500' == request_span.get_tag('http.status_code')
+        assert '/http_exception_500/' == request_span.get_tag('http.url')
+        assert 1 == request_span.error
+        assert 'HTTP 500: Server Error (server error)' == request_span.get_tag('error.msg')
+        assert 'HTTP 500: Server Error (server error)' in request_span.get_tag('error.stack')
 
     def test_sync_success_handler(self):
         # it should trace a synchronous handler that returns 200
         response = self.fetch('/sync_success/')
-        eq_(200, response.code)
+        assert 200 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.SyncSuccessHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/sync_success/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.SyncSuccessHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/sync_success/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
 
     def test_sync_exception_handler(self):
         # it should trace a handler that raises an exception
         response = self.fetch('/sync_exception/')
-        eq_(500, response.code)
+        assert 500 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.SyncExceptionHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('500', request_span.get_tag('http.status_code'))
-        eq_('/sync_exception/', request_span.get_tag('http.url'))
-        eq_(1, request_span.error)
-        eq_('Ouch!', request_span.get_tag('error.msg'))
-        ok_('Exception: Ouch!' in request_span.get_tag('error.stack'))
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.SyncExceptionHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '500' == request_span.get_tag('http.status_code')
+        assert '/sync_exception/' == request_span.get_tag('http.url')
+        assert 1 == request_span.error
+        assert 'Ouch!' == request_span.get_tag('error.msg')
+        assert 'Exception: Ouch!' in request_span.get_tag('error.stack')
 
     def test_404_handler(self):
         # it should trace 404
         response = self.fetch('/does_not_exist/')
-        eq_(404, response.code)
+        assert 404 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tornado.web.ErrorHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('404', request_span.get_tag('http.status_code'))
-        eq_('/does_not_exist/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tornado.web.ErrorHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '404' == request_span.get_tag('http.status_code')
+        assert '/does_not_exist/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
 
     def test_redirect_handler(self):
         # it should trace the built-in RedirectHandler
         response = self.fetch('/redirect/')
-        eq_(200, response.code)
+        assert 200 == response.code
 
         # we trace two different calls: the RedirectHandler and the SuccessHandler
         traces = self.tracer.writer.pop_traces()
-        eq_(2, len(traces))
-        eq_(1, len(traces[0]))
-        eq_(1, len(traces[1]))
+        assert 2 == len(traces)
+        assert 1 == len(traces[0])
+        assert 1 == len(traces[1])
 
         redirect_span = traces[0][0]
-        eq_('tornado-web', redirect_span.service)
-        eq_('tornado.request', redirect_span.name)
-        eq_('http', redirect_span.span_type)
-        eq_('tornado.web.RedirectHandler', redirect_span.resource)
-        eq_('GET', redirect_span.get_tag('http.method'))
-        eq_('301', redirect_span.get_tag('http.status_code'))
-        eq_('/redirect/', redirect_span.get_tag('http.url'))
-        eq_(0, redirect_span.error)
+        assert 'tornado-web' == redirect_span.service
+        assert 'tornado.request' == redirect_span.name
+        assert 'http' == redirect_span.span_type
+        assert 'tornado.web.RedirectHandler' == redirect_span.resource
+        assert 'GET' == redirect_span.get_tag('http.method')
+        assert '301' == redirect_span.get_tag('http.status_code')
+        assert '/redirect/' == redirect_span.get_tag('http.url')
+        assert 0 == redirect_span.error
 
         success_span = traces[1][0]
-        eq_('tornado-web', success_span.service)
-        eq_('tornado.request', success_span.name)
-        eq_('http', success_span.span_type)
-        eq_('tests.contrib.tornado.web.app.SuccessHandler', success_span.resource)
-        eq_('GET', success_span.get_tag('http.method'))
-        eq_('200', success_span.get_tag('http.status_code'))
-        eq_('/success/', success_span.get_tag('http.url'))
-        eq_(0, success_span.error)
+        assert 'tornado-web' == success_span.service
+        assert 'tornado.request' == success_span.name
+        assert 'http' == success_span.span_type
+        assert 'tests.contrib.tornado.web.app.SuccessHandler' == success_span.resource
+        assert 'GET' == success_span.get_tag('http.method')
+        assert '200' == success_span.get_tag('http.status_code')
+        assert '/success/' == success_span.get_tag('http.url')
+        assert 0 == success_span.error
 
     def test_static_handler(self):
         # it should trace the access to static files
         response = self.fetch('/statics/empty.txt')
-        eq_(200, response.code)
-        eq_('Static file\n', response.body.decode('utf-8'))
+        assert 200 == response.code
+        assert 'Static file\n' == response.body.decode('utf-8')
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tornado.web.StaticFileHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/statics/empty.txt', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tornado.web.StaticFileHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/statics/empty.txt' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
 
     def test_propagation(self):
         # it should trace a handler that returns 200 with a propagated context
@@ -240,24 +238,24 @@ class TestTornadoWeb(TornadoTestCase):
             'x-datadog-sampling-priority': '2'
         }
         response = self.fetch('/success/', headers=headers)
-        eq_(200, response.code)
+        assert 200 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         request_span = traces[0][0]
 
         # simple sanity check on the span
-        eq_('tornado.request', request_span.name)
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/success/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
+        assert 'tornado.request' == request_span.name
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/success/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
 
         # check propagation
-        eq_(1234, request_span.trace_id)
-        eq_(4567, request_span.parent_id)
-        eq_(2, request_span.get_metric(SAMPLING_PRIORITY_KEY))
+        assert 1234 == request_span.trace_id
+        assert 4567 == request_span.parent_id
+        assert 2 == request_span.get_metric(SAMPLING_PRIORITY_KEY)
 
     def test_success_handler_ot(self):
         """OpenTracing version of test_success_handler."""
@@ -265,29 +263,29 @@ class TestTornadoWeb(TornadoTestCase):
 
         with ot_tracer.start_active_span('tornado_op'):
             response = self.fetch('/success/')
-            eq_(200, response.code)
+            assert 200 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
         # dd_span will start and stop before the ot_span finishes
         ot_span, dd_span = traces[0]
 
         # confirm the parenting
-        eq_(ot_span.parent_id, None)
-        eq_(dd_span.parent_id, ot_span.span_id)
+        assert ot_span.parent_id is None
+        assert dd_span.parent_id == ot_span.span_id
 
-        eq_(ot_span.name, 'tornado_op')
-        eq_(ot_span.service, 'tornado_svc')
+        assert ot_span.name == 'tornado_op'
+        assert ot_span.service == 'tornado_svc'
 
-        eq_('tornado-web', dd_span.service)
-        eq_('tornado.request', dd_span.name)
-        eq_('http', dd_span.span_type)
-        eq_('tests.contrib.tornado.web.app.SuccessHandler', dd_span.resource)
-        eq_('GET', dd_span.get_tag('http.method'))
-        eq_('200', dd_span.get_tag('http.status_code'))
-        eq_('/success/', dd_span.get_tag('http.url'))
-        eq_(0, dd_span.error)
+        assert 'tornado-web' == dd_span.service
+        assert 'tornado.request' == dd_span.name
+        assert 'http' == dd_span.span_type
+        assert 'tests.contrib.tornado.web.app.SuccessHandler' == dd_span.resource
+        assert 'GET' == dd_span.get_tag('http.method')
+        assert '200' == dd_span.get_tag('http.status_code')
+        assert '/success/' == dd_span.get_tag('http.url')
+        assert 0 == dd_span.error
 
 
 class TestTornadoWebAnalyticsDefault(TornadoTestCase):
@@ -417,19 +415,19 @@ class TestNoPropagationTornadoWeb(TornadoTestCase):
             'x-datadog-origin': 'synthetics',
         }
         response = self.fetch('/success/', headers=headers)
-        eq_(200, response.code)
+        assert 200 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         request_span = traces[0][0]
 
         # simple sanity check on the span
-        eq_('tornado.request', request_span.name)
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/success/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
+        assert 'tornado.request' == request_span.name
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/success/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
 
         # check non-propagation
         assert request_span.trace_id != 1234
@@ -452,18 +450,18 @@ class TestCustomTornadoWeb(TornadoTestCase):
     def test_custom_default_handler(self):
         # it should trace any call that uses a custom default handler
         response = self.fetch('/custom_handler/')
-        eq_(400, response.code)
+        assert 400 == response.code
 
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(1, len(traces[0]))
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.CustomDefaultHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('400', request_span.get_tag('http.status_code'))
-        eq_('/custom_handler/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.CustomDefaultHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '400' == request_span.get_tag('http.status_code')
+        assert '/custom_handler/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error

--- a/tests/contrib/tornado/test_wrap_decorator.py
+++ b/tests/contrib/tornado/test_wrap_decorator.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_, ok_
-
 from .utils import TornadoTestCase
 
 
@@ -10,168 +8,168 @@ class TestTornadoWebWrapper(TornadoTestCase):
     def test_nested_wrap_handler(self):
         # it should trace a handler that calls a coroutine
         response = self.fetch('/nested_wrap/')
-        eq_(200, response.code)
+        assert 200 == response.code
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
         # check request span
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.NestedWrapHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/nested_wrap/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.NestedWrapHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/nested_wrap/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
         # check nested span
         nested_span = traces[0][1]
-        eq_('tornado-web', nested_span.service)
-        eq_('tornado.coro', nested_span.name)
-        eq_(0, nested_span.error)
+        assert 'tornado-web' == nested_span.service
+        assert 'tornado.coro' == nested_span.name
+        assert 0 == nested_span.error
         # check durations because of the yield sleep
-        ok_(request_span.duration >= 0.05)
-        ok_(nested_span.duration >= 0.05)
+        assert request_span.duration >= 0.05
+        assert nested_span.duration >= 0.05
 
     def test_nested_exception_wrap_handler(self):
         # it should trace a handler that calls a coroutine that raises an exception
         response = self.fetch('/nested_exception_wrap/')
-        eq_(500, response.code)
+        assert 500 == response.code
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
         # check request span
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.NestedExceptionWrapHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('500', request_span.get_tag('http.status_code'))
-        eq_('/nested_exception_wrap/', request_span.get_tag('http.url'))
-        eq_(1, request_span.error)
-        eq_('Ouch!', request_span.get_tag('error.msg'))
-        ok_('Exception: Ouch!' in request_span.get_tag('error.stack'))
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.NestedExceptionWrapHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '500' == request_span.get_tag('http.status_code')
+        assert '/nested_exception_wrap/' == request_span.get_tag('http.url')
+        assert 1 == request_span.error
+        assert 'Ouch!' == request_span.get_tag('error.msg')
+        assert 'Exception: Ouch!' in request_span.get_tag('error.stack')
         # check nested span
         nested_span = traces[0][1]
-        eq_('tornado-web', nested_span.service)
-        eq_('tornado.coro', nested_span.name)
-        eq_(1, nested_span.error)
-        eq_('Ouch!', nested_span.get_tag('error.msg'))
-        ok_('Exception: Ouch!' in nested_span.get_tag('error.stack'))
+        assert 'tornado-web' == nested_span.service
+        assert 'tornado.coro' == nested_span.name
+        assert 1 == nested_span.error
+        assert 'Ouch!' == nested_span.get_tag('error.msg')
+        assert 'Exception: Ouch!' in nested_span.get_tag('error.stack')
         # check durations because of the yield sleep
-        ok_(request_span.duration >= 0.05)
-        ok_(nested_span.duration >= 0.05)
+        assert request_span.duration >= 0.05
+        assert nested_span.duration >= 0.05
 
     def test_sync_nested_wrap_handler(self):
         # it should trace a handler that calls a coroutine
         response = self.fetch('/sync_nested_wrap/')
-        eq_(200, response.code)
+        assert 200 == response.code
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
         # check request span
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.SyncNestedWrapHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/sync_nested_wrap/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.SyncNestedWrapHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/sync_nested_wrap/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
         # check nested span
         nested_span = traces[0][1]
-        eq_('tornado-web', nested_span.service)
-        eq_('tornado.func', nested_span.name)
-        eq_(0, nested_span.error)
+        assert 'tornado-web' == nested_span.service
+        assert 'tornado.func' == nested_span.name
+        assert 0 == nested_span.error
         # check durations because of the yield sleep
-        ok_(request_span.duration >= 0.05)
-        ok_(nested_span.duration >= 0.05)
+        assert request_span.duration >= 0.05
+        assert nested_span.duration >= 0.05
 
     def test_sync_nested_exception_wrap_handler(self):
         # it should trace a handler that calls a coroutine that raises an exception
         response = self.fetch('/sync_nested_exception_wrap/')
-        eq_(500, response.code)
+        assert 500 == response.code
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
         # check request span
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.SyncNestedExceptionWrapHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('500', request_span.get_tag('http.status_code'))
-        eq_('/sync_nested_exception_wrap/', request_span.get_tag('http.url'))
-        eq_(1, request_span.error)
-        eq_('Ouch!', request_span.get_tag('error.msg'))
-        ok_('Exception: Ouch!' in request_span.get_tag('error.stack'))
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.SyncNestedExceptionWrapHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '500' == request_span.get_tag('http.status_code')
+        assert '/sync_nested_exception_wrap/' == request_span.get_tag('http.url')
+        assert 1 == request_span.error
+        assert 'Ouch!' == request_span.get_tag('error.msg')
+        assert 'Exception: Ouch!' in request_span.get_tag('error.stack')
         # check nested span
         nested_span = traces[0][1]
-        eq_('tornado-web', nested_span.service)
-        eq_('tornado.func', nested_span.name)
-        eq_(1, nested_span.error)
-        eq_('Ouch!', nested_span.get_tag('error.msg'))
-        ok_('Exception: Ouch!' in nested_span.get_tag('error.stack'))
+        assert 'tornado-web' == nested_span.service
+        assert 'tornado.func' == nested_span.name
+        assert 1 == nested_span.error
+        assert 'Ouch!' == nested_span.get_tag('error.msg')
+        assert 'Exception: Ouch!' in nested_span.get_tag('error.stack')
         # check durations because of the yield sleep
-        ok_(request_span.duration >= 0.05)
-        ok_(nested_span.duration >= 0.05)
+        assert request_span.duration >= 0.05
+        assert nested_span.duration >= 0.05
 
     def test_nested_wrap_executor_handler(self):
         # it should trace a handler that calls a blocking function in a different executor
         response = self.fetch('/executor_wrap_handler/')
-        eq_(200, response.code)
+        assert 200 == response.code
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
         # check request span
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.ExecutorWrapHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('200', request_span.get_tag('http.status_code'))
-        eq_('/executor_wrap_handler/', request_span.get_tag('http.url'))
-        eq_(0, request_span.error)
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.ExecutorWrapHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '200' == request_span.get_tag('http.status_code')
+        assert '/executor_wrap_handler/' == request_span.get_tag('http.url')
+        assert 0 == request_span.error
         # check nested span in the executor
         nested_span = traces[0][1]
-        eq_('tornado-web', nested_span.service)
-        eq_('tornado.executor.wrap', nested_span.name)
-        eq_(0, nested_span.error)
+        assert 'tornado-web' == nested_span.service
+        assert 'tornado.executor.wrap' == nested_span.name
+        assert 0 == nested_span.error
         # check durations because of the yield sleep
-        ok_(request_span.duration >= 0.05)
-        ok_(nested_span.duration >= 0.05)
+        assert request_span.duration >= 0.05
+        assert nested_span.duration >= 0.05
 
     def test_nested_exception_wrap_executor_handler(self):
         # it should trace a handler that calls a blocking function in a different
         # executor that raises an exception
         response = self.fetch('/executor_wrap_exception/')
-        eq_(500, response.code)
+        assert 500 == response.code
         traces = self.tracer.writer.pop_traces()
-        eq_(1, len(traces))
-        eq_(2, len(traces[0]))
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
         # check request span
         request_span = traces[0][0]
-        eq_('tornado-web', request_span.service)
-        eq_('tornado.request', request_span.name)
-        eq_('http', request_span.span_type)
-        eq_('tests.contrib.tornado.web.app.ExecutorExceptionWrapHandler', request_span.resource)
-        eq_('GET', request_span.get_tag('http.method'))
-        eq_('500', request_span.get_tag('http.status_code'))
-        eq_('/executor_wrap_exception/', request_span.get_tag('http.url'))
-        eq_(1, request_span.error)
-        eq_('Ouch!', request_span.get_tag('error.msg'))
-        ok_('Exception: Ouch!' in request_span.get_tag('error.stack'))
+        assert 'tornado-web' == request_span.service
+        assert 'tornado.request' == request_span.name
+        assert 'http' == request_span.span_type
+        assert 'tests.contrib.tornado.web.app.ExecutorExceptionWrapHandler' == request_span.resource
+        assert 'GET' == request_span.get_tag('http.method')
+        assert '500' == request_span.get_tag('http.status_code')
+        assert '/executor_wrap_exception/' == request_span.get_tag('http.url')
+        assert 1 == request_span.error
+        assert 'Ouch!' == request_span.get_tag('error.msg')
+        assert 'Exception: Ouch!' in request_span.get_tag('error.stack')
         # check nested span
         nested_span = traces[0][1]
-        eq_('tornado-web', nested_span.service)
-        eq_('tornado.executor.wrap', nested_span.name)
-        eq_(1, nested_span.error)
-        eq_('Ouch!', nested_span.get_tag('error.msg'))
-        ok_('Exception: Ouch!' in nested_span.get_tag('error.stack'))
+        assert 'tornado-web' == nested_span.service
+        assert 'tornado.executor.wrap' == nested_span.name
+        assert 1 == nested_span.error
+        assert 'Ouch!' == nested_span.get_tag('error.msg')
+        assert 'Exception: Ouch!' in nested_span.get_tag('error.stack')
         # check durations because of the yield sleep
-        ok_(request_span.duration >= 0.05)
-        ok_(nested_span.duration >= 0.05)
+        assert request_span.duration >= 0.05
+        assert nested_span.duration >= 0.05

--- a/tests/propagation/test_http.py
+++ b/tests/propagation/test_http.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-from nose.tools import eq_
 from tests.test_tracer import get_dummy_tracer
 
 from ddtrace.propagation.http import (
@@ -27,15 +26,15 @@ class TestHttpPropagation(TestCase):
             propagator = HTTPPropagator()
             propagator.inject(span.context, headers)
 
-            eq_(int(headers[HTTP_HEADER_TRACE_ID]), span.trace_id)
-            eq_(int(headers[HTTP_HEADER_PARENT_ID]), span.span_id)
-            eq_(
-                int(headers[HTTP_HEADER_SAMPLING_PRIORITY]),
-                span.context.sampling_priority,
+            assert int(headers[HTTP_HEADER_TRACE_ID]) == span.trace_id
+            assert int(headers[HTTP_HEADER_PARENT_ID]) == span.span_id
+            assert (
+                int(headers[HTTP_HEADER_SAMPLING_PRIORITY]) ==
+                span.context.sampling_priority
             )
-            eq_(
-                headers[HTTP_HEADER_ORIGIN],
-                span.context._dd_origin,
+            assert (
+                headers[HTTP_HEADER_ORIGIN] ==
+                span.context._dd_origin
             )
 
     def test_extract(self):
@@ -53,10 +52,10 @@ class TestHttpPropagation(TestCase):
         tracer.context_provider.activate(context)
 
         with tracer.trace("local_root_span") as span:
-            eq_(span.trace_id, 1234)
-            eq_(span.parent_id, 5678)
-            eq_(span.context.sampling_priority, 1)
-            eq_(span.context._dd_origin, "synthetics")
+            assert span.trace_id == 1234
+            assert span.parent_id == 5678
+            assert span.context.sampling_priority == 1
+            assert span.context._dd_origin == "synthetics"
 
     def test_WSGI_extract(self):
         """Ensure we support the WSGI formatted headers as well."""
@@ -74,7 +73,7 @@ class TestHttpPropagation(TestCase):
         tracer.context_provider.activate(context)
 
         with tracer.trace("local_root_span") as span:
-            eq_(span.trace_id, 1234)
-            eq_(span.parent_id, 5678)
-            eq_(span.context.sampling_priority, 1)
-            eq_(span.context._dd_origin, "synthetics")
+            assert span.trace_id == 1234
+            assert span.parent_id == 5678
+            assert span.context.sampling_priority == 1
+            assert span.context._dd_origin == "synthetics"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,6 @@ import re
 import warnings
 
 from unittest import TestCase
-from nose.tools import eq_, ok_
 
 from tests.test_tracer import get_dummy_tracer
 from ddtrace.api import API, Response
@@ -74,11 +73,11 @@ class APITests(TestCase):
 
             r = Response.from_http_response(ResponseMock(k))
             js = r.get_json()
-            eq_(v['js'], js)
+            assert v['js'] == js
             if 'log' in v:
                 log.assert_called_once()
                 msg = log.call_args[0][0] % log.call_args[0][1:]
-                ok_(re.match(v['log'], msg), msg)
+                assert re.match(v['log'], msg), msg
 
     @mock.patch('ddtrace.compat.httplib.HTTPConnection')
     def test_put_connection_close(self, HTTPConnection):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -3,7 +3,7 @@
 import sys
 
 # Third party
-from nose.tools import eq_, ok_, assert_raises
+import pytest
 
 # Project
 from ddtrace.compat import to_unicode, PY2, reraise, get_connection_response
@@ -17,56 +17,56 @@ if PY2:
         def test_to_unicode_string(self):
             # Calling `compat.to_unicode` on a non-unicode string
             res = to_unicode('test')
-            eq_(type(res), unicode)
-            eq_(res, 'test')
+            assert type(res) == unicode
+            assert res == 'test'
 
         def test_to_unicode_unicode_encoded(self):
             # Calling `compat.to_unicode` on a unicode encoded string
             res = to_unicode('\xc3\xbf')
-            eq_(type(res), unicode)
-            eq_(res, u'ÿ')
+            assert type(res) == unicode
+            assert res == u'ÿ'
 
         def test_to_unicode_unicode_double_decode(self):
             # Calling `compat.to_unicode` on a unicode decoded string
             # This represents the double-decode issue, which can cause a `UnicodeEncodeError`
             #   `'\xc3\xbf'.decode('utf-8').decode('utf-8')`
             res = to_unicode('\xc3\xbf'.decode('utf-8'))
-            eq_(type(res), unicode)
-            eq_(res, u'ÿ')
+            assert type(res) == unicode
+            assert res == u'ÿ'
 
         def test_to_unicode_unicode_string(self):
             # Calling `compat.to_unicode` on a unicode string
             res = to_unicode(u'ÿ')
-            eq_(type(res), unicode)
-            eq_(res, u'ÿ')
+            assert type(res) == unicode
+            assert res == u'ÿ'
 
         def test_to_unicode_bytearray(self):
             # Calling `compat.to_unicode` with a `bytearray` containing unicode
             res = to_unicode(bytearray('\xc3\xbf'))
-            eq_(type(res), unicode)
-            eq_(res, u'ÿ')
+            assert type(res) == unicode
+            assert res == u'ÿ'
 
         def test_to_unicode_bytearray_double_decode(self):
             #  Calling `compat.to_unicode` with an already decoded `bytearray`
             # This represents the double-decode issue, which can cause a `UnicodeEncodeError`
             #   `bytearray('\xc3\xbf').decode('utf-8').decode('utf-8')`
             res = to_unicode(bytearray('\xc3\xbf').decode('utf-8'))
-            eq_(type(res), unicode)
-            eq_(res, u'ÿ')
+            assert type(res) == unicode
+            assert res == u'ÿ'
 
         def test_to_unicode_non_string(self):
             #  Calling `compat.to_unicode` on non-string types
-            eq_(to_unicode(1), u'1')
-            eq_(to_unicode(True), u'True')
-            eq_(to_unicode(None), u'None')
-            eq_(to_unicode(dict(key='value')), u'{\'key\': \'value\'}')
+            assert to_unicode(1) == u'1'
+            assert to_unicode(True) == u'True'
+            assert to_unicode(None) == u'None'
+            assert to_unicode(dict(key='value')) == u'{\'key\': \'value\'}'
 
         def test_get_connection_response(self):
             """Ensure that buffering is in kwargs."""
 
             class MockConn(object):
                 def getresponse(self, *args, **kwargs):
-                    ok_('buffering' in kwargs)
+                    assert 'buffering' in kwargs
 
             mock = MockConn()
             get_connection_response(mock)
@@ -76,40 +76,40 @@ else:
         def test_to_unicode_string(self):
             # Calling `compat.to_unicode` on a non-unicode string
             res = to_unicode('test')
-            eq_(type(res), str)
-            eq_(res, 'test')
+            assert type(res) == str
+            assert res == 'test'
 
         def test_to_unicode_unicode_encoded(self):
             # Calling `compat.to_unicode` on a unicode encoded string
             res = to_unicode('\xff')
-            eq_(type(res), str)
-            eq_(res, 'ÿ')
+            assert type(res) == str
+            assert res == 'ÿ'
 
         def test_to_unicode_unicode_string(self):
             # Calling `compat.to_unicode` on a unicode string
             res = to_unicode('ÿ')
-            eq_(type(res), str)
-            eq_(res, 'ÿ')
+            assert type(res) == str
+            assert res == 'ÿ'
 
         def test_to_unicode_bytearray(self):
             # Calling `compat.to_unicode` with a `bytearray` containing unicode """
             res = to_unicode(bytearray('\xff', 'utf-8'))
-            eq_(type(res), str)
-            eq_(res, 'ÿ')
+            assert type(res) == str
+            assert res == 'ÿ'
 
         def test_to_unicode_non_string(self):
             # Calling `compat.to_unicode` on non-string types
-            eq_(to_unicode(1), '1')
-            eq_(to_unicode(True), 'True')
-            eq_(to_unicode(None), 'None')
-            eq_(to_unicode(dict(key='value')), '{\'key\': \'value\'}')
+            assert to_unicode(1) == '1'
+            assert to_unicode(True) == 'True'
+            assert to_unicode(None) == 'None'
+            assert to_unicode(dict(key='value')) == '{\'key\': \'value\'}'
 
         def test_get_connection_response(self):
             """Ensure that buffering is NOT in kwargs."""
 
             class MockConn(object):
                 def getresponse(self, *args, **kwargs):
-                    ok_('buffering' not in kwargs)
+                    assert 'buffering' not in kwargs
 
             mock = MockConn()
             get_connection_response(mock)
@@ -121,7 +121,7 @@ class TestPy2Py3Compat(object):
     """
     def test_reraise(self):
         # ensure the `raise` function is Python 2/3 compatible
-        with assert_raises(Exception) as ex:
+        with pytest.raises(Exception) as ex:
             try:
                 raise Exception('Ouch!')
             except Exception:
@@ -135,4 +135,4 @@ class TestPy2Py3Compat(object):
                     pass
                 # this call must be Python 2 and 3 compatible
                 raise reraise(typ, val, tb)
-        eq_(ex.exception.args[0], 'Ouch!')
+        assert ex.value.args[0] == 'Ouch!'

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -3,7 +3,6 @@ import mock
 import threading
 
 from unittest import TestCase
-from nose.tools import eq_, ok_
 from tests.test_tracer import get_dummy_tracer
 
 from ddtrace.span import Span
@@ -35,17 +34,17 @@ class TestTracingContext(TestCase):
         ctx = Context()
         span = Span(tracer=None, name='fake_span')
         ctx.add_span(span)
-        eq_(1, len(ctx._trace))
-        eq_('fake_span', ctx._trace[0].name)
-        eq_(ctx, span.context)
+        assert 1 == len(ctx._trace)
+        assert 'fake_span' == ctx._trace[0].name
+        assert ctx == span.context
 
     def test_context_sampled(self):
         # a context is sampled if the spans are sampled
         ctx = Context()
         span = Span(tracer=None, name='fake_span')
         ctx.add_span(span)
-        ok_(ctx._sampled is True)
-        ok_(ctx.sampling_priority is None)
+        assert ctx._sampled is True
+        assert ctx.sampling_priority is None
 
     def test_context_priority(self):
         # a context is sampled if the spans are sampled
@@ -58,27 +57,27 @@ class TestTracingContext(TestCase):
             # set to 0 or -1. It would stay false even even with priority set to 2.
             # The only criteria to send (or not) the spans to the agent should be
             # this "sampled" attribute, as it's tightly related to the trace weight.
-            ok_(ctx._sampled is True, 'priority has no impact on sampled status')
-            eq_(priority, ctx.sampling_priority)
+            assert ctx._sampled is True, 'priority has no impact on sampled status'
+            assert priority == ctx.sampling_priority
 
     def test_current_span(self):
         # it should return the current active span
         ctx = Context()
         span = Span(tracer=None, name='fake_span')
         ctx.add_span(span)
-        eq_(span, ctx.get_current_span())
+        assert span == ctx.get_current_span()
 
     def test_current_root_span_none(self):
         # it should return none when there is no root span
         ctx = Context()
-        eq_(None, ctx.get_current_root_span())
+        assert ctx.get_current_root_span() is None
 
     def test_current_root_span(self):
         # it should return the current active root span
         ctx = Context()
         span = Span(tracer=None, name='fake_span')
         ctx.add_span(span)
-        eq_(span, ctx.get_current_root_span())
+        assert span == ctx.get_current_root_span()
 
     def test_close_span(self):
         # it should keep track of closed spans, moving
@@ -87,8 +86,8 @@ class TestTracingContext(TestCase):
         span = Span(tracer=None, name='fake_span')
         ctx.add_span(span)
         ctx.close_span(span)
-        eq_(1, ctx._finished_spans)
-        ok_(ctx.get_current_span() is None)
+        assert 1 == ctx._finished_spans
+        assert ctx.get_current_span() is None
 
     def test_get_trace(self):
         # it should return the internal trace structure
@@ -98,14 +97,14 @@ class TestTracingContext(TestCase):
         ctx.add_span(span)
         ctx.close_span(span)
         trace, sampled = ctx.get()
-        eq_(1, len(trace))
-        eq_(span, trace[0])
-        ok_(sampled is True)
+        assert 1 == len(trace)
+        assert span == trace[0]
+        assert sampled is True
         # the context should be empty
-        eq_(0, len(ctx._trace))
-        eq_(0, ctx._finished_spans)
-        ok_(ctx._current_span is None)
-        ok_(ctx._sampled is True)
+        assert 0 == len(ctx._trace)
+        assert 0 == ctx._finished_spans
+        assert ctx._current_span is None
+        assert ctx._sampled is True
 
     def test_get_trace_empty(self):
         # it should return None if the Context is not finished
@@ -113,8 +112,8 @@ class TestTracingContext(TestCase):
         span = Span(tracer=None, name='fake_span')
         ctx.add_span(span)
         trace, sampled = ctx.get()
-        ok_(trace is None)
-        ok_(sampled is None)
+        assert trace is None
+        assert sampled is None
 
     def test_partial_flush(self):
         """
@@ -278,12 +277,12 @@ class TestTracingContext(TestCase):
         span = Span(tracer=None, name='fake_span')
         ctx.add_span(span)
         ctx.close_span(span)
-        ok_(ctx.is_finished())
+        assert ctx.is_finished()
 
     def test_finished_empty(self):
         # a Context is not finished if it's empty
         ctx = Context()
-        ok_(ctx.is_finished() is False)
+        assert ctx.is_finished() is False
 
     @mock.patch('logging.Logger.debug')
     def test_log_unfinished_spans(self, log):
@@ -302,15 +301,15 @@ class TestTracingContext(TestCase):
         ctx.add_span(child_2)
         # close only the parent
         root.finish()
-        ok_(ctx.is_finished() is False)
+        assert ctx.is_finished() is False
         unfinished_spans_log = log.call_args_list[-3][0][2]
         child_1_log = log.call_args_list[-2][0][1]
         child_2_log = log.call_args_list[-1][0][1]
-        eq_(2, unfinished_spans_log)
-        ok_('name child_1' in child_1_log)
-        ok_('name child_2' in child_2_log)
-        ok_('duration 0.000000s' in child_1_log)
-        ok_('duration 0.000000s' in child_2_log)
+        assert 2 == unfinished_spans_log
+        assert 'name child_1' in child_1_log
+        assert 'name child_2' in child_2_log
+        assert 'duration 0.000000s' in child_1_log
+        assert 'duration 0.000000s' in child_2_log
 
     @mock.patch('logging.Logger.debug')
     def test_log_unfinished_spans_disabled(self, log):
@@ -329,11 +328,11 @@ class TestTracingContext(TestCase):
         ctx.add_span(child_2)
         # close only the parent
         root.finish()
-        ok_(ctx.is_finished() is False)
+        assert ctx.is_finished() is False
         # the logger has never been invoked to print unfinished spans
         for call, _ in log.call_args_list:
             msg = call[0]
-            ok_('the trace has %d unfinished spans' not in msg)
+            assert 'the trace has %d unfinished spans' not in msg
 
     @mock.patch('logging.Logger.debug')
     def test_log_unfinished_spans_when_ok(self, log):
@@ -353,7 +352,7 @@ class TestTracingContext(TestCase):
         # the logger has never been invoked to print unfinished spans
         for call, _ in log.call_args_list:
             msg = call[0]
-            ok_('the trace has %d unfinished spans' not in msg)
+            assert 'the trace has %d unfinished spans' not in msg
 
     def test_thread_safe(self):
         # the Context must be thread-safe
@@ -372,7 +371,7 @@ class TestTracingContext(TestCase):
         for t in threads:
             t.join()
 
-        eq_(100, len(ctx._trace))
+        assert 100 == len(ctx._trace)
 
     def test_clone(self):
         ctx = Context()
@@ -384,14 +383,14 @@ class TestTracingContext(TestCase):
         ctx.add_span(root)
         ctx.add_span(child)
         cloned_ctx = ctx.clone()
-        eq_(cloned_ctx._parent_trace_id, ctx._parent_trace_id)
-        eq_(cloned_ctx._parent_span_id, ctx._parent_span_id)
-        eq_(cloned_ctx._sampled, ctx._sampled)
-        eq_(cloned_ctx._sampling_priority, ctx._sampling_priority)
-        eq_(cloned_ctx._dd_origin, ctx._dd_origin)
-        eq_(cloned_ctx._current_span, ctx._current_span)
-        eq_(cloned_ctx._trace, [])
-        eq_(cloned_ctx._finished_spans, 0)
+        assert cloned_ctx._parent_trace_id == ctx._parent_trace_id
+        assert cloned_ctx._parent_span_id == ctx._parent_span_id
+        assert cloned_ctx._sampled == ctx._sampled
+        assert cloned_ctx._sampling_priority == ctx._sampling_priority
+        assert cloned_ctx._dd_origin == ctx._dd_origin
+        assert cloned_ctx._current_span == ctx._current_span
+        assert cloned_ctx._trace == []
+        assert cloned_ctx._finished_spans == 0
 
 
 class TestThreadContext(TestCase):
@@ -403,16 +402,16 @@ class TestThreadContext(TestCase):
         # asking the Context multiple times should return
         # always the same instance
         l_ctx = ThreadLocalContext()
-        eq_(l_ctx.get(), l_ctx.get())
+        assert l_ctx.get() == l_ctx.get()
 
     def test_set_context(self):
         # the Context can be set in the current Thread
         ctx = Context()
         local = ThreadLocalContext()
-        ok_(local.get() is not ctx)
+        assert local.get() is not ctx
 
         local.set(ctx)
-        ok_(local.get() is ctx)
+        assert local.get() is ctx
 
     def test_multiple_threads_multiple_context(self):
         # each thread should have it's own Context
@@ -422,7 +421,7 @@ class TestThreadContext(TestCase):
             ctx = l_ctx.get()
             span = Span(tracer=None, name='fake_span')
             ctx.add_span(span)
-            eq_(1, len(ctx._trace))
+            assert 1 == len(ctx._trace)
 
         threads = [threading.Thread(target=_fill_ctx) for _ in range(100)]
 
@@ -436,4 +435,4 @@ class TestThreadContext(TestCase):
         # the main instance should have an empty Context
         # because it has not been used in this thread
         ctx = l_ctx.get()
-        eq_(0, len(ctx._trace))
+        assert 0 == len(ctx._trace)

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -2,7 +2,6 @@ import json
 import msgpack
 
 from unittest import TestCase
-from nose.tools import eq_, ok_
 
 from ddtrace.span import Span
 from ddtrace.compat import msgpack_type, string_type
@@ -31,13 +30,13 @@ class TestEncoders(TestCase):
 
         # test the encoded output that should be a string
         # and the output must be flatten
-        ok_(isinstance(spans, string_type))
-        eq_(len(items), 2)
-        eq_(len(items[0]), 2)
-        eq_(len(items[1]), 2)
+        assert isinstance(spans, string_type)
+        assert len(items) == 2
+        assert len(items[0]) == 2
+        assert len(items[1]) == 2
         for i in range(2):
             for j in range(2):
-                eq_('client.testing', items[i][j]['name'])
+                assert 'client.testing' == items[i][j]['name']
 
     def test_join_encoded_json(self):
         # test encoding for JSON format
@@ -67,13 +66,13 @@ class TestEncoders(TestCase):
 
         # test the encoded output that should be a string
         # and the output must be flatten
-        ok_(isinstance(data, string_type))
-        eq_(len(items), 2)
-        eq_(len(items[0]), 2)
-        eq_(len(items[1]), 2)
+        assert isinstance(data, string_type)
+        assert len(items) == 2
+        assert len(items[0]) == 2
+        assert len(items[1]) == 2
         for i in range(2):
             for j in range(2):
-                eq_('client.testing', items[i][j]['name'])
+                assert 'client.testing' == items[i][j]['name']
 
     def test_encode_traces_msgpack(self):
         # test encoding for MsgPack format
@@ -93,13 +92,13 @@ class TestEncoders(TestCase):
 
         # test the encoded output that should be a string
         # and the output must be flatten
-        ok_(isinstance(spans, msgpack_type))
-        eq_(len(items), 2)
-        eq_(len(items[0]), 2)
-        eq_(len(items[1]), 2)
+        assert isinstance(spans, msgpack_type)
+        assert len(items) == 2
+        assert len(items[0]) == 2
+        assert len(items[1]) == 2
         for i in range(2):
             for j in range(2):
-                eq_(b'client.testing', items[i][j][b'name'])
+                assert b'client.testing' == items[i][j][b'name']
 
     def test_join_encoded_msgpack(self):
         # test encoding for MsgPack format
@@ -128,10 +127,10 @@ class TestEncoders(TestCase):
 
         # test the encoded output that should be a string
         # and the output must be flatten
-        ok_(isinstance(data, msgpack_type))
-        eq_(len(items), 2)
-        eq_(len(items[0]), 2)
-        eq_(len(items[1]), 2)
+        assert isinstance(data, msgpack_type)
+        assert len(items) == 2
+        assert len(items[0]) == 2
+        assert len(items[1]) == 2
         for i in range(2):
             for j in range(2):
-                eq_(b'client.testing', items[i][j][b'name'])
+                assert b'client.testing' == items[i][j][b'name']

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -1,7 +1,7 @@
 import mock
 from unittest import TestCase
 
-from nose.tools import eq_, ok_, assert_raises
+import pytest
 
 from ddtrace import config as global_config
 from ddtrace.settings import Config
@@ -21,7 +21,7 @@ class GlobalConfigTestCase(TestCase):
             'distributed_tracing': True,
         }
         self.config._add('requests', settings)
-        ok_(self.config.requests['distributed_tracing'] is True)
+        assert self.config.requests['distributed_tracing'] is True
 
     def test_settings_copy(self):
         # ensure that once an integration is registered, a copy
@@ -37,21 +37,21 @@ class GlobalConfigTestCase(TestCase):
 
         settings['distributed_tracing'] = False
         experimental['request_enqueuing'] = False
-        ok_(self.config.requests['distributed_tracing'] is True)
-        ok_(self.config.requests['experimental']['request_enqueuing'] is True)
+        assert self.config.requests['distributed_tracing'] is True
+        assert self.config.requests['experimental']['request_enqueuing'] is True
 
     def test_missing_integration_key(self):
         # ensure a meaningful exception is raised when an integration
         # that is not available is retrieved in the configuration
         # object
-        with assert_raises(KeyError) as e:
+        with pytest.raises(KeyError) as e:
             self.config.new_integration['some_key']
 
-        ok_(isinstance(e.exception, KeyError))
+        assert isinstance(e.value, KeyError)
 
     def test_global_configuration(self):
         # ensure a global configuration is available in the `ddtrace` module
-        ok_(isinstance(global_config, Config))
+        assert isinstance(global_config, Config)
 
     def test_settings_merge(self):
         """
@@ -61,7 +61,7 @@ class GlobalConfigTestCase(TestCase):
         """
         self.config.requests['split_by_domain'] = True
         self.config._add('requests', dict(split_by_domain=False))
-        eq_(self.config.requests['split_by_domain'], True)
+        assert self.config.requests['split_by_domain'] is True
 
     def test_settings_overwrite(self):
         """
@@ -71,7 +71,7 @@ class GlobalConfigTestCase(TestCase):
         """
         self.config.requests['split_by_domain'] = True
         self.config._add('requests', dict(split_by_domain=False), merge=False)
-        eq_(self.config.requests['split_by_domain'], False)
+        assert self.config.requests['split_by_domain'] is False
 
     def test_settings_merge_deep(self):
         """
@@ -92,8 +92,8 @@ class GlobalConfigTestCase(TestCase):
                 ),
             ),
         ))
-        eq_(self.config.requests['a']['b']['c'], True)
-        eq_(self.config.requests['a']['b']['d'], True)
+        assert self.config.requests['a']['b']['c'] is True
+        assert self.config.requests['a']['b']['d'] is True
 
     def test_settings_hook(self):
         """
@@ -108,13 +108,13 @@ class GlobalConfigTestCase(TestCase):
 
         # Create our span
         span = self.tracer.start_span('web.request')
-        ok_('web.request' not in span.meta)
+        assert 'web.request' not in span.meta
 
         # Emit the span
         self.config.web.hooks._emit('request', span)
 
         # Assert we updated the span as expected
-        eq_(span.get_tag('web.request'), '/')
+        assert span.get_tag('web.request') == '/'
 
     def test_settings_hook_args(self):
         """
@@ -130,15 +130,15 @@ class GlobalConfigTestCase(TestCase):
 
         # Create our span
         span = self.tracer.start_span('web.request')
-        ok_('web.request' not in span.meta)
+        assert 'web.request' not in span.meta
 
         # Emit the span
         # DEV: The actual values don't matter, we just want to test args + kwargs usage
         self.config.web.hooks._emit('request', span, 'request', response='response')
 
         # Assert we updated the span as expected
-        eq_(span.get_tag('web.request'), 'request')
-        eq_(span.get_tag('web.response'), 'response')
+        assert span.get_tag('web.request') == 'request'
+        assert span.get_tag('web.response') == 'response'
 
     def test_settings_hook_args_failure(self):
         """
@@ -154,14 +154,14 @@ class GlobalConfigTestCase(TestCase):
 
         # Create our span
         span = self.tracer.start_span('web.request')
-        ok_('web.request' not in span.meta)
+        assert 'web.request' not in span.meta
 
         # Emit the span
         # DEV: This also asserts that no exception was raised
         self.config.web.hooks._emit('request', span, 'request', response='response')
 
         # Assert we did not update the span
-        ok_('web.request' not in span.meta)
+        assert 'web.request' not in span.meta
 
     def test_settings_multiple_hooks(self):
         """
@@ -184,17 +184,17 @@ class GlobalConfigTestCase(TestCase):
 
         # Create our span
         span = self.tracer.start_span('web.request')
-        ok_('web.request' not in span.meta)
-        ok_('web.status' not in span.meta)
-        ok_('web.method' not in span.meta)
+        assert 'web.request' not in span.meta
+        assert 'web.status' not in span.meta
+        assert 'web.method' not in span.meta
 
         # Emit the span
         self.config.web.hooks._emit('request', span)
 
         # Assert we updated the span as expected
-        eq_(span.get_tag('web.request'), '/')
-        eq_(span.get_tag('web.status'), '200')
-        eq_(span.get_tag('web.method'), 'GET')
+        assert span.get_tag('web.request') == '/'
+        assert span.get_tag('web.status') == '200'
+        assert span.get_tag('web.method') == 'GET'
 
     def test_settings_hook_failure(self):
         """

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -1,7 +1,5 @@
 from unittest import TestCase
 
-from nose.tools import eq_, ok_
-
 from ddtrace import config
 from ddtrace.pin import Pin
 from ddtrace.settings import IntegrationConfig
@@ -23,7 +21,7 @@ class InstanceConfigTestCase(TestCase):
     def test_configuration_get_from(self):
         # ensure a dictionary is returned
         cfg = config.get_from(self.Klass)
-        ok_(isinstance(cfg, dict))
+        assert isinstance(cfg, dict)
 
     def test_configuration_get_from_twice(self):
         # ensure the configuration is the same if `get_from` is used
@@ -31,21 +29,21 @@ class InstanceConfigTestCase(TestCase):
         instance = self.Klass()
         cfg1 = config.get_from(instance)
         cfg2 = config.get_from(instance)
-        ok_(cfg1 is cfg2)
+        assert cfg1 is cfg2
 
     def test_configuration_set(self):
         # ensure the configuration can be updated in the Pin
         instance = self.Klass()
         cfg = config.get_from(instance)
         cfg['distributed_tracing'] = True
-        ok_(config.get_from(instance)['distributed_tracing'] is True)
+        assert config.get_from(instance)['distributed_tracing'] is True
 
     def test_global_configuration_inheritance(self):
         # ensure global configuration is inherited when it's set
         cfg = config.get_from(self.Klass)
         cfg['distributed_tracing'] = True
         instance = self.Klass()
-        ok_(config.get_from(instance)['distributed_tracing'] is True)
+        assert config.get_from(instance)['distributed_tracing'] is True
 
     def test_configuration_override_instance(self):
         # ensure instance configuration doesn't override global settings
@@ -54,8 +52,8 @@ class InstanceConfigTestCase(TestCase):
         instance = self.Klass()
         cfg = config.get_from(instance)
         cfg['distributed_tracing'] = False
-        ok_(config.get_from(self.Klass)['distributed_tracing'] is True)
-        ok_(config.get_from(instance)['distributed_tracing'] is False)
+        assert config.get_from(self.Klass)['distributed_tracing'] is True
+        assert config.get_from(instance)['distributed_tracing'] is False
 
     def test_service_name_for_pin(self):
         # ensure for backward compatibility that changing the service
@@ -63,7 +61,7 @@ class InstanceConfigTestCase(TestCase):
         Pin(service='intake').onto(self.Klass)
         instance = self.Klass()
         cfg = config.get_from(instance)
-        eq_(cfg['service_name'], 'intake')
+        assert cfg['service_name'] == 'intake'
 
     def test_service_attribute_priority(self):
         # ensure the `service` arg has highest priority over configuration
@@ -74,7 +72,7 @@ class InstanceConfigTestCase(TestCase):
         Pin(service='service', _config=global_config).onto(self.Klass)
         instance = self.Klass()
         cfg = config.get_from(instance)
-        eq_(cfg['service_name'], 'service')
+        assert cfg['service_name'] == 'service'
 
     def test_configuration_copy(self):
         # ensure when a Pin is used, the given configuration is copied
@@ -85,7 +83,7 @@ class InstanceConfigTestCase(TestCase):
         instance = self.Klass()
         cfg = config.get_from(instance)
         cfg['service_name'] = 'metrics'
-        eq_(global_config['service_name'], 'service')
+        assert global_config['service_name'] == 'service'
 
     def test_configuration_copy_upside_down(self):
         # ensure when a Pin is created, it does not copy the given configuration
@@ -100,7 +98,7 @@ class InstanceConfigTestCase(TestCase):
         instance = self.Klass()
         cfg = config.get_from(instance)
         # it should have users updated value
-        eq_(cfg['service_name'], 'metrics')
+        assert cfg['service_name'] == 'metrics'
 
     def test_config_attr_and_key(self):
         """

--- a/tests/test_pin.py
+++ b/tests/test_pin.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 
+import pytest
+
 from ddtrace import Pin
-from nose.tools import eq_, ok_, assert_raises
 
 
 class PinTestCase(TestCase):
@@ -22,8 +23,8 @@ class PinTestCase(TestCase):
         pin.onto(obj)
 
         got = Pin.get_from(obj)
-        eq_(got.service, pin.service)
-        ok_(got is pin)
+        assert got.service == pin.service
+        assert got is pin
 
     def test_pin_find(self):
         # ensure Pin will find the first available pin
@@ -43,17 +44,17 @@ class PinTestCase(TestCase):
 
         # We find the first pin (obj_b)
         pin = Pin._find(obj_c, obj_b, obj_a)
-        ok_(pin is not None)
-        eq_(pin.service, 'service-b')
+        assert pin is not None
+        assert pin.service == 'service-b'
 
         # We find the first pin (obj_a)
         pin = Pin._find(obj_a, obj_b, obj_c)
-        ok_(pin is not None)
-        eq_(pin.service, 'service-a')
+        assert pin is not None
+        assert pin.service == 'service-a'
 
         # We don't find a pin if none is there
         pin = Pin._find(obj_c, obj_c, obj_c)
-        ok_(pin is None)
+        assert pin is None
 
     def test_cant_pin_with_slots(self):
         # ensure a Pin can't be attached if the __slots__ is defined
@@ -65,12 +66,12 @@ class PinTestCase(TestCase):
 
         Pin(service='metrics').onto(obj)
         got = Pin.get_from(obj)
-        ok_(got is None)
+        assert got is None
 
     def test_cant_modify(self):
         # ensure a Pin is immutable once initialized
         pin = Pin(service='metrics')
-        with assert_raises(AttributeError):
+        with pytest.raises(AttributeError):
             pin.service = 'intake'
 
     def test_copy(self):
@@ -78,24 +79,24 @@ class PinTestCase(TestCase):
         p1 = Pin(service='metrics', app='flask', tags={'key': 'value'})
         p2 = p1.clone(service='intake')
         # values are the same
-        eq_(p1.service, 'metrics')
-        eq_(p2.service, 'intake')
-        eq_(p1.app, 'flask')
-        eq_(p2.app, 'flask')
+        assert p1.service == 'metrics'
+        assert p2.service == 'intake'
+        assert p1.app == 'flask'
+        assert p2.app == 'flask'
         # but it's a copy
-        ok_(p1.tags is not p2.tags)
-        ok_(p1._config is not p2._config)
+        assert p1.tags is not p2.tags
+        assert p1._config is not p2._config
         # of almost everything
-        ok_(p1.tracer is p2.tracer)
+        assert p1.tracer is p2.tracer
 
     def test_none(self):
         # ensure get_from returns None if a Pin is not available
-        ok_(Pin.get_from(None) is None)
+        assert Pin.get_from(None) is None
 
     def test_repr(self):
         # ensure the service name is in the string representation of the Pin
         pin = Pin(service='metrics')
-        ok_('metrics' in str(pin))
+        assert 'metrics' in str(pin)
 
     def test_override(self):
         # ensure Override works for an instance object
@@ -105,12 +106,12 @@ class PinTestCase(TestCase):
         Pin(service='metrics', app='flask').onto(A)
         a = A()
         Pin.override(a, app='django')
-        eq_(Pin.get_from(a).app, 'django')
-        eq_(Pin.get_from(a).service, 'metrics')
+        assert Pin.get_from(a).app == 'django'
+        assert Pin.get_from(a).service == 'metrics'
 
         b = A()
-        eq_(Pin.get_from(b).app, 'flask')
-        eq_(Pin.get_from(b).service, 'metrics')
+        assert Pin.get_from(b).app == 'flask'
+        assert Pin.get_from(b).service == 'metrics'
 
     def test_override_missing(self):
         # ensure overriding an instance doesn't override the Class
@@ -118,37 +119,37 @@ class PinTestCase(TestCase):
             pass
 
         a = A()
-        ok_(Pin.get_from(a) is None)
+        assert Pin.get_from(a) is None
         Pin.override(a, service='metrics')
-        eq_(Pin.get_from(a).service, 'metrics')
+        assert Pin.get_from(a).service == 'metrics'
 
         b = A()
-        ok_(Pin.get_from(b) is None)
+        assert Pin.get_from(b) is None
 
     def test_pin_config(self):
         # ensure `Pin` has a configuration object that can be modified
         obj = self.Obj()
         Pin.override(obj, service='metrics')
         pin = Pin.get_from(obj)
-        ok_(pin._config is not None)
+        assert pin._config is not None
         pin._config['distributed_tracing'] = True
-        ok_(pin._config['distributed_tracing'] is True)
+        assert pin._config['distributed_tracing'] is True
 
     def test_pin_config_is_a_copy(self):
         # ensure that when a `Pin` is cloned, the config is a copy
         obj = self.Obj()
         Pin.override(obj, service='metrics')
         p1 = Pin.get_from(obj)
-        ok_(p1._config is not None)
+        assert p1._config is not None
         p1._config['distributed_tracing'] = True
 
         Pin.override(obj, service='intake')
         p2 = Pin.get_from(obj)
-        ok_(p2._config is not None)
+        assert p2._config is not None
         p2._config['distributed_tracing'] = False
 
-        ok_(p1._config['distributed_tracing'] is True)
-        ok_(p2._config['distributed_tracing'] is False)
+        assert p1._config['distributed_tracing'] is True
+        assert p2._config['distributed_tracing'] is False
 
     def test_pin_does_not_override_global(self):
         # ensure that when a `Pin` is created from a class, the specific
@@ -162,12 +163,12 @@ class PinTestCase(TestCase):
 
         a = A()
         pin = Pin.get_from(a)
-        ok_(pin is not None)
-        ok_(pin._config['distributed_tracing'] is True)
+        assert pin is not None
+        assert pin._config['distributed_tracing'] is True
         pin._config['distributed_tracing'] = False
 
-        ok_(global_pin._config['distributed_tracing'] is True)
-        ok_(pin._config['distributed_tracing'] is False)
+        assert global_pin._config['distributed_tracing'] is True
+        assert pin._config['distributed_tracing'] is False
 
     def test_pin_does_not_override_global_with_new_instance(self):
         # ensure that when a `Pin` is created from a class, the specific
@@ -183,9 +184,9 @@ class PinTestCase(TestCase):
 
         a = A()
         pin = Pin.get_from(a)
-        ok_(pin is not None)
-        ok_(pin._config['distributed_tracing'] is True)
+        assert pin is not None
+        assert pin._config['distributed_tracing'] is True
         pin._config['distributed_tracing'] = False
 
-        ok_(global_pin._config['distributed_tracing'] is True)
-        ok_(pin._config['distributed_tracing'] is False)
+        assert global_pin._config['distributed_tracing'] is True
+        assert pin._config['distributed_tracing'] is False

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -1,6 +1,5 @@
 import time
 
-from nose.tools import eq_, ok_
 from unittest.case import SkipTest
 
 from ddtrace.context import Context
@@ -16,9 +15,9 @@ def test_ids():
     assert not s.parent_id
 
     s2 = Span(tracer=None, name='t', trace_id=1, span_id=2, parent_id=1)
-    eq_(s2.trace_id, 1)
-    eq_(s2.span_id, 2)
-    eq_(s2.parent_id, 1)
+    assert s2.trace_id == 1
+    assert s2.span_id == 2
+    assert s2.parent_id == 1
 
 
 def test_tags():
@@ -32,7 +31,7 @@ def test_tags():
         'b': '1',
         'c': '1',
     }
-    eq_(d['meta'], expected)
+    assert d['meta'] == expected
 
 
 def test_set_valid_metrics():
@@ -50,7 +49,7 @@ def test_set_valid_metrics():
         'd': 1231543543265475686787869123,
         'e': 12.34,
     }
-    eq_(d['metrics'], expected)
+    assert d['metrics'] == expected
 
 
 def test_set_invalid_metric():
@@ -70,7 +69,7 @@ def test_set_invalid_metric():
     for i, m in enumerate(invalid_metrics):
         k = str(i)
         s.set_metric(k, m)
-        eq_(s.get_metric(k), None)
+        assert s.get_metric(k) is None
 
 
 def test_set_numpy_metric():
@@ -80,8 +79,8 @@ def test_set_numpy_metric():
         raise SkipTest('numpy not installed')
     s = Span(tracer=None, name='test.span')
     s.set_metric('a', np.int64(1))
-    eq_(s.get_metric('a'), 1)
-    eq_(type(s.get_metric('a')), float)
+    assert s.get_metric('a') == 1
+    assert type(s.get_metric('a')) == float
 
 
 def test_tags_not_string():
@@ -107,7 +106,7 @@ def test_finish():
         assert s is s1
         time.sleep(sleep)
     assert s.duration >= sleep, '%s < %s' % (s.duration, sleep)
-    eq_(1, dt.spans_recorded)
+    assert 1 == dt.spans_recorded
 
 
 def test_finish_no_tracer():
@@ -171,10 +170,10 @@ def test_ctx_mgr():
             time.sleep(0.01)
             raise e
     except Exception as out:
-        eq_(out, e)
+        assert out == e
         assert s.duration > 0, s.duration
         assert s.error
-        eq_(s.get_tag(errors.ERROR_MSG), 'boo')
+        assert s.get_tag(errors.ERROR_MSG) == 'boo'
         assert 'Exception' in s.get_tag(errors.ERROR_TYPE)
         assert s.get_tag(errors.ERROR_STACK)
 
@@ -191,13 +190,13 @@ def test_span_to_dict():
 
     d = s.to_dict()
     assert d
-    eq_(d['span_id'], s.span_id)
-    eq_(d['trace_id'], s.trace_id)
-    eq_(d['parent_id'], s.parent_id)
-    eq_(d['meta'], {'a': '1', 'b': '2'})
-    eq_(d['type'], 'foo')
-    eq_(d['error'], 0)
-    eq_(type(d['error']), int)
+    assert d['span_id'] == s.span_id
+    assert d['trace_id'] == s.trace_id
+    assert d['parent_id'] == s.parent_id
+    assert d['meta'] == {'a': '1', 'b': '2'}
+    assert d['type'] == 'foo'
+    assert d['error'] == 0
+    assert type(d['error']) == int
 
 
 def test_span_to_dict_sub():
@@ -211,13 +210,13 @@ def test_span_to_dict_sub():
 
     d = s.to_dict()
     assert d
-    eq_(d['span_id'], s.span_id)
-    eq_(d['trace_id'], s.trace_id)
-    eq_(d['parent_id'], s.parent_id)
-    eq_(d['meta'], {'a': '1', 'b': '2'})
-    eq_(d['type'], 'foo')
-    eq_(d['error'], 0)
-    eq_(type(d['error']), int)
+    assert d['span_id'] == s.span_id
+    assert d['trace_id'] == s.trace_id
+    assert d['parent_id'] == s.parent_id
+    assert d['meta'] == {'a': '1', 'b': '2'}
+    assert d['type'] == 'foo'
+    assert d['error'] == 0
+    assert type(d['error']) == int
 
 
 def test_span_boolean_err():
@@ -227,8 +226,8 @@ def test_span_boolean_err():
 
     d = s.to_dict()
     assert d
-    eq_(d['error'], 1)
-    eq_(type(d['error']), int)
+    assert d['error'] == 1
+    assert type(d['error']) == int
 
 
 def test_numeric_tags_none():
@@ -236,7 +235,7 @@ def test_numeric_tags_none():
     s.set_tag(ANALYTICS_SAMPLE_RATE_KEY, None)
     d = s.to_dict()
     assert d
-    ok_('metrics' not in d)
+    assert 'metrics' not in d
 
 
 def test_numeric_tags_true():
@@ -247,7 +246,7 @@ def test_numeric_tags_true():
     expected = {
         ANALYTICS_SAMPLE_RATE_KEY: 1.0
     }
-    eq_(d['metrics'], expected)
+    assert d['metrics'] == expected
 
 
 def test_numeric_tags_value():
@@ -258,7 +257,7 @@ def test_numeric_tags_value():
     expected = {
         ANALYTICS_SAMPLE_RATE_KEY: 0.5
     }
-    eq_(d['metrics'], expected)
+    assert d['metrics'] == expected
 
 
 def test_numeric_tags_bad_value():
@@ -266,7 +265,7 @@ def test_numeric_tags_bad_value():
     s.set_tag(ANALYTICS_SAMPLE_RATE_KEY, 'Hello')
     d = s.to_dict()
     assert d
-    ok_('metrics' not in d)
+    assert 'metrics' not in d
 
 
 class DummyTracer(object):

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,7 +4,6 @@ import mock
 
 import ddtrace
 from ddtrace import __file__ as root_file
-from nose.tools import ok_
 from contextlib import contextmanager
 
 
@@ -40,17 +39,13 @@ def patch_time():
 
 
 def assert_dict_issuperset(a, b):
-    ok_(
-        set(a.items()).issuperset(set(b.items())),
-        msg="{a} is not a superset of {b}".format(a=a, b=b),
-    )
+    assert set(a.items()).issuperset(set(b.items())), \
+        "{a} is not a superset of {b}".format(a=a, b=b)
 
 
 def assert_list_issuperset(a, b):
-    ok_(
-        set(a).issuperset(set(b)),
-        msg="{a} is not a superset of {b}".format(a=a, b=b),
-    )
+    assert set(a).issuperset(set(b)), \
+        "{a} is not a superset of {b}".format(a=a, b=b)
 
 
 @contextmanager

--- a/tox.ini
+++ b/tox.ini
@@ -131,7 +131,6 @@ deps =
     opentracing
 # test dependencies installed in all envs
     mock
-    nose
 # force the downgrade as a workaround
 # https://github.com/aio-libs/aiohttp/issues/2662
     yarl: yarl==0.18.0
@@ -282,24 +281,16 @@ deps =
     kombu42:  kombu>=4.2,<4.3
     kombu41:  kombu>=4.1,<4.2
     kombu40:  kombu>=4.0,<4.1
+    requests_contrib: requests-mock>=1.4
     requests200: requests>=2.0,<2.1
-    requests200: requests-mock>=1.3
     requests208: requests>=2.8,<2.9
-    requests208: requests-mock>=1.3
     requests209: requests>=2.9,<2.10
-    requests209: requests-mock>=1.3
     requests210: requests>=2.10,<2.11
-    requests210: requests-mock>=1.3
     requests211: requests>=2.11,<2.12
-    requests211: requests-mock>=1.3
     requests212: requests>=2.12,<2.13
-    requests212: requests-mock>=1.3
     requests213: requests>=2.13,<2.14
-    requests213: requests-mock>=1.3
     requests218: requests>=2.18,<2.19
-    requests218: requests-mock>=1.4
     requests219: requests>=2.19,<2.20
-    requests219: requests-mock>=1.4
     sqlalchemy10: sqlalchemy>=1.0,<1.1
     sqlalchemy11: sqlalchemy>=1.1,<1.2
     sqlalchemy12: sqlalchemy>=1.2,<1.3
@@ -337,7 +328,7 @@ commands =
     botocore_contrib: pytest {posargs} tests/contrib/botocore
     bottle_contrib: pytest {posargs} --ignore="tests/contrib/bottle/test_autopatch.py" tests/contrib/bottle/
     bottle_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/bottle/test_autopatch.py
-    cassandra_contrib: nosetests {posargs} tests/contrib/cassandra
+    cassandra_contrib: pytest {posargs} tests/contrib/cassandra
     celery_contrib: pytest {posargs} tests/contrib/celery
     dbapi_contrib: pytest {posargs} tests/contrib/dbapi
     django_contrib: python tests/contrib/django/runtests.py {posargs}
@@ -356,26 +347,26 @@ commands =
     jinja2_contrib: pytest {posargs} tests/contrib/jinja2
     mako_contrib: pytest {posargs} tests/contrib/mako
     molten_contrib: pytest {posargs} tests/contrib/molten
-    mongoengine_contrib: nosetests {posargs} tests/contrib/mongoengine
+    mongoengine_contrib: pytest {posargs} tests/contrib/mongoengine
     msgpack_contrib: pytest {posargs} tests/test_encoders.py
-    mysql_contrib: nosetests {posargs} tests/contrib/mysql
-    mysqldb_contrib: nosetests {posargs} tests/contrib/mysqldb
+    mysql_contrib: pytest {posargs} tests/contrib/mysql
+    mysqldb_contrib: pytest {posargs} tests/contrib/mysqldb
     psycopg_contrib: pytest {posargs} tests/contrib/psycopg
-    pylibmc_contrib: nosetests {posargs} tests/contrib/pylibmc
+    pylibmc_contrib: pytest {posargs} tests/contrib/pylibmc
     pylons_contrib: pytest {posargs} tests/contrib/pylons
     pymemcache_contrib: pytest {posargs} --ignore="tests/contrib/pymemcache/autopatch" tests/contrib/pymemcache/
     pymemcache_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/pymemcache/autopatch/
-    pymongo_contrib: nosetests {posargs} tests/contrib/pymongo
+    pymongo_contrib: pytest {posargs} tests/contrib/pymongo
     pymysql_contrib: pytest {posargs} tests/contrib/pymysql
-    pyramid_contrib: nosetests {posargs} tests/contrib/pyramid/test_pyramid.py
-    pyramid_contrib_autopatch: python tests/ddtrace_run.py nosetests {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
-    redis_contrib: nosetests {posargs} tests/contrib/redis
-    rediscluster_contrib: nosetests {posargs} tests/contrib/rediscluster
+    pyramid_contrib: pytest {posargs} tests/contrib/pyramid/test_pyramid.py
+    pyramid_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
+    redis_contrib: pytest {posargs} tests/contrib/redis
+    rediscluster_contrib: pytest {posargs} tests/contrib/rediscluster
     requests_contrib: pytest {posargs} tests/contrib/requests
-    requests_gevent_contrib: nosetests {posargs} tests/contrib/requests_gevent
-    kombu_contrib: nosetests {posargs} tests/contrib/kombu
+    requests_gevent_contrib: pytest {posargs} tests/contrib/requests_gevent
+    kombu_contrib: pytest {posargs} tests/contrib/kombu
     sqlalchemy_contrib: pytest {posargs} tests/contrib/sqlalchemy
-    sqlite3_contrib: nosetests {posargs} tests/contrib/sqlite3
+    sqlite3_contrib: pytest {posargs} tests/contrib/sqlite3
     tornado_contrib: pytest {posargs} tests/contrib/tornado
     vertica_contrib: pytest {posargs} tests/contrib/vertica/
 # run subsets of the tests for particular library versions


### PR DESCRIPTION
This has been deprecated and unmaintained for years; stop installing it.

 - Replaces `nose.tools.ok_` with `assert`
 - Replaces `nose.tools.eq_` with `assert ==`
 - Replaces `nose.tools.assert_raises` with `pytest.raises`
 - Add missing unittest.TestCase inheritance in some place
 - Only install requests-mock for requests_contrib scenarios;  this modules has a pytest plugin that gets loaded otherwise and pre-load
 - `requests`, making some test checking for module load ordering fail.