### PR TITLE
pymongo: Add missing 2013 opcode

### DIFF
--- a/ddtrace/contrib/pymongo/parse.py
+++ b/ddtrace/contrib/pymongo/parse.py
@@ -19,7 +19,7 @@ log = get_logger(__name__)
 # http://docs.mongodb.com/manual/reference/mongodb-wire-protocol
 OP_CODES = {
     1: 'reply',
-    1000: 'msg',
+    1000: 'msg',  # DEV: 1000 was deprecated at some point, use 2013 instead
     2001: 'update',
     2002: 'insert',
     2003: 'reserved',
@@ -29,6 +29,7 @@ OP_CODES = {
     2007: 'kill_cursors',
     2010: 'command',
     2011: 'command_reply',
+    2013: 'msg',
 }
 
 # The maximum message length we'll try to parse


### PR DESCRIPTION
opcode `1000` was deprecated awhile ago, `2013` is now used for `msg`.

This PR updates our parser to know about `2013`.