### PR TITLE
Support keyword 'target' parameter when wrapping GRPC channels

### DIFF
--- a/ddtrace/contrib/grpc/patch.py
+++ b/ddtrace/contrib/grpc/patch.py
@@ -31,7 +31,7 @@ def unpatch():
 def _insecure_channel_with_interceptor(wrapped, instance, args, kwargs):
     channel = wrapped(*args, **kwargs)
 
-    if kwargs.get('target'):
+    if 'target' in kwargs:
         target = kwargs['target']
     else:
         target = args[0]
@@ -44,7 +44,7 @@ def _insecure_channel_with_interceptor(wrapped, instance, args, kwargs):
 def _secure_channel_with_interceptor(wrapped, instance, args, kwargs):
     channel = wrapped(*args, **kwargs)
 
-    if kwargs.get('target'):
+    if 'target' in kwargs:
         target = kwargs['target']
     else:
         target = args[0]

--- a/ddtrace/contrib/grpc/patch.py
+++ b/ddtrace/contrib/grpc/patch.py
@@ -30,7 +30,12 @@ def unpatch():
 
 def _insecure_channel_with_interceptor(wrapped, instance, args, kwargs):
     channel = wrapped(*args, **kwargs)
-    target = args[0]
+
+    if kwargs.get('target'):
+        target = kwargs['target']
+    else:
+        target = args[0]
+
     (host, port) = get_host_port(target)
     channel = _intercept_channel(channel, host, port)
     return channel
@@ -38,7 +43,12 @@ def _insecure_channel_with_interceptor(wrapped, instance, args, kwargs):
 
 def _secure_channel_with_interceptor(wrapped, instance, args, kwargs):
     channel = wrapped(*args, **kwargs)
-    target = args[0]
+
+    if kwargs.get('target'):
+        target = kwargs['target']
+    else:
+        target = args[0]
+
     (host, port) = get_host_port(target)
     channel = _intercept_channel(channel, host, port)
     return channel

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -43,7 +43,8 @@ class GrpcTestCase(BaseTracerTestCase):
 
     def test_insecure_channel(self):
         # Create a channel and send one request to the server
-        with grpc.insecure_channel('localhost:%d' % (GRPC_PORT)) as channel:
+        target = 'localhost:%d' % (GRPC_PORT)
+        with grpc.insecure_channel(target=target) as channel:
             stub = HelloStub(channel)
             response = stub.SayHello(HelloRequest(name='test'))
 
@@ -62,7 +63,8 @@ class GrpcTestCase(BaseTracerTestCase):
 
     def test_secure_channel(self):
         # Create a channel and send one request to the server
-        with grpc.secure_channel('localhost:%d' % (GRPC_PORT), credentials=grpc.ChannelCredentials(None)) as channel:
+        target = 'localhost:%d' % (GRPC_PORT)
+        with grpc.secure_channel(target=target, credentials=grpc.ChannelCredentials(None)) as channel:
             stub = HelloStub(channel)
             response = stub.SayHello(HelloRequest(name='test'))
 

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -41,10 +41,20 @@ class GrpcTestCase(BaseTracerTestCase):
         self.assertEqual(span.meta['grpc.host'], 'localhost')
         self.assertEqual(span.meta['grpc.port'], '50531')
 
-    def test_insecure_channel(self):
+    def test_insecure_channel_using_args_parameter(self):
+        def insecure_channel_using_args(target):
+            return grpc.insecure_channel(target)
+        self._test_insecure_channel(insecure_channel_using_args)
+
+    def test_insecure_channel_using_kwargs_parameter(self):
+        def insecure_channel_using_kwargs(target):
+            return grpc.insecure_channel(target=target)
+        self._test_insecure_channel(insecure_channel_using_kwargs)
+
+    def _test_insecure_channel(self, insecure_channel_function):
         # Create a channel and send one request to the server
         target = 'localhost:%d' % (GRPC_PORT)
-        with grpc.insecure_channel(target=target) as channel:
+        with insecure_channel_function(target) as channel:
             stub = HelloStub(channel)
             response = stub.SayHello(HelloRequest(name='test'))
 
@@ -61,10 +71,20 @@ class GrpcTestCase(BaseTracerTestCase):
         )
         self._check_span(span)
 
-    def test_secure_channel(self):
+    def test_secure_channel_using_args_parameter(self):
+        def secure_channel_using_args(target, **kwargs):
+            return grpc.secure_channel(target, **kwargs)
+        self._test_secure_channel(secure_channel_using_args)
+
+    def test_secure_channel_using_kwargs_parameter(self):
+        def secure_channel_using_kwargs(target, **kwargs):
+            return grpc.secure_channel(target=target, **kwargs)
+        self._test_secure_channel(secure_channel_using_kwargs)
+
+    def _test_secure_channel(self, secure_channel_function):
         # Create a channel and send one request to the server
         target = 'localhost:%d' % (GRPC_PORT)
-        with grpc.secure_channel(target=target, credentials=grpc.ChannelCredentials(None)) as channel:
+        with secure_channel_function(target, credentials=grpc.ChannelCredentials(None)) as channel:
             stub = HelloStub(channel)
             response = stub.SayHello(HelloRequest(name='test'))
 


### PR DESCRIPTION
The `target` for a GRPC channel can be specified with a keyword argument instead of a positional argument in both the function `grpc.insecure_channel` and `grpc.secure_channel`. See, for example, this [usage](https://github.com/googleapis/google-cloud-python/blob/4166ddbf1f8b07c2a5e2db8f7955457b5cedd82d/pubsub/google/cloud/pubsub_v1/publisher/client.py#L70-L72) in the official google pubsub client.

Currently, the datadog patch only uses the positional argument to get the `target` parameter, which throws the following exception if the keyword argument is used by a client:

```
>       target = args[0]
E       IndexError: tuple index out of range
```

For a simple example of client code that reproduces this error, see this [gist](https://gist.github.com/asnr/8f4fdffef9bccb7d4632ae2a4968ee0b).


### Testing

I wasn't sure what the best way of testing this behaviour was. I settled on changing two existing tests to specify `target` using a keyword argument, but there might be a better way. I'd be happy to hear any suggestions.