### PR TITLE
[internal] enable rediscluster by default

### DIFF
--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -39,6 +39,7 @@ PATCH_MODULES = {
     'pymemcache': True,
     'pymongo': True,
     'redis': True,
+    'rediscluster': True,
     'requests': True,
     'sqlalchemy': False,  # Prefer DB client instrumentation
     'sqlite3': True,


### PR DESCRIPTION
Make expected behavior follow https://github.com/datadog/dd-trace-py/blob/majorgreys%2Fenable-rediscluster-by-default/docs/index.rst#L109 and the `rediscluster` integration be enabled by default.