### PR TITLE
[dev] Map .git into ddtest for setuptools_scm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,10 @@ services:
             - ./tox.ini:/src/tox.ini:ro
             - ./.ddtox:/src/.tox
             - ./scripts:/src/scripts
+            # setuptools_scm needs `.git` to figure out what version we are on
+            # DEV: We could use `SETUPTOOLS_SCM_PRETEND_VERSION` but prefer `.git`
+            #      to get the same behavior as during releases
+            - ./.git:/src/.git:ro
         command: bash
 
 volumes:


### PR DESCRIPTION
I was trying to decide between this and the env variable `setuptools_scm` allows for overriding the version, but decided to use `.git` since that is a behavior we want to test to ensure it always works.