### PR TITLE
[config] Force integration declaration

### DIFF
--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -31,9 +31,6 @@ class Config(object):
         )
 
     def __getattr__(self, name):
-        if name not in self._config:
-            self._config[name] = IntegrationConfig(self, name)
-
         return self._config[name]
 
     def get_from(self, obj):
@@ -61,8 +58,6 @@ class Config(object):
             or if we should overwrite the settings with those provided;
             Note: when merging existing settings take precedence.
         """
-        # DEV: Use `getattr()` to call our `__getattr__` helper
-        existing = getattr(self, integration)
         settings = deepcopy(settings)
 
         if merge:
@@ -74,6 +69,7 @@ class Config(object):
             # >>> config._add('requests', dict(split_by_domain=False))
             # >>> config.requests['split_by_domain']
             # True
+            existing = self._config.get(integration, {})
             self._config[integration] = IntegrationConfig(self, integration, deepmerge(existing, settings))
         else:
             self._config[integration] = IntegrationConfig(self, integration, settings)

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -33,7 +33,8 @@ class Config(object):
     def __getattr__(self, name):
         return self._config[name]
 
-    def get_from(self, obj):
+    @staticmethod
+    def get_from(obj):
         """Retrieves the configuration for the given object.
         Any object that has an attached `Pin` must have a configuration
         and if a wrong object is given, an empty `dict` is returned

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -142,24 +142,29 @@ class TestIntegrationConfig(BaseTestCase):
     def test_environment_analytics_enabled(self):
         # default
         self.assertFalse(self.config.analytics_enabled)
+        self.config._add("foo", {})
         self.assertIsNone(self.config.foo.analytics_enabled)
 
         with self.override_env(dict(DD_ANALYTICS_ENABLED='True')):
             config = Config()
             self.assertTrue(config.analytics_enabled)
+            config._add("foo", {})
             self.assertIsNone(config.foo.analytics_enabled)
 
         with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED='True')):
             config = Config()
+            config._add("foo", {})
             self.assertTrue(config.foo.analytics_enabled)
             self.assertEqual(config.foo.analytics_sample_rate, 1.0)
 
         with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED='False')):
             config = Config()
+            config._add("foo", {})
             self.assertFalse(config.foo.analytics_enabled)
 
         with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED='True', DD_FOO_ANALYTICS_SAMPLE_RATE='0.5')):
             config = Config()
+            config._add("foo", {})
             self.assertTrue(config.foo.analytics_enabled)
             self.assertEqual(config.foo.analytics_sample_rate, 0.5)
 


### PR DESCRIPTION
This simplifies the code and should avoid programming error where attributes
(integration configs) are accessed before being declared.