### PR TITLE
span: use system random source to generate span id

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -328,6 +328,9 @@ class Span(object):
         )
 
 
+_SystemRandom = random.SystemRandom()
+
+
 def _new_id():
     """Generate a random trace_id or span_id"""
-    return random.getrandbits(64)
+    return _SystemRandom.getrandbits(64)


### PR DESCRIPTION
The currently used random generator is not re-seeded on `os.fork` calls, making
span id collision a sure thing.

This is only a problem on Python 2 — Python 3 does not show this issue.

This patches changes the random number generator to use the system ones based
on urandom. This avoids the issue altogether.