### PR TITLE
tox: fix ignore path for integrations

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -323,7 +323,7 @@ passenv=TEST_*
 
 commands =
 # run only essential tests related to the tracing client
-    tracer: pytest {posargs} --ignore="tests/contrib" --ignore="tests/integration" --ignore="tests/commands" --ignore="tests/opentracer" --ignore="tests/unit" --ignore="tests/internal" tests
+    tracer: pytest {posargs} --ignore="tests/contrib" --ignore="tests/test_integration.py" --ignore="tests/commands" --ignore="tests/opentracer" --ignore="tests/unit" --ignore="tests/internal" tests
 # run only the `ddtrace.internal` tests
     internal: pytest {posargs} tests/internal
 # run only the opentrace tests


### PR DESCRIPTION
tests/integration does not exists; the file tests/test_integration.py is more
likely what we want to ignore.