### PR TITLE
[aiohttp] Fix race condition in testing

### DIFF
--- a/tests/contrib/aiohttp/test_request_safety.py
+++ b/tests/contrib/aiohttp/test_request_safety.py
@@ -68,14 +68,13 @@ class TestAiohttpSafety(TraceTestCase):
         ctx = self.tracer.get_call_context()
         threads = [threading.Thread(target=make_requests) for _ in range(10)]
         for t in threads:
-            t.daemon = True
             t.start()
 
-        # we should yield so that this loop can handle
-        # threads' requests
-        yield from asyncio.sleep(0.5)
         for t in threads:
-            t.join(timeout=0.5)
+            # we should yield so that this loop can handle
+            # threads' requests
+            yield from asyncio.sleep(0.1)
+            t.join(0.1)
 
         # the trace is wrong but the Context is finished
         traces = self.tracer.writer.pop_traces()


### PR DESCRIPTION
The current code only yield once the thread have started, though there's a
little chance that one of the thread did not had time to actually sent its
request yet. That means that the requests will never be served and the thread
will fail.

This patch fixes this by making sure to do pass the execution to the asyncio
loop between each join, just in case a request needs to be handled.

Fixes #876