### PR TITLE
[contrib/cassandra] Handle batched bound statements in python3

### DIFF
--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -261,7 +261,7 @@ def _sanitize_query(span, query):
         resource = getattr(query, 'query_string', query)
     elif t == 'BatchStatement':
         resource = 'BatchStatement'
-        q = '; '.join(q[1] for q in query._statements_and_parameters[:2])
+        q = '; '.join(q[1] for q in query._statements_and_parameters[:2] if not q[0])
         span.set_tag('cassandra.query', q)
         span.set_metric('cassandra.batch_size', len(query._statements_and_parameters))
     elif t == 'BoundStatement':

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -261,6 +261,14 @@ def _sanitize_query(span, query):
         resource = getattr(query, 'query_string', query)
     elif t == 'BatchStatement':
         resource = 'BatchStatement'
+        # Each element in `_statements_and_parameters` is:
+        #   (is_prepared, statement, parameters)
+        #  ref:https://github.com/datastax/python-driver/blob/13d6d72be74f40fcef5ec0f2b3e98538b3b87459/cassandra/query.py#L844
+        #
+        # For prepared statements, the `statement` value is just the query_id
+        #   which is not a statement and when trying to join with other strings
+        #   raises an error in python3 around joining bytes to unicode, so this
+        #   just filters out prepared statements from this tag value
         q = '; '.join(q[1] for q in query._statements_and_parameters[:2] if not q[0])
         span.set_tag('cassandra.query', q)
         span.set_metric('cassandra.batch_size', len(query._statements_and_parameters))

--- a/tests/contrib/cassandra/test.py
+++ b/tests/contrib/cassandra/test.py
@@ -338,6 +338,23 @@ class CassandraBase(object):
         assert s.get_metric('cassandra.batch_size') == 2
         assert 'test.person' in s.get_tag('cassandra.query')
 
+    def test_batched_bound_statement(self):
+        session, tracer = self._traced_session()
+        writer = tracer.writer
+
+        batch = BatchStatement()
+
+        prepared_statement = session.prepare('INSERT INTO test.person_write (name, age, description) VALUES (?, ?, ?)')
+        batch.add(
+            prepared_statement.bind(('matt', 34, 'can'))
+        )
+        session.execute(batch)
+
+        spans = writer.pop()
+        assert len(spans) == 1
+        s = spans[0]
+        assert s.resource == 'BatchStatement'
+
 
 class TestCassPatchDefault(unittest.TestCase, CassandraBase):
     """Test Cassandra instrumentation with patching and default configuration"""

--- a/tests/contrib/cassandra/test.py
+++ b/tests/contrib/cassandra/test.py
@@ -354,6 +354,7 @@ class CassandraBase(object):
         assert len(spans) == 1
         s = spans[0]
         assert s.resource == 'BatchStatement'
+        assert s.get_tag('cassandra.query') == ''
 
 
 class TestCassPatchDefault(unittest.TestCase, CassandraBase):


### PR DESCRIPTION
When a bound statement is batched, the query string it uses is it's
query_id which is bytestring (and not an encoded one, just a raw bytes
sequence) so when it is attempted to be joined using a unicode string
(in python3) it raises an exception due to mixed types during query
sanitization.  If the prepared flag is set to `True` on the statements
list, don't include the query_id.

With the added test (but before the change to `session.py`):
```
        elif t == 'BatchStatement':
            resource = 'BatchStatement'
>           q = '; '.join(q[1] for q in query._statements_and_parameters[:2])
E           TypeError: sequence item 0: expected str instance, bytes found

ddtrace/contrib/cassandra/session.py:264: TypeError
```