### PR TITLE
internal: use args for LogRecord when logging

### DIFF
--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -110,7 +110,8 @@ class DDLogger(logging.Logger):
         if logging_bucket.bucket != current_bucket:
             # Append count of skipped messages if we have skipped some since our last logging
             if logging_bucket.skipped:
-                record.msg = '{}, {} additional messages skipped'.format(record.msg, logging_bucket.skipped)
+                record.msg = '{}, %s additional messages skipped'.format(record.msg)
+                record.args = record.args + (logging_bucket.skipped,)
 
             # Reset our bucket
             self.buckets[key] = DDLogger.LoggingBucket(current_bucket, 0)

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -111,7 +111,7 @@ class DDLogger(logging.Logger):
             # Append count of skipped messages if we have skipped some since our last logging
             if logging_bucket.skipped:
                 record.msg = '{}, %s additional messages skipped'.format(record.msg)
-                record.args = record.args + (logging_bucket.skipped,)
+                record.args = record.args + (logging_bucket.skipped, )
 
             # Reset our bucket
             self.buckets[key] = DDLogger.LoggingBucket(current_bucket, 0)

--- a/tests/internal/test_logger.py
+++ b/tests/internal/test_logger.py
@@ -263,7 +263,9 @@ class DDLoggerTestCase(BaseTestCase):
         log = get_logger('test.logger')
 
         # Create log record to handle
-        record = self._make_record(log)
+        original_msg = 'hello %s'
+        original_args = (1,)
+        record = self._make_record(log, msg=original_msg, args=(1,))
 
         # Create a bucket entry for this record
         key = (record.name, record.levelno, record.pathname, record.lineno)
@@ -277,7 +279,9 @@ class DDLoggerTestCase(BaseTestCase):
         # We passed to base Logger.handle
         base_handle.assert_called_once_with(record)
 
-        self.assertEqual(record.msg, 'test, 20 additional messages skipped')
+        self.assertEqual(record.msg, original_msg + ', %s additional messages skipped')
+        self.assertEqual(record.args, original_args + (20,))
+        self.assertEqual(record.getMessage(), 'hello 1, 20 additional messages skipped')
 
     def test_logger_handle_bucket_key(self):
         """

--- a/tests/internal/test_logger.py
+++ b/tests/internal/test_logger.py
@@ -264,8 +264,8 @@ class DDLoggerTestCase(BaseTestCase):
 
         # Create log record to handle
         original_msg = 'hello %s'
-        original_args = (1,)
-        record = self._make_record(log, msg=original_msg, args=(1,))
+        original_args = (1, )
+        record = self._make_record(log, msg=original_msg, args=(1, ))
 
         # Create a bucket entry for this record
         key = (record.name, record.levelno, record.pathname, record.lineno)
@@ -280,7 +280,7 @@ class DDLoggerTestCase(BaseTestCase):
         base_handle.assert_called_once_with(record)
 
         self.assertEqual(record.msg, original_msg + ', %s additional messages skipped')
-        self.assertEqual(record.args, original_args + (20,))
+        self.assertEqual(record.args, original_args + (20, ))
         self.assertEqual(record.getMessage(), 'hello 1, 20 additional messages skipped')
 
     def test_logger_handle_bucket_key(self):


### PR DESCRIPTION
Fixes #1115.

This avoids message duplication in Sentry.