### PR TITLE
Remove confusing testing instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,29 +46,9 @@ launch them through:
 [docker-compose]: https://www.docker.com/products/docker-compose
 
 
-#### Running the Tests in your local environment
-
-Once docker is up and running you should be able to run the tests. To launch a
-single test manually. For example to run the tests for `redis-py` 2.10 on Python
-3.5 and 3.6:
-
-    $ tox -e '{py35,py36}-redis{210}'
-
-To see the defined test commands see `tox.ini`.
-
-To launch the complete test matrix run:
-
-    $ tox
-
-
 #### Running Tests in docker
 
-If you prefer not to setup your local machine to run tests, we provide a preconfigured docker image.
-Note that this image is the same used in CircleCI to run tests.
-
-You still need docker containers running additional services up and running.
-
-Run the test runner
+Once your docker-compose environment is running, you can run the test runner image:
 
     $ docker-compose run --rm testrunner
 


### PR DESCRIPTION
The current instructions are confusing as they start with talking about
docker-compose, and then talk about not using it !?.

It seems that it's barely possible to run most of the tests without
docker-compose anyway, so let's keep things simple and remove those
instructions entirely.