### PR TITLE
[core] Add HTTPS support

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -23,7 +23,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
 
     QUEUE_PROCESSING_INTERVAL = 1
 
-    def __init__(self, hostname='localhost', port=8126, uds_path=None,
+    def __init__(self, hostname='localhost', port=8126, uds_path=None, https=False,
                  shutdown_timeout=DEFAULT_TIMEOUT,
                  filters=None, priority_sampler=None,
                  dogstatsd=None):
@@ -35,7 +35,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         self._priority_sampler = priority_sampler
         self._last_error_ts = 0
         self.dogstatsd = dogstatsd
-        self.api = api.API(hostname, port, uds_path=uds_path,
+        self.api = api.API(hostname, port, uds_path=uds_path, https=https,
                            priority_sampling=priority_sampler is not None)
         self.start()
 

--- a/ddtrace/opentracer/settings.py
+++ b/ddtrace/opentracer/settings.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 
 CONFIG_KEY_NAMES = [
     'AGENT_HOSTNAME',
+    'AGENT_HTTPS',
     'AGENT_PORT',
     'DEBUG',
     'ENABLED',
@@ -17,6 +18,7 @@ ConfigKeyNames = namedtuple('ConfigKeyNames', CONFIG_KEY_NAMES)
 
 ConfigKeys = ConfigKeyNames(
     AGENT_HOSTNAME='agent_hostname',
+    AGENT_HTTPS='agent_https',
     AGENT_PORT='agent_port',
     DEBUG='debug',
     ENABLED='enabled',

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -20,6 +20,7 @@ log = get_logger(__name__)
 
 DEFAULT_CONFIG = {
     keys.AGENT_HOSTNAME: 'localhost',
+    keys.AGENT_HTTPS: False,
     keys.AGENT_PORT: 8126,
     keys.DEBUG: False,
     keys.ENABLED: True,
@@ -83,6 +84,7 @@ class Tracer(opentracing.Tracer):
         self._dd_tracer.set_tags(self._config.get(keys.GLOBAL_TAGS))
         self._dd_tracer.configure(enabled=self._enabled,
                                   hostname=self._config.get(keys.AGENT_HOSTNAME),
+                                  https=self._config.get(keys.AGENT_HTTPS),
                                   port=self._config.get(keys.AGENT_PORT),
                                   sampler=self._config.get(keys.SAMPLER),
                                   settings=self._config.get(keys.SETTINGS),

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -107,9 +107,9 @@ class Tracer(object):
         """Returns the current Tracer Context Provider"""
         return self._context_provider
 
-    def configure(self, enabled=None, hostname=None, port=None, uds_path=None, dogstatsd_host=None,
-                  dogstatsd_port=None, sampler=None, context_provider=None, wrap_executor=None,
-                  priority_sampling=None, settings=None, collect_metrics=None):
+    def configure(self, enabled=None, hostname=None, port=None, uds_path=None, https=None,
+                  dogstatsd_host=None, dogstatsd_port=None, sampler=None, context_provider=None,
+                  wrap_executor=None, priority_sampling=None, settings=None, collect_metrics=None):
         """
         Configure an existing Tracer the easy way.
         Allow to configure or reconfigure a Tracer instance.
@@ -119,6 +119,7 @@ class Tracer(object):
         :param str hostname: Hostname running the Trace Agent
         :param int port: Port of the Trace Agent
         :param str uds_path: The Unix Domain Socket path of the agent.
+        :param bool https: Whether to use HTTPS or HTTP.
         :param int metric_port: Port of DogStatsd
         :param object sampler: A custom Sampler instance, locally deciding to totally drop the trace or not.
         :param object context_provider: The ``ContextProvider`` that will be used to retrieve
@@ -163,18 +164,21 @@ class Tracer(object):
             port=self._dogstatsd_port,
         )
 
-        if hostname is not None or port is not None or uds_path is not None or filters is not None or \
-                priority_sampling is not None:
+        if hostname is not None or port is not None or uds_path is not None or https is not None or \
+                filters is not None or priority_sampling is not None:
             # Preserve hostname and port when overriding filters or priority sampling
             default_hostname = self.DEFAULT_HOSTNAME
             default_port = self.DEFAULT_PORT
             if hasattr(self, 'writer') and hasattr(self.writer, 'api'):
                 default_hostname = self.writer.api.hostname
                 default_port = self.writer.api.port
+                if https is None:
+                    https = self.writer.api.https
             self.writer = AgentWriter(
                 hostname or default_hostname,
                 port or default_port,
                 uds_path=uds_path,
+                https=https,
                 filters=filters,
                 priority_sampler=self.priority_sampler,
                 dogstatsd=self._dogstatsd_client,

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -10,9 +10,9 @@ is a small example showcasing this::
 
     from ddtrace import tracer
 
-    tracer.configure(hostname=<YOUR_HOST>, port=<YOUR_PORT>)
+    tracer.configure(hostname=<YOUR_HOST>, port=<YOUR_PORT>, https=<True/False>)
 
-By default, these will be set to ``localhost`` and ``8126`` respectively.
+By default, these will be set to ``localhost``, ``8126``, and ``False`` respectively.
 
 You can also use a Unix Domain Socket to connect to the agent::
 
@@ -440,6 +440,8 @@ for usage.
 | `debug`             | enable debug logging                   | `False`       |
 +---------------------+----------------------------------------+---------------+
 | `agent_hostname`    | hostname of the Datadog agent to use   | `localhost`   |
++---------------------+----------------------------------------+---------------+
+| `agent_https`       | use https to connect to the agent      | `False`       |
 +---------------------+----------------------------------------+---------------+
 | `agent_port`        | port the Datadog agent is listening on | `8126`        |
 +---------------------+----------------------------------------+---------------+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -110,10 +110,10 @@ class ResponseMock:
 
 
 def test_api_str():
-    api = API('localhost', 8126)
-    assert str(api) == 'localhost:8126'
+    api = API('localhost', 8126, https=True)
+    assert str(api) == 'https://localhost:8126'
     api = API('localhost', 8126, '/path/to/uds')
-    assert str(api) == '/path/to/uds'
+    assert str(api) == 'unix:///path/to/uds'
 
 
 class APITests(TestCase):
@@ -212,6 +212,16 @@ class APITests(TestCase):
 
         self.conn.request.assert_called_once()
         self.conn.close.assert_called_once()
+
+
+def test_https():
+    conn = mock.MagicMock(spec=httplib.HTTPSConnection)
+    api = API('localhost', 8126, https=True)
+    with mock.patch('ddtrace.compat.httplib.HTTPSConnection') as HTTPSConnection:
+        HTTPSConnection.return_value = conn
+        api._put('/test', '<test data>', 1)
+    conn.request.assert_called_once()
+    conn.close.assert_called_once()
 
 
 def test_flush_connection_timeout_connect():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -199,7 +199,7 @@ class TestWorkers(TestCase):
 
         logged_errors = log_handler.messages['error']
         assert len(logged_errors) == 1
-        assert 'Failed to send traces to Datadog Agent at localhost:8126: ' \
+        assert 'Failed to send traces to Datadog Agent at http://localhost:8126: ' \
             'HTTP error status 400, reason Bad Request, message Content-Type:' \
             in logged_errors[0]
 


### PR DESCRIPTION
We have collectors deployed behind an AWS NLB that does TLS termination so we'd like HTTPS support.

This will have conflicts with #1054.