### PR TITLE
[tests] Fix thread synchronization

### DIFF
--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -302,12 +302,11 @@ class TestTracer(object):
         def trace_one():
             id = 11
             with ot_tracer.start_active_span(str(id)):
-                event.set()
                 id += 1
                 with ot_tracer.start_active_span(str(id)):
                     id += 1
                     with ot_tracer.start_active_span(str(id)):
-                        pass
+                        event.set()
 
         def trace_two():
             id = 21

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -304,27 +304,20 @@ class TestTracer(object):
             with ot_tracer.start_active_span(str(id)):
                 event.set()
                 id += 1
-                event.wait()
                 with ot_tracer.start_active_span(str(id)):
-                    event.set()
                     id += 1
-                    event.wait()
                     with ot_tracer.start_active_span(str(id)):
-                        event.set()
+                        pass
 
         def trace_two():
             id = 21
             event.wait()
             with ot_tracer.start_active_span(str(id)):
-                event.set()
                 id += 1
-                event.wait()
                 with ot_tracer.start_active_span(str(id)):
-                    event.set()
                     id += 1
-                event.wait()
                 with ot_tracer.start_active_span(str(id)):
-                    event.set()
+                    pass
 
         # the ordering should be
         # t1.span1/t2.span1, t2.span2, t1.span2, t1.span3, t2.span3


### PR DESCRIPTION
The addition of event synchronization for threads in #924 still left the possibility for the second thread to start writing spans before the first. This PR ensures that the second waits for the first to start a span context.

```
=================================== FAILURES ===================================
_________________ TestTracer.test_start_span_multi_intertwined _________________

self = <tests.opentracer.test_tracer.TestTracer object at 0x7f168001ae48>
ot_tracer = <ddtrace.opentracer.tracer.Tracer object at 0x7f168001a208>
writer = <tests.utils.tracer.DummyWriter object at 0x7f16800845c0>

    def test_start_span_multi_intertwined(self, ot_tracer, writer):
        """Start multiple spans at the top level intertwined.
        Alternate calling between two traces.
        """
        import threading
    
        # synchronize threads with a threading event object
        event = threading.Event()
    
        def trace_one():
            id = 11
            with ot_tracer.start_active_span(str(id)):
                event.set()
                id += 1
                event.wait()
                with ot_tracer.start_active_span(str(id)):
                    event.set()
                    id += 1
                    event.wait()
                    with ot_tracer.start_active_span(str(id)):
                        event.set()
    
        def trace_two():
            id = 21
            event.wait()
            with ot_tracer.start_active_span(str(id)):
                event.set()
                id += 1
                event.wait()
                with ot_tracer.start_active_span(str(id)):
                    event.set()
                    id += 1
                event.wait()
                with ot_tracer.start_active_span(str(id)):
                    event.set()
    
        # the ordering should be
        # t1.span1/t2.span1, t2.span2, t1.span2, t1.span3, t2.span3
        t1 = threading.Thread(target=trace_one)
        t2 = threading.Thread(target=trace_two)
    
        t1.start()
        t2.start()
        # wait for threads to finish
        t1.join()
        t2.join()
    
        spans = writer.pop()
    
        # trace_one will finish before trace_two so its spans should be written
        # before the spans from trace_two, let's confirm this
>       assert spans[0].name == '11'
E       AssertionError: assert '21' == '11'
E         - 21
E         + 11

tests/opentracer/test_tracer.py:344: AssertionError
===================== 1 failed, 63 passed in 0.46 seconds ======================
```