### PR TITLE
[tests] Add benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,7 +682,14 @@ jobs:
     steps:
       - checkout
       - *restore_cache_step
-      - run: scripts/run-tox-scenario '^benchmarks-'
+      - run:
+          command: |
+            mkdir -p /tmp/test-reports
+            tox -e 'benchmarks-{py27,py34,py35,py36,py37}' --result-json /tmp/benchmarks.results -- --benchmark-storage=file:///tmp/test-reports/ --benchmark-autosave
+      - store_test_results:
+          path: /tmp/test-reports
+      - store_artifacts:
+          path: /tmp/test-reports
       - *persist_to_workspace_step
       - *save_cache_step
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -675,6 +675,17 @@ jobs:
       - *persist_to_workspace_step
       - *save_cache_step
 
+  benchmarks:
+    docker:
+      - *test_runner
+    resource_class: *resource_class
+    steps:
+      - checkout
+      - *restore_cache_step
+      - run: scripts/run-tox-scenario '^benchmarks-'
+      - *persist_to_workspace_step
+      - *save_cache_step
+
   deploy_dev:
     # build the master branch releasing development docs and wheels
     docker:
@@ -804,6 +815,9 @@ workflows:
           requires:
             - flake8
       - algoliasearch:
+          requires:
+            - flake8
+      - benchmarks:
           requires:
             - flake8
       - boto:
@@ -951,6 +965,7 @@ workflows:
             - aiopg
             - asyncio
             - algoliasearch
+            - benchmarks
             - boto
             - bottle
             - cassandra

--- a/README.md
+++ b/README.md
@@ -88,12 +88,3 @@ the CLI can be found at https://circleci.com/docs/2.0/local-cli/.
 After installing the `circleci` CLI, you can run jobs by name. For example:
 
     $ circleci build --job django
-
-
-### Benchmarking
-
-When two or more approaches must be compared, please write a benchmark in the
-[benchmark.py](tests/benchmark.py) module so that we can measure the efficiency
-of the algorithm. To run your benchmark, just:
-
-    $ python -m tests.benchmark

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -13,13 +13,8 @@ def tracer():
 
 def test_tracer_context(benchmark, tracer):
     def func(tracer):
-        with tracer.trace('a', service='s', resource='r', span_type='t') as s:
-            s.set_tag('a', 'b')
-            s.set_tag('b', 1)
-            with tracer.trace('another.thing'):
-                pass
-            with tracer.trace('another.thing'):
-                pass
+        with tracer.trace('a', service='s', resource='r', span_type='t'):
+            pass
 
     benchmark(func, tracer)
 
@@ -54,3 +49,44 @@ def test_tracer_wrap_instancemethod(benchmark, tracer):
 
     f = Foo()
     benchmark(f.func)
+
+
+def test_tracer_start_span(benchmark, tracer):
+    benchmark(tracer.start_span, 'benchmark')
+
+
+def test_tracer_start_finish_span(benchmark, tracer):
+    def func(tracer):
+        s = tracer.start_span('benchmark')
+        s.finish()
+
+    benchmark(func, tracer)
+
+
+def test_trace_simple_trace(benchmark, tracer):
+    def func(tracer):
+        with tracer.trace('parent'):
+            for i in range(5):
+                with tracer.trace('child') as c:
+                    c.set_tag('i', i)
+
+    benchmark(func, tracer)
+
+
+def test_tracer_large_trace(benchmark, tracer):
+    import random
+
+    # generate trace with 1024 spans
+    @tracer.wrap()
+    def func(tracer, level=0):
+        span = tracer.current_span()
+
+        # do some work
+        num = random.randint(1, 10)
+        span.set_tag('num', num)
+
+        if level < 10:
+            func(tracer, level+1)
+            func(tracer, level+1)
+
+    benchmark(func, tracer)

--- a/tox.ini
+++ b/tox.ini
@@ -118,6 +118,7 @@ envlist =
     py37-opentracer_gevent-gevent{13,14}
 # Unit tests: pytest based test suite that do not require any additional dependency
     unit_tests-{py27,py34,py35,py36,py37}
+    benchmarks-{py27,py34,py35,py36,py37}
 
 [testenv]
 usedevelop = True
@@ -134,6 +135,7 @@ deps =
     !ddtracerun: wrapt
     !msgpack03-!msgpack04-!msgpack05-!ddtracerun: msgpack-python
     pytest>=3
+    pytest-benchmark
     opentracing
     psutil
 # test dependencies installed in all envs
@@ -389,6 +391,7 @@ commands =
     test_logging: pytest {posargs} tests/contrib/logging/
 # Unit tests: pytest based test suite that do not require any additional dependency.
     unit_tests: pytest {posargs} tests/unit
+    benchmarks: pytest {posargs} tests/benchmark.py
 
 setenv =
     DJANGO_SETTINGS_MODULE = app.settings

--- a/tox.ini
+++ b/tox.ini
@@ -391,7 +391,7 @@ commands =
     test_logging: pytest {posargs} tests/contrib/logging/
 # Unit tests: pytest based test suite that do not require any additional dependency.
     unit_tests: pytest {posargs} tests/unit
-    benchmarks: pytest {posargs} tests/benchmark.py
+    benchmarks: pytest --benchmark-only {posargs} tests/benchmark.py
 
 setenv =
     DJANGO_SETTINGS_MODULE = app.settings


### PR DESCRIPTION
This PR adopts `pytest-benchmarks` for writing benchmarks, adds new benchmarks for the tracer, and includes reporting benchmarks results in the CI.