### PR TITLE
[core] Use constants for manual.keep and manual.drop

### DIFF
--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -5,3 +5,6 @@ ANALYTICS_SAMPLE_RATE_KEY = '_dd1.sr.eausr'
 ORIGIN_KEY = '_dd.origin'
 
 NUMERIC_TAGS = (ANALYTICS_SAMPLE_RATE_KEY, )
+
+MANUAL_DROP_KEY = 'manual.drop'
+MANUAL_KEEP_KEY = 'manual.keep'

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -5,7 +5,7 @@ import time
 import traceback
 
 from .compat import StringIO, stringify, iteritems, numeric_types
-from .constants import NUMERIC_TAGS
+from .constants import NUMERIC_TAGS, MANUAL_DROP_KEY, MANUAL_KEEP_KEY
 from .ext import errors, priority
 from .internal.logger import get_logger
 
@@ -138,10 +138,10 @@ class Span(object):
                 log.debug('error setting numeric metric {}:{}'.format(key, value))
 
             return
-        elif key == 'manual.keep':
+        elif key == MANUAL_KEEP_KEY:
             self.context.sampling_priority = priority.USER_KEEP
             return
-        elif key == 'manual.drop':
+        elif key == MANUAL_DROP_KEY:
             self.context.sampling_priority = priority.USER_REJECT
             return
 


### PR DESCRIPTION
We want to provide users with constants they can import and use instead of knowing the tag key.

```python
from ddtrace import tracer
from ddtrace.constants import MANUAL_DROP_KEY, MANUAL_KEEP_KEY

@tracer.wrap()
def handler():
    span = tracer.current_span()

    # Manually choose to drop healthcheck traces
    if is_healthcheck():
        span.set_tag(MANUAL_DROP_KEY)

    # Manually choose to keep error traces
    elif is_error():
        span.set_tag(MANUAL_KEEP_KEY)

```