### PR TITLE
fix documentation for current_root_span

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -387,7 +387,8 @@ class Tracer(object):
             # get the root span
             root_span = tracer.current_root_span()
             # set the host just once on the root span
-            root_span.set_tag('host', '127.0.0.1')
+            if root_span:
+                root_span.set_tag('host', '127.0.0.1')
         """
         ctx = self.get_call_context()
         if ctx:


### PR DESCRIPTION
the function may return `None`. guard against that in the example