### PR TITLE
Remove useless __future__ imports

### DIFF
--- a/ddtrace/commands/ddtrace_run.py
+++ b/ddtrace/commands/ddtrace_run.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-
 from distutils import spawn
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import copy
 import os
 import sys

--- a/tests/commands/ddtrace_minimal.py
+++ b/tests/commands/ddtrace_minimal.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import ddtrace.bootstrap.sitecustomize as module
 
 

--- a/tests/commands/ddtrace_run_app_name.py
+++ b/tests/commands/ddtrace_run_app_name.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from ddtrace.opentracer import Tracer
 
 if __name__ == '__main__':

--- a/tests/commands/ddtrace_run_argv.py
+++ b/tests/commands/ddtrace_run_argv.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from nose.tools import eq_
 import sys
 

--- a/tests/commands/ddtrace_run_debug.py
+++ b/tests/commands/ddtrace_run_debug.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from ddtrace import tracer
 
 from nose.tools import ok_

--- a/tests/commands/ddtrace_run_disabled.py
+++ b/tests/commands/ddtrace_run_disabled.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from ddtrace import tracer, monkey
 
 from nose.tools import ok_, eq_

--- a/tests/commands/ddtrace_run_enabled.py
+++ b/tests/commands/ddtrace_run_enabled.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from ddtrace import tracer
 
 from nose.tools import ok_

--- a/tests/commands/ddtrace_run_env.py
+++ b/tests/commands/ddtrace_run_env.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from ddtrace import tracer
 
 from nose.tools import eq_

--- a/tests/commands/ddtrace_run_hostname.py
+++ b/tests/commands/ddtrace_run_hostname.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from ddtrace import tracer
 
 from nose.tools import eq_

--- a/tests/commands/ddtrace_run_integration.py
+++ b/tests/commands/ddtrace_run_integration.py
@@ -3,8 +3,6 @@ An integration test that uses a real Redis client
 that we expect to be implicitly traced via `ddtrace-run`
 """
 
-from __future__ import print_function
-
 import redis
 
 from ddtrace import Pin

--- a/tests/commands/ddtrace_run_logs_injection.py
+++ b/tests/commands/ddtrace_run_logs_injection.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import logging
 
 if __name__ == '__main__':

--- a/tests/commands/ddtrace_run_no_debug.py
+++ b/tests/commands/ddtrace_run_no_debug.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from ddtrace import tracer
 
 from nose.tools import ok_

--- a/tests/commands/ddtrace_run_patched_modules.py
+++ b/tests/commands/ddtrace_run_patched_modules.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from ddtrace import monkey
 
 from nose.tools import ok_

--- a/tests/commands/ddtrace_run_priority_sampling.py
+++ b/tests/commands/ddtrace_run_priority_sampling.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from ddtrace import tracer
 
 from nose.tools import ok_

--- a/tests/commands/ddtrace_run_service.py
+++ b/tests/commands/ddtrace_run_service.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 
 from nose.tools import eq_

--- a/tests/commands/ddtrace_run_sitecustomize.py
+++ b/tests/commands/ddtrace_run_sitecustomize.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 from nose.tools import ok_
 

--- a/tests/contrib/celery/autopatch.py
+++ b/tests/contrib/celery/autopatch.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from nose.tools import ok_
 
 from ddtrace import Pin


### PR DESCRIPTION
The future is now! print as a function is available in Python >= 2.7.