### PR TITLE
Add support for dogpile.cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,6 +290,17 @@ jobs:
       - *persist_to_workspace_step
       - *save_cache_step
 
+  dogpile_cache:
+    docker:
+      - *test_runner
+    resource_class: *resource_class
+    steps:
+      - checkout
+      - *restore_cache_step
+      - run: scripts/run-tox-scenario '^dogpile_contrib-'
+      - *persist_to_workspace_step
+      - *save_cache_step
+
   elasticsearch:
     docker:
       - *test_runner
@@ -892,6 +903,10 @@ workflows:
           requires:
             - flake8
             - black
+      - dogpile_cache:
+          requires:
+            - flake8
+            - black
       - elasticsearch:
           requires:
             - flake8
@@ -1062,6 +1077,7 @@ workflows:
             - consul
             - dbapi
             - ddtracerun
+            - dogpile_cache
             - django
             - elasticsearch
             - falcon

--- a/ddtrace/contrib/dogpile_cache/__init__.py
+++ b/ddtrace/contrib/dogpile_cache/__init__.py
@@ -1,0 +1,48 @@
+"""
+Instrument dogpile.cache__ to report all cached lookups.
+
+This will add spans around the calls to your cache backend (eg. redis, memory,
+etc). The spans will also include the following tags:
+
+- key/keys: The key(s) dogpile passed to your backend. Note that this will be
+  the output of the region's ``function_key_generator``, but before any key
+  mangling is applied (ie. the region's ``key_mangler``).
+- region: Name of the region.
+- backend: Name of the backend class.
+- hit: If the key was found in the cache.
+- expired: If the key is expired. This is only relevant if the key was found.
+
+While cache tracing will generally already have keys in tags, some caching
+setups will not have useful tag values - such as when you're using consistent
+hashing with memcached - the key(s) will appear as a mangled hash.
+::
+
+    # Patch before importing dogpile.cache
+    from ddtrace import patch
+    patch(dogpile_cache=True)
+
+    from dogpile.cache import make_region
+
+    region = make_region().configure(
+        "dogpile.cache.pylibmc",
+        expiration_time=3600,
+        arguments={"url": ["127.0.0.1"]},
+    )
+
+    @region.cache_on_arguments()
+    def hello(name):
+        # Some complicated, slow calculation
+        return "Hello, {}".format(name)
+
+.. __: https://dogpilecache.sqlalchemy.org/
+"""
+from ...utils.importlib import require_modules
+
+
+required_modules = ['dogpile.cache']
+
+with require_modules(required_modules) as missing_modules:
+    if not missing_modules:
+        from .patch import patch, unpatch
+
+        __all__ = ['patch', 'unpatch']

--- a/ddtrace/contrib/dogpile_cache/lock.py
+++ b/ddtrace/contrib/dogpile_cache/lock.py
@@ -1,0 +1,32 @@
+import dogpile
+
+from ...pin import Pin
+
+
+def _wrap_lock_ctor(func, instance, args, kwargs):
+    """
+    This seems rather odd. But to track hits, we need to patch the wrapped function that
+    dogpile passes to the region and locks. Unfortunately it's a closure defined inside
+    the get_or_create* methods themselves, so we can't easily patch those.
+    """
+    func(*args, **kwargs)
+    ori_backend_fetcher = instance.value_and_created_fn
+
+    def wrapped_backend_fetcher():
+        pin = Pin.get_from(dogpile.cache)
+        if not pin or not pin.enabled():
+            return ori_backend_fetcher()
+
+        hit = False
+        expired = True
+        try:
+            value, createdtime = ori_backend_fetcher()
+            hit = value is not dogpile.cache.api.NO_VALUE
+            # dogpile sometimes returns None, but only checks for truthiness. Coalesce
+            # to minimize APM users' confusion.
+            expired = instance._is_expired(createdtime) or False
+            return value, createdtime
+        finally:
+            pin.tracer.current_span().set_tag('hit', hit)
+            pin.tracer.current_span().set_tag('expired', expired)
+    instance.value_and_created_fn = wrapped_backend_fetcher

--- a/ddtrace/contrib/dogpile_cache/patch.py
+++ b/ddtrace/contrib/dogpile_cache/patch.py
@@ -1,0 +1,37 @@
+import dogpile
+
+from ddtrace.pin import Pin, _DD_PIN_NAME, _DD_PIN_PROXY_NAME
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
+
+from .lock import _wrap_lock_ctor
+from .region import _wrap_get_create, _wrap_get_create_multi
+
+_get_or_create = dogpile.cache.region.CacheRegion.get_or_create
+_get_or_create_multi = dogpile.cache.region.CacheRegion.get_or_create_multi
+_lock_ctor = dogpile.lock.Lock.__init__
+
+
+def patch():
+    if getattr(dogpile.cache, '_datadog_patch', False):
+        return
+    setattr(dogpile.cache, '_datadog_patch', True)
+
+    _w('dogpile.cache.region', 'CacheRegion.get_or_create', _wrap_get_create)
+    _w('dogpile.cache.region', 'CacheRegion.get_or_create_multi', _wrap_get_create_multi)
+    _w('dogpile.lock', 'Lock.__init__', _wrap_lock_ctor)
+
+    Pin(app='dogpile.cache', service='dogpile.cache', app_type='CACHE').onto(dogpile.cache)
+
+
+def unpatch():
+    if not getattr(dogpile.cache, '_datadog_patch', False):
+        return
+    setattr(dogpile.cache, '_datadog_patch', False)
+    # This looks silly but the unwrap util doesn't support class instance methods, even
+    # though wrapt does. This was causing the patches to stack on top of each other
+    # during testing.
+    dogpile.cache.region.CacheRegion.get_or_create = _get_or_create
+    dogpile.cache.region.CacheRegion.get_or_create_multi = _get_or_create_multi
+    dogpile.lock.Lock.__init__ = _lock_ctor
+    setattr(dogpile.cache, _DD_PIN_NAME, None)
+    setattr(dogpile.cache, _DD_PIN_PROXY_NAME, None)

--- a/ddtrace/contrib/dogpile_cache/patch.py
+++ b/ddtrace/contrib/dogpile_cache/patch.py
@@ -20,7 +20,7 @@ def patch():
     _w('dogpile.cache.region', 'CacheRegion.get_or_create_multi', _wrap_get_create_multi)
     _w('dogpile.lock', 'Lock.__init__', _wrap_lock_ctor)
 
-    Pin(app='dogpile.cache', service='dogpile.cache', app_type='CACHE').onto(dogpile.cache)
+    Pin(app='dogpile.cache', service='dogpile.cache').onto(dogpile.cache)
 
 
 def unpatch():

--- a/ddtrace/contrib/dogpile_cache/region.py
+++ b/ddtrace/contrib/dogpile_cache/region.py
@@ -1,0 +1,29 @@
+import dogpile
+
+from ...pin import Pin
+
+
+def _wrap_get_create(func, instance, args, kwargs):
+    pin = Pin.get_from(dogpile.cache)
+    if not pin or not pin.enabled():
+        return func(*args, **kwargs)
+
+    key = args[0]
+    with pin.tracer.trace('dogpile.cache', resource='get_or_create', span_type='cache') as span:
+        span.set_tag('key', key)
+        span.set_tag('region', instance.name)
+        span.set_tag('backend', instance.actual_backend.__class__.__name__)
+        return func(*args, **kwargs)
+
+
+def _wrap_get_create_multi(func, instance, args, kwargs):
+    pin = Pin.get_from(dogpile.cache)
+    if not pin or not pin.enabled():
+        return func(*args, **kwargs)
+
+    keys = args[0]
+    with pin.tracer.trace('dogpile.cache', resource='get_or_create_multi', span_type='cache') as span:
+        span.set_tag('keys', keys)
+        span.set_tag('region', instance.name)
+        span.set_tag('backend', instance.actual_backend.__class__.__name__)
+        return func(*args, **kwargs)

--- a/docs/db_integrations.rst
+++ b/docs/db_integrations.rst
@@ -25,6 +25,14 @@ Consul
 .. automodule:: ddtrace.contrib.consul
 
 
+.. _dogpile.cache:
+
+dogpile.cache
+-------------
+
+.. automodule:: ddtrace.contrib.dogpile_cache
+
+
 .. _elasticsearch:
 
 Elasticsearch

--- a/tests/contrib/dogpile_cache/test_tracing.py
+++ b/tests/contrib/dogpile_cache/test_tracing.py
@@ -1,0 +1,184 @@
+import dogpile
+import pytest
+
+from ddtrace import Pin
+from ddtrace.contrib.dogpile_cache.patch import patch, unpatch
+
+from tests.test_tracer import get_dummy_tracer
+
+
+@pytest.fixture
+def tracer():
+    return get_dummy_tracer()
+
+
+@pytest.fixture
+def region(tracer):
+    patch()
+    # Setup a simple dogpile cache region for testing.
+    # The backend is trivial so we can use memory to simplify test setup.
+    test_region = dogpile.cache.make_region(name='TestRegion')
+    test_region.configure('dogpile.cache.memory')
+    Pin.override(dogpile.cache, tracer=tracer)
+    return test_region
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    unpatch()
+
+
+@pytest.fixture
+def single_cache(region):
+    @region.cache_on_arguments()
+    def fn(x):
+        return x * 2
+    return fn
+
+
+@pytest.fixture
+def multi_cache(region):
+    @region.cache_multi_on_arguments()
+    def fn(*x):
+        return [i * 2 for i in x]
+
+    return fn
+
+
+def test_doesnt_trace_with_no_pin(tracer, single_cache, multi_cache):
+    # No pin is set
+    unpatch()
+
+    assert single_cache(1) == 2
+    assert tracer.writer.pop_traces() == []
+
+    assert multi_cache(2, 3) == [4, 6]
+    assert tracer.writer.pop_traces() == []
+
+
+def test_doesnt_trace_with_disabled_pin(tracer, single_cache, multi_cache):
+    tracer.enabled = False
+
+    assert single_cache(1) == 2
+    assert tracer.writer.pop_traces() == []
+
+    assert multi_cache(2, 3) == [4, 6]
+    assert tracer.writer.pop_traces() == []
+
+
+def test_traces_get_or_create(tracer, single_cache):
+    assert single_cache(1) == 2
+    traces = tracer.writer.pop_traces()
+    assert len(traces) == 1
+    spans = traces[0]
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == 'dogpile.cache'
+    assert span.resource == 'get_or_create'
+    assert span.meta['key'] == 'tests.contrib.dogpile_cache.test_tracing:fn|1'
+    assert span.meta['hit'] == 'False'
+    assert span.meta['expired'] == 'True'
+    assert span.meta['backend'] == 'MemoryBackend'
+    assert span.meta['region'] == 'TestRegion'
+
+    # Now the results should be cached.
+    assert single_cache(1) == 2
+    traces = tracer.writer.pop_traces()
+    assert len(traces) == 1
+    spans = traces[0]
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == 'dogpile.cache'
+    assert span.resource == 'get_or_create'
+    assert span.meta['key'] == 'tests.contrib.dogpile_cache.test_tracing:fn|1'
+    assert span.meta['hit'] == 'True'
+    assert span.meta['expired'] == 'False'
+    assert span.meta['backend'] == 'MemoryBackend'
+    assert span.meta['region'] == 'TestRegion'
+
+
+def test_traces_get_or_create_multi(tracer, multi_cache):
+    assert multi_cache(2, 3) == [4, 6]
+    traces = tracer.writer.pop_traces()
+    assert len(traces) == 1
+    spans = traces[0]
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.meta['keys'] == (
+        "['tests.contrib.dogpile_cache.test_tracing:fn|2', " +
+        "'tests.contrib.dogpile_cache.test_tracing:fn|3']"
+    )
+    assert span.meta['hit'] == 'False'
+    assert span.meta['expired'] == 'True'
+    assert span.meta['backend'] == 'MemoryBackend'
+    assert span.meta['region'] == 'TestRegion'
+
+    # Partial hit
+    assert multi_cache(2, 4) == [4, 8]
+    traces = tracer.writer.pop_traces()
+    assert len(traces) == 1
+    spans = traces[0]
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.meta['keys'] == (
+        "['tests.contrib.dogpile_cache.test_tracing:fn|2', " +
+        "'tests.contrib.dogpile_cache.test_tracing:fn|4']"
+    )
+    assert span.meta['hit'] == 'False'
+    assert span.meta['expired'] == 'True'
+    assert span.meta['backend'] == 'MemoryBackend'
+    assert span.meta['region'] == 'TestRegion'
+
+    # Full hit
+    assert multi_cache(2, 4) == [4, 8]
+    traces = tracer.writer.pop_traces()
+    assert len(traces) == 1
+    spans = traces[0]
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.meta['keys'] == (
+        "['tests.contrib.dogpile_cache.test_tracing:fn|2', " +
+        "'tests.contrib.dogpile_cache.test_tracing:fn|4']"
+    )
+    assert span.meta['hit'] == 'True'
+    assert span.meta['expired'] == 'False'
+    assert span.meta['backend'] == 'MemoryBackend'
+    assert span.meta['region'] == 'TestRegion'
+
+
+class TestInnerFunctionCalls(object):
+    def single_cache(self, x):
+        return x * 2
+
+    def multi_cache(self, *x):
+        return [i * 2 for i in x]
+
+    def test_calls_inner_functions_correctly(self, region, mocker):
+        """ This ensures the get_or_create behavior of dogpile is not altered. """
+        spy_single_cache = mocker.spy(self, 'single_cache')
+        spy_multi_cache = mocker.spy(self, 'multi_cache')
+
+        single_cache = region.cache_on_arguments()(self.single_cache)
+        multi_cache = region.cache_multi_on_arguments()(self.multi_cache)
+
+        assert 2 == single_cache(1)
+        spy_single_cache.assert_called_once_with(1)
+
+        # It's now cached - shouldn't need to call the inner function.
+        spy_single_cache.reset_mock()
+        assert 2 == single_cache(1)
+        spy_single_cache.assert_not_called()
+
+        assert [6, 8] == multi_cache(3, 4)
+        spy_multi_cache.assert_called_once_with(3, 4)
+
+        # Partial hit. Only the "new" key should be passed to the inner function.
+        spy_multi_cache.reset_mock()
+        assert [6, 10] == multi_cache(3, 5)
+        spy_multi_cache.assert_called_once_with(5)
+
+        # Full hit. No call to inner function.
+        spy_multi_cache.reset_mock()
+        assert [6, 10] == multi_cache(3, 5)
+        spy_multi_cache.assert_not_called()

--- a/tests/contrib/dogpile_cache/test_tracing.py
+++ b/tests/contrib/dogpile_cache/test_tracing.py
@@ -168,7 +168,7 @@ class TestInnerFunctionCalls(object):
         # It's now cached - shouldn't need to call the inner function.
         spy_single_cache.reset_mock()
         assert 2 == single_cache(1)
-        spy_single_cache.assert_not_called()
+        assert spy_single_cache.call_count == 0
 
         assert [6, 8] == multi_cache(3, 4)
         spy_multi_cache.assert_called_once_with(3, 4)
@@ -181,4 +181,4 @@ class TestInnerFunctionCalls(object):
         # Full hit. No call to inner function.
         spy_multi_cache.reset_mock()
         assert [6, 10] == multi_cache(3, 5)
-        spy_multi_cache.assert_not_called()
+        assert spy_single_cache.call_count == 0

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ envlist =
     django_contrib{,_autopatch}-{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     django_drf_contrib-{py27,py34,py35,py36}-django{111}-djangorestframework{34,37,38}
     django_drf_contrib-{py34,py35,py36}-django{200}-djangorestframework{37,38}
-    dogpile_contrib-{py27,35,36,37}-dogpilecache{06,07,08,latest}
+    dogpile_contrib-{py27,py35,py36,py37}-dogpilecache{06,07,08,latest}
     elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63,64}
     elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch1{100}
     elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch2{50}

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,7 @@ envlist =
     django_contrib{,_autopatch}-{py34,py35,py36}-django{200}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     django_drf_contrib-{py27,py34,py35,py36}-django{111}-djangorestframework{34,37,38}
     django_drf_contrib-{py34,py35,py36}-django{200}-djangorestframework{37,38}
+    dogpile_contrib-{py27,35,36,37}-dogpilecache{06,07,08,latest}
     elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63,64}
     elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch1{100}
     elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch2{50}
@@ -139,6 +140,7 @@ deps =
     pytest-benchmark
     pytest-cov
     pytest-django
+    pytest-mock
     opentracing
     psutil
 # test dependencies installed in all envs
@@ -210,6 +212,10 @@ deps =
     djangorestframework34: djangorestframework>=3.4,<3.5
     djangorestframework37: djangorestframework>=3.7,<3.8
     djangorestframework38: djangorestframework>=3.8,<3.9
+    dogpilecache06: dogpile.cache==0.6.*
+    dogpilecache07: dogpile.cache==0.7.*
+    dogpilecache08: dogpile.cache==0.8.*
+    dogpilecachelatest: dogpile.cache
     elasticsearch16: elasticsearch>=1.6,<1.7
     elasticsearch17: elasticsearch>=1.7,<1.8
     elasticsearch18: elasticsearch>=1.8,<1.9
@@ -395,6 +401,7 @@ commands =
     django_contrib: pytest {posargs} tests/contrib/django
     django_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/django
     django_drf_contrib: pytest {posargs} tests/contrib/djangorestframework
+    dogpile_contrib: pytest {posargs} tests/contrib/dogpile_cache
     elasticsearch_contrib: pytest {posargs} tests/contrib/elasticsearch
     falcon_contrib: pytest {posargs} tests/contrib/falcon/test_middleware.py tests/contrib/falcon/test_distributed_tracing.py
     falcon_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/falcon/test_autopatch.py


### PR DESCRIPTION
[dogpile.cache](https://dogpilecache.sqlalchemy.org/en/latest/) is a library that provides a distributed locking mechanism to avoid the ['dogpile' problem](https://en.wikipedia.org/wiki/Cache_stampede) and provides an abstraction that simplifies the integration of multiple caching systems into an application.

Adding tracing to dogpile may sound redundant, but it turns out just tracing a caching system (eg. memcache) isn't that helpful _if_ you're using something like consistent hashing, which requires the cache keys be hashed so they can be evenly distributed across a cache cluster. So adding tracing at dogpile's layer can give us insight into the actual raw keys that were requested in a function call in addition to more information about the caching setup (eg. what caching system was being used, did we get a 'hit' on the cache keys?, etc).

Here's an example of what it looks like:
![Screenshot from 2019-11-01 16-02-46](https://user-images.githubusercontent.com/29210237/68064839-3e51d380-fcde-11e9-8462-9d359517c62c.png)
_Note: The hit tag value is wrong and has since been fixed._

Since dogpile also handles locking, you'd think we should also trace the locking mechanism. But in my own testing, I found this can have a non-trivial latency cost for calls to `get_or_create_multi` with a lot of cache keys. For example, imagine a cached function that looks up restaurant information and it's passed in a list of 10 or more restaurant IDs. dogpile's implementation tries to fetch locks for each of the uncached keys one by one to avoid a possible race condition. That itself can be slow, but I noticed a ~10-50ms performance regression on a normally ~800ms endpoint for one of the applications I usually work on. Which is a shame, since `get_or_create_multi` is generally the better pattern to use for the applications I work on. So I decided to nix this feature. We can add it back in a separate PR if there's interest.