### PR TITLE
Replace time.time by monotonic clock

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -7,6 +7,7 @@ from .. import api
 from .. import _worker
 from ..utils import sizeof
 from ..internal.logger import get_logger
+from ..vendor import monotonic
 from ddtrace.vendor.six.moves.queue import Queue, Full, Empty
 
 log = get_logger(__name__)
@@ -158,7 +159,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
 
     def _log_error_status(self, response):
         log_level = log.debug
-        now = time.time()
+        now = monotonic.monotonic()
         if now > self._last_error_ts + LOG_ERR_INTERVAL:
             log_level = log.error
             self._last_error_ts = now

--- a/ddtrace/utils/time.py
+++ b/ddtrace/utils/time.py
@@ -1,0 +1,58 @@
+from ..vendor import monotonic
+
+
+class StopWatch(object):
+    """A simple timer/stopwatch helper class.
+
+    Not thread-safe (when a single watch is mutated by multiple threads at
+    the same time). Thread-safe when used by a single thread (not shared) or
+    when operations are performed in a thread-safe manner on these objects by
+    wrapping those operations with locks.
+
+    It will use the `monotonic`_ pypi library to find an appropriate
+    monotonically increasing time providing function (which typically varies
+    depending on operating system and Python version).
+
+    .. _monotonic: https://pypi.python.org/pypi/monotonic/
+    """
+    def __init__(self):
+        self._started_at = None
+        self._stopped_at = None
+
+    def start(self):
+        """Starts the watch."""
+        self._started_at = monotonic.monotonic()
+        return self
+
+    def elapsed(self):
+        """Get how many seconds have elapsed.
+
+        :return: Number of seconds elapsed
+        :rtype: float
+        """
+        # NOTE: datetime.timedelta does not support nanoseconds, so keep a float here
+        if self._started_at is None:
+            raise RuntimeError('Can not get the elapsed time of a stopwatch'
+                               ' if it has not been started/stopped')
+        if self._stopped_at is None:
+            now = monotonic.monotonic()
+        else:
+            now = self._stopped_at
+        return now - self._started_at
+
+    def __enter__(self):
+        """Starts the watch."""
+        self.start()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        """Stops the watch."""
+        self.stop()
+
+    def stop(self):
+        """Stops the watch."""
+        if self._started_at is None:
+            raise RuntimeError('Can not stop a stopwatch that has not been'
+                               ' started')
+        self._stopped_at = monotonic.monotonic()
+        return self

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,5 @@
 import os
 import json
-import time
 import logging
 import mock
 import ddtrace
@@ -15,6 +14,7 @@ from ddtrace.tracer import Tracer
 from ddtrace.encoding import JSONEncoder, MsgpackEncoder, get_encoder
 from ddtrace.compat import httplib, PYTHON_INTERPRETER, PYTHON_VERSION
 from ddtrace.internal.runtime.container import CGroupInfo
+from ddtrace.vendor import monotonic
 from ddtrace.vendor import msgpack
 from tests.test_tracer import get_dummy_tracer
 
@@ -195,7 +195,7 @@ class TestWorkers(TestCase):
         log.addHandler(log_handler)
 
         self._wait_thread_flush()
-        assert tracer.writer._last_error_ts < time.time()
+        assert tracer.writer._last_error_ts < monotonic.monotonic()
 
         logged_errors = log_handler.messages['error']
         assert len(logged_errors) == 1

--- a/tests/unit/utils/test_time.py
+++ b/tests/unit/utils/test_time.py
@@ -1,0 +1,44 @@
+import pytest
+
+from ddtrace.utils import time
+
+
+def test_no_states():
+    watch = time.StopWatch()
+    with pytest.raises(RuntimeError):
+        watch.stop()
+
+
+def test_start_stop():
+    watch = time.StopWatch()
+    watch.start()
+    watch.stop()
+
+
+def test_start_stop_elapsed():
+    watch = time.StopWatch()
+    watch.start()
+    watch.stop()
+    e = watch.elapsed()
+    assert e > 0
+    watch.start()
+    assert watch.elapsed() != e
+
+
+def test_no_elapsed():
+    watch = time.StopWatch()
+    with pytest.raises(RuntimeError):
+        watch.elapsed()
+
+
+def test_elapsed():
+    watch = time.StopWatch()
+    watch.start()
+    watch.stop()
+    assert watch.elapsed() > 0
+
+
+def test_context_manager():
+    with time.StopWatch() as watch:
+        pass
+    assert watch.elapsed() > 0


### PR DESCRIPTION
`time.time` might jump around as the clock changes (NTP, leap seconds, etc).
It's safer to use monotonic.monotonic to get elapsed time ranges.