### PR TITLE
Add Python 3.8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -634,7 +634,7 @@ jobs:
       - run:
           command: |
             mkdir -p /tmp/test-reports
-            tox -e 'benchmarks-{py27,py34,py35,py36,py37}' --result-json /tmp/benchmarks.results -- --benchmark-storage=file:///tmp/test-reports/ --benchmark-autosave
+            tox -e 'benchmarks-{py27,py34,py35,py36,py37,py38}' --result-json /tmp/benchmarks.results -- --benchmark-storage=file:///tmp/test-reports/ --benchmark-autosave
       - store_test_results:
           path: /tmp/test-reports
       - store_artifacts:

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ setup_kwargs = dict(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     use_scm_version=True,
     setup_requires=["setuptools_scm", "cython"],

--- a/tox.ini
+++ b/tox.ini
@@ -21,32 +21,33 @@ envlist =
     flake8
     black
     wait
-    {py27,py34,py35,py36,py37}-tracer{,-msgpackmin,-msgpack056,-msgpack060}
-    {py27,py35,py36,py37}-profile{,-gevent}
-    {py27,py35,py36,py37}-profile-minreqs{,-gevent}
-    {py27,py34,py35,py36,py37}-internal
-    {py27,py34,py35,py36,py37}-integration{,-msgpackmin,-msgpack056,-msgpack060}
-    {py27,py34,py35,py36,py37}-ddtracerun
-    {py27,py34,py35,py36,py37}-test_utils
-    {py27,py34,py35,py36,py37}-test_logging
+    {py27,py34,py35,py36,py37,py38}-tracer{,-msgpackmin,-msgpack056,-msgpack060}
+    {py27,py35,py36,py37,py38}-profile{,-gevent}
+    {py27,py35,py36,py37,py38}-profile-minreqs{,-gevent}
+    {py27,py34,py35,py36,py37,py38}-internal
+    {py27,py34,py35,py36,py37,py38}-integration{,-msgpackmin,-msgpack056,-msgpack060}
+    {py27,py34,py35,py36,py37,py38}-ddtracerun
+    {py27,py34,py35,py36,py37,py38}-test_utils
+    {py27,py34,py35,py36,py37,py38}-test_logging
 # Integrations environments
     aiobotocore_contrib-py34-aiobotocore{02,03,04}
     aiobotocore_contrib-{py35,py36}-aiobotocore{02,03,04,05,07,08,09,010}
     # aiobotocore 0.2 and 0.4 do not work because they use async as a reserved keyword
-    aiobotocore_contrib-py37-aiobotocore{03,05,07,08,09,010}
+    aiobotocore_contrib-py{37,38}-aiobotocore{03,05,07,08,09,010}
     # Python 3.7 needs at least aiohttp 2.3
     aiohttp_contrib-{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
-    aiohttp_contrib-{py34,py35,py36,py37}-aiohttp23-aiohttp_jinja{015}-yarl10
+    aiohttp_contrib-{py34,py35,py36,py37,py38}-aiohttp23-aiohttp_jinja015-yarl10
     aiohttp_contrib-{py35,py36,py37}-aiohttp{30,31,32,33,34,35}-aiohttp_jinja{015}-yarl10
+    aiohttp_contrib-py38-aiohttp{30,31,32,33}-aiohttp_jinja015-yarl10
     aiopg_contrib-{py34,py35,py36}-aiopg{012,015}
-    aiopg_contrib-py37-aiopg015
-    algoliasearch_contrib-{py27,py34,py35,py36,py37}-algoliasearch{1,2}
-    asyncio_contrib-{py34,py35,py36,py37}
+    aiopg_contrib-py{37,38}-aiopg015
+    algoliasearch_contrib-{py27,py34,py35,py36,py37,py38}-algoliasearch{1,2}
+    asyncio_contrib-{py34,py35,py36,py37,py38}
 # boto needs moto<1 and moto<1 does not support Python >= 3.7
     boto_contrib-{py27,py34,py35,py36}-boto
-    botocore_contrib-{py27,py34,py35,py36,py37}-botocore
-    bottle_contrib{,_autopatch}-{py27,py34,py35,py36,py37}-bottle{11,12}-webtest
-    cassandra_contrib-{py27,py34,py35,py36,py37}-cassandra{35,36,37,38,315}
+    botocore_contrib-{py27,py34,py35,py36,py37,py38}-botocore
+    bottle_contrib{,_autopatch}-{py27,py34,py35,py36,py37,py38}-bottle{11,12}-webtest
+    cassandra_contrib-{py27,py34,py35,py36,py37,py38}-cassandra{35,36,37,38,315}
 # Non-4.x celery should be able to use the older redis lib, since it locks to an older kombu
     celery_contrib-{py27,py34,py35,py36}-celery{31}-redis{210}
 # 4.x celery bumps kombu to 4.4+, which requires redis 3.2 or later, this tests against
@@ -58,8 +59,8 @@ envlist =
     celery_contrib-{py27,py34,py35,py36}-celery42-redis210-kombu43
 # Celery 4.3 wants Kombu >= 4.4 and Redis >= 3.2
 # Python 3.7 needs Celery 4.3
-    celery_contrib-{py27,py34,py35,py36,py37}-celery43-redis320-kombu44
-    consul_contrib-py{27,34,35,36,37}-consul{07,10,11}
+    celery_contrib-{py27,py34,py35,py36,py37,py38}-celery43-redis320-kombu44
+    consul_contrib-py{27,34,35,36,37,38}-consul{07,10,11}
     dbapi_contrib-{py27,py34,py35,py36}
 # Django  Python version support
 # 1.11  2.7, 3.4, 3.5, 3.6, 3.7 (added in 1.11.17)
@@ -75,8 +76,8 @@ envlist =
     django_drf_contrib-{py27,py34,py35,py36}-django{111}-djangorestframework{34,37}
     django_drf_contrib-{py35}-django{22}-djangorestframework{38,310,latest}
     django_drf_contrib-{py36,py37}-django{22}-djangorestframework{38,310,latest}
-    django_drf_contrib-{py36,py37}-django{30}-djangorestframework{310,latest}
-    dogpile_contrib-{py27,py35,py36,py37}-dogpilecache{06,07,08,latest}
+    django_drf_contrib-{py36,py37,py38}-django{30}-djangorestframework{310,latest}
+    dogpile_contrib-{py27,py35,py36,py37,py38}-dogpilecache{06,07,08,latest}
     elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63,64}
     elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch1{100}
     elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch2{50}
@@ -86,58 +87,62 @@ envlist =
     flask_contrib{,_autopatch}-{py27,py34,py35,py36}-flask{010,011,012,10}-blinker
 # Flask <=0.9 does not support Python 3
     flask_contrib{,_autopatch}-{py27}-flask{09}-blinker
-    flask_cache_contrib{,_autopatch}-{py27,py34,py35,py36,py37}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker
+    flask_cache_contrib{,_autopatch}-{py27,py34,py35,py36,py37,py38}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker
     flask_cache_contrib{,_autopatch}-{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker
     futures_contrib-{py27}-futures{30,31,32}
-    futures_contrib-{py34,py35,py36,py37}
+    futures_contrib-{py34,py35,py36,py37,py38}
     gevent_contrib-{py27,py34,py35,py36}-gevent{11,12,13}
-    gevent_contrib-py37-gevent{13,14}
+    gevent_contrib-py{37,38}-gevent{13,14}
 # gevent 1.0 is not python 3 compatible
     gevent_contrib-{py27}-gevent{10}
-    grpc_contrib-{py27,py34,py35,py36,py37}-grpc{112,113,114,115,116,117,118,119,120,121,122}
-    httplib_contrib-{py27,py34,py35,py36,py37}
-    jinja2_contrib-{py27,py34,py35,py36,py37}-jinja{27,28,29,210}
-    mako_contrib-{py27,py34,py35,py36,py37}-mako{010,100}
-    molten_contrib-py{36,37}-molten{070,072}
-    mongoengine_contrib-{py27,py34,py35,py36,py37}-mongoengine{015,016,017,018,latest}-pymongo{latest}
+    grpc_contrib-{py27,py34,py35,py36,py37,py38}-grpc{112,113,114,115,116,117,118,119,120,121,122}
+    httplib_contrib-{py27,py34,py35,py36,py37,py38}
+    jinja2_contrib-{py27,py34,py35,py36,py37,py38}-jinja{27,28,29,210}
+    mako_contrib-{py27,py34,py35,py36,py37,py38}-mako{010,100}
+    molten_contrib-py{36,37,38}-molten{070,072}
+    mongoengine_contrib-{py27,py34,py35,py36,py37,py38}-mongoengine{015,016,017,018,latest}-pymongo{latest}
     mysql_contrib-{py27,py34,py35,py36,py37}-mysqlconnector
     mysqldb_contrib-{py27}-mysqldb{12}
-    mysqldb_contrib-{py27,py34,py35,py36,py37}-mysqlclient{13}
-    psycopg_contrib-{py27,py34,py35,py36}-psycopg2{24,25,26,27,28}
-    psycopg_contrib-py37-psycopg2{27,28}
-    pylibmc_contrib-{py27,py34,py35,py36,py37}-pylibmc{140,150}
+    mysqldb_contrib-{py27,py34,py35,py36,py37,py38}-mysqlclient{13}
+    psycopg_contrib-{py27,py34,py35,py36,37}-psycopg2{24,25,26,27,28}
+# psycopg <2.7 doesn't support Python 3.8: https://github.com/psycopg/psycopg2/issues/854
+    psycopg_contrib-py{38}-psycopg2{28}
+    pylibmc_contrib-{py27,py34,py35,py36,py37,py38}-pylibmc{140,150}
     pylons_contrib-{py27}-pylons{096,097,010,10}
-    pymemcache_contrib{,_autopatch}-{py27,py34,py35,py36,py37}-pymemcache{130,140}
+    pymemcache_contrib{,_autopatch}-{py27,py34,py35,py36,py37,py38}-pymemcache{130,140}
     pymongo_contrib-{py27,py34,py35,py36,py37}-pymongo{30,31,32,33,34,35,36,37,38,39,latest}-mongoengine{latest}
-    pymysql_contrib-{py27,py34,py35,py36,py37}-pymysql{07,08,09}
-    pyramid_contrib{,_autopatch}-{py27,py34,py35,py36,py37}-pyramid{17,18,19}-webtest
-    redis_contrib-{py27,py34,py35,py36,py37}-redis{26,27,28,29,210,300}
-    rediscluster_contrib-{py27,py34,py35,py36,py37}-rediscluster{135,136,200,latest}-redis210
-    requests_contrib{,_autopatch}-{py27,py34,py35,py36,py37}-requests{208,209,210,211,212,213,219}
+# pymongo does not yet support Python 3.8: https://github.com/pymssql/pymssql/issues/586
+# but these tests still work.
+    pymongo_contrib-{py38}-pymongo{30,31,32,33,35,36,37,38,39,latest}-mongoengine{latest}
+    pymysql_contrib-{py27,py34,py35,py36,py37,py38}-pymysql{07,08,09}
+    pyramid_contrib{,_autopatch}-{py27,py34,py35,py36,py37,py38}-pyramid{17,18,19}-webtest
+    redis_contrib-{py27,py34,py35,py36,py37,py38}-redis{26,27,28,29,210,300}
+    rediscluster_contrib-{py27,py34,py35,py36,py37,py38}-rediscluster{135,136,200,latest}-redis210
+    requests_contrib{,_autopatch}-{py27,py34,py35,py36,py37,py38}-requests{208,209,210,211,212,213,219}
     kombu_contrib-{py27,py34,py35,py36}-kombu{40,41,42}
     # Python 3.7 needs Kombu >= 4.2
-    kombu_contrib-py37-kombu42
+    kombu_contrib-py{37,38}-kombu42
 # python 3.6 requests + gevent regression test
 # DEV: This is a known issue for gevent 1.1, suggestion is to upgrade to gevent > 1.2
 #      https://github.com/gevent/gevent/issues/903
     requests_gevent_contrib-{py36}-requests{208,209,210,211,212,213,219}-gevent{12,13}
-    requests_gevent_contrib-py37-requests{208,209,210,211,212,213,219}-gevent13
-    sqlalchemy_contrib-{py27,py34,py35,py36,py37}-sqlalchemy{10,11,12}-psycopg228-mysqlconnector
-    sqlite3_contrib-{py27,py34,py35,py36,py37}-sqlite3
-    tornado_contrib-{py27,py34,py35,py36,py37}-tornado{40,41,42,43,44,45}
-    tornado_contrib-{py37}-tornado{50,51,60}
+    requests_gevent_contrib-py{37,38}-requests{208,209,210,211,212,213,219}-gevent13
+    sqlalchemy_contrib-{py27,py34,py35,py36,py37,py38}-sqlalchemy{10,11,12,13}-psycopg228-mysqlconnector
+    sqlite3_contrib-{py27,py34,py35,py36,py37,py38}-sqlite3
+    tornado_contrib-{py27,py34,py35,py36,py37,py38}-tornado{40,41,42,43,44,45}
+    tornado_contrib-py{37,38}-tornado{50,51,60}
     tornado_contrib-{py27}-tornado{40,41,42,43,44,45}-futures{30,31,32}
-    vertica_contrib-{py27,py34,py35,py36,py37}-vertica{060,070}
+    vertica_contrib-{py27,py34,py35,py36,py37,py38}-vertica{060,070}
 # Opentracer
-    {py27,py34,py35,py36,py37}-opentracer
-    {py34,py35,py36,py37}-opentracer_asyncio
-    {py34,py35,py36,py37}-opentracer_tornado-tornado{40,41,42,43,44}
+    {py27,py34,py35,py36,py37,py38}-opentracer
+    {py34,py35,py36,py37,py38}-opentracer_asyncio
+    {py34,py35,py36,py37,py38}-opentracer_tornado-tornado{40,41,42,43,44}
     {py27}-opentracer_gevent-gevent{10}
     {py27,py34,py35,py36}-opentracer_gevent-gevent{11,12}
-    py37-opentracer_gevent-gevent{13,14}
+    py{37,38}-opentracer_gevent-gevent{13,14}
 # Unit tests: pytest based test suite that do not require any additional dependency
-    unit_tests-{py27,py34,py35,py36,py37}
-    benchmarks-{py27,py34,py35,py36,py37}
+    unit_tests-{py27,py34,py35,py36,py37,py38}
+    benchmarks-{py27,py34,py35,py36,py37,py38}
 
 isolated_build = true
 
@@ -334,7 +339,7 @@ deps =
     mongoengine017: mongoengine>=0.17<0.18
     mongoengine018: mongoengine>=0.18<0.19
     mongoenginelatest: mongoengine>=0.18
-    mysqlconnector: mysql-connector-python!=8.0.18
+    mysqlconnector: mysql-connector-python==8.0.18
     mysqldb12: mysql-python>=1.2,<1.3
     mysqlclient13: mysqlclient>=1.3,<1.4
 # webob is required for Pylons < 1.0
@@ -400,6 +405,7 @@ deps =
     sqlalchemy10: sqlalchemy>=1.0,<1.1
     sqlalchemy11: sqlalchemy>=1.1,<1.2
     sqlalchemy12: sqlalchemy>=1.2,<1.3
+    sqlalchemy13: sqlalchemy>=1.3,<1.4
     tornado40: tornado>=4.0,<4.1
     tornado41: tornado>=4.1,<4.2
     tornado42: tornado>=4.2,<4.3
@@ -430,8 +436,8 @@ commands =
 # integration tests
     integration: pytest {posargs} tests/test_integration.py
 # Contribs
-    aiobotocore_contrib-{py34,py35,py36,py37}: pytest {posargs} tests/contrib/aiobotocore
-    aiopg_contrib-{py34,py35,py36,py37}: pytest {posargs} tests/contrib/aiopg
+    aiobotocore_contrib-{py34,py35,py36,py37,py38}: pytest {posargs} tests/contrib/aiobotocore
+    aiopg_contrib-{py34,py35,py36,py37,py38}: pytest {posargs} tests/contrib/aiopg
     aiohttp_contrib: pytest {posargs} tests/contrib/aiohttp
     algoliasearch_contrib: pytest {posargs} tests/contrib/algoliasearch
     asyncio_contrib: pytest {posargs} tests/contrib/asyncio
@@ -678,6 +684,21 @@ setenv =
 [testenv:falcon_contrib_autopatch-py37-falcon14]
 setenv =
     {[falcon_autopatch]setenv}
+[testenv:falcon_contrib_autopatch-py38-falcon10]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:falcon_contrib_autopatch-py38-falcon11]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:falcon_contrib_autopatch-py38-falcon12]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:falcon_contrib_autopatch-py38-falcon13]
+setenv =
+    {[falcon_autopatch]setenv}
+[testenv:falcon_contrib_autopatch-py38-falcon14]
+setenv =
+    {[falcon_autopatch]setenv}
 
 
 [pyramid_autopatch]
@@ -728,6 +749,15 @@ setenv =
 setenv =
     {[pyramid_autopatch]setenv}
 [testenv:pyramid_contrib_autopatch-py37-pyramid19-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:pyramid_contrib_autopatch-py38-pyramid17-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:pyramid_contrib_autopatch-py38-pyramid18-webtest]
+setenv =
+    {[pyramid_autopatch]setenv}
+[testenv:pyramid_contrib_autopatch-py38-pyramid19-webtest]
 setenv =
     {[pyramid_autopatch]setenv}
 
@@ -796,6 +826,18 @@ setenv =
 [testenv:flask_contrib_autopatch-py37-flask10-blinker]
 setenv =
     {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py38-flask010-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py38-flask011-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py38-flask012-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py38-flask10-blinker]
+setenv =
+    {[flask_autopatch]setenv}
 [testenv:flask_contrib_autopatch-py27-flask010-flaskcache013-memcached-redis210-blinker]
 setenv =
     {[flask_autopatch]setenv}
@@ -841,6 +883,15 @@ setenv =
 [testenv:flask_contrib_autopatch-py37-flask012-flaskcache013-memcached-redis210-blinker]
 setenv =
     {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py38-flask010-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py38-flask011-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
+[testenv:flask_contrib_autopatch-py38-flask012-flaskcache013-memcached-redis210-blinker]
+setenv =
+    {[flask_autopatch]setenv}
 [testenv:flask_contrib_autopatch-py27-flask010-flaskcache012-memcached-redis210-blinker]
 setenv =
     {[flask_autopatch]setenv}
@@ -867,6 +918,9 @@ setenv =
 [testenv:bottle_contrib_autopatch-py37-bottle11-webtest]
 setenv =
     {[bottle_autopatch]setenv}
+[testenv:bottle_contrib_autopatch-py38-bottle11-webtest]
+setenv =
+    {[bottle_autopatch]setenv}
 [testenv:bottle_contrib_autopatch-py27-bottle12-webtest]
 setenv =
     {[bottle_autopatch]setenv}
@@ -880,6 +934,9 @@ setenv =
 setenv =
     {[bottle_autopatch]setenv}
 [testenv:bottle_contrib_autopatch-py37-bottle12-webtest]
+setenv =
+    {[bottle_autopatch]setenv}
+[testenv:bottle_contrib_autopatch-py38-bottle12-webtest]
 setenv =
     {[bottle_autopatch]setenv}
 


### PR DESCRIPTION
Adds Python 3.8 support to `tox.ini` and `.circleci/config.yml`.

Also changes the docker image to use the one published to https://github.com/DataDog/dd-trace-ci.