### PR TITLE
span: fix {duration,start}_ns being float if {start,finish} is passed as float

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -88,7 +88,7 @@ class Span(object):
         self.metrics = {}
 
         # timing
-        self.start_ns = time_ns() if start is None else (start * 1e9)
+        self.start_ns = time_ns() if start is None else int(start * 1e9)
         self.duration_ns = None
 
         # tracing
@@ -137,7 +137,7 @@ class Span(object):
         self.finished = True
 
         if self.duration_ns is None:
-            ft = time_ns() if finish_time is None else (finish_time * 1e9)
+            ft = time_ns() if finish_time is None else int(finish_time * 1e9)
             # be defensive so we don't die if start isn't set
             self.duration_ns = ft - (self.start_ns or ft)
 

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -312,3 +312,33 @@ class SpanTestCase(BaseTracerTestCase):
         s.finish(finish_time=123)
         assert s.duration_ns == 0
         assert s.duration == 0
+
+    def test_start_int(self):
+        s = Span(tracer=None, name='foo.bar', service='s', resource='r', start=123)
+        assert s.start == 123
+        assert s.start_ns == 123000000000
+
+        s = Span(tracer=None, name='foo.bar', service='s', resource='r', start=123.123)
+        assert s.start == 123.123
+        assert s.start_ns == 123123000000
+
+    def test_duration_int(self):
+        s = Span(tracer=None, name='foo.bar', service='s', resource='r')
+        s.finish()
+        assert isinstance(s.duration_ns, int)
+        assert isinstance(s.duration, float)
+
+        s = Span(tracer=None, name='foo.bar', service='s', resource='r', start=123)
+        s.finish(finish_time=123.2)
+        assert s.duration_ns == 200000000
+        assert s.duration == 0.2
+
+        s = Span(tracer=None, name='foo.bar', service='s', resource='r', start=123.1)
+        s.finish(finish_time=123.2)
+        assert s.duration_ns == 100000000
+        assert s.duration == 0.1
+
+        s = Span(tracer=None, name='foo.bar', service='s', resource='r', start=122)
+        s.finish(finish_time=123)
+        assert s.duration_ns == 1000000000
+        assert s.duration == 1


### PR DESCRIPTION
duration_ns should always be an integer, though the current code would return a
float if finish_time is passed as a float.