### PR TITLE
[http] Add tracking for URL query string parameters

### DIFF
--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -61,5 +61,7 @@ class TracePlugin(object):
                     s.set_tag(http.STATUS_CODE, code or response.status_code)
                     s.set_tag(http.URL, request.urlparts._replace(query='').geturl())
                     s.set_tag(http.METHOD, request.method)
+                    if config.bottle.trace_query_string:
+                        s.set_tag(http.QUERY_STRING, request.query_string)
 
         return wrapped

--- a/ddtrace/contrib/django/conf.py
+++ b/ddtrace/contrib/django/conf.py
@@ -37,6 +37,7 @@ DEFAULTS = {
     'DISTRIBUTED_TRACING': True,
     'ANALYTICS_ENABLED': None,
     'ANALYTICS_SAMPLE_RATE': True,
+    'TRACE_QUERY_STRING': None,
     'TAGS': {},
     'TRACER': 'ddtrace.tracer',
 }

--- a/ddtrace/contrib/django/middleware.py
+++ b/ddtrace/contrib/django/middleware.py
@@ -138,6 +138,11 @@ class TraceMiddleware(InstrumentationMixin):
             # Set HTTP Request tags
             span.set_tag(http.METHOD, request.method)
             span.set_tag(http.URL, get_request_uri(request))
+            trace_query_string = settings.TRACE_QUERY_STRING
+            if trace_query_string is None:
+                trace_query_string = config.django.trace_query_string
+            if trace_query_string:
+                span.set_tag(http.QUERY_STRING, request.META['QUERY_STRING'])
             _set_req_span(request, span)
         except Exception as e:
             log.debug('error tracing request: %s', e)

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -66,6 +66,8 @@ def _get_perform_request(elasticsearch):
             span.set_tag(metadata.METHOD, method)
             span.set_tag(metadata.URL, url)
             span.set_tag(metadata.PARAMS, urlencode(params))
+            if config.elasticsearch.trace_query_string:
+                span.set_tag(http.QUERY_STRING, urlencode(params))
             if method == 'GET':
                 span.set_tag(metadata.BODY, instance.serializer.dumps(body))
             status = None

--- a/ddtrace/contrib/elasticsearch/transport.py
+++ b/ddtrace/contrib/elasticsearch/transport.py
@@ -7,6 +7,7 @@ from .quantize import quantize
 from ...utils.deprecation import deprecated
 from ...compat import urlencode
 from ...ext import http, elasticsearch as metadata
+from ...settings import config
 
 DEFAULT_SERVICE = 'elasticsearch'
 SPAN_TYPE = 'elasticsearch'
@@ -35,6 +36,8 @@ def get_traced_transport(datadog_tracer, datadog_service=DEFAULT_SERVICE):
                 s.set_tag(metadata.METHOD, method)
                 s.set_tag(metadata.URL, url)
                 s.set_tag(metadata.PARAMS, urlencode(params))
+                if config.elasticsearch.trace_query_string:
+                    s.set_tag(http.QUERY_STRING, urlencode(params))
                 if method == 'GET':
                     s.set_tag(metadata.BODY, self.serializer.dumps(body))
                 s = quantize(s)

--- a/ddtrace/contrib/falcon/middleware.py
+++ b/ddtrace/contrib/falcon/middleware.py
@@ -41,6 +41,8 @@ class TraceMiddleware(object):
 
         span.set_tag(httpx.METHOD, req.method)
         span.set_tag(httpx.URL, req.url)
+        if config.falcon.trace_query_string:
+            span.set_tag(httpx.QUERY_STRING, req.query_string)
 
         # Note: any request header set after this line will not be stored in the span
         store_request_headers(req.headers, span, config.falcon)

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -4,6 +4,7 @@ import flask
 import werkzeug
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
+from ddtrace import compat
 from ddtrace import config, Pin
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -328,6 +329,8 @@ def traced_wsgi_app(pin, wrapped, instance, args, kwargs):
         # DEV: Use `request.base_url` and not `request.url` to keep from leaking any query string parameters
         s.set_tag(http.URL, request.base_url)
         s.set_tag(http.METHOD, request.method)
+        if config.flask.trace_query_string:
+            s.set_tag(http.QUERY_STRING, compat.to_unicode(request.query_string))
 
         return wrapped(environ, start_response)
 

--- a/ddtrace/contrib/httplib/patch.py
+++ b/ddtrace/contrib/httplib/patch.py
@@ -79,6 +79,8 @@ def _wrap_putrequest(func, instance, args, kwargs):
 
         span.set_tag(ext_http.URL, sanitized_url)
         span.set_tag(ext_http.METHOD, method)
+        if config.httplib.trace_query_string:
+            span.set_tag(ext_http.QUERY_STRING, parsed.query)
 
         # set analytics sample rate
         span.set_tag(

--- a/ddtrace/contrib/molten/patch.py
+++ b/ddtrace/contrib/molten/patch.py
@@ -4,6 +4,7 @@ from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 import molten
 
 from ... import Pin, config
+from ...compat import urlencode
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...ext import AppTypes, http
 from ...propagation.http import HTTPPropagator
@@ -125,6 +126,8 @@ def patch_app_call(wrapped, instance, args, kwargs):
         span.set_tag(http.URL, '%s://%s:%s%s' % (
             request.scheme, request.host, request.port, request.path,
         ))
+        if config.molten.trace_query_string:
+            span.set_tag(http.QUERY_STRING, urlencode(dict(request.params)))
         span.set_tag('molten.version', molten.__version__)
         return wrapped(environ, start_response, **kwargs)
 

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -107,3 +107,5 @@ class PylonsTraceMiddleware(object):
                     'pylons.route.controller': controller,
                     'pylons.route.action': action,
                 })
+                if ddconfig.pylons.trace_query_string:
+                    span.set_tag(http.QUERY_STRING, environ.get('QUERY_STRING'))

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -104,6 +104,8 @@ def trace_tween_factory(handler, registry):
                     # set request tags
                     span.set_tag(http.URL, request.path_url)
                     span.set_tag(http.METHOD, request.method)
+                    if config.pyramid.trace_query_string:
+                        span.set_tag(http.QUERY_STRING, request.query_string)
                     if request.matched_route:
                         span.resource = '{} {}'.format(request.method, request.matched_route.name)
                         span.set_tag('pyramid.route.name', request.matched_route.name)

--- a/ddtrace/contrib/requests/connection.py
+++ b/ddtrace/contrib/requests/connection.py
@@ -103,6 +103,8 @@ def _wrap_send(func, instance, args, kwargs):
             try:
                 span.set_tag(http.METHOD, request.method.upper())
                 span.set_tag(http.URL, sanitized_url)
+                if config.requests.trace_query_string:
+                    span.set_tag(http.QUERY_STRING, parsed_uri.query)
                 if response is not None:
                     span.set_tag(http.STATUS_CODE, response.status_code)
                     # `span.error` must be an integer

--- a/ddtrace/contrib/tornado/handlers.py
+++ b/ddtrace/contrib/tornado/handlers.py
@@ -68,6 +68,8 @@ def on_finish(func, handler, args, kwargs):
         request_span.set_tag('http.method', request.method)
         request_span.set_tag('http.status_code', handler.get_status())
         request_span.set_tag(http.URL, request.full_url().rsplit('?', 1)[0])
+        if config.tornado.trace_query_string:
+            request_span.set_tag(http.QUERY_STRING, request.query)
         request_span.finish()
 
     return func(*args, **kwargs)

--- a/ddtrace/ext/http.py
+++ b/ddtrace/ext/http.py
@@ -14,6 +14,7 @@ TYPE = 'http'
 URL = 'http.url'
 METHOD = 'http.method'
 STATUS_CODE = 'http.status_code'
+QUERY_STRING = 'http.query.string'
 
 # template render span type
 TEMPLATE = 'template'

--- a/ddtrace/settings/http.py
+++ b/ddtrace/settings/http.py
@@ -12,6 +12,7 @@ class HttpConfig(object):
 
     def __init__(self):
         self._whitelist_headers = set()
+        self.trace_query_string = None
 
     @property
     def is_header_tracing_configured(self):
@@ -49,4 +50,5 @@ class HttpConfig(object):
         return normalized_header_name in self._whitelist_headers
 
     def __repr__(self):
-        return '<HttpConfig traced_headers={}>'.format(self._whitelist_headers)
+        return '<{} traced_headers={} trace_query_string={}>'.format(
+            self.__class__.__name__, self._whitelist_headers, self.trace_query_string)

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -52,6 +52,12 @@ class IntegrationConfig(AttrDict):
         new.http = deepcopy(self.http)
         return new
 
+    @property
+    def trace_query_string(self):
+        if self.http.trace_query_string is not None:
+            return self.http.trace_query_string
+        return self.global_config._http.trace_query_string
+
     def header_is_traced(self, header_name):
         """
         Returns whether or not the current header should be traced.

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -347,8 +347,26 @@ Logs Injection
 
 .. automodule:: ddtrace.contrib.logging
 
-Http layer
+HTTP layer
 ----------
+
+Query String Tracing
+^^^^^^^^^^^^^^^^^^^^
+
+It is possible to store the query string of the URL — the part after the ``?``
+in your URL — in the ``url.query.string`` tag.
+
+Configuration can be provided both at the global level and at the integration level.
+
+Examples::
+
+    from ddtrace import config
+
+    # Global config
+    config.http.trace_query_string = True
+
+    # Integration level config, e.g. 'falcon'
+    config.falcon.http.trace_query_string = True
 
 ..  _http-headers-tracing:
 

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -88,6 +88,27 @@ class BaseTestCase(unittest.TestCase):
 
     @staticmethod
     @contextlib.contextmanager
+    def override_http_config(integration, values):
+        """
+        Temporarily override an integration configuration for HTTP value
+        >>> with self.override_http_config('flask', dict(trace_query_string=True)):
+            # Your test
+        """
+        options = getattr(ddtrace.config, integration).http
+
+        original = {}
+        for key, value in values.items():
+            original[key] = getattr(options, key)
+            setattr(options, key, value)
+
+        try:
+            yield
+        finally:
+            for key, value in original.items():
+                setattr(options, key, value)
+
+    @staticmethod
+    @contextlib.contextmanager
     def override_sys_modules(modules):
         """
         Temporarily override ``sys.modules`` with provided dictionary of modules


### PR DESCRIPTION
This adds a new field http.queryString that stores the query parameter passed
to the requested URL.