### PR TITLE
[django] Only set sample rate if rate is set

### DIFF
--- a/ddtrace/contrib/django/middleware.py
+++ b/ddtrace/contrib/django/middleware.py
@@ -39,6 +39,13 @@ _django_default_views = {
 }
 
 
+def _analytics_enabled():
+    return (
+        (config.analytics_enabled and settings.ANALYTICS_ENABLED is not False)
+        or settings.ANALYTICS_ENABLED is True
+    ) and settings.ANALYTICS_SAMPLE_RATE is not None
+
+
 def get_middleware_insertion_point():
     """Returns the attribute name and collection object for the Django middleware.
     If middleware cannot be found, returns None for the middleware collection."""
@@ -121,12 +128,10 @@ class TraceMiddleware(InstrumentationMixin):
 
             # set analytics sample rate
             # DEV: django is special case maintains separate configuration from config api
-            if (
-                config.analytics_enabled and settings.ANALYTICS_ENABLED is not False
-            ) or settings.ANALYTICS_ENABLED is True:
+            if _analytics_enabled():
                 span.set_tag(
                     ANALYTICS_SAMPLE_RATE_KEY,
-                    settings.ANALYTICS_SAMPLE_RATE
+                    settings.ANALYTICS_SAMPLE_RATE,
                 )
 
             span.set_tag(http.METHOD, request.method)


### PR DESCRIPTION
Only try to set the analytics sample rate if a sample rate is available.

This saves us from potentially having `span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, None)`