### PR TITLE
[tornado] Add support for Tornado 5 and 6 with Python 3.7

### DIFF
--- a/ddtrace/contrib/tornado/__init__.py
+++ b/ddtrace/contrib/tornado/__init__.py
@@ -1,7 +1,11 @@
 """
 The Tornado integration traces all ``RequestHandler`` defined in a Tornado web application.
 Auto instrumentation is available using the ``patch`` function that **must be called before**
-importing the tornado library. The following is an example::
+importing the tornado library.
+
+**Note:** Tornado 5 and 6 supported only for Python 3.7.
+
+The following is an example::
 
     # patch before importing tornado and concurrent.futures
     from ddtrace import tracer, patch

--- a/ddtrace/contrib/tornado/decorators.py
+++ b/ddtrace/contrib/tornado/decorators.py
@@ -1,4 +1,3 @@
-import sys
 import ddtrace
 
 from functools import wraps
@@ -22,10 +21,14 @@ def _finish_span(future):
             if exc_info:
                 span.set_exc_info(*exc_info)
         elif callable(getattr(future, 'exception', None)):
+            # DEV: exc_info not supported in future PY37
             # retrieve the exception from the Future object
             # that is executed in a different Thread
-            if future.exception():
-                span.set_exc_info(*sys.exc_info())
+            exc = future.exception()
+            if exc:
+                exc_type = type(exc)
+                exc_tb = getattr(exc, '__traceback__', None)
+                span.set_exc_info(exc_type, exc, exc_tb)
 
         span.finish()
 

--- a/ddtrace/contrib/tornado/decorators.py
+++ b/ddtrace/contrib/tornado/decorators.py
@@ -1,5 +1,4 @@
 import ddtrace
-from ddtrace.compat import PY3
 import sys
 
 from functools import wraps
@@ -17,22 +16,36 @@ def _finish_span(future):
     span = getattr(future, FUTURE_SPAN_KEY, None)
 
     if span:
+        # `tornado.concurrent.Future` in PY3 tornado>=4.0,<5 has `exc_info`
         if callable(getattr(future, 'exc_info', None)):
             # retrieve the exception from the coroutine object
             exc_info = future.exc_info()
             if exc_info:
                 span.set_exc_info(*exc_info)
         elif callable(getattr(future, 'exception', None)):
-            # retrieve the exception from the Future object
-            # that is executed in a different Thread
-            exc = future.exception()
-            if exc:
-                if PY3:
+            # in tornado>=4.0,<5 with PY2 `concurrent.futures._base.Future`
+            # `exception_info()` returns `(exception, traceback)` but
+            # `exception()` only returns the first element in the tuple
+            if callable(getattr(future, 'exception_info', None)):
+                exc, exc_tb = future.exception_info()
+                if exc and exc_tb:
                     exc_type = type(exc)
-                    exc_tb = getattr(exc, '__traceback__', None)
                     span.set_exc_info(exc_type, exc, exc_tb)
-                else:
-                    span.set_exc_info(*sys.exc_info())
+            # in tornado>=5 with PY3, `tornado.concurrent.Future` is alias to
+            # `asyncio.Future` in PY3 `exc_info` not available, instead use
+            # exception method
+            else:
+                exc = future.exception()
+                if exc:
+                    # we expect exception object to have a traceback attached
+                    if hasattr(exc, '__traceback__'):
+                        exc_type = type(exc)
+                        exc_tb = getattr(exc, '__traceback__', None)
+                        span.set_exc_info(exc_type, exc, exc_tb)
+                    # if all else fails use currently handled exception for
+                    # current thread
+                    else:
+                        span.set_exc_info(*sys.exc_info())
 
         span.finish()
 

--- a/ddtrace/contrib/tornado/stack_context.py
+++ b/ddtrace/contrib/tornado/stack_context.py
@@ -1,118 +1,135 @@
+import tornado
 from tornado.ioloop import IOLoop
-from tornado.stack_context import StackContextInconsistentError, _state
+import sys
 
 from ...context import Context
 from ...provider import DefaultContextProvider
 
+# tornado.stack_context removed in >=6.0
+# instead use DefaultContextProvider with ContextVarContextManager for asyncio
+_USE_STACK_CONTEXT = not (
+    sys.version_info >= (3, 7) and tornado.version_info >= (6, 0)
+)
 
-class TracerStackContext(DefaultContextProvider):
-    """
-    A context manager that manages ``Context`` instances in a thread-local state.
-    It must be used everytime a Tornado's handler or coroutine is used within a
-    tracing Context. It is meant to work like a traditional ``StackContext``,
-    preserving the state across asynchronous calls.
+if _USE_STACK_CONTEXT:
+    from tornado.stack_context import StackContextInconsistentError, _state
 
-    Everytime a new manager is initialized, a new ``Context()`` is created for
-    this execution flow. A context created in a ``TracerStackContext`` is not
-    shared between different threads.
-
-    This implementation follows some suggestions provided here:
-    https://github.com/tornadoweb/tornado/issues/1063
-    """
-    def __init__(self):
-        # DEV: skip resetting context manager since TracerStackContext is used
-        # as a with-statement context where we do not want to be clearing the
-        # current context for a thread or task
-        super(TracerStackContext, self).__init__(reset_context_manager=False)
-        self._active = True
-        self._context = Context()
-
-    def enter(self):
+    class TracerStackContext(DefaultContextProvider):
         """
-        Required to preserve the ``StackContext`` protocol.
+        A context manager that manages ``Context`` instances in a thread-local state.
+        It must be used everytime a Tornado's handler or coroutine is used within a
+        tracing Context. It is meant to work like a traditional ``StackContext``,
+        preserving the state across asynchronous calls.
+
+        Everytime a new manager is initialized, a new ``Context()`` is created for
+        this execution flow. A context created in a ``TracerStackContext`` is not
+        shared between different threads.
+
+        This implementation follows some suggestions provided here:
+        https://github.com/tornadoweb/tornado/issues/1063
         """
-        pass
+        def __init__(self):
+            # DEV: skip resetting context manager since TracerStackContext is used
+            # as a with-statement context where we do not want to be clearing the
+            # current context for a thread or task
+            super(TracerStackContext, self).__init__(reset_context_manager=False)
+            self._active = True
+            self._context = Context()
 
-    def exit(self, type, value, traceback):
-        """
-        Required to preserve the ``StackContext`` protocol.
-        """
-        pass
+        def enter(self):
+            """
+            Required to preserve the ``StackContext`` protocol.
+            """
+            pass
 
-    def __enter__(self):
-        self.old_contexts = _state.contexts
-        self.new_contexts = (self.old_contexts[0] + (self,), self)
-        _state.contexts = self.new_contexts
-        return self
+        def exit(self, type, value, traceback):
+            """
+            Required to preserve the ``StackContext`` protocol.
+            """
+            pass
 
-    def __exit__(self, type, value, traceback):
-        final_contexts = _state.contexts
-        _state.contexts = self.old_contexts
+        def __enter__(self):
+            self.old_contexts = _state.contexts
+            self.new_contexts = (self.old_contexts[0] + (self,), self)
+            _state.contexts = self.new_contexts
+            return self
 
-        if final_contexts is not self.new_contexts:
-            raise StackContextInconsistentError(
-                'stack_context inconsistency (may be caused by yield '
-                'within a "with TracerStackContext" block)')
+        def __exit__(self, type, value, traceback):
+            final_contexts = _state.contexts
+            _state.contexts = self.old_contexts
 
-        # break the reference to allow faster GC on CPython
-        self.new_contexts = None
+            if final_contexts is not self.new_contexts:
+                raise StackContextInconsistentError(
+                    'stack_context inconsistency (may be caused by yield '
+                    'within a "with TracerStackContext" block)')
 
-    def deactivate(self):
-        self._active = False
+            # break the reference to allow faster GC on CPython
+            self.new_contexts = None
 
-    def _has_io_loop(self):
-        """Helper to determine if we are currently in an IO loop"""
-        return getattr(IOLoop._current, 'instance', None) is not None
+        def deactivate(self):
+            self._active = False
 
-    def _has_active_context(self):
-        """Helper to determine if we have an active context or not"""
-        if not self._has_io_loop():
-            return self._local._has_active_context()
-        else:
+        def _has_io_loop(self):
+            """Helper to determine if we are currently in an IO loop"""
+            return getattr(IOLoop._current, 'instance', None) is not None
+
+        def _has_active_context(self):
+            """Helper to determine if we have an active context or not"""
+            if not self._has_io_loop():
+                return self._local._has_active_context()
+            else:
+                # we're inside a Tornado loop so the TracerStackContext is used
+                return self._get_state_active_context() is not None
+
+        def _get_state_active_context(self):
+            """Helper to get the currently active context from the TracerStackContext"""
             # we're inside a Tornado loop so the TracerStackContext is used
-            return self._get_state_active_context() is not None
+            for stack in reversed(_state.contexts[0]):
+                if isinstance(stack, self.__class__) and stack._active:
+                    return stack._context
+            return None
 
-    def _get_state_active_context(self):
-        """Helper to get the currently active context from the TracerStackContext"""
-        # we're inside a Tornado loop so the TracerStackContext is used
-        for stack in reversed(_state.contexts[0]):
-            if isinstance(stack, self.__class__) and stack._active:
-                return stack._context
-        return None
+        def active(self):
+            """
+            Return the ``Context`` from the current execution flow. This method can be
+            used inside a Tornado coroutine to retrieve and use the current tracing context.
+            If used in a separated Thread, the `_state` thread-local storage is used to
+            propagate the current Active context from the `MainThread`.
+            """
+            if not self._has_io_loop():
+                # if a Tornado loop is not available, it means that this method
+                # has been called from a synchronous code, so we can rely in a
+                # thread-local storage
+                return self._local.get()
+            else:
+                # we're inside a Tornado loop so the TracerStackContext is used
+                return self._get_state_active_context()
 
-    def active(self):
-        """
-        Return the ``Context`` from the current execution flow. This method can be
-        used inside a Tornado coroutine to retrieve and use the current tracing context.
-        If used in a separated Thread, the `_state` thread-local storage is used to
-        propagate the current Active context from the `MainThread`.
-        """
-        if not self._has_io_loop():
-            # if a Tornado loop is not available, it means that this method
-            # has been called from a synchronous code, so we can rely in a
-            # thread-local storage
-            return self._local.get()
-        else:
-            # we're inside a Tornado loop so the TracerStackContext is used
-            return self._get_state_active_context()
+        def activate(self, ctx):
+            """
+            Set the active ``Context`` for this async execution. If a ``TracerStackContext``
+            is not found, the context is discarded.
+            If used in a separated Thread, the `_state` thread-local storage is used to
+            propagate the current Active context from the `MainThread`.
+            """
+            if not self._has_io_loop():
+                # because we're outside of an asynchronous execution, we store
+                # the current context in a thread-local storage
+                self._local.set(ctx)
+            else:
+                # we're inside a Tornado loop so the TracerStackContext is used
+                for stack_ctx in reversed(_state.contexts[0]):
+                    if isinstance(stack_ctx, self.__class__) and stack_ctx._active:
+                        stack_ctx._context = ctx
+            return ctx
+else:
+    # DEV: no-op for Tornado>=6 since stack_context has been removed
+    class TracerStackContext(DefaultContextProvider):
+        def __enter__(self):
+            pass
 
-    def activate(self, ctx):
-        """
-        Set the active ``Context`` for this async execution. If a ``TracerStackContext``
-        is not found, the context is discarded.
-        If used in a separated Thread, the `_state` thread-local storage is used to
-        propagate the current Active context from the `MainThread`.
-        """
-        if not self._has_io_loop():
-            # because we're outside of an asynchronous execution, we store
-            # the current context in a thread-local storage
-            self._local.set(ctx)
-        else:
-            # we're inside a Tornado loop so the TracerStackContext is used
-            for stack_ctx in reversed(_state.contexts[0]):
-                if isinstance(stack_ctx, self.__class__) and stack_ctx._active:
-                    stack_ctx._context = ctx
-        return ctx
+        def __exit__(self, *exc):
+            pass
 
 
 def run_with_trace_context(func, *args, **kwargs):

--- a/ddtrace/contrib/tornado/stack_context.py
+++ b/ddtrace/contrib/tornado/stack_context.py
@@ -5,10 +5,10 @@ import sys
 from ...context import Context
 from ...provider import DefaultContextProvider
 
-# tornado.stack_context removed in >=6.0
+# tornado.stack_context deprecated in Tornado 5 removed in Tornado 6
 # instead use DefaultContextProvider with ContextVarContextManager for asyncio
 _USE_STACK_CONTEXT = not (
-    sys.version_info >= (3, 7) and tornado.version_info >= (6, 0)
+    sys.version_info >= (3, 7) and tornado.version_info >= (5, 0)
 )
 
 if _USE_STACK_CONTEXT:
@@ -123,7 +123,7 @@ if _USE_STACK_CONTEXT:
                         stack_ctx._context = ctx
             return ctx
 else:
-    # DEV: no-op for Tornado>=6 since stack_context has been removed
+    # no-op when not using stack_context
     class TracerStackContext(DefaultContextProvider):
         def __enter__(self):
             pass

--- a/tests/contrib/tornado/test_stack_context.py
+++ b/tests/contrib/tornado/test_stack_context.py
@@ -9,8 +9,8 @@ from .web.compat import sleep
 
 
 class TestStackContext(TornadoTestCase):
-    @pytest.mark.skipif(tornado.version_info >= (6, 0),
-                        reason='tornado.stack_context removed in Tornado 6.0')
+    @pytest.mark.skipif(tornado.version_info >= (5, 0),
+                        reason='tornado.stack_context deprecated in Tornado 5.0 and removed in Tornado 6.0')
     def test_without_stack_context(self):
         # without a TracerStackContext, propagation is not available
         ctx = self.tracer.context_provider.active()
@@ -38,8 +38,8 @@ class TestStackContext(TornadoTestCase):
         assert traces[0][0].trace_id == 100
         assert traces[0][0].parent_id == 101
 
-    @pytest.mark.skipif(tornado.version_info >= (6, 0),
-                        reason='tornado.stack_context removed in Tornado 6.0')
+    @pytest.mark.skipif(tornado.version_info >= (5, 0),
+                        reason='tornado.stack_context deprecated in Tornado 5.0 and removed in Tornado 6.0')
     def test_propagation_without_stack_context(self):
         # a Context is discarded if not set inside a TracerStackContext
         ctx = Context(trace_id=100, span_id=101)

--- a/tests/contrib/tornado/test_stack_context.py
+++ b/tests/contrib/tornado/test_stack_context.py
@@ -1,3 +1,6 @@
+import pytest
+import tornado
+
 from ddtrace.context import Context
 from ddtrace.contrib.tornado import TracerStackContext
 
@@ -6,6 +9,8 @@ from .web.compat import sleep
 
 
 class TestStackContext(TornadoTestCase):
+    @pytest.mark.skipif(tornado.version_info >= (6, 0),
+                        reason='tornado.stack_context removed in Tornado 6.0')
     def test_without_stack_context(self):
         # without a TracerStackContext, propagation is not available
         ctx = self.tracer.context_provider.active()
@@ -33,6 +38,8 @@ class TestStackContext(TornadoTestCase):
         assert traces[0][0].trace_id == 100
         assert traces[0][0].parent_id == 101
 
+    @pytest.mark.skipif(tornado.version_info >= (6, 0),
+                        reason='tornado.stack_context removed in Tornado 6.0')
     def test_propagation_without_stack_context(self):
         # a Context is discarded if not set inside a TracerStackContext
         ctx = Context(trace_id=100, span_id=101)

--- a/tests/contrib/tornado/test_tornado_web.py
+++ b/tests/contrib/tornado/test_tornado_web.py
@@ -266,8 +266,10 @@ class TestTornadoWeb(TornadoTestCase):
         assert 4567 == request_span.parent_id
         assert 2 == request_span.get_metric(SAMPLING_PRIORITY_KEY)
 
-    @pytest.mark.skipif(tornado.version_info >= (6, 0),
-                        reason='Opentracing ScopeManager not available for Tornado 6.0')
+    # Opentracing support depends on new AsyncioScopeManager
+    # See: https://github.com/opentracing/opentracing-python/pull/118
+    @pytest.mark.skipif(tornado.version_info >= (5, 0),
+                        reason='Opentracing ScopeManager not available for Tornado >= 5')
     def test_success_handler_ot(self):
         """OpenTracing version of test_success_handler."""
         from opentracing.scope_managers.tornado import TornadoScopeManager

--- a/tests/contrib/tornado/test_tornado_web.py
+++ b/tests/contrib/tornado/test_tornado_web.py
@@ -3,8 +3,9 @@ from .utils import TornadoTestCase
 
 from ddtrace.constants import SAMPLING_PRIORITY_KEY, ORIGIN_KEY, ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.ext import http
+import pytest
+import tornado
 
-from opentracing.scope_managers.tornado import TornadoScopeManager
 from tests.opentracer.utils import init_tracer
 
 
@@ -265,8 +266,11 @@ class TestTornadoWeb(TornadoTestCase):
         assert 4567 == request_span.parent_id
         assert 2 == request_span.get_metric(SAMPLING_PRIORITY_KEY)
 
+    @pytest.mark.skipif(tornado.version_info >= (6, 0),
+                        reason='Opentracing ScopeManager not available for Tornado 6.0')
     def test_success_handler_ot(self):
         """OpenTracing version of test_success_handler."""
+        from opentracing.scope_managers.tornado import TornadoScopeManager
         ot_tracer = init_tracer('tornado_svc', self.tracer, scope_manager=TornadoScopeManager())
 
         with ot_tracer.start_active_span('tornado_op'):

--- a/tox.ini
+++ b/tox.ini
@@ -107,7 +107,7 @@ envlist =
     sqlalchemy_contrib-{py27,py34,py35,py36,py37}-sqlalchemy{10,11,12}-psycopg228-mysqlconnector
     sqlite3_contrib-{py27,py34,py35,py36,py37}-sqlite3
     tornado_contrib-{py27,py34,py35,py36,py37}-tornado{40,41,42,43,44,45}
-    tornado_contrib-{py37}-tornado{60}
+    tornado_contrib-{py37}-tornado{50,51,60}
     tornado_contrib-{py27}-tornado{40,41,42,43,44,45}-futures{30,31,32}
     vertica_contrib-{py27,py34,py35,py36,py37}-vertica{060,070}
 # Opentracer
@@ -348,6 +348,8 @@ deps =
     tornado43: tornado>=4.3,<4.4
     tornado44: tornado>=4.4,<4.5
     tornado45: tornado>=4.5,<4.6
+    tornado50: tornado>=5.0,<5.1
+    tornado51: tornado>=5.1,<5.2
     tornado60: tornado>=6.0,<6.1
     vertica060: vertica-python>=0.6.0,<0.7.0
     vertica070: vertica-python>=0.7.0,<0.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -107,6 +107,7 @@ envlist =
     sqlalchemy_contrib-{py27,py34,py35,py36,py37}-sqlalchemy{10,11,12}-psycopg228-mysqlconnector
     sqlite3_contrib-{py27,py34,py35,py36,py37}-sqlite3
     tornado_contrib-{py27,py34,py35,py36,py37}-tornado{40,41,42,43,44,45}
+    tornado_contrib-{py37}-tornado{60}
     tornado_contrib-{py27}-tornado{40,41,42,43,44,45}-futures{30,31,32}
     vertica_contrib-{py27,py34,py35,py36,py37}-vertica{060,070}
 # Opentracer
@@ -347,6 +348,7 @@ deps =
     tornado43: tornado>=4.3,<4.4
     tornado44: tornado>=4.4,<4.5
     tornado45: tornado>=4.5,<4.6
+    tornado60: tornado>=6.0,<6.1
     vertica060: vertica-python>=0.6.0,<0.7.0
     vertica070: vertica-python>=0.7.0,<0.8.0
     webtest: WebTest


### PR DESCRIPTION
This PR adds support for Tornado 5 and 6 for Python 3.7 since #990 makes `ddtrace.contrib.tornado.stack_context` unnecessary for handling contexts cleanly between asynchronous tasks.