### PR TITLE
writer: add memory size statistics to the queue

### DIFF
--- a/ddtrace/utils/sizeof.py
+++ b/ddtrace/utils/sizeof.py
@@ -1,0 +1,31 @@
+import collections
+import sys
+from itertools import chain
+
+
+def iter_object(o):
+    if hasattr(o, '__slots__'):
+        return (getattr(o, slot) for slot in o.__slots__)
+    elif hasattr(o, '__dict__'):
+        return list(o.__dict__.items())
+    elif isinstance(o, dict):
+        # Make a copy to avoid corruption
+        return chain.from_iterable(list(o.items()))
+    elif isinstance(o, (list, set, frozenset, tuple, collections.deque)):
+        # Make a copy to avoid corruption
+        return iter(list(o))
+    return []
+
+
+def sizeof(o):
+    """Returns the approximate memory footprint an object and all of its contents."""
+    seen = set()
+
+    def _sizeof(o):
+        # do not double count the same object
+        if id(o) in seen:
+            return 0
+        seen.add(id(o))
+        return sys.getsizeof(o) + sum(map(_sizeof, iter_object(o)))
+
+    return _sizeof(o)

--- a/tests/internal/test_writer.py
+++ b/tests/internal/test_writer.py
@@ -101,12 +101,14 @@ def test_queue_full():
             list(q.queue) == [[1], [4, 4], [3]] or
             list(q.queue) == [[4, 4], 2, [3]])
     assert q.dropped == 1
-    assert q.enqueued == 4
-    assert q.enqueued_lengths == 5
-    dropped, enqueued, enqueued_lengths = q.reset_stats()
+    assert q.accepted == 4
+    assert q.accepted_lengths == 5
+    assert q.accepted_size >= 100
+    dropped, accepted, accepted_lengths, accepted_size = q.reset_stats()
     assert dropped == 1
-    assert enqueued == 4
-    assert enqueued_lengths == 5
+    assert accepted == 4
+    assert accepted_lengths == 5
+    assert accepted_size >= 100
 
 
 def test_queue_get():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import warnings
 
 from ddtrace.utils.deprecation import deprecation, deprecated, format_message
 from ddtrace.utils.formats import asbool, get_env, flatten_dict
+from ddtrace.utils import sizeof
 
 
 class TestUtils(unittest.TestCase):
@@ -96,3 +97,12 @@ class TestUtils(unittest.TestCase):
         d = dict(A=1, B=2, C=dict(A=3, B=4, C=dict(A=5, B=6)))
         e = dict(A=1, B=2, C_A=3, C_B=4, C_C_A=5, C_C_B=6)
         self.assertEquals(flatten_dict(d, sep='_'), e)
+
+
+def test_sizeof():
+    sizeof_list = sizeof.sizeof([])
+    assert sizeof_list > 0
+    one_three = sizeof.sizeof([3])
+    assert one_three > sizeof_list
+    x = {'a': 1}
+    assert sizeof.sizeof([x, x]) < sizeof.sizeof([{'a': 1}, {'a': 1}])


### PR DESCRIPTION
This adds memory statistics to the Q object used by the internal writer.
This also renamed 'enqueued' to 'accepted' to make it easier to understand.