### PR TITLE
internal: Update dogstatsd to use ddtrace.internal.logger.get_logger

### DIFF
--- a/ddtrace/vendor/__init__.py
+++ b/ddtrace/vendor/__init__.py
@@ -59,7 +59,6 @@ Notes:
   `dogstatsd/__init__.py` was updated to include a copy of the `datadogpy` license: https://github.com/DataDog/datadogpy/blob/master/LICENSE
   Only `datadog.dogstatsd` module was vendored to avoid unnecessary dependencies
   `datadog/util/compat.py` was copied to `dogstatsd/compat.py`
-  `datadog/base.py` was updated to use `ddtrace.internal.logger.get_logger` instead of `logging.getLogger` to utilize internal rate limited logger
 
 monotonic
 ---------
@@ -74,3 +73,11 @@ Notes:
 
   No other changes were made
 """
+
+# Initialize `ddtrace.vendor.datadog.base.log` logger with our custom rate limited logger
+# DEV: This helps ensure if there are connection issues we do not spam their logs
+# DEV: Overwrite `base.log` instead of `get_logger('datadog.dogstatsd')` so we do
+#      not conflict with any non-vendored datadog.dogstatsd logger
+from ..internal.logger import get_logger
+from .dogstatsd import base
+base.log = get_logger('ddtrace.vendor.dogstatsd')

--- a/ddtrace/vendor/__init__.py
+++ b/ddtrace/vendor/__init__.py
@@ -59,6 +59,7 @@ Notes:
   `dogstatsd/__init__.py` was updated to include a copy of the `datadogpy` license: https://github.com/DataDog/datadogpy/blob/master/LICENSE
   Only `datadog.dogstatsd` module was vendored to avoid unnecessary dependencies
   `datadog/util/compat.py` was copied to `dogstatsd/compat.py`
+  `datadog/base.py` was updated to use `ddtrace.internal.logger.get_logger` instead of `logging.getLogger` to utilize internal rate limited logger
 
 monotonic
 ---------

--- a/ddtrace/vendor/dogstatsd/base.py
+++ b/ddtrace/vendor/dogstatsd/base.py
@@ -4,7 +4,6 @@ DogStatsd is a Python client for DogStatsd, a Statsd fork for Datadog.
 """
 # stdlib
 from random import random
-import logging
 import os
 import socket
 from threading import Lock
@@ -14,8 +13,11 @@ from .context import TimedContextManagerDecorator
 from .route import get_default_route
 from .compat import text
 
+# ddtrace
+from ...internal.logger import get_logger
+
 # Logging
-log = logging.getLogger('datadog.dogstatsd')
+log = get_logger('ddtrace.vendor.datadog.dogstatsd')
 
 # Default config
 DEFAULT_HOST = 'localhost'

--- a/ddtrace/vendor/dogstatsd/base.py
+++ b/ddtrace/vendor/dogstatsd/base.py
@@ -4,6 +4,7 @@ DogStatsd is a Python client for DogStatsd, a Statsd fork for Datadog.
 """
 # stdlib
 from random import random
+import logging
 import os
 import socket
 from threading import Lock
@@ -13,11 +14,8 @@ from .context import TimedContextManagerDecorator
 from .route import get_default_route
 from .compat import text
 
-# ddtrace
-from ...internal.logger import get_logger
-
 # Logging
-log = get_logger('ddtrace.vendor.datadog.dogstatsd')
+log = logging.getLogger('datadog.dogstatsd')
 
 # Default config
 DEFAULT_HOST = 'localhost'

--- a/tests/vendor/test_dogstatsd.py
+++ b/tests/vendor/test_dogstatsd.py
@@ -1,0 +1,7 @@
+from ddtrace.internal.logger import DDLogger
+from ddtrace.vendor.dogstatsd.base import log
+
+
+def test_dogstatsd_logger():
+    """Ensure dogstatsd logger is initialized as a rate limited logger"""
+    assert isinstance(log, DDLogger)


### PR DESCRIPTION
If we are unable to connect to a dogstatsd server then the log messages could get noisy if we have health metrics enabled by default