### PR TITLE
[core] Parse and send container id with payloads to the agent

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -8,6 +8,7 @@ import socket
 from .encoding import get_encoder, JSONEncoder
 from .compat import httplib, PYTHON_VERSION, PYTHON_INTERPRETER, get_connection_response
 from .internal.logger import get_logger
+from .internal.runtime import container
 from .payload import Payload, PayloadFull
 from .utils.deprecation import deprecated
 
@@ -150,6 +151,13 @@ class API(object):
             'Datadog-Meta-Lang-Interpreter': PYTHON_INTERPRETER,
             'Datadog-Meta-Tracer-Version': ddtrace.__version__,
         })
+
+        # Add container information if we have it
+        self._container_info = container.get_container_info()
+        if self._container_info and self._container_info.container_id:
+            self._headers.update({
+                'Datadog-Container-Id': self._container_info.container_id,
+            })
 
     def __str__(self):
         if self.uds_path:

--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -1,0 +1,119 @@
+import os
+import re
+
+from ..logger import get_logger
+
+log = get_logger(__name__)
+
+
+class CGroupInfo(object):
+    """
+    CGroup class for container information parsed from a group cgroup file
+    """
+    __slots__ = ('id', 'groups', 'path', 'container_id', 'controllers', 'pod_id')
+
+    UUID_SOURCE_PATTERN = r'[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}'
+    CONTAINER_SOURCE_PATTERN = r'[0-9a-f]{64}'
+
+    LINE_RE = re.compile(r'^(\d+):([^:]*):(.+)$')
+    POD_RE = re.compile(r'pod({0})(?:\.slice)?$'.format(UUID_SOURCE_PATTERN))
+    CONTAINER_RE = re.compile(r'({0}|{1})(?:\.scope)?$'.format(UUID_SOURCE_PATTERN, CONTAINER_SOURCE_PATTERN))
+
+    def __init__(self, **kwargs):
+        # Initialize all attributes in __slots__ to `None`
+        # DEV: Otherwise we'll get `AttributeError` when trying to access if they are unset
+        for attr in self.__slots__:
+            setattr(self, attr, kwargs.get(attr))
+
+    @classmethod
+    def from_line(cls, line):
+        """
+        Parse a new :class:`CGroupInfo` from the provided line
+
+        :param line: A line from a cgroup file (e.g. /proc/self/cgroup) to parse information from
+        :type line: str
+        :returns: A :class:`CGroupInfo` object with all parsed data, if the line is valid, otherwise `None`
+        :rtype: :class:`CGroupInfo` | None
+
+        """
+        # Clean up the line
+        line = line.strip()
+
+        # Ensure the line is valid
+        match = cls.LINE_RE.match(line)
+        if not match:
+            return None
+
+        # Create our new `CGroupInfo` and set attributes from the line
+        info = cls()
+        info.id, info.groups, info.path = match.groups()
+
+        # Parse the controllers from the groups
+        info.controllers = [c.strip() for c in info.groups.split(',') if c.strip()]
+
+        # Break up the path to grab container_id and pod_id if available
+        # e.g. /docker/<container_id>
+        # e.g. /kubepods/test/pod<pod_id>/<container_id>
+        parts = [p for p in info.path.split('/')]
+
+        # Grab the container id from the path if a valid id is present
+        if len(parts):
+            match = cls.CONTAINER_RE.match(parts.pop())
+            if match:
+                info.container_id = match.group(1)
+
+        # Grab the pod id from the path if a valid id is present
+        if len(parts):
+            match = cls.POD_RE.match(parts.pop())
+            if match:
+                info.pod_id = match.group(1)
+
+        return info
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __repr__(self):
+        return '{}(id={!r}, groups={!r}, path={!r}, container_id={!r}, controllers={!r}, pod_id={!r})'.format(
+            self.__class__.__name__,
+            self.id,
+            self.groups,
+            self.path,
+            self.container_id,
+            self.controllers,
+            self.pod_id,
+        )
+
+
+def _open_file(*args, **kwargs):
+    """Wrapper for `builtins.open` to make testing easier"""
+    return open(*args, **kwargs)
+
+
+def get_container_info(pid='self'):
+    """
+    Helper to fetch the current container id, if we are running in a container
+
+    We will parse `/proc/{pid}/cgroup` to determine our container id.
+
+    The results of calling this function are cached
+
+    :param pid: The pid of the cgroup file to parse (default: 'self')
+    :type pid: str | int
+    :returns: The cgroup file info if found, or else None
+    :rtype: :class:`CGroupInfo` | None
+    """
+    try:
+        cgroup_file = '/proc/{0}/cgroup'.format(pid)
+        if not os.path.exists(cgroup_file):
+            return None
+
+        with _open_file(cgroup_file, mode='r') as fp:
+            for line in fp:
+                info = CGroupInfo.from_line(line)
+                if info and info.container_id:
+                    return info
+    except Exception:
+        log.exception('Failed to parse cgroup file for pid %r', pid)
+
+    return None

--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -1,4 +1,3 @@
-import os
 import re
 
 from ..logger import get_logger

--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -85,11 +85,6 @@ class CGroupInfo(object):
         )
 
 
-def _open_file(*args, **kwargs):
-    """Wrapper for `builtins.open` to make testing easier"""
-    return open(*args, **kwargs)
-
-
 def get_container_info(pid='self'):
     """
     Helper to fetch the current container id, if we are running in a container
@@ -105,10 +100,7 @@ def get_container_info(pid='self'):
     """
     try:
         cgroup_file = '/proc/{0}/cgroup'.format(pid)
-        if not os.path.exists(cgroup_file):
-            return None
-
-        with _open_file(cgroup_file, mode='r') as fp:
+        with open(cgroup_file, mode='r') as fp:
             for line in fp:
                 info = CGroupInfo.from_line(line)
                 if info and info.container_id:

--- a/tests/internal/runtime/test_container.py
+++ b/tests/internal/runtime/test_container.py
@@ -1,0 +1,316 @@
+import mock
+
+import pytest
+
+from ddtrace.internal.runtime.container import CGroupInfo, get_container_info
+
+from .utils import cgroup_line_valid_test_cases, StringIOContext
+
+
+@pytest.fixture
+def mock_open():
+    with mock.patch('ddtrace.internal.runtime.container._open_file') as mocked:
+        yield mocked
+
+
+@pytest.fixture
+def mock_exists():
+    with mock.patch('os.path.exists') as mocked:
+        yield mocked
+
+
+def test_cgroup_info_init():
+    # Assert default all attributes to `None`
+    info = CGroupInfo()
+    for attr in ('id', 'groups', 'path', 'container_id', 'controllers', 'pod_id'):
+        assert getattr(info, attr) is None
+
+    # Assert init with property sets property
+    info = CGroupInfo(container_id='test-container-id')
+    assert info.container_id == 'test-container-id'
+
+
+@pytest.mark.parametrize(
+    'line,expected_info',
+
+    # Valid generated cases + one off cases
+    cgroup_line_valid_test_cases() + [
+        # Valid, extra spaces
+        (
+            '    13:name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860    ',
+            CGroupInfo(
+                id='13',
+                groups='name=systemd',
+                controllers=['name=systemd'],
+                path='/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860',
+                container_id='3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860',
+                pod_id=None,
+            ),
+        ),
+        # Valid, bookended newlines
+        (
+            '\r\n13:name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\r\n',
+            CGroupInfo(
+                id='13',
+                groups='name=systemd',
+                controllers=['name=systemd'],
+                path='/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860',
+                container_id='3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860',
+                pod_id=None,
+            ),
+        ),
+
+        # Invalid container_ids
+        (
+            # One character too short
+            '13:name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f86986',
+            CGroupInfo(
+                id='13',
+                groups='name=systemd',
+                controllers=['name=systemd'],
+                path='/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f86986',
+                container_id=None,
+                pod_id=None,
+            ),
+        ),
+        (
+            # One character too long
+            '13:name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f8698600',
+            CGroupInfo(
+                id='13',
+                groups='name=systemd',
+                controllers=['name=systemd'],
+                path='/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f8698600',
+                container_id=None,
+                pod_id=None,
+            ),
+        ),
+        (
+            # Non-hex
+            '13:name=systemd:/docker/3726184226f5d3147c25fzyxw5b60097e378e8a720503a5e19ecfdf29f869860',
+            CGroupInfo(
+                id='13',
+                groups='name=systemd',
+                controllers=['name=systemd'],
+                path='/docker/3726184226f5d3147c25fzyxw5b60097e378e8a720503a5e19ecfdf29f869860',
+                container_id=None,
+                pod_id=None,
+            ),
+        ),
+
+        # Invalid id
+        (
+            # non-digit
+            'a:name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860',
+            None,
+        ),
+        (
+            # missing
+            ':name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860',
+            None,
+        ),
+
+        # Missing group
+        (
+            # empty
+            '13::/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860',
+            CGroupInfo(
+                id='13',
+                groups='',
+                controllers=[],
+                path='/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860',
+                container_id='3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860',
+                pod_id=None,
+            ),
+        ),
+        (
+            # missing
+            '13:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860',
+            None,
+        ),
+
+
+        # Empty line
+        (
+            '',
+            None,
+        ),
+    ],
+)
+def test_cgroup_info_from_line(line, expected_info):
+    info = CGroupInfo.from_line(line)
+
+    if expected_info is None:
+        assert info is None, line
+    else:
+        for attr in ('id', 'groups', 'path', 'container_id', 'controllers', 'pod_id'):
+            assert getattr(info, attr) == getattr(expected_info, attr), line
+
+
+@pytest.mark.parametrize(
+    'file_contents,container_id',
+    (
+        # Docker file
+        (
+            """
+13:name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+12:pids:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+11:hugetlb:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+10:net_prio:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+9:perf_event:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+8:net_cls:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+7:freezer:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+6:devices:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+5:memory:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+4:blkio:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+3:cpuacct:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+2:cpu:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+1:cpuset:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+            """,
+            '3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860',
+        ),
+
+        # k8s file
+        (
+            """
+11:perf_event:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+10:pids:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+9:memory:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+8:cpu,cpuacct:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+7:blkio:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+6:cpuset:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+5:devices:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+4:freezer:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+3:net_cls,net_prio:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+2:hugetlb:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+1:name=systemd:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+            """,
+            '3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1',
+        ),
+
+        # ECS file
+        (
+            """
+9:perf_event:/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+8:memory:/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+7:hugetlb:/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+6:freezer:/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+5:devices:/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+4:cpuset:/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+3:cpuacct:/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+2:cpu:/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+1:blkio:/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+            """,
+            '38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce',
+        ),
+
+        # Fargate file
+        (
+            """
+11:hugetlb:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+10:pids:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+9:cpuset:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+8:net_cls,net_prio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+7:cpu,cpuacct:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+6:perf_event:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+5:freezer:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+4:devices:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+3:blkio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+2:memory:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+1:name=systemd:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+            """,
+            '432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da',
+        ),
+
+        # Linux non-containerized file
+        (
+            """
+11:blkio:/user.slice/user-0.slice/session-14.scope
+10:memory:/user.slice/user-0.slice/session-14.scope
+9:hugetlb:/
+8:cpuset:/
+7:pids:/user.slice/user-0.slice/session-14.scope
+6:freezer:/
+5:net_cls,net_prio:/
+4:perf_event:/
+3:cpu,cpuacct:/user.slice/user-0.slice/session-14.scope
+2:devices:/user.slice/user-0.slice/session-14.scope
+1:name=systemd:/user.slice/user-0.slice/session-14.scope
+            """,
+            None,
+        ),
+
+        # Empty file
+        (
+            '',
+            None,
+        ),
+
+        # Missing file
+        (
+            None,
+            None,
+        )
+    )
+)
+def test_get_container_info(file_contents, container_id, mock_open, mock_exists):
+    mock_exists.return_value = file_contents is not None
+    if file_contents:
+        mock_open.return_value = StringIOContext(file_contents)
+    else:
+        mock_open.side_effect = AssertionError
+
+    info = get_container_info()
+
+    if container_id is None:
+        assert info is None
+    else:
+        assert info.container_id == container_id
+
+    mock_exists.assert_called_once_with('/proc/self/cgroup')
+
+    if file_contents is not None:
+        mock_open.assert_called_once_with('/proc/self/cgroup', mode='r')
+    else:
+        mock_open.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    'pid,file_name',
+    (
+        ('13', '/proc/13/cgroup'),
+        (13, '/proc/13/cgroup'),
+        ('self', '/proc/self/cgroup'),
+    )
+)
+def test_get_container_info_with_pid(pid, file_name, mock_open, mock_exists):
+    mock_exists.return_value = True
+
+    # DEV: We need at least 1 line for the loop to call `CGroupInfo.from_line`
+    mock_open.return_value = StringIOContext('\r\n')
+
+    assert get_container_info(pid=pid) is None
+
+    mock_exists.assert_called_once_with(file_name)
+    mock_open.assert_called_once_with(file_name, mode='r')
+
+
+@mock.patch('ddtrace.internal.runtime.container.CGroupInfo.from_line')
+@mock.patch('ddtrace.internal.runtime.container.log')
+def test_get_container_info_exception(mock_log, mock_from_line, mock_open, mock_exists):
+    mock_from_line.side_effect = Exception
+    mock_exists.return_value = True
+
+    # DEV: We need at least 1 line for the loop to call `CGroupInfo.from_line`
+    mock_open.return_value = StringIOContext('\r\n')
+
+    # Assert calling `get_container_info()` does not bubble up the exception
+    assert get_container_info() is None
+
+    # Assert we called everything we expected
+    mock_from_line.assert_called_once_with('\r\n')
+    mock_exists.assert_called_once_with('/proc/self/cgroup')
+    mock_open.assert_called_once_with('/proc/self/cgroup', mode='r')
+
+    # Ensure we logged the exception
+    mock_log.exception.assert_called_once_with('Failed to parse cgroup file for pid %r', 'self')

--- a/tests/internal/runtime/test_container.py
+++ b/tests/internal/runtime/test_container.py
@@ -2,9 +2,14 @@ import mock
 
 import pytest
 
+from ddtraace.compat import PY2
 from ddtrace.internal.runtime.container import CGroupInfo, get_container_info
 
 from .utils import cgroup_line_valid_test_cases
+
+# Map expected Py2 exception to Py3 name
+if PY2:
+    FileNotFoundError = IOError
 
 
 def get_mock_open(read_data=None):

--- a/tests/internal/runtime/test_container.py
+++ b/tests/internal/runtime/test_container.py
@@ -261,6 +261,7 @@ def test_get_container_info(file_contents, container_id):
 
         mock_open.assert_called_once_with('/proc/self/cgroup', mode='r')
 
+
 @pytest.mark.parametrize(
     'pid,file_name',
     (

--- a/tests/internal/runtime/test_container.py
+++ b/tests/internal/runtime/test_container.py
@@ -2,7 +2,7 @@ import mock
 
 import pytest
 
-from ddtraace.compat import PY2
+from ddtrace.compat import PY2
 from ddtrace.internal.runtime.container import CGroupInfo, get_container_info
 
 from .utils import cgroup_line_valid_test_cases

--- a/tests/internal/runtime/utils.py
+++ b/tests/internal/runtime/utils.py
@@ -4,15 +4,20 @@ from ddtrace.compat import StringIO
 from ddtrace.internal.runtime.container import CGroupInfo
 
 
-class StringIOContext(StringIO):
+class StringIOContext():
     """
     Wrapper for :class:`StringIO` to provide `__enter__` and `__exit__` methods
     """
+    __slots__ = ('io', )
+
+    def __init__(self, *args, **kwargs):
+        self.io = StringIO(*args, **kwargs)
+
     def __enter__(self):
-        return self
+        return self.io
 
     def __exit__(self, *args, **kwargs):
-        self.close()
+        self.io.close()
 
 
 def cgroup_line_valid_test_cases():

--- a/tests/internal/runtime/utils.py
+++ b/tests/internal/runtime/utils.py
@@ -1,0 +1,84 @@
+import itertools
+
+from ddtrace.compat import StringIO
+from ddtrace.internal.runtime.container import CGroupInfo
+
+
+class StringIOContext(StringIO):
+    """
+    Wrapper for :class:`StringIO` to provide `__enter__` and `__exit__` methods
+    """
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+
+
+def cgroup_line_valid_test_cases():
+    controllers = [
+        ['name=systemd'],
+        ['pids'],
+        ['cpu', 'cpuacct'],
+        ['perf_event'],
+        ['net_cls', 'net_prio'],
+    ]
+
+    ids = [str(i) for i in range(10)]
+
+    container_ids = [
+        '3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860',
+        '37261842-26f5-d314-7c25-fdeab5b60097',
+        '37261842_26f5_d314_7c25_fdeab5b60097',
+    ]
+
+    pod_ids = [
+        '3d274242-8ee0-11e9-a8a6-1e68d864ef1a',
+        '3d274242_8ee0_11e9_a8a6_1e68d864ef1a',
+    ]
+
+    paths = [
+        # Docker
+        '/docker/{0}',
+        '/docker/{0}.scope',
+
+        # k8s
+        '/kubepods/test/pod{1}/{0}',
+        '/kubepods/test/pod{1}.slice/{0}',
+        '/kubepods/test/pod{1}/{0}.scope',
+        '/kubepods/test/pod{1}.slice/{0}.scope',
+
+        # ECS
+        '/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/{0}',
+        '/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/{0}.scope',
+
+        # Fargate
+        '/ecs/55091c13-b8cf-4801-b527-f4601742204d/{0}',
+        '/ecs/55091c13-b8cf-4801-b527-f4601742204d/{0}.scope',
+
+        # Linux non-containerized
+        '/user.slice/user-0.slice/session-83.scope',
+    ]
+
+    valid_test_cases = dict(
+        (
+            ':'.join([id, ','.join(groups), path.format(container_id, pod_id)]),
+            CGroupInfo(
+                id=id,
+                groups=','.join(groups),
+                path=path.format(container_id, pod_id),
+                controllers=groups,
+                container_id=container_id if '{0}' in path else None,
+                pod_id=pod_id if '{1}' in path else None,
+            )
+        )
+        for path, id, groups, container_id, pod_id
+        in itertools.product(paths, ids, controllers, container_ids, pod_ids)
+    )
+    # Dedupe test cases
+    valid_test_cases = list(valid_test_cases.items())
+
+    # Assert here to ensure we are always testing the number of cases we expect
+    assert len(valid_test_cases) == 2150
+
+    return valid_test_cases

--- a/tests/internal/runtime/utils.py
+++ b/tests/internal/runtime/utils.py
@@ -1,23 +1,6 @@
 import itertools
 
-from ddtrace.compat import StringIO
 from ddtrace.internal.runtime.container import CGroupInfo
-
-
-class StringIOContext():
-    """
-    Wrapper for :class:`StringIO` to provide `__enter__` and `__exit__` methods
-    """
-    __slots__ = ('io', )
-
-    def __init__(self, *args, **kwargs):
-        self.io = StringIO(*args, **kwargs)
-
-    def __enter__(self):
-        return self.io
-
-    def __exit__(self, *args, **kwargs):
-        self.io.close()
 
 
 def cgroup_line_valid_test_cases():


### PR DESCRIPTION
In this PR we are adding in a utility for parsing the current container id from `/proc/self/cgroup` and sending it as a header to the trace agent.