### PR TITLE
[django] Update how we get the http.url

### DIFF
--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -1,3 +1,9 @@
+from ...compat import parse
+from ...internal.logger import get_logger
+
+log = get_logger(__name__)
+
+
 def _resource_from_cache_prefix(resource, cache):
     """
     Combine the resource name with the cache prefix (if any)
@@ -24,3 +30,46 @@ def quantize_key_values(key):
         return key.keys()
 
     return key
+
+
+def get_request_uri(request):
+    """
+    Helper to rebuild the original request url
+
+    query string or fragments are not included.
+    """
+    # DEV: We do this instead of `request.build_absolute_uri()` since
+    #      an exception can get raised, we want to always build a url
+    #      regardless of any exceptions raised from `request.get_host()`
+    host = None
+    try:
+        host = request.get_host()  # this will include host:port
+    except Exception as e:
+        log.debug('Failed to get Django request host: %s', e)
+
+    if not host:
+        try:
+            # Try to build host how Django would have
+            # https://github.com/django/django/blob/e8d0d2a5efc8012dcc8bf1809dec065ebde64c81/django/http/request.py#L85-L102
+            if 'HTTP_HOST' in request.META:
+                host = request.META['HTTP_HOST']
+            else:
+                host = request.META['SERVER_NAME']
+                port = str(request.META['SERVER_PORT'])
+                if port != ('443' if request.is_secure() else '80'):
+                    host = '{0}:{1}'.format(host, port)
+        except Exception as e:
+            # This really shouldn't ever happen, but lets guard here just in case
+            log.debug('Failed to build Django request host: %s', e)
+            host = 'unknown'
+
+    # Build request url from the information available
+    # DEV: We are explicitly omitting query strings since they may contain sensitive information
+    return parse.urlunparse(parse.ParseResult(
+        scheme=request.scheme,
+        netloc=host,
+        path=request.path,
+        params='',
+        query='',
+        fragment='',
+    ))


### PR DESCRIPTION
There is a chance that building the original url from the Django request using `request.build_absolute_uri` could raise an exception and cause us to fail to trace the request all together.

This PR adds in a new helper which does (almost) what `build_absolute_uri` does but ensures that we guard against potential failures and ensures the url is formatted as we format them for other frameworks (without query string/fragments/etc).