### PR TITLE
tracer: remove debug_logging option

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -113,10 +113,6 @@ try:
         from ddtrace import patch_all
         patch_all(**EXTRA_PATCHED_MODULES)
 
-    debug = os.environ.get('DATADOG_TRACE_DEBUG')
-    if debug and debug.lower() == 'true':
-        tracer.debug_logging = True
-
     if 'DATADOG_ENV' in os.environ:
         tracer.set_tags({constants.ENV_KEY: os.environ['DATADOG_ENV']})
 

--- a/ddtrace/commands/ddtrace_run.py
+++ b/ddtrace/commands/ddtrace_run.py
@@ -25,7 +25,7 @@ Available environment variables:
 
     DATADOG_ENV : override an application's environment (no default)
     DATADOG_TRACE_ENABLED=true|false : override the value of tracer.enabled (default: true)
-    DATADOG_TRACE_DEBUG=true|false : override the value of tracer.debug_logging (default: false)
+    DATADOG_TRACE_DEBUG=true|false : enabled debug logging (default: false)
     DATADOG_PATCH_MODULES=module:patch,module:patch... e.g. boto:true,redis:false : override the modules patched for this execution of the program (default: none)
     DATADOG_TRACE_AGENT_HOSTNAME=localhost: override the address of the trace agent host that the default tracer will attempt to submit to  (default: localhost)
     DATADOG_TRACE_AGENT_PORT=8126: override the port that the default tracer will submit to (default: 8126)

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 
 from .constants import HOSTNAME_KEY, SAMPLING_PRIORITY_KEY, ORIGIN_KEY
@@ -131,13 +132,13 @@ class Context(object):
             self._set_current_span(span._parent)
 
             # notify if the trace is not closed properly; this check is executed only
-            # if the tracer debug_logging is enabled and when the root span is closed
+            # if the debug logging is enabled and when the root span is closed
             # for an unfinished trace. This logging is meant to be used for debugging
             # reasons, and it doesn't mean that the trace is wrongly generated.
             # In asynchronous environments, it's legit to close the root span before
             # some children. On the other hand, asynchronous web frameworks still expect
             # to close the root span after all the children.
-            if span.tracer and span.tracer.debug_logging and span._parent is None:
+            if span.tracer and span.tracer.log.isEnabledFor(logging.DEBUG) and span._parent is None:
                 unfinished_spans = [x for x in self._trace if not x.finished]
                 if unfinished_spans:
                     log.debug('Root span "%s" closed, but the trace has %d unfinished spans:',

--- a/tests/commands/ddtrace_run_debug.py
+++ b/tests/commands/ddtrace_run_debug.py
@@ -1,5 +1,7 @@
+import logging
+
 from ddtrace import tracer
 
 if __name__ == '__main__':
-    assert tracer.debug_logging
+    assert tracer.log.isEnabledFor(logging.DEBUG)
     print('Test success')

--- a/tests/commands/ddtrace_run_no_debug.py
+++ b/tests/commands/ddtrace_run_no_debug.py
@@ -1,5 +1,7 @@
+import logging
+
 from ddtrace import tracer
 
 if __name__ == '__main__':
-    assert not tracer.debug_logging
+    assert not tracer.log.isEnabledFor(logging.DEBUG)
     print('Test success')

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -83,7 +83,7 @@ class DdtraceRunTest(BaseTestCase):
 
     def test_debug_enabling(self):
         """
-        DATADOG_TRACE_DEBUG=true allows setting debug_logging of the global tracer
+        DATADOG_TRACE_DEBUG=true allows setting debug logging of the global tracer
         """
         with self.override_env(dict(DATADOG_TRACE_DEBUG='false')):
             out = subprocess.check_output(

--- a/tests/contrib/flask/test_middleware.py
+++ b/tests/contrib/flask/test_middleware.py
@@ -193,7 +193,6 @@ class TestFlask(TestCase):
         assert s.meta.get(http.METHOD) == 'GET'
 
     def test_template_render_err(self):
-        self.tracer.debug_logging = True
         start = time.time()
         try:
             self.app.get('/tmpl/render_err')

--- a/tests/memory.py
+++ b/tests/memory.py
@@ -24,7 +24,6 @@ from tests.contrib import config
 
 # verbosity
 logging.basicConfig(stream=sys.stderr, level=logging.INFO)
-ddtrace.tracer.debug_logging = False
 
 ddtrace.patch_all()
 ddtrace.tracer.writer = None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,6 @@ from unittest import TestCase
 
 import pytest
 
-from tests.test_tracer import get_dummy_tracer
 from ddtrace.api import API, Response
 from ddtrace.compat import iteritems, httplib, PY3
 from ddtrace.internal.runtime.container import CGroupInfo
@@ -134,9 +133,6 @@ class APITests(TestCase):
 
     @mock.patch('logging.Logger.debug')
     def test_parse_response_json(self, log):
-        tracer = get_dummy_tracer()
-        tracer.debug_logging = True
-
         test_cases = {
             'OK': dict(
                 js=None,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,14 +1,55 @@
 import contextlib
+import logging
 import mock
 import threading
 
 from .base import BaseTestCase
 from tests.test_tracer import get_dummy_tracer
 
+import pytest
+
 from ddtrace.span import Span
 from ddtrace.context import Context
 from ddtrace.constants import HOSTNAME_KEY
 from ddtrace.ext.priority import USER_REJECT, AUTO_REJECT, AUTO_KEEP, USER_KEEP
+
+
+@pytest.fixture
+def tracer_with_debug_logging():
+    # All the tracers, dummy or not, shares the same logging object.
+    tracer = get_dummy_tracer()
+    level = tracer.log.level
+    tracer.log.setLevel(logging.DEBUG)
+    try:
+        yield tracer
+    finally:
+        tracer.log.setLevel(level)
+
+
+@mock.patch('logging.Logger.debug')
+def test_log_unfinished_spans(log, tracer_with_debug_logging):
+    # when the root parent is finished, notify if there are spans still pending
+    tracer = tracer_with_debug_logging
+    ctx = Context()
+    # manually create a root-child trace
+    root = Span(tracer=tracer, name='root')
+    child_1 = Span(tracer=tracer, name='child_1', trace_id=root.trace_id, parent_id=root.span_id)
+    child_2 = Span(tracer=tracer, name='child_2', trace_id=root.trace_id, parent_id=root.span_id)
+    child_1._parent = root
+    child_2._parent = root
+    ctx.add_span(root)
+    ctx.add_span(child_1)
+    ctx.add_span(child_2)
+    # close only the parent
+    root.finish()
+    unfinished_spans_log = log.call_args_list[-3][0][2]
+    child_1_log = log.call_args_list[-2][0][1]
+    child_2_log = log.call_args_list[-1][0][1]
+    assert 2 == unfinished_spans_log
+    assert 'name child_1' in child_1_log
+    assert 'name child_2' in child_2_log
+    assert 'duration 0.000000s' in child_1_log
+    assert 'duration 0.000000s' in child_2_log
 
 
 class TestTracingContext(BaseTestCase):
@@ -332,36 +373,9 @@ class TestTracingContext(BaseTestCase):
         ctx.close_span(span)
 
     @mock.patch('logging.Logger.debug')
-    def test_log_unfinished_spans(self, log):
-        # when the root parent is finished, notify if there are spans still pending
-        tracer = get_dummy_tracer()
-        tracer.debug_logging = True
-        ctx = Context()
-        # manually create a root-child trace
-        root = Span(tracer=tracer, name='root')
-        child_1 = Span(tracer=tracer, name='child_1', trace_id=root.trace_id, parent_id=root.span_id)
-        child_2 = Span(tracer=tracer, name='child_2', trace_id=root.trace_id, parent_id=root.span_id)
-        child_1._parent = root
-        child_2._parent = root
-        ctx.add_span(root)
-        ctx.add_span(child_1)
-        ctx.add_span(child_2)
-        # close only the parent
-        root.finish()
-        unfinished_spans_log = log.call_args_list[-3][0][2]
-        child_1_log = log.call_args_list[-2][0][1]
-        child_2_log = log.call_args_list[-1][0][1]
-        assert 2 == unfinished_spans_log
-        assert 'name child_1' in child_1_log
-        assert 'name child_2' in child_2_log
-        assert 'duration 0.000000s' in child_1_log
-        assert 'duration 0.000000s' in child_2_log
-
-    @mock.patch('logging.Logger.debug')
     def test_log_unfinished_spans_disabled(self, log):
         # the trace finished status logging is disabled
         tracer = get_dummy_tracer()
-        tracer.debug_logging = False
         ctx = Context()
         # manually create a root-child trace
         root = Span(tracer=tracer, name='root')
@@ -383,7 +397,6 @@ class TestTracingContext(BaseTestCase):
     def test_log_unfinished_spans_when_ok(self, log):
         # if the unfinished spans logging is enabled but the trace is finished, don't log anything
         tracer = get_dummy_tracer()
-        tracer.debug_logging = True
         ctx = Context()
         # manually create a root-child trace
         root = Span(tracer=tracer, name='root')


### PR DESCRIPTION
This removes the debug_logging option. This should not be necessary as
configuring the logging level for the tracer ought to be enough to control what
is logged or not.

That simplifies the logging logic by avoiding two knobs to control one thing.