### PR TITLE
[internal] Add rate limit effective sample rate

### DIFF
--- a/ddtrace/internal/rate_limiter.py
+++ b/ddtrace/internal/rate_limiter.py
@@ -7,7 +7,15 @@ class RateLimiter(object):
     """
     A token bucket rate limiter implementation
     """
-    __slots__ = ('rate_limit', 'tokens', 'max_tokens', 'last_update', '_lock')
+    __slots__ = (
+        '_lock',
+        'last_update',
+        'max_tokens',
+        'rate_limit',
+        'tokens',
+        'current_window',
+        ''
+    )
 
     def __init__(self, rate_limit):
         """
@@ -24,6 +32,7 @@ class RateLimiter(object):
         self.max_tokens = rate_limit
 
         self.last_update = monotonic.monotonic()
+        self.current_window = self.last_update
         self._lock = threading.Lock()
 
     def is_allowed(self):
@@ -68,6 +77,13 @@ class RateLimiter(object):
             self.max_tokens,
             self.tokens + (elapsed * self.rate_limit),
         )
+
+    @property
+    def effective_rate(self):
+        if self.rate_limit == 0:
+            return 0.0
+        elif self.rate_limit < 0:
+            return 1.0
 
     def __repr__(self):
         return '{}(rate_limit={!r}, tokens={!r}, last_update={!r})'.format(

--- a/tests/internal/test_rate_limiter.py
+++ b/tests/internal/test_rate_limiter.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import mock
 
 import pytest
@@ -100,3 +101,91 @@ def test_rate_limiter_is_allowed_small_gaps():
             mock_time.return_value = now + (gap * i)
 
             assert limiter.is_allowed() is True
+
+
+def test_rate_liimter_effective_rate_rates():
+    limiter = RateLimiter(rate_limit=100)
+
+    # Static rate limit window
+    starting_window = monotonic.monotonic()
+    with mock.patch('ddtrace.vendor.monotonic.monotonic') as mock_time:
+        mock_time.return_value = starting_window
+
+        for _ in range(100):
+            assert limiter.is_allowed() is True
+            assert limiter.effective_rate == 1.0
+            assert limiter.current_window == starting_window
+
+        for i in range(1, 101):
+            assert limiter.is_allowed() is False
+            rate = 100 / (100 + i)
+            assert limiter.effective_rate == rate
+            assert limiter.current_window == starting_window
+
+    prev_rate = 0.5
+    with mock.patch('ddtrace.vendor.monotonic.monotonic') as mock_time:
+        window = starting_window + 1.0
+        mock_time.return_value = window
+
+        for i in range(100):
+            assert limiter.is_allowed() is True
+            assert limiter.effective_rate == 0.75
+            assert limiter.current_window == window
+
+        for i in range(1, 101):
+            assert limiter.is_allowed() is False
+            rate = 100 / (100 + i)
+            assert limiter.effective_rate == (rate + prev_rate) / 2
+            assert limiter.current_window == window
+
+
+def test_rate_liimter_effective_rate_starting_rate():
+    limiter = RateLimiter(rate_limit=1)
+
+    now = monotonic.monotonic()
+    with mock.patch('ddtrace.vendor.monotonic.monotonic') as mock_time:
+        mock_time.return_value = now
+
+        # Default values
+        assert limiter.current_window == 0
+        assert limiter.prev_window_rate is None
+
+        # Accessing the effective rate doesn't change anything
+        assert limiter.effective_rate == 1.0
+        assert limiter.current_window == 0
+        assert limiter.prev_window_rate is None
+
+        # Calling `.is_allowed()` updates the values
+        assert limiter.is_allowed() is True
+        assert limiter.effective_rate == 1.0
+        assert limiter.current_window == now
+        assert limiter.prev_window_rate is None
+
+        # Gap of 0.9999 seconds, same window
+        mock_time.return_value = now + 0.9999
+        assert limiter.is_allowed() is False
+        # DEV: We have rate_limit=1 set
+        assert limiter.effective_rate == 0.5
+        assert limiter.current_window == now
+        assert limiter.prev_window_rate is None
+
+        # Gap of 1.0 seconds, new window
+        mock_time.return_value = now + 1.0
+        assert limiter.is_allowed() is True
+        assert limiter.effective_rate == 0.75
+        assert limiter.current_window == (now + 1.0)
+        assert limiter.prev_window_rate == 0.5
+
+        # Gap of 1.9999 seconds, same window
+        mock_time.return_value = now + 1.9999
+        assert limiter.is_allowed() is False
+        assert limiter.effective_rate == 0.5
+        assert limiter.current_window == (now + 1.0)  # Same as old window
+        assert limiter.prev_window_rate == 0.5
+
+        # Large gap of 100 seconds, new window
+        mock_time.return_value = now + 100.0
+        assert limiter.is_allowed() is True
+        assert limiter.effective_rate == 0.75
+        assert limiter.current_window == (now + 100.0)
+        assert limiter.prev_window_rate == 0.5


### PR DESCRIPTION
**Note this PR is merging into `brettlangdon/datadog.sampler` not `master`**

This PR adds in `RateLimiter.effective_rate` to return the effective sample rate at that time based on the total number of traces seen vs the number of sampled traces in any given 1s rolling window.

TODO:

- [ ] Add tests for `RateLimiter.effective_rate`
- [ ] Properly set `_dd.limit_psr` tag on spans