### PR TITLE
[core] Add config to set hostname tag on trace root span

### DIFF
--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -3,6 +3,7 @@ SAMPLE_RATE_METRIC_KEY = '_sample_rate'
 SAMPLING_PRIORITY_KEY = '_sampling_priority_v1'
 ANALYTICS_SAMPLE_RATE_KEY = '_dd1.sr.eausr'
 ORIGIN_KEY = '_dd.origin'
+HOSTNAME_KEY = '_dd.hostname'
 
 NUMERIC_TAGS = (ANALYTICS_SAMPLE_RATE_KEY, )
 

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -1,7 +1,9 @@
 import threading
 
-from .constants import SAMPLING_PRIORITY_KEY, ORIGIN_KEY
+from .constants import HOSTNAME_KEY, SAMPLING_PRIORITY_KEY, ORIGIN_KEY
 from .internal.logger import get_logger
+from .internal import hostname
+from .settings import config
 from .utils.formats import asbool, get_env
 
 log = get_logger(__name__)
@@ -190,6 +192,11 @@ class Context(object):
                 if sampled and origin is not None and trace:
                     trace[0].set_tag(ORIGIN_KEY, origin)
 
+                # Set hostname tag if they requested it
+                if config.report_hostname:
+                    # DEV: `get_hostname()` value is cached
+                    trace[0].set_tag(HOSTNAME_KEY, hostname.get_hostname())
+
                 # clean the current state
                 self._trace = []
                 self._finished_spans = 0
@@ -211,6 +218,11 @@ class Context(object):
                 # attach the origin to the root span tag
                 if sampled and origin is not None and trace:
                     trace[0].set_tag(ORIGIN_KEY, origin)
+
+                # Set hostname tag if they requested it
+                if config.report_hostname:
+                    # DEV: `get_hostname()` value is cached
+                    trace[0].set_tag(HOSTNAME_KEY, hostname.get_hostname())
 
                 # Any open spans will remain as `self._trace`
                 # Any finished spans will get returned to be flushed

--- a/ddtrace/internal/hostname.py
+++ b/ddtrace/internal/hostname.py
@@ -1,0 +1,20 @@
+import functools
+import socket
+
+_hostname = None
+
+
+def _cached(func):
+    @functools.wraps(func)
+    def wrapper():
+        global _hostname
+        if not _hostname:
+            _hostname = func()
+
+        return _hostname
+    return wrapper
+
+
+@_cached
+def get_hostname():
+    return socket.gethostname()

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -30,6 +30,10 @@ class Config(object):
             get_env('trace', 'analytics_enabled', default=legacy_config_value)
         )
 
+        self.report_hostname = asbool(
+            get_env('trace', 'report_hostname', default=False)
+        )
+
     def __getattr__(self, name):
         if name not in self._config:
             self._config[name] = IntegrationConfig(self, name)

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -55,12 +55,15 @@ class BaseTestCase(unittest.TestCase):
         """
         # DEV: Uses dict as interface but internally handled as attributes on Config instance
         analytics_enabled_original = ddtrace.config.analytics_enabled
+        report_hostname_original = ddtrace.config.report_hostname
 
         ddtrace.config.analytics_enabled = values.get('analytics_enabled', analytics_enabled_original)
+        ddtrace.config.report_hostname = values.get('report_hostname', report_hostname_original)
         try:
             yield
         finally:
             ddtrace.config.analytics_enabled = analytics_enabled_original
+            ddtrace.config.report_hostname = report_hostname_original
 
     @staticmethod
     @contextlib.contextmanager

--- a/tests/internal/test_hostname.py
+++ b/tests/internal/test_hostname.py
@@ -1,0 +1,14 @@
+import mock
+
+from ddtrace.internal.hostname import get_hostname
+
+
+@mock.patch('socket.gethostname')
+def test_get_hostname(socket_gethostname):
+    # Test that `get_hostname()` just returns `socket.gethostname`
+    socket_gethostname.return_value = 'test-hostname'
+    assert get_hostname() == 'test-hostname'
+
+    # Change the value returned by `socket.gethostname` to test the cache
+    socket_gethostname.return_value = 'new-hostname'
+    assert get_hostname() == 'test-hostname'


### PR DESCRIPTION
This PR adds the ability to tag trace root spans with the system hostname.