### PR TITLE
internal: send health metrics on every flush

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -23,7 +23,6 @@ class AgentWriter(_worker.PeriodicWorkerThread):
     QUEUE_PROCESSING_INTERVAL = 1
 
     _ENABLE_STATS = False
-    _STATS_EVERY_INTERVAL = 10
 
     def __init__(self, hostname='localhost', port=8126, uds_path=None, https=False,
                  shutdown_timeout=DEFAULT_TIMEOUT,
@@ -39,7 +38,6 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         self.dogstatsd = dogstatsd
         self.api = api.API(hostname, port, uds_path=uds_path, https=https,
                            priority_sampling=priority_sampler is not None)
-        self._stats_rate_counter = 0
         self.start()
 
     def recreate(self):
@@ -61,24 +59,10 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         writer._ENABLE_STATS = self._ENABLE_STATS
         return writer
 
+    @property
     def _send_stats(self):
-        """Determine if we're sending stats or not.
-
-        This leverages _STATS_EVERY_INTERVAL to send metrics only after this amount of interval has elapsed.
-        """
-        if not self._ENABLE_STATS:
-            return False
-
-        if not self.dogstatsd:
-            return False
-
-        self._stats_rate_counter += 1
-
-        if self._stats_rate_counter % self._STATS_EVERY_INTERVAL == 0:
-            self._stats_rate_counter = 1
-            return True
-
-        return False
+        """Determine if we're sending stats or not."""
+        return self._ENABLE_STATS and self.dogstatsd
 
     def write(self, spans=None, services=None):
         if spans:
@@ -90,9 +74,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         except Empty:
             return
 
-        send_stats = self._send_stats()
-
-        if send_stats:
+        if self._send_stats:
             traces_queue_length = len(traces)
             traces_queue_spans = sum(map(len, traces))
 
@@ -104,7 +86,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
             log.error('error while filtering traces: {0}'.format(err))
             return
 
-        if send_stats:
+        if self._send_stats:
             traces_filtered = len(traces) - traces_queue_length
 
         # If we have data, let's try to send it.
@@ -120,7 +102,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         # Dump statistics
         # NOTE: Do not use the buffering of dogstatsd as it's not thread-safe
         # https://github.com/DataDog/datadogpy/issues/439
-        if send_stats:
+        if self._send_stats:
             # Statistics about the queue length, size and number of spans
             self.dogstatsd.gauge('datadog.tracer.queue.max_length', self._trace_queue.maxsize)
             self.dogstatsd.gauge('datadog.tracer.queue.length', traces_queue_length)


### PR DESCRIPTION
This PR removes the sampling logic and goes back to sending stats on every flush.

Since we removed the heavier `sizeof` metrics we should be able to do this no problem.

If we find that we do need to limit the frequency again we need to figure out how to still collect all the metrics between each flush (e.g. total traces flushed between each stats flush) and then ensure we flush them in a way that works for sending once per X seconds.