### PR TITLE
[consul] Add instrumentation for consul

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,6 +267,18 @@ jobs:
       - *persist_to_workspace_step
       - *save_cache_step
 
+  consul:
+    docker:
+      - *test_runner
+      - image: consul:1.6.0
+    resource_class: *resource_class
+    steps:
+      - checkout
+      - *restore_cache_step
+      - run: scripts/run-tox-scenario '^consul_contrib-'
+      - *persist_to_workspace_step
+      - *save_cache_step
+
   elasticsearch:
     docker:
       - *test_runner
@@ -842,6 +854,9 @@ workflows:
       - celery:
           requires:
             - flake8
+      - consul:
+          requires:
+            - flake8
       - dbapi:
           requires:
             - flake8
@@ -980,6 +995,7 @@ workflows:
             - bottle
             - cassandra
             - celery
+            - consul
             - dbapi
             - ddtracerun
             - django

--- a/ddtrace/contrib/consul/__init__.py
+++ b/ddtrace/contrib/consul/__init__.py
@@ -1,0 +1,29 @@
+"""Instrument Consul to trace KV queries.
+
+Only supports tracing for the syncronous client.
+
+``patch_all`` will automatically patch your Consul client to make it work.
+::
+
+    from ddtrace import Pin, patch
+    import consul
+
+    # If not patched yet, you can patch consul specifically
+    patch(consul=True)
+
+    # This will report a span with the default settings
+    client = consul.Consul(host="127.0.0.1", port=8500)
+    client.get("my-key")
+
+    # Use a pin to specify metadata related to this client
+    Pin.override(client, service='consul-kv')
+"""
+
+from ...utils.importlib import require_modules
+
+required_modules = ['consul']
+
+with require_modules(required_modules) as missing_modules:
+    if not missing_modules:
+        from .patch import patch, unpatch
+        __all__ = ['patch', 'unpatch']

--- a/ddtrace/contrib/consul/patch.py
+++ b/ddtrace/contrib/consul/patch.py
@@ -1,0 +1,51 @@
+import consul
+
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
+
+from ...ext import AppTypes
+from ...pin import Pin
+from ...utils.wrappers import unwrap as _u
+
+
+_KV_FUNCS = ['Consul.KV.put', 'Consul.KV.get', 'Consul.KV.delete']
+
+
+def patch():
+    if getattr(consul, '__datadog_patch', False):
+        return
+    setattr(consul, '__datadog_patch', True)
+
+    pin = Pin(service='consul', app='consul', app_type=AppTypes.cache)
+    pin.onto(consul.Consul.KV)
+
+    for f_name in _KV_FUNCS:
+        _w('consul', f_name, wrap_function(f_name))
+
+
+def unpatch():
+    if not getattr(consul, '__datadog_patch', False):
+        return
+    setattr(consul, '__datadog_patch', False)
+
+    for f_name in _KV_FUNCS:
+        name = f_name.split('.')[-1]
+        _u(consul.Consul.KV, name)
+
+
+def wrap_function(name):
+    def trace_func(wrapped, instance, args, kwargs):
+        pin = Pin.get_from(instance)
+        if not pin or not pin.enabled():
+            return wrapped(*args, **kwargs)
+
+        # Only patch the syncronous implementation
+        if not isinstance(instance.agent.http, consul.std.HTTPClient):
+            return wrapped(*args, **kwargs)
+
+        path = kwargs.get('key') or args[0]
+
+        with pin.tracer.trace(name, service=pin.service, resource=path) as span:
+            span.set_tag('consul.key', path)
+            return wrapped(*args, **kwargs)
+
+    return trace_func

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -25,6 +25,7 @@ PATCH_MODULES = {
     'bottle': False,
     'cassandra': True,
     'celery': True,
+    'consul': True,
     'elasticsearch': True,
     'algoliasearch': True,
     'futures': False,  # experimental propagation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,10 @@ services:
             - HEAP_NEWSIZE=256M
         ports:
             - "127.0.0.1:9042:9042"
+    consul:
+        image: consul:1.6.0
+        ports:
+            - "127.0.0.1:8500:8500"
     postgres:
         image: postgres:10.5-alpine
         environment:

--- a/docs/db_integrations.rst
+++ b/docs/db_integrations.rst
@@ -17,6 +17,14 @@ Cassandra
 .. automodule:: ddtrace.contrib.cassandra
 
 
+.. _consul:
+
+Consul
+------
+
+.. automodule:: ddtrace.contrib.consul
+
+
 .. _elasticsearch:
 
 Elasticsearch

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,8 @@ contacting support.
 +--------------------------------------------------+---------------+----------------+
 | :ref:`cassandra`                                 | >= 3.5        | Yes            |
 +--------------------------------------------------+---------------+----------------+
+| :ref:`consul`                                    | >= 0.7        | Yes [3]_       |
++--------------------------------------------------+---------------+----------------+
 | :ref:`django`                                    | >= 1.8        | No             |
 +--------------------------------------------------+---------------+----------------+
 | :ref:`djangorestframework <djangorestframework>` | >= 3.4        | No             |
@@ -122,6 +124,8 @@ contacting support.
   your Python entrypoint.
 
 .. [2] only third-party modules such as aiohttp_jinja2
+
+.. [3] only the syncronous client
 
 
 Indices and tables

--- a/tests/contrib/config.py
+++ b/tests/contrib/config.py
@@ -17,6 +17,11 @@ CASSANDRA_CONFIG = {
     'port': int(os.getenv('TEST_CASSANDRA_PORT', 9042)),
 }
 
+CONSUL_CONFIG = {
+    'host': '127.0.0.1',
+    'port': int(os.getenv('TEST_CONSUL_PORT', 8500)),
+}
+
 # Use host=127.0.0.1 since local docker testing breaks with localhost
 
 POSTGRES_CONFIG = {

--- a/tests/contrib/consul/test.py
+++ b/tests/contrib/consul/test.py
@@ -1,0 +1,128 @@
+import consul
+from ddtrace import Pin
+from ddtrace.vendor.wrapt import BoundFunctionWrapper
+from ddtrace.contrib.consul.patch import patch, unpatch
+
+from ..config import CONSUL_CONFIG
+from ...base import BaseTracerTestCase
+
+
+class TestConsulPatch(BaseTracerTestCase):
+
+    TEST_SERVICE = 'test-consul'
+
+    def setUp(self):
+        super(TestConsulPatch, self).setUp()
+        patch()
+        c = consul.Consul(
+                host=CONSUL_CONFIG['host'],
+                port=CONSUL_CONFIG['port'])
+        Pin.override(consul.Consul, service=self.TEST_SERVICE, tracer=self.tracer)
+        Pin.override(consul.Consul.KV, service=self.TEST_SERVICE, tracer=self.tracer)
+        self.c = c
+
+    def tearDown(self):
+        unpatch()
+        super(TestConsulPatch, self).tearDown()
+
+    def test_put(self):
+        key = 'test/put/consul'
+        value = 'test_value'
+
+        self.c.kv.put(key, value)
+
+        spans = self.get_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'Consul.KV.put'
+        assert span.resource == key
+        assert span.error == 0
+        tags = {
+            'consul.key': key,
+        }
+        for k, v in tags.items():
+            assert span.get_tag(k) == v
+
+    def test_get(self):
+        key = 'test/get/consul'
+
+        self.c.kv.get(key)
+
+        spans = self.get_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'Consul.KV.get'
+        assert span.resource == key
+        assert span.error == 0
+        tags = {
+            'consul.key': key,
+        }
+        for k, v in tags.items():
+            assert span.get_tag(k) == v
+
+    def test_delete(self):
+        key = 'test/delete/consul'
+
+        self.c.kv.delete(key)
+
+        spans = self.get_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'Consul.KV.delete'
+        assert span.resource == key
+        assert span.error == 0
+        tags = {
+            'consul.key': key,
+        }
+        for k, v in tags.items():
+            assert span.get_tag(k) == v
+
+    def test_kwargs(self):
+        key = 'test/kwargs/consul'
+        value = 'test_value'
+
+        self.c.kv.put(key=key, value=value)
+
+        spans = self.get_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.service == self.TEST_SERVICE
+        assert span.name == 'Consul.KV.put'
+        assert span.resource == key
+        assert span.error == 0
+        tags = {
+            'consul.key': key,
+        }
+        for k, v in tags.items():
+            assert span.get_tag(k) == v
+
+    def test_patch_idempotence(self):
+        key = 'test/patch/idempotence'
+
+        patch()
+        patch()
+
+        self.c.kv.get(key)
+        assert self.spans
+        assert isinstance(self.c.kv.get, BoundFunctionWrapper)
+
+        unpatch()
+        self.reset()
+
+        self.c.kv.get(key)
+        assert not self.spans
+        assert not isinstance(self.c.kv.get, BoundFunctionWrapper)
+
+    def test_patch_preserves_functionality(self):
+        key = 'test/functionality'
+        value = b'test_value'
+
+        self.c.kv.put(key, value)
+        _, data = self.c.kv.get(key)
+        assert data['Value'] == value
+        self.c.kv.delete(key)
+        _, data = self.c.kv.get(key)
+        assert data is None

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,7 @@ envlist =
 # Celery 4.3 wants Kombu >= 4.4 and Redis >= 3.2
 # Python 3.7 needs Celery 4.3
     celery_contrib-{py27,py34,py35,py36,py37}-celery43-redis320-kombu44
+    consul_contrib-py{27,34,35,36,37}-consul{07,10,11}
     dbapi_contrib-{py27,py34,py35,py36}
     django_contrib{,_autopatch}-{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     django_contrib{,_autopatch}-{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
@@ -195,6 +196,9 @@ deps =
     celery41: celery>=4.1,<4.2
     celery42: celery>=4.2,<4.3
     celery43: celery>=4.3,<4.4
+    consul07: python-consul>=0.7,<1.0
+    consul10: python-consul>=1.0,<1.1
+    consul11: python-consul>=1.1,<1.2
     ddtracerun: redis
     django18: django>=1.8,<1.9
     django111: django>=1.11,<1.12
@@ -378,6 +382,7 @@ commands =
     bottle_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/bottle/test_autopatch.py
     cassandra_contrib: pytest {posargs} tests/contrib/cassandra
     celery_contrib: pytest {posargs} tests/contrib/celery
+    consul_contrib: pytest {posargs} tests/contrib/consul
     dbapi_contrib: pytest {posargs} tests/contrib/dbapi
     django_contrib: pytest {posargs} tests/contrib/django
     django_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/django


### PR DESCRIPTION
Automatically instruments consul connections to trace KV calls. Only works for sync client.