### PR TITLE
internal,flask,grpc: Fix setting analytics sample rate of None

### DIFF
--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -287,10 +287,9 @@ def traced_wsgi_app(pin, wrapped, instance, args, kwargs):
     resource = u'{} {}'.format(request.method, request.path)
     with pin.tracer.trace('flask.request', service=pin.service, resource=resource, span_type=http.TYPE) as s:
         # set analytics sample rate with global config enabled
-        s.set_tag(
-            ANALYTICS_SAMPLE_RATE_KEY,
-            config.flask.get_analytics_sample_rate(use_global_config=True)
-        )
+        sample_rate = config.flask.get_analytics_sample_rate(use_global_config=True)
+        if sample_rate is not None:
+            s.set_tag(ANALYTICS_SAMPLE_RATE_KEY, sample_rate)
 
         s.set_tag(FLASK_VERSION, flask_version_str)
 

--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -159,7 +159,10 @@ class _ClientInterceptor(
         span.set_tag(constants.GRPC_HOST_KEY, self._host)
         span.set_tag(constants.GRPC_PORT_KEY, self._port)
         span.set_tag(constants.GRPC_SPAN_KIND_KEY, constants.GRPC_SPAN_KIND_VALUE_CLIENT)
-        span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, config.grpc.get_analytics_sample_rate())
+
+        sample_rate = config.grpc.get_analytics_sample_rate()
+        if sample_rate is not None:
+            span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, sample_rate)
 
         # inject tags from pin
         if self._pin.tags:

--- a/ddtrace/contrib/grpc/server_interceptor.py
+++ b/ddtrace/contrib/grpc/server_interceptor.py
@@ -77,7 +77,10 @@ class _TracedRpcMethodHandler(wrapt.ObjectProxy):
         span.set_tag(constants.GRPC_METHOD_NAME_KEY, method_name)
         span.set_tag(constants.GRPC_METHOD_KIND_KEY, method_kind)
         span.set_tag(constants.GRPC_SPAN_KIND_KEY, constants.GRPC_SPAN_KIND_VALUE_SERVER)
-        span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, config.grpc_server.get_analytics_sample_rate())
+
+        sample_rate = config.grpc_server.get_analytics_sample_rate()
+        if sample_rate is not None:
+            span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, sample_rate)
 
         # access server context by taking second argument as server context
         # if not found, skip using context to tag span with server state information

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -4,7 +4,7 @@ import sys
 import traceback
 
 from .compat import StringIO, stringify, iteritems, numeric_types, time_ns
-from .constants import NUMERIC_TAGS, MANUAL_DROP_KEY, MANUAL_KEEP_KEY, ANALYTICS_SAMPLE_RATE_KEY
+from .constants import NUMERIC_TAGS, MANUAL_DROP_KEY, MANUAL_KEEP_KEY
 from .ext import errors, priority
 from .internal.logger import get_logger
 

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -4,7 +4,7 @@ import sys
 import traceback
 
 from .compat import StringIO, stringify, iteritems, numeric_types, time_ns
-from .constants import NUMERIC_TAGS, MANUAL_DROP_KEY, MANUAL_KEEP_KEY
+from .constants import NUMERIC_TAGS, MANUAL_DROP_KEY, MANUAL_KEEP_KEY, ANALYTICS_SAMPLE_RATE_KEY
 from .ext import errors, priority
 from .internal.logger import get_logger
 
@@ -162,7 +162,8 @@ class Span(object):
 
         if key in NUMERIC_TAGS:
             try:
-                self.set_metric(key, float(value))
+                # DEV: `set_metric` will try to cast to `float()` for us
+                self.set_metric(key, value)
             except (TypeError, ValueError):
                 log.debug('error setting numeric metric {}:{}'.format(key, value))
 

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -1,3 +1,4 @@
+import mock
 import time
 
 from unittest.case import SkipTest
@@ -213,12 +214,20 @@ class SpanTestCase(BaseTracerTestCase):
         assert d['error'] == 1
         assert type(d['error']) == int
 
-    def test_numeric_tags_none(self):
+    @mock.patch('ddtrace.span.log')
+    def test_numeric_tags_none(self, span_log):
         s = Span(tracer=None, name='test.span')
         s.set_tag(ANALYTICS_SAMPLE_RATE_KEY, None)
         d = s.to_dict()
         assert d
         assert 'metrics' not in d
+
+        # Ensure we log a debug message
+        span_log.debug.assert_called_once_with(
+            'ignoring not number metric %s:%s',
+            ANALYTICS_SAMPLE_RATE_KEY,
+            None,
+        )
 
     def test_numeric_tags_true(self):
         s = Span(tracer=None, name='test.span')


### PR DESCRIPTION
If we try to set the `ANALAYTICS_SAMPLE_RATE_KEY` as `None` we will log a debug message
this is just noisy and adds to confusion when trying to debug issues.