### PR TITLE
api: implement __str__

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -151,6 +151,11 @@ class API(object):
             'Datadog-Meta-Tracer-Version': ddtrace.__version__,
         })
 
+    def __str__(self):
+        if self.uds_path:
+            return self.uds_path
+        return '%s:%s' % (self.hostname, self.port)
+
     def _set_version(self, version, encoder=None):
         if version not in _VERSIONS:
             version = 'v0.2'

--- a/ddtrace/writer.py
+++ b/ddtrace/writer.py
@@ -107,13 +107,11 @@ class AsyncWorker(_worker.PeriodicWorkerThread):
         if now > self._last_error_ts + LOG_ERR_INTERVAL:
             log_level = log.error
             self._last_error_ts = now
-        if self.api.uds_path:
-            prefix = 'Failed to send traces to Datadog Agent at %s: ' % self.api.uds_path
-        else:
-            prefix = 'Failed to send traces to Datadog Agent at %s:%s: ' % (self.api.hostname, self.api.port)
+        prefix = 'Failed to send traces to Datadog Agent at %s: '
         if isinstance(response, api.Response):
             log_level(
                 prefix + 'HTTP error status %s, reason %s, message %s',
+                self.api,
                 response.status,
                 response.reason,
                 response.msg,
@@ -121,6 +119,7 @@ class AsyncWorker(_worker.PeriodicWorkerThread):
         else:
             log_level(
                 prefix + '%s',
+                self.api,
                 response,
             )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -109,6 +109,13 @@ class ResponseMock:
         return self.content
 
 
+def test_api_str():
+    api = API('localhost', 8126)
+    assert str(api) == 'localhost:8126'
+    api = API('localhost', 8126, '/path/to/uds')
+    assert str(api) == '/path/to/uds'
+
+
 class APITests(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This should makes it easier to have a string representation of the API endpoint
when needed.