### PR TITLE
Use setuptools_scm to handle version numbers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -706,7 +706,6 @@ jobs:
       - run: sudo apt-get -y install rake
       - run: sudo pip install mkwheelhouse sphinx awscli
       - run: S3_DIR=trace-dev rake release:docs
-      - run: VERSION_SUFFIX=$CIRCLE_BRANCH$CIRCLE_BUILD_NUM S3_DIR=trace-dev rake release:wheel
 
   jinja2:
     docker:

--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -1,10 +1,18 @@
+import pkg_resources
+
 from .monkey import patch, patch_all
 from .pin import Pin
 from .span import Span
 from .tracer import Tracer
 from .settings import config
 
-__version__ = '0.27.0'
+
+try:
+    __version__ = pkg_resources.get_distribution(__name__).version
+except pkg_resources.DistributionNotFound:
+    # package is not installed
+    __version__ = None
+
 
 # a global tracer instance with integration settings
 tracer = Tracer()

--- a/scripts/build-dist
+++ b/scripts/build-dist
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 
-# DEV: `${VERSION_SUFFIX-}` means don't fail if it doesn't exist, use empty string instead (which is fine)
-echo "Building with version suffix: ${VERSION_SUFFIX-}"
-
 # Determine where "../dist" is
 PARENT_DIR="$( cd "$(dirname "${0}")/../" ; pwd -P )"
 DIST_DIR="${PARENT_DIR}/dist"
@@ -33,9 +30,7 @@ EOF
 python setup.py sdist --dist-dir dist
 
 # Build x86_64 linux and manylinux wheels
-# DEV: `${VERSION_SUFFIX-}` means don't fail if it doesn't exist, use empty string instead (which is fine)
-docker run -it --rm -v "${PARENT_DIR}:/dd-trace-py" -e "ARCH=x86_64" -e "VERSION_SUFFIX=${VERSION_SUFFIX-}" quay.io/pypa/manylinux1_x86_64 /bin/bash -c "${build_script}"
+docker run -it --rm -v "${PARENT_DIR}:/dd-trace-py" -e "ARCH=x86_64" quay.io/pypa/manylinux1_x86_64 /bin/bash -c "${build_script}"
 
 # Build i686 linux and manylinux wheels
-# DEV: `${VERSION_SUFFIX-}` means don't fail if it doesn't exist, use empty string instead (which is fine)
-docker run -it --rm -v "${PARENT_DIR}:/dd-trace-py" -e "ARCH=i686" -e "VERSION_SUFFIX=${VERSION_SUFFIX-}" quay.io/pypa/manylinux1_i686 linux32 /bin/bash -c "${build_script}"
+docker run -it --rm -v "${PARENT_DIR}:/dd-trace-py" -e "ARCH=i686" quay.io/pypa/manylinux1_i686 linux32 /bin/bash -c "${build_script}"

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,11 @@
 import copy
 import os
 import sys
-import re
 
 from distutils.command.build_ext import build_ext
 from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
 from setuptools import setup, find_packages, Extension
 from setuptools.command.test import test as TestCommand
-
-
-def get_version(package):
-    """
-    Return package version as listed in `__version__` in `__init__.py`.
-    This method prevents to import packages at setup-time.
-    """
-    init_py = open(os.path.join(package, '__init__.py')).read()
-    return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 
 class Tox(TestCommand):
@@ -41,14 +31,6 @@ class Tox(TestCommand):
         errno = tox.cmdline(args=args)
         sys.exit(errno)
 
-
-version = get_version('ddtrace')
-# Append a suffix to the version for dev builds
-if os.environ.get('VERSION_SUFFIX'):
-    version = '{v}+{s}'.format(
-        v=version,
-        s=os.environ.get('VERSION_SUFFIX'),
-    )
 
 long_description = """
 # dd-trace-py
@@ -76,7 +58,6 @@ documentation][visualization docs].
 # Base `setup()` kwargs without any C-extension registering
 setup_kwargs = dict(
     name='ddtrace',
-    version=version,
     description='Datadog tracing code',
     url='https://github.com/DataDog/dd-trace-py',
     author='Datadog, Inc.',
@@ -109,6 +90,8 @@ setup_kwargs = dict(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
 )
 
 


### PR DESCRIPTION
This leverages setuptools_scm to generate version number for the libary rather
than updating manually. It will leverages git tags to produce adequate numbers.

For dev version, it'll generate version numbers such as
`0.27.1.dev7+gdeb1fb54.d20190723` which are pretty explicity about where the
version is at.

Since we now produce and distribute wheels, setuptools-scm is only a
requirement if someone installs from source — which should not be the case for
anyone using pip.

This should simplify maintenance and distribution overall.