### PR TITLE
Remove extra import from tracer get_call_context code snippet

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -144,7 +144,7 @@ class Tracer(object):
         automatically called in the ``tracer.trace()``, but it can be used in the application
         code during manual instrumentation like::
 
-            from ddtrace import import tracer
+            from ddtrace import tracer
 
             async def web_handler(request):
                 context = tracer.get_call_context()


### PR DESCRIPTION
For the code example for get_call_context under the Tracer API, instead of

```
from ddtrace import import tracer
async def web_handler(request):
```

the import should look like this:

```
from ddtrace import tracer
async def web_handler(request):
```

This is to address this doc example: http://pypi.datadoghq.com/trace/docs/advanced_usage.html?highlight=tags#ddtrace.Tracer.get_call_context .