### PR TITLE
[dev/tooling] Enforce single quote strings

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -158,11 +158,11 @@ class API(object):
 
         # the API endpoint is not available so we should downgrade the connection and re-try the call
         if response.status in [404, 415] and self._fallback:
-            log.debug('calling endpoint "%s" but received %s; downgrading API', self._traces, response.status)
+            log.debug("calling endpoint '%s' but received %s; downgrading API", self._traces, response.status)
             self._downgrade()
             return self.send_traces(traces)
 
-        log.debug("reported %d traces in %.5fs", len(traces), time.time() - start)
+        log.debug('reported %d traces in %.5fs', len(traces), time.time() - start)
         return response
 
     @deprecated(message='Sending services to the API is no longer necessary', version='1.0.0')
@@ -177,7 +177,7 @@ class API(object):
                 headers = dict(self._headers)
                 headers[TRACE_COUNT_HEADER] = str(count)
 
-            conn.request("PUT", endpoint, data, headers)
+            conn.request('PUT', endpoint, data, headers)
 
             # Parse the HTTPResponse into an API.Response
             # DEV: This will call `resp.read()` which must happen before the `conn.close()` below,

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -20,7 +20,7 @@ if logs_injection:
     # immediately patch logging if trace id injected
     from ddtrace import patch; patch(logging=True)  # noqa
 
-debug = os.environ.get("DATADOG_TRACE_DEBUG")
+debug = os.environ.get('DATADOG_TRACE_DEBUG')
 
 # Set here a default logging format for basicConfig
 
@@ -28,7 +28,7 @@ debug = os.environ.get("DATADOG_TRACE_DEBUG")
 # change the formatter since it applies the formatter to the root handler only
 # upon initializing it the first time.
 # See https://github.com/python/cpython/blob/112e4afd582515fcdcc0cde5012a4866e5cfda12/Lib/logging/__init__.py#L1550
-if debug and debug.lower() == "true":
+if debug and debug.lower() == 'true':
     logging.basicConfig(level=logging.DEBUG, format=DD_LOG_FORMAT)
 else:
     logging.basicConfig(format=DD_LOG_FORMAT)
@@ -36,27 +36,27 @@ else:
 log = get_logger(__name__)
 
 EXTRA_PATCHED_MODULES = {
-    "bottle": True,
-    "django": True,
-    "falcon": True,
-    "flask": True,
-    "pylons": True,
-    "pyramid": True,
+    'bottle': True,
+    'django': True,
+    'falcon': True,
+    'flask': True,
+    'pylons': True,
+    'pyramid': True,
 }
 
 
 def update_patched_modules():
-    modules_to_patch = os.environ.get("DATADOG_PATCH_MODULES")
+    modules_to_patch = os.environ.get('DATADOG_PATCH_MODULES')
     if not modules_to_patch:
         return
     for patch in modules_to_patch.split(','):
         if len(patch.split(':')) != 2:
-            log.debug("skipping malformed patch instruction")
+            log.debug('skipping malformed patch instruction')
             continue
 
         module, should_patch = patch.split(':')
         if should_patch.lower() not in ['true', 'false']:
-            log.debug("skipping malformed patch instruction for %s", module)
+            log.debug('skipping malformed patch instruction for %s', module)
             continue
 
         EXTRA_PATCHED_MODULES.update({module: should_patch.lower() == 'true'})
@@ -81,22 +81,22 @@ try:
     # Respect DATADOG_* environment variables in global tracer configuration
     # TODO: these variables are deprecated; use utils method and update our documentation
     # correct prefix should be DD_*
-    enabled = os.environ.get("DATADOG_TRACE_ENABLED")
+    enabled = os.environ.get('DATADOG_TRACE_ENABLED')
     hostname = os.environ.get('DD_AGENT_HOST', os.environ.get('DATADOG_TRACE_AGENT_HOSTNAME'))
-    port = os.environ.get("DATADOG_TRACE_AGENT_PORT")
-    priority_sampling = os.environ.get("DATADOG_PRIORITY_SAMPLING")
+    port = os.environ.get('DATADOG_TRACE_AGENT_PORT')
+    priority_sampling = os.environ.get('DATADOG_PRIORITY_SAMPLING')
 
     opts = {}
 
-    if enabled and enabled.lower() == "false":
-        opts["enabled"] = False
+    if enabled and enabled.lower() == 'false':
+        opts['enabled'] = False
         patch = False
     if hostname:
-        opts["hostname"] = hostname
+        opts['hostname'] = hostname
     if port:
-        opts["port"] = int(port)
+        opts['port'] = int(port)
     if priority_sampling:
-        opts["priority_sampling"] = asbool(priority_sampling)
+        opts['priority_sampling'] = asbool(priority_sampling)
 
     opts['collect_metrics'] = asbool(get_env('runtime_metrics', 'enabled'))
 
@@ -110,12 +110,12 @@ try:
         update_patched_modules()
         from ddtrace import patch_all; patch_all(**EXTRA_PATCHED_MODULES) # noqa
 
-    debug = os.environ.get("DATADOG_TRACE_DEBUG")
-    if debug and debug.lower() == "true":
+    debug = os.environ.get('DATADOG_TRACE_DEBUG')
+    if debug and debug.lower() == 'true':
         tracer.debug_logging = True
 
     if 'DATADOG_ENV' in os.environ:
-        tracer.set_tags({"env": os.environ["DATADOG_ENV"]})
+        tracer.set_tags({'env': os.environ['DATADOG_ENV']})
 
     if 'DD_TRACE_GLOBAL_TAGS' in os.environ:
         add_global_tags(tracer)
@@ -145,4 +145,4 @@ try:
     loaded = True
 except Exception as e:
     loaded = False
-    log.warn("error configuring Datadog tracing", exc_info=True)
+    log.warn('error configuring Datadog tracing', exc_info=True)

--- a/ddtrace/commands/ddtrace_run.py
+++ b/ddtrace/commands/ddtrace_run.py
@@ -4,8 +4,8 @@ import os
 import sys
 import logging
 
-debug = os.environ.get("DATADOG_TRACE_DEBUG")
-if debug and debug.lower() == "true":
+debug = os.environ.get('DATADOG_TRACE_DEBUG')
+if debug and debug.lower() == 'true':
     logging.basicConfig(level=logging.DEBUG)
 
 # Do not use `ddtrace.internal.logger.get_logger` here
@@ -50,33 +50,33 @@ def _add_bootstrap_to_pythonpath(bootstrap_dir):
     python_path = os.environ.get('PYTHONPATH', '')
 
     if python_path:
-        new_path = "%s%s%s" % (bootstrap_dir, os.path.pathsep, os.environ['PYTHONPATH'])
+        new_path = '%s%s%s' % (bootstrap_dir, os.path.pathsep, os.environ['PYTHONPATH'])
         os.environ['PYTHONPATH'] = new_path
     else:
         os.environ['PYTHONPATH'] = bootstrap_dir
 
 
 def main():
-    if len(sys.argv) < 2 or sys.argv[1] == "-h":
+    if len(sys.argv) < 2 or sys.argv[1] == '-h':
         print(USAGE)
         return
 
-    log.debug("sys.argv: %s", sys.argv)
+    log.debug('sys.argv: %s', sys.argv)
 
     root_dir = _ddtrace_root()
-    log.debug("ddtrace root: %s", root_dir)
+    log.debug('ddtrace root: %s', root_dir)
 
     bootstrap_dir = os.path.join(root_dir, 'bootstrap')
-    log.debug("ddtrace bootstrap: %s", bootstrap_dir)
+    log.debug('ddtrace bootstrap: %s', bootstrap_dir)
 
     _add_bootstrap_to_pythonpath(bootstrap_dir)
-    log.debug("PYTHONPATH: %s", os.environ['PYTHONPATH'])
-    log.debug("sys.path: %s", sys.path)
+    log.debug('PYTHONPATH: %s', os.environ['PYTHONPATH'])
+    log.debug('sys.path: %s', sys.path)
 
     executable = sys.argv[1]
 
     # Find the executable path
     executable = spawn.find_executable(executable)
-    log.debug("program executable: %s", executable)
+    log.debug('program executable: %s', executable)
 
     os.execl(executable, executable, *sys.argv[2:])

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -28,7 +28,7 @@ def patch():
     setattr(botocore.client, '_datadog_patch', True)
 
     wrapt.wrap_function_wrapper('botocore.client', 'BaseClient._make_api_call', patched_api_call)
-    Pin(service="aws", app="aws", app_type="web").onto(botocore.client.BaseClient)
+    Pin(service='aws', app='aws', app_type='web').onto(botocore.client.BaseClient)
 
 
 def unpatch():
@@ -43,10 +43,10 @@ def patched_api_call(original_func, instance, args, kwargs):
     if not pin or not pin.enabled():
         return original_func(*args, **kwargs)
 
-    endpoint_name = deep_getattr(instance, "_endpoint._endpoint_prefix")
+    endpoint_name = deep_getattr(instance, '_endpoint._endpoint_prefix')
 
     with pin.tracer.trace('{}.command'.format(endpoint_name),
-                          service="{}.{}".format(pin.service, endpoint_name),
+                          service='{}.{}'.format(pin.service, endpoint_name),
                           span_type=SPAN_TYPE) as span:
 
         operation = None
@@ -59,7 +59,7 @@ def patched_api_call(original_func, instance, args, kwargs):
 
         aws.add_span_arg_tags(span, endpoint_name, args, ARGS_NAME, TRACED_ARGS)
 
-        region_name = deep_getattr(instance, "meta.region_name")
+        region_name = deep_getattr(instance, 'meta.region_name')
 
         meta = {
             'aws.agent': 'botocore',
@@ -71,7 +71,7 @@ def patched_api_call(original_func, instance, args, kwargs):
         result = original_func(*args, **kwargs)
 
         span.set_tag(http.STATUS_CODE, result['ResponseMetadata']['HTTPStatusCode'])
-        span.set_tag("retry_attempts", result['ResponseMetadata']['RetryAttempts'])
+        span.set_tag('retry_attempts', result['ResponseMetadata']['RetryAttempts'])
 
         # set analytics sample rate
         span.set_tag(

--- a/ddtrace/contrib/bottle/patch.py
+++ b/ddtrace/contrib/bottle/patch.py
@@ -20,7 +20,7 @@ def patch():
 def traced_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
 
-    service = os.environ.get("DATADOG_SERVICE_NAME") or "bottle"
+    service = os.environ.get('DATADOG_SERVICE_NAME') or 'bottle'
 
     plugin = TracePlugin(service=service)
     instance.install(plugin)

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -196,8 +196,8 @@ def _get_vendor(conn):
     try:
         name = _get_module_name(conn)
     except Exception:
-        log.debug("couldnt parse module name", exc_info=True)
-        name = "sql"
+        log.debug('couldnt parse module name', exc_info=True)
+        name = 'sql'
     return sql.normalize_vendor(name)
 
 

--- a/ddtrace/contrib/django/middleware.py
+++ b/ddtrace/contrib/django/middleware.py
@@ -96,7 +96,7 @@ class TraceExceptionMiddleware(InstrumentationMixin):
                 span.set_tag(http.STATUS_CODE, '500')
                 span.set_traceback()  # will set the exception info
         except Exception:
-            log.debug("error processing exception", exc_info=True)
+            log.debug('error processing exception', exc_info=True)
 
 
 class TraceMiddleware(InstrumentationMixin):
@@ -179,7 +179,7 @@ class TraceMiddleware(InstrumentationMixin):
                 span = _set_auth_tags(span, request)
                 span.finish()
         except Exception:
-            log.debug("error tracing request", exc_info=True)
+            log.debug('error tracing request', exc_info=True)
         finally:
             return response
 

--- a/ddtrace/contrib/django/templates.py
+++ b/ddtrace/contrib/django/templates.py
@@ -22,7 +22,7 @@ def patch_template(tracer):
     # patch so we can use multiple tracers at once, but i suspect this is fine
     # in practice.
     if getattr(Template, RENDER_ATTR, None):
-        log.debug("already patched")
+        log.debug('already patched')
         return
 
     setattr(Template, RENDER_ATTR, Template.render)

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -2,8 +2,8 @@ def _resource_from_cache_prefix(resource, cache):
     """
     Combine the resource name with the cache prefix (if any)
     """
-    if getattr(cache, "key_prefix", None):
-        name = "{} {}".format(resource, cache.key_prefix)
+    if getattr(cache, 'key_prefix', None):
+        name = '{} {}'.format(resource, cache.key_prefix)
     else:
         name = resource
 

--- a/ddtrace/contrib/elasticsearch/transport.py
+++ b/ddtrace/contrib/elasticsearch/transport.py
@@ -24,7 +24,7 @@ def get_traced_transport(datadog_tracer, datadog_service=DEFAULT_SERVICE):
         _datadog_service = datadog_service
 
         def perform_request(self, method, url, params=None, body=None):
-            with self._datadog_tracer.trace("elasticsearch.query") as s:
+            with self._datadog_tracer.trace('elasticsearch.query') as s:
                 # Don't instrument if the trace is not sampled
                 if not s.sampled:
                     return super(TracedTransport, self).perform_request(
@@ -35,7 +35,7 @@ def get_traced_transport(datadog_tracer, datadog_service=DEFAULT_SERVICE):
                 s.set_tag(metadata.METHOD, method)
                 s.set_tag(metadata.URL, url)
                 s.set_tag(metadata.PARAMS, urlencode(params))
-                if method == "GET":
+                if method == 'GET':
                     s.set_tag(metadata.BODY, self.serializer.dumps(body))
                 s = quantize(s)
 
@@ -57,7 +57,7 @@ def get_traced_transport(datadog_tracer, datadog_service=DEFAULT_SERVICE):
                 if status:
                     s.set_tag(http.STATUS_CODE, status)
 
-                took = data.get("took")
+                took = data.get('took')
                 if took:
                     s.set_metric(metadata.TOOK, int(took))
 

--- a/ddtrace/contrib/falcon/middleware.py
+++ b/ddtrace/contrib/falcon/middleware.py
@@ -11,7 +11,7 @@ from ...settings import config
 
 class TraceMiddleware(object):
 
-    def __init__(self, tracer, service="falcon", distributed_tracing=True):
+    def __init__(self, tracer, service='falcon', distributed_tracing=True):
         # store tracing references
         self.tracer = tracer
         self.service = service
@@ -28,7 +28,7 @@ class TraceMiddleware(object):
                 self.tracer.context_provider.activate(context)
 
         span = self.tracer.trace(
-            "falcon.request",
+            'falcon.request',
             service=self.service,
             span_type=httpx.TYPE,
         )
@@ -49,7 +49,7 @@ class TraceMiddleware(object):
         span = self.tracer.current_span()
         if not span:
             return  # unexpected
-        span.resource = "%s %s" % (req.method, _name(resource))
+        span.resource = '%s %s' % (req.method, _name(resource))
 
     def process_response(self, req, resp, resource, req_succeeded=None):
         # req_succeded is not a kwarg in the API, but we need that to support
@@ -68,7 +68,7 @@ class TraceMiddleware(object):
         # here. See https://github.com/falconry/falcon/issues/606
         if resource is None:
             status = '404'
-            span.resource = "%s 404" % req.method
+            span.resource = '%s 404' % req.method
             span.set_tag(httpx.STATUS_CODE, status)
             span.finish()
             return
@@ -111,4 +111,4 @@ def _detect_and_set_status_error(err_type, span):
 
 
 def _name(r):
-    return "%s.%s" % (r.__module__, r.__class__.__name__)
+    return '%s.%s' % (r.__module__, r.__class__.__name__)

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -17,7 +17,7 @@ SPAN_NAME = 'flask.request'
 class TraceMiddleware(object):
 
     @deprecated(message='Use patching instead (see the docs).', version='1.0.0')
-    def __init__(self, app, tracer, service="flask", use_signals=True, distributed_tracing=False):
+    def __init__(self, app, tracer, service='flask', use_signals=True, distributed_tracing=False):
         self.app = app
         log.debug('flask: initializing trace middleware')
 
@@ -62,7 +62,7 @@ class TraceMiddleware(object):
             s = getattr(signals, name, None)
             if not s:
                 connected = False
-                log.warn("trying to instrument missing signal %s", name)
+                log.warn('trying to instrument missing signal %s', name)
                 continue
             # we should connect to the signal without using weak references
             # otherwise they will be garbage collected and our handlers
@@ -126,7 +126,7 @@ class TraceMiddleware(object):
         span.set_tag(http.STATUS_CODE, code)
 
     def _request_exception(self, *args, **kwargs):
-        exception = kwargs.get("exception", None)
+        exception = kwargs.get('exception', None)
         span = getattr(g, 'flask_datadog_span', None)
         if span and exception:
             _set_error_on_span(span, exception)
@@ -191,7 +191,7 @@ def _patch_render(tracer):
     def _traced_render(template, context, app):
         with tracer.trace('flask.template') as span:
             span.span_type = http.TEMPLATE
-            span.set_tag("flask.template", template.name or "string")
+            span.set_tag('flask.template', template.name or 'string')
             return _render(template, context, app)
 
     flask.templating._render = _traced_render
@@ -204,6 +204,6 @@ def _signals_exist(names):
 
 
 _blinker_not_installed_msg = (
-    "please install blinker to use flask signals. "
-    "http://flask.pocoo.org/docs/0.11/signals/"
+    'please install blinker to use flask signals. '
+    'http://flask.pocoo.org/docs/0.11/signals/'
 )

--- a/ddtrace/contrib/flask_cache/tracers.py
+++ b/ddtrace/contrib/flask_cache/tracers.py
@@ -16,13 +16,13 @@ from flask.ext.cache import Cache
 
 log = logging.Logger(__name__)
 
-TYPE = "cache"
-DEFAULT_SERVICE = "flask-cache"
+TYPE = 'cache'
+DEFAULT_SERVICE = 'flask-cache'
 
 # standard tags
-COMMAND_KEY = "flask_cache.key"
-CACHE_BACKEND = "flask_cache.backend"
-CONTACT_POINTS = "flask_cache.contact_points"
+COMMAND_KEY = 'flask_cache.key'
+CACHE_BACKEND = 'flask_cache.backend'
+CONTACT_POINTS = 'flask_cache.contact_points'
 
 
 def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
@@ -51,7 +51,7 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
                 service=self._datadog_service
             )
             # set span tags
-            s.set_tag(CACHE_BACKEND, self.config.get("CACHE_TYPE"))
+            s.set_tag(CACHE_BACKEND, self.config.get('CACHE_TYPE'))
             s.set_tags(self._datadog_meta)
             # set analytics sample rate
             s.set_tag(
@@ -59,11 +59,11 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
                 config.flask_cache.get_analytics_sample_rate()
             )
             # add connection meta if there is one
-            if getattr(self.cache, "_client", None):
+            if getattr(self.cache, '_client', None):
                 try:
                     s.set_tags(_extract_conn_tags(self.cache._client))
                 except Exception:
-                    log.debug("error parsing connection tags", exc_info=True)
+                    log.debug('error parsing connection tags', exc_info=True)
 
             return s
 
@@ -71,8 +71,8 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
             """
             Track ``get`` operation
             """
-            with self.__trace("flask_cache.cmd") as span:
-                span.resource = _resource_from_cache_prefix("GET", self.config)
+            with self.__trace('flask_cache.cmd') as span:
+                span.resource = _resource_from_cache_prefix('GET', self.config)
                 if len(args) > 0:
                     span.set_tag(COMMAND_KEY, args[0])
                 return super(TracedCache, self).get(*args, **kwargs)
@@ -81,8 +81,8 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
             """
             Track ``set`` operation
             """
-            with self.__trace("flask_cache.cmd") as span:
-                span.resource = _resource_from_cache_prefix("SET", self.config)
+            with self.__trace('flask_cache.cmd') as span:
+                span.resource = _resource_from_cache_prefix('SET', self.config)
                 if len(args) > 0:
                     span.set_tag(COMMAND_KEY, args[0])
                 return super(TracedCache, self).set(*args, **kwargs)
@@ -91,8 +91,8 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
             """
             Track ``add`` operation
             """
-            with self.__trace("flask_cache.cmd") as span:
-                span.resource = _resource_from_cache_prefix("ADD", self.config)
+            with self.__trace('flask_cache.cmd') as span:
+                span.resource = _resource_from_cache_prefix('ADD', self.config)
                 if len(args) > 0:
                     span.set_tag(COMMAND_KEY, args[0])
                 return super(TracedCache, self).add(*args, **kwargs)
@@ -101,8 +101,8 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
             """
             Track ``delete`` operation
             """
-            with self.__trace("flask_cache.cmd") as span:
-                span.resource = _resource_from_cache_prefix("DELETE", self.config)
+            with self.__trace('flask_cache.cmd') as span:
+                span.resource = _resource_from_cache_prefix('DELETE', self.config)
                 if len(args) > 0:
                     span.set_tag(COMMAND_KEY, args[0])
                 return super(TracedCache, self).delete(*args, **kwargs)
@@ -111,8 +111,8 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
             """
             Track ``delete_many`` operation
             """
-            with self.__trace("flask_cache.cmd") as span:
-                span.resource = _resource_from_cache_prefix("DELETE_MANY", self.config)
+            with self.__trace('flask_cache.cmd') as span:
+                span.resource = _resource_from_cache_prefix('DELETE_MANY', self.config)
                 span.set_tag(COMMAND_KEY, list(args))
                 return super(TracedCache, self).delete_many(*args, **kwargs)
 
@@ -120,16 +120,16 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
             """
             Track ``clear`` operation
             """
-            with self.__trace("flask_cache.cmd") as span:
-                span.resource = _resource_from_cache_prefix("CLEAR", self.config)
+            with self.__trace('flask_cache.cmd') as span:
+                span.resource = _resource_from_cache_prefix('CLEAR', self.config)
                 return super(TracedCache, self).clear(*args, **kwargs)
 
         def get_many(self, *args, **kwargs):
             """
             Track ``get_many`` operation
             """
-            with self.__trace("flask_cache.cmd") as span:
-                span.resource = _resource_from_cache_prefix("GET_MANY", self.config)
+            with self.__trace('flask_cache.cmd') as span:
+                span.resource = _resource_from_cache_prefix('GET_MANY', self.config)
                 span.set_tag(COMMAND_KEY, list(args))
                 return super(TracedCache, self).get_many(*args, **kwargs)
 
@@ -137,8 +137,8 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
             """
             Track ``set_many`` operation
             """
-            with self.__trace("flask_cache.cmd") as span:
-                span.resource = _resource_from_cache_prefix("SET_MANY", self.config)
+            with self.__trace('flask_cache.cmd') as span:
+                span.resource = _resource_from_cache_prefix('SET_MANY', self.config)
                 if len(args) > 0:
                     span.set_tag(COMMAND_KEY, list(args[0].keys()))
                 return super(TracedCache, self).set_many(*args, **kwargs)

--- a/ddtrace/contrib/flask_cache/utils.py
+++ b/ddtrace/contrib/flask_cache/utils.py
@@ -8,8 +8,8 @@ def _resource_from_cache_prefix(resource, cache):
     """
     Combine the resource name with the cache prefix (if any)
     """
-    if getattr(cache, "key_prefix", None):
-        name = "{} {}".format(resource, cache.key_prefix)
+    if getattr(cache, 'key_prefix', None):
+        name = '{} {}'.format(resource, cache.key_prefix)
     else:
         name = resource
 
@@ -23,7 +23,7 @@ def _extract_conn_tags(client):
     """
     tags = {}
 
-    if hasattr(client, "servers"):
+    if hasattr(client, 'servers'):
         # Memcached backend supports an address pool
         if isinstance(client.servers, list) and len(client.servers) > 0:
             # use the first address of the pool as a host because
@@ -31,11 +31,11 @@ def _extract_conn_tags(client):
             contact_point = client.servers[0].address
             tags[net.TARGET_HOST] = contact_point[0]
             tags[net.TARGET_PORT] = contact_point[1]
-    elif hasattr(client, "connection_pool"):
+    elif hasattr(client, 'connection_pool'):
         # Redis main connection
         redis_tags = extract_redis_tags(client.connection_pool.connection_kwargs)
         tags.update(**redis_tags)
-    elif hasattr(client, "addresses"):
+    elif hasattr(client, 'addresses'):
         # pylibmc
         # FIXME[matt] should we memoize this?
         addrs = parse_addresses(client.addresses)

--- a/ddtrace/contrib/grpc/__init__.py
+++ b/ddtrace/contrib/grpc/__init__.py
@@ -31,7 +31,7 @@ To configure the Grpc integration on an per-channel basis use the
 
 from ...utils.importlib import require_modules
 
-required_modules = ["grpc"]
+required_modules = ['grpc']
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:

--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -38,7 +38,7 @@ def _connect(func, instance, args, kwargs):
 def patch_conn(conn):
 
     tags = {t: getattr(conn, a) for t, a in CONN_ATTR_BY_TAG.items() if getattr(conn, a, '') != ''}
-    pin = Pin(service="mysql", app="mysql", app_type=AppTypes.db, tags=tags)
+    pin = Pin(service='mysql', app='mysql', app_type=AppTypes.db, tags=tags)
 
     # grab the metadata from the conn
     wrapped = TracedConnection(conn, pin=pin)

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -55,7 +55,7 @@ def patch_conn(conn, *args, **kwargs):
             for t, (k, p) in KWPOS_BY_TAG.items()
             if k in kwargs or len(args) > p}
     tags[net.TARGET_PORT] = conn.port
-    pin = Pin(service="mysql", app="mysql", app_type=AppTypes.db, tags=tags)
+    pin = Pin(service='mysql', app='mysql', app_type=AppTypes.db, tags=tags)
 
     # grab the metadata from the conn
     wrapped = TracedConnection(conn, pin=pin)

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -79,17 +79,17 @@ def patch_conn(conn, traced_conn_cls=Psycopg2TracedConnection):
     # fetch tags from the dsn
     dsn = sql.parse_pg_dsn(conn.dsn)
     tags = {
-        net.TARGET_HOST: dsn.get("host"),
-        net.TARGET_PORT: dsn.get("port"),
-        db.NAME: dsn.get("dbname"),
-        db.USER: dsn.get("user"),
-        "db.application": dsn.get("application_name"),
+        net.TARGET_HOST: dsn.get('host'),
+        net.TARGET_PORT: dsn.get('port'),
+        db.NAME: dsn.get('dbname'),
+        db.USER: dsn.get('user'),
+        'db.application': dsn.get('application_name'),
     }
 
     Pin(
-        service="postgres",
-        app="postgres",
-        app_type="db",
+        service='postgres',
+        app='postgres',
+        app_type='db',
         tags=tags).onto(c)
 
     return c

--- a/ddtrace/contrib/pylibmc/client.py
+++ b/ddtrace/contrib/pylibmc/client.py
@@ -29,15 +29,15 @@ class TracedClient(ObjectProxy):
 
         """
         # The client instance/service/tracer attributes are kept for compatibility
-        # with the old interface: TracedClient(client=pylibmc.Client(["localhost:11211"]))
+        # with the old interface: TracedClient(client=pylibmc.Client(['localhost:11211']))
         # TODO(Benjamin): Remove these in favor of patching.
         if not isinstance(client, _Client):
             # We are in the patched situation, just pass down all arguments to the pylibmc.Client
             # Note that, in that case, client isn't a real client (just the first argument)
             client = _Client(client, *args, **kwargs)
         else:
-            log.warning("TracedClient instantiation is deprecated and will be remove "
-                        "in future versions (0.6.0). Use patching instead (see the docs).")
+            log.warning('TracedClient instantiation is deprecated and will be remove '
+                        'in future versions (0.6.0). Use patching instead (see the docs).')
 
         super(TracedClient, self).__init__(client)
 
@@ -48,7 +48,7 @@ class TracedClient(ObjectProxy):
         try:
             self._addresses = parse_addresses(client.addresses)
         except Exception:
-            log.debug("error setting addresses", exc_info=True)
+            log.debug('error setting addresses', exc_info=True)
 
     def clone(self, *args, **kwargs):
         # rewrap new connections.
@@ -60,43 +60,43 @@ class TracedClient(ObjectProxy):
         return traced_client
 
     def get(self, *args, **kwargs):
-        return self._trace_cmd("get", *args, **kwargs)
+        return self._trace_cmd('get', *args, **kwargs)
 
     def set(self, *args, **kwargs):
-        return self._trace_cmd("set", *args, **kwargs)
+        return self._trace_cmd('set', *args, **kwargs)
 
     def delete(self, *args, **kwargs):
-        return self._trace_cmd("delete", *args, **kwargs)
+        return self._trace_cmd('delete', *args, **kwargs)
 
     def gets(self, *args, **kwargs):
-        return self._trace_cmd("gets", *args, **kwargs)
+        return self._trace_cmd('gets', *args, **kwargs)
 
     def touch(self, *args, **kwargs):
-        return self._trace_cmd("touch", *args, **kwargs)
+        return self._trace_cmd('touch', *args, **kwargs)
 
     def cas(self, *args, **kwargs):
-        return self._trace_cmd("cas", *args, **kwargs)
+        return self._trace_cmd('cas', *args, **kwargs)
 
     def incr(self, *args, **kwargs):
-        return self._trace_cmd("incr", *args, **kwargs)
+        return self._trace_cmd('incr', *args, **kwargs)
 
     def decr(self, *args, **kwargs):
-        return self._trace_cmd("decr", *args, **kwargs)
+        return self._trace_cmd('decr', *args, **kwargs)
 
     def append(self, *args, **kwargs):
-        return self._trace_cmd("append", *args, **kwargs)
+        return self._trace_cmd('append', *args, **kwargs)
 
     def prepend(self, *args, **kwargs):
-        return self._trace_cmd("prepend", *args, **kwargs)
+        return self._trace_cmd('prepend', *args, **kwargs)
 
     def get_multi(self, *args, **kwargs):
-        return self._trace_multi_cmd("get_multi", *args, **kwargs)
+        return self._trace_multi_cmd('get_multi', *args, **kwargs)
 
     def set_multi(self, *args, **kwargs):
-        return self._trace_multi_cmd("set_multi", *args, **kwargs)
+        return self._trace_multi_cmd('set_multi', *args, **kwargs)
 
     def delete_multi(self, *args, **kwargs):
-        return self._trace_multi_cmd("delete_multi", *args, **kwargs)
+        return self._trace_multi_cmd('delete_multi', *args, **kwargs)
 
     def _trace_cmd(self, method_name, *args, **kwargs):
         """ trace the execution of the method with the given name and will
@@ -106,7 +106,7 @@ class TracedClient(ObjectProxy):
         with self._span(method_name) as span:
 
             if span and args:
-                span.set_tag(memcached.QUERY, "%s %s" % (method_name, args[0]))
+                span.set_tag(memcached.QUERY, '%s %s' % (method_name, args[0]))
 
             return method(*args, **kwargs)
 
@@ -117,7 +117,7 @@ class TracedClient(ObjectProxy):
 
             pre = kwargs.get('key_prefix')
             if span and pre:
-                span.set_tag(memcached.QUERY, "%s %s" % (method_name, pre))
+                span.set_tag(memcached.QUERY, '%s %s' % (method_name, pre))
 
             return method(*args, **kwargs)
 
@@ -126,16 +126,16 @@ class TracedClient(ObjectProxy):
         pin = ddtrace.Pin.get_from(self)
         if pin and pin.enabled():
             span = pin.tracer.trace(
-                "memcached.cmd",
+                'memcached.cmd',
                 service=pin.service,
                 resource=cmd_name,
                 # TODO(Benjamin): set a better span type
-                span_type="cache")
+                span_type='cache')
 
             try:
                 self._tag_span(span)
             except Exception:
-                log.debug("error tagging span", exc_info=True)
+                log.debug('error tagging span', exc_info=True)
             return span
 
     def _tag_span(self, span):

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -41,7 +41,7 @@ class PylonsTraceMiddleware(object):
             if context.trace_id:
                 self._tracer.context_provider.activate(context)
 
-        with self._tracer.trace("pylons.request", service=self._service) as span:
+        with self._tracer.trace('pylons.request', service=self._service) as span:
             # Set the service in tracer.trace() as priority sampling requires it to be
             # set as early as possible when different services share one single agent.
             span.span_type = http.TYPE
@@ -95,12 +95,12 @@ class PylonsTraceMiddleware(object):
                 # set resources. If this is so, don't do anything, otherwise
                 # set the resource to the controller / action that handled it.
                 if span.resource == span.name:
-                    span.resource = "%s.%s" % (controller, action)
+                    span.resource = '%s.%s' % (controller, action)
 
                 span.set_tags({
                     http.METHOD: environ.get('REQUEST_METHOD'),
                     http.URL: environ.get('PATH_INFO'),
-                    "pylons.user": environ.get('REMOTE_USER', ''),
-                    "pylons.route.controller": controller,
-                    "pylons.route.action": action,
+                    'pylons.user': environ.get('REMOTE_USER', ''),
+                    'pylons.route.controller': controller,
+                    'pylons.route.action': action,
                 })

--- a/ddtrace/contrib/pymemcache/client.py
+++ b/ddtrace/contrib/pymemcache/client.py
@@ -54,72 +54,72 @@ class WrappedClient(wrapt.ObjectProxy):
         pin.onto(self)
 
     def set(self, *args, **kwargs):
-        return self._traced_cmd("set", *args, **kwargs)
+        return self._traced_cmd('set', *args, **kwargs)
 
     def set_many(self, *args, **kwargs):
-        return self._traced_cmd("set_many", *args, **kwargs)
+        return self._traced_cmd('set_many', *args, **kwargs)
 
     def add(self, *args, **kwargs):
-        return self._traced_cmd("add", *args, **kwargs)
+        return self._traced_cmd('add', *args, **kwargs)
 
     def replace(self, *args, **kwargs):
-        return self._traced_cmd("replace", *args, **kwargs)
+        return self._traced_cmd('replace', *args, **kwargs)
 
     def append(self, *args, **kwargs):
-        return self._traced_cmd("append", *args, **kwargs)
+        return self._traced_cmd('append', *args, **kwargs)
 
     def prepend(self, *args, **kwargs):
-        return self._traced_cmd("prepend", *args, **kwargs)
+        return self._traced_cmd('prepend', *args, **kwargs)
 
     def cas(self, *args, **kwargs):
-        return self._traced_cmd("cas", *args, **kwargs)
+        return self._traced_cmd('cas', *args, **kwargs)
 
     def get(self, *args, **kwargs):
-        return self._traced_cmd("get", *args, **kwargs)
+        return self._traced_cmd('get', *args, **kwargs)
 
     def get_many(self, *args, **kwargs):
-        return self._traced_cmd("get_many", *args, **kwargs)
+        return self._traced_cmd('get_many', *args, **kwargs)
 
     def gets(self, *args, **kwargs):
-        return self._traced_cmd("gets", *args, **kwargs)
+        return self._traced_cmd('gets', *args, **kwargs)
 
     def gets_many(self, *args, **kwargs):
-        return self._traced_cmd("gets_many", *args, **kwargs)
+        return self._traced_cmd('gets_many', *args, **kwargs)
 
     def delete(self, *args, **kwargs):
-        return self._traced_cmd("delete", *args, **kwargs)
+        return self._traced_cmd('delete', *args, **kwargs)
 
     def delete_many(self, *args, **kwargs):
-        return self._traced_cmd("delete_many", *args, **kwargs)
+        return self._traced_cmd('delete_many', *args, **kwargs)
 
     def incr(self, *args, **kwargs):
-        return self._traced_cmd("incr", *args, **kwargs)
+        return self._traced_cmd('incr', *args, **kwargs)
 
     def decr(self, *args, **kwargs):
-        return self._traced_cmd("decr", *args, **kwargs)
+        return self._traced_cmd('decr', *args, **kwargs)
 
     def touch(self, *args, **kwargs):
-        return self._traced_cmd("touch", *args, **kwargs)
+        return self._traced_cmd('touch', *args, **kwargs)
 
     def stats(self, *args, **kwargs):
-        return self._traced_cmd("stats", *args, **kwargs)
+        return self._traced_cmd('stats', *args, **kwargs)
 
     def version(self, *args, **kwargs):
-        return self._traced_cmd("version", *args, **kwargs)
+        return self._traced_cmd('version', *args, **kwargs)
 
     def flush_all(self, *args, **kwargs):
-        return self._traced_cmd("flush_all", *args, **kwargs)
+        return self._traced_cmd('flush_all', *args, **kwargs)
 
     def quit(self, *args, **kwargs):
-        return self._traced_cmd("quit", *args, **kwargs)
+        return self._traced_cmd('quit', *args, **kwargs)
 
     def set_multi(self, *args, **kwargs):
         """set_multi is an alias for set_many"""
-        return self._traced_cmd("set_many", *args, **kwargs)
+        return self._traced_cmd('set_many', *args, **kwargs)
 
     def get_multi(self, *args, **kwargs):
         """set_multi is an alias for set_many"""
-        return self._traced_cmd("get_many", *args, **kwargs)
+        return self._traced_cmd('get_many', *args, **kwargs)
 
     def _traced_cmd(self, method_name, *args, **kwargs):
         """Run and trace the given command.
@@ -154,10 +154,10 @@ class WrappedClient(wrapt.ObjectProxy):
             try:
                 span.set_tags(p.tags)
                 vals = _get_query_string(args)
-                query = "{}{}{}".format(method_name, " " if vals else "", vals)
+                query = '{}{}{}'.format(method_name, ' ' if vals else '', vals)
                 span.set_tag(memcachedx.QUERY, query)
             except Exception:
-                log.debug("Error setting relevant pymemcache tags")
+                log.debug('Error setting relevant pymemcache tags')
 
             try:
                 return method(*args, **kwargs)
@@ -182,7 +182,7 @@ def _get_address_tags(*args, **kwargs):
             tags[net.TARGET_HOST] = host
             tags[net.TARGET_PORT] = port
     except Exception:
-        log.debug("Error collecting client address tags")
+        log.debug('Error collecting client address tags')
 
     return tags
 
@@ -193,7 +193,7 @@ def _get_query_string(args):
     If there are multiple query values, they are joined together
     space-separated.
     """
-    keys = ""
+    keys = ''
 
     # shortcut if no args
     if not args:
@@ -212,8 +212,8 @@ def _get_query_string(args):
         keys = arg.decode()
     elif type(arg) is list and len(arg):
         if type(arg[0]) is str:
-            keys = " ".join(arg)
+            keys = ' '.join(arg)
         elif type(arg[0]) is bytes:
-            keys = b" ".join(arg).decode()
+            keys = b' '.join(arg).decode()
 
     return keys

--- a/ddtrace/contrib/pymemcache/patch.py
+++ b/ddtrace/contrib/pymemcache/patch.py
@@ -8,11 +8,11 @@ _Client = pymemcache.client.base.Client
 
 
 def patch():
-    if getattr(pymemcache.client, "_datadog_patch", False):
+    if getattr(pymemcache.client, '_datadog_patch', False):
         return
 
-    setattr(pymemcache.client, "_datadog_patch", True)
-    setattr(pymemcache.client.base, "Client", WrappedClient)
+    setattr(pymemcache.client, '_datadog_patch', True)
+    setattr(pymemcache.client.base, 'Client', WrappedClient)
 
     # Create a global pin with default configuration for our pymemcache clients
     Pin(
@@ -22,10 +22,10 @@ def patch():
 
 def unpatch():
     """Remove pymemcache tracing"""
-    if not getattr(pymemcache.client, "_datadog_patch", False):
+    if not getattr(pymemcache.client, '_datadog_patch', False):
         return
-    setattr(pymemcache.client, "_datadog_patch", False)
-    setattr(pymemcache.client.base, "Client", _Client)
+    setattr(pymemcache.client, '_datadog_patch', False)
+    setattr(pymemcache.client.base, 'Client', _Client)
 
     # Remove any pins that may exist on the pymemcache reference
     setattr(pymemcache, _DD_PIN_NAME, None)

--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -97,7 +97,7 @@ class TracedServer(ObjectProxy):
             try:
                 cmd = parse_query(operation)
             except Exception:
-                log.exception("error parsing query")
+                log.exception('error parsing query')
 
         pin = ddtrace.Pin.get_from(self)
 
@@ -109,7 +109,7 @@ class TracedServer(ObjectProxy):
                 **kwargs)
 
         with pin.tracer.trace(
-                "pymongo.cmd",
+                'pymongo.cmd',
                 span_type=mongox.TYPE,
                 service=pin.service) as span:
 
@@ -159,7 +159,7 @@ class TracedSocket(ObjectProxy):
         try:
             cmd = parse_spec(spec, dbname)
         except Exception:
-            log.exception("error parsing spec. skipping trace")
+            log.exception('error parsing spec. skipping trace')
 
         pin = ddtrace.Pin.get_from(self)
         # skip tracing if we don't have a piece of data we need
@@ -175,7 +175,7 @@ class TracedSocket(ObjectProxy):
         try:
             cmd = parse_msg(msg)
         except Exception:
-            log.exception("error parsing msg")
+            log.exception('error parsing msg')
 
         pin = ddtrace.Pin.get_from(self)
         # if we couldn't parse it, don't try to trace it.
@@ -185,13 +185,13 @@ class TracedSocket(ObjectProxy):
         with self.__trace(cmd) as s:
             result = self.__wrapped__.write_command(request_id, msg)
             if result:
-                s.set_metric(mongox.ROWS, result.get("n", -1))
+                s.set_metric(mongox.ROWS, result.get('n', -1))
             return result
 
     def __trace(self, cmd):
         pin = ddtrace.Pin.get_from(self)
         s = pin.tracer.trace(
-            "pymongo.cmd",
+            'pymongo.cmd',
             span_type=mongox.TYPE,
             service=pin.service)
 
@@ -228,9 +228,9 @@ def normalize_filter(f=None):
         #   {$or: [ { age: { $lt: 30 } }, { type: 1 } ]})
         out = {}
         for k, v in iteritems(f):
-            if k == "$in" or k == "$nin":
+            if k == '$in' or k == '$nin':
                 # special case $in queries so we don't loop over lists.
-                out[k] = "?"
+                out[k] = '?'
             elif isinstance(v, list) or isinstance(v, dict):
                 # RECURSION ALERT: needs to move to the agent
                 out[k] = normalize_filter(v)

--- a/ddtrace/contrib/pymongo/parse.py
+++ b/ddtrace/contrib/pymongo/parse.py
@@ -18,23 +18,23 @@ log = get_logger(__name__)
 # MongoDB wire protocol commands
 # http://docs.mongodb.com/manual/reference/mongodb-wire-protocol
 OP_CODES = {
-    1: "reply",
-    1000: "msg",
-    2001: "update",
-    2002: "insert",
-    2003: "reserved",
-    2004: "query",
-    2005: "get_more",
-    2006: "delete",
-    2007: "kill_cursors",
-    2010: "command",
-    2011: "command_reply",
+    1: 'reply',
+    1000: 'msg',
+    2001: 'update',
+    2002: 'insert',
+    2003: 'reserved',
+    2004: 'query',
+    2005: 'get_more',
+    2006: 'delete',
+    2007: 'kill_cursors',
+    2010: 'command',
+    2011: 'command_reply',
 }
 
 # The maximum message length we'll try to parse
 MAX_MSG_PARSE_LEN = 1024 * 1024
 
-header_struct = struct.Struct("<iiii")
+header_struct = struct.Struct('<iiii')
 
 
 class Command(object):
@@ -52,10 +52,10 @@ class Command(object):
 
     def __repr__(self):
         return (
-            "Command("
-            "name=%s,"
-            "db=%s,"
-            "coll=%s)"
+            'Command('
+            'name=%s,'
+            'db=%s,'
+            'coll=%s)'
         ) % (self.name, self.db, self.coll)
 
 
@@ -75,7 +75,7 @@ def parse_msg(msg_bytes):
 
     op = OP_CODES.get(op_code)
     if not op:
-        log.debug("unknown op code: %s", op_code)
+        log.debug('unknown op code: %s', op_code)
         return None
 
     db = None
@@ -83,7 +83,7 @@ def parse_msg(msg_bytes):
 
     offset = header_struct.size
     cmd = None
-    if op == "query":
+    if op == 'query':
         # NOTE[matt] inserts, updates and queries can all use this opcode
 
         offset += 4  # skip flags
@@ -91,7 +91,7 @@ def parse_msg(msg_bytes):
         offset += len(ns) + 1  # include null terminator
 
         # note: here coll could be '$cmd' because it can be overridden in the
-        # query itself (like {"insert":"songs"})
+        # query itself (like {'insert':'songs'})
         db, coll = _split_namespace(ns)
 
         offset += 8  # skip numberToSkip & numberToReturn
@@ -106,7 +106,7 @@ def parse_msg(msg_bytes):
             cmd = parse_spec(spec, db)
         else:
             # let's still note that a command happened.
-            cmd = Command("command", db, "untraced_message_too_large")
+            cmd = Command('command', db, 'untraced_message_too_large')
 
         # If the command didn't contain namespace info, set it here.
         if not cmd.coll:
@@ -119,14 +119,14 @@ def parse_msg(msg_bytes):
 def parse_query(query):
     """ Return a command parsed from the given mongo db query. """
     db, coll = None, None
-    ns = getattr(query, "ns", None)
+    ns = getattr(query, 'ns', None)
     if ns:
         # version < 3.1 stores the full namespace
         db, coll = _split_namespace(ns)
     else:
         # version >= 3.1 stores the db and coll seperately
-        coll = getattr(query, "coll", None)
-        db = getattr(query, "db", None)
+        coll = getattr(query, 'coll', None)
+        db = getattr(query, 'db', None)
 
     # pymongo < 3.1 _Query does not have a name field, so default to 'query'
     cmd = Command(getattr(query, 'name', 'query'), db, coll)
@@ -157,13 +157,13 @@ def parse_spec(spec, db=None):
         updates = spec.get('updates')
         if updates:
             # FIXME[matt] is there ever more than one here?
-            cmd.query = updates[0].get("q")
+            cmd.query = updates[0].get('q')
 
     elif cmd.name == 'delete':
         dels = spec.get('deletes')
         if dels:
             # FIXME[matt] is there ever more than one here?
-            cmd.query = dels[0].get("q")
+            cmd.query = dels[0].get('q')
 
     return cmd
 
@@ -174,11 +174,11 @@ def _cstring(raw):
 
 
 def _split_namespace(ns):
-    """ Return a tuple of (db, collecton) from the "db.coll" string. """
+    """ Return a tuple of (db, collecton) from the 'db.coll' string. """
     if ns:
         # NOTE[matt] ns is unicode or bytes depending on the client version
         # so force cast to unicode
-        split = to_unicode(ns).split(".", 1)
+        split = to_unicode(ns).split('.', 1)
         if len(split) == 1:
             raise Exception("namespace doesn't contain period: %s" % ns)
         return split

--- a/ddtrace/contrib/pymysql/patch.py
+++ b/ddtrace/contrib/pymysql/patch.py
@@ -31,7 +31,7 @@ def _connect(func, instance, args, kwargs):
 
 def patch_conn(conn):
     tags = {t: getattr(conn, a, '') for t, a in CONN_ATTR_BY_TAG.items()}
-    pin = Pin(service="pymysql", app="pymysql", app_type=AppTypes.db, tags=tags)
+    pin = Pin(service='pymysql', app='pymysql', app_type=AppTypes.db, tags=tags)
 
     # grab the metadata from the conn
     wrapped = TracedConnection(conn, pin=pin)

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -81,4 +81,4 @@ def insert_tween_if_needed(settings):
     if idx == -1:
         settings['pyramid.tweens'] = tweens + '\n' + DD_TWEEN_NAME
     else:
-        settings['pyramid.tweens'] = tweens[:idx] + DD_TWEEN_NAME + "\n" + tweens[idx:]
+        settings['pyramid.tweens'] = tweens[:idx] + DD_TWEEN_NAME + '\n' + tweens[idx:]

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -42,11 +42,11 @@ def trace_render(func, instance, args, kwargs):
     # If the request is not traced, we do not trace
     request = kwargs.get('request', {})
     if not request:
-        log.debug("No request passed to render, will not be traced")
+        log.debug('No request passed to render, will not be traced')
         return func(*args, **kwargs)
     span = getattr(request, DD_SPAN, None)
     if not span:
-        log.debug("No span found in request, will not be traced")
+        log.debug('No span found in request, will not be traced')
         return func(*args, **kwargs)
 
     tracer = span.tracer()

--- a/ddtrace/contrib/redis/util.py
+++ b/ddtrace/contrib/redis/util.py
@@ -4,9 +4,9 @@ Some utils used by the dogtrace redis integration
 from ...compat import stringify
 from ...ext import redis as redisx, net
 
-VALUE_PLACEHOLDER = "?"
+VALUE_PLACEHOLDER = '?'
 VALUE_MAX_LEN = 100
-VALUE_TOO_LONG_MARK = "..."
+VALUE_TOO_LONG_MARK = '...'
 CMD_MAX_LEN = 1000
 
 
@@ -40,7 +40,7 @@ def format_command_args(args):
 
             if length + len(cmd) > CMD_MAX_LEN:
                 prefix = cmd[:CMD_MAX_LEN - length]
-                out.append("%s%s" % (prefix, VALUE_TOO_LONG_MARK))
+                out.append('%s%s' % (prefix, VALUE_TOO_LONG_MARK))
                 break
 
             out.append(cmd)
@@ -49,4 +49,4 @@ def format_command_args(args):
             out.append(VALUE_PLACEHOLDER)
             break
 
-    return " ".join(out)
+    return ' '.join(out)

--- a/ddtrace/contrib/requests/connection.py
+++ b/ddtrace/contrib/requests/connection.py
@@ -113,4 +113,4 @@ def _wrap_send(func, instance, args, kwargs):
                     response_headers = dict(getattr(response, 'headers', {}))
                     store_response_headers(response_headers, span, config.requests)
             except Exception:
-                log.debug("requests: error adding tags", exc_info=True)
+                log.debug('requests: error adding tags', exc_info=True)

--- a/ddtrace/contrib/sqlalchemy/engine.py
+++ b/ddtrace/contrib/sqlalchemy/engine.py
@@ -7,9 +7,9 @@ instance you are using::
     from sqlalchemy import create_engine
 
     engine = create_engine('sqlite:///:memory:')
-    trace_engine(engine, tracer, "my-database")
+    trace_engine(engine, tracer, 'my-database')
 
-    engine.connect().execute("select count(*) from users")
+    engine.connect().execute('select count(*) from users')
 """
 # 3p
 from sqlalchemy.event import listen
@@ -57,7 +57,7 @@ class EngineTracer(object):
         self.engine = engine
         self.vendor = sqlx.normalize_vendor(engine.name)
         self.service = service or self.vendor
-        self.name = "%s.query" % self.vendor
+        self.name = '%s.query' % self.vendor
 
         # attach the PIN
         Pin(
@@ -144,6 +144,6 @@ def _set_tags_from_cursor(span, vendor, cursor):
             dsn = getattr(cursor.connection, 'dsn', None)
             if dsn:
                 d = sqlx.parse_pg_dsn(dsn)
-                span.set_tag(sqlx.DB, d.get("dbname"))
-                span.set_tag(netx.TARGET_HOST, d.get("host"))
-                span.set_tag(netx.TARGET_PORT, d.get("port"))
+                span.set_tag(sqlx.DB, d.get('dbname'))
+                span.set_tag(netx.TARGET_HOST, d.get('host'))
+                span.set_tag(netx.TARGET_PORT, d.get('port'))

--- a/ddtrace/contrib/sqlite3/patch.py
+++ b/ddtrace/contrib/sqlite3/patch.py
@@ -32,7 +32,7 @@ def traced_connect(func, _, args, kwargs):
 
 def patch_conn(conn):
     wrapped = TracedSQLite(conn)
-    Pin(service="sqlite", app="sqlite", app_type=AppTypes.db).onto(wrapped)
+    Pin(service='sqlite', app='sqlite', app_type=AppTypes.db).onto(wrapped)
     return wrapped
 
 

--- a/ddtrace/contrib/vertica/__init__.py
+++ b/ddtrace/contrib/vertica/__init__.py
@@ -36,13 +36,13 @@ To configure the Vertica integration on an instance-per-instance basis use the
     conn = vertica_python.connect(**YOUR_VERTICA_CONFIG)
 
     # override the service and tracer to be used
-    Pin.override(conn, service="myverticaservice", tracer=custom_tracer)
+    Pin.override(conn, service='myverticaservice', tracer=custom_tracer)
 """
 
 from ...utils.importlib import require_modules
 
 
-required_modules = ["vertica_python"]
+required_modules = ['vertica_python']
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:

--- a/ddtrace/contrib/vertica/constants.py
+++ b/ddtrace/contrib/vertica/constants.py
@@ -1,2 +1,2 @@
 # Service info
-APP = "vertica"
+APP = 'vertica'

--- a/ddtrace/contrib/vertica/patch.py
+++ b/ddtrace/contrib/vertica/patch.py
@@ -36,66 +36,66 @@ def fetch_span_end(instance, result, span, conf, *args, **kwargs):
 
 def cursor_span_end(instance, cursor, _, conf, *args, **kwargs):
     tags = {}
-    tags[net.TARGET_HOST] = instance.options["host"]
-    tags[net.TARGET_PORT] = instance.options["port"]
-    if "user" in instance.options:
-        tags[dbx.USER] = instance.options["user"]
-    if "database" in instance.options:
-        tags[dbx.NAME] = instance.options["database"]
+    tags[net.TARGET_HOST] = instance.options['host']
+    tags[net.TARGET_PORT] = instance.options['port']
+    if 'user' in instance.options:
+        tags[dbx.USER] = instance.options['user']
+    if 'database' in instance.options:
+        tags[dbx.NAME] = instance.options['database']
 
     pin = Pin(
-        service=config.vertica["service_name"],
+        service=config.vertica['service_name'],
         app=APP,
         app_type=AppTypes.db,
         tags=tags,
-        _config=config.vertica["patch"]["vertica_python.vertica.cursor.Cursor"],
+        _config=config.vertica['patch']['vertica_python.vertica.cursor.Cursor'],
     )
     pin.onto(cursor)
 
 
 # tracing configuration
 config._add(
-    "vertica",
+    'vertica',
     {
-        "service_name": "vertica",
-        "app": "vertica",
-        "app_type": "db",
-        "patch": {
-            "vertica_python.vertica.connection.Connection": {
-                "routines": {
-                    "cursor": {
-                        "trace_enabled": False,
-                        "span_end": cursor_span_end,
+        'service_name': 'vertica',
+        'app': 'vertica',
+        'app_type': 'db',
+        'patch': {
+            'vertica_python.vertica.connection.Connection': {
+                'routines': {
+                    'cursor': {
+                        'trace_enabled': False,
+                        'span_end': cursor_span_end,
                     },
                 },
             },
-            "vertica_python.vertica.cursor.Cursor": {
-                "routines": {
-                    "execute": {
-                        "operation_name": "vertica.query",
-                        "span_type": sql.TYPE,
-                        "span_start": execute_span_start,
-                        "span_end": execute_span_end,
+            'vertica_python.vertica.cursor.Cursor': {
+                'routines': {
+                    'execute': {
+                        'operation_name': 'vertica.query',
+                        'span_type': sql.TYPE,
+                        'span_start': execute_span_start,
+                        'span_end': execute_span_end,
                     },
-                    "copy": {
-                        "operation_name": "vertica.copy",
-                        "span_type": sql.TYPE,
-                        "span_start": copy_span_start,
+                    'copy': {
+                        'operation_name': 'vertica.copy',
+                        'span_type': sql.TYPE,
+                        'span_start': copy_span_start,
                     },
-                    "fetchone": {
-                        "operation_name": "vertica.fetchone",
-                        "span_type": "vertica",
-                        "span_end": fetch_span_end,
+                    'fetchone': {
+                        'operation_name': 'vertica.fetchone',
+                        'span_type': 'vertica',
+                        'span_end': fetch_span_end,
                     },
-                    "fetchall": {
-                        "operation_name": "vertica.fetchall",
-                        "span_type": "vertica",
-                        "span_end": fetch_span_end,
+                    'fetchall': {
+                        'operation_name': 'vertica.fetchall',
+                        'span_type': 'vertica',
+                        'span_end': fetch_span_end,
                     },
-                    "nextset": {
-                        "operation_name": "vertica.nextset",
-                        "span_type": "vertica",
-                        "span_end": fetch_span_end,
+                    'nextset': {
+                        'operation_name': 'vertica.nextset',
+                        'span_type': 'vertica',
+                        'span_end': fetch_span_end,
                     },
                 },
             },
@@ -121,8 +121,8 @@ def unpatch():
 
 
 def _uninstall(config):
-    for patch_class_path in config["patch"]:
-        patch_mod, _, patch_class = patch_class_path.rpartition(".")
+    for patch_class_path in config['patch']:
+        patch_mod, _, patch_class = patch_class_path.rpartition('.')
         mod = importlib.import_module(patch_mod)
         cls = getattr(mod, patch_class, None)
 
@@ -135,7 +135,7 @@ def _uninstall(config):
             )
             continue
 
-        for patch_routine in config["patch"][patch_class_path]["routines"]:
+        for patch_routine in config['patch'][patch_class_path]['routines']:
             unwrap(cls, patch_routine)
 
 
@@ -145,11 +145,11 @@ def _find_routine_config(config, instance, routine_name):
     """
     bases = instance.__class__.__mro__
     for base in bases:
-        full_name = "{}.{}".format(base.__module__, base.__name__)
-        if full_name not in config["patch"]:
+        full_name = '{}.{}'.format(base.__module__, base.__name__)
+        if full_name not in config['patch']:
             continue
 
-        config_routines = config["patch"][full_name]["routines"]
+        config_routines = config['patch'][full_name]['routines']
 
         if routine_name in config_routines:
             return config_routines[routine_name]
@@ -157,7 +157,7 @@ def _find_routine_config(config, instance, routine_name):
 
 
 def _install_init(patch_item, patch_class, patch_mod, config):
-    patch_class_routine = "{}.{}".format(patch_class, "__init__")
+    patch_class_routine = '{}.{}'.format(patch_class, '__init__')
 
     # patch the __init__ of the class with a Pin instance containing the defaults
     @wrapt.patch_function_wrapper(patch_mod, patch_class_routine)
@@ -166,30 +166,30 @@ def _install_init(patch_item, patch_class, patch_mod, config):
 
         # create and attach a pin with the defaults
         Pin(
-            service=config["service_name"],
-            app=config["app"],
-            app_type=config["app_type"],
-            tags=config.get("tags", {}),
-            tracer=config.get("tracer", ddtrace.tracer),
-            _config=config["patch"][patch_item],
+            service=config['service_name'],
+            app=config['app'],
+            app_type=config['app_type'],
+            tags=config.get('tags', {}),
+            tracer=config.get('tracer', ddtrace.tracer),
+            _config=config['patch'][patch_item],
         ).onto(instance)
         return r
 
 
 def _install_routine(patch_routine, patch_class, patch_mod, config):
-    patch_class_routine = "{}.{}".format(patch_class, patch_routine)
+    patch_class_routine = '{}.{}'.format(patch_class, patch_routine)
 
     @wrapt.patch_function_wrapper(patch_mod, patch_class_routine)
     def wrapper(wrapped, instance, args, kwargs):
         # TODO?: remove Pin dependence
         pin = Pin.get_from(instance)
 
-        if patch_routine in pin._config["routines"]:
-            conf = pin._config["routines"][patch_routine]
+        if patch_routine in pin._config['routines']:
+            conf = pin._config['routines'][patch_routine]
         else:
             conf = _find_routine_config(config, instance, patch_routine)
 
-        enabled = conf.get("trace_enabled", True)
+        enabled = conf.get('trace_enabled', True)
 
         span = None
 
@@ -199,15 +199,15 @@ def _install_routine(patch_routine, patch_class, patch_mod, config):
                 result = wrapped(*args, **kwargs)
                 return result
 
-            operation_name = conf["operation_name"]
+            operation_name = conf['operation_name']
             tracer = pin.tracer
             with tracer.trace(operation_name, service=pin.service) as span:
                 span.set_tags(pin.tags)
-                if "span_type" in conf:
-                    span.span_type = conf["span_type"]
+                if 'span_type' in conf:
+                    span.span_type = conf['span_type']
 
-                if "span_start" in conf:
-                    conf["span_start"](instance, span, conf, *args, **kwargs)
+                if 'span_start' in conf:
+                    conf['span_start'](instance, span, conf, *args, **kwargs)
 
                 # set analytics sample rate
                 span.set_tag(
@@ -218,21 +218,21 @@ def _install_routine(patch_routine, patch_class, patch_mod, config):
                 result = wrapped(*args, **kwargs)
                 return result
         except Exception as err:
-            if "on_error" in conf:
-                conf["on_error"](instance, err, span, conf, *args, **kwargs)
+            if 'on_error' in conf:
+                conf['on_error'](instance, err, span, conf, *args, **kwargs)
             raise
         finally:
             # if an exception is raised result will not exist
-            if "result" not in locals():
+            if 'result' not in locals():
                 result = None
-            if "span_end" in conf:
-                conf["span_end"](instance, result, span, conf, *args, **kwargs)
+            if 'span_end' in conf:
+                conf['span_end'](instance, result, span, conf, *args, **kwargs)
 
 
 def _install(config):
-    for patch_class_path in config["patch"]:
-        patch_mod, _, patch_class = patch_class_path.rpartition(".")
+    for patch_class_path in config['patch']:
+        patch_mod, _, patch_class = patch_class_path.rpartition('.')
         _install_init(patch_class_path, patch_class, patch_mod, config)
 
-        for patch_routine in config["patch"][patch_class_path]["routines"]:
+        for patch_routine in config['patch'][patch_class_path]['routines']:
             _install_routine(patch_routine, patch_class, patch_mod, config)

--- a/ddtrace/ext/__init__.py
+++ b/ddtrace/ext/__init__.py
@@ -1,5 +1,5 @@
 class AppTypes(object):
-    web = "web"
-    db = "db"
-    cache = "cache"
-    worker = "worker"
+    web = 'web'
+    db = 'db'
+    cache = 'cache'
+    worker = 'worker'

--- a/ddtrace/ext/aws.py
+++ b/ddtrace/ext/aws.py
@@ -34,6 +34,6 @@ def add_span_arg_tags(span, endpoint_name, args, args_names, args_traced):
         span.set_tags(tags)
 
 
-REGION = "aws.region"
-AGENT = "aws.agent"
-OPERATION = "aws.operation"
+REGION = 'aws.region'
+AGENT = 'aws.agent'
+OPERATION = 'aws.operation'

--- a/ddtrace/ext/cassandra.py
+++ b/ddtrace/ext/cassandra.py
@@ -1,11 +1,11 @@
 
 # the type of the spans
-TYPE = "cassandra"
+TYPE = 'cassandra'
 
 # tags
-CLUSTER = "cassandra.cluster"
-KEYSPACE = "cassandra.keyspace"
-CONSISTENCY_LEVEL = "cassandra.consistency_level"
-PAGINATED = "cassandra.paginated"
-ROW_COUNT = "cassandra.row_count"
-PAGE_NUMBER = "cassandra.page_number"
+CLUSTER = 'cassandra.cluster'
+KEYSPACE = 'cassandra.keyspace'
+CONSISTENCY_LEVEL = 'cassandra.consistency_level'
+PAGINATED = 'cassandra.paginated'
+ROW_COUNT = 'cassandra.row_count'
+PAGE_NUMBER = 'cassandra.page_number'

--- a/ddtrace/ext/db.py
+++ b/ddtrace/ext/db.py
@@ -1,4 +1,4 @@
 # tags
-NAME = "db.name"     # the database name (eg: dbname for pgsql)
-USER = "db.user"     # the user connecting to the db
-ROWCOUNT = "db.rowcount"  # the rowcount of a query
+NAME = 'db.name'     # the database name (eg: dbname for pgsql)
+USER = 'db.user'     # the user connecting to the db
+ROWCOUNT = 'db.rowcount'  # the rowcount of a query

--- a/ddtrace/ext/errors.py
+++ b/ddtrace/ext/errors.py
@@ -5,9 +5,9 @@ tags for common error attributes
 import traceback
 
 
-ERROR_MSG = "error.msg"  # a string representing the error message
-ERROR_TYPE = "error.type"  # a string representing the type of the error
-ERROR_STACK = "error.stack"  # a human readable version of the stack. beta.
+ERROR_MSG = 'error.msg'  # a string representing the error message
+ERROR_TYPE = 'error.type'  # a string representing the type of the error
+ERROR_STACK = 'error.stack'  # a human readable version of the stack. beta.
 
 # shorthand for -----^
 MSG = ERROR_MSG
@@ -20,4 +20,4 @@ def get_traceback(tb=None, error=None):
     if error:
         t = type(error)
     lines = traceback.format_exception(t, error, tb, limit=20)
-    return "\n".join(lines)
+    return '\n'.join(lines)

--- a/ddtrace/ext/http.py
+++ b/ddtrace/ext/http.py
@@ -3,17 +3,17 @@ Standard http tags.
 
 For example:
 
-span.set_tag(URL, "/user/home")
+span.set_tag(URL, '/user/home')
 span.set_tag(STATUS_CODE, 404)
 """
 
 # type of the spans
-TYPE = "http"
+TYPE = 'http'
 
 # tags
-URL = "http.url"
-METHOD = "http.method"
-STATUS_CODE = "http.status_code"
+URL = 'http.url'
+METHOD = 'http.method'
+STATUS_CODE = 'http.status_code'
 
 # template render span type
 TEMPLATE = 'template'

--- a/ddtrace/ext/memcached.py
+++ b/ddtrace/ext/memcached.py
@@ -1,4 +1,4 @@
-CMD = "memcached.command"
-SERVICE = "memcached"
-TYPE = "memcached"
-QUERY = "memcached.query"
+CMD = 'memcached.command'
+SERVICE = 'memcached'
+TYPE = 'memcached'
+QUERY = 'memcached.query'

--- a/ddtrace/ext/net.py
+++ b/ddtrace/ext/net.py
@@ -3,7 +3,7 @@ Standard network tags.
 """
 
 # request targets
-TARGET_HOST = "out.host"
-TARGET_PORT = "out.port"
+TARGET_HOST = 'out.host'
+TARGET_PORT = 'out.port'
 
-BYTES_OUT = "net.out.bytes"
+BYTES_OUT = 'net.out.bytes'

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -2,13 +2,13 @@ from ddtrace.ext import AppTypes
 
 
 # the type of the spans
-TYPE = "sql"
+TYPE = 'sql'
 APP_TYPE = AppTypes.db
 
 # tags
-QUERY = "sql.query"   # the query text
-ROWS = "sql.rows"     # number of rows returned by a query
-DB = "sql.db"         # the name of the database
+QUERY = 'sql.query'   # the query text
+ROWS = 'sql.rows'     # number of rows returned by a query
+DB = 'sql.db'         # the name of the database
 
 
 def normalize_vendor(vendor):
@@ -18,7 +18,7 @@ def normalize_vendor(vendor):
     elif 'sqlite' in vendor:
         return 'sqlite'
     elif 'postgres' in vendor or vendor == 'psycopg2':
-        return "postgres"
+        return 'postgres'
     else:
         return vendor
 
@@ -28,8 +28,8 @@ def parse_pg_dsn(dsn):
     Return a dictionary of the components of a postgres DSN.
 
     >>> parse_pg_dsn('user=dog port=1543 dbname=dogdata')
-    {"user":"dog", "port":"1543", "dbname":"dogdata"}
+    {'user':'dog', 'port':'1543', 'dbname':'dogdata'}
     """
     # FIXME: replace by psycopg2.extensions.parse_dsn when available
     # https://github.com/psycopg/psycopg2/pull/321
-    return {c.split("=")[0]: c.split("=")[1] for c in dsn.split() if "=" in c}
+    return {c.split('=')[0]: c.split('=')[1] for c in dsn.split() if '=' in c}

--- a/ddtrace/ext/system.py
+++ b/ddtrace/ext/system.py
@@ -2,4 +2,4 @@
 Standard system tags
 """
 
-PID = "system.pid"
+PID = 'system.pid'

--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -74,7 +74,7 @@ class RuntimeWorker(object):
 
     def start(self):
         if not self._thread:
-            log.debug("Starting {}".format(self))
+            log.debug('Starting {}'.format(self))
             self._stay_alive = True
             self._thread = threading.Thread(target=self._target)
             self._thread.setDaemon(True)
@@ -82,7 +82,7 @@ class RuntimeWorker(object):
 
     def stop(self):
         if self._thread and self._stay_alive:
-            log.debug("Stopping {}".format(self))
+            log.debug('Stopping {}'.format(self))
             self._stay_alive = False
 
     def _write_metric(self, key, value):

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -52,10 +52,10 @@ PATCH_MODULES = {
     'kombu': False,
 
     # Ignore some web framework integrations that might be configured explicitly in code
-    "django": False,
-    "falcon": False,
-    "pylons": False,
-    "pyramid": False,
+    'django': False,
+    'falcon': False,
+    'pylons': False,
+    'pyramid': False,
 
     # Standard library modules off by default
     'logging': False,
@@ -133,10 +133,10 @@ def patch(raise_errors=True, **patch_modules):
 
     patched_modules = get_patched_modules()
     log.info(
-        "patched %s/%s modules (%s)",
+        'patched %s/%s modules (%s)',
         len(patched_modules),
         len(modules),
-        ",".join(patched_modules),
+        ','.join(patched_modules),
     )
 
 
@@ -150,7 +150,7 @@ def patch_module(module, raise_errors=True):
     except Exception as exc:
         if raise_errors:
             raise
-        log.debug("failed to patch %s: %s", module, exc)
+        log.debug('failed to patch %s: %s', module, exc)
         return False
 
 
@@ -169,7 +169,7 @@ def _patch_module(module):
     path = 'ddtrace.contrib.%s' % module
     with _LOCK:
         if module in _PATCHED_MODULES and module not in _PATCH_ON_IMPORT:
-            log.debug("already patched: %s", path)
+            log.debug('already patched: %s', path)
             return False
 
         try:

--- a/ddtrace/opentracer/utils.py
+++ b/ddtrace/opentracer/utils.py
@@ -13,9 +13,9 @@ def get_context_provider_for_scope_manager(scope_manager):
 
     # avoid having to import scope managers which may not be compatible
     # with the version of python being used
-    if scope_manager_type == "AsyncioScopeManager":
+    if scope_manager_type == 'AsyncioScopeManager':
         dd_context_provider = ddtrace.contrib.asyncio.context_provider
-    elif scope_manager_type == "GeventScopeManager":
+    elif scope_manager_type == 'GeventScopeManager':
         dd_context_provider = ddtrace.contrib.gevent.context_provider
     else:
         dd_context_provider = DefaultContextProvider()

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -19,10 +19,10 @@ class Pin(object):
     This is useful if you wanted to, say, trace two different
     database clusters.
 
-        >>> conn = sqlite.connect("/tmp/user.db")
+        >>> conn = sqlite.connect('/tmp/user.db')
         >>> # Override a pin for a specific connection
-        >>> pin = Pin.override(conn, service="user-db")
-        >>> conn = sqlite.connect("/tmp/image.db")
+        >>> pin = Pin.override(conn, service='user-db')
+        >>> conn = sqlite.connect('/tmp/image.db')
     """
     __slots__ = ['app', 'app_type', 'tags', 'tracer', '_target', '_config', '_initialized']
 
@@ -53,7 +53,7 @@ class Pin(object):
         super(Pin, self).__setattr__(name, value)
 
     def __repr__(self):
-        return "Pin(service=%s, app=%s, app_type=%s, tags=%s, tracer=%s)" % (
+        return 'Pin(service=%s, app=%s, app_type=%s, tags=%s, tracer=%s)' % (
             self.service, self.app, self.app_type, self.tags, self.tracer)
 
     @staticmethod
@@ -107,9 +107,9 @@ class Pin(object):
         That's the recommended way to customize an already instrumented client, without
         losing existing attributes.
 
-            >>> conn = sqlite.connect("/tmp/user.db")
+            >>> conn = sqlite.connect('/tmp/user.db')
             >>> # Override a pin for a specific connection
-            >>> Pin.override(conn, service="user-db")
+            >>> Pin.override(conn, service='user-db')
         """
         if not obj:
             return
@@ -156,7 +156,7 @@ class Pin(object):
             if pin is not None:
                 delattr(obj, pin_name)
         except AttributeError:
-            log.debug('can\'t remove pin from object. skipping', exc_info=True)
+            log.debug("can't remove pin from object. skipping", exc_info=True)
 
     def clone(self, service=None, app=None, app_type=None, tags=None, tracer=None):
         """Return a clone of the pin with the given attributes replaced."""

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -7,10 +7,10 @@ log = get_logger(__name__)
 
 # HTTP headers one should set for distributed tracing.
 # These are cross-language (eg: Python, Go and other implementations should honor these)
-HTTP_HEADER_TRACE_ID = "x-datadog-trace-id"
-HTTP_HEADER_PARENT_ID = "x-datadog-parent-id"
-HTTP_HEADER_SAMPLING_PRIORITY = "x-datadog-sampling-priority"
-HTTP_HEADER_ORIGIN = "x-datadog-origin"
+HTTP_HEADER_TRACE_ID = 'x-datadog-trace-id'
+HTTP_HEADER_PARENT_ID = 'x-datadog-parent-id'
+HTTP_HEADER_SAMPLING_PRIORITY = 'x-datadog-sampling-priority'
+HTTP_HEADER_ORIGIN = 'x-datadog-origin'
 
 
 # Note that due to WSGI spec we have to also check for uppercased and prefixed
@@ -41,11 +41,11 @@ class HTTPPropagator(object):
             from ddtrace.propagation.http import HTTPPropagator
 
             def parent_call():
-                with tracer.trace("parent_span") as span:
+                with tracer.trace('parent_span') as span:
                     headers = {}
                     propagator = HTTPPropagator()
                     propagator.inject(span.context, headers)
-                    url = "<some RPC endpoint>"
+                    url = '<some RPC endpoint>'
                     r = requests.get(url, headers=headers)
 
         :param Context span_context: Span context to propagate.
@@ -110,7 +110,7 @@ class HTTPPropagator(object):
                 context = propagator.extract(headers)
                 tracer.context_provider.activate(context)
 
-                with tracer.trace("my_controller") as span:
+                with tracer.trace('my_controller') as span:
                     span.set_meta('http.url', url)
 
         :param dict headers: HTTP headers to extract tracing attributes.
@@ -138,7 +138,7 @@ class HTTPPropagator(object):
         except Exception as error:
             try:
                 log.debug(
-                    "invalid x-datadog-* headers, trace-id: %s, parent-id: %s, priority: %s, origin: %s, error: %s",
+                    'invalid x-datadog-* headers, trace-id: %s, parent-id: %s, priority: %s, origin: %s, error: %s',
                     headers.get(HTTP_HEADER_TRACE_ID, 0),
                     headers.get(HTTP_HEADER_PARENT_ID, 0),
                     headers.get(HTTP_HEADER_SAMPLING_PRIORITY),

--- a/ddtrace/propagation/utils.py
+++ b/ddtrace/propagation/utils.py
@@ -3,4 +3,4 @@ def get_wsgi_header(header):
     See https://www.python.org/dev/peps/pep-3333/#environ-variables for
     information from the spec.
     """
-    return "HTTP_{}".format(header.upper().replace("-", "_"))
+    return 'HTTP_{}'.format(header.upper().replace('-', '_'))

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -31,14 +31,14 @@ class RateSampler(object):
 
     def __init__(self, sample_rate=1):
         if sample_rate <= 0:
-            log.error("sample_rate is negative or null, disable the Sampler")
+            log.error('sample_rate is negative or null, disable the Sampler')
             sample_rate = 1
         elif sample_rate > 1:
             sample_rate = 1
 
         self.set_sample_rate(sample_rate)
 
-        log.debug("initialized RateSampler, sample %s%% of traces", 100 * sample_rate)
+        log.debug('initialized RateSampler, sample %s%% of traces', 100 * sample_rate)
 
     def set_sample_rate(self, sample_rate):
         self.sample_rate = sample_rate
@@ -51,9 +51,9 @@ class RateSampler(object):
 
 
 def _key(service=None, env=None):
-    service = service or ""
-    env = env or ""
-    return "service:" + service + ",env:" + env
+    service = service or ''
+    env = env or ''
+    return 'service:' + service + ',env:' + env
 
 
 _default_key = _key()
@@ -78,7 +78,7 @@ class RateByServiceSampler(object):
             else:
                 self._by_service_samplers[key] = RateSampler(sample_rate)
 
-    def set_sample_rate(self, sample_rate, service="", env=""):
+    def set_sample_rate(self, sample_rate, service='', env=''):
         self._set_sample_rate_by_key(sample_rate, _key(service, env))
 
     def sample(self, span):

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -123,7 +123,7 @@ class Span(object):
                 self._context.close_span(self)
                 self._tracer.record(self._context)
             except Exception:
-                log.exception("error recording finished trace")
+                log.exception('error recording finished trace')
 
     def set_tag(self, key, value):
         """ Set the given key / value tag pair on the span. Keys and values
@@ -135,13 +135,13 @@ class Span(object):
             try:
                 self.set_metric(key, float(value))
             except (TypeError, ValueError):
-                log.debug("error setting numeric metric {}:{}".format(key, value))
+                log.debug('error setting numeric metric {}:{}'.format(key, value))
 
             return
         try:
             self.meta[key] = stringify(value)
         except Exception:
-            log.debug("error setting tag %s, ignoring it", key, exc_info=True)
+            log.debug('error setting tag %s, ignoring it', key, exc_info=True)
 
     def _remove_tag(self, key):
         if key in self.meta:
@@ -178,12 +178,12 @@ class Span(object):
             try:
                 value = float(value)
             except (ValueError, TypeError):
-                log.debug("ignoring not number metric %s:%s", key, value)
+                log.debug('ignoring not number metric %s:%s', key, value)
                 return
 
         # don't allow nan or inf
         if math.isnan(value) or math.isinf(value):
-            log.debug("ignoring not real metric %s:%s", key, value)
+            log.debug('ignoring not real metric %s:%s', key, value)
             return
 
         self.metrics[key] = value
@@ -241,7 +241,7 @@ class Span(object):
             self.set_exc_info(exc_type, exc_val, exc_tb)
         else:
             tb = ''.join(traceback.format_stack(limit=limit + 1)[:-1])
-            self.set_tag(errors.ERROR_STACK, tb)  # FIXME[gabin] Want to replace "error.stack" tag with "python.stack"
+            self.set_tag(errors.ERROR_STACK, tb)  # FIXME[gabin] Want to replace 'error.stack' tag with 'python.stack'
 
     def set_exc_info(self, exc_type, exc_val, exc_tb):
         """ Tag the span with an error tuple as from `sys.exc_info()`. """
@@ -256,7 +256,7 @@ class Span(object):
         tb = buff.getvalue()
 
         # readable version of type (e.g. exceptions.ZeroDivisionError)
-        exc_type_str = "%s.%s" % (exc_type.__module__, exc_type.__name__)
+        exc_type_str = '%s.%s' % (exc_type.__module__, exc_type.__name__)
 
         self.set_tag(errors.ERROR_MSG, exc_val)
         self.set_tag(errors.ERROR_TYPE, exc_type_str)
@@ -273,21 +273,21 @@ class Span(object):
         """ Return a human readable version of the span. """
         lines = [
             ('name', self.name),
-            ("id", self.span_id),
-            ("trace_id", self.trace_id),
-            ("parent_id", self.parent_id),
-            ("service", self.service),
-            ("resource", self.resource),
+            ('id', self.span_id),
+            ('trace_id', self.trace_id),
+            ('parent_id', self.parent_id),
+            ('service', self.service),
+            ('resource', self.resource),
             ('type', self.span_type),
-            ("start", self.start),
-            ("end", "" if not self.duration else self.start + self.duration),
-            ("duration", "%fs" % (self.duration or 0)),
-            ("error", self.error),
-            ("tags", "")
+            ('start', self.start),
+            ('end', '' if not self.duration else self.start + self.duration),
+            ('duration', '%fs' % (self.duration or 0)),
+            ('error', self.error),
+            ('tags', '')
         ]
 
-        lines.extend((" ", "%s:%s" % kv) for kv in sorted(self.meta.items()))
-        return "\n".join("%10s %s" % l for l in lines)
+        lines.extend((' ', '%s:%s' % kv) for kv in sorted(self.meta.items()))
+        return '\n'.join('%10s %s' % l for l in lines)
 
     @property
     def context(self):
@@ -310,10 +310,10 @@ class Span(object):
                 self.set_exc_info(exc_type, exc_val, exc_tb)
             self.finish()
         except Exception:
-            log.exception("error closing trace")
+            log.exception('error closing trace')
 
     def __repr__(self):
-        return "<Span(id=%s,trace_id=%s,parent_id=%s,name=%s)>" % (
+        return '<Span(id=%s,trace_id=%s,parent_id=%s,name=%s)>' % (
             self.span_id,
             self.trace_id,
             self.parent_id,

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -31,7 +31,7 @@ class Tracer(object):
     you can use the global tracer instance::
 
         from ddtrace import tracer
-        trace = tracer.trace("app.request", "web-server").finish()
+        trace = tracer.trace('app.request', 'web-server').finish()
     """
     DEFAULT_HOSTNAME = environ.get('DD_AGENT_HOST', environ.get('DATADOG_TRACE_AGENT_HOSTNAME', 'localhost'))
     DEFAULT_PORT = int(environ.get('DD_TRACE_AGENT_PORT', 8126))
@@ -177,17 +177,17 @@ class Tracer(object):
 
         To start a new root span, simply::
 
-            span = tracer.start_span("web.request")
+            span = tracer.start_span('web.request')
 
         If you want to create a child for a root span, just::
 
-            root_span = tracer.start_span("web.request")
-            span = tracer.start_span("web.decoder", child_of=root_span)
+            root_span = tracer.start_span('web.request')
+            span = tracer.start_span('web.decoder', child_of=root_span)
 
         Or if you have a ``Context`` object::
 
             context = tracer.get_call_context()
-            span = tracer.start_span("web.worker", child_of=context)
+            span = tracer.start_span('web.worker', child_of=context)
         """
         if child_of is not None:
             # retrieve if the span is a child_of a Span or a of Context
@@ -345,24 +345,24 @@ class Tracer(object):
         You must call `finish` on all spans, either directly or with a context
         manager::
 
-            >>> span = tracer.trace("web.request")
+            >>> span = tracer.trace('web.request')
                 try:
                     # do something
                 finally:
                     span.finish()
 
-            >>> with tracer.trace("web.request") as span:
+            >>> with tracer.trace('web.request') as span:
                     # do something
 
         Trace will store the current active span and subsequent child traces will
         become its children::
 
-            parent = tracer.trace("parent")     # has no parent span
-            child  = tracer.trace("child")      # is a child of a parent
+            parent = tracer.trace('parent')     # has no parent span
+            child  = tracer.trace('child')      # is a child of a parent
             child.finish()
             parent.finish()
 
-            parent2 = tracer.trace("parent2")   # has no parent span
+            parent2 = tracer.trace('parent2')   # has no parent span
             parent2.finish()
         """
         # retrieve the Context using the context provider and create
@@ -422,9 +422,9 @@ class Tracer(object):
             return  # nothing to do
 
         if self.debug_logging:
-            log.debug("writing %s spans (enabled:%s)", len(spans), self.enabled)
+            log.debug('writing %s spans (enabled:%s)', len(spans), self.enabled)
             for span in spans:
-                log.debug("\n%s", span.pprint())
+                log.debug('\n%s', span.pprint())
 
         if self.enabled and self.writer:
             # only submit the spans if we're actually enabled (and don't crash :)

--- a/ddtrace/utils/config.py
+++ b/ddtrace/utils/config.py
@@ -4,7 +4,7 @@ import os
 
 def get_application_name():
     """Attempts to find the application name using system arguments."""
-    if hasattr(sys, "argv") and sys.argv[0]:
+    if hasattr(sys, 'argv') and sys.argv[0]:
         app_name = os.path.basename(sys.argv[0])
     else:
         app_name = None

--- a/ddtrace/utils/formats.py
+++ b/ddtrace/utils/formats.py
@@ -36,13 +36,13 @@ def deep_getattr(obj, attr_string, default=None):
     Returns the attribute of `obj` at the dotted path given by `attr_string`
     If no such attribute is reachable, returns `default`
 
-    >>> deep_getattr(cass, "cluster")
+    >>> deep_getattr(cass, 'cluster')
     <cassandra.cluster.Cluster object at 0xa20c350
 
-    >>> deep_getattr(cass, "cluster.metadata.partitioner")
+    >>> deep_getattr(cass, 'cluster.metadata.partitioner')
     u'org.apache.cassandra.dht.Murmur3Partitioner'
 
-    >>> deep_getattr(cass, "i.dont.exist", default="default")
+    >>> deep_getattr(cass, 'i.dont.exist', default='default')
     'default'
     """
     attrs = attr_string.split('.')
@@ -64,7 +64,7 @@ def asbool(value):
     if isinstance(value, bool):
         return value
 
-    return value.lower() in ("true", "1")
+    return value.lower() in ('true', '1')
 
 
 def flatten_dict(d, sep='.', prefix=''):

--- a/ddtrace/utils/importlib.py
+++ b/ddtrace/utils/importlib.py
@@ -23,7 +23,7 @@ class require_modules(object):
 def func_name(f):
     """Return a human readable version of the function's name."""
     if hasattr(f, '__module__'):
-        return "%s.%s" % (f.__module__, getattr(f, '__name__', f.__class__.__name__))
+        return '%s.%s' % (f.__module__, getattr(f, '__name__', f.__class__.__name__))
     return getattr(f, '__name__', f.__class__.__name__)
 
 

--- a/ddtrace/utils/wrappers.py
+++ b/ddtrace/utils/wrappers.py
@@ -27,7 +27,7 @@ def safe_patch(patchable, key, patch_func, service, meta, tracer):
       then patchable[key] contains an already patched command!
       To workaround this, check if patchable or patchable.__class__ are _dogtraced
       If is isn't, nothing to worry about, patch the key as usual
-      But if it is, search for a "__dd_orig_{key}" method on the class, which is
+      But if it is, search for a '__dd_orig_{key}' method on the class, which is
       the original unpatched method we wish to trace.
 
     """
@@ -35,11 +35,11 @@ def safe_patch(patchable, key, patch_func, service, meta, tracer):
         orig = None
         if hasattr(thing, '_dogtraced'):
             # Search for original method
-            orig = getattr(thing, "__dd_orig_{}".format(key), None)
+            orig = getattr(thing, '__dd_orig_{}'.format(key), None)
         else:
             orig = getattr(thing, key)
             # Set it for the next time we attempt to patch `thing`
-            setattr(thing, "__dd_orig_{}".format(key), orig)
+            setattr(thing, '__dd_orig_{}'.format(key), orig)
 
         return orig
 

--- a/ddtrace/writer.py
+++ b/ddtrace/writer.py
@@ -40,7 +40,7 @@ class AgentWriter(object):
         # forked) reset everything so that we can safely work from it.
         pid = os.getpid()
         if self._pid != pid:
-            log.debug("resetting queues. pids(old:%s new:%s)", self._pid, pid)
+            log.debug('resetting queues. pids(old:%s new:%s)', self._pid, pid)
             self._traces = Q(max_size=MAX_TRACES)
             self._worker = None
             self._pid = pid
@@ -75,7 +75,7 @@ class AsyncWorker(object):
     def start(self):
         with self._lock:
             if not self._thread:
-                log.debug("starting flush thread")
+                log.debug('starting flush thread')
                 self._thread = threading.Thread(target=self._target)
                 self._thread.setDaemon(True)
                 self._thread.start()
@@ -107,9 +107,9 @@ class AsyncWorker(object):
 
             size = self._trace_queue.size()
             if size:
-                key = "ctrl-break" if os.name == 'nt' else 'ctrl-c'
+                key = 'ctrl-break' if os.name == 'nt' else 'ctrl-c'
                 log.debug(
-                    "Waiting %ss for traces to be sent. Hit %s to quit.",
+                    'Waiting %ss for traces to be sent. Hit %s to quit.',
                     self._shutdown_timeout,
                     key,
                 )
@@ -129,13 +129,13 @@ class AsyncWorker(object):
                 try:
                     traces = self._apply_filters(traces)
                 except Exception as err:
-                    log.error("error while filtering traces:{0}".format(err))
+                    log.error('error while filtering traces:{0}'.format(err))
             if traces:
                 # If we have data, let's try to send it.
                 try:
                     traces_response = self.api.send_traces(traces)
                 except Exception as err:
-                    log.error("cannot send spans to {1}:{2}: {0}".format(err, self.api.hostname, self.api.port))
+                    log.error('cannot send spans to {1}:{2}: {0}'.format(err, self.api.hostname, self.api.port))
 
             if self._trace_queue.closed() and self._trace_queue.size() == 0:
                 # no traces and the queue is closed. our work is done
@@ -146,7 +146,7 @@ class AsyncWorker(object):
                 if result_traces_json and 'rate_by_service' in result_traces_json:
                     self._priority_sampler.set_sample_rate_by_service(result_traces_json['rate_by_service'])
 
-            self._log_error_status(traces_response, "traces")
+            self._log_error_status(traces_response, 'traces')
             traces_response = None
 
             time.sleep(1)  # replace with a blocking pop.

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -12,7 +12,7 @@ NUMBER = 10000
 
 def trace_error(tracer):
     # explicit vars
-    with tracer.trace("a", service="s", resource="r", span_type="t"):
+    with tracer.trace('a', service='s', resource='r', span_type='t'):
         1 / 0
 
 
@@ -23,19 +23,19 @@ def benchmark_tracer_trace():
     # testcase
     def trace(tracer):
         # explicit vars
-        with tracer.trace("a", service="s", resource="r", span_type="t") as s:
-            s.set_tag("a", "b")
-            s.set_tag("b", 1)
-            with tracer.trace("another.thing"):
+        with tracer.trace('a', service='s', resource='r', span_type='t') as s:
+            s.set_tag('a', 'b')
+            s.set_tag('b', 1)
+            with tracer.trace('another.thing'):
                 pass
-            with tracer.trace("another.thing"):
+            with tracer.trace('another.thing'):
                 pass
 
     # benchmark
-    print("## tracer.trace() benchmark: {} loops ##".format(NUMBER))
+    print('## tracer.trace() benchmark: {} loops ##'.format(NUMBER))
     timer = timeit.Timer(lambda: trace(tracer))
     result = timer.repeat(repeat=REPEAT, number=NUMBER)
-    print("- trace execution time: {:8.6f}".format(min(result)))
+    print('- trace execution time: {:8.6f}'.format(min(result)))
 
 
 def benchmark_tracer_wrap():
@@ -61,23 +61,23 @@ def benchmark_tracer_wrap():
     f = Foo()
 
     # benchmark
-    print("## tracer.trace() wrapper benchmark: {} loops ##".format(NUMBER))
+    print('## tracer.trace() wrapper benchmark: {} loops ##'.format(NUMBER))
     timer = timeit.Timer(f.s)
     result = timer.repeat(repeat=REPEAT, number=NUMBER)
-    print("- staticmethod execution time: {:8.6f}".format(min(result)))
+    print('- staticmethod execution time: {:8.6f}'.format(min(result)))
     timer = timeit.Timer(f.c)
     result = timer.repeat(repeat=REPEAT, number=NUMBER)
-    print("- classmethod execution time: {:8.6f}".format(min(result)))
+    print('- classmethod execution time: {:8.6f}'.format(min(result)))
     timer = timeit.Timer(f.m)
     result = timer.repeat(repeat=REPEAT, number=NUMBER)
-    print("- method execution time: {:8.6f}".format(min(result)))
+    print('- method execution time: {:8.6f}'.format(min(result)))
 
 
 def benchmark_getpid():
     timer = timeit.Timer(getpid)
     result = timer.repeat(repeat=REPEAT, number=NUMBER)
-    print("## getpid wrapper benchmark: {} loops ##".format(NUMBER))
-    print("- getpid execution time: {:8.6f}".format(min(result)))
+    print('## getpid wrapper benchmark: {} loops ##'.format(NUMBER))
+    print('- getpid execution time: {:8.6f}'.format(min(result)))
 
 
 if __name__ == '__main__':

--- a/tests/commands/ddtrace_run_debug.py
+++ b/tests/commands/ddtrace_run_debug.py
@@ -2,4 +2,4 @@ from ddtrace import tracer
 
 if __name__ == '__main__':
     assert tracer.debug_logging
-    print("Test success")
+    print('Test success')

--- a/tests/commands/ddtrace_run_disabled.py
+++ b/tests/commands/ddtrace_run_disabled.py
@@ -3,4 +3,4 @@ from ddtrace import tracer, monkey
 if __name__ == '__main__':
     assert not tracer.enabled
     assert len(monkey.get_patched_modules()) == 0
-    print("Test success")
+    print('Test success')

--- a/tests/commands/ddtrace_run_dogstatsd.py
+++ b/tests/commands/ddtrace_run_dogstatsd.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from ddtrace import tracer
 
 if __name__ == '__main__':
-    assert tracer._dogstatsd_client.host == "172.10.0.1"
+    assert tracer._dogstatsd_client.host == '172.10.0.1'
     assert tracer._dogstatsd_client.port == 8120
-    print("Test success")
+    print('Test success')

--- a/tests/commands/ddtrace_run_enabled.py
+++ b/tests/commands/ddtrace_run_enabled.py
@@ -2,4 +2,4 @@ from ddtrace import tracer
 
 if __name__ == '__main__':
     assert tracer.enabled
-    print("Test success")
+    print('Test success')

--- a/tests/commands/ddtrace_run_hostname.py
+++ b/tests/commands/ddtrace_run_hostname.py
@@ -1,6 +1,6 @@
 from ddtrace import tracer
 
 if __name__ == '__main__':
-    assert tracer.writer.api.hostname == "172.10.0.1"
+    assert tracer.writer.api.hostname == '172.10.0.1'
     assert tracer.writer.api.port == 8120
-    print("Test success")
+    print('Test success')

--- a/tests/commands/ddtrace_run_integration.py
+++ b/tests/commands/ddtrace_run_integration.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     assert spans[0].service == 'redis'
     assert spans[0].resource == 'FLUSHALL'
 
-    long_cmd = "mget %s" % " ".join(map(str, range(1000)))
+    long_cmd = 'mget %s' % ' '.join(map(str, range(1000)))
     us = r.execute_command(long_cmd)
 
     spans = pin.tracer.writer.pop()
@@ -45,4 +45,4 @@ if __name__ == '__main__':
     assert span.get_tag('redis.raw_command').startswith(u'mget 0 1 2 3')
     assert span.get_tag('redis.raw_command').endswith(u'...')
 
-    print("Test success")
+    print('Test success')

--- a/tests/commands/ddtrace_run_no_debug.py
+++ b/tests/commands/ddtrace_run_no_debug.py
@@ -2,4 +2,4 @@ from ddtrace import tracer
 
 if __name__ == '__main__':
     assert not tracer.debug_logging
-    print("Test success")
+    print('Test success')

--- a/tests/commands/ddtrace_run_patched_modules.py
+++ b/tests/commands/ddtrace_run_patched_modules.py
@@ -2,4 +2,4 @@ from ddtrace import monkey
 
 if __name__ == '__main__':
     assert 'redis' in monkey.get_patched_modules()
-    print("Test success")
+    print('Test success')

--- a/tests/commands/ddtrace_run_priority_sampling.py
+++ b/tests/commands/ddtrace_run_priority_sampling.py
@@ -2,4 +2,4 @@ from ddtrace import tracer
 
 if __name__ == '__main__':
     assert tracer.priority_sampler is not None
-    print("Test success")
+    print('Test success')

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -9,37 +9,37 @@ class DdtraceRunTest(BaseTestCase):
         """
         $DATADOG_SERVICE_NAME gets passed through to the program
         """
-        with self.override_env(dict(DATADOG_SERVICE_NAME="my_test_service")):
+        with self.override_env(dict(DATADOG_SERVICE_NAME='my_test_service')):
             out = subprocess.check_output(
                 ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_service.py']
             )
-            assert out.startswith(b"Test success")
+            assert out.startswith(b'Test success')
 
     def test_env_name_passthrough(self):
         """
         $DATADOG_ENV gets passed through to the global tracer as an 'env' tag
         """
-        with self.override_env(dict(DATADOG_ENV="test")):
+        with self.override_env(dict(DATADOG_ENV='test')):
             out = subprocess.check_output(
                 ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_env.py']
             )
-            assert out.startswith(b"Test success")
+            assert out.startswith(b'Test success')
 
     def test_env_enabling(self):
         """
         DATADOG_TRACE_ENABLED=false allows disabling of the global tracer
         """
-        with self.override_env(dict(DATADOG_TRACE_ENABLED="false")):
+        with self.override_env(dict(DATADOG_TRACE_ENABLED='false')):
             out = subprocess.check_output(
                 ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_disabled.py']
             )
-            assert out.startswith(b"Test success")
+            assert out.startswith(b'Test success')
 
-        with self.override_env(dict(DATADOG_TRACE_ENABLED="true")):
+        with self.override_env(dict(DATADOG_TRACE_ENABLED='true')):
             out = subprocess.check_output(
                 ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_enabled.py']
             )
-            assert out.startswith(b"Test success")
+            assert out.startswith(b'Test success')
 
     def test_patched_modules(self):
         """
@@ -48,41 +48,41 @@ class DdtraceRunTest(BaseTestCase):
         out = subprocess.check_output(
             ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_patched_modules.py']
         )
-        assert out.startswith(b"Test success")
+        assert out.startswith(b'Test success')
 
     def test_integration(self):
         out = subprocess.check_output(
             ['ddtrace-run', 'python', '-m', 'tests.commands.ddtrace_run_integration']
         )
-        assert out.startswith(b"Test success")
+        assert out.startswith(b'Test success')
 
     def test_debug_enabling(self):
         """
         DATADOG_TRACE_DEBUG=true allows setting debug_logging of the global tracer
         """
-        with self.override_env(dict(DATADOG_TRACE_DEBUG="false")):
+        with self.override_env(dict(DATADOG_TRACE_DEBUG='false')):
             out = subprocess.check_output(
                 ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_no_debug.py']
             )
-            assert out.startswith(b"Test success")
+            assert out.startswith(b'Test success')
 
-        with self.override_env(dict(DATADOG_TRACE_DEBUG="true")):
+        with self.override_env(dict(DATADOG_TRACE_DEBUG='true')):
             out = subprocess.check_output(
                 ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_debug.py']
             )
-            assert out.startswith(b"Test success")
+            assert out.startswith(b'Test success')
 
     def test_host_port_from_env(self):
         """
         DATADOG_TRACE_AGENT_HOSTNAME|PORT point to the tracer
         to the correct host/port for submission
         """
-        with self.override_env(dict(DATADOG_TRACE_AGENT_HOSTNAME="172.10.0.1",
-                                    DATADOG_TRACE_AGENT_PORT="8120")):
+        with self.override_env(dict(DATADOG_TRACE_AGENT_HOSTNAME='172.10.0.1',
+                                    DATADOG_TRACE_AGENT_PORT='8120')):
             out = subprocess.check_output(
                 ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_hostname.py']
             )
-            assert out.startswith(b"Test success")
+            assert out.startswith(b'Test success')
 
     def test_host_port_from_env_dd(self):
         """
@@ -119,11 +119,11 @@ class DdtraceRunTest(BaseTestCase):
         """
         DATADOG_PRIORITY_SAMPLING enables Distributed Sampling
         """
-        with self.override_env(dict(DATADOG_PRIORITY_SAMPLING="True")):
+        with self.override_env(dict(DATADOG_PRIORITY_SAMPLING='True')):
             out = subprocess.check_output(
                 ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_priority_sampling.py']
             )
-            assert out.startswith(b"Test success")
+            assert out.startswith(b'Test success')
 
     def test_patch_modules_from_env(self):
         """
@@ -133,40 +133,40 @@ class DdtraceRunTest(BaseTestCase):
         orig = EXTRA_PATCHED_MODULES.copy()
 
         # empty / malformed strings are no-ops
-        with self.override_env(dict(DATADOG_PATCH_MODULES="")):
+        with self.override_env(dict(DATADOG_PATCH_MODULES='')):
             update_patched_modules()
             assert orig == EXTRA_PATCHED_MODULES
 
-        with self.override_env(dict(DATADOG_PATCH_MODULES=":")):
+        with self.override_env(dict(DATADOG_PATCH_MODULES=':')):
             update_patched_modules()
             assert orig == EXTRA_PATCHED_MODULES
 
-        with self.override_env(dict(DATADOG_PATCH_MODULES=",")):
+        with self.override_env(dict(DATADOG_PATCH_MODULES=',')):
             update_patched_modules()
             assert orig == EXTRA_PATCHED_MODULES
 
-        with self.override_env(dict(DATADOG_PATCH_MODULES=",:")):
+        with self.override_env(dict(DATADOG_PATCH_MODULES=',:')):
             update_patched_modules()
             assert orig == EXTRA_PATCHED_MODULES
 
         # overrides work in either direction
-        with self.override_env(dict(DATADOG_PATCH_MODULES="django:false")):
+        with self.override_env(dict(DATADOG_PATCH_MODULES='django:false')):
             update_patched_modules()
-            assert EXTRA_PATCHED_MODULES["django"] is False
+            assert EXTRA_PATCHED_MODULES['django'] is False
 
-        with self.override_env(dict(DATADOG_PATCH_MODULES="boto:true")):
+        with self.override_env(dict(DATADOG_PATCH_MODULES='boto:true')):
             update_patched_modules()
-            assert EXTRA_PATCHED_MODULES["boto"] is True
+            assert EXTRA_PATCHED_MODULES['boto'] is True
 
-        with self.override_env(dict(DATADOG_PATCH_MODULES="django:true,boto:false")):
+        with self.override_env(dict(DATADOG_PATCH_MODULES='django:true,boto:false')):
             update_patched_modules()
-            assert EXTRA_PATCHED_MODULES["boto"] is False
-            assert EXTRA_PATCHED_MODULES["django"] is True
+            assert EXTRA_PATCHED_MODULES['boto'] is False
+            assert EXTRA_PATCHED_MODULES['django'] is True
 
-        with self.override_env(dict(DATADOG_PATCH_MODULES="django:false,boto:true")):
+        with self.override_env(dict(DATADOG_PATCH_MODULES='django:false,boto:true')):
             update_patched_modules()
-            assert EXTRA_PATCHED_MODULES["boto"] is True
-            assert EXTRA_PATCHED_MODULES["django"] is False
+            assert EXTRA_PATCHED_MODULES['boto'] is True
+            assert EXTRA_PATCHED_MODULES['django'] is False
 
     def test_sitecustomize_without_ddtrace_run_command(self):
         # [Regression test]: ensure `sitecustomize` path is removed only if it's
@@ -191,7 +191,7 @@ class DdtraceRunTest(BaseTestCase):
             ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_sitecustomize.py'],
             env=env,
         )
-        assert out.startswith(b"Test success")
+        assert out.startswith(b'Test success')
 
     def test_sitecustomize_run_suppressed(self):
         # ensure `sitecustomize.py` is not loaded if `-S` is used
@@ -200,13 +200,13 @@ class DdtraceRunTest(BaseTestCase):
             ['ddtrace-run', 'python', '-S', 'tests/commands/ddtrace_run_sitecustomize.py', '-S'],
             env=env,
         )
-        assert out.startswith(b"Test success")
+        assert out.startswith(b'Test success')
 
     def test_argv_passed(self):
         out = subprocess.check_output(
             ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_argv.py', 'foo', 'bar']
         )
-        assert out.startswith(b"Test success")
+        assert out.startswith(b'Test success')
 
     def test_got_app_name(self):
         """
@@ -215,7 +215,7 @@ class DdtraceRunTest(BaseTestCase):
         out = subprocess.check_output(
             ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_app_name.py']
         )
-        assert out.startswith(b"ddtrace_run_app_name.py")
+        assert out.startswith(b'ddtrace_run_app_name.py')
 
     def test_global_trace_tags(self):
         """ Ensure global tags are passed in from environment
@@ -224,7 +224,7 @@ class DdtraceRunTest(BaseTestCase):
             out = subprocess.check_output(
                 ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_global_tags.py']
             )
-            assert out.startswith(b"Test success")
+            assert out.startswith(b'Test success')
 
     def test_logs_injection(self):
         """ Ensure logs injection works
@@ -233,4 +233,4 @@ class DdtraceRunTest(BaseTestCase):
             out = subprocess.check_output(
                 ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_logs_injection.py']
             )
-            assert out.startswith(b"Test success")
+            assert out.startswith(b'Test success')

--- a/tests/contrib/boto/test.py
+++ b/tests/contrib/boto/test.py
@@ -23,7 +23,7 @@ from ...base import BaseTracerTestCase
 class BotoTest(BaseTracerTestCase):
     """Botocore integration testsuite"""
 
-    TEST_SERVICE = "test-boto-tracing"
+    TEST_SERVICE = 'test-boto-tracing'
 
     def setUp(self):
         super(BotoTest, self).setUp()
@@ -31,7 +31,7 @@ class BotoTest(BaseTracerTestCase):
 
     @mock_ec2
     def test_ec2_client(self):
-        ec2 = boto.ec2.connect_to_region("us-west-2")
+        ec2 = boto.ec2.connect_to_region('us-west-2')
         writer = self.tracer.writer
         Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(ec2)
 
@@ -67,7 +67,7 @@ class BotoTest(BaseTracerTestCase):
                 'boto',
                 dict(analytics_enabled=True, analytics_sample_rate=0.5)
         ):
-            ec2 = boto.ec2.connect_to_region("us-west-2")
+            ec2 = boto.ec2.connect_to_region('us-west-2')
             writer = self.tracer.writer
             Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(ec2)
 
@@ -84,7 +84,7 @@ class BotoTest(BaseTracerTestCase):
                 'boto',
                 dict(analytics_enabled=True)
         ):
-            ec2 = boto.ec2.connect_to_region("us-west-2")
+            ec2 = boto.ec2.connect_to_region('us-west-2')
             writer = self.tracer.writer
             Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(ec2)
 

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -17,7 +17,7 @@ from ...base import BaseTracerTestCase
 class BotocoreTest(BaseTracerTestCase):
     """Botocore integration testsuite"""
 
-    TEST_SERVICE = "test-botocore-tracing"
+    TEST_SERVICE = 'test-botocore-tracing'
 
     def setUp(self):
         patch()
@@ -43,7 +43,7 @@ class BotocoreTest(BaseTracerTestCase):
         assert spans
         span = spans[0]
         self.assertEqual(len(spans), 1)
-        self.assertEqual(span.get_tag('aws.agent'), "botocore")
+        self.assertEqual(span.get_tag('aws.agent'), 'botocore')
         self.assertEqual(span.get_tag('aws.region'), 'us-west-2')
         self.assertEqual(span.get_tag('aws.operation'), 'DescribeInstances')
         self.assertEqual(span.get_tag(http.STATUS_CODE), '200')

--- a/tests/contrib/cassandra/test.py
+++ b/tests/contrib/cassandra/test.py
@@ -437,4 +437,4 @@ class TestCassPatchOne(TestCassPatchDefault):
 def test_backwards_compat_get_traced_cassandra():
     cluster = get_traced_cassandra()
     session = cluster(port=CASSANDRA_CONFIG['port']).connect()
-    session.execute("drop table if exists test.person")
+    session.execute('drop table if exists test.person')

--- a/tests/contrib/celery/autopatch.py
+++ b/tests/contrib/celery/autopatch.py
@@ -6,4 +6,4 @@ if __name__ == '__main__':
 
     # now celery.Celery should be patched and should have a pin
     assert Pin.get_from(celery.Celery)
-    print("Test success")
+    print('Test success')

--- a/tests/contrib/celery/test_autopatch.py
+++ b/tests/contrib/celery/test_autopatch.py
@@ -10,4 +10,4 @@ class DdtraceRunTest(unittest.TestCase):
         out = subprocess.check_output(
             ['ddtrace-run', 'python', 'tests/contrib/celery/autopatch.py']
         )
-        assert out.startswith(b"Test success")
+        assert out.startswith(b'Test success')

--- a/tests/contrib/celery/test_old_style_task.py
+++ b/tests/contrib/celery/test_old_style_task.py
@@ -22,7 +22,7 @@ class CeleryOldStyleTaskTest(CeleryBaseTestCase):
                 if 'stop' in kwargs:
                     # avoid call loop
                     return
-                CelerySubClass.apply_async(args=[], kwargs={"stop": True})
+                CelerySubClass.apply_async(args=[], kwargs={'stop': True})
 
         class CelerySubClass(CelerySuperClass):
             pass

--- a/tests/contrib/config.py
+++ b/tests/contrib/config.py
@@ -10,33 +10,33 @@ import os
 # simply write down a function that parses the .env file
 
 ELASTICSEARCH_CONFIG = {
-    'port': int(os.getenv("TEST_ELASTICSEARCH_PORT", 9200)),
+    'port': int(os.getenv('TEST_ELASTICSEARCH_PORT', 9200)),
 }
 
 CASSANDRA_CONFIG = {
-    'port': int(os.getenv("TEST_CASSANDRA_PORT", 9042)),
+    'port': int(os.getenv('TEST_CASSANDRA_PORT', 9042)),
 }
 
 # Use host=127.0.0.1 since local docker testing breaks with localhost
 
 POSTGRES_CONFIG = {
     'host': '127.0.0.1',
-    'port': int(os.getenv("TEST_POSTGRES_PORT", 5432)),
-    'user': os.getenv("TEST_POSTGRES_USER", "postgres"),
-    'password': os.getenv("TEST_POSTGRES_PASSWORD", "postgres"),
-    'dbname': os.getenv("TEST_POSTGRES_DB", "postgres"),
+    'port': int(os.getenv('TEST_POSTGRES_PORT', 5432)),
+    'user': os.getenv('TEST_POSTGRES_USER', 'postgres'),
+    'password': os.getenv('TEST_POSTGRES_PASSWORD', 'postgres'),
+    'dbname': os.getenv('TEST_POSTGRES_DB', 'postgres'),
 }
 
 MYSQL_CONFIG = {
     'host': '127.0.0.1',
-    'port': int(os.getenv("TEST_MYSQL_PORT", 3306)),
-    'user': os.getenv("TEST_MYSQL_USER", 'test'),
-    'password': os.getenv("TEST_MYSQL_PASSWORD", 'test'),
-    'database': os.getenv("TEST_MYSQL_DATABASE", 'test'),
+    'port': int(os.getenv('TEST_MYSQL_PORT', 3306)),
+    'user': os.getenv('TEST_MYSQL_USER', 'test'),
+    'password': os.getenv('TEST_MYSQL_PASSWORD', 'test'),
+    'database': os.getenv('TEST_MYSQL_DATABASE', 'test'),
 }
 
 REDIS_CONFIG = {
-    'port': int(os.getenv("TEST_REDIS_PORT", 6379)),
+    'port': int(os.getenv('TEST_REDIS_PORT', 6379)),
 }
 
 REDISCLUSTER_CONFIG = {
@@ -45,12 +45,12 @@ REDISCLUSTER_CONFIG = {
 }
 
 MONGO_CONFIG = {
-    'port': int(os.getenv("TEST_MONGO_PORT", 27017)),
+    'port': int(os.getenv('TEST_MONGO_PORT', 27017)),
 }
 
 MEMCACHED_CONFIG = {
     'host': os.getenv('TEST_MEMCACHED_HOST', '127.0.0.1'),
-    'port': int(os.getenv("TEST_MEMCACHED_PORT", 11211)),
+    'port': int(os.getenv('TEST_MEMCACHED_PORT', 11211)),
 }
 
 VERTICA_CONFIG = {
@@ -65,5 +65,5 @@ RABBITMQ_CONFIG = {
     'host': os.getenv('TEST_RABBITMQ_HOST', '127.0.0.1'),
     'user': os.getenv('TEST_RABBITMQ_USER', 'guest'),
     'password': os.getenv('TEST_RABBITMQ_PASSWORD', 'guest'),
-    'port': int(os.getenv("TEST_RABBITMQ_PORT", 5672)),
+    'port': int(os.getenv('TEST_RABBITMQ_PORT', 5672)),
 }

--- a/tests/contrib/django/runtests.py
+++ b/tests/contrib/django/runtests.py
@@ -3,9 +3,9 @@ import os
 import sys
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     # define django defaults
-    app_to_test = "tests/contrib/django"
+    app_to_test = 'tests/contrib/django'
 
     # append the project root to the PYTHONPATH:
     # this is required because we don't want to put the current file
@@ -15,4 +15,4 @@ if __name__ == "__main__":
     sys.path.append(project_root)
 
     from django.core.management import execute_from_command_line
-    execute_from_command_line([sys.argv[0], "test", app_to_test])
+    execute_from_command_line([sys.argv[0], 'test', app_to_test])

--- a/tests/contrib/django/test_middleware.py
+++ b/tests/contrib/django/test_middleware.py
@@ -186,7 +186,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         assert span.get_tag('http.status_code') == '500'
         assert span.get_tag('http.url') == '/error-500/'
         assert span.resource == 'tests.contrib.django.app.views.error_500'
-        assert "Error 500" in span.get_tag('error.stack')
+        assert 'Error 500' in span.get_tag('error.stack')
 
     def test_middleware_trace_callable_view(self):
         # ensures that the internals are properly traced when using callable views

--- a/tests/contrib/django/test_templates.py
+++ b/tests/contrib/django/test_templates.py
@@ -13,7 +13,7 @@ class DjangoTemplateTest(DjangoTraceTestCase):
     """
     def test_template(self):
         # prepare a base template using the default engine
-        template = Template("Hello {{name}}!")
+        template = Template('Hello {{name}}!')
         ctx = Context({'name': 'Django'})
 
         # (trace) the template rendering
@@ -35,7 +35,7 @@ class DjangoTemplateTest(DjangoTraceTestCase):
     @override_ddtrace_settings(INSTRUMENT_TEMPLATE=False)
     def test_template_disabled(self):
         # prepare a base template using the default engine
-        template = Template("Hello {{name}}!")
+        template = Template('Hello {{name}}!')
         ctx = Context({'name': 'Django'})
 
         # (trace) the template rendering

--- a/tests/contrib/django/test_tracing_disabled.py
+++ b/tests/contrib/django/test_tracing_disabled.py
@@ -37,6 +37,6 @@ class DjangoTracingDisabledTest(TestCase):
         assert len(services) == 0
 
     def test_no_trace_is_written(self):
-        settings.TRACER.trace("client.testing").finish()
+        settings.TRACER.trace('client.testing').finish()
         traces = self.tracer.writer.pop_traces()
         assert len(traces) == 0

--- a/tests/contrib/djangorestframework/runtests.py
+++ b/tests/contrib/djangorestframework/runtests.py
@@ -3,9 +3,9 @@ import os
 import sys
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     # define django defaults
-    app_to_test = "tests/contrib/djangorestframework"
+    app_to_test = 'tests/contrib/djangorestframework'
 
     # project_root is the path of dd-trace-py (ex: ~/go/src/DataDog/dd-trace-py/)
     # We need to append the project_root path to the PYTHONPATH
@@ -15,4 +15,4 @@ if __name__ == "__main__":
     sys.path.append(project_root)
 
     from django.core.management import execute_from_command_line
-    execute_from_command_line([sys.argv[0], "test", app_to_test])
+    execute_from_command_line([sys.argv[0], 'test', app_to_test])

--- a/tests/contrib/elasticsearch/test.py
+++ b/tests/contrib/elasticsearch/test.py
@@ -284,7 +284,7 @@ class ElasticsearchPatchTest(BaseTracerTestCase):
         assert span.resource == 'GET /%s/%s/_search' % (self.ES_INDEX, self.ES_TYPE)
         assert span.get_tag('elasticsearch.method') == 'GET'
         assert span.get_tag('elasticsearch.url') == '/%s/%s/_search' % (self.ES_INDEX, self.ES_TYPE)
-        assert span.get_tag('elasticsearch.body').replace(' ', '') == "{'query':{'match_all':{}}}"
+        assert span.get_tag('elasticsearch.body').replace(' ', '') == '{"query":{"match_all":{}}}'
         assert set(span.get_tag('elasticsearch.params').split('&')) == {'sort=name%3Adesc', 'size=100'}
 
         self.assertTrue(span.get_metric('elasticsearch.took') > 0)

--- a/tests/contrib/elasticsearch/test.py
+++ b/tests/contrib/elasticsearch/test.py
@@ -59,12 +59,12 @@ class ElasticsearchTest(unittest.TestCase):
         assert len(spans) == 1
         span = spans[0]
         assert span.service == self.TEST_SERVICE
-        assert span.name == "elasticsearch.query"
-        assert span.span_type == "elasticsearch"
+        assert span.name == 'elasticsearch.query'
+        assert span.span_type == 'elasticsearch'
         assert span.error == 0
-        assert span.get_tag('elasticsearch.method') == "PUT"
-        assert span.get_tag('elasticsearch.url') == "/%s" % self.ES_INDEX
-        assert span.resource == "PUT /%s" % self.ES_INDEX
+        assert span.get_tag('elasticsearch.method') == 'PUT'
+        assert span.get_tag('elasticsearch.url') == '/%s' % self.ES_INDEX
+        assert span.resource == 'PUT /%s' % self.ES_INDEX
 
         # Put data
         args = {'index': self.ES_INDEX, 'doc_type': self.ES_TYPE}
@@ -77,9 +77,9 @@ class ElasticsearchTest(unittest.TestCase):
         assert len(spans) == 3
         span = spans[0]
         assert span.error == 0
-        assert span.get_tag('elasticsearch.method') == "PUT"
-        assert span.get_tag('elasticsearch.url') == "/%s/%s/%s" % (self.ES_INDEX, self.ES_TYPE, 10)
-        assert span.resource == "PUT /%s/%s/?" % (self.ES_INDEX, self.ES_TYPE)
+        assert span.get_tag('elasticsearch.method') == 'PUT'
+        assert span.get_tag('elasticsearch.url') == '/%s/%s/%s' % (self.ES_INDEX, self.ES_TYPE, 10)
+        assert span.resource == 'PUT /%s/%s/?' % (self.ES_INDEX, self.ES_TYPE)
 
         # Make the data available
         es.indices.refresh(index=self.ES_INDEX)
@@ -88,9 +88,9 @@ class ElasticsearchTest(unittest.TestCase):
         assert spans, spans
         assert len(spans) == 1
         span = spans[0]
-        assert span.resource == "POST /%s/_refresh" % self.ES_INDEX
-        assert span.get_tag('elasticsearch.method') == "POST"
-        assert span.get_tag('elasticsearch.url') == "/%s/_refresh" % self.ES_INDEX
+        assert span.resource == 'POST /%s/_refresh' % self.ES_INDEX
+        assert span.get_tag('elasticsearch.method') == 'POST'
+        assert span.get_tag('elasticsearch.url') == '/%s/_refresh' % self.ES_INDEX
 
         # Search data
         result = es.search(
@@ -99,32 +99,32 @@ class ElasticsearchTest(unittest.TestCase):
             **args
         )
 
-        assert len(result["hits"]["hits"]) == 3, result
+        assert len(result['hits']['hits']) == 3, result
 
         spans = writer.pop()
         assert spans
         assert len(spans) == 1
         span = spans[0]
         assert span.resource == 'GET /%s/%s/_search' % (self.ES_INDEX, self.ES_TYPE)
-        assert span.get_tag('elasticsearch.method') == "GET"
+        assert span.get_tag('elasticsearch.method') == 'GET'
         assert span.get_tag('elasticsearch.url') == '/%s/%s/_search' % (self.ES_INDEX, self.ES_TYPE)
 
-        assert span.get_tag('elasticsearch.body').replace(" ", "") == '{"query":{"match_all":{}}}'
+        assert span.get_tag('elasticsearch.body').replace(' ', '') == "{'query':{'match_all':{}}}"
         assert set(span.get_tag('elasticsearch.params').split('&')) == {'sort=name%3Adesc', 'size=100'}
 
         self.assertTrue(span.get_metric('elasticsearch.took') > 0)
 
         # Search by type not supported by default json encoder
-        query = {"range": {"created": {"gte": datetime.date(2016, 2, 1)}}}
-        result = es.search(size=100, body={"query": query}, **args)
+        query = {'range': {'created': {'gte': datetime.date(2016, 2, 1)}}}
+        result = es.search(size=100, body={'query': query}, **args)
 
-        assert len(result["hits"]["hits"]) == 2, result
+        assert len(result['hits']['hits']) == 2, result
 
         # Raise error 404 with a non existent index
         writer.pop()
         try:
-            es.get(index="non_existent_index", id=100, doc_type="_all")
-            assert "error_not_raised" == "elasticsearch.exceptions.TransportError"
+            es.get(index='non_existent_index', id=100, doc_type='_all')
+            assert 'error_not_raised' == 'elasticsearch.exceptions.TransportError'
         except elasticsearch.exceptions.TransportError:
             spans = writer.pop()
             assert spans
@@ -135,7 +135,7 @@ class ElasticsearchTest(unittest.TestCase):
         try:
             es.indices.create(index=10)
             es.indices.create(index=10)
-            assert "error_not_raised" == "elasticsearch.exceptions.TransportError"
+            assert 'error_not_raised' == 'elasticsearch.exceptions.TransportError'
         except elasticsearch.exceptions.TransportError:
             spans = writer.pop()
             assert spans
@@ -173,16 +173,16 @@ class ElasticsearchTest(unittest.TestCase):
         assert ot_span.parent_id is None
         assert dd_span.parent_id == ot_span.span_id
 
-        assert ot_span.service == "my_svc"
-        assert ot_span.resource == "ot_span"
+        assert ot_span.service == 'my_svc'
+        assert ot_span.resource == 'ot_span'
 
         assert dd_span.service == self.TEST_SERVICE
-        assert dd_span.name == "elasticsearch.query"
-        assert dd_span.span_type == "elasticsearch"
+        assert dd_span.name == 'elasticsearch.query'
+        assert dd_span.span_type == 'elasticsearch'
         assert dd_span.error == 0
-        assert dd_span.get_tag('elasticsearch.method') == "PUT"
-        assert dd_span.get_tag('elasticsearch.url') == "/%s" % self.ES_INDEX
-        assert dd_span.resource == "PUT /%s" % self.ES_INDEX
+        assert dd_span.get_tag('elasticsearch.method') == 'PUT'
+        assert dd_span.get_tag('elasticsearch.url') == '/%s' % self.ES_INDEX
+        assert dd_span.resource == 'PUT /%s' % self.ES_INDEX
 
 
 class ElasticsearchPatchTest(BaseTracerTestCase):
@@ -229,12 +229,12 @@ class ElasticsearchPatchTest(BaseTracerTestCase):
         assert len(spans) == 1
         span = spans[0]
         assert span.service == self.TEST_SERVICE
-        assert span.name == "elasticsearch.query"
-        assert span.span_type == "elasticsearch"
+        assert span.name == 'elasticsearch.query'
+        assert span.span_type == 'elasticsearch'
         assert span.error == 0
-        assert span.get_tag('elasticsearch.method') == "PUT"
-        assert span.get_tag('elasticsearch.url') == "/%s" % self.ES_INDEX
-        assert span.resource == "PUT /%s" % self.ES_INDEX
+        assert span.get_tag('elasticsearch.method') == 'PUT'
+        assert span.get_tag('elasticsearch.url') == '/%s' % self.ES_INDEX
+        assert span.resource == 'PUT /%s' % self.ES_INDEX
 
         args = {'index': self.ES_INDEX, 'doc_type': self.ES_TYPE}
         es.index(id=10, body={'name': 'ten', 'created': datetime.date(2016, 1, 1)}, **args)
@@ -247,9 +247,9 @@ class ElasticsearchPatchTest(BaseTracerTestCase):
         assert len(spans) == 3
         span = spans[0]
         assert span.error == 0
-        assert span.get_tag('elasticsearch.method') == "PUT"
-        assert span.get_tag('elasticsearch.url') == "/%s/%s/%s" % (self.ES_INDEX, self.ES_TYPE, 10)
-        assert span.resource == "PUT /%s/%s/?" % (self.ES_INDEX, self.ES_TYPE)
+        assert span.get_tag('elasticsearch.method') == 'PUT'
+        assert span.get_tag('elasticsearch.url') == '/%s/%s/%s' % (self.ES_INDEX, self.ES_TYPE, 10)
+        assert span.resource == 'PUT /%s/%s/?' % (self.ES_INDEX, self.ES_TYPE)
 
         args = {'index': self.ES_INDEX, 'doc_type': self.ES_TYPE}
         es.indices.refresh(index=self.ES_INDEX)
@@ -259,9 +259,9 @@ class ElasticsearchPatchTest(BaseTracerTestCase):
         assert spans, spans
         assert len(spans) == 1
         span = spans[0]
-        assert span.resource == "POST /%s/_refresh" % self.ES_INDEX
-        assert span.get_tag('elasticsearch.method') == "POST"
-        assert span.get_tag('elasticsearch.url') == "/%s/_refresh" % self.ES_INDEX
+        assert span.resource == 'POST /%s/_refresh' % self.ES_INDEX
+        assert span.get_tag('elasticsearch.method') == 'POST'
+        assert span.get_tag('elasticsearch.url') == '/%s/_refresh' % self.ES_INDEX
 
         # search data
         args = {'index': self.ES_INDEX, 'doc_type': self.ES_TYPE}
@@ -275,25 +275,25 @@ class ElasticsearchPatchTest(BaseTracerTestCase):
             **args
         )
 
-        assert len(result["hits"]["hits"]) == 3, result
+        assert len(result['hits']['hits']) == 3, result
         spans = self.get_spans()
         self.reset()
         assert spans, spans
         assert len(spans) == 4
         span = spans[-1]
-        assert span.resource == "GET /%s/%s/_search" % (self.ES_INDEX, self.ES_TYPE)
-        assert span.get_tag('elasticsearch.method') == "GET"
-        assert span.get_tag('elasticsearch.url') == "/%s/%s/_search" % (self.ES_INDEX, self.ES_TYPE)
-        assert span.get_tag('elasticsearch.body').replace(" ", "") == '{"query":{"match_all":{}}}'
+        assert span.resource == 'GET /%s/%s/_search' % (self.ES_INDEX, self.ES_TYPE)
+        assert span.get_tag('elasticsearch.method') == 'GET'
+        assert span.get_tag('elasticsearch.url') == '/%s/%s/_search' % (self.ES_INDEX, self.ES_TYPE)
+        assert span.get_tag('elasticsearch.body').replace(' ', '') == "{'query':{'match_all':{}}}"
         assert set(span.get_tag('elasticsearch.params').split('&')) == {'sort=name%3Adesc', 'size=100'}
 
         self.assertTrue(span.get_metric('elasticsearch.took') > 0)
 
         # Search by type not supported by default json encoder
-        query = {"range": {"created": {"gte": datetime.date(2016, 2, 1)}}}
-        result = es.search(size=100, body={"query": query}, **args)
+        query = {'range': {'created': {'gte': datetime.date(2016, 2, 1)}}}
+        result = es.search(size=100, body={'query': query}, **args)
 
-        assert len(result["hits"]["hits"]) == 2, result
+        assert len(result['hits']['hits']) == 2, result
 
     def test_analytics_default(self):
         es = self.es

--- a/tests/contrib/elasticsearch/test.py
+++ b/tests/contrib/elasticsearch/test.py
@@ -109,7 +109,7 @@ class ElasticsearchTest(unittest.TestCase):
         assert span.get_tag('elasticsearch.method') == 'GET'
         assert span.get_tag('elasticsearch.url') == '/%s/%s/_search' % (self.ES_INDEX, self.ES_TYPE)
 
-        assert span.get_tag('elasticsearch.body').replace(' ', '') == "{'query':{'match_all':{}}}"
+        assert span.get_tag('elasticsearch.body').replace(' ', '') == '{"query":{"match_all":{}}}'
         assert set(span.get_tag('elasticsearch.params').split('&')) == {'sort=name%3Adesc', 'size=100'}
 
         self.assertTrue(span.get_metric('elasticsearch.took') > 0)

--- a/tests/contrib/flask/test_middleware.py
+++ b/tests/contrib/flask/test_middleware.py
@@ -269,7 +269,7 @@ class TestFlask(TestCase):
         assert s.meta.get(http.METHOD) == 'GET'
         assert 'ZeroDivisionError' in s.meta.get(errors.ERROR_TYPE), s.meta
         assert 'by zero' in s.meta.get(errors.ERROR_MSG)
-        assert re.search("File '.*/contrib/flask/web.py', line [0-9]+, in fatal", s.meta.get(errors.ERROR_STACK))
+        assert re.search('File ".*/contrib/flask/web.py", line [0-9]+, in fatal', s.meta.get(errors.ERROR_STACK))
 
     def test_unicode(self):
         start = time.time()

--- a/tests/contrib/flask/test_middleware.py
+++ b/tests/contrib/flask/test_middleware.py
@@ -76,7 +76,7 @@ class TestFlask(TestCase):
         assert s.trace_id
         assert not s.parent_id
         assert s.service == 'test.flask.service'
-        assert s.resource == "child"
+        assert s.resource == 'child'
         assert s.start >= start
         assert s.duration <= end - start
         assert s.error == 0
@@ -106,7 +106,7 @@ class TestFlask(TestCase):
         assert len(spans) == 1
         s = spans[0]
         assert s.service == 'test.flask.service'
-        assert s.resource == "index"
+        assert s.resource == 'index'
         assert s.start >= start
         assert s.duration <= end - start
         assert s.error == 0
@@ -131,17 +131,17 @@ class TestFlask(TestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 2
         by_name = {s.name: s for s in spans}
-        s = by_name["flask.request"]
-        assert s.service == "test.flask.service"
-        assert s.resource == "tmpl"
+        s = by_name['flask.request']
+        assert s.service == 'test.flask.service'
+        assert s.resource == 'tmpl'
         assert s.start >= start
         assert s.duration <= end - start
         assert s.error == 0
         assert s.meta.get(http.STATUS_CODE) == '200'
         assert s.meta.get(http.METHOD) == 'GET'
 
-        t = by_name["flask.template"]
-        assert t.get_tag("flask.template") == "test.html"
+        t = by_name['flask.template']
+        assert t.get_tag('flask.template') == 'test.html'
         assert t.parent_id == s.span_id
         assert t.trace_id == s.trace_id
         assert s.start < t.start < t.start + t.duration < end
@@ -160,8 +160,8 @@ class TestFlask(TestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == "test.flask.service"
-        assert s.resource == "handle_me"
+        assert s.service == 'test.flask.service'
+        assert s.resource == 'handle_me'
         assert s.start >= start
         assert s.duration <= end - start
         assert s.error == 0
@@ -183,9 +183,9 @@ class TestFlask(TestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         by_name = {s.name: s for s in spans}
-        s = by_name["flask.request"]
-        assert s.service == "test.flask.service"
-        assert s.resource == "tmpl_err"
+        s = by_name['flask.request']
+        assert s.service == 'test.flask.service'
+        assert s.resource == 'tmpl_err'
         assert s.start >= start
         assert s.duration <= end - start
         assert s.error == 1
@@ -208,16 +208,16 @@ class TestFlask(TestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 2
         by_name = {s.name: s for s in spans}
-        s = by_name["flask.request"]
-        assert s.service == "test.flask.service"
-        assert s.resource == "tmpl_render_err"
+        s = by_name['flask.request']
+        assert s.service == 'test.flask.service'
+        assert s.resource == 'tmpl_render_err'
         assert s.start >= start
         assert s.duration <= end - start
         assert s.error == 1
         assert s.meta.get(http.STATUS_CODE) == '500'
         assert s.meta.get(http.METHOD) == 'GET'
-        t = by_name["flask.template"]
-        assert t.get_tag("flask.template") == "render_err.html"
+        t = by_name['flask.template']
+        assert t.get_tag('flask.template') == 'render_err.html'
         assert t.error == 1
         assert t.parent_id == s.span_id
         assert t.trace_id == s.trace_id
@@ -236,8 +236,8 @@ class TestFlask(TestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == "test.flask.service"
-        assert s.resource == "error"
+        assert s.service == 'test.flask.service'
+        assert s.resource == 'error'
         assert s.start >= start
         assert s.duration <= end - start
         assert s.meta.get(http.STATUS_CODE) == '500'
@@ -261,15 +261,15 @@ class TestFlask(TestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == "test.flask.service"
-        assert s.resource == "fatal"
+        assert s.service == 'test.flask.service'
+        assert s.resource == 'fatal'
         assert s.start >= start
         assert s.duration <= end - start
         assert s.meta.get(http.STATUS_CODE) == '500'
         assert s.meta.get(http.METHOD) == 'GET'
-        assert "ZeroDivisionError" in s.meta.get(errors.ERROR_TYPE), s.meta
-        assert "by zero" in s.meta.get(errors.ERROR_MSG)
-        assert re.search('File ".*/contrib/flask/web.py", line [0-9]+, in fatal', s.meta.get(errors.ERROR_STACK))
+        assert 'ZeroDivisionError' in s.meta.get(errors.ERROR_TYPE), s.meta
+        assert 'by zero' in s.meta.get(errors.ERROR_MSG)
+        assert re.search("File '.*/contrib/flask/web.py', line [0-9]+, in fatal", s.meta.get(errors.ERROR_STACK))
 
     def test_unicode(self):
         start = time.time()
@@ -285,7 +285,7 @@ class TestFlask(TestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == "test.flask.service"
+        assert s.service == 'test.flask.service'
         assert s.resource == u'üŋïĉóđē'
         assert s.start >= start
         assert s.duration <= end - start
@@ -307,7 +307,7 @@ class TestFlask(TestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == "test.flask.service"
+        assert s.service == 'test.flask.service'
         assert s.resource == u'404'
         assert s.start >= start
         assert s.duration <= end - start
@@ -346,8 +346,8 @@ class TestFlask(TestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == "test.flask.service"
-        assert s.resource == "overridden"
+        assert s.service == 'test.flask.service'
+        assert s.resource == 'overridden'
         assert s.error == 0
         assert s.meta.get(http.STATUS_CODE) == '200'
         assert s.meta.get(http.METHOD) == 'GET'
@@ -379,7 +379,7 @@ class TestFlask(TestCase):
         assert ot_span.resource == 'ot_span'
         assert ot_span.service == 'my_svc'
 
-        assert dd_span.resource == "index"
+        assert dd_span.resource == 'index'
         assert dd_span.start >= start
         assert dd_span.duration <= end - start
         assert dd_span.error == 0

--- a/tests/contrib/flask/web.py
+++ b/tests/contrib/flask/web.py
@@ -39,7 +39,7 @@ def create_app():
 
     @app.route('/tmpl')
     def tmpl():
-        return render_template('test.html', world="earth")
+        return render_template('test.html', world='earth')
 
     @app.route('/tmpl/err')
     def tmpl_err():
@@ -55,11 +55,11 @@ def create_app():
             span.set_tag('a', 'b')
             return 'child'
 
-    @app.route("/custom_span")
+    @app.route('/custom_span')
     def custom_span():
         span = app._tracer.current_span()
         assert span
-        span.resource = "overridden"
+        span.resource = 'overridden'
         return 'hiya'
 
     def unicode_view():

--- a/tests/contrib/flask_cache/test.py
+++ b/tests/contrib/flask_cache/test.py
@@ -17,7 +17,7 @@ from ...util import assert_dict_issuperset
 
 
 class FlaskCacheTest(BaseTracerTestCase):
-    SERVICE = "test-flask-cache"
+    SERVICE = 'test-flask-cache'
     TEST_REDIS_PORT = str(REDIS_CONFIG['port'])
     TEST_MEMCACHED_PORT = str(MEMCACHED_CONFIG['port'])
 
@@ -27,94 +27,94 @@ class FlaskCacheTest(BaseTracerTestCase):
         # create the TracedCache instance for a Flask app
         Cache = get_traced_cache(self.tracer, service=self.SERVICE)
         app = Flask(__name__)
-        self.cache = Cache(app, config={"CACHE_TYPE": "simple"})
+        self.cache = Cache(app, config={'CACHE_TYPE': 'simple'})
 
     def test_simple_cache_get(self):
-        self.cache.get(u"á_complex_operation")
+        self.cache.get(u'á_complex_operation')
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertEqual(span.service, self.SERVICE)
-        self.assertEqual(span.resource, "get")
-        self.assertEqual(span.name, "flask_cache.cmd")
-        self.assertEqual(span.span_type, "cache")
+        self.assertEqual(span.resource, 'get')
+        self.assertEqual(span.name, 'flask_cache.cmd')
+        self.assertEqual(span.span_type, 'cache')
         self.assertEqual(span.error, 0)
 
         expected_meta = {
-            "flask_cache.key": u"á_complex_operation",
-            "flask_cache.backend": "simple",
+            'flask_cache.key': u'á_complex_operation',
+            'flask_cache.backend': 'simple',
         }
 
         assert_dict_issuperset(span.meta, expected_meta)
 
     def test_simple_cache_set(self):
-        self.cache.set(u"á_complex_operation", u"with_á_value\nin two lines")
+        self.cache.set(u'á_complex_operation', u'with_á_value\nin two lines')
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertEqual(span.service, self.SERVICE)
-        self.assertEqual(span.resource, "set")
-        self.assertEqual(span.name, "flask_cache.cmd")
-        self.assertEqual(span.span_type, "cache")
+        self.assertEqual(span.resource, 'set')
+        self.assertEqual(span.name, 'flask_cache.cmd')
+        self.assertEqual(span.span_type, 'cache')
         self.assertEqual(span.error, 0)
 
         expected_meta = {
-            "flask_cache.key": u"á_complex_operation",
-            "flask_cache.backend": "simple",
+            'flask_cache.key': u'á_complex_operation',
+            'flask_cache.backend': 'simple',
         }
 
         assert_dict_issuperset(span.meta, expected_meta)
 
     def test_simple_cache_add(self):
-        self.cache.add(u"á_complex_number", 50)
+        self.cache.add(u'á_complex_number', 50)
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertEqual(span.service, self.SERVICE)
-        self.assertEqual(span.resource, "add")
-        self.assertEqual(span.name, "flask_cache.cmd")
-        self.assertEqual(span.span_type, "cache")
+        self.assertEqual(span.resource, 'add')
+        self.assertEqual(span.name, 'flask_cache.cmd')
+        self.assertEqual(span.span_type, 'cache')
         self.assertEqual(span.error, 0)
 
         expected_meta = {
-            "flask_cache.key": u"á_complex_number",
-            "flask_cache.backend": "simple",
+            'flask_cache.key': u'á_complex_number',
+            'flask_cache.backend': 'simple',
         }
 
         assert_dict_issuperset(span.meta, expected_meta)
 
     def test_simple_cache_delete(self):
-        self.cache.delete(u"á_complex_operation")
+        self.cache.delete(u'á_complex_operation')
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertEqual(span.service, self.SERVICE)
-        self.assertEqual(span.resource, "delete")
-        self.assertEqual(span.name, "flask_cache.cmd")
-        self.assertEqual(span.span_type, "cache")
+        self.assertEqual(span.resource, 'delete')
+        self.assertEqual(span.name, 'flask_cache.cmd')
+        self.assertEqual(span.span_type, 'cache')
         self.assertEqual(span.error, 0)
 
         expected_meta = {
-            "flask_cache.key": u"á_complex_operation",
-            "flask_cache.backend": "simple",
+            'flask_cache.key': u'á_complex_operation',
+            'flask_cache.backend': 'simple',
         }
 
         assert_dict_issuperset(span.meta, expected_meta)
 
     def test_simple_cache_delete_many(self):
-        self.cache.delete_many("complex_operation", "another_complex_op")
+        self.cache.delete_many('complex_operation', 'another_complex_op')
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertEqual(span.service, self.SERVICE)
-        self.assertEqual(span.resource, "delete_many")
-        self.assertEqual(span.name, "flask_cache.cmd")
-        self.assertEqual(span.span_type, "cache")
+        self.assertEqual(span.resource, 'delete_many')
+        self.assertEqual(span.name, 'flask_cache.cmd')
+        self.assertEqual(span.span_type, 'cache')
         self.assertEqual(span.error, 0)
 
         expected_meta = {
-            "flask_cache.key": "['complex_operation', 'another_complex_op']",
-            "flask_cache.backend": "simple",
+            'flask_cache.key': "['complex_operation', 'another_complex_op']",
+            'flask_cache.backend': 'simple',
         }
 
         assert_dict_issuperset(span.meta, expected_meta)
@@ -125,13 +125,13 @@ class FlaskCacheTest(BaseTracerTestCase):
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertEqual(span.service, self.SERVICE)
-        self.assertEqual(span.resource, "clear")
-        self.assertEqual(span.name, "flask_cache.cmd")
-        self.assertEqual(span.span_type, "cache")
+        self.assertEqual(span.resource, 'clear')
+        self.assertEqual(span.name, 'flask_cache.cmd')
+        self.assertEqual(span.span_type, 'cache')
         self.assertEqual(span.error, 0)
 
         expected_meta = {
-            "flask_cache.backend": "simple",
+            'flask_cache.backend': 'simple',
         }
 
         assert_dict_issuperset(span.meta, expected_meta)
@@ -142,14 +142,14 @@ class FlaskCacheTest(BaseTracerTestCase):
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertEqual(span.service, self.SERVICE)
-        self.assertEqual(span.resource, "get_many")
-        self.assertEqual(span.name, "flask_cache.cmd")
-        self.assertEqual(span.span_type, "cache")
+        self.assertEqual(span.resource, 'get_many')
+        self.assertEqual(span.name, 'flask_cache.cmd')
+        self.assertEqual(span.span_type, 'cache')
         self.assertEqual(span.error, 0)
 
         expected_meta = {
-            "flask_cache.key": "['first_complex_op', 'second_complex_op']",
-            "flask_cache.backend": "simple",
+            'flask_cache.key': "['first_complex_op', 'second_complex_op']",
+            'flask_cache.backend': 'simple',
         }
 
         assert_dict_issuperset(span.meta, expected_meta)
@@ -163,21 +163,21 @@ class FlaskCacheTest(BaseTracerTestCase):
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertEqual(span.service, self.SERVICE)
-        self.assertEqual(span.resource, "set_many")
-        self.assertEqual(span.name, "flask_cache.cmd")
-        self.assertEqual(span.span_type, "cache")
+        self.assertEqual(span.resource, 'set_many')
+        self.assertEqual(span.name, 'flask_cache.cmd')
+        self.assertEqual(span.span_type, 'cache')
         self.assertEqual(span.error, 0)
 
-        self.assertEqual(span.meta["flask_cache.backend"], "simple")
-        self.assertTrue("first_complex_op" in span.meta["flask_cache.key"])
-        self.assertTrue("second_complex_op" in span.meta["flask_cache.key"])
+        self.assertEqual(span.meta['flask_cache.backend'], 'simple')
+        self.assertTrue('first_complex_op' in span.meta['flask_cache.key'])
+        self.assertTrue('second_complex_op' in span.meta['flask_cache.key'])
 
     def test_default_span_tags(self):
         # test tags and attributes
-        with self.cache._TracedCache__trace("flask_cache.cmd") as span:
+        with self.cache._TracedCache__trace('flask_cache.cmd') as span:
             self.assertEqual(span.service, self.SERVICE)
             self.assertEqual(span.span_type, TYPE)
-            self.assertEqual(span.meta[CACHE_BACKEND], "simple")
+            self.assertEqual(span.meta[CACHE_BACKEND], 'simple')
             self.assertTrue(net.TARGET_HOST not in span.meta)
             self.assertTrue(net.TARGET_PORT not in span.meta)
 
@@ -186,15 +186,15 @@ class FlaskCacheTest(BaseTracerTestCase):
         Cache = get_traced_cache(self.tracer, service=self.SERVICE)
         app = Flask(__name__)
         config = {
-            "CACHE_TYPE": "redis",
-            "CACHE_REDIS_PORT": self.TEST_REDIS_PORT,
+            'CACHE_TYPE': 'redis',
+            'CACHE_REDIS_PORT': self.TEST_REDIS_PORT,
         }
         cache = Cache(app, config=config)
         # test tags and attributes
-        with cache._TracedCache__trace("flask_cache.cmd") as span:
+        with cache._TracedCache__trace('flask_cache.cmd') as span:
             self.assertEqual(span.service, self.SERVICE)
             self.assertEqual(span.span_type, TYPE)
-            self.assertEqual(span.meta[CACHE_BACKEND], "redis")
+            self.assertEqual(span.meta[CACHE_BACKEND], 'redis')
             self.assertEqual(span.meta[net.TARGET_HOST], 'localhost')
             self.assertEqual(span.meta[net.TARGET_PORT], self.TEST_REDIS_PORT)
 
@@ -203,29 +203,29 @@ class FlaskCacheTest(BaseTracerTestCase):
         Cache = get_traced_cache(self.tracer, service=self.SERVICE)
         app = Flask(__name__)
         config = {
-            "CACHE_TYPE": "memcached",
-            "CACHE_MEMCACHED_SERVERS": ["127.0.0.1:{}".format(self.TEST_MEMCACHED_PORT)],
+            'CACHE_TYPE': 'memcached',
+            'CACHE_MEMCACHED_SERVERS': ['127.0.0.1:{}'.format(self.TEST_MEMCACHED_PORT)],
         }
         cache = Cache(app, config=config)
         # test tags and attributes
-        with cache._TracedCache__trace("flask_cache.cmd") as span:
+        with cache._TracedCache__trace('flask_cache.cmd') as span:
             self.assertEqual(span.service, self.SERVICE)
             self.assertEqual(span.span_type, TYPE)
-            self.assertEqual(span.meta[CACHE_BACKEND], "memcached")
-            self.assertEqual(span.meta[net.TARGET_HOST], "127.0.0.1")
+            self.assertEqual(span.meta[CACHE_BACKEND], 'memcached')
+            self.assertEqual(span.meta[net.TARGET_HOST], '127.0.0.1')
             self.assertEqual(span.meta[net.TARGET_PORT], self.TEST_MEMCACHED_PORT)
 
     def test_simple_cache_get_ot(self):
         """OpenTracing version of test_simple_cache_get."""
-        ot_tracer = init_tracer("my_svc", self.tracer)
+        ot_tracer = init_tracer('my_svc', self.tracer)
 
         # create the TracedCache instance for a Flask app
         Cache = get_traced_cache(self.tracer, service=self.SERVICE)
         app = Flask(__name__)
-        cache = Cache(app, config={"CACHE_TYPE": "simple"})
+        cache = Cache(app, config={'CACHE_TYPE': 'simple'})
 
-        with ot_tracer.start_active_span("ot_span"):
-            cache.get(u"á_complex_operation")
+        with ot_tracer.start_active_span('ot_span'):
+            cache.get(u'á_complex_operation')
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 2)
@@ -235,24 +235,24 @@ class FlaskCacheTest(BaseTracerTestCase):
         self.assertIsNone(ot_span.parent_id)
         self.assertEqual(dd_span.parent_id, ot_span.span_id)
 
-        self.assertEqual(ot_span.resource, "ot_span")
-        self.assertEqual(ot_span.service, "my_svc")
+        self.assertEqual(ot_span.resource, 'ot_span')
+        self.assertEqual(ot_span.service, 'my_svc')
 
         self.assertEqual(dd_span.service, self.SERVICE)
-        self.assertEqual(dd_span.resource, "get")
-        self.assertEqual(dd_span.name, "flask_cache.cmd")
-        self.assertEqual(dd_span.span_type, "cache")
+        self.assertEqual(dd_span.resource, 'get')
+        self.assertEqual(dd_span.name, 'flask_cache.cmd')
+        self.assertEqual(dd_span.span_type, 'cache')
         self.assertEqual(dd_span.error, 0)
 
         expected_meta = {
-            "flask_cache.key": u"á_complex_operation",
-            "flask_cache.backend": "simple",
+            'flask_cache.key': u'á_complex_operation',
+            'flask_cache.backend': 'simple',
         }
 
         assert_dict_issuperset(dd_span.meta, expected_meta)
 
     def test_analytics_default(self):
-        self.cache.get(u"á_complex_operation")
+        self.cache.get(u'á_complex_operation')
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
         self.assertIsNone(spans[0].get_metric(ANALYTICS_SAMPLE_RATE_KEY))
@@ -262,7 +262,7 @@ class FlaskCacheTest(BaseTracerTestCase):
             'flask_cache',
             dict(analytics_enabled=True, analytics_sample_rate=0.5)
         ):
-            self.cache.get(u"á_complex_operation")
+            self.cache.get(u'á_complex_operation')
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
@@ -273,7 +273,7 @@ class FlaskCacheTest(BaseTracerTestCase):
             'flask_cache',
             dict(analytics_enabled=True)
         ):
-            self.cache.get(u"á_complex_operation")
+            self.cache.get(u'á_complex_operation')
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)

--- a/tests/contrib/flask_cache/test_utils.py
+++ b/tests/contrib/flask_cache/test_utils.py
@@ -13,7 +13,7 @@ from ..config import REDIS_CONFIG, MEMCACHED_CONFIG
 
 
 class FlaskCacheUtilsTest(unittest.TestCase):
-    SERVICE = "test-flask-cache"
+    SERVICE = 'test-flask-cache'
 
     def test_extract_redis_connection_metadata(self):
         # create the TracedCache instance for a Flask app
@@ -21,8 +21,8 @@ class FlaskCacheUtilsTest(unittest.TestCase):
         Cache = get_traced_cache(tracer, service=self.SERVICE)
         app = Flask(__name__)
         config = {
-            "CACHE_TYPE": "redis",
-            "CACHE_REDIS_PORT": REDIS_CONFIG['port'],
+            'CACHE_TYPE': 'redis',
+            'CACHE_REDIS_PORT': REDIS_CONFIG['port'],
         }
         traced_cache = Cache(app, config=config)
         # extract client data
@@ -36,8 +36,8 @@ class FlaskCacheUtilsTest(unittest.TestCase):
         Cache = get_traced_cache(tracer, service=self.SERVICE)
         app = Flask(__name__)
         config = {
-            "CACHE_TYPE": "memcached",
-            "CACHE_MEMCACHED_SERVERS": ["127.0.0.1:{}".format(MEMCACHED_CONFIG['port'])],
+            'CACHE_TYPE': 'memcached',
+            'CACHE_MEMCACHED_SERVERS': ['127.0.0.1:{}'.format(MEMCACHED_CONFIG['port'])],
         }
         traced_cache = Cache(app, config=config)
         # extract client data
@@ -51,10 +51,10 @@ class FlaskCacheUtilsTest(unittest.TestCase):
         Cache = get_traced_cache(tracer, service=self.SERVICE)
         app = Flask(__name__)
         config = {
-            "CACHE_TYPE": "memcached",
-            "CACHE_MEMCACHED_SERVERS": [
-                "127.0.0.1:{}".format(MEMCACHED_CONFIG['port']),
-                "localhost:{}".format(MEMCACHED_CONFIG['port']),
+            'CACHE_TYPE': 'memcached',
+            'CACHE_MEMCACHED_SERVERS': [
+                '127.0.0.1:{}'.format(MEMCACHED_CONFIG['port']),
+                'localhost:{}'.format(MEMCACHED_CONFIG['port']),
             ],
         }
         traced_cache = Cache(app, config=config)
@@ -72,14 +72,14 @@ class FlaskCacheUtilsTest(unittest.TestCase):
         Cache = get_traced_cache(tracer, service=self.SERVICE)
         app = Flask(__name__)
         config = {
-            "CACHE_TYPE": "redis",
-            "CACHE_REDIS_PORT": REDIS_CONFIG['port'],
-            "CACHE_KEY_PREFIX": "users",
+            'CACHE_TYPE': 'redis',
+            'CACHE_REDIS_PORT': REDIS_CONFIG['port'],
+            'CACHE_KEY_PREFIX': 'users',
         }
         traced_cache = Cache(app, config=config)
         # expect a resource with a prefix
-        expected_resource = "get users"
-        resource = _resource_from_cache_prefix("GET", traced_cache.cache)
+        expected_resource = 'get users'
+        resource = _resource_from_cache_prefix('GET', traced_cache.cache)
         assert resource == expected_resource
 
     def test_resource_from_cache_with_empty_prefix(self):
@@ -88,14 +88,14 @@ class FlaskCacheUtilsTest(unittest.TestCase):
         Cache = get_traced_cache(tracer, service=self.SERVICE)
         app = Flask(__name__)
         config = {
-            "CACHE_TYPE": "redis",
-            "CACHE_REDIS_PORT": REDIS_CONFIG['port'],
-            "CACHE_KEY_PREFIX": "",
+            'CACHE_TYPE': 'redis',
+            'CACHE_REDIS_PORT': REDIS_CONFIG['port'],
+            'CACHE_KEY_PREFIX': '',
         }
         traced_cache = Cache(app, config=config)
         # expect a resource with a prefix
-        expected_resource = "get"
-        resource = _resource_from_cache_prefix("GET", traced_cache.cache)
+        expected_resource = 'get'
+        resource = _resource_from_cache_prefix('GET', traced_cache.cache)
         assert resource == expected_resource
 
     def test_resource_from_cache_without_prefix(self):
@@ -103,8 +103,8 @@ class FlaskCacheUtilsTest(unittest.TestCase):
         tracer = Tracer()
         Cache = get_traced_cache(tracer, service=self.SERVICE)
         app = Flask(__name__)
-        traced_cache = Cache(app, config={"CACHE_TYPE": "redis"})
+        traced_cache = Cache(app, config={'CACHE_TYPE': 'redis'})
         # expect only the resource name
-        expected_resource = "get"
-        resource = _resource_from_cache_prefix("GET", traced_cache.config)
+        expected_resource = 'get'
+        resource = _resource_from_cache_prefix('GET', traced_cache.config)
         assert resource == expected_resource

--- a/tests/contrib/flask_cache/test_wrapper_safety.py
+++ b/tests/contrib/flask_cache/test_wrapper_safety.py
@@ -17,7 +17,7 @@ from ...test_tracer import DummyWriter
 
 
 class FlaskCacheWrapperTest(unittest.TestCase):
-    SERVICE = "test-flask-cache"
+    SERVICE = 'test-flask-cache'
 
     def test_cache_get_without_arguments(self):
         # initialize the dummy writer
@@ -28,23 +28,23 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         # create the TracedCache instance for a Flask app
         Cache = get_traced_cache(tracer, service=self.SERVICE)
         app = Flask(__name__)
-        cache = Cache(app, config={"CACHE_TYPE": "simple"})
+        cache = Cache(app, config={'CACHE_TYPE': 'simple'})
 
         # make a wrong call
         with pytest.raises(TypeError) as ex:
             cache.get()
 
         # ensure that the error is not caused by our tracer
-        assert "get()" in ex.value.args[0]
-        assert "argument" in ex.value.args[0]
+        assert 'get()' in ex.value.args[0]
+        assert 'argument' in ex.value.args[0]
         spans = writer.pop()
         # an error trace must be sent
         assert len(spans) == 1
         span = spans[0]
         assert span.service == self.SERVICE
-        assert span.resource == "get"
-        assert span.name == "flask_cache.cmd"
-        assert span.span_type == "cache"
+        assert span.resource == 'get'
+        assert span.name == 'flask_cache.cmd'
+        assert span.span_type == 'cache'
         assert span.error == 1
 
     def test_cache_set_without_arguments(self):
@@ -56,23 +56,23 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         # create the TracedCache instance for a Flask app
         Cache = get_traced_cache(tracer, service=self.SERVICE)
         app = Flask(__name__)
-        cache = Cache(app, config={"CACHE_TYPE": "simple"})
+        cache = Cache(app, config={'CACHE_TYPE': 'simple'})
 
         # make a wrong call
         with pytest.raises(TypeError) as ex:
             cache.set()
 
         # ensure that the error is not caused by our tracer
-        assert "set()" in ex.value.args[0]
-        assert "argument" in ex.value.args[0]
+        assert 'set()' in ex.value.args[0]
+        assert 'argument' in ex.value.args[0]
         spans = writer.pop()
         # an error trace must be sent
         assert len(spans) == 1
         span = spans[0]
         assert span.service == self.SERVICE
-        assert span.resource == "set"
-        assert span.name == "flask_cache.cmd"
-        assert span.span_type == "cache"
+        assert span.resource == 'set'
+        assert span.name == 'flask_cache.cmd'
+        assert span.span_type == 'cache'
         assert span.error == 1
 
     def test_cache_add_without_arguments(self):
@@ -84,23 +84,23 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         # create the TracedCache instance for a Flask app
         Cache = get_traced_cache(tracer, service=self.SERVICE)
         app = Flask(__name__)
-        cache = Cache(app, config={"CACHE_TYPE": "simple"})
+        cache = Cache(app, config={'CACHE_TYPE': 'simple'})
 
         # make a wrong call
         with pytest.raises(TypeError) as ex:
             cache.add()
 
         # ensure that the error is not caused by our tracer
-        assert "add()" in ex.value.args[0]
-        assert "argument" in ex.value.args[0]
+        assert 'add()' in ex.value.args[0]
+        assert 'argument' in ex.value.args[0]
         spans = writer.pop()
         # an error trace must be sent
         assert len(spans) == 1
         span = spans[0]
         assert span.service == self.SERVICE
-        assert span.resource == "add"
-        assert span.name == "flask_cache.cmd"
-        assert span.span_type == "cache"
+        assert span.resource == 'add'
+        assert span.name == 'flask_cache.cmd'
+        assert span.span_type == 'cache'
         assert span.error == 1
 
     def test_cache_delete_without_arguments(self):
@@ -112,23 +112,23 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         # create the TracedCache instance for a Flask app
         Cache = get_traced_cache(tracer, service=self.SERVICE)
         app = Flask(__name__)
-        cache = Cache(app, config={"CACHE_TYPE": "simple"})
+        cache = Cache(app, config={'CACHE_TYPE': 'simple'})
 
         # make a wrong call
         with pytest.raises(TypeError) as ex:
             cache.delete()
 
         # ensure that the error is not caused by our tracer
-        assert "delete()" in ex.value.args[0]
-        assert "argument" in ex.value.args[0]
+        assert 'delete()' in ex.value.args[0]
+        assert 'argument' in ex.value.args[0]
         spans = writer.pop()
         # an error trace must be sent
         assert len(spans) == 1
         span = spans[0]
         assert span.service == self.SERVICE
-        assert span.resource == "delete"
-        assert span.name == "flask_cache.cmd"
-        assert span.span_type == "cache"
+        assert span.resource == 'delete'
+        assert span.name == 'flask_cache.cmd'
+        assert span.span_type == 'cache'
         assert span.error == 1
 
     def test_cache_set_many_without_arguments(self):
@@ -140,23 +140,23 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         # create the TracedCache instance for a Flask app
         Cache = get_traced_cache(tracer, service=self.SERVICE)
         app = Flask(__name__)
-        cache = Cache(app, config={"CACHE_TYPE": "simple"})
+        cache = Cache(app, config={'CACHE_TYPE': 'simple'})
 
         # make a wrong call
         with pytest.raises(TypeError) as ex:
             cache.set_many()
 
         # ensure that the error is not caused by our tracer
-        assert "set_many()" in ex.value.args[0]
-        assert "argument" in ex.value.args[0]
+        assert 'set_many()' in ex.value.args[0]
+        assert 'argument' in ex.value.args[0]
         spans = writer.pop()
         # an error trace must be sent
         assert len(spans) == 1
         span = spans[0]
         assert span.service == self.SERVICE
-        assert span.resource == "set_many"
-        assert span.name == "flask_cache.cmd"
-        assert span.span_type == "cache"
+        assert span.resource == 'set_many'
+        assert span.name == 'flask_cache.cmd'
+        assert span.span_type == 'cache'
         assert span.error == 1
 
     def test_redis_cache_tracing_with_a_wrong_connection(self):
@@ -169,27 +169,27 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         Cache = get_traced_cache(tracer, service=self.SERVICE)
         app = Flask(__name__)
         config = {
-            "CACHE_TYPE": "redis",
-            "CACHE_REDIS_PORT": 2230,
-            "CACHE_REDIS_HOST": "127.0.0.1"
+            'CACHE_TYPE': 'redis',
+            'CACHE_REDIS_PORT': 2230,
+            'CACHE_REDIS_HOST': '127.0.0.1'
         }
         cache = Cache(app, config=config)
 
         # use a wrong redis connection
         with pytest.raises(ConnectionError) as ex:
-            cache.get(u"á_complex_operation")
+            cache.get(u'á_complex_operation')
 
         # ensure that the error is not caused by our tracer
-        assert "127.0.0.1:2230. Connection refused." in ex.value.args[0]
+        assert '127.0.0.1:2230. Connection refused.' in ex.value.args[0]
         spans = writer.pop()
         # an error trace must be sent
         assert len(spans) == 1
         span = spans[0]
         assert span.service == self.SERVICE
-        assert span.resource == "get"
-        assert span.name == "flask_cache.cmd"
-        assert span.span_type == "cache"
-        assert span.meta[CACHE_BACKEND] == "redis"
+        assert span.resource == 'get'
+        assert span.name == 'flask_cache.cmd'
+        assert span.span_type == 'cache'
+        assert span.meta[CACHE_BACKEND] == 'redis'
         assert span.meta[net.TARGET_HOST] == '127.0.0.1'
         assert span.meta[net.TARGET_PORT] == '2230'
         assert span.error == 1
@@ -204,14 +204,14 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         Cache = get_traced_cache(tracer, service=self.SERVICE)
         app = Flask(__name__)
         config = {
-            "CACHE_TYPE": "memcached",
-            "CACHE_MEMCACHED_SERVERS": ['localhost:2230'],
+            'CACHE_TYPE': 'memcached',
+            'CACHE_MEMCACHED_SERVERS': ['localhost:2230'],
         }
         cache = Cache(app, config=config)
 
         # use a wrong memcached connection
         try:
-            cache.get(u"á_complex_operation")
+            cache.get(u'á_complex_operation')
         except Exception:
             pass
 
@@ -220,10 +220,10 @@ class FlaskCacheWrapperTest(unittest.TestCase):
         assert len(spans) == 1
         span = spans[0]
         assert span.service == self.SERVICE
-        assert span.resource == "get"
-        assert span.name == "flask_cache.cmd"
-        assert span.span_type == "cache"
-        assert span.meta[CACHE_BACKEND] == "memcached"
+        assert span.resource == 'get'
+        assert span.name == 'flask_cache.cmd'
+        assert span.span_type == 'cache'
+        assert span.meta[CACHE_BACKEND] == 'memcached'
         assert span.meta[net.TARGET_HOST] == 'localhost'
         assert span.meta[net.TARGET_PORT] == '2230'
 

--- a/tests/contrib/jinja2/test_jinja2.py
+++ b/tests/contrib/jinja2/test_jinja2.py
@@ -9,13 +9,13 @@ from ddtrace.contrib.jinja2 import patch, unpatch
 from tests.test_tracer import get_dummy_tracer
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
-TMPL_DIR = os.path.join(TEST_DIR, "templates")
+TMPL_DIR = os.path.join(TEST_DIR, 'templates')
 
 
 class Jinja2Test(unittest.TestCase):
     def setUp(self):
         patch()
-        # prevent cache effects when using Template("code...")
+        # prevent cache effects when using Template('code...')
         jinja2.environment._spontaneous_environments.clear()
         # provide a dummy tracer
         self.tracer = get_dummy_tracer()
@@ -26,8 +26,8 @@ class Jinja2Test(unittest.TestCase):
         unpatch()
 
     def test_render_inline_template(self):
-        t = jinja2.environment.Template("Hello {{name}}!")
-        assert t.render(name="Jinja") == "Hello Jinja!"
+        t = jinja2.environment.Template('Hello {{name}}!')
+        assert t.render(name='Jinja') == 'Hello Jinja!'
 
         # tests
         spans = self.tracer.writer.pop()
@@ -35,15 +35,15 @@ class Jinja2Test(unittest.TestCase):
 
         for span in spans:
             assert span.service is None
-            assert span.span_type == "template"
-            assert span.get_tag("jinja2.template_name") == "<memory>"
+            assert span.span_type == 'template'
+            assert span.get_tag('jinja2.template_name') == '<memory>'
 
-        assert spans[0].name == "jinja2.compile"
-        assert spans[1].name == "jinja2.render"
+        assert spans[0].name == 'jinja2.compile'
+        assert spans[1].name == 'jinja2.render'
 
     def test_generate_inline_template(self):
-        t = jinja2.environment.Template("Hello {{name}}!")
-        assert "".join(t.generate(name="Jinja")) == "Hello Jinja!"
+        t = jinja2.environment.Template('Hello {{name}}!')
+        assert ''.join(t.generate(name='Jinja')) == 'Hello Jinja!'
 
         # tests
         spans = self.tracer.writer.pop()
@@ -51,39 +51,39 @@ class Jinja2Test(unittest.TestCase):
 
         for span in spans:
             assert span.service is None
-            assert span.span_type == "template"
-            assert span.get_tag("jinja2.template_name") == "<memory>"
+            assert span.span_type == 'template'
+            assert span.get_tag('jinja2.template_name') == '<memory>'
 
-        assert spans[0].name == "jinja2.compile"
-        assert spans[1].name == "jinja2.render"
+        assert spans[0].name == 'jinja2.compile'
+        assert spans[1].name == 'jinja2.render'
 
     def test_file_template(self):
         loader = jinja2.loaders.FileSystemLoader(TMPL_DIR)
         env = jinja2.Environment(loader=loader)
-        t = env.get_template("template.html")
-        assert t.render(name="Jinja") == "Message: Hello Jinja!"
+        t = env.get_template('template.html')
+        assert t.render(name='Jinja') == 'Message: Hello Jinja!'
 
         # tests
         spans = self.tracer.writer.pop()
         assert len(spans) == 5
 
         for span in spans:
-            assert span.span_type == "template"
+            assert span.span_type == 'template'
             assert span.service is None
 
         # templates.html extends base.html
         def get_def(s):
-            return s.name, s.get_tag("jinja2.template_name")
+            return s.name, s.get_tag('jinja2.template_name')
 
-        assert get_def(spans[0]) == ("jinja2.load", "template.html")
-        assert get_def(spans[1]) == ("jinja2.compile", "template.html")
-        assert get_def(spans[2]) == ("jinja2.render", "template.html")
-        assert get_def(spans[3]) == ("jinja2.load", "base.html")
-        assert get_def(spans[4]) == ("jinja2.compile", "base.html")
+        assert get_def(spans[0]) == ('jinja2.load', 'template.html')
+        assert get_def(spans[1]) == ('jinja2.compile', 'template.html')
+        assert get_def(spans[2]) == ('jinja2.render', 'template.html')
+        assert get_def(spans[3]) == ('jinja2.load', 'base.html')
+        assert get_def(spans[4]) == ('jinja2.compile', 'base.html')
 
         # additionnal checks for jinja2.load
-        assert spans[0].get_tag("jinja2.template_path") == os.path.join(TMPL_DIR, "template.html")
-        assert spans[3].get_tag("jinja2.template_path") == os.path.join(TMPL_DIR, "base.html")
+        assert spans[0].get_tag('jinja2.template_path') == os.path.join(TMPL_DIR, 'template.html')
+        assert spans[3].get_tag('jinja2.template_path') == os.path.join(TMPL_DIR, 'base.html')
 
     def test_service_name(self):
         # don't inherit the service name from the parent span, but force the value.
@@ -93,15 +93,15 @@ class Jinja2Test(unittest.TestCase):
         cfg = config.get_from(env)
         cfg['service_name'] = 'renderer'
 
-        t = env.get_template("template.html")
-        assert t.render(name="Jinja") == "Message: Hello Jinja!"
+        t = env.get_template('template.html')
+        assert t.render(name='Jinja') == 'Message: Hello Jinja!'
 
         # tests
         spans = self.tracer.writer.pop()
         assert len(spans) == 5
 
         for span in spans:
-            assert span.service == "renderer"
+            assert span.service == 'renderer'
 
     def test_inherit_service(self):
         # When there is a parent span and no custom service_name, the service name is inherited
@@ -109,12 +109,12 @@ class Jinja2Test(unittest.TestCase):
         env = jinja2.Environment(loader=loader)
 
         with self.tracer.trace('parent.span', service='web'):
-            t = env.get_template("template.html")
-            assert t.render(name="Jinja") == "Message: Hello Jinja!"
+            t = env.get_template('template.html')
+            assert t.render(name='Jinja') == 'Message: Hello Jinja!'
 
         # tests
         spans = self.tracer.writer.pop()
         assert len(spans) == 6
 
         for span in spans:
-            assert span.service == "web"
+            assert span.service == 'web'

--- a/tests/contrib/kombu/test.py
+++ b/tests/contrib/kombu/test.py
@@ -18,7 +18,7 @@ class TestKombuPatch(BaseTracerTestCase):
     def setUp(self):
         super(TestKombuPatch, self).setUp()
 
-        conn = kombu.Connection("amqp://guest:guest@127.0.0.1:{p}//".format(p=self.TEST_PORT))
+        conn = kombu.Connection('amqp://guest:guest@127.0.0.1:{p}//'.format(p=self.TEST_PORT))
         conn.connect()
         producer = conn.Producer()
         Pin.override(producer, service=self.TEST_SERVICE, tracer=self.tracer)

--- a/tests/contrib/mongoengine/test.py
+++ b/tests/contrib/mongoengine/test.py
@@ -87,7 +87,7 @@ class MongoEngineCore(object):
 
         # ensure filtered queries work
         start = time.time()
-        artists = [a for a in Artist.objects(first_name="Joni")]
+        artists = [a for a in Artist.objects(first_name='Joni')]
         end = time.time()
         assert len(artists) == 1
         joni = artists[0]
@@ -97,7 +97,7 @@ class MongoEngineCore(object):
         spans = tracer.writer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.resource == '{} artist {{"first_name": "?"}}'.format(name)
+        assert span.resource == "{} artist {{'first_name': '?'}}".format(name)
         assert span.span_type == 'mongodb'
         assert span.service == self.TEST_SERVICE
         _assert_timing(span, start, end)
@@ -111,7 +111,7 @@ class MongoEngineCore(object):
         spans = tracer.writer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.resource == 'update artist {"_id": "?"}'
+        assert span.resource == "update artist {'_id': '?'}"
         assert span.span_type == 'mongodb'
         assert span.service == self.TEST_SERVICE
         _assert_timing(span, start, end)
@@ -124,7 +124,7 @@ class MongoEngineCore(object):
         spans = tracer.writer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.resource == 'delete artist {"_id": "?"}'
+        assert span.resource == "delete artist {'_id': '?'}"
         assert span.span_type == 'mongodb'
         assert span.service == self.TEST_SERVICE
         _assert_timing(span, start, end)

--- a/tests/contrib/mongoengine/test.py
+++ b/tests/contrib/mongoengine/test.py
@@ -97,7 +97,7 @@ class MongoEngineCore(object):
         spans = tracer.writer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.resource == "{} artist {{'first_name': '?'}}".format(name)
+        assert span.resource == '{} artist {{"first_name": "?"}}'.format(name)
         assert span.span_type == 'mongodb'
         assert span.service == self.TEST_SERVICE
         _assert_timing(span, start, end)
@@ -111,7 +111,7 @@ class MongoEngineCore(object):
         spans = tracer.writer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.resource == "update artist {'_id': '?'}"
+        assert span.resource == 'update artist {"_id": "?"}'
         assert span.span_type == 'mongodb'
         assert span.service == self.TEST_SERVICE
         _assert_timing(span, start, end)
@@ -124,7 +124,7 @@ class MongoEngineCore(object):
         spans = tracer.writer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.resource == "delete artist {'_id': '?'}"
+        assert span.resource == 'delete artist {"_id": "?"}'
         assert span.span_type == 'mongodb'
         assert span.service == self.TEST_SERVICE
         _assert_timing(span, start, end)

--- a/tests/contrib/mongoengine/test_backwards.py
+++ b/tests/contrib/mongoengine/test_backwards.py
@@ -17,7 +17,7 @@ def test_less_than_v04():
     from ddtrace.contrib.mongoengine import trace_mongoengine
     tracer = get_dummy_tracer()
 
-    connect = trace_mongoengine(tracer, service="my-mongo-db", patch=False)
+    connect = trace_mongoengine(tracer, service='my-mongo-db', patch=False)
     connect(port=config.MONGO_CONFIG['port'])
 
     lc = Singer()

--- a/tests/contrib/mysql/test_backwards_compatibility.py
+++ b/tests/contrib/mysql/test_backwards_compatibility.py
@@ -6,8 +6,8 @@ from tests.contrib import config
 
 def test_pre_v4():
     tracer = get_dummy_tracer()
-    MySQL = get_traced_mysql_connection(tracer, service="my-mysql-server")
+    MySQL = get_traced_mysql_connection(tracer, service='my-mysql-server')
     conn = MySQL(**config.MYSQL_CONFIG)
     cursor = conn.cursor()
-    cursor.execute("SELECT 1")
+    cursor.execute('SELECT 1')
     assert cursor.fetchone()[0] == 1

--- a/tests/contrib/mysql/test_mysql.py
+++ b/tests/contrib/mysql/test_mysql.py
@@ -39,7 +39,7 @@ class MySQLCore(object):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         cursor = conn.cursor()
-        cursor.execute("SELECT 1")
+        cursor.execute('SELECT 1')
         rows = cursor.fetchall()
         assert len(rows) == 1
         spans = writer.pop()
@@ -62,7 +62,7 @@ class MySQLCore(object):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
             spans = writer.pop()
@@ -86,7 +86,7 @@ class MySQLCore(object):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         cursor = conn.cursor()
-        query = "SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m"
+        query = 'SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m'
         cursor.execute(query)
         rows = cursor.fetchall()
         assert len(rows) == 3
@@ -100,7 +100,7 @@ class MySQLCore(object):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
-            query = "SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m"
+            query = 'SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m'
             cursor.execute(query)
             rows = cursor.fetchall()
             assert len(rows) == 3
@@ -123,26 +123,26 @@ class MySQLCore(object):
                 dummy_value TEXT NOT NULL)""")
         tracer.enabled = True
 
-        stmt = "INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)"
+        stmt = 'INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)'
         data = [
             ('foo', 'this is foo'),
             ('bar', 'this is bar'),
         ]
         cursor.executemany(stmt, data)
-        query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
+        query = 'SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key'
         cursor.execute(query)
         rows = cursor.fetchall()
         assert len(rows) == 2
-        assert rows[0][0] == "bar"
-        assert rows[0][1] == "this is bar"
-        assert rows[1][0] == "foo"
-        assert rows[1][1] == "this is foo"
+        assert rows[0][0] == 'bar'
+        assert rows[0][1] == 'this is bar'
+        assert rows[1][0] == 'foo'
+        assert rows[1][1] == 'this is foo'
 
         spans = writer.pop()
         assert len(spans) == 2
         span = spans[-1]
         assert span.get_tag('sql.query') is None
-        cursor.execute("drop table if exists dummy")
+        cursor.execute('drop table if exists dummy')
 
     def test_query_many_fetchall(self):
         with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
@@ -158,26 +158,26 @@ class MySQLCore(object):
                     dummy_value TEXT NOT NULL)""")
             tracer.enabled = True
 
-            stmt = "INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)"
+            stmt = 'INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)'
             data = [
                 ('foo', 'this is foo'),
                 ('bar', 'this is bar'),
             ]
             cursor.executemany(stmt, data)
-            query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
+            query = 'SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key'
             cursor.execute(query)
             rows = cursor.fetchall()
             assert len(rows) == 2
-            assert rows[0][0] == "bar"
-            assert rows[0][1] == "this is bar"
-            assert rows[1][0] == "foo"
-            assert rows[1][1] == "this is foo"
+            assert rows[0][0] == 'bar'
+            assert rows[0][1] == 'this is bar'
+            assert rows[1][0] == 'foo'
+            assert rows[1][1] == 'this is foo'
 
             spans = writer.pop()
             assert len(spans) == 3
             span = spans[-1]
             assert span.get_tag('sql.query') is None
-            cursor.execute("drop table if exists dummy")
+            cursor.execute('drop table if exists dummy')
 
             assert spans[2].name == 'mysql.query.fetchall'
 
@@ -188,7 +188,7 @@ class MySQLCore(object):
         # create a procedure
         tracer.enabled = False
         cursor = conn.cursor()
-        cursor.execute("DROP PROCEDURE IF EXISTS sp_sum")
+        cursor.execute('DROP PROCEDURE IF EXISTS sp_sum')
         cursor.execute("""
             CREATE PROCEDURE sp_sum (IN p1 INTEGER, IN p2 INTEGER, OUT p3 INTEGER)
             BEGIN
@@ -196,7 +196,7 @@ class MySQLCore(object):
             END;""")
 
         tracer.enabled = True
-        proc = "sp_sum"
+        proc = 'sp_sum'
         data = (40, 2, None)
         output = cursor.callproc(proc, data)
         assert len(output) == 3
@@ -230,7 +230,7 @@ class MySQLCore(object):
 
         with ot_tracer.start_active_span('mysql_op'):
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
 
@@ -267,7 +267,7 @@ class MySQLCore(object):
 
             with ot_tracer.start_active_span('mysql_op'):
                 cursor = conn.cursor()
-                cursor.execute("SELECT 1")
+                cursor.execute('SELECT 1')
                 rows = cursor.fetchall()
                 assert len(rows) == 1
 
@@ -320,7 +320,7 @@ class MySQLCore(object):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         cursor = conn.cursor()
-        cursor.execute("SELECT 1")
+        cursor.execute('SELECT 1')
         rows = cursor.fetchall()
         assert len(rows) == 1
         spans = writer.pop()
@@ -337,7 +337,7 @@ class MySQLCore(object):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
             spans = writer.pop()
@@ -354,7 +354,7 @@ class MySQLCore(object):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
             spans = writer.pop()
@@ -407,7 +407,7 @@ class TestMysqlPatch(MySQLCore, BaseTracerTestCase):
             assert conn.is_connected()
 
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
             spans = writer.pop()

--- a/tests/contrib/mysqldb/test_mysql.py
+++ b/tests/contrib/mysqldb/test_mysql.py
@@ -41,7 +41,7 @@ class MySQLCore(object):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         cursor = conn.cursor()
-        rowcount = cursor.execute("SELECT 1")
+        rowcount = cursor.execute('SELECT 1')
         assert rowcount == 1
         rows = cursor.fetchall()
         assert len(rows) == 1
@@ -65,7 +65,7 @@ class MySQLCore(object):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
             spans = writer.pop()
@@ -89,7 +89,7 @@ class MySQLCore(object):
         conn, tracer = self._get_conn_tracer_with_positional_args()
         writer = tracer.writer
         cursor = conn.cursor()
-        cursor.execute("SELECT 1")
+        cursor.execute('SELECT 1')
         rows = cursor.fetchall()
         assert len(rows) == 1
         spans = writer.pop()
@@ -112,7 +112,7 @@ class MySQLCore(object):
             conn, tracer = self._get_conn_tracer_with_positional_args()
             writer = tracer.writer
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
             spans = writer.pop()
@@ -136,7 +136,7 @@ class MySQLCore(object):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         cursor = conn.cursor()
-        query = "SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m"
+        query = 'SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m'
         cursor.execute(query)
         rows = cursor.fetchall()
         assert len(rows) == 3
@@ -150,7 +150,7 @@ class MySQLCore(object):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
-            query = "SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m"
+            query = 'SELECT n FROM (SELECT 42 n UNION SELECT 421 UNION SELECT 4210) m'
             cursor.execute(query)
             rows = cursor.fetchall()
             assert len(rows) == 3
@@ -174,26 +174,26 @@ class MySQLCore(object):
                 dummy_value TEXT NOT NULL)""")
         tracer.enabled = True
 
-        stmt = "INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)"
+        stmt = 'INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)'
         data = [
             ('foo', 'this is foo'),
             ('bar', 'this is bar'),
         ]
         cursor.executemany(stmt, data)
-        query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
+        query = 'SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key'
         cursor.execute(query)
         rows = cursor.fetchall()
         assert len(rows) == 2
-        assert rows[0][0] == "bar"
-        assert rows[0][1] == "this is bar"
-        assert rows[1][0] == "foo"
-        assert rows[1][1] == "this is foo"
+        assert rows[0][0] == 'bar'
+        assert rows[0][1] == 'this is bar'
+        assert rows[1][0] == 'foo'
+        assert rows[1][1] == 'this is foo'
 
         spans = writer.pop()
         assert len(spans) == 2
         span = spans[1]
         assert span.get_tag('sql.query') is None
-        cursor.execute("drop table if exists dummy")
+        cursor.execute('drop table if exists dummy')
 
     def test_query_many_fetchall(self):
         with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
@@ -209,26 +209,26 @@ class MySQLCore(object):
                     dummy_value TEXT NOT NULL)""")
             tracer.enabled = True
 
-            stmt = "INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)"
+            stmt = 'INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)'
             data = [
                 ('foo', 'this is foo'),
                 ('bar', 'this is bar'),
             ]
             cursor.executemany(stmt, data)
-            query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
+            query = 'SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key'
             cursor.execute(query)
             rows = cursor.fetchall()
             assert len(rows) == 2
-            assert rows[0][0] == "bar"
-            assert rows[0][1] == "this is bar"
-            assert rows[1][0] == "foo"
-            assert rows[1][1] == "this is foo"
+            assert rows[0][0] == 'bar'
+            assert rows[0][1] == 'this is bar'
+            assert rows[1][0] == 'foo'
+            assert rows[1][1] == 'this is foo'
 
             spans = writer.pop()
             assert len(spans) == 3
             span = spans[1]
             assert span.get_tag('sql.query') is None
-            cursor.execute("drop table if exists dummy")
+            cursor.execute('drop table if exists dummy')
             fetch_span = spans[2]
             assert fetch_span.name == 'mysql.query.fetchall'
 
@@ -239,7 +239,7 @@ class MySQLCore(object):
         # create a procedure
         tracer.enabled = False
         cursor = conn.cursor()
-        cursor.execute("DROP PROCEDURE IF EXISTS sp_sum")
+        cursor.execute('DROP PROCEDURE IF EXISTS sp_sum')
         cursor.execute("""
             CREATE PROCEDURE sp_sum (IN p1 INTEGER, IN p2 INTEGER, OUT p3 INTEGER)
             BEGIN
@@ -247,13 +247,13 @@ class MySQLCore(object):
             END;""")
 
         tracer.enabled = True
-        proc = "sp_sum"
+        proc = 'sp_sum'
         data = (40, 2, None)
         output = cursor.callproc(proc, data)
         assert len(output) == 3
         # resulted p3 isn't stored on output[2], we need to fetch it with select
         # http://mysqlclient.readthedocs.io/user_guide.html#cursor-objects
-        cursor.execute("SELECT @_sp_sum_2;")
+        cursor.execute('SELECT @_sp_sum_2;')
         assert cursor.fetchone()[0] == 42
 
         spans = writer.pop()
@@ -282,7 +282,7 @@ class MySQLCore(object):
         ot_tracer = init_tracer('mysql_svc', tracer)
         with ot_tracer.start_active_span('mysql_op'):
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
 
@@ -316,7 +316,7 @@ class MySQLCore(object):
             ot_tracer = init_tracer('mysql_svc', tracer)
             with ot_tracer.start_active_span('mysql_op'):
                 cursor = conn.cursor()
-                cursor.execute("SELECT 1")
+                cursor.execute('SELECT 1')
                 rows = cursor.fetchall()
                 assert len(rows) == 1
 
@@ -368,7 +368,7 @@ class MySQLCore(object):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         cursor = conn.cursor()
-        cursor.execute("SELECT 1")
+        cursor.execute('SELECT 1')
         rows = cursor.fetchall()
         assert len(rows) == 1
         spans = writer.pop()
@@ -385,7 +385,7 @@ class MySQLCore(object):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
             spans = writer.pop()
@@ -402,7 +402,7 @@ class MySQLCore(object):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
             spans = writer.pop()
@@ -475,7 +475,7 @@ class TestMysqlPatch(MySQLCore, BaseTracerTestCase):
             conn.ping()
 
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
             spans = writer.pop()

--- a/tests/contrib/pylibmc/test.py
+++ b/tests/contrib/pylibmc/test.py
@@ -32,23 +32,23 @@ class PylibmcCore(object):
         pass
 
     def test_upgrade(self):
-        raise SkipTest("upgrade memcached")
+        raise SkipTest('upgrade memcached')
         # add tests for touch, cas, gets etc
 
     def test_append_prepend(self):
         client, tracer = self.get_client()
         # test
         start = time.time()
-        client.set("a", "crow")
-        client.prepend("a", "holy ")
-        client.append("a", "!")
+        client.set('a', 'crow')
+        client.prepend('a', 'holy ')
+        client.append('a', '!')
 
         # FIXME[matt] there is a bug in pylibmc & python 3 (perhaps with just
         # some versions of the libmemcache?) where append/prepend are replaced
         # with get. our traced versions do the right thing, so skipping this
         # test.
         try:
-            assert client.get("a") == "holy crow!"
+            assert client.get('a') == 'holy crow!'
         except AssertionError:
             pass
 
@@ -57,7 +57,7 @@ class PylibmcCore(object):
         spans = tracer.writer.pop()
         for s in spans:
             self._verify_cache_span(s, start, end)
-        expected_resources = sorted(["append", "prepend", "get", "set"])
+        expected_resources = sorted(['append', 'prepend', 'get', 'set'])
         resources = sorted(s.resource for s in spans)
         assert expected_resources == resources
 
@@ -65,17 +65,17 @@ class PylibmcCore(object):
         client, tracer = self.get_client()
         # test
         start = time.time()
-        client.set("a", 1)
-        client.incr("a", 2)
-        client.decr("a", 1)
-        v = client.get("a")
+        client.set('a', 1)
+        client.incr('a', 2)
+        client.decr('a', 1)
+        v = client.get('a')
         assert v == 2
         end = time.time()
         # verify spans
         spans = tracer.writer.pop()
         for s in spans:
             self._verify_cache_span(s, start, end)
-        expected_resources = sorted(["get", "set", "incr", "decr"])
+        expected_resources = sorted(['get', 'set', 'incr', 'decr'])
         resources = sorted(s.resource for s in spans)
         assert expected_resources == resources
 
@@ -86,10 +86,10 @@ class PylibmcCore(object):
 
         start = time.time()
         with ot_tracer.start_active_span('mc_ops'):
-            client.set("a", 1)
-            client.incr("a", 2)
-            client.decr("a", 1)
-            v = client.get("a")
+            client.set('a', 1)
+            client.incr('a', 2)
+            client.decr('a', 1)
+            v = client.get('a')
             assert v == 2
         end = time.time()
 
@@ -102,7 +102,7 @@ class PylibmcCore(object):
         for s in spans[1:]:
             assert s.parent_id == ot_span.span_id
             self._verify_cache_span(s, start, end)
-        expected_resources = sorted(["get", "set", "incr", "decr"])
+        expected_resources = sorted(['get', 'set', 'incr', 'decr'])
         resources = sorted(s.resource for s in spans[1:])
         assert expected_resources == resources
 
@@ -111,12 +111,12 @@ class PylibmcCore(object):
         client, tracer = self.get_client()
         cloned = client.clone()
         start = time.time()
-        cloned.get("a")
+        cloned.get('a')
         end = time.time()
         spans = tracer.writer.pop()
         for s in spans:
             self._verify_cache_span(s, start, end)
-        expected_resources = ["get"]
+        expected_resources = ['get']
         resources = sorted(s.resource for s in spans)
         assert expected_resources == resources
 
@@ -125,15 +125,15 @@ class PylibmcCore(object):
         # test
         start = time.time()
         client.set_multi({'a': 1, 'b': 2})
-        out = client.get_multi(["a", "c"])
+        out = client.get_multi(['a', 'c'])
         assert out == {'a': 1}
-        client.delete_multi(["a", "c"])
+        client.delete_multi(['a', 'c'])
         end = time.time()
         # verify
         spans = tracer.writer.pop()
         for s in spans:
             self._verify_cache_span(s, start, end)
-        expected_resources = sorted(["get_multi", "set_multi", "delete_multi"])
+        expected_resources = sorted(['get_multi', 'set_multi', 'delete_multi'])
         resources = sorted(s.resource for s in spans)
         assert expected_resources == resources
 
@@ -142,16 +142,16 @@ class PylibmcCore(object):
         # test
         start = time.time()
         client.set_multi({'a': 1, 'b': 2}, key_prefix='foo')
-        out = client.get_multi(["a", "c"], key_prefix='foo')
+        out = client.get_multi(['a', 'c'], key_prefix='foo')
         assert out == {'a': 1}
-        client.delete_multi(["a", "c"], key_prefix='foo')
+        client.delete_multi(['a', 'c'], key_prefix='foo')
         end = time.time()
         # verify
         spans = tracer.writer.pop()
         for s in spans:
             self._verify_cache_span(s, start, end)
-            assert s.get_tag("memcached.query") == "%s foo" % s.resource
-        expected_resources = sorted(["get_multi", "set_multi", "delete_multi"])
+            assert s.get_tag('memcached.query') == '%s foo' % s.resource
+        expected_resources = sorted(['get_multi', 'set_multi', 'delete_multi'])
         resources = sorted(s.resource for s in spans)
         assert expected_resources == resources
 
@@ -159,7 +159,7 @@ class PylibmcCore(object):
         client, tracer = self.get_client()
         # test
         k = u'cafe'
-        v = "val-foo"
+        v = 'val-foo'
         start = time.time()
         client.delete(k)  # just in case
         out = client.get(k)
@@ -172,8 +172,8 @@ class PylibmcCore(object):
         spans = tracer.writer.pop()
         for s in spans:
             self._verify_cache_span(s, start, end)
-            assert s.get_tag("memcached.query") == "%s %s" % (s.resource, k)
-        expected_resources = sorted(["get", "get", "delete", "set"])
+            assert s.get_tag('memcached.query') == '%s %s' % (s.resource, k)
+        expected_resources = sorted(['get', 'get', 'delete', 'set'])
         resources = sorted(s.resource for s in spans)
         assert expected_resources == resources
 
@@ -181,14 +181,14 @@ class PylibmcCore(object):
         assert s.start > start
         assert s.start + s.duration < end
         assert s.service == self.TEST_SERVICE
-        assert s.span_type == "cache"
-        assert s.name == "memcached.cmd"
-        assert s.get_tag("out.host") == cfg["host"]
-        assert s.get_tag("out.port") == str(cfg["port"])
+        assert s.span_type == 'cache'
+        assert s.name == 'memcached.cmd'
+        assert s.get_tag('out.host') == cfg['host']
+        assert s.get_tag('out.port') == str(cfg['port'])
 
     def test_analytics_default(self):
         client, tracer = self.get_client()
-        client.set("a", "crow")
+        client.set('a', 'crow')
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
@@ -200,7 +200,7 @@ class PylibmcCore(object):
             dict(analytics_enabled=True, analytics_sample_rate=0.5)
         ):
             client, tracer = self.get_client()
-            client.set("a", "crow")
+            client.set('a', 'crow')
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
@@ -212,7 +212,7 @@ class PylibmcCore(object):
             dict(analytics_enabled=True)
         ):
             client, tracer = self.get_client()
-            client.set("a", "crow")
+            client.set('a', 'crow')
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
@@ -225,7 +225,7 @@ class TestPylibmcLegacy(BaseTracerTestCase, PylibmcCore):
     TEST_SERVICE = 'mc-legacy'
 
     def get_client(self):
-        url = "%s:%s" % (cfg["host"], cfg["port"])
+        url = '%s:%s' % (cfg['host'], cfg['port'])
         raw_client = pylibmc.Client([url])
         raw_client.flush_all()
 
@@ -245,7 +245,7 @@ class TestPylibmcPatchDefault(BaseTracerTestCase, PylibmcCore):
         super(TestPylibmcPatchDefault, self).tearDown()
 
     def get_client(self):
-        url = "%s:%s" % (cfg["host"], cfg["port"])
+        url = '%s:%s' % (cfg['host'], cfg['port'])
         client = pylibmc.Client([url])
         client.flush_all()
 
@@ -267,7 +267,7 @@ class TestPylibmcPatch(TestPylibmcPatchDefault):
         return client, tracer
 
     def test_patch_unpatch(self):
-        url = "%s:%s" % (cfg["host"], cfg["port"])
+        url = '%s:%s' % (cfg['host'], cfg['port'])
 
         # Test patch idempotence
         patch()
@@ -278,7 +278,7 @@ class TestPylibmcPatch(TestPylibmcPatchDefault):
             service=self.TEST_SERVICE,
             tracer=self.tracer).onto(client)
 
-        client.set("a", 1)
+        client.set('a', 1)
 
         spans = self.tracer.writer.pop()
         assert spans, spans
@@ -288,7 +288,7 @@ class TestPylibmcPatch(TestPylibmcPatchDefault):
         unpatch()
 
         client = pylibmc.Client([url])
-        client.set("a", 1)
+        client.set('a', 1)
 
         spans = self.tracer.writer.pop()
         assert not spans, spans
@@ -298,7 +298,7 @@ class TestPylibmcPatch(TestPylibmcPatchDefault):
 
         client = pylibmc.Client([url])
         Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(client)
-        client.set("a", 1)
+        client.set('a', 1)
 
         spans = self.tracer.writer.pop()
         assert spans, spans

--- a/tests/contrib/pymemcache/test_client.py
+++ b/tests/contrib/pymemcache/test_client.py
@@ -38,143 +38,143 @@ class PymemcacheClientTestCase(PymemcacheClientTestCaseMixin):
         self.assertEqual(Client, _Client)
 
     def test_set_get(self):
-        client = self.make_client([b"STORED\r\n", b"VALUE key 0 5\r\nvalue\r\nEND\r\n"])
-        client.set(b"key", b"value", noreply=False)
-        result = client.get(b"key")
-        assert _str(result) == "value"
+        client = self.make_client([b'STORED\r\n', b'VALUE key 0 5\r\nvalue\r\nEND\r\n'])
+        client.set(b'key', b'value', noreply=False)
+        result = client.get(b'key')
+        assert _str(result) == 'value'
 
-        self.check_spans(2, ["set", "get"], ["set key", "get key"])
+        self.check_spans(2, ['set', 'get'], ['set key', 'get key'])
 
     def test_append_stored(self):
-        client = self.make_client([b"STORED\r\n"])
-        result = client.append(b"key", b"value", noreply=False)
+        client = self.make_client([b'STORED\r\n'])
+        result = client.append(b'key', b'value', noreply=False)
         assert result is True
 
-        self.check_spans(1, ["append"], ["append key"])
+        self.check_spans(1, ['append'], ['append key'])
 
     def test_prepend_stored(self):
-        client = self.make_client([b"STORED\r\n"])
-        result = client.prepend(b"key", b"value", noreply=False)
+        client = self.make_client([b'STORED\r\n'])
+        result = client.prepend(b'key', b'value', noreply=False)
         assert result is True
 
-        self.check_spans(1, ["prepend"], ["prepend key"])
+        self.check_spans(1, ['prepend'], ['prepend key'])
 
     def test_cas_stored(self):
-        client = self.make_client([b"STORED\r\n"])
-        result = client.cas(b"key", b"value", b"cas", noreply=False)
+        client = self.make_client([b'STORED\r\n'])
+        result = client.cas(b'key', b'value', b'cas', noreply=False)
         assert result is True
 
-        self.check_spans(1, ["cas"], ["cas key"])
+        self.check_spans(1, ['cas'], ['cas key'])
 
     def test_cas_exists(self):
-        client = self.make_client([b"EXISTS\r\n"])
-        result = client.cas(b"key", b"value", b"cas", noreply=False)
+        client = self.make_client([b'EXISTS\r\n'])
+        result = client.cas(b'key', b'value', b'cas', noreply=False)
         assert result is False
 
-        self.check_spans(1, ["cas"], ["cas key"])
+        self.check_spans(1, ['cas'], ['cas key'])
 
     def test_cas_not_found(self):
-        client = self.make_client([b"NOT_FOUND\r\n"])
-        result = client.cas(b"key", b"value", b"cas", noreply=False)
+        client = self.make_client([b'NOT_FOUND\r\n'])
+        result = client.cas(b'key', b'value', b'cas', noreply=False)
         assert result is None
 
-        self.check_spans(1, ["cas"], ["cas key"])
+        self.check_spans(1, ['cas'], ['cas key'])
 
     def test_delete_exception(self):
-        client = self.make_client([Exception("fail")])
+        client = self.make_client([Exception('fail')])
 
         def _delete():
-            client.delete(b"key", noreply=False)
+            client.delete(b'key', noreply=False)
 
         pytest.raises(Exception, _delete)
 
-        spans = self.check_spans(1, ["delete"], ["delete key"])
+        spans = self.check_spans(1, ['delete'], ['delete key'])
         self.assertEqual(spans[0].error, 1)
 
     def test_flush_all(self):
-        client = self.make_client([b"OK\r\n"])
+        client = self.make_client([b'OK\r\n'])
         result = client.flush_all(noreply=False)
         assert result is True
 
-        self.check_spans(1, ["flush_all"], ["flush_all"])
+        self.check_spans(1, ['flush_all'], ['flush_all'])
 
     def test_incr_exception(self):
-        client = self.make_client([Exception("fail")])
+        client = self.make_client([Exception('fail')])
 
         def _incr():
-            client.incr(b"key", 1)
+            client.incr(b'key', 1)
 
         pytest.raises(Exception, _incr)
 
-        spans = self.check_spans(1, ["incr"], ["incr key"])
+        spans = self.check_spans(1, ['incr'], ['incr key'])
         self.assertEqual(spans[0].error, 1)
 
     def test_get_error(self):
-        client = self.make_client([b"ERROR\r\n"])
+        client = self.make_client([b'ERROR\r\n'])
 
         def _get():
-            client.get(b"key")
+            client.get(b'key')
 
         pytest.raises(MemcacheUnknownCommandError, _get)
 
-        spans = self.check_spans(1, ["get"], ["get key"])
+        spans = self.check_spans(1, ['get'], ['get key'])
         self.assertEqual(spans[0].error, 1)
 
     def test_get_unknown_error(self):
-        client = self.make_client([b"foobarbaz\r\n"])
+        client = self.make_client([b'foobarbaz\r\n'])
 
         def _get():
-            client.get(b"key")
+            client.get(b'key')
 
         pytest.raises(MemcacheUnknownError, _get)
 
-        self.check_spans(1, ["get"], ["get key"])
+        self.check_spans(1, ['get'], ['get key'])
 
     def test_gets_found(self):
-        client = self.make_client([b"VALUE key 0 5 10\r\nvalue\r\nEND\r\n"])
-        result = client.gets(b"key")
-        assert result == (b"value", b"10")
+        client = self.make_client([b'VALUE key 0 5 10\r\nvalue\r\nEND\r\n'])
+        result = client.gets(b'key')
+        assert result == (b'value', b'10')
 
-        self.check_spans(1, ["gets"], ["gets key"])
+        self.check_spans(1, ['gets'], ['gets key'])
 
     def test_touch_not_found(self):
-        client = self.make_client([b"NOT_FOUND\r\n"])
-        result = client.touch(b"key", noreply=False)
+        client = self.make_client([b'NOT_FOUND\r\n'])
+        result = client.touch(b'key', noreply=False)
         assert result is False
 
-        self.check_spans(1, ["touch"], ["touch key"])
+        self.check_spans(1, ['touch'], ['touch key'])
 
     def test_set_client_error(self):
-        client = self.make_client([b"CLIENT_ERROR some message\r\n"])
+        client = self.make_client([b'CLIENT_ERROR some message\r\n'])
 
         def _set():
-            client.set("key", "value", noreply=False)
+            client.set('key', 'value', noreply=False)
 
         pytest.raises(MemcacheClientError, _set)
 
-        spans = self.check_spans(1, ["set"], ["set key"])
+        spans = self.check_spans(1, ['set'], ['set key'])
         self.assertEqual(spans[0].error, 1)
 
     def test_set_server_error(self):
-        client = self.make_client([b"SERVER_ERROR some message\r\n"])
+        client = self.make_client([b'SERVER_ERROR some message\r\n'])
 
         def _set():
-            client.set(b"key", b"value", noreply=False)
+            client.set(b'key', b'value', noreply=False)
 
         pytest.raises(MemcacheServerError, _set)
 
-        spans = self.check_spans(1, ["set"], ["set key"])
+        spans = self.check_spans(1, ['set'], ['set key'])
         self.assertEqual(spans[0].error, 1)
 
     def test_set_key_with_space(self):
-        client = self.make_client([b""])
+        client = self.make_client([b''])
 
         def _set():
-            client.set(b"key has space", b"value", noreply=False)
+            client.set(b'key has space', b'value', noreply=False)
 
         pytest.raises(MemcacheIllegalInputError, _set)
 
-        spans = self.check_spans(1, ["set"], ["set key has space"])
+        spans = self.check_spans(1, ['set'], ['set key has space'])
         self.assertEqual(spans[0].error, 1)
 
     def test_quit(self):
@@ -182,40 +182,40 @@ class PymemcacheClientTestCase(PymemcacheClientTestCaseMixin):
         result = client.quit()
         assert result is None
 
-        self.check_spans(1, ["quit"], ["quit"])
+        self.check_spans(1, ['quit'], ['quit'])
 
     def test_replace_not_stored(self):
-        client = self.make_client([b"NOT_STORED\r\n"])
-        result = client.replace(b"key", b"value", noreply=False)
+        client = self.make_client([b'NOT_STORED\r\n'])
+        result = client.replace(b'key', b'value', noreply=False)
         assert result is False
 
-        self.check_spans(1, ["replace"], ["replace key"])
+        self.check_spans(1, ['replace'], ['replace key'])
 
     def test_version_success(self):
-        client = self.make_client([b"VERSION 1.2.3\r\n"], default_noreply=False)
+        client = self.make_client([b'VERSION 1.2.3\r\n'], default_noreply=False)
         result = client.version()
-        assert result == b"1.2.3"
+        assert result == b'1.2.3'
 
-        self.check_spans(1, ["version"], ["version"])
+        self.check_spans(1, ['version'], ['version'])
 
     def test_stats(self):
-        client = self.make_client([b"STAT fake_stats 1\r\n", b"END\r\n"])
+        client = self.make_client([b'STAT fake_stats 1\r\n', b'END\r\n'])
         result = client.stats()
-        assert client.sock.send_bufs == [b"stats \r\n"]
-        assert result == {b"fake_stats": 1}
+        assert client.sock.send_bufs == [b'stats \r\n']
+        assert result == {b'fake_stats': 1}
 
-        self.check_spans(1, ["stats"], ["stats"])
+        self.check_spans(1, ['stats'], ['stats'])
 
     def test_service_name_override(self):
-        client = self.make_client([b"STORED\r\n", b"VALUE key 0 5\r\nvalue\r\nEND\r\n"])
-        Pin.override(client, service="testsvcname")
-        client.set(b"key", b"value", noreply=False)
-        result = client.get(b"key")
-        assert _str(result) == "value"
+        client = self.make_client([b'STORED\r\n', b'VALUE key 0 5\r\nvalue\r\nEND\r\n'])
+        Pin.override(client, service='testsvcname')
+        client.set(b'key', b'value', noreply=False)
+        result = client.get(b'key')
+        assert _str(result) == 'value'
 
         spans = self.get_spans()
-        self.assertEqual(spans[0].service, "testsvcname")
-        self.assertEqual(spans[1].service, "testsvcname")
+        self.assertEqual(spans[0].service, 'testsvcname')
+        self.assertEqual(spans[1].service, 'testsvcname')
 
 
 class PymemcacheHashClientTestCase(PymemcacheClientTestCaseMixin):
@@ -249,7 +249,7 @@ class PymemcacheHashClientTestCase(PymemcacheClientTestCaseMixin):
         ip = TEST_HOST
 
         for vals in mock_socket_values:
-            s = "{}:{}".format(ip, current_port)
+            s = '{}:{}'.format(ip, current_port)
             c = self.make_client_pool((ip, current_port), vals, **kwargs)
             self.client.clients[s] = c
             self.client.hasher.add_node(s)
@@ -264,12 +264,12 @@ class PymemcacheHashClientTestCase(PymemcacheClientTestCaseMixin):
         for base.Clients self.delete() is called which by-passes our tracing
         on delete()
         """
-        client = self.make_client([b"STORED\r", b"\n", b"DELETED\r\n"])
-        result = client.add(b"key", b"value", noreply=False)
-        result = client.delete_many([b"key"], noreply=False)
+        client = self.make_client([b'STORED\r', b'\n', b'DELETED\r\n'])
+        result = client.add(b'key', b'value', noreply=False)
+        result = client.delete_many([b'key'], noreply=False)
         assert result is True
 
-        self.check_spans(2, ["add", "delete"], ["add key", "delete key"])
+        self.check_spans(2, ['add', 'delete'], ['add key', 'delete key'])
 
 
 class PymemcacheClientConfiguration(unittest.TestCase):
@@ -297,25 +297,25 @@ class PymemcacheClientConfiguration(unittest.TestCase):
 
     def test_override_parent_pin(self):
         """Test that the service set on `pymemcache` is used for Clients."""
-        Pin.override(pymemcache, service="mysvc")
-        client = self.make_client([b"STORED\r\n", b"VALUE key 0 5\r\nvalue\r\nEND\r\n"])
-        client.set(b"key", b"value", noreply=False)
+        Pin.override(pymemcache, service='mysvc')
+        client = self.make_client([b'STORED\r\n', b'VALUE key 0 5\r\nvalue\r\nEND\r\n'])
+        client.set(b'key', b'value', noreply=False)
 
         pin = Pin.get_from(pymemcache)
         tracer = pin.tracer
         spans = tracer.writer.pop()
 
-        self.assertEqual(spans[0].service, "mysvc")
+        self.assertEqual(spans[0].service, 'mysvc')
 
     def test_override_client_pin(self):
         """Test that the service set on `pymemcache` is used for Clients."""
-        client = self.make_client([b"STORED\r\n", b"VALUE key 0 5\r\nvalue\r\nEND\r\n"])
-        Pin.override(client, service="mysvc2")
+        client = self.make_client([b'STORED\r\n', b'VALUE key 0 5\r\nvalue\r\nEND\r\n'])
+        Pin.override(client, service='mysvc2')
 
-        client.set(b"key", b"value", noreply=False)
+        client.set(b'key', b'value', noreply=False)
 
         pin = Pin.get_from(pymemcache)
         tracer = pin.tracer
         spans = tracer.writer.pop()
 
-        self.assertEqual(spans[0].service, "mysvc2")
+        self.assertEqual(spans[0].service, 'mysvc2')

--- a/tests/contrib/pymemcache/test_client_mixin.py
+++ b/tests/contrib/pymemcache/test_client_mixin.py
@@ -16,7 +16,7 @@ from ...base import override_config
 
 _Client = pymemcache.client.base.Client
 
-TEST_HOST = "localhost"
+TEST_HOST = 'localhost'
 TEST_PORT = 117711
 
 
@@ -59,90 +59,90 @@ class PymemcacheClientTestCaseMixin(unittest.TestCase):
         return self.client
 
     def test_set_success(self):
-        client = self.make_client([b"STORED\r\n"])
-        result = client.set(b"key", b"value", noreply=False)
+        client = self.make_client([b'STORED\r\n'])
+        result = client.set(b'key', b'value', noreply=False)
         assert result is True
 
-        self.check_spans(1, ["set"], ["set key"])
+        self.check_spans(1, ['set'], ['set key'])
 
     def test_get_many_none_found(self):
-        client = self.make_client([b"END\r\n"])
-        result = client.get_many([b"key1", b"key2"])
+        client = self.make_client([b'END\r\n'])
+        result = client.get_many([b'key1', b'key2'])
         assert result == {}
 
-        self.check_spans(1, ["get_many"], ["get_many key1 key2"])
+        self.check_spans(1, ['get_many'], ['get_many key1 key2'])
 
     def test_get_multi_none_found(self):
-        client = self.make_client([b"END\r\n"])
-        result = client.get_multi([b"key1", b"key2"])
+        client = self.make_client([b'END\r\n'])
+        result = client.get_multi([b'key1', b'key2'])
         assert result == {}
 
-        self.check_spans(1, ["get_many"], ["get_many key1 key2"])
+        self.check_spans(1, ['get_many'], ['get_many key1 key2'])
 
     def test_delete_not_found(self):
-        client = self.make_client([b"NOT_FOUND\r\n"])
-        result = client.delete(b"key", noreply=False)
+        client = self.make_client([b'NOT_FOUND\r\n'])
+        result = client.delete(b'key', noreply=False)
         assert result is False
 
-        self.check_spans(1, ["delete"], ["delete key"])
+        self.check_spans(1, ['delete'], ['delete key'])
 
     def test_incr_found(self):
-        client = self.make_client([b"STORED\r\n", b"1\r\n"])
-        client.set(b"key", 0, noreply=False)
-        result = client.incr(b"key", 1, noreply=False)
+        client = self.make_client([b'STORED\r\n', b'1\r\n'])
+        client.set(b'key', 0, noreply=False)
+        result = client.incr(b'key', 1, noreply=False)
         assert result == 1
 
-        self.check_spans(2, ["set", "incr"], ["set key", "incr key"])
+        self.check_spans(2, ['set', 'incr'], ['set key', 'incr key'])
 
     def test_get_found(self):
-        client = self.make_client([b"STORED\r\n", b"VALUE key 0 5\r\nvalue\r\nEND\r\n"])
-        result = client.set(b"key", b"value", noreply=False)
-        result = client.get(b"key")
-        assert result == b"value"
+        client = self.make_client([b'STORED\r\n', b'VALUE key 0 5\r\nvalue\r\nEND\r\n'])
+        result = client.set(b'key', b'value', noreply=False)
+        result = client.get(b'key')
+        assert result == b'value'
 
-        self.check_spans(2, ["set", "get"], ["set key", "get key"])
+        self.check_spans(2, ['set', 'get'], ['set key', 'get key'])
 
     def test_decr_found(self):
-        client = self.make_client([b"STORED\r\n", b"1\r\n"])
-        client.set(b"key", 2, noreply=False)
-        result = client.decr(b"key", 1, noreply=False)
+        client = self.make_client([b'STORED\r\n', b'1\r\n'])
+        client.set(b'key', 2, noreply=False)
+        result = client.decr(b'key', 1, noreply=False)
         assert result == 1
 
-        self.check_spans(2, ["set", "decr"], ["set key", "decr key"])
+        self.check_spans(2, ['set', 'decr'], ['set key', 'decr key'])
 
     def test_add_stored(self):
-        client = self.make_client([b"STORED\r", b"\n"])
-        result = client.add(b"key", b"value", noreply=False)
+        client = self.make_client([b'STORED\r', b'\n'])
+        result = client.add(b'key', b'value', noreply=False)
         assert result is True
 
-        self.check_spans(1, ["add"], ["add key"])
+        self.check_spans(1, ['add'], ['add key'])
 
     def test_delete_many_found(self):
-        client = self.make_client([b"STORED\r", b"\n", b"DELETED\r\n"])
-        result = client.add(b"key", b"value", noreply=False)
-        result = client.delete_many([b"key"], noreply=False)
+        client = self.make_client([b'STORED\r', b'\n', b'DELETED\r\n'])
+        result = client.add(b'key', b'value', noreply=False)
+        result = client.delete_many([b'key'], noreply=False)
         assert result is True
 
-        self.check_spans(2, ["add", "delete_many"], ["add key", "delete_many key"])
+        self.check_spans(2, ['add', 'delete_many'], ['add key', 'delete_many key'])
 
     def test_set_many_success(self):
-        client = self.make_client([b"STORED\r\n"])
-        result = client.set_many({b"key": b"value"}, noreply=False)
+        client = self.make_client([b'STORED\r\n'])
+        result = client.set_many({b'key': b'value'}, noreply=False)
         assert result is True
 
-        self.check_spans(1, ["set_many"], ["set_many key"])
+        self.check_spans(1, ['set_many'], ['set_many key'])
 
     def test_set_multi_success(self):
         # Should just map to set_many
-        client = self.make_client([b"STORED\r\n"])
-        result = client.set_multi({b"key": b"value"}, noreply=False)
+        client = self.make_client([b'STORED\r\n'])
+        result = client.set_multi({b'key': b'value'}, noreply=False)
         assert result is True
 
-        self.check_spans(1, ["set_many"], ["set_many key"])
+        self.check_spans(1, ['set_many'], ['set_many key'])
 
     def test_analytics_default(self):
-        client = self.make_client([b"STORED\r\n"])
-        result = client.set(b"key", b"value", noreply=False)
+        client = self.make_client([b'STORED\r\n'])
+        result = client.set(b'key', b'value', noreply=False)
         assert result is True
 
         spans = self.get_spans()
@@ -154,8 +154,8 @@ class PymemcacheClientTestCaseMixin(unittest.TestCase):
             'pymemcache',
             dict(analytics_enabled=True, analytics_sample_rate=0.5)
         ):
-            client = self.make_client([b"STORED\r\n"])
-            result = client.set(b"key", b"value", noreply=False)
+            client = self.make_client([b'STORED\r\n'])
+            result = client.set(b'key', b'value', noreply=False)
             assert result is True
 
         spans = self.get_spans()
@@ -167,8 +167,8 @@ class PymemcacheClientTestCaseMixin(unittest.TestCase):
             'pymemcache',
             dict(analytics_enabled=True)
         ):
-            client = self.make_client([b"STORED\r\n"])
-            result = client.set(b"key", b"value", noreply=False)
+            client = self.make_client([b'STORED\r\n'])
+            result = client.set(b'key', b'value', noreply=False)
             assert result is True
 
         spans = self.get_spans()

--- a/tests/contrib/pymysql/test_backwards_compatibility.py
+++ b/tests/contrib/pymysql/test_backwards_compatibility.py
@@ -5,8 +5,8 @@ from tests.contrib import config
 
 def test_pre_v4():
     tracer = get_dummy_tracer()
-    MySQL = get_traced_pymysql_connection(tracer, service="my-mysql-server")
+    MySQL = get_traced_pymysql_connection(tracer, service='my-mysql-server')
     conn = MySQL(**config.MYSQL_CONFIG)
     cursor = conn.cursor()
-    cursor.execute("SELECT 1")
+    cursor.execute('SELECT 1')
     assert cursor.fetchone()[0] == 1

--- a/tests/contrib/pymysql/test_pymysql.py
+++ b/tests/contrib/pymysql/test_pymysql.py
@@ -135,26 +135,26 @@ class PyMySQLCore(object):
                 dummy_value TEXT NOT NULL)""")
         tracer.enabled = True
 
-        stmt = "INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)"
-        data = [("foo", "this is foo"),
-                ("bar", "this is bar")]
+        stmt = 'INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)'
+        data = [('foo', 'this is foo'),
+                ('bar', 'this is bar')]
 
         # PyMySQL `executemany()` returns the rowcount
         rowcount = cursor.executemany(stmt, data)
         assert rowcount == 2
 
-        query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
+        query = 'SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key'
         cursor.execute(query)
         rows = cursor.fetchall()
         assert len(rows) == 2
-        assert rows[0][0] == "bar"
-        assert rows[0][1] == "this is bar"
-        assert rows[1][0] == "foo"
-        assert rows[1][1] == "this is foo"
+        assert rows[0][0] == 'bar'
+        assert rows[0][1] == 'this is bar'
+        assert rows[1][0] == 'foo'
+        assert rows[1][1] == 'this is foo'
 
         spans = writer.pop()
         assert len(spans) == 2
-        cursor.execute("drop table if exists dummy")
+        cursor.execute('drop table if exists dummy')
 
     def test_query_many_fetchall(self):
         with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
@@ -170,22 +170,22 @@ class PyMySQLCore(object):
                     dummy_value TEXT NOT NULL)""")
             tracer.enabled = True
 
-            stmt = "INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)"
-            data = [("foo", "this is foo"),
-                    ("bar", "this is bar")]
+            stmt = 'INSERT INTO dummy (dummy_key, dummy_value) VALUES (%s, %s)'
+            data = [('foo', 'this is foo'),
+                    ('bar', 'this is bar')]
             cursor.executemany(stmt, data)
-            query = "SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key"
+            query = 'SELECT dummy_key, dummy_value FROM dummy ORDER BY dummy_key'
             cursor.execute(query)
             rows = cursor.fetchall()
             assert len(rows) == 2
-            assert rows[0][0] == "bar"
-            assert rows[0][1] == "this is bar"
-            assert rows[1][0] == "foo"
-            assert rows[1][1] == "this is foo"
+            assert rows[0][0] == 'bar'
+            assert rows[0][1] == 'this is bar'
+            assert rows[1][0] == 'foo'
+            assert rows[1][1] == 'this is foo'
 
             spans = writer.pop()
             assert len(spans) == 3
-            cursor.execute("drop table if exists dummy")
+            cursor.execute('drop table if exists dummy')
 
             fetch_span = spans[2]
             assert fetch_span.name == 'pymysql.query.fetchall'
@@ -197,7 +197,7 @@ class PyMySQLCore(object):
         # create a procedure
         tracer.enabled = False
         cursor = conn.cursor()
-        cursor.execute("DROP PROCEDURE IF EXISTS sp_sum")
+        cursor.execute('DROP PROCEDURE IF EXISTS sp_sum')
         cursor.execute("""
             CREATE PROCEDURE sp_sum (IN p1 INTEGER, IN p2 INTEGER, OUT p3 INTEGER)
             BEGIN
@@ -205,7 +205,7 @@ class PyMySQLCore(object):
             END;""")
 
         tracer.enabled = True
-        proc = "sp_sum"
+        proc = 'sp_sum'
         data = (40, 2, None)
 
         # spans[len(spans) - 2]
@@ -241,7 +241,7 @@ class PyMySQLCore(object):
         ot_tracer = init_tracer('mysql_svc', tracer)
         with ot_tracer.start_active_span('mysql_op'):
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
 
@@ -272,7 +272,7 @@ class PyMySQLCore(object):
             ot_tracer = init_tracer('mysql_svc', tracer)
             with ot_tracer.start_active_span('mysql_op'):
                 cursor = conn.cursor()
-                cursor.execute("SELECT 1")
+                cursor.execute('SELECT 1')
                 rows = cursor.fetchall()
                 assert len(rows) == 1
 
@@ -321,7 +321,7 @@ class PyMySQLCore(object):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         cursor = conn.cursor()
-        cursor.execute("SELECT 1")
+        cursor.execute('SELECT 1')
         rows = cursor.fetchall()
         assert len(rows) == 1
         spans = writer.pop()
@@ -338,7 +338,7 @@ class PyMySQLCore(object):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
             spans = writer.pop()
@@ -355,7 +355,7 @@ class PyMySQLCore(object):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
             spans = writer.pop()
@@ -397,7 +397,7 @@ class TestPyMysqlPatch(PyMySQLCore, BaseTracerTestCase):
             assert not conn._closed
 
             cursor = conn.cursor()
-            cursor.execute("SELECT 1")
+            cursor.execute('SELECT 1')
             rows = cursor.fetchall()
             assert len(rows) == 1
             spans = writer.pop()

--- a/tests/contrib/pyramid/app/web.py
+++ b/tests/contrib/pyramid/app/web.py
@@ -18,7 +18,7 @@ def create_app(settings, instrument):
         return Response('idx')
 
     def error(request):
-        raise HTTPInternalServerError("oh no")
+        raise HTTPInternalServerError('oh no')
 
     def exception(request):
         1 / 0

--- a/tests/contrib/redis/test.py
+++ b/tests/contrib/redis/test.py
@@ -15,11 +15,11 @@ from ...base import BaseTracerTestCase
 def test_redis_legacy():
     # ensure the old interface isn't broken, but doesn't trace
     tracer = get_dummy_tracer()
-    TracedRedisCache = get_traced_redis(tracer, "foo")
+    TracedRedisCache = get_traced_redis(tracer, 'foo')
     r = TracedRedisCache(port=REDIS_CONFIG['port'])
-    r.set("a", "b")
-    got = r.get("a")
-    assert compat.to_unicode(got) == "b"
+    r.set('a', 'b')
+    got = r.get('a')
+    assert compat.to_unicode(got) == 'b'
     assert not tracer.writer.pop()
 
 
@@ -164,7 +164,7 @@ class TestRedisPatch(BaseTracerTestCase):
 
         r = redis.Redis(port=REDIS_CONFIG['port'])
         Pin.get_from(r).clone(tracer=tracer).onto(r)
-        r.get("key")
+        r.get('key')
 
         spans = writer.pop()
         assert spans, spans
@@ -174,7 +174,7 @@ class TestRedisPatch(BaseTracerTestCase):
         unpatch()
 
         r = redis.Redis(port=REDIS_CONFIG['port'])
-        r.get("key")
+        r.get('key')
 
         spans = writer.pop()
         assert not spans, spans
@@ -184,7 +184,7 @@ class TestRedisPatch(BaseTracerTestCase):
 
         r = redis.Redis(port=REDIS_CONFIG['port'])
         Pin.get_from(r).clone(tracer=tracer).onto(r)
-        r.get("key")
+        r.get('key')
 
         spans = writer.pop()
         assert spans, spans

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -44,7 +44,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.get_tag("http.url") == URL_200
+        assert s.get_tag('http.url') == URL_200
 
     def test_tracer_disabled(self):
         # ensure all valid combinations of args / kwargs work
@@ -171,17 +171,17 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         except Exception:
             pass
         else:
-            assert 0, "expected error"
+            assert 0, 'expected error'
 
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         s = spans[0]
         assert s.get_tag(http.METHOD) == 'GET'
         assert s.error == 1
-        assert "Failed to establish a new connection" in s.get_tag(errors.MSG)
-        assert "Failed to establish a new connection" in s.get_tag(errors.STACK)
-        assert "Traceback (most recent call last)" in s.get_tag(errors.STACK)
-        assert "requests.exception" in s.get_tag(errors.TYPE)
+        assert 'Failed to establish a new connection' in s.get_tag(errors.MSG)
+        assert 'Failed to establish a new connection' in s.get_tag(errors.STACK)
+        assert 'Traceback (most recent call last)' in s.get_tag(errors.STACK)
+        assert 'requests.exception' in s.get_tag(errors.TYPE)
 
     def test_500(self):
         out = self.session.get(URL_500)
@@ -435,13 +435,13 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
                 We expect the root span to have the appropriate tag
         """
         pin = Pin(service=__name__,
-                  app="requests",
+                  app='requests',
                   _config={
-                      "service_name": __name__,
-                      "distributed_tracing": False,
-                      "split_by_domain": False,
-                      "analytics_enabled": True,
-                      "analytics_sample_rate": 0.5,
+                      'service_name': __name__,
+                      'distributed_tracing': False,
+                      'split_by_domain': False,
+                      'analytics_enabled': True,
+                      'analytics_sample_rate': 0.5,
                   })
         pin.onto(self.session)
         self.session.get(URL_200)
@@ -458,12 +458,12 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
                 We expect the root span to have the appropriate tag
         """
         pin = Pin(service=__name__,
-                  app="requests",
+                  app='requests',
                   _config={
-                      "service_name": __name__,
-                      "distributed_tracing": False,
-                      "split_by_domain": False,
-                      "analytics_enabled": True,
+                      'service_name': __name__,
+                      'distributed_tracing': False,
+                      'split_by_domain': False,
+                      'analytics_enabled': True,
                   })
         pin.onto(self.session)
         self.session.get(URL_200)

--- a/tests/contrib/tornado/web/uimodules.py
+++ b/tests/contrib/tornado/web/uimodules.py
@@ -3,4 +3,4 @@ import tornado
 
 class Item(tornado.web.UIModule):
     def render(self, item):
-        return self.render_string("templates/item.html", item=item)
+        return self.render_string('templates/item.html', item=item)

--- a/tests/contrib/vertica/test_vertica.py
+++ b/tests/contrib/vertica/test_vertica.py
@@ -16,7 +16,7 @@ from tests.contrib.config import VERTICA_CONFIG
 from tests.opentracer.utils import init_tracer
 from tests.test_tracer import get_dummy_tracer
 
-TEST_TABLE = "test_table"
+TEST_TABLE = 'test_table'
 
 
 @pytest.fixture(scope='function')
@@ -35,7 +35,7 @@ def test_conn(request, test_tracer):
     conn = vertica_python.connect(**VERTICA_CONFIG)
 
     cur = conn.cursor()
-    cur.execute("DROP TABLE IF EXISTS {}".format(TEST_TABLE))
+    cur.execute('DROP TABLE IF EXISTS {}'.format(TEST_TABLE))
     cur.execute(
         """CREATE TABLE {} (
         a INT,
@@ -151,10 +151,10 @@ class TestVertica(BaseTracerTestCase):
             cur = conn.cursor()
             Pin.override(cur, tracer=test_tracer)
             with conn:
-                cur.execute("DROP TABLE IF EXISTS {}".format(TEST_TABLE))
+                cur.execute('DROP TABLE IF EXISTS {}'.format(TEST_TABLE))
         spans = test_tracer.writer.pop()
         assert len(spans) == 1
-        assert spans[0].service == "test_svc_name"
+        assert spans[0].service == 'test_svc_name'
 
     def test_configuration_routine(self):
         """Ensure that the integration routines can be configured."""
@@ -182,13 +182,13 @@ class TestVertica(BaseTracerTestCase):
             test_tracer = get_dummy_tracer()
 
             conn = vertica_python.connect(**VERTICA_CONFIG)
-            Pin.override(conn, service="mycustomservice", tracer=test_tracer)
+            Pin.override(conn, service='mycustomservice', tracer=test_tracer)
             conn.cursor()  # should be traced now
             conn.close()
         spans = test_tracer.writer.pop()
         assert len(spans) == 1
-        assert spans[0].name == "get_cursor"
-        assert spans[0].service == "mycustomservice"
+        assert spans[0].name == 'get_cursor'
+        assert spans[0].service == 'mycustomservice'
 
     def test_execute_metadata(self):
         """Metadata related to an `execute` call should be captured."""
@@ -197,25 +197,25 @@ class TestVertica(BaseTracerTestCase):
         Pin.override(cur, tracer=self.test_tracer)
 
         with conn:
-            cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
-            cur.execute("SELECT * FROM {};".format(TEST_TABLE))
+            cur.execute('INSERT INTO {} (a, b) VALUES (1, "aa");'.format(TEST_TABLE))
+            cur.execute('SELECT * FROM {};'.format(TEST_TABLE))
 
         spans = self.test_tracer.writer.pop()
         assert len(spans) == 2
 
         # check all the metadata
-        assert spans[0].service == "vertica"
-        assert spans[0].span_type == "sql"
-        assert spans[0].name == "vertica.query"
-        assert spans[0].get_metric("db.rowcount") == -1
-        query = "INSERT INTO test_table (a, b) VALUES (1, 'aa');"
+        assert spans[0].service == 'vertica'
+        assert spans[0].span_type == 'sql'
+        assert spans[0].name == 'vertica.query'
+        assert spans[0].get_metric('db.rowcount') == -1
+        query = 'INSERT INTO test_table (a, b) VALUES (1, "aa");'
         assert spans[0].resource == query
-        assert spans[0].get_tag("out.host") == "127.0.0.1"
-        assert spans[0].get_tag("out.port") == "5433"
-        assert spans[0].get_tag("db.name") == "docker"
-        assert spans[0].get_tag("db.user") == "dbadmin"
+        assert spans[0].get_tag('out.host') == '127.0.0.1'
+        assert spans[0].get_tag('out.port') == '5433'
+        assert spans[0].get_tag('db.name') == 'docker'
+        assert spans[0].get_tag('db.user') == 'dbadmin'
 
-        assert spans[1].resource == "SELECT * FROM test_table;"
+        assert spans[1].resource == 'SELECT * FROM test_table;'
 
     def test_cursor_override(self):
         """Test overriding the tracer with our own."""
@@ -224,23 +224,23 @@ class TestVertica(BaseTracerTestCase):
         Pin.override(cur, tracer=self.test_tracer)
 
         with conn:
-            cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
-            cur.execute("SELECT * FROM {};".format(TEST_TABLE))
+            cur.execute('INSERT INTO {} (a, b) VALUES (1, "aa");'.format(TEST_TABLE))
+            cur.execute('SELECT * FROM {};'.format(TEST_TABLE))
 
         spans = self.test_tracer.writer.pop()
         assert len(spans) == 2
 
         # check all the metadata
-        assert spans[0].service == "vertica"
-        assert spans[0].span_type == "sql"
-        assert spans[0].name == "vertica.query"
-        assert spans[0].get_metric("db.rowcount") == -1
-        query = "INSERT INTO test_table (a, b) VALUES (1, 'aa');"
+        assert spans[0].service == 'vertica'
+        assert spans[0].span_type == 'sql'
+        assert spans[0].name == 'vertica.query'
+        assert spans[0].get_metric('db.rowcount') == -1
+        query = 'INSERT INTO test_table (a, b) VALUES (1, "aa");'
         assert spans[0].resource == query
-        assert spans[0].get_tag("out.host") == "127.0.0.1"
-        assert spans[0].get_tag("out.port") == "5433"
+        assert spans[0].get_tag('out.host') == '127.0.0.1'
+        assert spans[0].get_tag('out.port') == '5433'
 
-        assert spans[1].resource == "SELECT * FROM test_table;"
+        assert spans[1].resource == 'SELECT * FROM test_table;'
 
     def test_execute_exception(self):
         """Exceptions should result in appropriate span tagging."""
@@ -249,20 +249,20 @@ class TestVertica(BaseTracerTestCase):
         conn, cur = self.test_conn
 
         with conn, pytest.raises(VerticaSyntaxError):
-            cur.execute("INVALID QUERY")
+            cur.execute('INVALID QUERY')
 
         spans = self.test_tracer.writer.pop()
         assert len(spans) == 2
 
         # check all the metadata
-        assert spans[0].service == "vertica"
+        assert spans[0].service == 'vertica'
         assert spans[0].error == 1
-        assert "INVALID QUERY" in spans[0].get_tag(errors.ERROR_MSG)
-        error_type = "vertica_python.errors.VerticaSyntaxError"
+        assert 'INVALID QUERY' in spans[0].get_tag(errors.ERROR_MSG)
+        error_type = 'vertica_python.errors.VerticaSyntaxError'
         assert spans[0].get_tag(errors.ERROR_TYPE) == error_type
         assert spans[0].get_tag(errors.ERROR_STACK)
 
-        assert spans[1].resource == "COMMIT;"
+        assert spans[1].resource == 'COMMIT;'
 
     def test_rowcount_oddity(self):
         """Vertica treats rowcount specially. Ensure we handle it.
@@ -290,7 +290,7 @@ class TestVertica(BaseTracerTestCase):
             )
             assert cur.rowcount == -1
 
-            cur.execute("SELECT * FROM {};".format(TEST_TABLE))
+            cur.execute('SELECT * FROM {};'.format(TEST_TABLE))
             cur.fetchone()
             cur.rowcount == 1
             cur.fetchone()
@@ -303,37 +303,37 @@ class TestVertica(BaseTracerTestCase):
         assert len(spans) == 9
 
         # check all the rowcounts
-        assert spans[0].name == "vertica.query"
-        assert spans[1].get_metric("db.rowcount") == -1
-        assert spans[1].name == "vertica.query"
-        assert spans[1].get_metric("db.rowcount") == -1
-        assert spans[2].name == "vertica.fetchone"
-        assert spans[2].get_tag("out.host") == "127.0.0.1"
-        assert spans[2].get_tag("out.port") == "5433"
-        assert spans[2].get_metric("db.rowcount") == 1
-        assert spans[3].name == "vertica.fetchone"
-        assert spans[3].get_metric("db.rowcount") == 2
-        assert spans[4].name == "vertica.fetchall"
-        assert spans[4].get_metric("db.rowcount") == 5
+        assert spans[0].name == 'vertica.query'
+        assert spans[1].get_metric('db.rowcount') == -1
+        assert spans[1].name == 'vertica.query'
+        assert spans[1].get_metric('db.rowcount') == -1
+        assert spans[2].name == 'vertica.fetchone'
+        assert spans[2].get_tag('out.host') == '127.0.0.1'
+        assert spans[2].get_tag('out.port') == '5433'
+        assert spans[2].get_metric('db.rowcount') == 1
+        assert spans[3].name == 'vertica.fetchone'
+        assert spans[3].get_metric('db.rowcount') == 2
+        assert spans[4].name == 'vertica.fetchall'
+        assert spans[4].get_metric('db.rowcount') == 5
 
     def test_nextset(self):
         """cursor.nextset() should be traced."""
         conn, cur = self.test_conn
 
         with conn:
-            cur.execute("SELECT * FROM {0}; SELECT * FROM {0}".format(TEST_TABLE))
+            cur.execute('SELECT * FROM {0}; SELECT * FROM {0}'.format(TEST_TABLE))
             cur.nextset()
 
         spans = self.test_tracer.writer.pop()
         assert len(spans) == 3
 
         # check all the rowcounts
-        assert spans[0].name == "vertica.query"
-        assert spans[1].get_metric("db.rowcount") == -1
-        assert spans[1].name == "vertica.nextset"
-        assert spans[1].get_metric("db.rowcount") == -1
-        assert spans[2].name == "vertica.query"
-        assert spans[2].resource == "COMMIT;"
+        assert spans[0].name == 'vertica.query'
+        assert spans[1].get_metric('db.rowcount') == -1
+        assert spans[1].name == 'vertica.nextset'
+        assert spans[1].get_metric('db.rowcount') == -1
+        assert spans[2].name == 'vertica.query'
+        assert spans[2].resource == 'COMMIT;'
 
     def test_copy(self):
         """cursor.copy() should be traced."""
@@ -341,28 +341,28 @@ class TestVertica(BaseTracerTestCase):
 
         with conn:
             cur.copy(
-                "COPY {0} (a, b) FROM STDIN DELIMITER ','".format(TEST_TABLE),
-                "1,foo\n2,bar",
+                'COPY {0} (a, b) FROM STDIN DELIMITER ","'.format(TEST_TABLE),
+                '1,foo\n2,bar',
             )
 
         spans = self.test_tracer.writer.pop()
         assert len(spans) == 2
 
         # check all the rowcounts
-        assert spans[0].name == "vertica.copy"
-        query = "COPY test_table (a, b) FROM STDIN DELIMITER ','"
+        assert spans[0].name == 'vertica.copy'
+        query = 'COPY test_table (a, b) FROM STDIN DELIMITER ","'
         assert spans[0].resource == query
-        assert spans[1].name == "vertica.query"
-        assert spans[1].resource == "COMMIT;"
+        assert spans[1].name == 'vertica.query'
+        assert spans[1].resource == 'COMMIT;'
 
     def test_opentracing(self):
         """Ensure OpenTracing works with vertica."""
         conn, cur = self.test_conn
 
-        ot_tracer = init_tracer("vertica_svc", self.test_tracer)
+        ot_tracer = init_tracer('vertica_svc', self.test_tracer)
 
-        with ot_tracer.start_active_span("vertica_execute"):
-            cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
+        with ot_tracer.start_active_span('vertica_execute'):
+            cur.execute('INSERT INTO {} (a, b) VALUES (1, "aa");'.format(TEST_TABLE))
             conn.close()
 
         spans = self.test_tracer.writer.pop()
@@ -373,14 +373,14 @@ class TestVertica(BaseTracerTestCase):
         assert ot_span.parent_id is None
         assert dd_span.parent_id == ot_span.span_id
 
-        assert dd_span.service == "vertica"
-        assert dd_span.span_type == "sql"
-        assert dd_span.name == "vertica.query"
-        assert dd_span.get_metric("db.rowcount") == -1
-        query = "INSERT INTO test_table (a, b) VALUES (1, 'aa');"
+        assert dd_span.service == 'vertica'
+        assert dd_span.span_type == 'sql'
+        assert dd_span.name == 'vertica.query'
+        assert dd_span.get_metric('db.rowcount') == -1
+        query = 'INSERT INTO test_table (a, b) VALUES (1, "aa");'
         assert dd_span.resource == query
-        assert dd_span.get_tag("out.host") == "127.0.0.1"
-        assert dd_span.get_tag("out.port") == "5433"
+        assert dd_span.get_tag('out.host') == '127.0.0.1'
+        assert dd_span.get_tag('out.port') == '5433'
 
     def test_analytics_default(self):
         conn, cur = self.test_conn
@@ -388,8 +388,8 @@ class TestVertica(BaseTracerTestCase):
         Pin.override(cur, tracer=self.test_tracer)
 
         with conn:
-            cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
-            cur.execute("SELECT * FROM {};".format(TEST_TABLE))
+            cur.execute('INSERT INTO {} (a, b) VALUES (1, "aa");'.format(TEST_TABLE))
+            cur.execute('SELECT * FROM {};'.format(TEST_TABLE))
 
         spans = self.test_tracer.writer.pop()
         self.assertEqual(len(spans), 2)
@@ -405,8 +405,8 @@ class TestVertica(BaseTracerTestCase):
             Pin.override(cur, tracer=self.test_tracer)
 
             with conn:
-                cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
-                cur.execute("SELECT * FROM {};".format(TEST_TABLE))
+                cur.execute('INSERT INTO {} (a, b) VALUES (1, "aa");'.format(TEST_TABLE))
+                cur.execute('SELECT * FROM {};'.format(TEST_TABLE))
 
         spans = self.test_tracer.writer.pop()
         self.assertEqual(len(spans), 2)
@@ -422,8 +422,8 @@ class TestVertica(BaseTracerTestCase):
             Pin.override(cur, tracer=self.test_tracer)
 
             with conn:
-                cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
-                cur.execute("SELECT * FROM {};".format(TEST_TABLE))
+                cur.execute('INSERT INTO {} (a, b) VALUES (1, "aa");'.format(TEST_TABLE))
+                cur.execute('SELECT * FROM {};'.format(TEST_TABLE))
 
         spans = self.test_tracer.writer.pop()
         self.assertEqual(len(spans), 2)

--- a/tests/contrib/vertica/test_vertica.py
+++ b/tests/contrib/vertica/test_vertica.py
@@ -197,7 +197,7 @@ class TestVertica(BaseTracerTestCase):
         Pin.override(cur, tracer=self.test_tracer)
 
         with conn:
-            cur.execute('INSERT INTO {} (a, b) VALUES (1, "aa");'.format(TEST_TABLE))
+            cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
             cur.execute('SELECT * FROM {};'.format(TEST_TABLE))
 
         spans = self.test_tracer.writer.pop()
@@ -208,7 +208,7 @@ class TestVertica(BaseTracerTestCase):
         assert spans[0].span_type == 'sql'
         assert spans[0].name == 'vertica.query'
         assert spans[0].get_metric('db.rowcount') == -1
-        query = 'INSERT INTO test_table (a, b) VALUES (1, "aa");'
+        query = "INSERT INTO test_table (a, b) VALUES (1, 'aa');"
         assert spans[0].resource == query
         assert spans[0].get_tag('out.host') == '127.0.0.1'
         assert spans[0].get_tag('out.port') == '5433'
@@ -224,7 +224,7 @@ class TestVertica(BaseTracerTestCase):
         Pin.override(cur, tracer=self.test_tracer)
 
         with conn:
-            cur.execute('INSERT INTO {} (a, b) VALUES (1, "aa");'.format(TEST_TABLE))
+            cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
             cur.execute('SELECT * FROM {};'.format(TEST_TABLE))
 
         spans = self.test_tracer.writer.pop()
@@ -235,7 +235,7 @@ class TestVertica(BaseTracerTestCase):
         assert spans[0].span_type == 'sql'
         assert spans[0].name == 'vertica.query'
         assert spans[0].get_metric('db.rowcount') == -1
-        query = 'INSERT INTO test_table (a, b) VALUES (1, "aa");'
+        query = "INSERT INTO test_table (a, b) VALUES (1, 'aa');"
         assert spans[0].resource == query
         assert spans[0].get_tag('out.host') == '127.0.0.1'
         assert spans[0].get_tag('out.port') == '5433'
@@ -362,7 +362,7 @@ class TestVertica(BaseTracerTestCase):
         ot_tracer = init_tracer('vertica_svc', self.test_tracer)
 
         with ot_tracer.start_active_span('vertica_execute'):
-            cur.execute('INSERT INTO {} (a, b) VALUES (1, "aa");'.format(TEST_TABLE))
+            cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
             conn.close()
 
         spans = self.test_tracer.writer.pop()
@@ -377,7 +377,7 @@ class TestVertica(BaseTracerTestCase):
         assert dd_span.span_type == 'sql'
         assert dd_span.name == 'vertica.query'
         assert dd_span.get_metric('db.rowcount') == -1
-        query = 'INSERT INTO test_table (a, b) VALUES (1, "aa");'
+        query = "INSERT INTO test_table (a, b) VALUES (1, 'aa');"
         assert dd_span.resource == query
         assert dd_span.get_tag('out.host') == '127.0.0.1'
         assert dd_span.get_tag('out.port') == '5433'
@@ -388,7 +388,7 @@ class TestVertica(BaseTracerTestCase):
         Pin.override(cur, tracer=self.test_tracer)
 
         with conn:
-            cur.execute('INSERT INTO {} (a, b) VALUES (1, "aa");'.format(TEST_TABLE))
+            cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
             cur.execute('SELECT * FROM {};'.format(TEST_TABLE))
 
         spans = self.test_tracer.writer.pop()
@@ -405,7 +405,7 @@ class TestVertica(BaseTracerTestCase):
             Pin.override(cur, tracer=self.test_tracer)
 
             with conn:
-                cur.execute('INSERT INTO {} (a, b) VALUES (1, "aa");'.format(TEST_TABLE))
+                cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
                 cur.execute('SELECT * FROM {};'.format(TEST_TABLE))
 
         spans = self.test_tracer.writer.pop()
@@ -422,7 +422,7 @@ class TestVertica(BaseTracerTestCase):
             Pin.override(cur, tracer=self.test_tracer)
 
             with conn:
-                cur.execute('INSERT INTO {} (a, b) VALUES (1, "aa");'.format(TEST_TABLE))
+                cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
                 cur.execute('SELECT * FROM {};'.format(TEST_TABLE))
 
         spans = self.test_tracer.writer.pop()

--- a/tests/contrib/vertica/test_vertica.py
+++ b/tests/contrib/vertica/test_vertica.py
@@ -341,7 +341,7 @@ class TestVertica(BaseTracerTestCase):
 
         with conn:
             cur.copy(
-                'COPY {0} (a, b) FROM STDIN DELIMITER ","'.format(TEST_TABLE),
+                "COPY {0} (a, b) FROM STDIN DELIMITER ','".format(TEST_TABLE),
                 '1,foo\n2,bar',
             )
 
@@ -350,7 +350,7 @@ class TestVertica(BaseTracerTestCase):
 
         # check all the rowcounts
         assert spans[0].name == 'vertica.copy'
-        query = 'COPY test_table (a, b) FROM STDIN DELIMITER ","'
+        query = "COPY test_table (a, b) FROM STDIN DELIMITER ','"
         assert spans[0].resource == query
         assert spans[1].name == 'vertica.query'
         assert spans[1].resource == 'COMMIT;'

--- a/tests/ddtrace_run.py
+++ b/tests/ddtrace_run.py
@@ -5,5 +5,5 @@ import sys
 sys.path.append('.')
 from ddtrace.commands import ddtrace_run  # noqa
 
-os.environ['PYTHONPATH'] = "{}:{}".format(os.getenv('PYTHONPATH'), os.path.abspath('.'))
+os.environ['PYTHONPATH'] = '{}:{}'.format(os.getenv('PYTHONPATH'), os.path.abspath('.'))
 ddtrace_run.main()

--- a/tests/memory.py
+++ b/tests/memory.py
@@ -36,9 +36,9 @@ class KitchenSink(object):
         self._redis = redis.Redis(**config.REDIS_CONFIG)
         self._pg = psycopg2.connect(**config.POSTGRES_CONFIG)
 
-        url = "%s:%s" % (
-            config.MEMCACHED_CONFIG["host"],
-            config.MEMCACHED_CONFIG["port"])
+        url = '%s:%s' % (
+            config.MEMCACHED_CONFIG['host'],
+            config.MEMCACHED_CONFIG['port'])
         self._pylibmc = pylibmc.Client([url])
 
     def ping(self, i):
@@ -48,9 +48,9 @@ class KitchenSink(object):
 
     def _ping_redis(self, i):
         with self._redis.pipeline() as p:
-            p.get("a")
-        self._redis.set("a", "b")
-        self._redis.get("a")
+            p.get('a')
+        self._redis.set('a', 'b')
+        self._redis.get('a')
 
     def _ping_pg(self, i):
         cur = self._pg.cursor()
@@ -61,9 +61,9 @@ class KitchenSink(object):
             cur.close()
 
     def _ping_pylibmc(self, i):
-        self._pylibmc.set("a", 1)
-        self._pylibmc.incr("a", 2)
-        self._pylibmc.decr("a", 1)
+        self._pylibmc.set('a', 1)
+        self._pylibmc.incr('a', 2)
+        self._pylibmc.decr('a', 1)
 
 
 if __name__ == '__main__':

--- a/tests/opentracer/conftest.py
+++ b/tests/opentracer/conftest.py
@@ -16,7 +16,7 @@ def ot_tracer_factory():
     """Fixture which returns an opentracer ready to use for testing."""
 
     def make_ot_tracer(
-        service_name="my_svc", config=None, scope_manager=None, context_provider=None
+        service_name='my_svc', config=None, scope_manager=None, context_provider=None
     ):
         config = config or {}
         tracer = Tracer(

--- a/tests/opentracer/test_dd_compatibility.py
+++ b/tests/opentracer/test_dd_compatibility.py
@@ -36,8 +36,8 @@ class TestTracerCompatibility(object):
     def test_ot_dd_nested_trace(self, ot_tracer, dd_tracer, writer):
         """Ensure intertwined usage of the opentracer and ddtracer."""
 
-        with ot_tracer.start_span("my_ot_span") as ot_span:
-            with dd_tracer.trace("my_dd_span") as dd_span:
+        with ot_tracer.start_span('my_ot_span') as ot_span:
+            with dd_tracer.trace('my_dd_span') as dd_span:
                 pass
         spans = writer.pop()
         assert len(spans) == 2
@@ -52,8 +52,8 @@ class TestTracerCompatibility(object):
 
     def test_dd_ot_nested_trace(self, ot_tracer, dd_tracer, writer):
         """Ensure intertwined usage of the opentracer and ddtracer."""
-        with dd_tracer.trace("my_dd_span") as dd_span:
-            with ot_tracer.start_span("my_ot_span") as ot_span:
+        with dd_tracer.trace('my_dd_span') as dd_span:
+            with ot_tracer.start_span('my_ot_span') as ot_span:
                 pass
         spans = writer.pop()
         assert len(spans) == 2
@@ -68,10 +68,10 @@ class TestTracerCompatibility(object):
 
     def test_ot_dd_ot_dd_nested_trace(self, ot_tracer, dd_tracer, writer):
         """Ensure intertwined usage of the opentracer and ddtracer."""
-        with ot_tracer.start_span("my_ot_span") as ot_span:
-            with dd_tracer.trace("my_dd_span") as dd_span:
-                with ot_tracer.start_span("my_ot_span") as ot_span2:
-                    with dd_tracer.trace("my_dd_span") as dd_span2:
+        with ot_tracer.start_span('my_ot_span') as ot_span:
+            with dd_tracer.trace('my_dd_span') as dd_span:
+                with ot_tracer.start_span('my_ot_span') as ot_span2:
+                    with dd_tracer.trace('my_dd_span') as dd_span2:
                         pass
 
         spans = writer.pop()
@@ -91,11 +91,11 @@ class TestTracerCompatibility(object):
 
     def test_ot_ot_dd_ot_dd_nested_trace_active(self, ot_tracer, dd_tracer, writer):
         """Ensure intertwined usage of the opentracer and ddtracer."""
-        with ot_tracer.start_active_span("my_ot_span") as ot_scope:
-            with ot_tracer.start_active_span("my_ot_span") as ot_scope2:
-                with dd_tracer.trace("my_dd_span") as dd_span:
-                    with ot_tracer.start_active_span("my_ot_span") as ot_scope3:
-                        with dd_tracer.trace("my_dd_span") as dd_span2:
+        with ot_tracer.start_active_span('my_ot_span') as ot_scope:
+            with ot_tracer.start_active_span('my_ot_span') as ot_scope2:
+                with dd_tracer.trace('my_dd_span') as dd_span:
+                    with ot_tracer.start_active_span('my_ot_span') as ot_scope3:
+                        with dd_tracer.trace('my_dd_span') as dd_span2:
                             pass
 
         spans = writer.pop()
@@ -117,16 +117,16 @@ class TestTracerCompatibility(object):
 
     def test_consecutive_trace(self, ot_tracer, dd_tracer, writer):
         """Ensure consecutive usage of the opentracer and ddtracer."""
-        with ot_tracer.start_active_span("my_ot_span") as ot_scope:
+        with ot_tracer.start_active_span('my_ot_span') as ot_scope:
             pass
 
-        with dd_tracer.trace("my_dd_span") as dd_span:
+        with dd_tracer.trace('my_dd_span') as dd_span:
             pass
 
-        with ot_tracer.start_active_span("my_ot_span") as ot_scope2:
+        with ot_tracer.start_active_span('my_ot_span') as ot_scope2:
             pass
 
-        with dd_tracer.trace("my_dd_span") as dd_span2:
+        with dd_tracer.trace('my_dd_span') as dd_span2:
             pass
 
         spans = writer.pop()
@@ -149,19 +149,19 @@ class TestTracerCompatibility(object):
 
         @dd_tracer.wrap()
         def fn():
-            with ot_tracer.start_span("ot_span_inner"):
+            with ot_tracer.start_span('ot_span_inner'):
                 pass
 
-        with ot_tracer.start_active_span("ot_span_outer"):
+        with ot_tracer.start_active_span('ot_span_outer'):
             fn()
 
         spans = writer.pop()
         assert len(spans) == 3
 
         # confirm the ordering
-        assert spans[0].name == "ot_span_outer"
-        assert spans[1].name == "tests.opentracer.test_dd_compatibility.fn"
-        assert spans[2].name == "ot_span_inner"
+        assert spans[0].name == 'ot_span_outer'
+        assert spans[1].name == 'tests.opentracer.test_dd_compatibility.fn'
+        assert spans[2].name == 'ot_span_inner'
 
         # check the parenting
         assert spans[0].parent_id is None

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -20,54 +20,54 @@ import pytest
 class TestTracerConfig(object):
     def test_config(self):
         """Test the configuration of the tracer"""
-        config = {"enabled": True}
-        tracer = Tracer(service_name="myservice", config=config)
+        config = {'enabled': True}
+        tracer = Tracer(service_name='myservice', config=config)
 
-        assert tracer._service_name == "myservice"
+        assert tracer._service_name == 'myservice'
         assert tracer._enabled is True
 
     def test_no_service_name(self):
         """A service_name should be generated if one is not provided."""
         tracer = Tracer()
-        assert tracer._service_name == "pytest"
+        assert tracer._service_name == 'pytest'
 
     def test_multiple_tracer_configs(self):
         """Ensure that a tracer config is a copy of the passed config."""
-        config = {"enabled": True}
+        config = {'enabled': True}
 
-        tracer1 = Tracer(service_name="serv1", config=config)
-        assert tracer1._service_name == "serv1"
+        tracer1 = Tracer(service_name='serv1', config=config)
+        assert tracer1._service_name == 'serv1'
 
-        config["enabled"] = False
-        tracer2 = Tracer(service_name="serv2", config=config)
+        config['enabled'] = False
+        tracer2 = Tracer(service_name='serv2', config=config)
 
         # Ensure tracer1's config was not mutated
-        assert tracer1._service_name == "serv1"
+        assert tracer1._service_name == 'serv1'
         assert tracer1._enabled is True
 
-        assert tracer2._service_name == "serv2"
+        assert tracer2._service_name == 'serv2'
         assert tracer2._enabled is False
 
     def test_invalid_config_key(self):
         """A config with an invalid key should raise a ConfigException."""
 
-        config = {"enabeld": False}
+        config = {'enabeld': False}
 
         # No debug flag should not raise an error
-        tracer = Tracer(service_name="mysvc", config=config)
+        tracer = Tracer(service_name='mysvc', config=config)
 
         # With debug flag should raise an error
-        config["debug"] = True
+        config['debug'] = True
         with pytest.raises(ConfigException) as ce_info:
             tracer = Tracer(config=config)
-            assert "enabeld" in str(ce_info)
+            assert 'enabeld' in str(ce_info)
             assert tracer is not None
 
         # Test with multiple incorrect keys
-        config["setttings"] = {}
+        config['setttings'] = {}
         with pytest.raises(ConfigException) as ce_info:
-            tracer = Tracer(service_name="mysvc", config=config)
-            assert ["enabeld", "setttings"] in str(ce_info)
+            tracer = Tracer(service_name='mysvc', config=config)
+            assert ['enabeld', 'setttings'] in str(ce_info)
             assert tracer is not None
 
     def test_global_tags(self):
@@ -95,7 +95,7 @@ class TestTracer(object):
         """Start and finish a span."""
         import time
 
-        with ot_tracer.start_span("myop") as span:
+        with ot_tracer.start_span('myop') as span:
             time.sleep(0.005)
 
         # span should be finished when the context manager exits
@@ -107,16 +107,16 @@ class TestTracer(object):
     def test_start_span_references(self, ot_tracer, writer):
         """Start a span using references."""
 
-        with ot_tracer.start_span("one", references=[child_of()]):
+        with ot_tracer.start_span('one', references=[child_of()]):
             pass
 
         spans = writer.pop()
         assert spans[0].parent_id is None
 
-        root = ot_tracer.start_active_span("root")
+        root = ot_tracer.start_active_span('root')
         # create a child using a parent reference that is not the context parent
-        with ot_tracer.start_active_span("one"):
-            with ot_tracer.start_active_span("two", references=[child_of(root.span)]):
+        with ot_tracer.start_active_span('one'):
+            with ot_tracer.start_active_span('two', references=[child_of(root.span)]):
                 pass
         root.close()
 
@@ -128,7 +128,7 @@ class TestTracer(object):
         import time
 
         t = time.time() + 0.002
-        with ot_tracer.start_span("myop", start_time=t) as span:
+        with ot_tracer.start_span('myop', start_time=t) as span:
             time.sleep(0.005)
 
         # it should be certain that the span duration is strictly less than
@@ -141,9 +141,9 @@ class TestTracer(object):
         """
         import time
 
-        with ot_tracer.start_span("myop") as span:
+        with ot_tracer.start_span('myop') as span:
             time.sleep(0.005)
-            with ot_tracer.start_span("myop", child_of=span.context) as span2:
+            with ot_tracer.start_span('myop', child_of=span.context) as span2:
                 time.sleep(0.008)
 
         # span should be finished when the context manager exits
@@ -158,12 +158,12 @@ class TestTracer(object):
 
     def test_start_span_with_tags(self, ot_tracer):
         """Create a span with initial tags."""
-        tags = {"key": "value", "key2": "value2"}
-        with ot_tracer.start_span("myop", tags=tags) as span:
+        tags = {'key': 'value', 'key2': 'value2'}
+        with ot_tracer.start_span('myop', tags=tags) as span:
             pass
 
-        assert span._dd_span.get_tag("key") == "value"
-        assert span._dd_span.get_tag("key2") == "value2"
+        assert span._dd_span.get_tag('key') == 'value'
+        assert span._dd_span.get_tag('key2') == 'value2'
 
     def test_start_active_span_multi_child(self, ot_tracer, writer):
         """Start and finish multiple child spans.
@@ -171,11 +171,11 @@ class TestTracer(object):
         """
         import time
 
-        with ot_tracer.start_active_span("myfirstop") as scope1:
+        with ot_tracer.start_active_span('myfirstop') as scope1:
             time.sleep(0.009)
-            with ot_tracer.start_active_span("mysecondop") as scope2:
+            with ot_tracer.start_active_span('mysecondop') as scope2:
                 time.sleep(0.007)
-                with ot_tracer.start_active_span("mythirdop") as scope3:
+                with ot_tracer.start_active_span('mythirdop') as scope3:
                     time.sleep(0.005)
 
         # spans should be finished when the context manager exits
@@ -206,11 +206,11 @@ class TestTracer(object):
         """
         import time
 
-        with ot_tracer.start_active_span("myfirstop") as scope1:
+        with ot_tracer.start_active_span('myfirstop') as scope1:
             time.sleep(0.009)
-            with ot_tracer.start_active_span("mysecondop") as scope2:
+            with ot_tracer.start_active_span('mysecondop') as scope2:
                 time.sleep(0.007)
-            with ot_tracer.start_active_span("mythirdop") as scope3:
+            with ot_tracer.start_active_span('mythirdop') as scope3:
                 time.sleep(0.005)
 
         # spans should be finished when the context manager exits
@@ -241,13 +241,13 @@ class TestTracer(object):
         """
         import time
 
-        root = ot_tracer.start_span("zero")
+        root = ot_tracer.start_span('zero')
 
-        with ot_tracer.start_span("one", child_of=root):
+        with ot_tracer.start_span('one', child_of=root):
             time.sleep(0.009)
-            with ot_tracer.start_span("two", child_of=root):
+            with ot_tracer.start_span('two', child_of=root):
                 time.sleep(0.007)
-                with ot_tracer.start_span("three", child_of=root):
+                with ot_tracer.start_span('three', child_of=root):
                     time.sleep(0.005)
         root.finish()
 
@@ -270,11 +270,11 @@ class TestTracer(object):
         """
         import time
 
-        with ot_tracer.start_span("one", ignore_active_span=True):
+        with ot_tracer.start_span('one', ignore_active_span=True):
             time.sleep(0.009)
-            with ot_tracer.start_span("two", ignore_active_span=True):
+            with ot_tracer.start_span('two', ignore_active_span=True):
                 time.sleep(0.007)
-            with ot_tracer.start_span("three", ignore_active_span=True):
+            with ot_tracer.start_span('three', ignore_active_span=True):
                 time.sleep(0.005)
 
         spans = writer.pop()
@@ -294,8 +294,8 @@ class TestTracer(object):
         """Start a child span and finish it after its parent."""
         import time
 
-        span1 = ot_tracer.start_active_span("one").span
-        span2 = ot_tracer.start_active_span("two").span
+        span1 = ot_tracer.start_active_span('one').span
+        span2 = ot_tracer.start_active_span('two').span
         span1.finish()
         time.sleep(0.005)
         span2.finish()
@@ -351,12 +351,12 @@ class TestTracer(object):
 
         # trace_one will finish before trace_two so its spans should be written
         # before the spans from trace_two, let's confirm this
-        assert spans[0].name == "11"
-        assert spans[1].name == "12"
-        assert spans[2].name == "13"
-        assert spans[3].name == "21"
-        assert spans[4].name == "22"
-        assert spans[5].name == "23"
+        assert spans[0].name == '11'
+        assert spans[1].name == '12'
+        assert spans[2].name == '13'
+        assert spans[3].name == '21'
+        assert spans[4].name == '22'
+        assert spans[5].name == '23'
 
         # next let's ensure that each span has the correct parent:
         # trace_one
@@ -383,48 +383,48 @@ class TestTracer(object):
         )
 
     def test_start_active_span(self, ot_tracer, writer):
-        with ot_tracer.start_active_span("one") as scope:
+        with ot_tracer.start_active_span('one') as scope:
             pass
 
-        assert scope.span._dd_span.name == "one"
+        assert scope.span._dd_span.name == 'one'
         assert scope.span._finished
         spans = writer.pop()
         assert spans
 
     def test_start_active_span_finish_on_close(self, ot_tracer, writer):
-        with ot_tracer.start_active_span("one", finish_on_close=False) as scope:
+        with ot_tracer.start_active_span('one', finish_on_close=False) as scope:
             pass
 
-        assert scope.span._dd_span.name == "one"
+        assert scope.span._dd_span.name == 'one'
         assert not scope.span._finished
         spans = writer.pop()
         assert not spans
 
     def test_start_active_span_nested(self, ot_tracer):
         """Test the active span of multiple nested calls of start_active_span."""
-        with ot_tracer.start_active_span("one") as outer_scope:
+        with ot_tracer.start_active_span('one') as outer_scope:
             assert ot_tracer.active_span == outer_scope.span
-            with ot_tracer.start_active_span("two") as inner_scope:
+            with ot_tracer.start_active_span('two') as inner_scope:
                 assert ot_tracer.active_span == inner_scope.span
                 with ot_tracer.start_active_span(
-                    "three"
+                    'three'
                 ) as innest_scope:  # why isn't it innest? innermost so verbose
                     assert ot_tracer.active_span == innest_scope.span
-            with ot_tracer.start_active_span("two") as inner_scope:
+            with ot_tracer.start_active_span('two') as inner_scope:
                 assert ot_tracer.active_span == inner_scope.span
             assert ot_tracer.active_span == outer_scope.span
         assert ot_tracer.active_span is None
 
     def test_start_active_span_trace(self, ot_tracer, writer):
         """Test the active span of multiple nested calls of start_active_span."""
-        with ot_tracer.start_active_span("one") as outer_scope:
-            outer_scope.span.set_tag("outer", 2)
-            with ot_tracer.start_active_span("two") as inner_scope:
-                inner_scope.span.set_tag("inner", 3)
-            with ot_tracer.start_active_span("two") as inner_scope:
-                inner_scope.span.set_tag("inner", 3)
-                with ot_tracer.start_active_span("three") as innest_scope:
-                    innest_scope.span.set_tag("innerest", 4)
+        with ot_tracer.start_active_span('one') as outer_scope:
+            outer_scope.span.set_tag('outer', 2)
+            with ot_tracer.start_active_span('two') as inner_scope:
+                inner_scope.span.set_tag('inner', 3)
+            with ot_tracer.start_active_span('two') as inner_scope:
+                inner_scope.span.set_tag('inner', 3)
+                with ot_tracer.start_active_span('three') as innest_scope:
+                    innest_scope.span.set_tag('innerest', 4)
 
         spans = writer.pop()
 
@@ -479,7 +479,7 @@ class TestTracerSpanContextPropagation(object):
     def test_http_headers_baggage(self, ot_tracer):
         """extract should undo inject for http headers."""
         span_ctx = SpanContext(
-            trace_id=123, span_id=456, baggage={"test": 4, "test2": "string"}
+            trace_id=123, span_id=456, baggage={'test': 4, 'test2': 'string'}
         )
         carrier = {}
 
@@ -502,7 +502,7 @@ class TestTracerSpanContextPropagation(object):
     def test_text(self, ot_tracer):
         """extract should undo inject for http headers"""
         span_ctx = SpanContext(
-            trace_id=123, span_id=456, baggage={"test": 4, "test2": "string"}
+            trace_id=123, span_id=456, baggage={'test': 4, 'test2': 'string'}
         )
         carrier = {}
 
@@ -517,7 +517,7 @@ class TestTracerSpanContextPropagation(object):
     def test_corrupted_propagated_context(self, ot_tracer):
         """Corrupted context should raise a SpanContextCorruptedException."""
         span_ctx = SpanContext(
-            trace_id=123, span_id=456, baggage={"test": 4, "test2": "string"}
+            trace_id=123, span_id=456, baggage={'test': 4, 'test2': 'string'}
         )
         carrier = {}
 
@@ -534,12 +534,12 @@ class TestTracerSpanContextPropagation(object):
 
     def test_immutable_span_context(self, ot_tracer):
         """Span contexts should be immutable."""
-        with ot_tracer.start_span("root") as root:
+        with ot_tracer.start_span('root') as root:
             ctx_before = root.context
-            root.set_baggage_item("test", 2)
+            root.set_baggage_item('test', 2)
             assert ctx_before is not root.context
-            with ot_tracer.start_span("child") as level1:
-                with ot_tracer.start_span("child") as level2:
+            with ot_tracer.start_span('child') as level1:
+                with ot_tracer.start_span('child') as level2:
                     pass
         assert root.context is not level1.context
         assert level2.context is not level1.context
@@ -547,27 +547,27 @@ class TestTracerSpanContextPropagation(object):
 
     def test_inherited_baggage(self, ot_tracer):
         """Baggage should be inherited by child spans."""
-        with ot_tracer.start_active_span("root") as root:
+        with ot_tracer.start_active_span('root') as root:
             # this should be passed down to the child
-            root.span.set_baggage_item("root", 1)
-            root.span.set_baggage_item("root2", 1)
-            with ot_tracer.start_active_span("child") as level1:
-                level1.span.set_baggage_item("level1", 1)
-                with ot_tracer.start_active_span("child") as level2:
-                    level2.span.set_baggage_item("level2", 1)
+            root.span.set_baggage_item('root', 1)
+            root.span.set_baggage_item('root2', 1)
+            with ot_tracer.start_active_span('child') as level1:
+                level1.span.set_baggage_item('level1', 1)
+                with ot_tracer.start_active_span('child') as level2:
+                    level2.span.set_baggage_item('level2', 1)
         # ensure immutability
         assert level1.span.context is not root.span.context
         assert level2.span.context is not level1.span.context
 
         # level1 should have inherited the baggage of root
-        assert level1.span.get_baggage_item("root")
-        assert level1.span.get_baggage_item("root2")
+        assert level1.span.get_baggage_item('root')
+        assert level1.span.get_baggage_item('root2')
 
         # level2 should have inherited the baggage of both level1 and level2
-        assert level2.span.get_baggage_item("root")
-        assert level2.span.get_baggage_item("root2")
-        assert level2.span.get_baggage_item("level1")
-        assert level2.span.get_baggage_item("level2")
+        assert level2.span.get_baggage_item('root')
+        assert level2.span.get_baggage_item('root2')
+        assert level2.span.get_baggage_item('level1')
+        assert level2.span.get_baggage_item('level2')
 
 
 class TestTracerCompatibility(object):
@@ -578,14 +578,14 @@ class TestTracerCompatibility(object):
         by the underlying datadog tracer.
         """
         # a service name is required
-        tracer = Tracer("service")
-        with tracer.start_span("my_span") as span:
+        tracer = Tracer('service')
+        with tracer.start_span('my_span') as span:
             assert span._dd_span.service
 
 
 def test_set_global_tracer():
     """Sanity check for set_global_tracer"""
-    my_tracer = Tracer("service")
+    my_tracer = Tracer('service')
     set_global_tracer(my_tracer)
 
     assert opentracing.tracer is my_tracer

--- a/tests/opentracer/test_tracer_gevent.py
+++ b/tests/opentracer/test_tracer_gevent.py
@@ -13,7 +13,7 @@ def ot_tracer(ot_tracer_factory):
     # patch gevent
     patch()
     yield ot_tracer_factory(
-        "gevent_svc", {}, GeventScopeManager(), ddtrace.contrib.gevent.context_provider
+        'gevent_svc', {}, GeventScopeManager(), ddtrace.contrib.gevent.context_provider
     )
     # unpatch gevent
     unpatch()
@@ -27,23 +27,23 @@ class TestTracerGevent(object):
     """
 
     def test_no_threading(self, ot_tracer):
-        with ot_tracer.start_span("span") as span:
-            span.set_tag("tag", "value")
+        with ot_tracer.start_span('span') as span:
+            span.set_tag('tag', 'value')
 
         assert span._finished
 
     def test_greenlets(self, ot_tracer, writer):
         def f():
-            with ot_tracer.start_span("f") as span:
+            with ot_tracer.start_span('f') as span:
                 gevent.sleep(0.04)
-                span.set_tag("f", "yes")
+                span.set_tag('f', 'yes')
 
         def g():
-            with ot_tracer.start_span("g") as span:
+            with ot_tracer.start_span('g') as span:
                 gevent.sleep(0.03)
-                span.set_tag("g", "yes")
+                span.set_tag('g', 'yes')
 
-        with ot_tracer.start_span("root"):
+        with ot_tracer.start_span('root'):
             gevent.joinall([gevent.spawn(f), gevent.spawn(g)])
 
         traces = writer.pop_traces()
@@ -52,19 +52,19 @@ class TestTracerGevent(object):
     def test_trace_greenlet(self, ot_tracer, writer):
         # a greenlet can be traced using the trace API
         def greenlet():
-            with ot_tracer.start_span("greenlet"):
+            with ot_tracer.start_span('greenlet'):
                 pass
 
         gevent.spawn(greenlet).join()
         traces = writer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 1
-        assert traces[0][0].name == "greenlet"
+        assert traces[0][0].name == 'greenlet'
 
     def test_trace_later_greenlet(self, ot_tracer, writer):
         # a greenlet can be traced using the trace API
         def greenlet():
-            with ot_tracer.start_span("greenlet"):
+            with ot_tracer.start_span('greenlet'):
                 pass
 
         gevent.spawn_later(0.01, greenlet).join()
@@ -72,13 +72,13 @@ class TestTracerGevent(object):
 
         assert len(traces) == 1
         assert len(traces[0]) == 1
-        assert traces[0][0].name == "greenlet"
+        assert traces[0][0].name == 'greenlet'
 
     def test_trace_concurrent_calls(self, ot_tracer, writer):
         # create multiple futures so that we expect multiple
         # traces instead of a single one
         def greenlet():
-            with ot_tracer.start_span("greenlet"):
+            with ot_tracer.start_span('greenlet'):
                 gevent.sleep(0.01)
 
         jobs = [gevent.spawn(greenlet) for x in range(100)]
@@ -88,14 +88,14 @@ class TestTracerGevent(object):
 
         assert len(traces) == 100
         assert len(traces[0]) == 1
-        assert traces[0][0].name == "greenlet"
+        assert traces[0][0].name == 'greenlet'
 
     def test_trace_concurrent_spawn_later_calls(self, ot_tracer, writer):
         # create multiple futures so that we expect multiple
         # traces instead of a single one, even if greenlets
         # are delayed
         def greenlet():
-            with ot_tracer.start_span("greenlet"):
+            with ot_tracer.start_span('greenlet'):
                 gevent.sleep(0.01)
 
         jobs = [gevent.spawn_later(0.01, greenlet) for x in range(100)]
@@ -104,7 +104,7 @@ class TestTracerGevent(object):
         traces = writer.pop_traces()
         assert len(traces) == 100
         assert len(traces[0]) == 1
-        assert traces[0][0].name == "greenlet"
+        assert traces[0][0].name == 'greenlet'
 
 
 class TestTracerGeventCompatibility(object):
@@ -121,18 +121,18 @@ class TestTracerGeventCompatibility(object):
         """
         # multiple greenlets must be part of the same trace
         def entrypoint():
-            with ot_tracer.start_active_span("greenlet.main"):
+            with ot_tracer.start_active_span('greenlet.main'):
                 jobs = [gevent.spawn(green_1), gevent.spawn(green_2)]
                 gevent.joinall(jobs)
 
         def green_1():
-            with dd_tracer.trace("greenlet.worker") as span:
-                span.set_tag("worker_id", "1")
+            with dd_tracer.trace('greenlet.worker') as span:
+                span.set_tag('worker_id', '1')
                 gevent.sleep(0.01)
 
         def green_2():
-            with ot_tracer.start_span("greenlet.worker") as span:
-                span.set_tag("worker_id", "2")
+            with ot_tracer.start_span('greenlet.worker') as span:
+                span.set_tag('worker_id', '2')
                 gevent.sleep(0.01)
 
         gevent.spawn(entrypoint).join()
@@ -143,14 +143,14 @@ class TestTracerGeventCompatibility(object):
         worker_1 = traces[0][0]
         worker_2 = traces[1][0]
         # check spans data and hierarchy
-        assert parent_span.name == "greenlet.main"
-        assert worker_1.get_tag("worker_id") == "1"
-        assert worker_1.name == "greenlet.worker"
-        assert worker_1.resource == "greenlet.worker"
+        assert parent_span.name == 'greenlet.main'
+        assert worker_1.get_tag('worker_id') == '1'
+        assert worker_1.name == 'greenlet.worker'
+        assert worker_1.resource == 'greenlet.worker'
         assert worker_1.parent_id == parent_span.span_id
-        assert worker_2.get_tag("worker_id") == "2"
-        assert worker_2.name == "greenlet.worker"
-        assert worker_2.resource == "greenlet.worker"
+        assert worker_2.get_tag('worker_id') == '2'
+        assert worker_2.name == 'greenlet.worker'
+        assert worker_2.resource == 'greenlet.worker'
         assert worker_2.parent_id == parent_span.span_id
 
     def test_trace_spawn_multiple_greenlets_multiple_traces_dd_parent(
@@ -164,18 +164,18 @@ class TestTracerGeventCompatibility(object):
         """
         # multiple greenlets must be part of the same trace
         def entrypoint():
-            with dd_tracer.trace("greenlet.main"):
+            with dd_tracer.trace('greenlet.main'):
                 jobs = [gevent.spawn(green_1), gevent.spawn(green_2)]
                 gevent.joinall(jobs)
 
         def green_1():
-            with ot_tracer.start_span("greenlet.worker") as span:
-                span.set_tag("worker_id", "1")
+            with ot_tracer.start_span('greenlet.worker') as span:
+                span.set_tag('worker_id', '1')
                 gevent.sleep(0.01)
 
         def green_2():
-            with dd_tracer.trace("greenlet.worker") as span:
-                span.set_tag("worker_id", "2")
+            with dd_tracer.trace('greenlet.worker') as span:
+                span.set_tag('worker_id', '2')
                 gevent.sleep(0.01)
 
         gevent.spawn(entrypoint).join()
@@ -186,14 +186,14 @@ class TestTracerGeventCompatibility(object):
         worker_1 = traces[0][0]
         worker_2 = traces[1][0]
         # check spans data and hierarchy
-        assert parent_span.name == "greenlet.main"
-        assert worker_1.get_tag("worker_id") == "1"
-        assert worker_1.name == "greenlet.worker"
-        assert worker_1.resource == "greenlet.worker"
+        assert parent_span.name == 'greenlet.main'
+        assert worker_1.get_tag('worker_id') == '1'
+        assert worker_1.name == 'greenlet.worker'
+        assert worker_1.resource == 'greenlet.worker'
         assert worker_1.parent_id == parent_span.span_id
-        assert worker_2.get_tag("worker_id") == "2"
-        assert worker_2.name == "greenlet.worker"
-        assert worker_2.resource == "greenlet.worker"
+        assert worker_2.get_tag('worker_id') == '2'
+        assert worker_2.name == 'greenlet.worker'
+        assert worker_2.resource == 'greenlet.worker'
         assert worker_2.parent_id == parent_span.span_id
 
 
@@ -210,7 +210,7 @@ class TestUtilsGevent(object):
         )
 
     def test_tracer_context_provider_config(self):
-        tracer = ddtrace.opentracer.Tracer("mysvc", scope_manager=GeventScopeManager())
+        tracer = ddtrace.opentracer.Tracer('mysvc', scope_manager=GeventScopeManager())
         assert isinstance(
             tracer._dd_tracer.context_provider,
             ddtrace.contrib.gevent.provider.GeventContextProvider,

--- a/tests/opentracer/test_tracer_tornado.py
+++ b/tests/opentracer/test_tracer_tornado.py
@@ -5,7 +5,7 @@ from opentracing.scope_managers.tornado import TornadoScopeManager
 @pytest.fixture()
 def ot_tracer(ot_tracer_factory):
     """Fixture providing an opentracer configured for tornado usage."""
-    yield ot_tracer_factory("tornado_svc", {}, TornadoScopeManager())
+    yield ot_tracer_factory('tornado_svc', {}, TornadoScopeManager())
 
 
 class TestTracerTornado(object):

--- a/tests/propagation/test_http.py
+++ b/tests/propagation/test_http.py
@@ -19,9 +19,9 @@ class TestHttpPropagation(TestCase):
     def test_inject(self):
         tracer = get_dummy_tracer()
 
-        with tracer.trace("global_root_span") as span:
+        with tracer.trace('global_root_span') as span:
             span.context.sampling_priority = 2
-            span.context._dd_origin = "synthetics"
+            span.context._dd_origin = 'synthetics'
             headers = {}
             propagator = HTTPPropagator()
             propagator.inject(span.context, headers)
@@ -41,39 +41,39 @@ class TestHttpPropagation(TestCase):
         tracer = get_dummy_tracer()
 
         headers = {
-            "x-datadog-trace-id": "1234",
-            "x-datadog-parent-id": "5678",
-            "x-datadog-sampling-priority": "1",
-            "x-datadog-origin": "synthetics",
+            'x-datadog-trace-id': '1234',
+            'x-datadog-parent-id': '5678',
+            'x-datadog-sampling-priority': '1',
+            'x-datadog-origin': 'synthetics',
         }
 
         propagator = HTTPPropagator()
         context = propagator.extract(headers)
         tracer.context_provider.activate(context)
 
-        with tracer.trace("local_root_span") as span:
+        with tracer.trace('local_root_span') as span:
             assert span.trace_id == 1234
             assert span.parent_id == 5678
             assert span.context.sampling_priority == 1
-            assert span.context._dd_origin == "synthetics"
+            assert span.context._dd_origin == 'synthetics'
 
     def test_WSGI_extract(self):
         """Ensure we support the WSGI formatted headers as well."""
         tracer = get_dummy_tracer()
 
         headers = {
-            "HTTP_X_DATADOG_TRACE_ID": "1234",
-            "HTTP_X_DATADOG_PARENT_ID": "5678",
-            "HTTP_X_DATADOG_SAMPLING_PRIORITY": "1",
-            "HTTP_X_DATADOG_ORIGIN": "synthetics",
+            'HTTP_X_DATADOG_TRACE_ID': '1234',
+            'HTTP_X_DATADOG_PARENT_ID': '5678',
+            'HTTP_X_DATADOG_SAMPLING_PRIORITY': '1',
+            'HTTP_X_DATADOG_ORIGIN': 'synthetics',
         }
 
         propagator = HTTPPropagator()
         context = propagator.extract(headers)
         tracer.context_provider.activate(context)
 
-        with tracer.trace("local_root_span") as span:
+        with tracer.trace('local_root_span') as span:
             assert span.trace_id == 1234
             assert span.parent_id == 5678
             assert span.context.sampling_priority == 1
-            assert span.context._dd_origin == "synthetics"
+            assert span.context._dd_origin == 'synthetics'

--- a/tests/propagation/test_utils.py
+++ b/tests/propagation/test_utils.py
@@ -3,4 +3,4 @@ from ddtrace.propagation.utils import get_wsgi_header
 
 class TestPropagationUtils(object):
     def test_get_wsgi_header(self):
-        assert get_wsgi_header("x-datadog-trace-id") == "HTTP_X_DATADOG_TRACE_ID"
+        assert get_wsgi_header('x-datadog-trace-id') == 'HTTP_X_DATADOG_TRACE_ID'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -155,7 +155,7 @@ class TestWorkers(TestCase):
         self.tracer.writer.api = FlawedAPI(Tracer.DEFAULT_HOSTNAME, Tracer.DEFAULT_PORT)
         tracer.trace('client.testing').finish()
 
-        log = logging.getLogger("ddtrace.writer")
+        log = logging.getLogger('ddtrace.writer')
         log_handler = MockedLogHandler(level='DEBUG')
         log.addHandler(log_handler)
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -32,9 +32,9 @@ class RateSamplerTest(unittest.TestCase):
             # We must have at least 1 sample, check that it has its sample rate properly assigned
             assert samples[0].get_metric(SAMPLE_RATE_METRIC_KEY) == sample_rate
 
-            # Less than 2% deviation when "enough" iterations (arbitrary, just check if it converges)
+            # Less than 2% deviation when 'enough' iterations (arbitrary, just check if it converges)
             deviation = abs(len(samples) - (iterations * sample_rate)) / (iterations * sample_rate)
-            assert deviation < 0.02, "Deviation too high %f with sample_rate %f" % (deviation, sample_rate)
+            assert deviation < 0.02, 'Deviation too high %f with sample_rate %f' % (deviation, sample_rate)
 
     def test_deterministic_behavior(self):
         """ Test that for a given trace ID, the result is always the same """
@@ -50,7 +50,7 @@ class RateSamplerTest(unittest.TestCase):
             span.finish()
 
             samples = writer.pop()
-            assert len(samples) <= 1, "there should be 0 or 1 spans"
+            assert len(samples) <= 1, 'there should be 0 or 1 spans'
             sampled = (1 == len(samples))
             for j in range(10):
                 other_span = Span(tracer, i, trace_id=span.trace_id)
@@ -61,14 +61,14 @@ class RateSamplerTest(unittest.TestCase):
 
 class RateByServiceSamplerTest(unittest.TestCase):
     def test_default_key(self):
-        assert "service:,env:" == _default_key, "default key should correspond to no service and no env"
+        assert 'service:,env:' == _default_key, 'default key should correspond to no service and no env'
 
     def test_key(self):
         assert _default_key == _key()
-        assert "service:mcnulty,env:" == _key(service="mcnulty")
-        assert "service:,env:test" == _key(env="test")
-        assert "service:mcnulty,env:test" == _key(service="mcnulty", env="test")
-        assert "service:mcnulty,env:test" == _key("mcnulty", "test")
+        assert 'service:mcnulty,env:' == _key(service='mcnulty')
+        assert 'service:,env:test' == _key(env='test')
+        assert 'service:mcnulty,env:test' == _key(service='mcnulty', env='test')
+        assert 'service:mcnulty,env:test' == _key('mcnulty', 'test')
 
     def test_sample_rate_deviation(self):
         for sample_rate in [0.1, 0.25, 0.5, 1]:
@@ -79,7 +79,7 @@ class RateByServiceSamplerTest(unittest.TestCase):
             # indeed, as we enable priority sampling, we must ensure the writer
             # is priority sampling aware and pass it a reference on the
             # priority sampler to send the feedback it gets from the agent
-            assert writer != tracer.writer, "writer should have been updated by configure"
+            assert writer != tracer.writer, 'writer should have been updated by configure'
             tracer.writer = writer
             tracer.priority_sampler.set_sample_rate(sample_rate)
 
@@ -105,9 +105,9 @@ class RateByServiceSamplerTest(unittest.TestCase):
             # We must have at least 1 sample, check that it has its sample rate properly assigned
             assert samples[0].get_metric(SAMPLE_RATE_METRIC_KEY) is None
 
-            # Less than 2% deviation when "enough" iterations (arbitrary, just check if it converges)
+            # Less than 2% deviation when 'enough' iterations (arbitrary, just check if it converges)
             deviation = abs(samples_with_high_priority - (iterations * sample_rate)) / (iterations * sample_rate)
-            assert deviation < 0.02, "Deviation too high %f with sample_rate %f" % (deviation, sample_rate)
+            assert deviation < 0.02, 'Deviation too high %f with sample_rate %f' % (deviation, sample_rate)
 
     def test_set_sample_rate_by_service(self):
         cases = [
@@ -135,7 +135,7 @@ class RateByServiceSamplerTest(unittest.TestCase):
             rates = {}
             for k, v in iteritems(priority_sampler._by_service_samplers):
                 rates[k] = v.sample_rate
-            assert case == rates, "%s != %s" % (case, rates)
+            assert case == rates, '%s != %s' % (case, rates)
         # It's important to also test in reverse mode for we want to make sure key deletion
         # works as well as key insertion (and doing this both ways ensures we trigger both cases)
         cases.reverse()
@@ -144,4 +144,4 @@ class RateByServiceSamplerTest(unittest.TestCase):
             rates = {}
             for k, v in iteritems(priority_sampler._by_service_samplers):
                 rates[k] = v.sample_rate
-            assert case == rates, "%s != %s" % (case, rates)
+            assert case == rates, '%s != %s' % (case, rates)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -30,7 +30,7 @@ class AddTagFilter():
     def process_trace(self, trace):
         self.filtered_traces += 1
         for span in trace:
-            span.set_tag(self.tag_name, "A value")
+            span.set_tag(self.tag_name, 'A value')
         return trace
 
 
@@ -53,7 +53,7 @@ class AsyncWorkerTests(TestCase):
         self.services = Q()
         for i in range(N_TRACES):
             self.traces.add([
-                Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None)
+                Span(tracer=None, name='name', trace_id=i, span_id=j, parent_id=j - 1 or None)
                 for j in range(7)
             ])
 
@@ -76,7 +76,7 @@ class AsyncWorkerTests(TestCase):
         self.assertEqual(filtr.filtered_traces, N_TRACES)
 
     def test_filters_add_tag(self):
-        tag_name = "Tag"
+        tag_name = 'Tag'
         filtr = AddTagFilter(tag_name)
         filters = [filtr]
         worker = AsyncWorker(self.api, self.traces, self.services, filters=filters)

--- a/tests/util.py
+++ b/tests/util.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 
 
 class FakeTime(object):
-    """"Allow to mock time.time for tests
+    """'Allow to mock time.time for tests
 
     `time.time` returns a defined `current_time` instead.
     Any `time.time` call also increase the `current_time` of `delta` seconds.
@@ -40,12 +40,12 @@ def patch_time():
 
 def assert_dict_issuperset(a, b):
     assert set(a.items()).issuperset(set(b.items())), \
-        "{a} is not a superset of {b}".format(a=a, b=b)
+        '{a} is not a superset of {b}'.format(a=a, b=b)
 
 
 def assert_list_issuperset(a, b):
     assert set(a).issuperset(set(b)), \
-        "{a} is not a superset of {b}".format(a=a, b=b)
+        '{a} is not a superset of {b}'.format(a=a, b=b)
 
 
 @contextmanager

--- a/tests/wait-for-services.py
+++ b/tests/wait-for-services.py
@@ -46,7 +46,7 @@ def try_until_timeout(exception):
 def check_postgres():
     conn = connect(**POSTGRES_CONFIG)
     try:
-        conn.cursor().execute("SELECT 1;")
+        conn.cursor().execute('SELECT 1;')
     finally:
         conn.close()
 
@@ -54,14 +54,14 @@ def check_postgres():
 @try_until_timeout(NoHostAvailable)
 def check_cassandra():
     with Cluster(**CASSANDRA_CONFIG).connect() as conn:
-        conn.execute("SELECT now() FROM system.local")
+        conn.execute('SELECT now() FROM system.local')
 
 
 @try_until_timeout(Exception)
 def check_mysql():
     conn = mysql.connector.connect(**MYSQL_CONFIG)
     try:
-        conn.cursor().execute("SELECT 1;")
+        conn.cursor().execute('SELECT 1;')
     finally:
         conn.close()
 
@@ -82,14 +82,14 @@ def check_rediscluster():
 def check_vertica():
     conn = vertica_python.connect(**VERTICA_CONFIG)
     try:
-        conn.cursor().execute("SELECT 1;")
+        conn.cursor().execute('SELECT 1;')
     finally:
         conn.close()
 
 
 @try_until_timeout(Exception)
 def check_rabbitmq():
-    url = "amqp://{user}:{password}@{host}:{port}//".format(**RABBITMQ_CONFIG)
+    url = 'amqp://{user}:{password}@{host}:{port}//'.format(**RABBITMQ_CONFIG)
     conn = kombu.Connection(url)
     try:
         conn.connect()
@@ -110,5 +110,5 @@ if __name__ == '__main__':
         for service in sys.argv[1:]:
             check_functions[service]()
     else:
-        print("usage: python {} SERVICE_NAME".format(sys.argv[0]))
+        print('usage: python {} SERVICE_NAME'.format(sys.argv[0]))
         sys.exit(1)

--- a/tox.ini
+++ b/tox.ini
@@ -404,9 +404,12 @@ deps=
 ignore_outcome=true
 
 [testenv:flake8]
-deps=flake8>=3.7,<=3.8
+deps=
+  flake8>=3.7,<=3.8
+  flake8-quotes==1.0.0
 commands=flake8 .
 basepython=python2
+inline-quotes = '
 
 [falcon_autopatch]
 setenv =


### PR DESCRIPTION
_Finally_ this PR adds a `flake8` plugin (https://github.com/zheller/flake8-quotes) to enforce single quote usage.

![brettlinter](https://user-images.githubusercontent.com/6321485/56076425-d8801780-5d9e-11e9-87a1-7ce8381a8011.png)

This removes the dependency we had on the `brettlinter` :smile:.

This PR also replaces double quote strings with the corresponding single quote string. Strings containing single quotes remained untouched (which is permitted in the plugin https://github.com/zheller/flake8-quotes#caveats). We may want to figure out our convention for these cases.

*Note:* update branch to `master` once #881 has been merged.