### PR TITLE
Record HTTP status code correctly when using abort() with Bottle

### DIFF
--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -1,5 +1,5 @@
 # 3p
-from bottle import response, request
+from bottle import response, request, HTTPError
 
 # stdlib
 import ddtrace
@@ -47,6 +47,11 @@ class TracePlugin(object):
                 code = 0
                 try:
                     return callback(*args, **kwargs)
+                except HTTPError as e:
+                    # you can interrupt flows using abort(status_code, 'message')...
+                    # we need to respect the defined status_code.
+                    code = e.status_code
+                    raise
                 except Exception:
                     # bottle doesn't always translate unhandled exceptions, so
                     # we mark it here.

--- a/tests/contrib/bottle/test.py
+++ b/tests/contrib/bottle/test.py
@@ -97,7 +97,7 @@ class TraceBottleTest(BaseTracerTestCase):
     def test_abort(self):
         @self.app.route('/hi')
         def hi():
-            raise bottle.abort(420,  'Enhance Your Calm')
+            raise bottle.abort(420, 'Enhance Your Calm')
         self._trace_app(self.tracer)
 
         # make a request

--- a/tests/contrib/bottle/test.py
+++ b/tests/contrib/bottle/test.py
@@ -104,7 +104,7 @@ class TraceBottleTest(BaseTracerTestCase):
         try:
             resp = self.app.get('/hi')
             assert resp.status_int == 420
-        except Exception as e:
+        except Exception:
             pass
 
         spans = self.tracer.writer.pop()


### PR DESCRIPTION
Datadog isn't recording the correct HTTP status code when using `abort(status_code, 'message)`.

This PR fix this issue.

Thanks.
