### PR TITLE
tests: always skip sdist, use develop mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,6 @@ httpbin_local: &httpbin_local
   name: httpbin.org
 test_runner: &test_runner
   image: datadog/docker-library:ddtrace_py
-  env:
-    TOX_SKIP_DIST: True
 restore_cache_step: &restore_cache_step
   restore_cache:
     keys:
@@ -113,7 +111,6 @@ jobs:
     docker:
       - <<: *test_runner
         env:
-          TOX_SKIP_DIST: True
           TEST_DATADOG_INTEGRATION: 1
       - image: datadog/docker-dd-agent
         env:
@@ -154,8 +151,6 @@ jobs:
     docker:
       - *test_runner
       - image: redis:4.0-alpine
-    environment:
-      TOX_SKIP_DIST: False
     resource_class: *resource_class
     steps:
       - checkout
@@ -243,7 +238,6 @@ jobs:
     docker:
       - <<: *test_runner
         env:
-          TOX_SKIP_DIST: True
           CASS_DRIVER_NO_EXTENSIONS: 1
       - image: spotify/cassandra:latest
         env:
@@ -260,9 +254,7 @@ jobs:
 
   celery:
     docker:
-      - <<: *test_runner
-        env:
-          TOX_SKIP_DIST: False
+      - *test_runner
       - image: redis:4.0-alpine
     resource_class: *resource_class
     steps:
@@ -322,8 +314,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: scripts/run-tox-scenario '^flask_\(cache_\)\?contrib-'
-      - run: TOX_SKIP_DIST=False scripts/run-tox-scenario '^flask_\(cache_\)\?contrib_autopatch-'
+      - run: scripts/run-tox-scenario '^flask_\(cache_\)\?contrib\(_autopatch\)\?-'
       - *persist_to_workspace_step
       - *save_cache_step
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,15 +3,6 @@
 # versions.
 
 [tox]
-# By default the tox process includes a 'dist'->'install'->'test' workflow.
-# Instead of creating a dist and install it at every step, some tests can directly use the source code to run
-# tests: `skipsdist=True`. This is much faster.
-# On the other hand, both autopatch tests and the ddtracerun test cannot use the source code as they required the
-# module to be installed.
-# This variable can be set to True in our circleci env to speed up the process, but still we default to false so
-# locally we can run `tox` without any further requirement.
-skipsdist={env:TOX_SKIP_DIST:False}
-
 # Our various test environments. The py*-all tasks will run the core
 # library tests and all contrib tests with the latest library versions.
 # The others will test specific versions of libraries.
@@ -129,6 +120,7 @@ envlist =
     unit_tests-{py27,py34,py35,py36,py37}
 
 [testenv]
+usedevelop = True
 basepython =
     py27: python2.7
     py34: python3.4


### PR DESCRIPTION
This should make installation faster and development easier.