### PR TITLE
tests/tornado: enhance `test_concurrent_requests`

### DIFF
--- a/tests/contrib/tornado/web/compat.py
+++ b/tests/contrib/tornado/web/compat.py
@@ -1,4 +1,5 @@
 from tornado.concurrent import Future
+import tornado.gen
 from tornado.ioloop import IOLoop
 
 
@@ -24,12 +25,16 @@ except ImportError:
             super(ThreadPoolExecutor, self).__init__()
 
 
-def sleep(duration):
-    """
-    Compatibility helper that return a Future() that can be yielded.
-    This is used because Tornado 4.0 doesn't have a ``gen.sleep()``
-    function, that we require to test the ``TracerStackContext``.
-    """
-    f = Future()
-    IOLoop.current().call_later(duration, lambda: f.set_result(None))
-    return f
+if hasattr(tornado.gen, 'sleep'):
+    sleep = tornado.gen.sleep
+else:
+    # Tornado <= 4.0
+    def sleep(duration):
+        """
+        Compatibility helper that return a Future() that can be yielded.
+        This is used because Tornado 4.0 doesn't have a ``gen.sleep()``
+        function, that we require to test the ``TracerStackContext``.
+        """
+        f = Future()
+        IOLoop.current().call_later(duration, lambda: f.set_result(None))
+        return f


### PR DESCRIPTION
This tries to enhance test_concurrent_requests by waiting until all responses
have completed. There's still a default timeout set by tornado testing
framework (5 seconds) that can be exceeded, but that should be more solid in
practice than the previous 0.5 seconds delay that was used.

We also make sure threads worked fine by joining them rather than setting them
as daemons.

This also makes sure we use `tornado.gen.sleep` function when available.

Fixes #914