### PR TITLE
[core] Ensure we cast sample rate to a float

### DIFF
--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -52,8 +52,8 @@ class RateSampler(BaseSampler):
         log.debug('initialized RateSampler, sample %s%% of traces', 100 * sample_rate)
 
     def set_sample_rate(self, sample_rate):
-        self.sample_rate = sample_rate
-        self.sampling_id_threshold = sample_rate * MAX_TRACE_ID
+        self.sample_rate = float(sample_rate)
+        self.sampling_id_threshold = self.sample_rate * MAX_TRACE_ID
 
     def sample(self, span):
         return ((span.trace_id * KNUTH_FACTOR) % MAX_TRACE_ID) <= self.sampling_id_threshold

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -41,6 +41,22 @@ def create_span(tracer=None, name='test.span', meta=None, *args, **kwargs):
 
 class RateSamplerTest(unittest.TestCase):
 
+    def test_set_sample_rate(self):
+        sampler = RateSampler()
+        assert sampler.sample_rate == 1.0
+
+        for rate in [0.001, 0.01, 0.1, 0.25, 0.5, 0.75, 0.99999999, 1.0, 1]:
+            sampler.set_sample_rate(rate)
+            assert sampler.sample_rate == float(rate)
+
+            sampler.set_sample_rate(str(rate))
+            assert sampler.sample_rate == float(rate)
+
+    def test_set_sample_rate_str(self):
+        sampler = RateSampler()
+        sampler.set_sample_rate('0.5')
+        assert sampler.sample_rate == 0.5
+
     def test_sample_rate_deviation(self):
         for sample_rate in [0.1, 0.25, 0.5, 1]:
             tracer = get_dummy_tracer()


### PR DESCRIPTION
If a string is passed in then we get the following error:

```python
>>> '1' * (2 ** 64)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OverflowError: cannot fit 'int' into an index-sized integer
```

Explicitly cast sample rate to a `float` to at least raise a `TypeError` if it isn't "floatable"