### PR TITLE
utils/sizeof: allow to ignore certain field when computing object size

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -39,6 +39,12 @@ class Span(object):
         '__weakref__',
     ]
 
+    __sizeof_ignore_attributes__ = (
+        '_context',
+        '__weakref__',
+        'tracer',
+    )
+
     def __init__(
         self,
         tracer,

--- a/ddtrace/utils/sizeof.py
+++ b/ddtrace/utils/sizeof.py
@@ -3,17 +3,25 @@ import sys
 from itertools import chain
 
 _UNSET = object()
+_DEFAULT_IGNORE_ATTRIBUTES = tuple()
 
 
 def iter_object(o):
     if hasattr(o, '__slots__'):
+        ignore_attributes = getattr(o, '__sizeof_ignore_attributes__', _DEFAULT_IGNORE_ATTRIBUTES)
         return (
             s
-            for s in (getattr(o, slot, _UNSET) for slot in o.__slots__)
+            for s in (getattr(o, slot, _UNSET)
+                      for slot in o.__slots__
+                      if slot not in ignore_attributes)
             if s != _UNSET
         )
     elif hasattr(o, '__dict__'):
-        return list(o.__dict__.items())
+        ignore_attributes = getattr(o, '__sizeof_ignore_attributes__', _DEFAULT_IGNORE_ATTRIBUTES)
+        return (
+            (k, v) for k, v in list(o.__dict__.items())
+            if k not in ignore_attributes
+        )
     elif isinstance(o, dict):
         # Make a copy to avoid corruption
         return chain.from_iterable(list(o.items()))
@@ -24,7 +32,11 @@ def iter_object(o):
 
 
 def sizeof(o):
-    """Returns the approximate memory footprint an object and all of its contents."""
+    """Returns the approximate memory footprint an object and all of its contents.
+
+    If an object implements `__sizeof_ignore_attributes__`, those attributes will be ignored when computing the size of
+    the object.
+    """
     seen = set()
 
     def _sizeof(o):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -128,3 +128,42 @@ class BrokenSlots(object):
 def test_sizeof_broken_slots():
     """https://github.com/DataDog/dd-trace-py/issues/1079"""
     assert sizeof.sizeof(BrokenSlots()) >= 1
+
+
+class WithAttributes(object):
+
+    def __init__(self):
+        self.foobar = list(range(100000))
+
+
+class IgnoreAttributes(object):
+
+    __sizeof_ignore_attributes__ = ('foobar',)
+
+    def __init__(self):
+        self.foobar = list(range(100000))
+
+
+def test_sizeof_ignore_attributes():
+    assert sizeof.sizeof(WithAttributes()) > sizeof.sizeof(IgnoreAttributes())
+
+
+class SlotsWithAttributes(object):
+
+    __slots__ = ('foobar',)
+
+    def __init__(self):
+        self.foobar = list(range(100000))
+
+
+class SlotsIgnoreAttributes(object):
+
+    __slots__ = ('foobar',)
+    __sizeof_ignore_attributes__ = ('foobar',)
+
+    def __init__(self):
+        self.foobar = list(range(100000))
+
+
+def test_sizeof_slots_ignore_attributes():
+    assert sizeof.sizeof(SlotsWithAttributes()) > sizeof.sizeof(SlotsIgnoreAttributes())


### PR DESCRIPTION
This should make computing the size of e.g. Spans faster, as the code currently
tries to compute also the size of the Tracer and attached Context.