### PR TITLE
tracer: fix configure(collect_metrics) argument

### DIFF
--- a/tests/internal/runtime/test_runtime_metrics.py
+++ b/tests/internal/runtime/test_runtime_metrics.py
@@ -1,9 +1,10 @@
 import time
 
+import mock
+
 from ddtrace.internal.runtime.runtime_metrics import (
     RuntimeTags,
     RuntimeMetrics,
-    RuntimeWorker,
 )
 from ddtrace.internal.runtime.constants import (
     DEFAULT_RUNTIME_METRICS,
@@ -11,13 +12,11 @@ from ddtrace.internal.runtime.constants import (
     SERVICE,
     ENV
 )
-from ddtrace.vendor.dogstatsd import DogStatsd
 
 from ...base import (
     BaseTestCase,
     BaseTracerTestCase,
 )
-from ...utils.tracer import FakeSocket
 
 
 class TestRuntimeTags(BaseTracerTestCase):
@@ -74,52 +73,41 @@ class TestRuntimeMetrics(BaseTestCase):
 
 class TestRuntimeWorker(BaseTracerTestCase):
     def test_tracer_metrics(self):
-        # mock dogstatsd client before configuring tracer for runtime metrics
-        self.tracer._dogstatsd_client = DogStatsd()
-        self.tracer._dogstatsd_client.socket = FakeSocket()
-
-        default_flush_interval = RuntimeWorker.FLUSH_INTERVAL
-        try:
-            # lower flush interval
-            RuntimeWorker.FLUSH_INTERVAL = 1./4
-
+        # Mock socket.socket to hijack the dogstatsd socket
+        with mock.patch('socket.socket'):
             # configure tracer for runtime metrics
+            self.tracer._RUNTIME_METRICS_INTERVAL = 1./4
             self.tracer.configure(collect_metrics=True)
-        finally:
-            # reset flush interval
-            RuntimeWorker.FLUSH_INTERVAL = default_flush_interval
 
-        with self.override_global_tracer(self.tracer):
-            root = self.start_span('parent', service='parent')
-            context = root.context
-            self.start_span('child', service='child', child_of=context)
+            with self.override_global_tracer(self.tracer):
+                root = self.start_span('parent', service='parent')
+                context = root.context
+                self.start_span('child', service='child', child_of=context)
 
-            time.sleep(self.tracer._runtime_worker.interval * 2)
-            self.tracer._runtime_worker.stop()
-            self.tracer._runtime_worker.join()
+            time.sleep(self.tracer._RUNTIME_METRICS_INTERVAL * 2)
 
-            # get all received metrics
-            received = []
-            while True:
-                new = self.tracer._dogstatsd_client.socket.recv()
-                if not new:
-                    break
+            # Get the socket before it disappears
+            statsd_socket = self.tracer._dogstatsd_client.socket
+            # now stop collection
+            self.tracer.configure(collect_metrics=False)
 
-                received.append(new)
+        received = [
+            s.args[0].decode('utf-8') for s in statsd_socket.send.mock_calls
+        ]
 
-            # we expect more than one flush since it is also called on shutdown
-            assert len(received) > 1
+        # we expect more than one flush since it is also called on shutdown
+        assert len(received) > 1
 
-            # expect all metrics in default set are received
-            # DEV: dogstatsd gauges in form "{metric_name}:{metric_value}|g#t{tag_name}:{tag_value},..."
-            self.assertSetEqual(
-                set([gauge.split(':')[0]
-                     for packet in received
-                     for gauge in packet.split('\n')]),
-                DEFAULT_RUNTIME_METRICS
-            )
+        # expect all metrics in default set are received
+        # DEV: dogstatsd gauges in form "{metric_name}:{metric_value}|g#t{tag_name}:{tag_value},..."
+        self.assertSetEqual(
+            set([gauge.split(':')[0]
+                 for packet in received
+                 for gauge in packet.split('\n')]),
+            DEFAULT_RUNTIME_METRICS
+        )
 
-            # check to last set of metrics returned to confirm tags were set
-            for gauge in received[-len(DEFAULT_RUNTIME_METRICS):]:
-                self.assertRegexpMatches(gauge, 'service:parent')
-                self.assertRegexpMatches(gauge, 'service:child')
+        # check to last set of metrics returned to confirm tags were set
+        for gauge in received[-len(DEFAULT_RUNTIME_METRICS):]:
+            self.assertRegexpMatches(gauge, 'service:parent')
+            self.assertRegexpMatches(gauge, 'service:child')

--- a/tests/utils/tracer.py
+++ b/tests/utils/tracer.py
@@ -1,8 +1,6 @@
-from collections import deque
 from ddtrace.encoding import JSONEncoder, MsgpackEncoder
 from ddtrace.internal.writer import AgentWriter
 from ddtrace.tracer import Tracer
-from ddtrace.compat import PY3
 
 
 class DummyWriter(AgentWriter):
@@ -77,32 +75,3 @@ class DummyTracer(Tracer):
         super(DummyTracer, self).configure(*args, **kwargs)
         # `.configure()` may reset the writer
         self._update_writer()
-
-
-class FakeSocket(object):
-    """ A fake socket for testing dogstatsd client.
-
-        Adapted from https://github.com/DataDog/datadogpy/blob/master/tests/unit/dogstatsd/test_statsd.py#L31
-    """
-
-    def __init__(self):
-        self.payloads = deque()
-
-    def send(self, payload):
-        if PY3:
-            assert type(payload) == bytes
-        else:
-            assert type(payload) == str
-        self.payloads.append(payload)
-
-    def recv(self):
-        try:
-            return self.payloads.popleft().decode('utf-8')
-        except IndexError:
-            return None
-
-    def close(self):
-        pass
-
-    def __repr__(self):
-        return str(self.payloads)


### PR DESCRIPTION
- The current code does not allow to disable collect_metrics by passing `False`
  to it.
- The recent change from 2c41f15838d1baa96ef3fda2e37e5bc182c9f774 made the hack
  in test_runtime_metrics to change the FLUSH_INTERVAL a noop, making the test
  taking 20 seconds to complete.

This patch fixes both issues by allowing the `collect_metrics` arguments to be
a boolean or a float representing the interval in seconds to use to collect the
runtime metrics. This makes sure users can disabled runtime metrics at any
time, and fixes the test for running in a less than a second.