### PR TITLE
[tests] fix threading synchronization to opentracer test

### DIFF
--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -296,23 +296,35 @@ class TestTracer(object):
         """
         import threading
 
+        # synchronize threads with a threading event object
+        event = threading.Event()
+
         def trace_one():
             id = 11
             with ot_tracer.start_active_span(str(id)):
+                event.set()
                 id += 1
+                event.wait()
                 with ot_tracer.start_active_span(str(id)):
+                    event.set()
                     id += 1
+                    event.wait()
                     with ot_tracer.start_active_span(str(id)):
-                        pass
+                        event.set()
 
         def trace_two():
             id = 21
+            event.wait()
             with ot_tracer.start_active_span(str(id)):
+                event.set()
                 id += 1
+                event.wait()
                 with ot_tracer.start_active_span(str(id)):
+                    event.set()
                     id += 1
+                event.wait()
                 with ot_tracer.start_active_span(str(id)):
-                    pass
+                    event.set()
 
         # the ordering should be
         # t1.span1/t2.span1, t2.span2, t1.span2, t1.span3, t2.span3


### PR DESCRIPTION
The `opentracer` tests failed in CI on a test where spans written by two threads were expected to be in a specific order, but this was not stable. This PR adds thread synchronization to ensure the order for spans is as expected.

Fixes #893