### PR TITLE
bottle: fix query string embedded in URL

### DIFF
--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -54,7 +54,7 @@ class TracePlugin(object):
                     raise
                 finally:
                     s.set_tag(http.STATUS_CODE, code or response.status_code)
-                    s.set_tag(http.URL, request.url)
+                    s.set_tag(http.URL, request.urlparts._replace(query='').geturl())
                     s.set_tag(http.METHOD, request.method)
 
         return wrapped


### PR DESCRIPTION
There was no test checking that the query string was not part of the URL and it
was actually added. Fix that and add proper testing.