### PR TITLE
Add a PeriodicWorker base class for periodic tasks

### DIFF
--- a/ddtrace/_worker.py
+++ b/ddtrace/_worker.py
@@ -1,0 +1,82 @@
+import atexit
+import threading
+import os
+
+from .internal.logger import get_logger
+
+_LOG = get_logger(__name__)
+
+
+class PeriodicWorkerThread(object):
+    """Periodic worker thread.
+
+    This class can be used to instantiate a worker thread that will run its `run_periodic` function every `interval`
+    seconds.
+
+    The method `on_shutdown` will be called on worker shutdown. The worker will be shutdown when the program exits and
+    can be waited for with the `exit_timeout` parameter.
+
+    """
+
+    _DEFAULT_INTERVAL = 1.0
+
+    def __init__(self, interval=_DEFAULT_INTERVAL, exit_timeout=None, name=None, daemon=True):
+        """Create a new worker thread that runs a function periodically.
+
+        :param interval: The interval in seconds to wait between calls to `run_periodic`.
+        :param exit_timeout: The timeout to use when exiting the program and waiting for the thread to finish.
+        :param name: Name of the worker.
+        :param daemon: Whether the worker should be a daemon.
+        """
+
+        self._thread = threading.Thread(target=self._target, name=name)
+        self._thread.daemon = daemon
+        self._stop = threading.Event()
+        self.interval = interval
+        self.exit_timeout = exit_timeout
+        atexit.register(self._atexit)
+
+    def _atexit(self):
+        self.stop()
+        if self.exit_timeout is not None:
+            key = 'ctrl-break' if os.name == 'nt' else 'ctrl-c'
+            _LOG.debug(
+                'Waiting %d seconds for %s to finish. Hit %s to quit.',
+                self.exit_timeout, self._thread.name, key,
+            )
+            self.join(self.exit_timeout)
+
+    def start(self):
+        """Start the periodic worker."""
+        _LOG.debug('Starting %s thread', self._thread.name)
+        self._thread.start()
+
+    def stop(self):
+        """Stop the worker."""
+        _LOG.debug('Stopping %s thread', self._thread.name)
+        self._stop.set()
+
+    def is_alive(self):
+        return self._thread.is_alive()
+
+    def join(self, timeout=None):
+        return self._thread.join(timeout)
+
+    def _target(self):
+        while not self._stop.wait(self.interval):
+            self.run_periodic()
+        self._on_shutdown()
+
+    @staticmethod
+    def run_periodic():
+        """Method executed every interval."""
+        pass
+
+    def _on_shutdown(self):
+        _LOG.debug('Shutting down %s thread', self._thread.name)
+        self.on_shutdown()
+
+    @staticmethod
+    def on_shutdown():
+        """Method ran on worker shutdown."""
+        pass

--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -1,7 +1,7 @@
-import threading
-import time
 import itertools
 
+
+from ... import _worker
 from ..logger import get_logger
 from .constants import (
     DEFAULT_RUNTIME_METRICS,
@@ -53,7 +53,7 @@ class RuntimeMetrics(RuntimeCollectorsIterable):
     ]
 
 
-class RuntimeWorker(object):
+class RuntimeWorker(_worker.PeriodicWorkerThread):
     """ Worker thread for collecting and writing runtime metrics to a DogStatsd
         client.
     """
@@ -61,33 +61,10 @@ class RuntimeWorker(object):
     FLUSH_INTERVAL = 10
 
     def __init__(self, statsd_client, flush_interval=FLUSH_INTERVAL):
-        self._stay_alive = None
-        self._thread = None
-        self._flush_interval = flush_interval
+        super(RuntimeWorker, self).__init__(interval=flush_interval,
+                                            name=self.__class__.__name__)
         self._statsd_client = statsd_client
         self._runtime_metrics = RuntimeMetrics()
-
-    def _target(self):
-        while self._stay_alive:
-            self.flush()
-            time.sleep(self._flush_interval)
-
-    def start(self):
-        if not self._thread:
-            log.debug('Starting {}'.format(self))
-            self._stay_alive = True
-            self._thread = threading.Thread(target=self._target)
-            self._thread.setDaemon(True)
-            self._thread.start()
-
-    def stop(self):
-        if self._thread and self._stay_alive:
-            log.debug('Stopping {}'.format(self))
-            self._stay_alive = False
-
-    def join(self, timeout=None):
-        if self._thread:
-            return self._thread.join(timeout)
 
     def _write_metric(self, key, value):
         log.debug('Writing metric {}:{}'.format(key, value))
@@ -100,6 +77,9 @@ class RuntimeWorker(object):
 
         for key, value in self._runtime_metrics:
             self._write_metric(key, value)
+
+    on_periodic = flush
+    on_shutdown = flush
 
     def reset(self):
         self._runtime_metrics = RuntimeMetrics()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,58 @@
+import pytest
+
+from ddtrace import _worker
+
+
+def test_start():
+    w = _worker.PeriodicWorkerThread()
+    w.start()
+    assert w.is_alive()
+    w.stop()
+    w.join()
+    assert not w.is_alive()
+
+
+def test_periodic():
+    results = []
+
+    class MyWorker(_worker.PeriodicWorkerThread):
+        @staticmethod
+        def run_periodic():
+            results.append(object())
+
+    w = MyWorker(interval=0, daemon=False)
+    w.start()
+    # results should be filled really quickly, but just in case the thread is a snail, wait
+    while not results:
+        pass
+    w.stop()
+    w.join()
+    assert results
+
+
+def test_on_shutdown():
+    results = []
+
+    class MyWorker(_worker.PeriodicWorkerThread):
+        @staticmethod
+        def on_shutdown():
+            results.append(object())
+
+    w = MyWorker()
+    w.start()
+    assert not results
+    w.stop()
+    w.join()
+    assert results
+
+
+def test_restart():
+    w = _worker.PeriodicWorkerThread()
+    w.start()
+    assert w.is_alive()
+    w.stop()
+    w.join()
+    assert not w.is_alive()
+
+    with pytest.raises(RuntimeError):
+        w.start()


### PR DESCRIPTION
There is at least 2 places (writer and runtime metric collectors) where the
code needs to start worker threads doing regular tasks.

This patch merge the existing code in a simple PeriodicWorker base class that
can be enhanced with custom code. It has the upside of using a
`threading.Event` rather than a sleep timer, making the exit code running as
soon as `stop()` is called.