### PR TITLE
Fix for opentracing compatibility tags not being set correctly when creating a new span.

### DIFF
--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -257,12 +257,16 @@ class Tracer(opentracing.Tracer):
 
         # set the start time if one is specified
         ddspan.start = start_time or ddspan.start
-        if tags is not None:
-            ddspan.set_tags(tags)
 
         otspan = Span(self, ot_parent_context, operation_name)
         # sync up the OT span with the DD span
         otspan._associate_dd_span(ddspan)
+
+        if tags is not None:
+            for k in tags:
+                # Make sure we set the tags on the otspan to ensure that the special compatibility tags
+                # are handled correctly (resource name, span type, sampling priority, etc).
+                otspan.set_tag(k, tags[k])
 
         return otspan
 

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -162,6 +162,20 @@ class TestTracer(object):
         assert span._dd_span.get_tag('key') == 'value'
         assert span._dd_span.get_tag('key2') == 'value2'
 
+    def test_start_span_with_resource_name_tag(self, ot_tracer):
+        """Create a span with the tag to set the resource name"""
+        tags = {'resource.name': 'value', 'key2': 'value2'}
+        with ot_tracer.start_span('myop', tags=tags) as span:
+            pass
+
+        # Span resource name should be set to tag value, and should not get set as
+        # a tag on the underlying span.
+        assert span._dd_span.resource == 'value'
+        assert span._dd_span.get_tag('resource.name') is None
+
+        # Other tags are set as normal
+        assert span._dd_span.get_tag('key2') == 'value2'
+
     def test_start_active_span_multi_child(self, ot_tracer, writer):
         """Start and finish multiple child spans.
         This should ensure that child spans can be created 2 levels deep.


### PR DESCRIPTION
When creating a new opentracing span via the tracer, it must set the tags on the
opentracing span, and not directly on the underlying ddspan in order to ensure
that the special compatibility tags (resource name, sampling priority, etc) are
processed correctly.