### PR TITLE
Flush writer stats to dogstatsd

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -196,6 +196,9 @@ class API(object):
         :param traces: A list of traces.
         :return: The list of API HTTP responses.
         """
+        if not traces:
+            return []
+
         start = time.time()
         responses = []
         payload = Payload(encoder=self._encoder)


### PR DESCRIPTION
This adds dogstatsd support to the AgentWriter thread. When flushing traces,
the writer will flush various statistics to the local dogstatsd agent.