### PR TITLE
span: use ns time directly rather than converting

### DIFF
--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -50,6 +50,16 @@ if PYTHON_VERSION_INFO >= (3, 7):
 else:
     pattern_type = re._pattern_type
 
+
+try:
+    from time import time_ns
+except ImportError:
+    from time import time as _time
+
+    def time_ns():
+        return int(_time() * 10e5) * 1000
+
+
 if PYTHON_VERSION_INFO[0:2] >= (3, 4):
     from asyncio import iscoroutinefunction
 

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -1,10 +1,9 @@
 import math
 import random
 import sys
-import time
 import traceback
 
-from .compat import StringIO, stringify, iteritems, numeric_types
+from .compat import StringIO, stringify, iteritems, numeric_types, time_ns
 from .constants import NUMERIC_TAGS, MANUAL_DROP_KEY, MANUAL_KEEP_KEY
 from .ext import errors, priority
 from .internal.logger import get_logger
@@ -27,8 +26,8 @@ class Span(object):
         'error',
         'metrics',
         'span_type',
-        'start',
-        'duration',
+        'start_ns',
+        'duration_ns',
         'tracer',
         # Sampler attributes
         'sampled',
@@ -89,8 +88,8 @@ class Span(object):
         self.metrics = {}
 
         # timing
-        self.start = start or time.time()
-        self.duration = None
+        self.start_ns = time_ns() if start is None else (start * 1e9)
+        self.duration_ns = None
 
         # tracing
         self.trace_id = trace_id or _new_id()
@@ -107,21 +106,40 @@ class Span(object):
         # state
         self.finished = False
 
-    def finish(self, finish_time=None):
-        """ Mark the end time of the span and submit it to the tracer.
-            If the span has already been finished don't do anything
+    @property
+    def start(self):
+        """The start timestamp in Unix epoch seconds."""
+        return self.start_ns / 1e9
 
-            :param int finish_time: the end time of the span in seconds.
-                                    Defaults to now.
+    @start.setter
+    def start(self, value):
+        self.start_ns = value * 1e9
+
+    @property
+    def duration(self):
+        """The span duration in seconds."""
+        if self.duration_ns:
+            return self.duration_ns / 1e9
+
+    @duration.setter
+    def duration(self, value):
+        self.duration_ns = value * 1e9
+
+    def finish(self, finish_time=None):
+        """Mark the end time of the span and submit it to the tracer.
+        If the span has already been finished don't do anything
+
+        :param int finish_time: The end time of the span in seconds.
+                                Defaults to now.
         """
         if self.finished:
             return
         self.finished = True
 
-        if self.duration is None:
-            ft = finish_time or time.time()
+        if self.duration_ns is None:
+            ft = time_ns() if finish_time is None else (finish_time * 1e9)
             # be defensive so we don't die if start isn't set
-            self.duration = ft - (self.start or ft)
+            self.duration_ns = ft - (self.start_ns or ft)
 
         if self._context:
             try:
@@ -232,11 +250,11 @@ class Span(object):
         if err and type(err) == bool:
             d['error'] = 1
 
-        if self.start:
-            d['start'] = int(self.start * 1e9)  # ns
+        if self.start_ns:
+            d['start'] = self.start_ns
 
-        if self.duration:
-            d['duration'] = int(self.duration * 1e9)  # ns
+        if self.duration_ns:
+            d['duration'] = self.duration_ns
 
         if self.meta:
             d['meta'] = self.meta

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -127,8 +127,8 @@ class TestTracer(object):
     def test_start_span_custom_start_time(self, ot_tracer):
         """Start a span with a custom start time."""
         t = 100
-        with mock.patch('time.time') as time:
-            time.return_value = 102
+        with mock.patch('ddtrace.span.time_ns') as time:
+            time.return_value = 102 * 1e9
             with ot_tracer.start_span('myop', start_time=t) as span:
                 pass
 


### PR DESCRIPTION
This improves span precision. Note that time_ns is only available on Python 3.