### PR TITLE
context: don't count finished spans

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -117,13 +117,18 @@ class Span(object):
             # be defensive so we don't die if start isn't set
             self.duration = ft - (self.start or ft)
 
-        # if a tracer is available to process the current context
-        if self._tracer and self._context:
+        if self._context:
             try:
                 self._context.close_span(self)
-                self._tracer.record(self._context)
             except Exception:
                 log.exception('error recording finished trace')
+            else:
+                # if a tracer is available to process the current context
+                if self._tracer:
+                    try:
+                        self._tracer.record(self._context)
+                    except Exception:
+                        log.exception('error recording finished trace')
 
     def set_tag(self, key, value=None):
         """ Set the given key / value tag pair on the span. Keys and values

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -87,7 +87,6 @@ class TestTracingContext(BaseTestCase):
         span = Span(tracer=None, name='fake_span')
         ctx.add_span(span)
         ctx.close_span(span)
-        assert 1 == ctx._finished_spans
         assert ctx.get_current_span() is None
 
     def test_get_trace(self):
@@ -96,14 +95,12 @@ class TestTracingContext(BaseTestCase):
         ctx = Context()
         span = Span(tracer=None, name='fake_span')
         ctx.add_span(span)
-        ctx.close_span(span)
+        span.finish()
         trace, sampled = ctx.get()
-        assert 1 == len(trace)
-        assert span == trace[0]
+        assert [span] == trace
         assert sampled is True
         # the context should be empty
         assert 0 == len(ctx._trace)
-        assert 0 == ctx._finished_spans
         assert ctx._current_span is None
         assert ctx._sampled is True
 
@@ -125,7 +122,7 @@ class TestTracingContext(BaseTestCase):
             ctx = Context()
             span = Span(tracer=None, name='fake_span')
             ctx.add_span(span)
-            ctx.close_span(span)
+            span.finish()
 
             # Assert that we have not added the tag to the span yet
             assert span.get_tag(HOSTNAME_KEY) is None
@@ -144,7 +141,7 @@ class TestTracingContext(BaseTestCase):
             ctx = Context()
             span = Span(tracer=None, name='fake_span')
             ctx.add_span(span)
-            ctx.close_span(span)
+            span.finish()
 
             # Assert that we have not added the tag to the span yet
             assert span.get_tag(HOSTNAME_KEY) is None
@@ -162,7 +159,7 @@ class TestTracingContext(BaseTestCase):
         ctx = Context()
         span = Span(tracer=None, name='fake_span')
         ctx.add_span(span)
-        ctx.close_span(span)
+        span.finish()
 
         # Assert that we have not added the tag to the span yet
         assert span.get_tag(HOSTNAME_KEY) is None
@@ -205,7 +202,6 @@ class TestTracingContext(BaseTestCase):
         )
 
         # Ensure we clear/reset internal stats as expected
-        self.assertEqual(ctx._finished_spans, 0)
         self.assertEqual(ctx._trace, [root])
         with self.override_partial_flush(ctx, enabled=True, min_spans=5):
             trace, sampled = ctx.get()
@@ -245,7 +241,6 @@ class TestTracingContext(BaseTestCase):
         )
 
         # Ensure we clear/reset internal stats as expected
-        self.assertEqual(ctx._finished_spans, 0)
         self.assertEqual(ctx._trace, [root])
         with self.override_partial_flush(ctx, enabled=True, min_spans=5):
             trace, sampled = ctx.get()
@@ -280,7 +275,6 @@ class TestTracingContext(BaseTestCase):
         self.assertIsNone(sampled)
 
         self.assertEqual(len(ctx._trace), 6)
-        self.assertEqual(ctx._finished_spans, 5)
         self.assertEqual(
             set(['root', 'child_0', 'child_1', 'child_2', 'child_3', 'child_4']),
             set([span.name for span in ctx._trace])
@@ -322,7 +316,6 @@ class TestTracingContext(BaseTestCase):
 
         # Assert remaining unclosed spans
         self.assertEqual(len(ctx._trace), 6)
-        self.assertEqual(ctx._finished_spans, 0)
         self.assertEqual(
             set(['root', 'child_5', 'child_6', 'child_7', 'child_8', 'child_9']),
             set([span.name for span in ctx._trace]),
@@ -334,12 +327,6 @@ class TestTracingContext(BaseTestCase):
         span = Span(tracer=None, name='fake_span')
         ctx.add_span(span)
         ctx.close_span(span)
-        assert ctx.is_finished()
-
-    def test_finished_empty(self):
-        # a Context is not finished if it's empty
-        ctx = Context()
-        assert ctx.is_finished() is False
 
     @mock.patch('logging.Logger.debug')
     def test_log_unfinished_spans(self, log):
@@ -358,7 +345,6 @@ class TestTracingContext(BaseTestCase):
         ctx.add_span(child_2)
         # close only the parent
         root.finish()
-        assert ctx.is_finished() is False
         unfinished_spans_log = log.call_args_list[-3][0][2]
         child_1_log = log.call_args_list[-2][0][1]
         child_2_log = log.call_args_list[-1][0][1]
@@ -385,7 +371,6 @@ class TestTracingContext(BaseTestCase):
         ctx.add_span(child_2)
         # close only the parent
         root.finish()
-        assert ctx.is_finished() is False
         # the logger has never been invoked to print unfinished spans
         for call, _ in log.call_args_list:
             msg = call[0]
@@ -447,7 +432,6 @@ class TestTracingContext(BaseTestCase):
         assert cloned_ctx._dd_origin == ctx._dd_origin
         assert cloned_ctx._current_span == ctx._current_span
         assert cloned_ctx._trace == []
-        assert cloned_ctx._finished_spans == 0
 
 
 class TestThreadContext(BaseTestCase):


### PR DESCRIPTION
Rather than using a clumsy way of counting finished spans, actually checks
the traces attached to the context. This simplify the logic.

We also make sure that the context.close_span() method is always called when
finishing a span, whether a tracer is present or not.