### PR TITLE
Store span ids in profiling events

### DIFF
--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -1,8 +1,11 @@
 """CPU profiling collector."""
 from __future__ import absolute_import
 
+import collections
+import logging
 import sys
 import threading
+import weakref
 
 from ddtrace import compat
 from ddtrace.profiling import _attr
@@ -12,6 +15,23 @@ from ddtrace.profiling import event
 from ddtrace.profiling.collector import _traceback
 from ddtrace.utils import formats
 from ddtrace.vendor import attr
+from ddtrace.vendor import six
+
+
+_LOG = logging.getLogger(__name__)
+
+
+if "gevent" in sys.modules:
+    try:
+        import gevent.monkey
+    except ImportError:
+        _LOG.error("gevent loaded but unable to import gevent.monkey")
+        from ddtrace.vendor.six.moves._thread import get_ident as _thread_get_ident
+    else:
+        _thread_get_ident = gevent.monkey.get_original("thread" if six.PY2 else "_thread", "get_ident")
+else:
+    from ddtrace.vendor.six.moves._thread import get_ident as _thread_get_ident
+
 
 # NOTE: Do not use LOG here. This code runs under a real OS thread and is unable to acquire any lock of the `logging`
 # module without having gevent crashing our dedicated thread.
@@ -112,6 +132,7 @@ class StackBasedEvent(event.SampleEvent):
     thread_name = attr.ib(default=None)
     frames = attr.ib(default=None)
     nframes = attr.ib(default=None)
+    trace_ids = attr.ib(default=None)
 
 
 @event.event_class
@@ -198,7 +219,7 @@ cdef get_thread_name(thread_id):
             return "Anonymous Thread %d" % thread_id
 
 
-cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_time):
+cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_time, thread_span_links):
     current_exceptions = []
 
     IF PY_MAJOR_VERSION >= 3 and PY_MINOR_VERSION >= 7:
@@ -241,6 +262,8 @@ cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_tim
 
     running_thread_ids = {t[0] for t in running_threads}
 
+    thread_span_links.clear_threads(running_thread_ids)
+
     if ignore_profiler:
         running_thread_ids -= _periodic.PERIODIC_THREAD_IDS
 
@@ -250,11 +273,13 @@ cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_tim
     for tid, frame in running_threads:
         if ignore_profiler and tid in _periodic.PERIODIC_THREAD_IDS:
             continue
+        spans = thread_span_links.get_active_leaf_spans_from_thread_id(tid)
         frames, nframes = _traceback.pyframe_to_frames(frame, max_nframes)
         stack_events.append(
             StackSampleEvent(
                 thread_id=tid,
                 thread_name=get_thread_name(tid),
+                trace_ids=set(span.trace_id for span in spans),
                 nframes=nframes, frames=frames,
                 wall_time_ns=wall_time,
                 cpu_time_ns=cpu_time[tid],
@@ -281,6 +306,59 @@ cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_tim
     return stack_events, exc_events
 
 
+@attr.s(slots=True, eq=False)
+class _ThreadSpanLinks(object):
+
+    _thread_id_to_spans = attr.ib(factory=lambda: collections.defaultdict(weakref.WeakSet), repr=False, init=False)
+
+    # We do not use a lock because:
+    # - When adding new items, it's not possible for a same thread to call `link_span` at different time
+    #   Since the WeakSet are per-thread, there's no chance of creating 2 WeakSet for the same thread
+    # - When reading the span WeakSet for a thread, the set is copied which means that if it was ever mutated during
+    #   our reading, we wouldn't care.
+    #   In practice, here, it won't even mutate during the reading since this only used by the stack collector which
+    #   already owns the GIL.
+
+    def link_span(self, span):
+        """Link a span to its running environment.
+
+        Track threads, tasks, etc.
+        """
+        self._thread_id_to_spans[_thread_get_ident()].add(span)
+
+    def clear_threads(self, existing_thread_ids):
+        """Clear the stored list of threads based on the list of existing thread ids.
+
+        If any thread that is part of this list was stored, its data will be deleted.
+
+        :param existing_thread_ids: A set of thread ids to keep.
+        """
+        # Iterate over a copy of the list of keys in case it's mutated during our iteration.
+        for thread_id in list(self._thread_id_to_spans.keys()):
+            if thread_id not in existing_thread_ids:
+                del self._thread_id_to_spans[thread_id]
+
+    def get_active_leaf_spans_from_thread_id(self, thread_id):
+        """Return the latest active spans for a thread.
+
+        In theory this should return a single span, though if multiple children span are active without being finished,
+        there can be several spans returned.
+
+        :param thread_id: The thread id.
+        :return: A set with the active spans.
+        """
+        spans = set(self._thread_id_to_spans.get(thread_id, ()))
+        # Iterate over a copy so we can modify the original
+        for span in set(spans):
+            if not span.finished:
+                try:
+                    spans.remove(span._parent)
+                except KeyError:
+                    pass
+
+        return {span for span in spans if not span.finished}
+
+
 @attr.s(slots=True)
 class StackCollector(collector.PeriodicCollector):
     """Execution stacks collector."""
@@ -295,8 +373,10 @@ class StackCollector(collector.PeriodicCollector):
     max_time_usage_pct = attr.ib(factory=_attr.from_env("DD_PROFILING_MAX_TIME_USAGE_PCT", 2, float))
     nframes = attr.ib(factory=_attr.from_env("DD_PROFILING_MAX_FRAMES", 64, int))
     ignore_profiler = attr.ib(factory=_attr.from_env("DD_PROFILING_IGNORE_PROFILER", True, formats.asbool))
+    tracer = attr.ib(default=None)
     _thread_time = attr.ib(init=False, repr=False)
     _last_wall_time = attr.ib(init=False, repr=False)
+    _thread_span_links = attr.ib(factory=_ThreadSpanLinks, init=False, repr=False)
 
     @max_time_usage_pct.validator
     def _check_max_time_usage(self, attribute, value):
@@ -306,7 +386,14 @@ class StackCollector(collector.PeriodicCollector):
     def start(self):
         self._thread_time = ThreadTime()
         self._last_wall_time = compat.monotonic_ns()
+        if self.tracer is not None:
+            self.tracer.on_start_span(self._thread_span_links.link_span)
         super(StackCollector, self).start()
+
+    def stop(self):
+        super(StackCollector, self).stop()
+        if self.tracer is not None:
+            self.tracer.deregister_on_start_span(self._thread_span_links.link_span)
 
     def _compute_new_interval(self, used_wall_time_ns):
         interval = (used_wall_time_ns / (self.max_time_usage_pct / 100.0)) - used_wall_time_ns
@@ -319,7 +406,7 @@ class StackCollector(collector.PeriodicCollector):
         self._last_wall_time = now
 
         all_events = stack_collect(
-            self.ignore_profiler, self._thread_time, self.nframes, self.interval, wall_time,
+            self.ignore_profiler, self._thread_time, self.nframes, self.interval, wall_time, self._thread_span_links,
         )
 
         used_wall_time_ns = compat.monotonic_ns() - now

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -2,6 +2,7 @@
 import logging
 import os
 
+import ddtrace
 from ddtrace.profiling import recorder
 from ddtrace.profiling import scheduler
 from ddtrace.vendor import attr
@@ -34,7 +35,7 @@ def _build_default_exporters():
 def _build_default_collectors():
     r = recorder.Recorder()
     return [
-        stack.StackCollector(r),
+        stack.StackCollector(r, tracer=ddtrace.tracer),
         memory.MemoryCollector(r),
         exceptions.UncaughtExceptionCollector(r),
         threading.LockCollector(r),

--- a/ddtrace/settings/__init__.py
+++ b/ddtrace/settings/__init__.py
@@ -8,10 +8,10 @@ from .integration import IntegrationConfig
 config = Config()
 
 __all__ = [
-    'config',
-    'Config',
-    'ConfigException',
-    'HttpConfig',
-    'Hooks',
-    'IntegrationConfig',
+    "config",
+    "Config",
+    "ConfigException",
+    "HttpConfig",
+    "Hooks",
+    "IntegrationConfig",
 ]

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -38,6 +38,7 @@ class Config(object):
     this instance to register their defaults, so that they're public
     available and can be updated by users.
     """
+
     def __init__(self):
         # use a dict as underlying storing mechanism
         self._config = {}
@@ -45,11 +46,9 @@ class Config(object):
         # Master switch for turning on and off trace search by default
         # this weird invocation of get_env is meant to read the DD_ANALYTICS_ENABLED
         # legacy environment variable. It should be removed in the future
-        legacy_config_value = get_env('analytics', 'enabled', default=False)
+        legacy_config_value = get_env("analytics", "enabled", default=False)
 
-        self.analytics_enabled = asbool(
-            get_env('trace', 'analytics_enabled', default=legacy_config_value)
-        )
+        self.analytics_enabled = asbool(get_env("trace", "analytics_enabled", default=legacy_config_value))
 
         # DEV: we don't use `self._get_service()` here because {DD,DATADOG}_SERVICE and
         # {DD,DATADOG}_SERVICE_NAME (deprecated) are distinct functionalities.
@@ -59,13 +58,9 @@ class Config(object):
         self.version = get_env("version")
         self.logs_injection = asbool(get_env("logs", "injection", default=False))
 
-        self.report_hostname = asbool(
-            get_env('trace', 'report_hostname', default=False)
-        )
+        self.report_hostname = asbool(get_env("trace", "report_hostname", default=False))
 
-        self.health_metrics_enabled = asbool(
-            get_env('trace', 'health_metrics_enabled', default=False)
-        )
+        self.health_metrics_enabled = asbool(get_env("trace", "health_metrics_enabled", default=False))
 
     def __getattr__(self, name):
         if name not in self._config:
@@ -81,7 +76,7 @@ class Config(object):
         """
         pin = Pin.get_from(obj)
         if pin is None:
-            log.debug('No configuration found for %s', obj)
+            log.debug("No configuration found for %s", obj)
             return {}
 
         return pin._config
@@ -155,5 +150,5 @@ class Config(object):
 
     def __repr__(self):
         cls = self.__class__
-        integrations = ', '.join(self._config.keys())
-        return '{}.{}({})'.format(cls.__module__, cls.__name__, integrations)
+        integrations = ", ".join(self._config.keys())
+        return "{}.{}({})".format(cls.__module__, cls.__name__, integrations)

--- a/ddtrace/settings/exceptions.py
+++ b/ddtrace/settings/exceptions.py
@@ -2,4 +2,5 @@ class ConfigException(Exception):
     """Configuration exception when an integration that is not available
     is called in the `Config` object.
     """
+
     pass

--- a/ddtrace/settings/http.py
+++ b/ddtrace/settings/http.py
@@ -46,9 +46,10 @@ class HttpConfig(object):
         :rtype: bool
         """
         normalized_header_name = normalize_header_name(header_name)
-        log.debug('Checking header \'%s\' tracing in whitelist %s', normalized_header_name, self._whitelist_headers)
+        log.debug("Checking header '%s' tracing in whitelist %s", normalized_header_name, self._whitelist_headers)
         return normalized_header_name in self._whitelist_headers
 
     def __repr__(self):
-        return '<{} traced_headers={} trace_query_string={}>'.format(
-            self.__class__.__name__, self._whitelist_headers, self.trace_query_string)
+        return "<{} traced_headers={} trace_query_string={}>".format(
+            self.__class__.__name__, self._whitelist_headers, self.trace_query_string
+        )

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -21,6 +21,7 @@ class IntegrationConfig(AttrDict):
         config.flask['service_name'] = 'my-service-name'
         config.flask.service_name = 'my-service-name'
     """
+
     def __init__(self, global_config, name, *args, **kwargs):
         """
         :param global_config:
@@ -32,19 +33,19 @@ class IntegrationConfig(AttrDict):
 
         # Set internal properties for this `IntegrationConfig`
         # DEV: By-pass the `__setattr__` overrides from `AttrDict` to set real properties
-        object.__setattr__(self, 'global_config', global_config)
-        object.__setattr__(self, 'integration_name', name)
-        object.__setattr__(self, 'hooks', Hooks())
-        object.__setattr__(self, 'http', HttpConfig())
+        object.__setattr__(self, "global_config", global_config)
+        object.__setattr__(self, "integration_name", name)
+        object.__setattr__(self, "hooks", Hooks())
+        object.__setattr__(self, "http", HttpConfig())
 
         # Set default analytics configuration, default is disabled
         # DEV: Default to `None` which means do not set this key
         # Inject environment variables for integration
-        analytics_enabled_env = get_env(name, 'analytics_enabled')
+        analytics_enabled_env = get_env(name, "analytics_enabled")
         if analytics_enabled_env is not None:
             analytics_enabled_env = asbool(analytics_enabled_env)
-        self.setdefault('analytics_enabled', analytics_enabled_env)
-        self.setdefault('analytics_sample_rate', float(get_env(name, 'analytics_sample_rate', default=1.0)))
+        self.setdefault("analytics_enabled", analytics_enabled_env)
+        self.setdefault("analytics_sample_rate", float(get_env(name, "analytics_sample_rate", default=1.0)))
 
     def __deepcopy__(self, memodict=None):
         new = IntegrationConfig(self.global_config, self.integration_name, deepcopy(dict(self), memodict))
@@ -92,7 +93,7 @@ class IntegrationConfig(AttrDict):
         configuration
         """
         if self._is_analytics_enabled(use_global_config):
-            analytics_sample_rate = getattr(self, 'analytics_sample_rate', None)
+            analytics_sample_rate = getattr(self, "analytics_sample_rate", None)
             # return True if attribute is None or attribute not found
             if analytics_sample_rate is None:
                 return True
@@ -105,5 +106,5 @@ class IntegrationConfig(AttrDict):
 
     def __repr__(self):
         cls = self.__class__
-        keys = ', '.join(self.keys())
-        return '{}.{}({})'.format(cls.__module__, cls.__name__, keys)
+        keys = ", ".join(self.keys())
+        return "{}.{}({})".format(cls.__module__, cls.__name__, keys)

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -19,6 +19,7 @@ from .utils.formats import get_env, parse_tags_str
 from .utils.deprecation import deprecated, RemovedInDDTrace10Warning
 from .vendor.dogstatsd import DogStatsd
 from . import compat
+from . import _hooks
 
 
 log = get_logger(__name__)
@@ -140,6 +141,30 @@ class Tracer(object):
             dogstatsd_url=dogstatsd_url,
             writer=writer,
         )
+
+        self._hooks = _hooks.Hooks()
+
+    def on_start_span(self, func):
+        """Register a function to execute when a span start.
+
+        Can be used as a decorator.
+
+        :param func: The function to call when starting a span.
+                     The started span will be passed as argument.
+        """
+        self._hooks.register(self.__class__.start_span, func)
+        return func
+
+    def deregister_on_start_span(self, func):
+        """Unregister a function registered to execute when a span starts.
+
+        Can be used as a decorator.
+
+        :param func: The function to stop calling when starting a span.
+        """
+
+        self._hooks.deregister(self.__class__.start_span, func)
+        return func
 
     @property
     def debug_logging(self):
@@ -455,6 +480,8 @@ class Tracer(object):
             # The constant tags for the dogstatsd client needs to updated with any new
             # service(s) that may have been added.
             self._update_dogstatsd_constant_tags()
+
+        self._hooks.emit(self.__class__.start_span, span)
 
         return span
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ exclude = '''
     | opentracer/
     | profiling/exporter/pprof_pb2.py$
     | propagation/
-    | settings/
     | vendor/
   )
   | tests/

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 import os
 import threading
 import time
@@ -5,6 +6,7 @@ import timeit
 
 import pytest
 
+import ddtrace
 from ddtrace.vendor import six
 from ddtrace.vendor.six.moves import _thread
 
@@ -112,7 +114,7 @@ def test_repr():
         stack.StackCollector,
         "StackCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
         "recorder=Recorder(max_size=49152), max_time_usage_pct=2.0, "
-        "nframes=64, ignore_profiler=True)",
+        "nframes=64, ignore_profiler=True, tracer=None)",
     )
 
 
@@ -215,6 +217,114 @@ def test_exception_collection():
     if not TESTING_GEVENT:
         assert e.thread_id == _thread.get_ident()
         assert e.thread_name == "MainThread"
-    assert e.frames == [(__file__, 207, "test_exception_collection")]
+    assert e.frames == [(__file__, 209, "test_exception_collection")]
     assert e.nframes == 1
     assert e.exc_type == ValueError
+
+
+@pytest.fixture
+def tracer_and_collector():
+    t = ddtrace.Tracer()
+    r = recorder.Recorder()
+    c = stack.StackCollector(r, tracer=t)
+    c.start()
+    try:
+        yield t, c
+    finally:
+        c.stop()
+
+
+def test_thread_to_span_thread_isolation(tracer_and_collector):
+    t, c = tracer_and_collector
+    root = t.start_span("root")
+    thread_id = stack._thread_get_ident()
+    assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {root}
+
+    store = {}
+
+    def start_span():
+        store["span2"] = t.start_span("thread2")
+
+    th = threading.Thread(target=start_span)
+    th.start()
+    th.join()
+    if TESTING_GEVENT:
+        # We track *real* threads, gevent is using only one in this case
+        assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {root, store["span2"]}
+        assert c._thread_span_links.get_active_leaf_spans_from_thread_id(th.ident) == set()
+    else:
+        assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {root}
+        assert c._thread_span_links.get_active_leaf_spans_from_thread_id(th.ident) == {store["span2"]}
+
+
+def test_thread_to_span_multiple(tracer_and_collector):
+    t, c = tracer_and_collector
+    root = t.start_span("root")
+    thread_id = stack._thread_get_ident()
+    assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {root}
+    subspan = t.start_span("subtrace", child_of=root)
+    assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {subspan}
+    subspan.finish()
+    assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {root}
+    root.finish()
+    assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == set()
+
+
+def test_thread_to_child_span_multiple_unknown_thread(tracer_and_collector):
+    t, c = tracer_and_collector
+    t.start_span("root")
+    assert c._thread_span_links.get_active_leaf_spans_from_thread_id(3456789) == set()
+
+
+def test_thread_to_child_span_clear(tracer_and_collector):
+    t, c = tracer_and_collector
+    root = t.start_span("root")
+    thread_id = stack._thread_get_ident()
+    assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {root}
+    c._thread_span_links.clear_threads(set())
+    assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == set()
+
+
+def test_thread_to_child_span_multiple_more_children(tracer_and_collector):
+    t, c = tracer_and_collector
+    root = t.start_span("root")
+    thread_id = stack._thread_get_ident()
+    assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {root}
+    subspan = t.start_span("subtrace", child_of=root)
+    subsubspan = t.start_span("subsubtrace", child_of=subspan)
+    assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {subsubspan}
+    subsubspan2 = t.start_span("subsubtrace2", child_of=subspan)
+    assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {subsubspan, subsubspan2}
+    # ⚠ subspan is not supposed to finish before its children, but the API authorizes it
+    # In that case, we would return also the root span as it's becoming a parent without children 🤷
+    subspan.finish()
+    assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {root, subsubspan, subsubspan2}
+
+
+def test_collect_span_ids(tracer_and_collector):
+    t, c = tracer_and_collector
+    span = t.start_span("foobar")
+    # This test will run forever if it fails. Don't make it fail.
+    while True:
+        try:
+            event = c.recorder.events[stack.StackSampleEvent].pop()
+        except IndexError:
+            # No event left or no event yet
+            continue
+        if span.trace_id in event.trace_ids:
+            break
+
+
+def test_collect_multiple_span_ids(tracer_and_collector):
+    t, c = tracer_and_collector
+    span = t.start_span("foobar")
+    child = t.start_span("foobar", child_of=span)
+    # This test will run forever if it fails. Don't make it fail.
+    while True:
+        try:
+            event = c.recorder.events[stack.StackSampleEvent].pop()
+        except IndexError:
+            # No event left or no event yet
+            continue
+        if child.trace_id in event.trace_ids:
+            break

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -982,3 +982,33 @@ def test_tracer_runtime_tags_fork():
 
     children_tag = q.get()
     assert children_tag != span.get_tag("runtime-id")
+
+
+def test_start_span_hooks():
+    t = ddtrace.Tracer()
+
+    result = {}
+
+    @t.on_start_span
+    def store_span(span):
+        result['span'] = span
+
+    span = t.start_span("hello")
+
+    assert span == result["span"]
+
+
+def test_deregister_start_span_hooks():
+    t = ddtrace.Tracer()
+
+    result = {}
+
+    @t.on_start_span
+    def store_span(span):
+        result['span'] = span
+
+    t.deregister_on_start_span(store_span)
+
+    t.start_span("hello")
+
+    assert result == {}


### PR DESCRIPTION
## feat(tracer): add a on_start_span hook

This allows to register a function to be called when a new span is being
started by a Tracer.

## chore(black): blackify ddtrace/settings


## feat(profiling/stack): collect span ids for running thread and stack frames
