### PR TITLE
sampler: rewrite RateByServiceSampler without using Lock

### DIFF
--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -2,8 +2,6 @@
 
 Any `sampled = False` trace won't be written, and can be ignored by the instrumentation.
 """
-from threading import Lock
-
 from .compat import iteritems
 from .internal.logger import get_logger
 
@@ -50,15 +48,6 @@ class RateSampler(object):
         return sampled
 
 
-def _key(service=None, env=None):
-    service = service or ''
-    env = env or ''
-    return 'service:' + service + ',env:' + env
-
-
-_default_key = _key()
-
-
 class RateByServiceSampler(object):
     """Sampler based on a rate, by service
 
@@ -66,34 +55,40 @@ class RateByServiceSampler(object):
     The sample rate is kept independently for each service/env tuple.
     """
 
-    def __init__(self, sample_rate=1):
-        self._lock = Lock()
-        self._by_service_samplers = {}
-        self._by_service_samplers[_default_key] = RateSampler(sample_rate)
+    @staticmethod
+    def _key(service=None, env=None):
+        """Compute a key with the same format used by the Datadog agent API."""
+        service = service or ''
+        env = env or ''
+        return 'service:' + service + ',env:' + env
 
-    def _set_sample_rate_by_key(self, sample_rate, key):
-        with self._lock:
-            if key in self._by_service_samplers:
-                self._by_service_samplers[key].set_sample_rate(sample_rate)
-            else:
-                self._by_service_samplers[key] = RateSampler(sample_rate)
+    def __init__(self, sample_rate=1):
+        self.sample_rate = sample_rate
+        self._by_service_samplers = self._get_new_by_service_sampler()
+
+    def _get_new_by_service_sampler(self):
+        return {
+            self._default_key: RateSampler(self.sample_rate)
+        }
 
     def set_sample_rate(self, sample_rate, service='', env=''):
-        self._set_sample_rate_by_key(sample_rate, _key(service, env))
+        self._by_service_samplers[self._key(service, env)] = RateSampler(sample_rate)
 
     def sample(self, span):
         tags = span.tracer().tags
         env = tags['env'] if 'env' in tags else None
-        key = _key(span.service, env)
-        with self._lock:
-            if key in self._by_service_samplers:
-                return self._by_service_samplers[key].sample(span)
-            return self._by_service_samplers[_default_key].sample(span)
+        key = self._key(span.service, env)
+        return self._by_service_samplers.get(
+            key, self._by_service_samplers[self._default_key]
+        ).sample(span)
 
     def set_sample_rate_by_service(self, rate_by_service):
+        new_by_service_samplers = self._get_new_by_service_sampler()
         for key, sample_rate in iteritems(rate_by_service):
-            self._set_sample_rate_by_key(sample_rate, key)
-        with self._lock:
-            for key in list(self._by_service_samplers):
-                if key not in rate_by_service and key != _default_key:
-                    del self._by_service_samplers[key]
+            new_by_service_samplers[key] = RateSampler(sample_rate)
+
+        self._by_service_samplers = new_by_service_samplers
+
+
+# Default key for service with no specific rate
+RateByServiceSampler._default_key = RateByServiceSampler._key()

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -3,7 +3,7 @@ from __future__ import division
 import unittest
 
 from ddtrace.span import Span
-from ddtrace.sampler import RateSampler, AllSampler, _key, _default_key
+from ddtrace.sampler import RateSampler, AllSampler, RateByServiceSampler
 from ddtrace.compat import iteritems
 from tests.test_tracer import get_dummy_tracer
 from ddtrace.constants import SAMPLING_PRIORITY_KEY, SAMPLE_RATE_METRIC_KEY
@@ -56,14 +56,16 @@ class RateSamplerTest(unittest.TestCase):
 
 class RateByServiceSamplerTest(unittest.TestCase):
     def test_default_key(self):
-        assert 'service:,env:' == _default_key, 'default key should correspond to no service and no env'
+        assert (
+            'service:,env:' == RateByServiceSampler._default_key
+        ), 'default key should correspond to no service and no env'
 
     def test_key(self):
-        assert _default_key == _key()
-        assert 'service:mcnulty,env:' == _key(service='mcnulty')
-        assert 'service:,env:test' == _key(env='test')
-        assert 'service:mcnulty,env:test' == _key(service='mcnulty', env='test')
-        assert 'service:mcnulty,env:test' == _key('mcnulty', 'test')
+        assert RateByServiceSampler._default_key == RateByServiceSampler._key()
+        assert 'service:mcnulty,env:' == RateByServiceSampler._key(service='mcnulty')
+        assert 'service:,env:test' == RateByServiceSampler._key(env='test')
+        assert 'service:mcnulty,env:test' == RateByServiceSampler._key(service='mcnulty', env='test')
+        assert 'service:mcnulty,env:test' == RateByServiceSampler._key('mcnulty', 'test')
 
     def test_sample_rate_deviation(self):
         for sample_rate in [0.1, 0.25, 0.5, 1]:


### PR DESCRIPTION
The current implementation it overly complicated and needs to use a Lock to be
thread safe. This new one does not.

Fixes #935