### PR TITLE
context: determine if context is sampled based on traces

### DIFF
--- a/ddtrace/opentracer/span_context.py
+++ b/ddtrace/opentracer/span_context.py
@@ -6,7 +6,7 @@ from ddtrace.context import Context as DatadogContext
 class SpanContext(OpenTracingSpanContext):
     """Implementation of the OpenTracing span context."""
 
-    def __init__(self, trace_id=None, span_id=None, sampled=True,
+    def __init__(self, trace_id=None, span_id=None,
                  sampling_priority=None, baggage=None, ddcontext=None):
         # create a new dict for the baggage if it is not provided
         # NOTE: it would be preferable to use opentracing.SpanContext.EMPTY_BAGGAGE
@@ -20,7 +20,6 @@ class SpanContext(OpenTracingSpanContext):
             self._dd_context = DatadogContext(
                 trace_id=trace_id,
                 span_id=span_id,
-                sampled=sampled,
                 sampling_priority=sampling_priority,
             )
 

--- a/tests/opentracer/test_span.py
+++ b/tests/opentracer/test_span.py
@@ -16,7 +16,7 @@ def nop_tracer():
 def nop_span_ctx():
     from ddtrace.ext.priority import AUTO_KEEP
     from ddtrace.opentracer.span_context import SpanContext
-    return SpanContext(sampling_priority=AUTO_KEEP, sampled=True)
+    return SpanContext(sampling_priority=AUTO_KEEP)
 
 
 @pytest.fixture

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -419,7 +419,7 @@ class TestTracer(object):
 @pytest.fixture
 def nop_span_ctx():
 
-    return SpanContext(sampling_priority=AUTO_KEEP, sampled=True)
+    return SpanContext(sampling_priority=AUTO_KEEP)
 
 
 class TestTracerSpanContextPropagation(object):


### PR DESCRIPTION
Rather than carrying a dedicated flag on the Context object, sample the spans
if any of them is sampled.