### PR TITLE
make psutil requirement more accurate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup_kwargs = dict(
     license='BSD',
     packages=find_packages(exclude=['tests*']),
     install_requires=[
-        'psutil',
+        'psutil>=5.0.0',
     ],
     extras_require={
         # users can include opentracing by having:


### PR DESCRIPTION
PSUtilRuntimeMetricCollector uses `.oneshot` which only comes with version 5 or higher.