### PR TITLE
Fix a typo in AIOTracedCursor docstring

### DIFF
--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -11,7 +11,7 @@ from ...settings import config
 
 
 class AIOTracedCursor(wrapt.ObjectProxy):
-    """ TracedCursor wraps a psql cursor and traces it's queries. """
+    """ TracedCursor wraps a psql cursor and traces its queries. """
 
     def __init__(self, cursor, pin):
         super(AIOTracedCursor, self).__init__(cursor)

--- a/ddtrace/contrib/aiopg/patch.py
+++ b/ddtrace/contrib/aiopg/patch.py
@@ -7,7 +7,7 @@ from ddtrace.vendor import wrapt
 
 from .connection import AIOTracedConnection
 from ..psycopg.patch import _patch_extensions, \
-    _unpatch_extensions, patch_conn as psycppg_patch_conn
+    _unpatch_extensions, patch_conn as psycopg_patch_conn
 from ...utils.wrappers import unwrap as _u
 
 
@@ -33,7 +33,7 @@ def unpatch():
 @asyncio.coroutine
 def patched_connect(connect_func, _, args, kwargs):
     conn = yield from connect_func(*args, **kwargs)
-    return psycppg_patch_conn(conn, traced_conn_cls=AIOTracedConnection)
+    return psycopg_patch_conn(conn, traced_conn_cls=AIOTracedConnection)
 
 
 def _extensions_register_type(func, _, args, kwargs):

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -69,7 +69,7 @@ class Psycopg2TracedConnection(dbapi.TracedConnection):
 
 
 def patch_conn(conn, traced_conn_cls=Psycopg2TracedConnection):
-    """ Wrap will patch the instance so that it's queries are traced."""
+    """ Wrap will patch the instance so that its queries are traced."""
     # ensure we've patched extensions (this is idempotent) in
     # case we're only tracing some connections.
     _patch_extensions(_psycopg2_extensions)


### PR DESCRIPTION
Not sure if I need to add much more information, it's just a typo fix.