### PR TITLE
tornado: do not include query string in the http.url tag

### DIFF
--- a/ddtrace/contrib/tornado/handlers.py
+++ b/ddtrace/contrib/tornado/handlers.py
@@ -67,7 +67,7 @@ def on_finish(func, handler, args, kwargs):
         request_span.resource = '{}.{}'.format(klass.__module__, klass.__name__)
         request_span.set_tag('http.method', request.method)
         request_span.set_tag('http.status_code', handler.get_status())
-        request_span.set_tag('http.url', request.full_url())
+        request_span.set_tag(http.URL, request.full_url().rsplit('?', 1)[0])
         request_span.finish()
 
     return func(*args, **kwargs)

--- a/tests/contrib/tornado/test_safety.py
+++ b/tests/contrib/tornado/test_safety.py
@@ -99,7 +99,7 @@ class TestAppSafety(TornadoTestCase):
 
         request_span = traces[0][0]
         assert 'tests.contrib.tornado.web.app.SuccessHandler' == request_span.resource
-        assert self.get_url('/success/?magic_number=42') == request_span.get_tag(http.URL)
+        assert self.get_url('/success/') == request_span.get_tag(http.URL)
 
     def test_arbitrary_resource_404(self):
         # users inputs should not determine `span.resource` field

--- a/tests/contrib/tornado/test_tornado_web.py
+++ b/tests/contrib/tornado/test_tornado_web.py
@@ -12,9 +12,13 @@ class TestTornadoWeb(TornadoTestCase):
     """
     Ensure that Tornado web handlers are properly traced.
     """
-    def test_success_handler(self):
+    def test_success_handler(self, query_string=''):
         # it should trace a handler that returns 200
-        response = self.fetch('/success/')
+        if query_string:
+            fqs = '?' + query_string
+        else:
+            fqs = ''
+        response = self.fetch('/success/' + fqs)
         assert 200 == response.code
 
         traces = self.tracer.writer.pop_traces()
@@ -30,6 +34,9 @@ class TestTornadoWeb(TornadoTestCase):
         assert '200' == request_span.get_tag('http.status_code')
         assert self.get_url('/success/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
+
+    def test_success_handler_query_string(self):
+        self.test_success_handler('foo=bar')
 
     def test_nested_handler(self):
         # it should trace a handler that calls the tracer.trace() method


### PR DESCRIPTION
The query string used to be included in http.url tag for Tornado. Let's match
the behavior of other frameworks and remove it.