### PR TITLE
[tests] Leverage tox environment listing to simplify CircleCI tox target list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e '{py27,py34,py35,py36}-tracer' --result-json /tmp/tracer.results
+      - run: scripts/run-tox-scenario '^py..-tracer$'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -94,7 +94,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e '{py27,py34,py35,py36}-internal' --result-json /tmp/internal.results
+      - run: scripts/run-tox-scenario '^py..-internal'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -105,11 +105,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e '{py27,py34,py35,py36}-opentracer' --result-json /tmp/opentracer.results
-      - run: tox -e '{py34,py35,py36}-opentracer_asyncio' --result-json /tmp/opentracer-asyncio.results
-      - run: tox -e '{py34,py35,py36}-opentracer_tornado-tornado{40,41,42,43,44}' --result-json /tmp/opentracer-tornado.results
-      - run: tox -e '{py27}-opentracer_gevent-gevent{10}' --result-json /tmp/opentracer-gevent.1.results
-      - run: tox -e '{py27,py34,py35,py36}-opentracer_gevent-gevent{11,12}' --result-json /tmp/opentracer-gevent.2.results
+      - run: scripts/run-tox-scenario '^py..-opentracer'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -128,7 +124,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e '{py27,py34,py35,py36}-integration' --result-json /tmp/integration.results
+      - run: scripts/run-tox-scenario '^py..-integration$'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -139,8 +135,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'futures_contrib-{py27}-futures{30,31,32}' --result-json /tmp/futures.1.results
-      - run: tox -e 'futures_contrib-{py34,py35,py36}' --result-json /tmp/futures.2.results
+      - run: scripts/run-tox-scenario '^futures_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -151,8 +146,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'boto_contrib-{py27,py34}-boto' --result-json /tmp/boto.1.results
-      - run: tox -e 'botocore_contrib-{py27,py34,py35,py36}-botocore' --result-json /tmp/boto.2.results
+      - run: scripts/run-tox-scenario '^boto\(core\)\?_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -165,7 +159,7 @@ jobs:
     resource_class: *resource_class
     steps:
       - checkout
-      - run: tox -e '{py27,py34,py35,py36}-ddtracerun' --result-json /tmp/ddtracerun.results
+      - run: scripts/run-tox-scenario '^py..-ddtracerun$'
       - *persist_to_workspace_step
 
   test_utils:
@@ -175,7 +169,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e '{py27,py34,py35,py36}-test_utils' --result-json /tmp/test_utils.results
+      - run: scripts/run-tox-scenario '^py..-test_utils$'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -186,7 +180,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e '{py27,py34,py35,py36}-test_logging' --result-json /tmp/test_logging.results
+      - run: scripts/run-tox-scenario '^py..-test_logging$'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -197,7 +191,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'asyncio_contrib-{py34,py35,py36}' --result-json /tmp/asyncio.results
+      - run: scripts/run-tox-scenario '^asyncio_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -208,7 +202,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'pylons_contrib-{py27}-pylons{096,097,010,10}' --result-json /tmp/pylons.results
+      - run: scripts/run-tox-scenario '^pylons_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -219,7 +213,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'aiohttp_contrib-{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl,aiohttp_contrib-{py34,py35,py36}-aiohttp23-aiohttp_jinja015-yarl10,aiohttp_contrib-{py35,py36}-aiohttp{30,31,32,33,34,35}-aiohttp_jinja015-yarl10' --result-json /tmp/aiohttp.results
+      - run: scripts/run-tox-scenario '^aiohttp_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -230,8 +224,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'tornado_contrib-{py27,py34,py35,py36}-tornado{40,41,42,43,44,45}' --result-json /tmp/tornado.1.results
-      - run: tox -e 'tornado_contrib-{py27}-tornado{40,41,42,43,44,45}-futures{30,31,32}' --result-json /tmp/tornado.2.results
+      - run: scripts/run-tox-scenario '^tornado_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -242,7 +235,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'bottle_contrib{,_autopatch}-{py27,py34,py35,py36}-bottle{11,12}-webtest' --result-json /tmp/bottle.results
+      - run: scripts/run-tox-scenario '^bottle_contrib\(_autopatch\)\?-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -261,7 +254,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e wait cassandra
-      - run: tox -e 'cassandra_contrib-{py27,py34,py35,py36}-cassandra{35,36,37,38,315}' --result-json /tmp/cassandra.results
+      - run: scripts/run-tox-scenario '^cassandra_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -275,10 +268,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'celery_contrib-{py27,py34,py35,py36}-celery{31}-redis{210}' --result-json /tmp/celery31.results
-      - run: tox -e 'celery_contrib-{py27,py34,py35,py36}-celery{40,41}-{redis210-kombu43,redis320-kombu44}' --result-json /tmp/celery40-41.results
-      - run: tox -e 'celery_contrib-{py27,py34,py35,py36}-celery42-redis210-kombu43' --result-json /tmp/celery42.results
-      - run: tox -e 'celery_contrib-{py27,py34,py35,py36}-celery43-redis320-kombu44' --result-json /tmp/celery43.results
+      - run: scripts/run-tox-scenario '^celery_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -290,13 +280,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run:
-          command: |
-            tox -e 'elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63}' \
-                -e 'elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch1{100}' \
-                -e 'elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch2{50}' \
-                -e 'elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch5{50}' \
-                --result-json /tmp/elasticsearch.results
+      - run: scripts/run-tox-scenario '^elasticsearch_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -325,10 +309,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'django_contrib{,_autopatch}-{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.1.results
-      - run: tox -e 'django_drf_contrib-{py27,py34,py35,py36}-django{111}-djangorestframework{34,37,38}' --result-json /tmp/django.2.results
-      - run: tox -e 'django_contrib{,_autopatch}-{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached' --result-json /tmp/django.3.results
-      - run: tox -e 'django_drf_contrib-{py34,py35,py36}-django{200}-djangorestframework{37,38}' --result-json /tmp/django.4.results
+      - run: scripts/run-tox-scenario '^django_'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -341,14 +322,8 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'flask_contrib-{py27,py34,py35,py36}-flask{010,011,012,10}-blinker' --result-json /tmp/flask.1.results
-      - run: TOX_SKIP_DIST=False tox -e 'flask_contrib_autopatch-{py27,py34,py35,py36}-flask{010,011,012,10}-blinker' --result-json /tmp/flask.2.results
-      - run: tox -e 'flask_contrib-{py27}-flask{09}-blinker' --result-json /tmp/flask.3.results
-      - run: TOX_SKIP_DIST=False tox -e 'flask_contrib_autopatch-{py27}-flask{09}-blinker' --result-json /tmp/flask.4.results
-      - run: tox -e 'flask_cache_contrib-{py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.5.results
-      - run: TOX_SKIP_DIST=False tox -e 'flask_cache_contrib_autopatch-{py27,py34,py35,py36}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker' --result-json /tmp/flask.6.results
-      - run: tox -e 'flask_cache_contrib-{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.7.results
-      - run: TOX_SKIP_DIST=False tox -e 'flask_cache_contrib_autopatch-{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker' --result-json /tmp/flask.8.results
+      - run: scripts/run-tox-scenario '^flask_\(cache_\)\?contrib-'
+      - run: TOX_SKIP_DIST=False scripts/run-tox-scenario '^flask_\(cache_\)\?contrib_autopatch-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -359,8 +334,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'gevent_contrib-{py27,py34,py35,py36}-gevent{11,12,13}' --result-json /tmp/gevent.1.results
-      - run: tox -e 'gevent_contrib-{py27}-gevent{10}' --result-json /tmp/gevent.2.results
+      - run: scripts/run-tox-scenario '^gevent_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -371,7 +345,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'httplib_contrib-{py27,py34,py35,py36}' --result-json /tmp/httplib.results
+      - run: scripts/run-tox-scenario '^httplib_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -382,7 +356,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'grpc_contrib-{py27,py34,py35,py36}-grpc' --result-json /tmp/grpc.results
+      - run: scripts/run-tox-scenario '^grpc_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -393,7 +367,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'molten_contrib-{py36}-molten{070,072}' --result-json /tmp/molten.results
+      - run: scripts/run-tox-scenario '^molten_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -411,7 +385,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'wait' mysql
-      - run: tox -e 'mysql_contrib-{py27,py34,py35,py36}-mysqlconnector' --result-json /tmp/mysqlconnector.results
+      - run: scripts/run-tox-scenario '^mysql_contrib-.*-mysqlconnector'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -429,7 +403,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'wait' mysql
-      - run: tox -e 'mysqldb_contrib-{py27,py34,py35,py36}-mysqlclient{13}' --result-json /tmp/mysqlpython.results
+      - run: scripts/run-tox-scenario '^mysqldb_contrib-.*-mysqlclient'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -447,7 +421,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'wait' mysql
-      - run: tox -e 'mysqldb_contrib-{py27}-mysqldb{12}' --result-json /tmp/mysqldb.results
+      - run: scripts/run-tox-scenario '^mysqldb_contrib-.*-mysqldb'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -465,7 +439,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'wait' mysql
-      - run: tox -e 'pymysql_contrib-{py27,py34,py35,py36}-pymysql{07,08,09}' --result-json /tmp/pymysql.results
+      - run: scripts/run-tox-scenario '^pymysql_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -477,7 +451,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'pylibmc_contrib-{py27,py34,py35,py36}-pylibmc{140,150}' --result-json /tmp/pylibmc.results
+      - run: scripts/run-tox-scenario '^pylibmc_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -489,7 +463,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'pymemcache_contrib{,_autopatch}-{py27,py34,py35,py36}-pymemcache{130,140}' --result-json /tmp/pymemcache.results
+      - run: scripts/run-tox-scenario '^pymemcache_contrib\(_autopatch\)\?-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -501,7 +475,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'mongoengine_contrib-{py27,py34,py35,py36}-mongoengine{015}' --result-json /tmp/mongoengine.results
+      - run: scripts/run-tox-scenario '^mongoengine_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -513,7 +487,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'pymongo_contrib-{py27,py34,py35,py36}-pymongo{30,31,32,33,34,36}-mongoengine{015}' --result-json /tmp/pymongo.results
+      - run: scripts/run-tox-scenario '^pymongo_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -524,7 +498,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'pyramid_contrib{,_autopatch}-{py27,py34,py35,py36}-pyramid{17,18,19}-webtest' --result-json /tmp/pyramid.results
+      - run: scripts/run-tox-scenario '^pyramid_contrib\(_autopatch\)\?-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -536,7 +510,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'requests_contrib{,_autopatch}-{py27,py34,py35,py36}-requests{208,209,210,211,212,213,219}' --result-json /tmp/requests.results
+      - run: scripts/run-tox-scenario '^requests_contrib\(_autopatch\)\?-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -547,7 +521,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'requests_gevent_contrib-{py36}-requests{208,209,210,211,212,213,219}-gevent{12,13}' --result-json /tmp/requestsgevent.results
+      - run: scripts/run-tox-scenario '^requests_gevent_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -570,7 +544,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'wait' postgres mysql
-      - run: tox -e 'sqlalchemy_contrib-{py27,py34,py35,py36}-sqlalchemy{10,11,12}-psycopg228-mysqlconnector' --result-json /tmp/sqlalchemy.results
+      - run: scripts/run-tox-scenario '^sqlalchemy_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -581,7 +555,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'dbapi_contrib-{py27,py34,py35,py36}' --result-json /tmp/dbapi.results
+      - run: scripts/run-tox-scenario '^dbapi_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -598,7 +572,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'wait' postgres
-      - run: tox -e 'psycopg_contrib-{py27,py34,py35,py36}-psycopg2{24,25,26,27,28}' --result-json /tmp/psycopg.results
+      - run: scripts/run-tox-scenario '^psycopg_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -610,7 +584,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'aiobotocore_contrib-py34-aiobotocore{02,03,04},aiobotocore_contrib-{py35,py36}-aiobotocore{02,03,04,05,07,08,09,010}' --result-json /tmp/aiobotocore.results
+      - run: scripts/run-tox-scenario '^aiobotocore_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -627,7 +601,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e 'wait' postgres
-      - run: tox -e 'aiopg_contrib-{py34,py35,py36}-aiopg{012,015}' --result-json /tmp/aiopg.results
+      - run: scripts/run-tox-scenario '^aiopg_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -639,7 +613,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'redis_contrib-{py27,py34,py35,py36}-redis{26,27,28,29,210,300}' --result-json /tmp/redis.results
+      - run: scripts/run-tox-scenario '^redis_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -654,7 +628,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e wait rediscluster
-      - run: tox -e 'rediscluster_contrib-{py27,py34,py35,py36}-rediscluster{135,136}-redis210' --result-json /tmp/rediscluster.results
+      - run: scripts/run-tox-scenario '^rediscluster_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -671,7 +645,7 @@ jobs:
       - checkout
       - *restore_cache_step
       - run: tox -e wait vertica
-      - run: tox -e 'vertica_contrib-{py27,py34,py35,py36}-vertica{060,070}' --result-json /tmp/vertica.results
+      - run: scripts/run-tox-scenario '^vertica_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -684,7 +658,7 @@ jobs:
     - checkout
     - *restore_cache_step
     - run: tox -e wait rabbitmq
-    - run: tox -e 'kombu_contrib-{py27,py34,py35,py36}-kombu{40,41,42}' --result-json /tmp/kombu.results
+    - run: scripts/run-tox-scenario '^kombu_contrib-'
     - *persist_to_workspace_step
     - *save_cache_step
 
@@ -695,7 +669,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'sqlite3_contrib-{py27,py34,py35,py36}-sqlite3' --result-json /tmp/sqlite3.results
+      - run: scripts/run-tox-scenario '^sqlite3_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -706,7 +680,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'unit_tests-{py27,py34,py35,py36}' --result-json /tmp/unit_tests.results
+      - run: scripts/run-tox-scenario '^unit_tests-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -729,7 +703,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'jinja2_contrib-{py27,py34,py35,py36}-jinja{27,28,29,210}' --result-json /tmp/jinja2.results
+      - run: scripts/run-tox-scenario '^jinja2_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 
@@ -740,7 +714,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: tox -e 'mako_contrib-{py27,py34,py35,py36}-mako{010,100}' --result-json /tmp/mako.results
+      - run: scripts/run-tox-scenario '^mako_contrib-'
       - *persist_to_workspace_step
       - *save_cache_step
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ For example to run the tests for `redis-py` 2.10 on Python 3.5 and 3.6:
 
     $ ./scripts/ddtest tox -e '{py35,py36}-redis{210}'
 
+If you want to run a list of tox environment (as CircleCI does) based on a
+pattern, you can use the following command:
+
+    $ scripts/ddtest scripts/run-tox-scenario '^futures_contrib-'
 
 ### Continuous Integration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,4 +103,5 @@ services:
             - ./conftest.py:/src/conftest.py:ro
             - ./tox.ini:/src/tox.ini:ro
             - ./.ddtox:/src/.tox
+            - ./scripts:/src/scripts
         command: bash

--- a/scripts/run-tox-scenario
+++ b/scripts/run-tox-scenario
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+PATTERN="$1"
+# CircleCI has a bug in its workspace code where it can't handle filenames with some chars
+CLEANED_PATTERN=`echo $PATTERN | tr '^?()$' '_'`
+exec tox -l | grep "$PATTERN" | tr '\n' ',' | xargs tox --result-json /tmp/"$CLEANED_PATTERN".results -e


### PR DESCRIPTION
This allows to group the running of tox environment list by pattern rather than
having to type and maintain the entire list of environment both in `tox.ini`
and `.circleci/config`.