### PR TITLE
writer: fix deprecated log.warn use

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -207,7 +207,7 @@ class API(object):
                         payload.add_trace(trace)
                     except PayloadFull:
                         # If the trace does not fit in a payload on its own, that's bad. Drop it.
-                        log.warn('Trace %r is too big to fit in a payload, dropping it', trace)
+                        log.warning('Trace %r is too big to fit in a payload, dropping it', trace)
 
         # Check that the Payload is not empty:
         # it could be empty if the last trace was too big to fit.

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -147,4 +147,4 @@ try:
     loaded = True
 except Exception:
     loaded = False
-    log.warn('error configuring Datadog tracing', exc_info=True)
+    log.warning('error configuring Datadog tracing', exc_info=True)

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -62,7 +62,7 @@ class TraceMiddleware(object):
             s = getattr(signals, name, None)
             if not s:
                 connected = False
-                log.warn('trying to instrument missing signal %s', name)
+                log.warning('trying to instrument missing signal %s', name)
                 continue
             # we should connect to the signal without using weak references
             # otherwise they will be garbage collected and our handlers

--- a/ddtrace/internal/runtime/collector.py
+++ b/ddtrace/internal/runtime/collector.py
@@ -45,7 +45,7 @@ class ValueCollector(object):
         except ImportError:
             # DEV: disable collector if we cannot load any of the required modules
             self.enabled = False
-            log.warn('Could not import module "{}" for {}. Disabling collector.'.format(module, self))
+            log.warning('Could not import module "{}" for {}. Disabling collector.'.format(module, self))
             return None
         return modules
 

--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -73,7 +73,7 @@ class RuntimeWorker(_worker.PeriodicWorkerThread):
 
     def flush(self):
         if not self._statsd_client:
-            log.warn('Attempted flush with uninitialized or failed statsd client')
+            log.warning('Attempted flush with uninitialized or failed statsd client')
             return
 
         for key, value in self._runtime_metrics:

--- a/ddtrace/utils/hook.py
+++ b/ddtrace/utils/hook.py
@@ -87,7 +87,7 @@ def notify_module_loaded(module):
         try:
             hook(module)
         except Exception as err:
-            log.warn('hook "{}" for module "{}" failed: {}'.format(hook, name, err))
+            log.warning('hook "{}" for module "{}" failed: {}'.format(hook, name, err))
 
 
 class _ImportHookLoader(object):

--- a/ddtrace/writer.py
+++ b/ddtrace/writer.py
@@ -160,7 +160,7 @@ class Q(Queue):
                 if qsize != 0:
                     idx = random.randrange(0, qsize)
                     self.queue[idx] = item
-                    log.warn('Writer queue is full has more than %d traces, some traces will be lost', self.maxsize)
+                    log.warning('Writer queue is full has more than %d traces, some traces will be lost', self.maxsize)
                     return
             # The queue has been emptied, simply retry putting item
             return self.put(item)

--- a/tests/internal/runtime/test_metrics.py
+++ b/tests/internal/runtime/test_metrics.py
@@ -89,7 +89,7 @@ class TestValueCollector(BaseTestCase):
                 'Disabling collector.'
             ))
         ]
-        log_mock.warn.assert_has_calls(calls)
+        log_mock.warning.assert_has_calls(calls)
 
     def test_collected_values(self):
         class V(ValueCollector):

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -176,7 +176,7 @@ class TestHook(SubprocessTestCase):
             calls = [
                 mock.call('hook "{}" for module "tests.utils.test_module" failed: test_hook_failed'.format(test_hook))
             ]
-            log_mock.warn.assert_has_calls(calls)
+            log_mock.warning.assert_has_calls(calls)
 
     def test_hook_called_with_module(self):
         """


### PR DESCRIPTION
I have 100's of deprecation warnings in my tests because `log.warn` is deprecated.

Example of warning:
```
  /usr/local/lib/python3.6/site-packages/ddtrace/writer.py:163: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

This PR simple use log.warning - nothing impressive :)