### PR TITLE
WIP: Implement a ContextVarProvider for Python 3.7+

### DIFF
--- a/ddtrace/contrib/asyncio/patch.py
+++ b/ddtrace/contrib/asyncio/patch.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
@@ -15,7 +16,8 @@ def patch():
     setattr(asyncio, '_datadog_patch', True)
 
     loop = asyncio.get_event_loop()
-    _w(loop, 'create_task', _wrapped_create_task)
+    if sys.version_info < (3, 7):
+        _w(loop, 'create_task', _wrapped_create_task)
 
 
 def unpatch():
@@ -24,4 +26,5 @@ def unpatch():
     if getattr(asyncio, '_datadog_patch', False):
         setattr(asyncio, '_datadog_patch', False)
         loop = asyncio.get_event_loop()
-        _u(loop, 'create_task')
+        if sys.version_info < (3, 7):
+            _u(loop, 'create_task')

--- a/ddtrace/contrib/asyncio/provider.py
+++ b/ddtrace/contrib/asyncio/provider.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 from ...context import Context
 from ...provider import DefaultContextProvider
@@ -7,80 +8,83 @@ from ...provider import DefaultContextProvider
 CONTEXT_ATTR = '__datadog_context'
 
 
-class AsyncioContextProvider(DefaultContextProvider):
-    """
-    Context provider that retrieves all contexts for the current asyncio
-    execution. It must be used in asynchronous programming that relies
-    in the built-in ``asyncio`` library. Framework instrumentation that
-    is built on top of the ``asyncio`` library, can use this provider.
-
-    This Context Provider inherits from ``DefaultContextProvider`` because
-    it uses a thread-local storage when the ``Context`` is propagated to
-    a different thread, than the one that is running the async loop.
-    """
-    def activate(self, context, loop=None):
-        """Sets the scoped ``Context`` for the current running ``Task``.
+if sys.version_info >= (3, 7):
+    AsyncioContextProvider = DefaultContextProvider
+else:
+    class AsyncioContextProvider(DefaultContextProvider):
         """
-        loop = self._get_loop(loop)
-        if not loop:
-            self._local.set(context)
+        Context provider that retrieves all contexts for the current asyncio
+        execution. It must be used in asynchronous programming that relies
+        in the built-in ``asyncio`` library. Framework instrumentation that
+        is built on top of the ``asyncio`` library, can use this provider.
+
+        This Context Provider inherits from ``DefaultContextProvider`` because
+        it uses a thread-local storage when the ``Context`` is propagated to
+        a different thread, than the one that is running the async loop.
+        """
+        def activate(self, context, loop=None):
+            """Sets the scoped ``Context`` for the current running ``Task``.
+            """
+            loop = self._get_loop(loop)
+            if not loop:
+                self._local.set(context)
+                return context
+
+            # the current unit of work (if tasks are used)
+            task = asyncio.Task.current_task(loop=loop)
+            setattr(task, CONTEXT_ATTR, context)
             return context
 
-        # the current unit of work (if tasks are used)
-        task = asyncio.Task.current_task(loop=loop)
-        setattr(task, CONTEXT_ATTR, context)
-        return context
+        def _get_loop(self, loop=None):
+            """Helper to try and resolve the current loop"""
+            try:
+                return loop or asyncio.get_event_loop()
+            except RuntimeError:
+                # Detects if a loop is available in the current thread;
+                # DEV: This happens when a new thread is created from the out that is running the async loop
+                # DEV: It's possible that a different Executor is handling a different Thread that
+                #      works with blocking code. In that case, we fallback to a thread-local Context.
+                pass
+            return None
 
-    def _get_loop(self, loop=None):
-        """Helper to try and resolve the current loop"""
-        try:
-            return loop or asyncio.get_event_loop()
-        except RuntimeError:
-            # Detects if a loop is available in the current thread;
-            # DEV: This happens when a new thread is created from the out that is running the async loop
-            # DEV: It's possible that a different Executor is handling a different Thread that
-            #      works with blocking code. In that case, we fallback to a thread-local Context.
-            pass
-        return None
+        def _has_active_context(self, loop=None):
+            """Helper to determine if we have a currently active context"""
+            loop = self._get_loop(loop=loop)
+            if loop is None:
+                return self._local._has_active_context()
 
-    def _has_active_context(self, loop=None):
-        """Helper to determine if we have a currently active context"""
-        loop = self._get_loop(loop=loop)
-        if loop is None:
-            return self._local._has_active_context()
+            # the current unit of work (if tasks are used)
+            task = asyncio.Task.current_task(loop=loop)
+            if task is None:
+                return False
 
-        # the current unit of work (if tasks are used)
-        task = asyncio.Task.current_task(loop=loop)
-        if task is None:
-            return False
+            ctx = getattr(task, CONTEXT_ATTR, None)
+            return ctx is not None
 
-        ctx = getattr(task, CONTEXT_ATTR, None)
-        return ctx is not None
+        def active(self, loop=None):
+            """
+            Returns the scoped Context for this execution flow. The ``Context`` uses
+            the current task as a carrier so if a single task is used for the entire application,
+            the context must be handled separately.
+            """
+            loop = self._get_loop(loop=loop)
+            if not loop:
+                return self._local.get()
 
-    def active(self, loop=None):
-        """
-        Returns the scoped Context for this execution flow. The ``Context`` uses
-        the current task as a carrier so if a single task is used for the entire application,
-        the context must be handled separately.
-        """
-        loop = self._get_loop(loop=loop)
-        if not loop:
-            return self._local.get()
+            # the current unit of work (if tasks are used)
+            task = asyncio.Task.current_task(loop=loop)
+            if task is None:
+                # providing a detached Context from the current Task, may lead to
+                # wrong traces. This defensive behavior grants that a trace can
+                # still be built without raising exceptions
+                return Context()
 
-        # the current unit of work (if tasks are used)
-        task = asyncio.Task.current_task(loop=loop)
-        if task is None:
-            # providing a detached Context from the current Task, may lead to
-            # wrong traces. This defensive behavior grants that a trace can
-            # still be built without raising exceptions
-            return Context()
+            ctx = getattr(task, CONTEXT_ATTR, None)
+            if ctx is not None:
+                # return the active Context for this task (if any)
+                return ctx
 
-        ctx = getattr(task, CONTEXT_ATTR, None)
-        if ctx is not None:
-            # return the active Context for this task (if any)
+            # create a new Context using the Task as a Context carrier
+            ctx = Context()
+            setattr(task, CONTEXT_ATTR, ctx)
             return ctx
-
-        # create a new Context using the Task as a Context carrier
-        ctx = Context()
-        setattr(task, CONTEXT_ATTR, ctx)
-        return ctx

--- a/ddtrace/provider.py
+++ b/ddtrace/provider.py
@@ -1,5 +1,10 @@
 from .context import ThreadLocalContext
 
+try:
+    from .context import ContextVarContext
+except ImportError:
+    ContextVarContext = None
+
 
 class BaseContextProvider(object):
     """
@@ -33,7 +38,10 @@ class DefaultContextProvider(BaseContextProvider):
     Python WSGI frameworks.
     """
     def __init__(self):
-        self._local = ThreadLocalContext()
+        if ContextVarContext is not None:
+            self._local = ContextVarContext()
+        else:
+            self._local = ThreadLocalContext()
 
     def _has_active_context(self):
         """

--- a/tests/contrib/asyncio/test_helpers.py
+++ b/tests/contrib/asyncio/test_helpers.py
@@ -27,9 +27,9 @@ class TestAsyncioHelpers(AsyncioTestCase):
         def future_work():
             # the ctx is available in this task
             ctx = self.tracer.get_call_context()
-            assert 1 == len(ctx._trace)
-            assert 'coroutine' == ctx._trace[0].name
-            return ctx._trace[0].name
+            current_span = ctx.get_current_span()
+            assert 'coroutine' == current_span.name
+            return current_span.name
 
         self.tracer.trace('coroutine')
         # schedule future work and wait for a result

--- a/tests/contrib/asyncio/test_tracer.py
+++ b/tests/contrib/asyncio/test_tracer.py
@@ -1,8 +1,10 @@
 # flake8: noqa
 # DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from `yield from`
 import asyncio
+import sys
 
 from asyncio import BaseEventLoop
+from unittest import skipIf
 
 from ddtrace.context import Context
 from ddtrace.provider import DefaultContextProvider
@@ -21,6 +23,7 @@ class TestAsyncioTracer(AsyncioTestCase):
     the same ``IOLoop``.
     """
     @mark_asyncio
+    @skipIf(sys.version_info >= (3, 7), '__datadog_context is not attached in Python 3.7')
     def test_get_call_context(self):
         # it should return the context attached to the current Task
         # or create a new one

--- a/tests/contrib/asyncio/test_tracer_safety.py
+++ b/tests/contrib/asyncio/test_tracer_safety.py
@@ -1,11 +1,14 @@
 # flake8: noqa
 # DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from `yield from`
 import asyncio
+import sys
+from unittest import skipIf
 
 from ddtrace.provider import DefaultContextProvider
 from .utils import AsyncioTestCase, mark_asyncio
 
 
+@skipIf(sys.version_info >= (3, 7), 'AsyncioTracer context_provider cannot be misconfigured')
 class TestAsyncioSafety(AsyncioTestCase):
     """
     Ensure that if the ``AsyncioTracer`` is not properly configured,


### PR DESCRIPTION
This is a continuation of https://github.com/DataDog/dd-trace-py/pull/723.

I adapted this a bit, I realized that on 3.7+ we can just use a ContextVar based provider instead of any thread locals, and not even need an asyncio based one.

Lets hope the tests pass.