### PR TITLE
writer: log a message when a trace is dropped

### DIFF
--- a/ddtrace/writer.py
+++ b/ddtrace/writer.py
@@ -159,6 +159,7 @@ class Q(Queue):
                 if qsize != 0:
                     idx = random.randrange(0, qsize)
                     self.queue[idx] = item
+                    log.warn('Writer queue is full has more than %d traces, some traces will be lost', self.maxsize)
                     return
             # The queue has been emptied, simply retry putting item
             return self.put(item)


### PR DESCRIPTION
There's no way to know that the queue is getting full and that some traces are
dropped. At least write a log message so the user knows something's wrong.