### PR TITLE
fix for context propagation when first span is closed

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -45,6 +45,13 @@ class Context(object):
         self._sampling_priority = sampling_priority
         self._dd_origin = _dd_origin
 
+        self._root_state = {
+            'parent_trace_id': trace_id,
+            'parent_span_id': span_id,
+            'sampled': sampled,
+            'sampling_priority': sampling_priority
+        }
+
     @property
     def trace_id(self):
         """Return current context trace_id."""
@@ -181,9 +188,10 @@ class Context(object):
                 # clean the current state
                 self._trace = []
                 self._finished_spans = 0
-                self._parent_trace_id = None
-                self._parent_span_id = None
-                self._sampling_priority = None
+                self._parent_trace_id = self._root_state['parent_trace_id']
+                self._parent_span_id = self._root_state['parent_span_id']
+                self._sampling_priority = self._root_state['sampling_priority']
+                self._sampled = self._root_state['sampled']
                 return trace, sampled
 
             elif self._partial_flush_enabled:

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -48,6 +48,7 @@ class Context(object):
         self._root_state = {
             'parent_trace_id': trace_id,
             'parent_span_id': span_id,
+            'sampled': sampled,
             'sampling_priority': sampling_priority
         }
 

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -48,7 +48,6 @@ class Context(object):
         self._root_state = {
             'parent_trace_id': trace_id,
             'parent_span_id': span_id,
-            'sampled': sampled,
             'sampling_priority': sampling_priority
         }
 

--- a/tests/contrib/asyncio/test_tracer.py
+++ b/tests/contrib/asyncio/test_tracer.py
@@ -227,8 +227,17 @@ class TestAsyncioPropagation(AsyncioTestCase):
         # ensures that the context is propagated between different tasks
         @self.tracer.wrap('spawn_task')
         @asyncio.coroutine
-        def coro_2():
+        def coro_3():
             yield from asyncio.sleep(0.01)
+
+        @asyncio.coroutine
+        def coro_2():
+            # This will have a new context, first run will test that the
+            # new context works correctly, second run will test if when we
+            # pop off the last span on the context if it is still parented
+            # correctly
+            yield from coro_3()
+            yield from coro_3()
 
         @self.tracer.wrap('main_task')
         @asyncio.coroutine
@@ -238,14 +247,18 @@ class TestAsyncioPropagation(AsyncioTestCase):
         yield from coro_1()
 
         traces = self.tracer.writer.pop_traces()
-        assert len(traces) == 2
+        assert len(traces) == 3
         assert len(traces[0]) == 1
         assert len(traces[1]) == 1
-        spawn_task = traces[0][0]
-        main_task = traces[1][0]
+        main_task = traces[-1][0]
+        spawn_task1 = traces[0][0]
+        spawn_task2 = traces[1][0]
         # check if the context has been correctly propagated
-        assert spawn_task.trace_id == main_task.trace_id
-        assert spawn_task.parent_id == main_task.span_id
+        assert spawn_task1.trace_id == main_task.trace_id
+        assert spawn_task1.parent_id == main_task.span_id
+
+        assert spawn_task2.trace_id == main_task.trace_id
+        assert spawn_task2.parent_id == main_task.span_id
 
     @mark_asyncio
     def test_concurrent_chaining(self):

--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -2,6 +2,7 @@
 from ddtrace.compat import PY2
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.flask.patch import flask_version
+from ddtrace.context import Context
 from ddtrace.ext import http
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID, HTTP_HEADER_PARENT_ID
 from flask import abort
@@ -235,6 +236,10 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(span.parent_id, 12345)
 
         # With distributed tracing disabled
+        # NOTE: while distributed tracing is disabled, the previous context is
+        #   still active so we need to clear it
+        self.tracer.context_provider.activate(Context())
+
         with self.override_config('flask', dict(distributed_tracing_enabled=False)):
             res = self.client.get('/', headers={
                 HTTP_HEADER_PARENT_ID: '12345',

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -7,7 +7,7 @@ from ddtrace.ext import errors, http
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID, HTTP_HEADER_PARENT_ID
 from ddtrace.contrib.molten import patch, unpatch
 from ddtrace.contrib.molten.patch import MOLTEN_VERSION
-
+from ddtrace.context import Context
 from ...base import BaseTracerTestCase
 from ...utils import assert_span_http_status_code, assert_is_measured
 
@@ -265,6 +265,10 @@ class TestMolten(BaseTracerTestCase):
         self.assertEqual(span.parent_id, 42)
 
         # Now without tracing on
+        # NOTE: while distributed tracing is disabled, the previous context is
+        #   still active so we need to clear it
+        self.tracer.context_provider.activate(Context())
+
         with self.override_config('molten', dict(distributed_tracing=False)):
             response = molten_client(headers={
                 HTTP_HEADER_TRACE_ID: '100',


### PR DESCRIPTION
subset of https://github.com/DataDog/dd-trace-py/pull/398

Currently when the last span is closed from a context, it resets the parent trace information to `None`, this is wrong.  If a context has a parent span, it should maintain the parent affiliation until the end of the context, as the context was created by said parent trace.