### PR TITLE
[sqlalchemy] Only set sample rate if configured

### DIFF
--- a/ddtrace/contrib/sqlalchemy/engine.py
+++ b/ddtrace/contrib/sqlalchemy/engine.py
@@ -88,10 +88,9 @@ class EngineTracer(object):
             _set_tags_from_cursor(span, self.vendor, cursor)
 
         # set analytics sample rate
-        span.set_tag(
-            ANALYTICS_SAMPLE_RATE_KEY,
-            config.sqlalchemy.get_analytics_sample_rate()
-        )
+        sample_rate = config.sqlalchemy.get_analytics_sample_rate()
+        if sample_rate is not None:
+            span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, sample_rate)
 
     def _after_cur_exec(self, conn, cursor, statement, *args):
         pin = Pin.get_from(self.engine)

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -82,10 +82,14 @@ class IntegrationConfig(AttrDict):
         if self._is_analytics_enabled(use_global_config):
             analytics_sample_rate = getattr(self, 'analytics_sample_rate', None)
             # return True if attribute is None or attribute not found
-            if not analytics_sample_rate:
+            if analytics_sample_rate is None:
                 return True
             # otherwise return rate
             return analytics_sample_rate
+
+        # Use `None` as a way to say that it was not defined,
+        #   `False` would mean `0` which is a different thing
+        return None
 
     def __repr__(self):
         cls = self.__class__

--- a/tests/contrib/sqlalchemy/test_patch.py
+++ b/tests/contrib/sqlalchemy/test_patch.py
@@ -96,7 +96,8 @@ class SQLAlchemyPatchTestCase(BaseTracerTestCase):
                 root.assert_matches(name='postgres.query')
 
                 # If the value is None assert it was not set, otherwise assert the expected value
-                # DEV: root.assert_metrics(metrics, exact=True) won't work here since we have another sample rate keys getting added
+                # DEV: root.assert_metrics(metrics, exact=True) won't work here since we have another sample
+                #      rate keys getting added
                 if metric_value is None:
                     assert ANALYTICS_SAMPLE_RATE_KEY not in root.metrics
                 else:


### PR DESCRIPTION
We were always attempting to set the sample rate for `sqlalchemy`, the default value is `None` which causes `span.set_tag(ANALYTICS_SAMPLE_RATE, None)` to log an error (debug).