### PR TITLE
[core] Fix logging with unset DATADOG_PATCH_MODULES

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -46,7 +46,10 @@ EXTRA_PATCHED_MODULES = {
 
 
 def update_patched_modules():
-    for patch in os.environ.get("DATADOG_PATCH_MODULES", '').split(','):
+    modules_to_patch = os.environ.get("DATADOG_PATCH_MODULES")
+    if not modules_to_patch:
+        return
+    for patch in modules_to_patch.split(','):
         if len(patch.split(':')) != 2:
             log.debug("skipping malformed patch instruction")
             continue


### PR DESCRIPTION
If DATADOG_PATCH_MODULES is unset, the default value was '' which when used
with .split(',') does not return 2 items, logging that the patch instruction is
malformed.

This patch fixes that by checking that the value is set and non empty before
trying to patch anything.