### PR TITLE
tracer: allow to override agent URL with a env var

### DIFF
--- a/docs/installation_quickstart.rst
+++ b/docs/installation_quickstart.rst
@@ -34,6 +34,28 @@ For more advanced usage of ``ddtrace-run`` refer to the documentation :ref:`here
 To find out how to trace your own code manually refer to the documentation :ref:`here<basic usage>`.
 
 
+Configuration
+~~~~~~~~~~~~~
+
+You can configure some parameters of the library by setting environment
+variable before starting your application and importing the library:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 1 1 2
+
+   * - Configuration Variable
+     - Configuration Type
+     - Default Value
+     - Value Description
+   * - ``DD_TRACE_AGENT_URL``
+     - URL
+     - ``http://localhost:8126``
+     - The URL to use to connect the Datadog agent. The url can starts with
+       ``http://`` to connect using HTTP or with ``unix://`` to use a Unix
+       Domain Socket.
+
+
 OpenTracing
 -----------
 


### PR DESCRIPTION
This makes possible to use an URL to configure the Tracer rather than different
variables.

This also starts a process where Tracer.configure is not going to be the right
way to set the tracer up, but the parameter are used on Tracer initialization.

Fixes #1052