### PR TITLE
runtime metrics: fix gc0 test

### DIFF
--- a/tests/internal/runtime/test_metric_collectors.py
+++ b/tests/internal/runtime/test_metric_collectors.py
@@ -58,4 +58,6 @@ class TestGCRuntimeMetricCollector(BaseTestCase):
         del a
         gc.collect()
         collected_after = collector.collect([GC_COUNT_GEN0])
-        self.assertLess(collected_after[0][1], collected[0][1])
+        assert len(collected_after) == 1
+        assert collected_after[0][0] == 'runtime.python.gc.count.gen0'
+        assert isinstance(collected_after[0][1], int)


### PR DESCRIPTION
The current test checks the value returned by the gc, but it regularly fails:

>       self.assertLess(collected_after[0][1], collected[0][1])
E       AssertionError: 9 not less than 8

The computing method is not 100% reproducible and depends on the GC state.
Since we're not really interested in testing the GC anyway, let's simplify the
test and check what's important for us.