### PR TITLE
django: use tracer.configure()

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -51,12 +51,8 @@ def apply_django_patches(patch_rest_framework):
         tracer.set_tags(settings.TAGS)
 
     # configure the tracer instance
-    # TODO[manu]: we may use configure() but because it creates a new
-    # AgentWriter, it breaks all tests. The configure() behavior must
-    # be changed to use it in this integration
     tracer.enabled = settings.ENABLED
-    tracer.writer.api.hostname = settings.AGENT_HOSTNAME
-    tracer.writer.api.port = settings.AGENT_PORT
+    tracer.configure(hostname=settings.AGENT_HOSTNAME, port=settings.AGENT_PORT)
 
     if settings.AUTO_INSTRUMENT:
         # trace Django internals

--- a/tests/contrib/django/test_tracing_disabled.py
+++ b/tests/contrib/django/test_tracing_disabled.py
@@ -3,11 +3,10 @@ from django.apps import apps
 from django.test import TestCase
 
 # project
-from ddtrace.tracer import Tracer
 from ddtrace.contrib.django.conf import settings
 
 # testing
-from ...test_tracer import DummyWriter
+from ...utils.tracer import DummyTracer
 
 
 class DjangoTracingDisabledTest(TestCase):
@@ -18,8 +17,7 @@ class DjangoTracingDisabledTest(TestCase):
 
         # Use a new tracer to be sure that a new service
         # would be sent to the the writer
-        self.tracer = Tracer()
-        self.tracer.writer = DummyWriter()
+        self.tracer = DummyTracer()
 
         # Restart app with tracing disabled
         settings.ENABLED = False

--- a/tests/contrib/django/utils.py
+++ b/tests/contrib/django/utils.py
@@ -5,7 +5,6 @@ from django.apps import apps
 from django.test import TestCase
 
 # project
-from ddtrace.tracer import Tracer
 from ddtrace.contrib.django.conf import settings
 from ddtrace.contrib.django.db import patch_db, unpatch_db
 from ddtrace.contrib.django.cache import unpatch_cache
@@ -14,12 +13,11 @@ from ddtrace.contrib.django.middleware import remove_exception_middleware, remov
 
 # testing
 from ...base import BaseTestCase
-from ...test_tracer import DummyWriter
+from ...utils.tracer import DummyTracer
 
 
 # testing tracer
-tracer = Tracer()
-tracer.writer = DummyWriter()
+tracer = DummyTracer()
 
 
 class DjangoTraceTestCase(BaseTestCase, TestCase):


### PR DESCRIPTION
Minor update to django integration that uses the otherwise standard method for configuring the global tracer rather than directly manipulating internals of the tracer object.

Though we would benefit with not having to reconfigure the tracer and do this at initialization.