### PR TITLE
span: expose finished attribute

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -138,7 +138,7 @@ class Context(object):
             # some children. On the other hand, asynchronous web frameworks still expect
             # to close the root span after all the children.
             if span.tracer and span.tracer.debug_logging and span._parent is None:
-                unfinished_spans = [x for x in self._trace if not x._finished]
+                unfinished_spans = [x for x in self._trace if not x.finished]
                 if unfinished_spans:
                     log.debug('Root span "%s" closed, but the trace has %d unfinished spans:',
                               span.name, len(unfinished_spans))
@@ -186,7 +186,7 @@ class Context(object):
                 return trace, sampled
 
             elif self._partial_flush_enabled:
-                finished_spans = [t for t in self._trace if t._finished]
+                finished_spans = [t for t in self._trace if t.finished]
                 if len(finished_spans) >= self._partial_flush_min_spans:
                     # partial flush when enabled and we have more than the minimal required spans
                     trace = self._trace
@@ -209,7 +209,7 @@ class Context(object):
 
                     # Any open spans will remain as `self._trace`
                     # Any finished spans will get returned to be flushed
-                    self._trace = [t for t in self._trace if not t._finished]
+                    self._trace = [t for t in self._trace if not t.finished]
 
                     return finished_spans, sampled
             return None, None

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -21,7 +21,7 @@ class Span(OpenTracingSpan):
 
         super(Span, self).__init__(tracer, context)
 
-        self._finished = False
+        self.finished = False
         self._lock = threading.Lock()
         # use a datadog span
         self._dd_span = DatadogSpan(tracer._dd_tracer, operation_name,
@@ -36,12 +36,12 @@ class Span(OpenTracingSpan):
             per time.time()
         :type timestamp: float
         """
-        if self._finished:
+        if self.finished:
             return
 
         # finish the datadog span
         self._dd_span.finish(finish_time)
-        self._finished = True
+        self.finished = True
 
     def set_baggage_item(self, key, value):
         """Sets a baggage item in the span context of this span.

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -34,7 +34,7 @@ class Span(object):
         'sampled',
         # Internal attributes
         '_context',
-        '_finished',
+        'finished',
         '_parent',
         '__weakref__',
     ]
@@ -99,7 +99,7 @@ class Span(object):
         self._parent = None
 
         # state
-        self._finished = False
+        self.finished = False
 
     def finish(self, finish_time=None):
         """ Mark the end time of the span and submit it to the tracer.
@@ -108,9 +108,9 @@ class Span(object):
             :param int finish_time: the end time of the span in seconds.
                                     Defaults to now.
         """
-        if self._finished:
+        if self.finished:
             return
-        self._finished = True
+        self.finished = True
 
         if self.duration is None:
             ft = finish_time or time.time()

--- a/tests/opentracer/test_span.py
+++ b/tests/opentracer/test_span.py
@@ -30,7 +30,7 @@ class TestSpan(object):
     def test_init(self, nop_tracer, nop_span_ctx):
         """Very basic test for skeleton code"""
         span = Span(nop_tracer, nop_span_ctx, 'my_op_name')
-        assert not span._finished
+        assert not span.finished
 
     def test_tags(self, nop_span):
         """Set a tag and get it back."""
@@ -95,14 +95,14 @@ class TestSpan(object):
         """Test the span context manager."""
         import time
 
-        assert not nop_span._finished
+        assert not nop_span.finished
         # run the context manager but since the span has not been added
         # to the span context, we will not get any traces
         with nop_span:
             time.sleep(0.005)
 
         # span should be finished when the context manager exits
-        assert nop_span._finished
+        assert nop_span.finished
 
         # there should be no traces (see above comment)
         spans = nop_span.tracer._tracer.writer.pop()

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -100,7 +100,7 @@ class TestTracer(object):
             pass
 
         # span should be finished when the context manager exits
-        assert span._finished
+        assert span.finished
 
         spans = writer.pop()
         assert len(spans) == 1
@@ -144,8 +144,8 @@ class TestTracer(object):
                 pass
 
         # span should be finished when the context manager exits
-        assert span._finished
-        assert span2._finished
+        assert span.finished
+        assert span2.finished
 
         spans = writer.pop()
         assert len(spans) == 2
@@ -174,9 +174,9 @@ class TestTracer(object):
                     time.sleep(0.005)
 
         # spans should be finished when the context manager exits
-        assert scope1.span._finished
-        assert scope2.span._finished
-        assert scope3.span._finished
+        assert scope1.span.finished
+        assert scope2.span.finished
+        assert scope3.span.finished
 
         spans = writer.pop()
 
@@ -207,9 +207,9 @@ class TestTracer(object):
                 time.sleep(0.005)
 
         # spans should be finished when the context manager exits
-        assert scope1.span._finished
-        assert scope2.span._finished
-        assert scope3.span._finished
+        assert scope1.span.finished
+        assert scope2.span.finished
+        assert scope3.span.finished
 
         spans = writer.pop()
 
@@ -369,7 +369,7 @@ class TestTracer(object):
             pass
 
         assert scope.span._dd_span.name == 'one'
-        assert scope.span._finished
+        assert scope.span.finished
         spans = writer.pop()
         assert spans
 
@@ -378,7 +378,7 @@ class TestTracer(object):
             pass
 
         assert scope.span._dd_span.name == 'one'
-        assert not scope.span._finished
+        assert not scope.span.finished
         spans = writer.pop()
         assert not spans
 

--- a/tests/opentracer/test_tracer_gevent.py
+++ b/tests/opentracer/test_tracer_gevent.py
@@ -30,7 +30,7 @@ class TestTracerGevent(object):
         with ot_tracer.start_span('span') as span:
             span.set_tag('tag', 'value')
 
-        assert span._finished
+        assert span.finished
 
     def test_greenlets(self, ot_tracer, writer):
         def f():

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -188,7 +188,7 @@ class TestTracingContext(BaseTestCase):
         for i in range(5):
             child = Span(tracer=tracer, name='child_{}'.format(i), trace_id=root.trace_id, parent_id=root.span_id)
             child._parent = root
-            child._finished = True
+            child.finished = True
             ctx.add_span(child)
             ctx.close_span(child)
 
@@ -227,7 +227,7 @@ class TestTracingContext(BaseTestCase):
         for i in range(5):
             child = Span(tracer=tracer, name='child_{}'.format(i), trace_id=root.trace_id, parent_id=root.span_id)
             child._parent = root
-            child._finished = True
+            child.finished = True
             ctx.add_span(child)
             ctx.close_span(child)
 
@@ -266,7 +266,7 @@ class TestTracingContext(BaseTestCase):
         for i in range(5):
             child = Span(tracer=tracer, name='child_{}'.format(i), trace_id=root.trace_id, parent_id=root.span_id)
             child._parent = root
-            child._finished = True
+            child.finished = True
             ctx.add_span(child)
             ctx.close_span(child)
 
@@ -303,7 +303,7 @@ class TestTracingContext(BaseTestCase):
 
             # CLose the first 5 only
             if i < 5:
-                child._finished = True
+                child.finished = True
                 ctx.close_span(child)
 
         with self.override_partial_flush(ctx, enabled=True, min_spans=5):


### PR DESCRIPTION
There is currently no way to know if a span is finished or not. There's no
reason to keep this attribute private.