### PR TITLE
Patch DBs in django app config

### DIFF
--- a/ddtrace/contrib/django/apps.py
+++ b/ddtrace/contrib/django/apps.py
@@ -2,15 +2,7 @@
 from django.apps import AppConfig, apps
 
 # project
-from .db import patch_db
-from .conf import settings
-from .cache import patch_cache
-from .templates import patch_template
-from .middleware import insert_exception_middleware, insert_trace_middleware
-
-from ...internal.logger import get_logger
-
-log = get_logger(__name__)
+from .patch import apply_django_patches
 
 
 class TracerConfig(AppConfig):
@@ -23,46 +15,5 @@ class TracerConfig(AppConfig):
         Tracing capabilities must be enabled in this function so that
         all Django internals are properly configured.
         """
-        tracer = settings.TRACER
-
-        if settings.TAGS:
-            tracer.set_tags(settings.TAGS)
-
-        # configure the tracer instance
-        # TODO[manu]: we may use configure() but because it creates a new
-        # AgentWriter, it breaks all tests. The configure() behavior must
-        # be changed to use it in this integration
-        tracer.enabled = settings.ENABLED
-        tracer.writer.api.hostname = settings.AGENT_HOSTNAME
-        tracer.writer.api.port = settings.AGENT_PORT
-
-        if settings.AUTO_INSTRUMENT:
-            # trace Django internals
-            insert_trace_middleware()
-            insert_exception_middleware()
-
-            if settings.INSTRUMENT_TEMPLATE:
-                try:
-                    patch_template(tracer)
-                except Exception:
-                    log.exception('error patching Django template rendering')
-
-            if settings.INSTRUMENT_DATABASE:
-                try:
-                    patch_db(tracer)
-                except Exception:
-                    log.exception('error patching Django database connections')
-
-            if settings.INSTRUMENT_CACHE:
-                try:
-                    patch_cache(tracer)
-                except Exception:
-                    log.exception('error patching Django cache')
-
-            # Instrument rest_framework app to trace custom exception handling.
-            if apps.is_installed('rest_framework'):
-                try:
-                    from .restframework import patch_restframework
-                    patch_restframework(tracer)
-                except Exception:
-                    log.exception('error patching rest_framework app')
+        rest_framework_is_installed = apps.is_installed('rest_framework')
+        apply_django_patches(patch_rest_framework=rest_framework_is_installed)

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -1,6 +1,18 @@
+# 3rd party
 from ddtrace.vendor import wrapt
-
 import django
+from django.db import connections
+
+# project
+from .db import patch_db
+from .conf import settings
+from .cache import patch_cache
+from .templates import patch_template
+from .middleware import insert_exception_middleware, insert_trace_middleware
+
+from ...internal.logger import get_logger
+
+log = get_logger(__name__)
 
 
 def patch():
@@ -25,3 +37,58 @@ def traced_setup(wrapped, instance, args, kwargs):
             settings.INSTALLED_APPS.append('ddtrace.contrib.django')
 
     wrapped(*args, **kwargs)
+
+
+def apply_django_patches(patch_rest_framework):
+    """
+    Ready is called as soon as the registry is fully populated.
+    In order for all Django internals are properly configured, this
+    must be called after the app is finished starting
+    """
+    tracer = settings.TRACER
+
+    if settings.TAGS:
+        tracer.set_tags(settings.TAGS)
+
+    # configure the tracer instance
+    # TODO[manu]: we may use configure() but because it creates a new
+    # AgentWriter, it breaks all tests. The configure() behavior must
+    # be changed to use it in this integration
+    tracer.enabled = settings.ENABLED
+    tracer.writer.api.hostname = settings.AGENT_HOSTNAME
+    tracer.writer.api.port = settings.AGENT_PORT
+
+    if settings.AUTO_INSTRUMENT:
+        # trace Django internals
+        insert_trace_middleware()
+        insert_exception_middleware()
+
+        if settings.INSTRUMENT_TEMPLATE:
+            try:
+                patch_template(tracer)
+            except Exception:
+                log.exception('error patching Django template rendering')
+
+        if settings.INSTRUMENT_DATABASE:
+            try:
+                patch_db(tracer)
+                # This is the trigger to patch individual connections.
+                # By patching these here, all processes including
+                # management commands are also traced.
+                connections.all()
+            except Exception:
+                log.exception('error patching Django database connections')
+
+        if settings.INSTRUMENT_CACHE:
+            try:
+                patch_cache(tracer)
+            except Exception:
+                log.exception('error patching Django cache')
+
+        # Instrument rest_framework app to trace custom exception handling.
+        if patch_rest_framework:
+            try:
+                from .restframework import patch_restframework
+                patch_restframework(tracer)
+            except Exception:
+                log.exception('error patching rest_framework app')

--- a/tests/contrib/django/test_connection.py
+++ b/tests/contrib/django/test_connection.py
@@ -1,9 +1,11 @@
+import mock
 import time
 
 # 3rd party
 from django.contrib.auth.models import User
 
 from ddtrace.contrib.django.conf import settings
+from ddtrace.contrib.django.patch import apply_django_patches, connections
 
 # testing
 from .utils import DjangoTraceTestCase, override_ddtrace_settings
@@ -61,3 +63,10 @@ class DjangoConnectionTest(DjangoTraceTestCase):
         assert len(traces[0]) == 1
         span = traces[0][0]
         assert span.service == 'my_prefix_db-defaultdb'
+
+    def test_apply_django_patches_calls_connections_all(self):
+        with mock.patch.object(connections, 'all') as mock_connections:
+            apply_django_patches(patch_rest_framework=False)
+
+        assert mock_connections.call_count == 1
+        assert mock_connections.mock_calls == [mock.call()]


### PR DESCRIPTION
Fixes #1014

Management commands don't call `connections.all()` anywhere by default and as a result, are excluded from being patched unless a user manually makes that call. This will instead call this inside the AppConfig for the Django app so that all processes benefit from tracing by default.

This also moves the code into a function outside the ready which solves 2 things:
1. It's easier to test.
1. It means we can reuse this code in our django 1.6 app rather than copying it in.