### PR TITLE
writer: fix a possible race condition in put() if queue is full

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,7 +1,9 @@
 from unittest import TestCase
 
+import pytest
+
 from ddtrace.span import Span
-from ddtrace.writer import AsyncWorker, Q
+from ddtrace.writer import AsyncWorker, Q, Empty
 
 
 class RemoveAllFilter():
@@ -107,3 +109,12 @@ def test_queue_full():
     assert (list(q.queue) == [1, 2, 4] or
             list(q.queue) == [1, 4, 3] or
             list(q.queue) == [4, 2, 3])
+
+
+def test_queue_get():
+    q = Q(maxsize=3)
+    q.put(1)
+    q.put(2)
+    assert list(q.get()) == [1, 2]
+    with pytest.raises(Empty):
+        q.get(block=False)


### PR DESCRIPTION
In this new episode of "Multithreading is Hard", let's a fix a rare race
condition that could occur if a thread emptied the queue just before another
thread tries to replace a random item (because the queue is full).

In order to avoid that, we check the size of the queue, and simply retry to put
the item if the queue has been emptied in the meantime.

This also adds a tiny test for the `get` method.