### PR TITLE
internal: report cpu time as histogram diff of last time

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -158,30 +158,6 @@ class AgentWriter(_worker.PeriodicWorkerThread):
             if not self._send_stats:
                 return
 
-    def run_periodic(self):
-        if self._send_stats:
-            self.dogstatsd.gauge('datadog.tracer.heartbeat', 1)
-
-        try:
-            self.flush_queue()
-        finally:
-            if not self._send_stats:
-                return
-
-            # Statistics about the rate at which spans are inserted in the queue
-            dropped, enqueued, enqueued_lengths = self._trace_queue.reset_stats()
-            self.dogstatsd.gauge('datadog.tracer.queue.max_length', self._trace_queue.maxsize)
-            self.dogstatsd.histogram('datadog.tracer.queue.dropped.traces', dropped)
-            self.dogstatsd.histogram('datadog.tracer.queue.enqueued.traces', enqueued)
-            self.dogstatsd.histogram('datadog.tracer.queue.enqueued.spans', enqueued_lengths)
-
-    def on_shutdown(self):
-        try:
-            self.run_periodic()
-        finally:
-            if not self._send_stats:
-                return
-
             self.dogstatsd.increment('datadog.tracer.shutdown')
 
     def _log_error_status(self, response):

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -23,7 +23,6 @@ class AgentWriter(_worker.PeriodicWorkerThread):
     QUEUE_PROCESSING_INTERVAL = 1
 
     _ENABLE_STATS = False
-    _STATS_EVERY_INTERVAL = 10
 
     def __init__(self, hostname='localhost', port=8126, uds_path=None, https=False,
                  shutdown_timeout=DEFAULT_TIMEOUT,
@@ -39,7 +38,6 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         self.dogstatsd = dogstatsd
         self.api = api.API(hostname, port, uds_path=uds_path, https=https,
                            priority_sampling=priority_sampler is not None)
-        self._stats_rate_counter = 0
         self.start()
 
     def recreate(self):
@@ -61,24 +59,10 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         writer._ENABLE_STATS = self._ENABLE_STATS
         return writer
 
+    @property
     def _send_stats(self):
-        """Determine if we're sending stats or not.
-
-        This leverages _STATS_EVERY_INTERVAL to send metrics only after this amount of interval has elapsed.
-        """
-        if not self._ENABLE_STATS:
-            return False
-
-        if not self.dogstatsd:
-            return False
-
-        self._stats_rate_counter += 1
-
-        if self._stats_rate_counter % self._STATS_EVERY_INTERVAL == 0:
-            self._stats_rate_counter = 1
-            return True
-
-        return False
+        """Determine if we're sending stats or not."""
+        return self._ENABLE_STATS and self.dogstatsd
 
     def write(self, spans=None, services=None):
         if spans:
@@ -90,9 +74,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         except Empty:
             return
 
-        send_stats = self._send_stats()
-
-        if send_stats:
+        if self._send_stats:
             traces_queue_length = len(traces)
             traces_queue_spans = sum(map(len, traces))
 
@@ -104,7 +86,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
             log.error('error while filtering traces: {0}'.format(err))
             return
 
-        if send_stats:
+        if self._send_stats:
             traces_filtered = len(traces) - traces_queue_length
 
         # If we have data, let's try to send it.
@@ -120,7 +102,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         # Dump statistics
         # NOTE: Do not use the buffering of dogstatsd as it's not thread-safe
         # https://github.com/DataDog/datadogpy/issues/439
-        if send_stats:
+        if self._send_stats:
             # Statistics about the queue length, size and number of spans
             self.dogstatsd.gauge('datadog.tracer.queue.max_length', self._trace_queue.maxsize)
             self.dogstatsd.gauge('datadog.tracer.queue.length', traces_queue_length)

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -38,7 +38,6 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         self.dogstatsd = dogstatsd
         self.api = api.API(hostname, port, uds_path=uds_path, https=https,
                            priority_sampling=priority_sampler is not None)
-        self._last_thread_time = 0
         if hasattr(time, 'thread_time'):
             self._last_thread_time = time.thread_time()
         self.start()

--- a/tests/internal/test_writer.py
+++ b/tests/internal/test_writer.py
@@ -131,41 +131,55 @@ class AgentWriterTests(TestCase):
     def test_dogstatsd(self):
         self.create_worker(enable_stats=True)
         assert [
+            mock.call('datadog.tracer.heartbeat', 1),
             mock.call('datadog.tracer.queue.max_length', 1000),
-            mock.call('datadog.tracer.queue.length', 11),
-            mock.call('datadog.tracer.queue.spans', 77),
         ] == self.dogstatsd.gauge.mock_calls
+
         increment_calls = [
-            mock.call('datadog.tracer.queue.dropped', 0),
-            mock.call('datadog.tracer.queue.accepted', 11),
-            mock.call('datadog.tracer.queue.accepted_lengths', 77),
-            mock.call('datadog.tracer.traces.filtered', 0),
-            mock.call('datadog.tracer.api.requests', 11),
-            mock.call('datadog.tracer.api.errors', 0),
-            mock.call('datadog.tracer.api.responses', 11, tags=['status:200']),
+            mock.call('datadog.tracer.flushes'),
         ]
         if hasattr(time, 'thread_time_ns'):
             increment_calls.append(mock.call('datadog.tracer.writer.cpu_time', mock.ANY))
+        increment_calls.append(mock.call('datadog.tracer.shutdown'))
         assert increment_calls == self.dogstatsd.increment.mock_calls
+
+        assert [
+            mock.call('datadog.tracer.flush.traces', 11),
+            mock.call('datadog.tracer.flush.spans', 77),
+            mock.call('datadog.tracer.flush.traces_filtered', 0),
+            mock.call('datadog.tracer.api.requests', 11),
+            mock.call('datadog.tracer.api.errors', 0),
+            mock.call('datadog.tracer.api.responses', 11, tags=['status:200']),
+            mock.call('datadog.tracer.queue.dropped.traces', 0),
+            mock.call('datadog.tracer.queue.enqueued.traces', 11),
+            mock.call('datadog.tracer.queue.enqueued.spans', 77),
+        ] == self.dogstatsd.histogram.mock_calls
 
     def test_dogstatsd_failing_api(self):
         self.create_worker(api_class=FailingAPI, enable_stats=True)
         assert [
+            mock.call('datadog.tracer.heartbeat', 1),
             mock.call('datadog.tracer.queue.max_length', 1000),
-            mock.call('datadog.tracer.queue.length', 11),
-            mock.call('datadog.tracer.queue.spans', 77),
         ] == self.dogstatsd.gauge.mock_calls
+
         increment_calls = [
-            mock.call('datadog.tracer.queue.dropped', 0),
-            mock.call('datadog.tracer.queue.accepted', 11),
-            mock.call('datadog.tracer.queue.accepted_lengths', 77),
-            mock.call('datadog.tracer.traces.filtered', 0),
-            mock.call('datadog.tracer.api.requests', 1),
-            mock.call('datadog.tracer.api.errors', 1),
+            mock.call('datadog.tracer.flushes'),
         ]
         if hasattr(time, 'thread_time_ns'):
             increment_calls.append(mock.call('datadog.tracer.writer.cpu_time', mock.ANY))
+        increment_calls.append(mock.call('datadog.tracer.shutdown'))
         assert increment_calls == self.dogstatsd.increment.mock_calls
+
+        assert [
+            mock.call('datadog.tracer.flush.traces', 11),
+            mock.call('datadog.tracer.flush.spans', 77),
+            mock.call('datadog.tracer.flush.traces_filtered', 0),
+            mock.call('datadog.tracer.api.requests', 1),
+            mock.call('datadog.tracer.api.errors', 1),
+            mock.call('datadog.tracer.queue.dropped.traces', 0),
+            mock.call('datadog.tracer.queue.enqueued.traces', 11),
+            mock.call('datadog.tracer.queue.enqueued.spans', 77),
+        ] == self.dogstatsd.histogram.mock_calls
 
 
 def test_queue_full():


### PR DESCRIPTION
We currently report CPU time as an ever increasing number, instead we want to report it as the difference between the previous CPU time and now in seconds.