### PR TITLE
Make sure to close out spans on exceptions in Django

### DIFF
--- a/tests/contrib/django/test_middleware.py
+++ b/tests/contrib/django/test_middleware.py
@@ -197,6 +197,8 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         assert span.get_tag(http.URL) == 'http://testserver/error-500/'
         assert span.resource == 'tests.contrib.django.app.views.error_500'
         assert 'Error 500' in span.get_tag('error.stack')
+        # confirm that the context was properly closed out
+        assert span._context._is_finished()
 
     def test_middleware_trace_callable_view(self):
         # ensures that the internals are properly traced when using callable views


### PR DESCRIPTION
From the Django docs:

>Django calls process_exception() when a view raises an exception. process_exception() should return either None or an HttpResponse object. If it returns an HttpResponse object, the template response and response middleware will be applied and the resulting response returned to the browser. Otherwise, default exception handling kicks in.

This means that when `process_exception` is called in `TraceExceptionMiddleware`, `process_response` of `TraceMiddeleware` is _not_ called, and the top level span is not closed. This can be witnessed by writing a test where you try to go to a view that 500s. After the response is finished the top-level request span will still be open