### PR TITLE
[tests] Adding in helpful default packages

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -134,8 +134,10 @@ deps =
 # distribution build.
     !ddtracerun: wrapt
     !msgpack03-!msgpack04-!msgpack05-!ddtracerun: msgpack-python
+    pdbpp
     pytest>=3
     pytest-benchmark
+    pytest-cov
     opentracing
     psutil
 # test dependencies installed in all envs


### PR DESCRIPTION
Some generic test utilities that are either nice to have or plan to use in the future. Adding now to make it easier to run/test locally.

`pdbpp` - a better `pdb`... because... it's better.

`pytest-cov` - we want to add coverage testing and reporting across everything at some point, but for now I find it is sometimes helpful to have and use `pytest-cov` locally when building something new to ensure I didn't miss a branch of code in my tests.