### PR TITLE
[pymongo] Support newer msg requests

### DIFF
--- a/ddtrace/contrib/pymongo/parse.py
+++ b/ddtrace/contrib/pymongo/parse.py
@@ -113,7 +113,8 @@ def parse_msg(msg_bytes):
         if not cmd.coll:
             cmd.coll = coll
 
-    cmd.metrics[netx.BYTES_OUT] = msg_len
+    if cmd:
+        cmd.metrics[netx.BYTES_OUT] = msg_len
     return cmd
 
 

--- a/ddtrace/contrib/pymongo/parse.py
+++ b/ddtrace/contrib/pymongo/parse.py
@@ -79,12 +79,14 @@ def parse_msg(msg_bytes):
         log.debug('unknown op code: %s', op_code)
         return None
 
-    # Only parse query messages
-    # NOTE[matt] inserts, updates and queries can all use this opcode
     db = None
     coll = None
+
+    offset = header_struct.size
+    cmd = None
     if op == 'query':
-        offset = header_struct.size
+        # NOTE[matt] inserts, updates and queries can all use this opcode
+
         offset += 4  # skip flags
         ns = _cstring(msg_bytes[offset:])
         offset += len(ns) + 1  # include null terminator
@@ -112,7 +114,6 @@ def parse_msg(msg_bytes):
             cmd.coll = coll
     elif op == 'msg':
         # Skip header and flag bits
-        offset = header_struct.size
         offset += 4
 
         # Parse the msg kind

--- a/ddtrace/contrib/pymongo/parse.py
+++ b/ddtrace/contrib/pymongo/parse.py
@@ -116,7 +116,7 @@ def parse_msg(msg_bytes):
         offset += 4
 
         # Parse the msg kind
-        kind = int(msg_bytes[offset:offset+1].encode('hex'), 16)
+        kind = ord(msg_bytes[offset:offset+1])
         offset += 1
 
         # Kinds: https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#sections

--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,7 @@ envlist =
     pylibmc_contrib-{py27,py34,py35,py36,py37}-pylibmc{140,150}
     pylons_contrib-{py27}-pylons{096,097,010,10}
     pymemcache_contrib{,_autopatch}-{py27,py34,py35,py36,py37}-pymemcache{130,140}
-    pymongo_contrib-{py27,py34,py35,py36,py37}-pymongo{30,31,32,33,34,36}-mongoengine{015}
+    pymongo_contrib-{py27,py34,py35,py36,py37}-pymongo{30,31,32,33,34,36,37,38}-mongoengine{015,016,017}
     pymysql_contrib-{py27,py34,py35,py36,py37}-pymysql{07,08,09}
     pyramid_contrib{,_autopatch}-{py27,py34,py35,py36,py37}-pyramid{17,18,19}-webtest
     redis_contrib-{py27,py34,py35,py36,py37}-redis{26,27,28,29,210,300}
@@ -250,6 +250,8 @@ deps =
     molten070: molten>=0.7.0,<0.7.2
     molten072: molten>=0.7.2,<0.8.0
     mongoengine015: mongoengine>=0.15<0.16
+    mongoengine016: mongoengine>=0.16<0.17
+    mongoengine017: mongoengine>=0.17<0.18
     mysqlconnector: mysql-connector-python
     mysqldb12: mysql-python>=1.2,<1.3
     mysqlclient13: mysqlclient>=1.3,<1.4
@@ -272,6 +274,8 @@ deps =
     pymongo33: pymongo>=3.3,<3.4
     pymongo34: pymongo>=3.4,<3.5
     pymongo36: pymongo>=3.6,<3.7
+    pymongo37: pymongo>=3.7,<3.8
+    pymongo38: pymongo>=3.8,<3.9
     pymysql07: pymysql>=0.7,<0.8
     pymysql08: pymysql>=0.8,<0.9
     pymysql09: pymysql>=0.9,<0.10


### PR DESCRIPTION
Newer versions of Mongo support sending a generic `OP_MSG` request instead of `OP_QUERY`, we should support these versions.