### PR TITLE
Run flake8 with Python 3

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -18,7 +18,8 @@ DD_LOG_FORMAT = '%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] 
 
 if logs_injection:
     # immediately patch logging if trace id injected
-    from ddtrace import patch; patch(logging=True)  # noqa
+    from ddtrace import patch
+    patch(logging=True)
 
 debug = os.environ.get('DATADOG_TRACE_DEBUG')
 
@@ -108,7 +109,8 @@ try:
 
     if patch:
         update_patched_modules()
-        from ddtrace import patch_all; patch_all(**EXTRA_PATCHED_MODULES) # noqa
+        from ddtrace import patch_all
+        patch_all(**EXTRA_PATCHED_MODULES)
 
     debug = os.environ.get('DATADOG_TRACE_DEBUG')
     if debug and debug.lower() == 'true':
@@ -143,6 +145,6 @@ try:
     # properly loaded without exceptions. This must be the last action in the module
     # when the execution ends with a success.
     loaded = True
-except Exception as e:
+except Exception:
     loaded = False
     log.warn('error configuring Datadog tracing', exc_info=True)

--- a/ddtrace/commands/ddtrace_run.py
+++ b/ddtrace/commands/ddtrace_run.py
@@ -34,7 +34,7 @@ Available environment variables:
                            (e.g. pylons, flask, django)
                            For tracing without a web integration, prefer setting the service name in code.
     DATADOG_PRIORITY_SAMPLING=true|false : (default: false): enables Priority Sampling.
-""" # noqa
+"""  # noqa: E501
 
 
 def _ddtrace_root():

--- a/ddtrace/contrib/aiobotocore/patch.py
+++ b/ddtrace/contrib/aiobotocore/patch.py
@@ -49,7 +49,7 @@ class WrappedClientResponseContentProxy(wrapt.ObjectProxy):
             span.span_type = self._self_parent_span.span_type
             span.meta = dict(self._self_parent_span.meta)
 
-            result = yield from self.__wrapped__.read(*args, **kwargs)  # noqa: E999
+            result = yield from self.__wrapped__.read(*args, **kwargs)
             span.set_tag('Length', len(result))
 
         return result
@@ -72,7 +72,7 @@ class WrappedClientResponseContentProxy(wrapt.ObjectProxy):
 def _wrapped_api_call(original_func, instance, args, kwargs):
     pin = Pin.get_from(instance)
     if not pin or not pin.enabled():
-        result = yield from original_func(*args, **kwargs)  # noqa: E999
+        result = yield from original_func(*args, **kwargs)
         return result
 
     endpoint_name = deep_getattr(instance, '_endpoint._endpoint_prefix')
@@ -99,7 +99,7 @@ def _wrapped_api_call(original_func, instance, args, kwargs):
         }
         span.set_tags(meta)
 
-        result = yield from original_func(*args, **kwargs)  # noqa: E999
+        result = yield from original_func(*args, **kwargs)
 
         body = result.get('Body')
         if isinstance(body, ClientResponseContentProxy):

--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -60,7 +60,7 @@ def trace_middleware(app, handler):
         request[REQUEST_CONTEXT_KEY] = request_span.context
         request[REQUEST_SPAN_KEY] = request_span
         try:
-            response = yield from handler(request)  # noqa: E999
+            response = yield from handler(request)
             return response
         except Exception:
             request_span.set_traceback()

--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -23,7 +23,7 @@ class AIOTracedCursor(wrapt.ObjectProxy):
     def _trace_method(self, method, resource, extra_tags, *args, **kwargs):
         pin = Pin.get_from(self)
         if not pin or not pin.enabled():
-            result = yield from method(*args, **kwargs)  # noqa: E999
+            result = yield from method(*args, **kwargs)
             return result
         service = pin.service
 
@@ -44,7 +44,7 @@ class AIOTracedCursor(wrapt.ObjectProxy):
                 result = yield from method(*args, **kwargs)
                 return result
             finally:
-                s.set_metric("db.rowcount", self.rowcount)
+                s.set_metric('db.rowcount', self.rowcount)
 
     @asyncio.coroutine
     def executemany(self, query, *args, **kwargs):
@@ -52,7 +52,7 @@ class AIOTracedCursor(wrapt.ObjectProxy):
         # with different libs.
         result = yield from self._trace_method(
             self.__wrapped__.executemany, query, {'sql.executemany': 'true'},
-            query, *args, **kwargs)  # noqa: E999
+            query, *args, **kwargs)
         return result
 
     @asyncio.coroutine
@@ -64,7 +64,7 @@ class AIOTracedCursor(wrapt.ObjectProxy):
     @asyncio.coroutine
     def callproc(self, proc, args):
         result = yield from self._trace_method(
-            self.__wrapped__.callproc, proc, {}, proc, args)  # noqa: E999
+            self.__wrapped__.callproc, proc, {}, proc, args)
         return result
 
 
@@ -88,7 +88,7 @@ class AIOTracedConnection(wrapt.ObjectProxy):
 
     @asyncio.coroutine
     def _cursor(self, *args, **kwargs):
-        cursor = yield from self.__wrapped__._cursor(*args, **kwargs)  # noqa: E999
+        cursor = yield from self.__wrapped__._cursor(*args, **kwargs)
         pin = Pin.get_from(self)
         if not pin:
             return cursor

--- a/ddtrace/contrib/aiopg/patch.py
+++ b/ddtrace/contrib/aiopg/patch.py
@@ -32,7 +32,7 @@ def unpatch():
 
 @asyncio.coroutine
 def patched_connect(connect_func, _, args, kwargs):
-    conn = yield from connect_func(*args, **kwargs)  # noqa: E999
+    conn = yield from connect_func(*args, **kwargs)
     return psycppg_patch_conn(conn, traced_conn_cls=AIOTracedConnection)
 
 

--- a/ddtrace/contrib/asyncio/helpers.py
+++ b/ddtrace/contrib/asyncio/helpers.py
@@ -25,7 +25,7 @@ def set_call_context(task, ctx):
     setattr(task, CONTEXT_ATTR, ctx)
 
 
-def ensure_future(coro_or_future, *, loop=None, tracer=None):  # noqa: E999
+def ensure_future(coro_or_future, *, loop=None, tracer=None):
     """
     Wrapper for the asyncio.ensure_future() function that
     sets a context to the newly created Task. If the current

--- a/tests/contrib/aiobotocore/py35/test.py
+++ b/tests/contrib/aiobotocore/py35/test.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-# DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from `async`
 import aiobotocore
 
 from ddtrace.contrib.aiobotocore.patch import patch, unpatch
@@ -37,7 +35,7 @@ class AIOBotocoreTest(AsyncioTestCase):
 
         traces = self.tracer.writer.pop_traces()
 
-        version = aiobotocore.__version__.split(".")
+        version = aiobotocore.__version__.split('.')
         pre_08 = int(version[0]) == 0 and int(version[1]) < 8
         # Version 0.8+ generates only one span for reading an object.
         if pre_08:

--- a/tests/contrib/aiobotocore/test.py
+++ b/tests/contrib/aiobotocore/test.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-# DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from `yield from`
 import aiobotocore
 from botocore.errorfactory import ClientError
 
@@ -126,7 +124,7 @@ class AIOBotocoreTest(AsyncioTestCase):
             yield from response['Body'].read()
 
         traces = self.tracer.writer.pop_traces()
-        version = aiobotocore.__version__.split(".")
+        version = aiobotocore.__version__.split('.')
         pre_08 = int(version[0]) == 0 and int(version[1]) < 8
         if pre_08:
             self.assertEqual(len(traces), 2)
@@ -247,7 +245,7 @@ class AIOBotocoreTest(AsyncioTestCase):
 
         with ot_tracer.start_active_span('ot_outer_span'):
             with aiobotocore_client('ec2', self.tracer) as ec2:
-                    yield from ec2.describe_instances()
+                yield from ec2.describe_instances()
 
         traces = self.tracer.writer.pop_traces()
         print(traces)

--- a/tests/contrib/aiohttp/app/web.py
+++ b/tests/contrib/aiohttp/app/web.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import os
 import jinja2
 import asyncio
@@ -60,6 +59,7 @@ def route_sub_span(request):
     with tracer.trace('aiohttp.sub_span') as span:
         span.set_tag('sub_span', 'true')
         return web.Response(text='OK')
+
 
 @asyncio.coroutine
 def coro_2(request):

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import asyncio
 
 from aiohttp.test_utils import unittest_run_loop
@@ -30,7 +29,7 @@ class TestTraceMiddleware(TraceTestCase):
         request = yield from self.client.request('GET', '/')
         assert 200 == request.status
         text = yield from request.text()
-        assert "What's tracing?" == text
+        assert 'What\'s tracing?' == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         assert 1 == len(traces)
@@ -73,11 +72,11 @@ class TestTraceMiddleware(TraceTestCase):
 
     @unittest_run_loop
     def test_query_string(self):
-        return self._test_param_handler("foo=bar")
+        return self._test_param_handler('foo=bar')
 
     @unittest_run_loop
     def test_query_string_duplicate_keys(self):
-        return self._test_param_handler("foo=bar&foo=baz&x=y")
+        return self._test_param_handler('foo=bar&foo=baz&x=y')
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -214,7 +213,7 @@ class TestTraceMiddleware(TraceTestCase):
         assert 'GET /wrapped_coroutine' == span.resource
         span = spans[1]
         assert 'nested' == span.name
-        assert span.duration > 0.25, "span.duration={0}".format(span.duration)
+        assert span.duration > 0.25, 'span.duration={0}'.format(span.duration)
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -237,7 +236,7 @@ class TestTraceMiddleware(TraceTestCase):
         # with the right trace_id and parent_id
         assert span.trace_id == 100
         assert span.parent_id == 42
-        assert span.get_metric(SAMPLING_PRIORITY_KEY) == None
+        assert span.get_metric(SAMPLING_PRIORITY_KEY) is None
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -309,8 +308,8 @@ class TestTraceMiddleware(TraceTestCase):
         assert 1 == len(traces[0])
         span = traces[0][0]
         # distributed tracing must be ignored by default
-        assert span.trace_id is not 100
-        assert span.parent_id is not 42
+        assert span.trace_id != 100
+        assert span.parent_id != 42
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -327,7 +326,7 @@ class TestTraceMiddleware(TraceTestCase):
         request = yield from self.client.request('GET', '/sub_span', headers=tracing_headers)
         assert 200 == request.status
         text = yield from request.text()
-        assert "OK" == text
+        assert 'OK' == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         assert 1 == len(traces)
@@ -340,7 +339,7 @@ class TestTraceMiddleware(TraceTestCase):
         # check parenting is OK with custom sub-span created within server code
         assert 100 == sub_span.trace_id
         assert span.span_id == sub_span.parent_id
-        assert None == sub_span.get_metric(SAMPLING_PRIORITY_KEY)
+        assert sub_span.get_metric(SAMPLING_PRIORITY_KEY) is None
 
     def _assert_200_parenting(self, traces):
         """Helper to assert parenting when handling aiohttp requests.
@@ -357,8 +356,8 @@ class TestTraceMiddleware(TraceTestCase):
         outer_span = traces[1][0]
 
         # confirm the parenting
-        assert outer_span.parent_id == None
-        assert inner_span.parent_id == None
+        assert outer_span.parent_id is None
+        assert inner_span.parent_id is None
 
         assert outer_span.name == 'aiohttp_op'
 

--- a/tests/contrib/aiohttp/test_request.py
+++ b/tests/contrib/aiohttp/test_request.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import threading
 import asyncio
 import aiohttp_jinja2
@@ -7,7 +6,6 @@ from urllib import request
 from aiohttp.test_utils import unittest_run_loop
 
 from ddtrace.pin import Pin
-from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.aiohttp.patch import patch, unpatch
 from ddtrace.contrib.aiohttp.middlewares import trace_app
 
@@ -51,7 +49,6 @@ class TestRequestTracing(TraceTestCase):
         assert 'aiohttp-web' == template_span.service
         assert 'aiohttp.template' == template_span.name
         assert 'aiohttp.template' == template_span.resource
-
 
     @unittest_run_loop
     @asyncio.coroutine

--- a/tests/contrib/aiohttp/test_request_safety.py
+++ b/tests/contrib/aiohttp/test_request_safety.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import threading
 import asyncio
 import aiohttp_jinja2

--- a/tests/contrib/aiohttp/test_templates.py
+++ b/tests/contrib/aiohttp/test_templates.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import asyncio
 import aiohttp_jinja2
 

--- a/tests/contrib/aiopg/py35/test.py
+++ b/tests/contrib/aiopg/py35/test.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-# DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from `async`
 # stdlib
 import asyncio
 

--- a/tests/contrib/aiopg/test.py
+++ b/tests/contrib/aiopg/test.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-# DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from `yield from`
 # stdlib
 import time
 import asyncio
@@ -90,7 +88,7 @@ class AiopgTestCase(AsyncioTestCase):
         assert len(spans) == 2
         ot_span, dd_span = spans
         # confirm the parenting
-        assert ot_span.parent_id == None
+        assert ot_span.parent_id is None
         assert dd_span.parent_id == ot_span.span_id
         assert ot_span.name == 'aiopg_op'
         assert ot_span.service == 'aiopg_svc'
@@ -202,7 +200,6 @@ class AiopgTestCase(AsyncioTestCase):
 class AiopgAnalyticsTestCase(AiopgTestCase):
     @asyncio.coroutine
     def trace_spans(self):
-        service = 'db'
         conn, _ = yield from self._get_conn_and_tracer()
 
         Pin.get_from(conn).clone(service='db', tracer=self.tracer).onto(conn)

--- a/tests/contrib/asyncio/test_helpers.py
+++ b/tests/contrib/asyncio/test_helpers.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-# DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from `yield from`
 import asyncio
 
 from ddtrace.context import Context

--- a/tests/contrib/asyncio/test_tracer.py
+++ b/tests/contrib/asyncio/test_tracer.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-# DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from `yield from`
 import asyncio
 
 from asyncio import BaseEventLoop
@@ -131,7 +129,7 @@ class TestAsyncioTracer(AsyncioTestCase):
         assert 2 == len(spans)
         span = spans[0]
         assert 'f2' == span.name
-        assert 1 == span.error # f2 did not catch the exception
+        assert 1 == span.error  # f2 did not catch the exception
         assert 'f1 error' == span.get_tag('error.msg')
         assert 'Exception: f1 error' in span.get_tag('error.stack')
         span = spans[1]
@@ -163,7 +161,7 @@ class TestAsyncioTracer(AsyncioTestCase):
         assert 2 == len(spans)
         span = spans[0]
         assert 'f2' == span.name
-        assert 0 == span.error # f2 caught the exception
+        assert 0 == span.error  # f2 caught the exception
         span = spans[1]
         assert 'f1' == span.name
         assert 1 == span.error
@@ -296,7 +294,6 @@ class TestAsyncioPropagation(AsyncioTestCase):
     def test_propagation_with_new_context(self):
         # ensures that if a new Context is activated, a trace
         # with the Context arguments is created
-        task = asyncio.Task.current_task()
         ctx = Context(trace_id=100, span_id=101)
         self.tracer.context_provider.activate(ctx)
 

--- a/tests/contrib/asyncio/test_tracer_safety.py
+++ b/tests/contrib/asyncio/test_tracer_safety.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-# DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from `yield from`
 import asyncio
 
 from ddtrace.provider import DefaultContextProvider

--- a/tests/contrib/flask/test_middleware.py
+++ b/tests/contrib/flask/test_middleware.py
@@ -35,7 +35,7 @@ class TestFlask(TestCase):
         # and `TraceMiddleware` are used together. `traced_app` MUST
         # be assigned otherwise it's not possible to reproduce the
         # problem (the test scope must keep a strong reference)
-        traced_app = TraceMiddleware(self.flask_app, self.tracer)  # noqa
+        traced_app = TraceMiddleware(self.flask_app, self.tracer)  # noqa: F841
         rv = self.app.get('/child')
         assert rv.status_code == 200
         spans = self.tracer.writer.pop()

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 import molten
 from molten.testing import TestClient
 
@@ -175,7 +173,7 @@ class TestMolten(BaseTracerTestCase):
 
     def test_resources(self):
         """ Tests request has expected span resources """
-        response = molten_client()
+        molten_client()
         spans = self.tracer.writer.pop()
 
         # `can_handle_parameter` appears twice since two parameters are in request

--- a/tests/contrib/molten/test_molten_di.py
+++ b/tests/contrib/molten/test_molten_di.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-# DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from annotations
 from unittest import TestCase
 
 # Test base adapted from molten/tests/test_dependency_injection.py
@@ -112,7 +110,7 @@ class TestMoltenDI(TestCase):
         # Then all the parameters should resolve as expected
         resolver = di.get_resolver()
         resolved_example = resolver.resolve(example)
-        accounts_1 = resolved_example()
+        resolved_example()
 
         spans = self.tracer.writer.pop()
 

--- a/tests/contrib/test_utils.py
+++ b/tests/contrib/test_utils.py
@@ -37,7 +37,7 @@ def minus(a, b):
 minus_two = partial(minus, b=2)  # partial funcs need special handling (no module)
 
 # disabling flake8 test below, yes, declaring a func like this is bad, we know
-plus_three = lambda x : x + 3  # noqa
+plus_three = lambda x: x + 3  # noqa: E731
 
 
 class TestContrib(object):

--- a/tests/contrib/tornado/test_executor_decorator.py
+++ b/tests/contrib/tornado/test_executor_decorator.py
@@ -171,7 +171,8 @@ class TestTornadoExecutor(TornadoTestCase):
     def test_futures_double_instrumentation(self):
         # it should not double wrap `ThreadpPoolExecutor.submit` method if
         # `futures` is already instrumented
-        from ddtrace import patch; patch(futures=True)  # noqa
+        from ddtrace import patch
+        patch(futures=True)
         from concurrent.futures import ThreadPoolExecutor
         from ddtrace.vendor.wrapt import BoundFunctionWrapper
 

--- a/tests/contrib/tornado/utils.py
+++ b/tests/contrib/tornado/utils.py
@@ -1,6 +1,7 @@
 from tornado.testing import AsyncHTTPTestCase
 
 from ddtrace.contrib.tornado import patch, unpatch
+from ddtrace.compat import reload_module
 
 from .web import app, compat
 from ...base import BaseTracerTestCase
@@ -15,8 +16,8 @@ class TornadoTestCase(BaseTracerTestCase, AsyncHTTPTestCase):
     def get_app(self):
         # patch Tornado and reload module app
         patch()
-        compat.reload_module(compat)
-        compat.reload_module(app)
+        reload_module(compat)
+        reload_module(app)
 
         settings = self.get_settings()
         trace_settings = settings.get('datadog_trace', {})
@@ -33,5 +34,5 @@ class TornadoTestCase(BaseTracerTestCase, AsyncHTTPTestCase):
         super(TornadoTestCase, self).tearDown()
         # unpatch Tornado
         unpatch()
-        compat.reload_module(compat)
-        compat.reload_module(app)
+        reload_module(compat)
+        reload_module(app)

--- a/tests/contrib/tornado/web/compat.py
+++ b/tests/contrib/tornado/web/compat.py
@@ -4,11 +4,6 @@ from tornado.ioloop import IOLoop
 
 
 try:
-    from importlib import reload as reload_module
-except ImportError:
-    reload_module = reload
-
-try:
     from concurrent.futures import ThreadPoolExecutor
 except ImportError:
     from tornado.concurrent import DummyExecutor

--- a/tests/opentracer/test_tracer_asyncio.py
+++ b/tests/opentracer/test_tracer_asyncio.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-# DEV: Skip linting, we lint with Python 2, we'll get SyntaxErrors from `yield from`
 import asyncio
 import pytest
 from opentracing.scope_managers.asyncio import AsyncioScopeManager
@@ -8,14 +6,14 @@ import ddtrace
 from ddtrace.opentracer.utils import get_context_provider_for_scope_manager
 
 from tests.contrib.asyncio.utils import AsyncioTestCase, mark_asyncio
-from .conftest import ot_tracer_factory
+from .conftest import ot_tracer_factory  # noqa: F401
 
 
 @pytest.fixture()
-def ot_tracer(request, ot_tracer_factory):
+def ot_tracer(request, ot_tracer_factory):  # noqa: F811
     # use the dummy asyncio ot tracer
     request.instance.ot_tracer = ot_tracer_factory(
-        "asyncio_svc",
+        'asyncio_svc',
         config={},
         scope_manager=AsyncioScopeManager(),
         context_provider=ddtrace.contrib.asyncio.context_provider,
@@ -23,7 +21,8 @@ def ot_tracer(request, ot_tracer_factory):
     request.instance.ot_writer = request.instance.ot_tracer._dd_tracer.writer
     request.instance.dd_tracer = request.instance.ot_tracer._dd_tracer
 
-@pytest.mark.usefixtures("ot_tracer")
+
+@pytest.mark.usefixtures('ot_tracer')
 class TestTracerAsyncio(AsyncioTestCase):
 
     def reset(self):
@@ -32,14 +31,14 @@ class TestTracerAsyncio(AsyncioTestCase):
     @mark_asyncio
     def test_trace_coroutine(self):
         # it should use the task context when invoked in a coroutine
-        with self.ot_tracer.start_span("coroutine"):
+        with self.ot_tracer.start_span('coroutine'):
             pass
 
         traces = self.ot_writer.pop_traces()
 
         assert len(traces) == 1
         assert len(traces[0]) == 1
-        assert traces[0][0].name == "coroutine"
+        assert traces[0][0].name == 'coroutine'
 
     @mark_asyncio
     def test_trace_multiple_coroutines(self):
@@ -48,10 +47,10 @@ class TestTracerAsyncio(AsyncioTestCase):
         @asyncio.coroutine
         def coro():
             # another traced coroutine
-            with self.ot_tracer.start_active_span("coroutine_2"):
+            with self.ot_tracer.start_active_span('coroutine_2'):
                 return 42
 
-        with self.ot_tracer.start_active_span("coroutine_1"):
+        with self.ot_tracer.start_active_span('coroutine_1'):
             value = yield from coro()
 
         # the coroutine has been called correctly
@@ -60,8 +59,8 @@ class TestTracerAsyncio(AsyncioTestCase):
         traces = self.ot_writer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 2
-        assert traces[0][0].name == "coroutine_1"
-        assert traces[0][1].name == "coroutine_2"
+        assert traces[0][0].name == 'coroutine_1'
+        assert traces[0][1].name == 'coroutine_2'
         # the parenting is correct
         assert traces[0][0] == traces[0][1]._parent
         assert traces[0][0].trace_id == traces[0][1].trace_id
@@ -70,8 +69,8 @@ class TestTracerAsyncio(AsyncioTestCase):
     def test_exception(self):
         @asyncio.coroutine
         def f1():
-            with self.ot_tracer.start_span("f1"):
-                raise Exception("f1 error")
+            with self.ot_tracer.start_span('f1'):
+                raise Exception('f1 error')
 
         with pytest.raises(Exception):
             yield from f1()
@@ -82,8 +81,8 @@ class TestTracerAsyncio(AsyncioTestCase):
         assert len(spans) == 1
         span = spans[0]
         assert span.error == 1
-        assert span.get_tag("error.msg") == "f1 error"
-        assert "Exception: f1 error" in span.get_tag("error.stack")
+        assert span.get_tag('error.msg') == 'f1 error'
+        assert 'Exception: f1 error' in span.get_tag('error.stack')
 
     @mark_asyncio
     def test_trace_multiple_calls(self):
@@ -92,7 +91,7 @@ class TestTracerAsyncio(AsyncioTestCase):
         @asyncio.coroutine
         def coro():
             # another traced coroutine
-            with self.ot_tracer.start_span("coroutine"):
+            with self.ot_tracer.start_span('coroutine'):
                 yield from asyncio.sleep(0.01)
 
         futures = [asyncio.ensure_future(coro()) for x in range(10)]
@@ -103,10 +102,10 @@ class TestTracerAsyncio(AsyncioTestCase):
 
         assert len(traces) == 10
         assert len(traces[0]) == 1
-        assert traces[0][0].name == "coroutine"
+        assert traces[0][0].name == 'coroutine'
 
 
-@pytest.mark.usefixtures("ot_tracer")
+@pytest.mark.usefixtures('ot_tracer')
 class TestTracerAsyncioCompatibility(AsyncioTestCase):
     """Ensure the opentracer works in tandem with the ddtracer and asyncio."""
 
@@ -121,10 +120,10 @@ class TestTracerAsyncioCompatibility(AsyncioTestCase):
         @asyncio.coroutine
         def coro():
             # another traced coroutine
-            with self.dd_tracer.trace("coroutine_2"):
+            with self.dd_tracer.trace('coroutine_2'):
                 return 42
 
-        with self.ot_tracer.start_active_span("coroutine_1"):
+        with self.ot_tracer.start_active_span('coroutine_1'):
             value = yield from coro()
 
         # the coroutine has been called correctly
@@ -133,8 +132,8 @@ class TestTracerAsyncioCompatibility(AsyncioTestCase):
         traces = self.ot_tracer._dd_tracer.writer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 2
-        assert traces[0][0].name == "coroutine_1"
-        assert traces[0][1].name == "coroutine_2"
+        assert traces[0][0].name == 'coroutine_1'
+        assert traces[0][1].name == 'coroutine_2'
         # the parenting is correct
         assert traces[0][0] == traces[0][1]._parent
         assert traces[0][0].trace_id == traces[0][1].trace_id
@@ -150,10 +149,10 @@ class TestTracerAsyncioCompatibility(AsyncioTestCase):
         @asyncio.coroutine
         def coro():
             # another traced coroutine
-            with self.ot_tracer.start_span("coroutine_2"):
+            with self.ot_tracer.start_span('coroutine_2'):
                 return 42
 
-        with self.dd_tracer.trace("coroutine_1"):
+        with self.dd_tracer.trace('coroutine_1'):
             value = yield from coro()
 
         # the coroutine has been called correctly
@@ -162,8 +161,8 @@ class TestTracerAsyncioCompatibility(AsyncioTestCase):
         traces = self.ot_tracer._dd_tracer.writer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 2
-        assert traces[0][0].name == "coroutine_1"
-        assert traces[0][1].name == "coroutine_2"
+        assert traces[0][0].name == 'coroutine_1'
+        assert traces[0][1].name == 'coroutine_2'
         # the parenting is correct
         assert traces[0][0] == traces[0][1]._parent
         assert traces[0][0].trace_id == traces[0][1].trace_id
@@ -182,7 +181,7 @@ class TestUtilsAsyncio(object):
         )
 
     def test_tracer_context_provider_config(self):
-        tracer = ddtrace.opentracer.Tracer("mysvc", scope_manager=AsyncioScopeManager())
+        tracer = ddtrace.opentracer.Tracer('mysvc', scope_manager=AsyncioScopeManager())
         assert isinstance(
             tracer._dd_tracer.context_provider,
             ddtrace.contrib.asyncio.provider.AsyncioContextProvider,

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -6,113 +6,74 @@ import sys
 import pytest
 
 # Project
-from ddtrace.compat import to_unicode, PY2, reraise, get_connection_response
+from ddtrace.compat import to_unicode, PY3, reraise, get_connection_response
 
 
-# Use different test suites for each Python version, this allows us to test the expected
-#   results for each Python version rather than writing a generic "works for both" test suite
-if PY2:
-    class TestCompatPY2(object):
+if PY3:
+    unicode = str
 
-        def test_to_unicode_string(self):
-            # Calling `compat.to_unicode` on a non-unicode string
-            res = to_unicode('test')
-            assert type(res) == unicode
-            assert res == 'test'
 
-        def test_to_unicode_unicode_encoded(self):
-            # Calling `compat.to_unicode` on a unicode encoded string
-            res = to_unicode('\xc3\xbf')
-            assert type(res) == unicode
-            assert res == u'ÿ'
+class TestCompat(object):
 
-        def test_to_unicode_unicode_double_decode(self):
-            # Calling `compat.to_unicode` on a unicode decoded string
-            # This represents the double-decode issue, which can cause a `UnicodeEncodeError`
-            #   `'\xc3\xbf'.decode('utf-8').decode('utf-8')`
-            res = to_unicode('\xc3\xbf'.decode('utf-8'))
-            assert type(res) == unicode
-            assert res == u'ÿ'
+    def test_to_unicode_string(self):
+        # Calling `compat.to_unicode` on a non-unicode string
+        res = to_unicode(b'test')
+        assert type(res) == unicode
+        assert res == 'test'
 
-        def test_to_unicode_unicode_string(self):
-            # Calling `compat.to_unicode` on a unicode string
-            res = to_unicode(u'ÿ')
-            assert type(res) == unicode
-            assert res == u'ÿ'
+    def test_to_unicode_unicode_encoded(self):
+        # Calling `compat.to_unicode` on a unicode encoded string
+        res = to_unicode(b'\xc3\xbf')
+        assert type(res) == unicode
+        assert res == u'ÿ'
 
-        def test_to_unicode_bytearray(self):
-            # Calling `compat.to_unicode` with a `bytearray` containing unicode
-            res = to_unicode(bytearray('\xc3\xbf'))
-            assert type(res) == unicode
-            assert res == u'ÿ'
+    def test_to_unicode_unicode_double_decode(self):
+        # Calling `compat.to_unicode` on a unicode decoded string
+        # This represents the double-decode issue, which can cause a `UnicodeEncodeError`
+        #   `'\xc3\xbf'.decode('utf-8').decode('utf-8')`
+        res = to_unicode(b'\xc3\xbf'.decode('utf-8'))
+        assert type(res) == unicode
+        assert res == u'ÿ'
 
-        def test_to_unicode_bytearray_double_decode(self):
-            #  Calling `compat.to_unicode` with an already decoded `bytearray`
-            # This represents the double-decode issue, which can cause a `UnicodeEncodeError`
-            #   `bytearray('\xc3\xbf').decode('utf-8').decode('utf-8')`
-            res = to_unicode(bytearray('\xc3\xbf').decode('utf-8'))
-            assert type(res) == unicode
-            assert res == u'ÿ'
+    def test_to_unicode_unicode_string(self):
+        # Calling `compat.to_unicode` on a unicode string
+        res = to_unicode(u'ÿ')
+        assert type(res) == unicode
+        assert res == u'ÿ'
 
-        def test_to_unicode_non_string(self):
-            #  Calling `compat.to_unicode` on non-string types
-            assert to_unicode(1) == u'1'
-            assert to_unicode(True) == u'True'
-            assert to_unicode(None) == u'None'
-            assert to_unicode(dict(key='value')) == u'{\'key\': \'value\'}'
+    def test_to_unicode_bytearray(self):
+        # Calling `compat.to_unicode` with a `bytearray` containing unicode
+        res = to_unicode(bytearray(b'\xc3\xbf'))
+        assert type(res) == unicode
+        assert res == u'ÿ'
 
-        def test_get_connection_response(self):
-            """Ensure that buffering is in kwargs."""
+    def test_to_unicode_bytearray_double_decode(self):
+        #  Calling `compat.to_unicode` with an already decoded `bytearray`
+        # This represents the double-decode issue, which can cause a `UnicodeEncodeError`
+        #   `bytearray('\xc3\xbf').decode('utf-8').decode('utf-8')`
+        res = to_unicode(bytearray(b'\xc3\xbf').decode('utf-8'))
+        assert type(res) == unicode
+        assert res == u'ÿ'
 
-            class MockConn(object):
-                def getresponse(self, *args, **kwargs):
+    def test_to_unicode_non_string(self):
+        #  Calling `compat.to_unicode` on non-string types
+        assert to_unicode(1) == u'1'
+        assert to_unicode(True) == u'True'
+        assert to_unicode(None) == u'None'
+        assert to_unicode(dict(key='value')) == u'{\'key\': \'value\'}'
+
+    def test_get_connection_response(self):
+        """Ensure that buffering is in kwargs."""
+
+        class MockConn(object):
+            def getresponse(self, *args, **kwargs):
+                if PY3:
+                    assert 'buffering' not in kwargs
+                else:
                     assert 'buffering' in kwargs
 
-            mock = MockConn()
-            get_connection_response(mock)
-
-else:
-    class TestCompatPY3(object):
-        def test_to_unicode_string(self):
-            # Calling `compat.to_unicode` on a non-unicode string
-            res = to_unicode('test')
-            assert type(res) == str
-            assert res == 'test'
-
-        def test_to_unicode_unicode_encoded(self):
-            # Calling `compat.to_unicode` on a unicode encoded string
-            res = to_unicode('\xff')
-            assert type(res) == str
-            assert res == 'ÿ'
-
-        def test_to_unicode_unicode_string(self):
-            # Calling `compat.to_unicode` on a unicode string
-            res = to_unicode('ÿ')
-            assert type(res) == str
-            assert res == 'ÿ'
-
-        def test_to_unicode_bytearray(self):
-            # Calling `compat.to_unicode` with a `bytearray` containing unicode """
-            res = to_unicode(bytearray('\xff', 'utf-8'))
-            assert type(res) == str
-            assert res == 'ÿ'
-
-        def test_to_unicode_non_string(self):
-            # Calling `compat.to_unicode` on non-string types
-            assert to_unicode(1) == '1'
-            assert to_unicode(True) == 'True'
-            assert to_unicode(None) == 'None'
-            assert to_unicode(dict(key='value')) == '{\'key\': \'value\'}'
-
-        def test_get_connection_response(self):
-            """Ensure that buffering is NOT in kwargs."""
-
-            class MockConn(object):
-                def getresponse(self, *args, **kwargs):
-                    assert 'buffering' not in kwargs
-
-            mock = MockConn()
-            get_connection_response(mock)
+        mock = MockConn()
+        get_connection_response(mock)
 
 
 class TestPy2Py3Compat(object):

--- a/tox.ini
+++ b/tox.ini
@@ -413,7 +413,7 @@ deps=
   flake8>=3.7,<=3.8
   flake8-quotes==1.0.0
 commands=flake8 .
-basepython=python2
+basepython=python3.7
 inline-quotes = '
 
 [falcon_autopatch]


### PR DESCRIPTION
This allows to remove a few noqa flag from files using `yield from` and fixing
various errors.

The compat tests have been merged to a single scenario that works for both
Python version in order to make flake8 happier.

Some wild noqa tag have been replaced by specific flake8 error code ignore tag
so avoid skipping non-wanted mistakes.