### PR TITLE
payload: raise PayloadFull on full payload

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -7,7 +7,7 @@ from json import loads
 from .encoding import get_encoder, JSONEncoder
 from .compat import httplib, PYTHON_VERSION, PYTHON_INTERPRETER, get_connection_response
 from .internal.logger import get_logger
-from .payload import Payload
+from .payload import Payload, PayloadFull
 from .utils.deprecation import deprecated
 
 
@@ -148,23 +148,50 @@ class API(object):
         self._set_version(self._fallback)
 
     def send_traces(self, traces):
-        if not traces:
-            return
+        """Send traces to the API.
 
+        :param traces: A list of traces.
+        :return: The list of API HTTP responses.
+        """
         start = time.time()
+        responses = []
         payload = Payload(encoder=self._encoder)
         for trace in traces:
-            payload.add_trace(trace)
+            try:
+                payload.add_trace(trace)
+            except PayloadFull:
+                # Is payload full or is the trace too big?
+                # If payload is not empty, then using a new Payload might allow us to fit the trace.
+                # Let's flush the Payload and try to put the trace in a new empty Payload.
+                if not payload.empty:
+                    responses.append(self._flush(payload))
+                    # Create a new payload
+                    payload = Payload(encoder=self._encoder)
+                    try:
+                        # Add the trace that we were unable to add in that iteration
+                        payload.add_trace(trace)
+                    except PayloadFull:
+                        # If the trace does not fit in a payload on its own, that's bad. Drop it.
+                        log.warn('Trace %r is too big to fit in a payload, dropping it', trace)
 
+        # Check that the Payload is not empty:
+        # it could be empty if the last trace was too big to fit.
+        if not payload.empty:
+            responses.append(self._flush(payload))
+
+        log.debug('reported %d traces in %.5fs', len(traces), time.time() - start)
+
+        return responses
+
+    def _flush(self, payload):
         response = self._put(self._traces, payload.get_payload(), payload.length)
 
         # the API endpoint is not available so we should downgrade the connection and re-try the call
         if response.status in [404, 415] and self._fallback:
             log.debug("calling endpoint '%s' but received %s; downgrading API", self._traces, response.status)
             self._downgrade()
-            return self.send_traces(traces)
+            return self._flush(payload)
 
-        log.debug('reported %d traces in %.5fs', len(traces), time.time() - start)
         return response
 
     @deprecated(message='Sending services to the API is no longer necessary', version='1.0.0')

--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -184,7 +184,10 @@ class API(object):
         return responses
 
     def _flush(self, payload):
-        response = self._put(self._traces, payload.get_payload(), payload.length)
+        try:
+            response = self._put(self._traces, payload.get_payload(), payload.length)
+        except (httplib.HTTPException, IOError) as e:
+            return e
 
         # the API endpoint is not available so we should downgrade the connection and re-try the call
         if response.status in [404, 415] and self._fallback:

--- a/ddtrace/writer.py
+++ b/ddtrace/writer.py
@@ -83,6 +83,7 @@ class AsyncWorker(_worker.PeriodicWorkerThread):
             traces = self._apply_filters(traces)
         except Exception as err:
             log.error('error while filtering traces: {0}'.format(err))
+            return
 
         traces_responses = None
 

--- a/ddtrace/writer.py
+++ b/ddtrace/writer.py
@@ -88,11 +88,11 @@ class AsyncWorker(_worker.PeriodicWorkerThread):
 
         if traces:
             # If we have data, let's try to send it.
-            try:
-                traces_responses = self.api.send_traces(traces)
-            except Exception as err:
-                log.error('cannot send spans to {1}:{2}: {0}'.format(
-                    err, self.api.hostname, self.api.port))
+            traces_responses = self.api.send_traces(traces)
+            for response in traces_responses:
+                if isinstance(response, Exception):
+                    log.error('cannot send spans to {1}:{2}: {0}'.format(
+                        response, self.api.hostname, self.api.port))
 
         if self._priority_sampler and traces_responses:
             for traces_response in traces_responses:

--- a/ddtrace/writer.py
+++ b/ddtrace/writer.py
@@ -84,20 +84,21 @@ class AsyncWorker(_worker.PeriodicWorkerThread):
         except Exception as err:
             log.error('error while filtering traces: {0}'.format(err))
 
-        traces_response = None
+        traces_responses = None
 
         if traces:
             # If we have data, let's try to send it.
             try:
-                traces_response = self.api.send_traces(traces)
+                traces_responses = self.api.send_traces(traces)
             except Exception as err:
                 log.error('cannot send spans to {1}:{2}: {0}'.format(
                     err, self.api.hostname, self.api.port))
 
-        if self._priority_sampler and traces_response:
-            result_traces_json = traces_response.get_json()
-            if result_traces_json and 'rate_by_service' in result_traces_json:
-                self._priority_sampler.set_sample_rate_by_service(result_traces_json['rate_by_service'])
+        if self._priority_sampler and traces_responses:
+            for traces_response in traces_responses:
+                result_traces_json = traces_response.get_json()
+                if result_traces_json and 'rate_by_service' in result_traces_json:
+                    self._priority_sampler.set_sample_rate_by_service(result_traces_json['rate_by_service'])
 
         self._log_error_status(traces_response, 'traces')
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -252,21 +252,35 @@ class TestAPITransport(TestCase):
         request_call = mocked_http.return_value.request
         assert request_call.call_count == 0
 
+    def _send_traces_and_check(self, traces, nresponses=1):
+        # test JSON encoder
+        responses = self.api_json.send_traces(traces)
+        assert len(responses) == nresponses
+        for response in responses:
+            assert response.status == 200
+
+        # test Msgpack encoder
+        responses = self.api_msgpack.send_traces(traces)
+        assert len(responses) == nresponses
+        for response in responses:
+            assert response.status == 200
+
     def test_send_single_trace(self):
         # register a single trace with a span and send them to the trace agent
         self.tracer.trace('client.testing').finish()
         trace = self.tracer.writer.pop()
         traces = [trace]
 
-        # test JSON encoder
-        response = self.api_json.send_traces(traces)
-        assert response
-        assert response.status == 200
+        self._send_traces_and_check(traces)
 
-        # test Msgpack encoder
-        response = self.api_msgpack.send_traces(traces)
-        assert response
-        assert response.status == 200
+    def test_send_many_traces(self):
+        # register a single trace with a span and send them to the trace agent
+        self.tracer.trace('client.testing').finish()
+        trace = self.tracer.writer.pop()
+        # 30k is a right number to have both json and msgpack send 2 payload :)
+        traces = [trace] * 30000
+
+        self._send_traces_and_check(traces, 2)
 
     def test_send_single_with_wrong_errors(self):
         # if the error field is set to True, it must be cast as int so
@@ -278,15 +292,7 @@ class TestAPITransport(TestCase):
         trace = self.tracer.writer.pop()
         traces = [trace]
 
-        # test JSON encoder
-        response = self.api_json.send_traces(traces)
-        assert response
-        assert response.status == 200
-
-        # test Msgpack encoder
-        response = self.api_msgpack.send_traces(traces)
-        assert response
-        assert response.status == 200
+        self._send_traces_and_check(traces)
 
     def test_send_multiple_traces(self):
         # register some traces and send them to the trace agent
@@ -296,15 +302,7 @@ class TestAPITransport(TestCase):
         trace_2 = self.tracer.writer.pop()
         traces = [trace_1, trace_2]
 
-        # test JSON encoder
-        response = self.api_json.send_traces(traces)
-        assert response
-        assert response.status == 200
-
-        # test Msgpack encoder
-        response = self.api_msgpack.send_traces(traces)
-        assert response
-        assert response.status == 200
+        self._send_traces_and_check(traces)
 
     def test_send_single_trace_multiple_spans(self):
         # register some traces and send them to the trace agent
@@ -313,15 +311,7 @@ class TestAPITransport(TestCase):
         trace = self.tracer.writer.pop()
         traces = [trace]
 
-        # test JSON encoder
-        response = self.api_json.send_traces(traces)
-        assert response
-        assert response.status == 200
-
-        # test Msgpack encoder
-        response = self.api_msgpack.send_traces(traces)
-        assert response
-        assert response.status == 200
+        self._send_traces_and_check(traces)
 
     def test_send_multiple_traces_multiple_spans(self):
         # register some traces and send them to the trace agent
@@ -335,15 +325,7 @@ class TestAPITransport(TestCase):
 
         traces = [trace_1, trace_2]
 
-        # test JSON encoder
-        response = self.api_json.send_traces(traces)
-        assert response
-        assert response.status == 200
-
-        # test Msgpack encoder
-        response = self.api_msgpack.send_traces(traces)
-        assert response
-        assert response.status == 200
+        self._send_traces_and_check(traces)
 
     def test_send_single_service(self):
         # register some services and send them to the trace agent
@@ -457,16 +439,16 @@ class TestRateByService(TestCase):
         # - make sure the priority sampler (if enabled) is updated
 
         # test JSON encoder
-        response = self.api_json.send_traces(traces)
-        assert response
-        assert response.status == 200
-        assert response.get_json() == dict(rate_by_service={'service:,env:': 1})
+        responses = self.api_json.send_traces(traces)
+        assert len(responses) == 1
+        assert responses[0].status == 200
+        assert responses[0].get_json() == dict(rate_by_service={'service:,env:': 1})
 
         # test Msgpack encoder
-        response = self.api_msgpack.send_traces(traces)
-        assert response
-        assert response.status == 200
-        assert response.get_json() == dict(rate_by_service={'service:,env:': 1})
+        responses = self.api_msgpack.send_traces(traces)
+        assert len(responses) == 1
+        assert responses[0].status == 200
+        assert responses[0].get_json() == dict(rate_by_service={'service:,env:': 1})
 
 
 @skipUnless(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -164,7 +164,7 @@ class TestWorkers(TestCase):
 
         logged_errors = log_handler.messages['error']
         assert len(logged_errors) == 1
-        assert 'failed_to_send traces to Datadog Agent: ' \
+        assert 'Failed to send traces to Datadog Agent at localhost:8126: ' \
             'HTTP error status 400, reason Bad Request, message Content-Type:' \
             in logged_errors[0]
 


### PR DESCRIPTION
Rather than trying to guess if we're going to hit the maximum size, actually
raise a PayloadFull exception when the payload is full and let the caller
handle the problem. This should divide the number of API call by 2 when a lot
of traces are being sent at once.

This patch also fixes the hypothetical case where a trace wouldn't fit in a
single Payload.

This also makes sure we don't re-build the payload when we need to downgrade
the API by splitting out the _flush method out of the `send_traces` method.