### PR TITLE
Improve flake8 checks

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -33,10 +33,10 @@ __all__ = [
 _ORIGINAL_EXCEPTHOOK = sys.excepthook
 
 
-def _excepthook(type, value, traceback):
-    tracer.global_excepthook(type, value, traceback)
+def _excepthook(tp, value, traceback):
+    tracer.global_excepthook(tp, value, traceback)
     if _ORIGINAL_EXCEPTHOOK:
-        return _ORIGINAL_EXCEPTHOOK(type, value, traceback)
+        return _ORIGINAL_EXCEPTHOOK(tp, value, traceback)
 
 
 def install_excepthook():

--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -84,8 +84,8 @@ class Response(object):
                 return
 
             return loads(body)
-        except (ValueError, TypeError) as err:
-            log.debug('Unable to parse Datadog Agent JSON response: %s %r', err, body)
+        except (ValueError, TypeError):
+            log.debug('Unable to parse Datadog Agent JSON response: %r', body, exc_info=True)
 
     def __repr__(self):
         return '{0}(status={1!r}, body={2!r}, reason={3!r}, msg={4!r})'.format(

--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -20,8 +20,9 @@ def trace_middleware(app, handler):
     ``aiohttp`` middleware that traces the handler execution.
     Because handlers are run in different tasks for each request, we attach the Context
     instance both to the Task and to the Request objects. In this way:
-        * the Task is used by the internal automatic instrumentation
-        * the ``Context`` attached to the request can be freely used in the application code
+
+    * the Task is used by the internal automatic instrumentation
+    * the ``Context`` attached to the request can be freely used in the application code
     """
     @asyncio.coroutine
     def attach_context(request):

--- a/ddtrace/contrib/asyncio/helpers.py
+++ b/ddtrace/contrib/asyncio/helpers.py
@@ -23,11 +23,9 @@ def set_call_context(task, ctx):
 
 
 def ensure_future(coro_or_future, *, loop=None, tracer=None):
-    """
-    Wrapper for the asyncio.ensure_future() function that
-    sets a context to the newly created Task. If the current
-    task already has a Context, it will be attached to the
-    new Task so the Trace list will be preserved.
+    """Wrapper that sets a context to the newly created Task.
+
+    If the current task already has a Context, it will be attached to the new Task so the Trace list will be preserved.
     """
     tracer = tracer or ddtrace.tracer
     current_ctx = tracer.get_call_context()
@@ -37,12 +35,10 @@ def ensure_future(coro_or_future, *, loop=None, tracer=None):
 
 
 def run_in_executor(loop, executor, func, *args, tracer=None):
-    """
-    Wrapper for the loop.run_in_executor() function that
-    sets a context to the newly created Thread. If the current
-    task has a Context, it will be attached as an empty Context
-    with the current_span activated to inherit the ``trace_id``
-    and the ``parent_id``.
+    """Wrapper function that sets a context to the newly created Thread.
+
+    If the current task has a Context, it will be attached as an empty Context with the current_span activated to
+    inherit the ``trace_id`` and the ``parent_id``.
 
     Because the Executor can run the Thread immediately or after the
     coroutine is executed, we may have two different scenarios:
@@ -53,6 +49,7 @@ def run_in_executor(loop, executor, func, *args, tracer=None):
     To support both situations, we create a new Context that knows only what was
     the latest active Span when the new thread was created. In this new thread,
     we fallback to the thread-local ``Context`` storage.
+
     """
     tracer = tracer or ddtrace.tracer
     ctx = Context()

--- a/ddtrace/contrib/asyncio/helpers.py
+++ b/ddtrace/contrib/asyncio/helpers.py
@@ -48,7 +48,7 @@ def run_in_executor(loop, executor, func, *args, tracer=None):
     coroutine is executed, we may have two different scenarios:
     * the Context is copied in the new Thread and the trace is sent twice
     * the coroutine flushes the Context and when the Thread copies the
-      Context it is already empty (so it will be a root Span)
+    Context it is already empty (so it will be a root Span)
 
     To support both situations, we create a new Context that knows only what was
     the latest active Span when the new thread was created. In this new thread,

--- a/ddtrace/contrib/boto/patch.py
+++ b/ddtrace/contrib/boto/patch.py
@@ -28,15 +28,13 @@ AWS_AUTH_TRACED_ARGS = ['path', 'data', 'host']
 
 
 def patch():
-
-    """ AWSQueryConnection and AWSAuthConnection are two different classes called by
-    different services for connection. For exemple EC2 uses AWSQueryConnection and
-    S3 uses AWSAuthConnection
-    """
     if getattr(boto.connection, '_datadog_patch', False):
         return
     setattr(boto.connection, '_datadog_patch', True)
 
+    # AWSQueryConnection and AWSAuthConnection are two different classes called by
+    # different services for connection.
+    # For exemple EC2 uses AWSQueryConnection and S3 uses AWSAuthConnection
     wrapt.wrap_function_wrapper(
         'boto.connection', 'AWSQueryConnection.make_request', patched_query_request
     )

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -54,8 +54,8 @@ def _close_span_on_success(result, future):
         return
     try:
         span.set_tags(_extract_result_metas(cassandra.cluster.ResultSet(future, result)))
-    except Exception as e:
-        log.debug('an exception occured while setting tags: %s', e)
+    except Exception:
+        log.debug('an exception occured while setting tags', exc_info=True)
     finally:
         span.finish()
         delattr(future, CURRENT_SPAN)
@@ -78,8 +78,8 @@ def _close_span_on_error(exc, future):
         span.error = 1
         span.set_tag(errors.ERROR_MSG, exc.args[0])
         span.set_tag(errors.ERROR_TYPE, exc.__class__.__name__)
-    except Exception as e:
-        log.debug('traced_set_final_exception was not able to set the error, failed with error: %s', e)
+    except Exception:
+        log.debug('traced_set_final_exception was not able to set the error, failed with error', exc_info=True)
     finally:
         span.finish()
         delattr(future, CURRENT_SPAN)

--- a/ddtrace/contrib/django/cache.py
+++ b/ddtrace/contrib/django/cache.py
@@ -78,7 +78,7 @@ def patch_cache(tracer):
 
         # prevent patching each backend's method more than once
         if hasattr(cls, DATADOG_NAMESPACE.format(method=method_name)):
-            log.debug('{} already traced'.format(method_name))
+            log.debug('%s already traced', method_name)
         else:
             method = getattr(cls, method_name)
             setattr(cls, DATADOG_NAMESPACE.format(method=method_name), method)

--- a/ddtrace/contrib/django/cache.py
+++ b/ddtrace/contrib/django/cache.py
@@ -35,9 +35,10 @@ def patch_cache(tracer):
     can have different implementations and connectors, this function must
     handle all possible interactions with the Django cache. What follows
     is currently traced:
-        * in-memory cache
-        * the cache client wrapper that could use any of the common
-          Django supported cache servers (Redis, Memcached, Database, Custom)
+
+    * in-memory cache
+    * the cache client wrapper that could use any of the common
+      Django supported cache servers (Redis, Memcached, Database, Custom)
     """
     # discover used cache backends
     cache_backends = set([cache['BACKEND'] for cache in django_settings.CACHES.values()])

--- a/ddtrace/contrib/django/conf.py
+++ b/ddtrace/contrib/django/conf.py
@@ -1,10 +1,10 @@
 """
 Settings for Datadog tracer are all namespaced in the DATADOG_TRACE setting.
-For example your project's `settings.py` file might look like this:
+For example your project's `settings.py` file might look like this::
 
-DATADOG_TRACE = {
-    'TRACER': 'myapp.tracer',
-}
+    DATADOG_TRACE = {
+        'TRACER': 'myapp.tracer',
+    }
 
 This module provides the `setting` object, that is used to access
 Datadog settings, checking for user settings first, then falling

--- a/ddtrace/contrib/django/middleware.py
+++ b/ddtrace/contrib/django/middleware.py
@@ -42,8 +42,8 @@ _django_default_views = {
 
 def _analytics_enabled():
     return (
-        (config.analytics_enabled and settings.ANALYTICS_ENABLED is not False)
-        or settings.ANALYTICS_ENABLED is True
+        (config.analytics_enabled and settings.ANALYTICS_ENABLED is not False) or
+        settings.ANALYTICS_ENABLED is True
     ) and settings.ANALYTICS_SAMPLE_RATE is not None
 
 

--- a/ddtrace/contrib/django/middleware.py
+++ b/ddtrace/contrib/django/middleware.py
@@ -144,8 +144,8 @@ class TraceMiddleware(InstrumentationMixin):
             if trace_query_string:
                 span.set_tag(http.QUERY_STRING, request.META['QUERY_STRING'])
             _set_req_span(request, span)
-        except Exception as e:
-            log.debug('error tracing request: %s', e)
+        except Exception:
+            log.debug('error tracing request', exc_info=True)
 
     def process_view(self, request, view_func, *args, **kwargs):
         span = _get_req_span(request)
@@ -190,8 +190,8 @@ class TraceMiddleware(InstrumentationMixin):
                 span.set_tag(http.STATUS_CODE, response.status_code)
                 span = _set_auth_tags(span, request)
                 span.finish()
-        except Exception as e:
-            log.debug('error tracing request: %s', e)
+        except Exception:
+            log.debug('error tracing request', exc_info=True)
         finally:
             return response
 

--- a/ddtrace/contrib/django/middleware.py
+++ b/ddtrace/contrib/django/middleware.py
@@ -49,7 +49,9 @@ def _analytics_enabled():
 
 def get_middleware_insertion_point():
     """Returns the attribute name and collection object for the Django middleware.
-    If middleware cannot be found, returns None for the middleware collection."""
+
+    If middleware cannot be found, returns None for the middleware collection.
+    """
     middleware = getattr(django_settings, MIDDLEWARE, None)
     # Prioritise MIDDLEWARE over ..._CLASSES, but only in 1.10 and later.
     if middleware is not None and django.VERSION >= (1, 10):

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -44,8 +44,8 @@ def get_request_uri(request):
     host = None
     try:
         host = request.get_host()  # this will include host:port
-    except Exception as e:
-        log.debug('Failed to get Django request host: %s', e)
+    except Exception:
+        log.debug('Failed to get Django request host', exc_info=True)
 
     if not host:
         try:
@@ -58,9 +58,9 @@ def get_request_uri(request):
                 port = str(request.META['SERVER_PORT'])
                 if port != ('443' if request.is_secure() else '80'):
                     host = '{0}:{1}'.format(host, port)
-        except Exception as e:
+        except Exception:
             # This really shouldn't ever happen, but lets guard here just in case
-            log.debug('Failed to build Django request host: %s', e)
+            log.debug('Failed to build Django request host', exc_info=True)
             host = 'unknown'
 
     # Build request url from the information available

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -470,8 +470,8 @@ def request_tracer(name):
             if not span.get_tag(FLASK_VIEW_ARGS) and request.view_args and config.flask.get('collect_view_args'):
                 for k, v in request.view_args.items():
                     span.set_tag(u'{}.{}'.format(FLASK_VIEW_ARGS, k), v)
-        except Exception as e:
-            log.debug('failed to set tags for "flask.request" span: {}'.format(e))
+        except Exception:
+            log.debug('failed to set tags for "flask.request" span', exc_info=True)
 
         with pin.tracer.trace('flask.{}'.format(name), service=pin.service):
             return wrapped(*args, **kwargs)

--- a/ddtrace/contrib/flask_cache/tracers.py
+++ b/ddtrace/contrib/flask_cache/tracers.py
@@ -33,8 +33,8 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
     class TracedCache(Cache):
         """
         Traced cache backend that monitors any operations done by flask_cache. Observed actions are:
-            * get, set, add, delete, clear
-            * all many_ operations
+        * get, set, add, delete, clear
+        * all ``many_`` operations
         """
         _datadog_tracer = ddtracer
         _datadog_service = service

--- a/ddtrace/contrib/mysql/__init__.py
+++ b/ddtrace/contrib/mysql/__init__.py
@@ -1,7 +1,9 @@
 """Instrument mysql to report MySQL queries.
 
 ``patch_all`` will automatically patch your mysql connection to make it work.
+
 ::
+
     # Make sure to import mysql.connector and not the 'connect' function,
     # otherwise you won't have access to the patched version
     from ddtrace import Pin, patch

--- a/ddtrace/contrib/mysqldb/__init__.py
+++ b/ddtrace/contrib/mysqldb/__init__.py
@@ -1,7 +1,9 @@
 """Instrument mysqlclient / MySQL-python to report MySQL queries.
 
 ``patch_all`` will automatically patch your mysql connection to make it work.
+
 ::
+
     # Make sure to import MySQLdb and not the 'connect' function,
     # otherwise you won't have access to the patched version
     from ddtrace import Pin, patch

--- a/ddtrace/contrib/psycopg/connection.py
+++ b/ddtrace/contrib/psycopg/connection.py
@@ -39,7 +39,7 @@ class TracedCursor(cursor):
         self._datadog_tags = kwargs.pop('datadog_tags', None)
         super(TracedCursor, self).__init__(*args, **kwargs)
 
-    def execute(self, query, vars=None):
+    def execute(self, query, vars=None):  # noqa: A002
         """ just wrap the cursor execution in a span """
         if not self._datadog_tracer:
             return cursor.execute(self, query, vars)
@@ -56,7 +56,7 @@ class TracedCursor(cursor):
             finally:
                 s.set_metric('db.rowcount', self.rowcount)
 
-    def callproc(self, procname, vars=None):
+    def callproc(self, procname, vars=None):  # noqa: A002
         """ just wrap the execution in a span """
         return cursor.callproc(self, procname, vars)
 

--- a/ddtrace/contrib/pymongo/__init__.py
+++ b/ddtrace/contrib/pymongo/__init__.py
@@ -3,7 +3,9 @@
 The pymongo integration works by wrapping pymongo's MongoClient to trace
 network calls. Pymongo 3.0 and greater are the currently supported versions.
 ``patch_all`` will automatically patch your MongoClient instance to make it work.
+
 ::
+
     # Be sure to import pymongo and not pymongo.MongoClient directly,
     # otherwise you won't have access to the patched version
     from ddtrace import Pin, patch

--- a/ddtrace/contrib/pymongo/parse.py
+++ b/ddtrace/contrib/pymongo/parse.py
@@ -117,7 +117,7 @@ def parse_msg(msg_bytes):
         offset += 4
 
         # Parse the msg kind
-        kind = ord(msg_bytes[offset:offset+1])
+        kind = ord(msg_bytes[offset:offset + 1])
         offset += 1
 
         # Kinds: https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#sections

--- a/ddtrace/contrib/pyramid/__init__.py
+++ b/ddtrace/contrib/pyramid/__init__.py
@@ -1,4 +1,4 @@
-"""To trace requests from a Pyramid application, trace your application
+r"""To trace requests from a Pyramid application, trace your application
 config::
 
 

--- a/ddtrace/contrib/requests/connection.py
+++ b/ddtrace/contrib/requests/connection.py
@@ -16,12 +16,11 @@ def _extract_service_name(session, span, hostname=None):
     """Extracts the right service name based on the following logic:
     - `requests` is the default service name
     - users can change it via `session.service_name = 'clients'`
-    - if the Span doesn't have a parent, use the set service name
-      or fallback to the default
+    - if the Span doesn't have a parent, use the set service name or fallback to the default
     - if the Span has a parent, use the set service name or the
-      parent service value if the set service name is the default
+    parent service value if the set service name is the default
     - if `split_by_domain` is used, always override users settings
-      and use the network location as a service name
+    and use the network location as a service name
 
     The priority can be represented as:
     Updated service name > parent service name > default to `requests`.

--- a/ddtrace/contrib/tornado/__init__.py
+++ b/ddtrace/contrib/tornado/__init__.py
@@ -1,4 +1,4 @@
-"""
+r"""
 The Tornado integration traces all ``RequestHandler`` defined in a Tornado web application.
 Auto instrumentation is available using the ``patch`` function that **must be called before**
 importing the tornado library.

--- a/ddtrace/contrib/tornado/stack_context.py
+++ b/ddtrace/contrib/tornado/stack_context.py
@@ -42,7 +42,7 @@ if _USE_STACK_CONTEXT:
             """
             pass
 
-        def exit(self, type, value, traceback):
+        def exit(self, type, value, traceback):  # noqa: A002
             """
             Required to preserve the ``StackContext`` protocol.
             """
@@ -54,7 +54,7 @@ if _USE_STACK_CONTEXT:
             _state.contexts = self.new_contexts
             return self
 
-        def __exit__(self, type, value, traceback):
+        def __exit__(self, type, value, traceback):  # noqa: A002
             final_contexts = _state.contexts
             _state.contexts = self.old_contexts
 

--- a/ddtrace/filters.py
+++ b/ddtrace/filters.py
@@ -4,7 +4,8 @@ from .ext import http
 
 
 class FilterRequestsOnUrl(object):
-    """Filter out traces from incoming http requests based on the request's url.
+    r"""Filter out traces from incoming http requests based on the request's url.
+
     This class takes as argument a list of regular expression patterns
     representing the urls to be excluded from tracing. A trace will be excluded
     if its root span contains a ``http.url`` tag and if this tag matches any of
@@ -15,7 +16,6 @@ class FilterRequestsOnUrl(object):
                          the urls that should be filtered out.
 
     Examples:
-
     To filter out http calls to domain api.example.com::
 
         FilterRequestsOnUrl(r'http://api\\.example\\.com')

--- a/ddtrace/http/headers.py
+++ b/ddtrace/http/headers.py
@@ -70,9 +70,9 @@ def _normalize_tag_name(request_or_response, header_name):
     """
     Given a tag name, e.g. 'Content-Type', returns a corresponding normalized tag name, i.e
     'http.request.headers.content_type'. Rules applied actual header name are:
-       - any letter is converted to lowercase
-       - any digit is left unchanged
-       - any block of any length of different ASCII chars is converted to a single underscore '_'
+    - any letter is converted to lowercase
+    - any digit is left unchanged
+    - any block of any length of different ASCII chars is converted to a single underscore '_'
     :param request_or_response: The context of the headers: request|response
     :param header_name: The header's name
     :type header_name: str

--- a/ddtrace/internal/runtime/collector.py
+++ b/ddtrace/internal/runtime/collector.py
@@ -45,7 +45,7 @@ class ValueCollector(object):
         except ImportError:
             # DEV: disable collector if we cannot load any of the required modules
             self.enabled = False
-            log.warning('Could not import module "{}" for {}. Disabling collector.'.format(module, self))
+            log.warning('Could not import module "%s" for %s. Disabling collector.', module, self)
             return None
         return modules
 

--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -104,7 +104,7 @@ def get_container_info(pid='self'):
                 info = CGroupInfo.from_line(line)
                 if info and info.container_id:
                     return info
-    except Exception as err:
-        log.debug('Failed to parse cgroup file for pid %r: %s', pid, err)
+    except Exception:
+        log.debug('Failed to parse cgroup file for pid %r', pid, exc_info=True)
 
     return None

--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -71,7 +71,7 @@ class RuntimeWorker(_worker.PeriodicWorkerThread):
     def flush(self):
         with self._statsd_client:
             for key, value in self._runtime_metrics:
-                log.debug('Writing metric {}:{}'.format(key, value))
+                log.debug('Writing metric %s:%s', key, value)
                 self._statsd_client.gauge(key, value)
 
     run_periodic = flush

--- a/ddtrace/internal/runtime/tag_collectors.py
+++ b/ddtrace/internal/runtime/tag_collectors.py
@@ -31,16 +31,16 @@ class PlatformTagCollector(RuntimeTagCollector):
     """ Tag collector for the Python interpreter implementation.
 
     Tags collected:
-    - lang_interpreter:
-      - For CPython this is 'CPython'.
-      - For Pypy this is 'PyPy'.
-      - For Jython this is 'Jython'.
-    - lang_version:
-      - eg. '2.7.10'
-    - lang:
-      - e.g. 'Python'
-    - tracer_version:
-      - e.g. '0.29.0'
+    - ``lang_interpreter``:
+
+      * For CPython this is 'CPython'.
+      * For Pypy this is ``PyPy``
+      * For Jython this is ``Jython``
+
+    - `lang_version``,  eg ``2.7.10``
+    - ``lang`` e.g. ``Python``
+    - ``tracer_version`` e.g. ``0.29.0``
+
     """
     required_modules = ('platform', 'ddtrace')
 

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -84,8 +84,8 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         # filters
         try:
             traces = self._apply_filters(traces)
-        except Exception as err:
-            log.error('error while filtering traces: {0}'.format(err))
+        except Exception:
+            log.error('error while filtering traces', exc_info=True)
             return
 
         if self._send_stats:

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -150,10 +150,10 @@ def patch_module(module, raise_errors=True):
     """
     try:
         return _patch_module(module)
-    except Exception as exc:
+    except Exception:
         if raise_errors:
             raise
-        log.debug('failed to patch %s: %s', module, exc)
+        log.debug('failed to patch %s', module, exc_info=True)
         return False
 
 

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -176,13 +176,11 @@ class Tracer(opentracing.Tracer):
                 '...',
                 references=[opentracing.child_of(parent_span)])
 
-        Note: the precedence when defining a relationship is the following:
-        (highest)
-            1. *child_of*
-            2. *references*
-            3. `scope_manager.active` (unless *ignore_active_span* is True)
-            4. None
-        (lowest)
+        Note: the precedence when defining a relationship is the following, from highest to lowest:
+        1. *child_of*
+        2. *references*
+        3. `scope_manager.active` (unless *ignore_active_span* is True)
+        4. None
 
         Currently Datadog only supports `child_of` references.
 

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -270,7 +270,7 @@ class Tracer(opentracing.Tracer):
 
         return otspan
 
-    def inject(self, span_context, format, carrier):
+    def inject(self, span_context, format, carrier):  # noqa: A002
         """Injects a span context into a carrier.
 
         :param span_context: span context to inject.
@@ -284,7 +284,7 @@ class Tracer(opentracing.Tracer):
 
         propagator.inject(span_context, carrier)
 
-    def extract(self, format, carrier):
+    def extract(self, format, carrier):  # noqa: A002
         """Extracts a span context from a carrier.
 
         :param format: format that the carrier is encoded with.

--- a/ddtrace/payload.py
+++ b/ddtrace/payload.py
@@ -41,7 +41,7 @@ class Payload(object):
         Encode and append a trace to this payload
 
         :param trace: A trace to append
-        :type trace: A list of ``ddtrace.span.Span``s
+        :type trace: A list of :class:`ddtrace.span.Span`
         """
         # No trace or empty trace was given, ignore
         if not trace:

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -64,7 +64,7 @@ class Pin(object):
 
             >>> pin = Pin._find(wrapper, instance, conn, app)
 
-        :param *objs: The objects to search for a :class:`ddtrace.pin.Pin` on
+        :param objs: The objects to search for a :class:`ddtrace.pin.Pin` on
         :type objs: List of objects
         :rtype: :class:`ddtrace.pin.Pin`, None
         :returns: The first found :class:`ddtrace.pin.Pin` or `None` is none was found

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -135,17 +135,13 @@ class HTTPPropagator(object):
                 _dd_origin=origin,
             )
         # If headers are invalid and cannot be parsed, return a new context and log the issue.
-        except Exception as error:
-            try:
-                log.debug(
-                    'invalid x-datadog-* headers, trace-id: %s, parent-id: %s, priority: %s, origin: %s, error: %s',
-                    headers.get(HTTP_HEADER_TRACE_ID, 0),
-                    headers.get(HTTP_HEADER_PARENT_ID, 0),
-                    headers.get(HTTP_HEADER_SAMPLING_PRIORITY),
-                    headers.get(HTTP_HEADER_ORIGIN, ''),
-                    error,
-                )
-            # We might fail on string formatting errors ; in that case only format the first error
-            except Exception:
-                log.debug(error)
+        except Exception:
+            log.debug(
+                'invalid x-datadog-* headers, trace-id: %s, parent-id: %s, priority: %s, origin: %s',
+                headers.get(HTTP_HEADER_TRACE_ID, 0),
+                headers.get(HTTP_HEADER_PARENT_ID, 0),
+                headers.get(HTTP_HEADER_SAMPLING_PRIORITY),
+                headers.get(HTTP_HEADER_ORIGIN, ''),
+                exc_info=True,
+            )
             return Context()

--- a/ddtrace/provider.py
+++ b/ddtrace/provider.py
@@ -10,8 +10,8 @@ class BaseContextProvider(six.with_metaclass(abc.ABCMeta)):
     for a callable class, capable to retrieve the current active
     ``Context`` instance. Context providers must inherit this class
     and implement:
-        * the ``active`` method, that returns the current active ``Context``
-        * the ``activate`` method, that sets the current active ``Context``
+    * the ``active`` method, that returns the current active ``Context``
+    * the ``activate`` method, that sets the current active ``Context``
     """
     @abc.abstractmethod
     def _has_active_context(self):

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -275,8 +275,8 @@ class SamplingRule(object):
         if callable(pattern):
             try:
                 return bool(pattern(prop))
-            except Exception as e:
-                log.warning('%r pattern %r failed with %r: %s', self, pattern, prop, e)
+            except Exception:
+                log.warning('%r pattern %r failed with %r', self, pattern, prop, exc_info=True)
                 # Their function failed to validate, assume it is a False
                 return False
 
@@ -284,9 +284,9 @@ class SamplingRule(object):
         if isinstance(pattern, pattern_type):
             try:
                 return bool(pattern.match(str(prop)))
-            except (ValueError, TypeError) as e:
+            except (ValueError, TypeError):
                 # This is to guard us against the casting to a string (shouldn't happen, but still)
-                log.warning('%r pattern %r failed with %r: %s', self, pattern, prop, e)
+                log.warning('%r pattern %r failed with %r', self, pattern, prop, exc_info=True)
                 return False
 
         # Exact match on the values

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -304,8 +304,8 @@ class SamplingRule(object):
         return all(
             self._pattern_matches(prop, pattern)
             for prop, pattern in [
-                    (span.service, self.service),
-                    (span.name, self.name),
+                (span.service, self.service),
+                (span.name, self.name),
             ]
         )
 

--- a/ddtrace/settings/hooks.py
+++ b/ddtrace/settings/hooks.py
@@ -111,9 +111,9 @@ class Hooks(object):
         for func in self._hooks[hook]:
             try:
                 func(span, *args, **kwargs)
-            except Exception as e:
+            except Exception:
                 # DEV: Use log.debug instead of log.error until we have a throttled logger
-                log.debug('Failed to run hook {} function {}: {}'.format(hook, func, e))
+                log.debug('Failed to run hook %s function %s', hook, func, exc_info=True)
 
     def __repr__(self):
         """Return string representation of this class instance"""

--- a/ddtrace/settings/hooks.py
+++ b/ddtrace/settings/hooks.py
@@ -94,9 +94,9 @@ class Hooks(object):
         :type hook: str
         :param span: The span to call the hook with
         :type span: :class:`ddtrace.span.Span`
-        :param *args: Positional arguments to pass to the hook functions
+        :param args: Positional arguments to pass to the hook functions
         :type args: list
-        :param **kwargs: Keyword arguments to pass to the hook functions
+        :param kwargs: Keyword arguments to pass to the hook functions
         :type kwargs: dict
         """
         # Return early if no hooks are registered

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -159,7 +159,7 @@ class Span(object):
                 # DEV: `set_metric` will try to cast to `float()` for us
                 self.set_metric(key, value)
             except (TypeError, ValueError):
-                log.debug('error setting numeric metric {}:{}'.format(key, value))
+                log.debug('error setting numeric metric %s:%s', key, value)
 
             return
         elif key == MANUAL_KEEP_KEY:

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -133,10 +133,10 @@ class Tracer(object):
     def __call__(self):
         return self
 
-    def global_excepthook(self, type, value, traceback):
+    def global_excepthook(self, tp, value, traceback):
         """The global tracer except hook."""
         self._dogstatsd_client.increment('datadog.tracer.uncaught_exceptions', 1,
-                                         tags=['class:%s' % type.__name__])
+                                         tags=['class:%s' % tp.__name__])
 
     def get_call_context(self, *args, **kwargs):
         """

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -218,7 +218,7 @@ class Tracer(object):
 
         if dogstatsd_url is not None:
             dogstatsd_kwargs = _parse_dogstatsd_url(dogstatsd_url)
-            self.log.debug('Connecting to DogStatsd({})'.format(dogstatsd_url))
+            self.log.debug('Connecting to DogStatsd(%s)', dogstatsd_url)
             self._dogstatsd_client = DogStatsd(**dogstatsd_kwargs)
 
         if hostname is not None or port is not None or uds_path is not None or https is not None or \
@@ -398,7 +398,7 @@ class Tracer(object):
             '{}:{}'.format(k, v)
             for k, v in RuntimeTags()
         ]
-        self.log.debug('Updating constant tags {}'.format(tags))
+        self.log.debug('Updating constant tags %s', tags)
         self._dogstatsd_client.constant_tags = tags
 
     def _start_runtime_worker(self):

--- a/ddtrace/utils/formats.py
+++ b/ddtrace/utils/formats.py
@@ -58,8 +58,10 @@ def deep_getattr(obj, attr_string, default=None):
 
 
 def asbool(value):
-    """Convert the given String to a boolean object. Accepted
-    values are `True` and `1`."""
+    """Convert the given String to a boolean object.
+
+    Accepted values are `True` and `1`.
+    """
     if value is None:
         return False
 

--- a/ddtrace/utils/formats.py
+++ b/ddtrace/utils/formats.py
@@ -7,11 +7,13 @@ def get_env(integration, variable, default=None):
     """Retrieves environment variables value for the given integration. It must be used
     for consistency between integrations. The implementation is backward compatible
     with legacy nomenclature:
-        * `DATADOG_` is a legacy prefix with lower priority
-        * `DD_` environment variables have the highest priority
-        * the environment variable is built concatenating `integration` and `variable`
-          arguments
-        * return `default` otherwise
+
+    * `DATADOG_` is a legacy prefix with lower priority
+    * `DD_` environment variables have the highest priority
+    * the environment variable is built concatenating `integration` and `variable`
+      arguments
+    * return `default` otherwise
+
     """
     key = '{}_{}'.format(integration, variable).upper()
     legacy_env = 'DATADOG_{}'.format(key)

--- a/ddtrace/utils/hook.py
+++ b/ddtrace/utils/hook.py
@@ -54,14 +54,14 @@ def register_post_import_hook(name, hook):
     hooks = _post_import_hooks.get(name, [])
 
     if hook in hooks:
-        log.debug('hook "{}" already exists on module "{}"'.format(hook, name))
+        log.debug('hook "%s" already exists on module "%s"', hook, name)
         return
 
     module = sys.modules.get(name, None)
 
     # If the module has been imported already fire the hook and log a debug msg.
     if module:
-        log.debug('module "{}" already imported, firing hook'.format(name))
+        log.debug('module "%s" already imported, firing hook', name)
         hook(module)
 
     hooks.append(hook)
@@ -86,8 +86,8 @@ def notify_module_loaded(module):
     for hook in hooks:
         try:
             hook(module)
-        except Exception as err:
-            log.warning('hook "{}" for module "{}" failed: {}'.format(hook, name, err))
+        except Exception:
+            log.warning('hook "%s" for module "%s" failed', hook, name, exc_info=True)
 
 
 class _ImportHookLoader(object):

--- a/ddtrace/utils/time.py
+++ b/ddtrace/utils/time.py
@@ -45,7 +45,7 @@ class StopWatch(object):
         self.start()
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, tp, value, traceback):
         """Stops the watch."""
         self.stop()
 

--- a/ddtrace/utils/wrappers.py
+++ b/ddtrace/utils/wrappers.py
@@ -16,20 +16,17 @@ def safe_patch(patchable, key, patch_func, service, meta, tracer):
     wrapped in the monkey patch == UNBOUND + service and meta) and
     attach the patched result to patchable at patchable.key
 
-
-      - if this is the module/class we can rely on methods being unbound, and just have to
+    - If this is the module/class we can rely on methods being unbound, and just have to
       update the __dict__
-
-      - if this is an instance, we have to unbind the current and rebind our
+    - If this is an instance, we have to unbind the current and rebind our
       patched method
-
-      - If patchable is an instance and if we've already patched at the module/class level
+    - If patchable is an instance and if we've already patched at the module/class level
       then patchable[key] contains an already patched command!
-      To workaround this, check if patchable or patchable.__class__ are _dogtraced
-      If is isn't, nothing to worry about, patch the key as usual
-      But if it is, search for a '__dd_orig_{key}' method on the class, which is
-      the original unpatched method we wish to trace.
 
+    To workaround this, check if patchable or patchable.__class__ are ``_dogtraced``
+    If is isn't, nothing to worry about, patch the key as usual
+    But if it is, search for a '__dd_orig_{key}' method on the class, which is
+    the original unpatched method we wish to trace.
     """
     def _get_original_method(thing, key):
         orig = None

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -265,21 +265,21 @@ htmlhelp_basename = 'ddtracedoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-     # The paper size ('letterpaper' or 'a4paper').
-     #
-     # 'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #
+    # 'papersize': 'letterpaper',
 
-     # The font size ('10pt', '11pt' or '12pt').
-     #
-     # 'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #
+    # 'pointsize': '10pt',
 
-     # Additional stuff for the LaTeX preamble.
-     #
-     # 'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #
+    # 'preamble': '',
 
-     # Latex figure (float) alignment
-     #
-     # 'figure_align': 'htbp',
+    # Latex figure (float) alignment
+    #
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ master_doc = 'index'
 # General information about the project.
 year = datetime.now().year
 project = u'ddtrace'
-copyright = u'2016-{}, Datadog, Inc.'.format(year)
+copyright = u'2016-{}, Datadog, Inc.'.format(year)  # noqa: A001
 author = u'Datadog, Inc.'
 
 # document in order of source

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -29,9 +29,10 @@ class BaseTestCase(unittest.TestCase):
     @contextlib.contextmanager
     def override_env(env):
         """
-        Temporarily override ``os.environ`` with provided values
-        >>> with self.override_env(dict(DATADOG_TRACE_DEBUG=True)):
-            # Your test
+        Temporarily override ``os.environ`` with provided values::
+
+            >>> with self.override_env(dict(DATADOG_TRACE_DEBUG=True)):
+                # Your test
         """
         # Copy the full original environment
         original = dict(os.environ)
@@ -49,9 +50,10 @@ class BaseTestCase(unittest.TestCase):
     @contextlib.contextmanager
     def override_global_config(values):
         """
-        Temporarily override an global configuration
-        >>> with self.override_global_config(dict(name=value,...)):
-            # Your test
+        Temporarily override an global configuration::
+
+            >>> with self.override_global_config(dict(name=value,...)):
+                # Your test
         """
         # DEV: Uses dict as interface but internally handled as attributes on Config instance
         analytics_enabled_original = ddtrace.config.analytics_enabled
@@ -69,9 +71,10 @@ class BaseTestCase(unittest.TestCase):
     @contextlib.contextmanager
     def override_config(integration, values):
         """
-        Temporarily override an integration configuration value
-        >>> with self.override_config('flask', dict(service_name='test-service')):
-            # Your test
+        Temporarily override an integration configuration value::
+
+            >>> with self.override_config('flask', dict(service_name='test-service')):
+                # Your test
         """
         options = getattr(ddtrace.config, integration)
 
@@ -90,9 +93,10 @@ class BaseTestCase(unittest.TestCase):
     @contextlib.contextmanager
     def override_http_config(integration, values):
         """
-        Temporarily override an integration configuration for HTTP value
-        >>> with self.override_http_config('flask', dict(trace_query_string=True)):
-            # Your test
+        Temporarily override an integration configuration for HTTP value::
+
+            >>> with self.override_http_config('flask', dict(trace_query_string=True)):
+                # Your test
         """
         options = getattr(ddtrace.config, integration).http
 
@@ -111,11 +115,12 @@ class BaseTestCase(unittest.TestCase):
     @contextlib.contextmanager
     def override_sys_modules(modules):
         """
-        Temporarily override ``sys.modules`` with provided dictionary of modules
-        >>> mock_module = mock.MagicMock()
-        >>> mock_module.fn.side_effect = lambda: 'test'
-        >>> with self.override_sys_modules(dict(A=mock_module)):
-            # Your test
+        Temporarily override ``sys.modules`` with provided dictionary of modules::
+
+            >>> mock_module = mock.MagicMock()
+            >>> mock_module.fn.side_effect = lambda: 'test'
+            >>> with self.override_sys_modules(dict(A=mock_module)):
+                # Your test
         """
         original = dict(sys.modules)
 

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -86,7 +86,7 @@ def test_tracer_large_trace(benchmark, tracer):
         span.set_tag('num', num)
 
         if level < 10:
-            func(tracer, level+1)
-            func(tracer, level+1)
+            func(tracer, level + 1)
+            func(tracer, level + 1)
 
     benchmark(func, tracer)

--- a/tests/contrib/cassandra/test.py
+++ b/tests/contrib/cassandra/test.py
@@ -269,7 +269,7 @@ class CassandraBase(object):
                 assert query.get_tag(cassx.ROW_COUNT) == '1'
             assert query.get_tag(net.TARGET_HOST) == '127.0.0.1'
             assert query.get_tag(cassx.PAGINATED) == 'True'
-            assert query.get_tag(cassx.PAGE_NUMBER) == str(i+1)
+            assert query.get_tag(cassx.PAGE_NUMBER) == str(i + 1)
 
     def test_trace_with_service(self):
         session, tracer = self._traced_session()

--- a/tests/contrib/cassandra/test.py
+++ b/tests/contrib/cassandra/test.py
@@ -80,7 +80,7 @@ class CassandraBase(object):
         """
         Temporarily override an integration configuration value
         >>> with self.override_config('flask', dict(service_name='test-service')):
-            # Your test
+        ... # Your test
         """
         options = getattr(config, integration)
 

--- a/tests/contrib/consul/test.py
+++ b/tests/contrib/consul/test.py
@@ -17,8 +17,9 @@ class TestConsulPatch(BaseTracerTestCase):
         super(TestConsulPatch, self).setUp()
         patch()
         c = consul.Consul(
-                host=CONSUL_CONFIG['host'],
-                port=CONSUL_CONFIG['port'])
+            host=CONSUL_CONFIG['host'],
+            port=CONSUL_CONFIG['port'],
+        )
         Pin.override(consul.Consul, service=self.TEST_SERVICE, tracer=self.tracer)
         Pin.override(consul.Consul.KV, service=self.TEST_SERVICE, tracer=self.tracer)
         self.c = c

--- a/tests/contrib/django/test_middleware.py
+++ b/tests/contrib/django/test_middleware.py
@@ -155,10 +155,10 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
     def test_analytics_global_off_integration_on_and_none(self):
         """
         When making a request
-            When an integration trace search is enabled
-            Sample rate is set to None
-            Globally trace search is disabled
-                We expect the root span to have the appropriate tag
+        When an integration trace search is enabled
+        Sample rate is set to None
+        Globally trace search is disabled
+        We expect the root span to have the appropriate tag
         """
         with self.override_global_config(dict(analytics_enabled=False)):
             url = reverse('users-list')

--- a/tests/contrib/elasticsearch/test.py
+++ b/tests/contrib/elasticsearch/test.py
@@ -45,8 +45,9 @@ class ElasticsearchTest(unittest.TestCase):
         tracer = get_dummy_tracer()
         writer = tracer.writer
         transport_class = get_traced_transport(
-                datadog_tracer=tracer,
-                datadog_service=self.TEST_SERVICE)
+            datadog_tracer=tracer,
+            datadog_service=self.TEST_SERVICE,
+        )
 
         es = elasticsearch.Elasticsearch(transport_class=transport_class, port=ELASTICSEARCH_CONFIG['port'])
 
@@ -154,8 +155,9 @@ class ElasticsearchTest(unittest.TestCase):
         ot_tracer = init_tracer('my_svc', tracer)
 
         transport_class = get_traced_transport(
-                datadog_tracer=tracer,
-                datadog_service=self.TEST_SERVICE)
+            datadog_tracer=tracer,
+            datadog_service=self.TEST_SERVICE,
+        )
 
         es = elasticsearch.Elasticsearch(transport_class=transport_class, port=ELASTICSEARCH_CONFIG['port'])
 

--- a/tests/contrib/patch.py
+++ b/tests/contrib/patch.py
@@ -204,12 +204,12 @@ class PatchTestCase(object):
 
             So an appropriate assert_module_patched would look like::
 
-            def assert_module_patched(self, redis):
-                self.assert_wrapped(redis.StrictRedis.execute_command)
-                self.assert_wrapped(redis.StrictRedis.pipeline)
-                self.assert_wrapped(redis.Redis.pipeline)
-                self.assert_wrapped(redis.client.BasePipeline.execute)
-                self.assert_wrapped(redis.client.BasePipeline.immediate_execute_command)
+                def assert_module_patched(self, redis):
+                    self.assert_wrapped(redis.StrictRedis.execute_command)
+                    self.assert_wrapped(redis.StrictRedis.pipeline)
+                    self.assert_wrapped(redis.Redis.pipeline)
+                    self.assert_wrapped(redis.client.BasePipeline.execute)
+                    self.assert_wrapped(redis.client.BasePipeline.immediate_execute_command)
 
             :param module: module to check
             :return: None
@@ -229,12 +229,12 @@ class PatchTestCase(object):
 
             So an appropriate assert_not_module_patched would look like::
 
-            def assert_not_module_patched(self, redis):
-                self.assert_not_wrapped(redis.StrictRedis.execute_command)
-                self.assert_not_wrapped(redis.StrictRedis.pipeline)
-                self.assert_not_wrapped(redis.Redis.pipeline)
-                self.assert_not_wrapped(redis.client.BasePipeline.execute)
-                self.assert_not_wrapped(redis.client.BasePipeline.immediate_execute_command)
+                def assert_not_module_patched(self, redis):
+                    self.assert_not_wrapped(redis.StrictRedis.execute_command)
+                    self.assert_not_wrapped(redis.StrictRedis.pipeline)
+                    self.assert_not_wrapped(redis.Redis.pipeline)
+                    self.assert_not_wrapped(redis.client.BasePipeline.execute)
+                    self.assert_not_wrapped(redis.client.BasePipeline.immediate_execute_command)
 
             :param module:
             :return: None
@@ -254,12 +254,12 @@ class PatchTestCase(object):
 
             So an appropriate assert_not_module_double_patched would look like::
 
-            def assert_not_module_double_patched(self, redis):
-                self.assert_not_double_wrapped(redis.StrictRedis.execute_command)
-                self.assert_not_double_wrapped(redis.StrictRedis.pipeline)
-                self.assert_not_double_wrapped(redis.Redis.pipeline)
-                self.assert_not_double_wrapped(redis.client.BasePipeline.execute)
-                self.assert_not_double_wrapped(redis.client.BasePipeline.immediate_execute_command)
+                def assert_not_module_double_patched(self, redis):
+                    self.assert_not_double_wrapped(redis.StrictRedis.execute_command)
+                    self.assert_not_double_wrapped(redis.StrictRedis.pipeline)
+                    self.assert_not_double_wrapped(redis.Redis.pipeline)
+                    self.assert_not_double_wrapped(redis.client.BasePipeline.execute)
+                    self.assert_not_double_wrapped(redis.client.BasePipeline.immediate_execute_command)
 
             :param module: module to check
             :return: None

--- a/tests/contrib/patch.py
+++ b/tests/contrib/patch.py
@@ -85,9 +85,7 @@ class PatchTestCase(object):
     """
     @run_in_subprocess
     class Base(SubprocessTestCase, PatchMixin):
-        """PatchTestCase provides default test methods to be used for testing
-        common integration patching logic.
-
+        """Provides default test methods to be used for testing common integration patching logic.
         Each test method provides a default implementation which will use the
         provided attributes (described below). If the attributes are not
         provided a NotImplementedError will be raised for each method that is
@@ -99,7 +97,6 @@ class PatchTestCase(object):
             __unpatch_func__ unpatch function from the integration.
 
         Example:
-
         A simple implementation inheriting this TestCase looks like::
 
             from ddtrace.contrib.redis import unpatch

--- a/tests/contrib/pymemcache/utils.py
+++ b/tests/contrib/pymemcache/utils.py
@@ -41,7 +41,7 @@ class MockSocketModule(object):
         self.connect_failure = connect_failure
         self.sockets = []
 
-    def socket(self, family, type):
+    def socket(self, family, type):  # noqa: A002
         socket = MockSocket([], connect_failure=self.connect_failure)
         self.sockets.append(socket)
         return socket

--- a/tests/contrib/pyramid/test_pyramid_autopatch.py
+++ b/tests/contrib/pyramid/test_pyramid_autopatch.py
@@ -44,7 +44,6 @@ def _include_me(config):
 
 
 def test_config_include():
-    """ This test makes sure that relative imports still work when the
-    application is run with ddtrace-run """
+    """Makes sure that relative imports still work when the application is run with ddtrace-run."""
     config = Configurator()
     config.include('tests.contrib.pyramid._include_me')

--- a/tests/contrib/sqlalchemy/mixins.py
+++ b/tests/contrib/sqlalchemy/mixins.py
@@ -42,11 +42,10 @@ class SQLAlchemyTestMixin(object):
     To support a new engine, create a new `TestCase` that inherits from
     `SQLAlchemyTestMixin` and `TestCase`. Then you must define the following
     static class variables:
-      * VENDOR: the database vendor name
-      * SQL_DB: the `sql.db` tag that we expect (it's the name of the database
-        available in the `.env` file)
-      * SERVICE: the service that we expect by default
-      * ENGINE_ARGS: all arguments required to create the engine
+    * VENDOR: the database vendor name
+    * SQL_DB: the `sql.db` tag that we expect (it's the name of the database available in the `.env` file)
+    * SERVICE: the service that we expect by default
+    * ENGINE_ARGS: all arguments required to create the engine
 
     To check specific tags in each test, you must implement the
     `check_meta(self, span)` method.

--- a/tests/contrib/tornado/test_config.py
+++ b/tests/contrib/tornado/test_config.py
@@ -18,7 +18,7 @@ class TestTornadoSettings(TornadoTestCase):
                 'agent_hostname': 'dd-agent.service.consul',
                 'agent_port': 8126,
                 'settings': {
-                    'FILTERS':  [
+                    'FILTERS': [
                         FilterRequestsOnUrl(r'http://test\.example\.com'),
                     ],
                 },

--- a/tests/internal/runtime/test_container.py
+++ b/tests/internal/runtime/test_container.py
@@ -299,4 +299,4 @@ def test_get_container_info_exception(mock_log, mock_from_line):
         mock_open.assert_called_once_with('/proc/self/cgroup', mode='r')
 
         # Ensure we logged the exception
-        mock_log.debug.assert_called_once_with('Failed to parse cgroup file for pid %r: %s', 'self', exception)
+        mock_log.debug.assert_called_once_with('Failed to parse cgroup file for pid %r', 'self', exc_info=True)

--- a/tests/internal/runtime/test_container.py
+++ b/tests/internal/runtime/test_container.py
@@ -9,7 +9,7 @@ from .utils import cgroup_line_valid_test_cases
 
 # Map expected Py2 exception to Py3 name
 if PY2:
-    FileNotFoundError = IOError
+    FileNotFoundError = IOError  # noqa: A001
 
 
 def get_mock_open(read_data=None):

--- a/tests/internal/runtime/test_metrics.py
+++ b/tests/internal/runtime/test_metrics.py
@@ -83,11 +83,10 @@ class TestValueCollector(BaseTestCase):
             collect.assert_not_called()
 
         calls = [
-            mock.call((
-                'Could not import module "moduleshouldnotexist" for '
-                '<ValueCollector(enabled=False,periodic=False,required_modules=[\'moduleshouldnotexist\'])>. '
-                'Disabling collector.'
-            ))
+            mock.call(
+                'Could not import module "%s" for %s. Disabling collector.',
+                'moduleshouldnotexist', vc,
+            )
         ]
         log_mock.warning.assert_has_calls(calls)
 

--- a/tests/internal/runtime/test_runtime_metrics.py
+++ b/tests/internal/runtime/test_runtime_metrics.py
@@ -76,7 +76,7 @@ class TestRuntimeWorker(BaseTracerTestCase):
         # Mock socket.socket to hijack the dogstatsd socket
         with mock.patch('socket.socket'):
             # configure tracer for runtime metrics
-            self.tracer._RUNTIME_METRICS_INTERVAL = 1./4
+            self.tracer._RUNTIME_METRICS_INTERVAL = 1. / 4
             self.tracer.configure(collect_metrics=True)
             self.tracer.set_tags({'env': 'tests.dog'})
 

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -314,7 +314,7 @@ class TestTracer(object):
         event = threading.Event()
 
         def trace_one():
-            id = 11
+            id = 11             # noqa: A001
             with ot_tracer.start_active_span(str(id)):
                 id += 1
                 with ot_tracer.start_active_span(str(id)):
@@ -323,7 +323,7 @@ class TestTracer(object):
                         event.set()
 
         def trace_two():
-            id = 21
+            id = 21             # noqa: A001
             event.wait()
             with ot_tracer.start_active_span(str(id)):
                 id += 1

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -262,8 +262,8 @@ class TestTracer(object):
         assert spans[2].parent_id is root._dd_span.span_id
         assert spans[3].parent_id is root._dd_span.span_id
         assert (
-            spans[0].trace_id == spans[1].trace_id
-            and spans[1].trace_id == spans[2].trace_id
+            spans[0].trace_id == spans[1].trace_id and
+            spans[1].trace_id == spans[2].trace_id
         )
 
     def test_start_span_no_active_span(self, ot_tracer, writer):
@@ -285,9 +285,9 @@ class TestTracer(object):
         assert spans[2].parent_id is None
         # and that each span is a new trace
         assert (
-            spans[0].trace_id != spans[1].trace_id
-            and spans[1].trace_id != spans[2].trace_id
-            and spans[0].trace_id != spans[2].trace_id
+            spans[0].trace_id != spans[1].trace_id and
+            spans[1].trace_id != spans[2].trace_id and
+            spans[0].trace_id != spans[2].trace_id
         )
 
     def test_start_active_span_child_finish_after_parent(self, ot_tracer, writer):
@@ -367,15 +367,15 @@ class TestTracer(object):
         # finally we should ensure that the trace_ids are reasonable
         # trace_one
         assert (
-            spans[0].trace_id == spans[1].trace_id
-            and spans[1].trace_id == spans[2].trace_id
+            spans[0].trace_id == spans[1].trace_id and
+            spans[1].trace_id == spans[2].trace_id
         )
         # traces should be independent
         assert spans[2].trace_id != spans[3].trace_id
         # trace_two
         assert (
-            spans[3].trace_id == spans[4].trace_id
-            and spans[4].trace_id == spans[5].trace_id
+            spans[3].trace_id == spans[4].trace_id and
+            spans[4].trace_id == spans[5].trace_id
         )
 
     def test_start_active_span(self, ot_tracer, writer):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -144,11 +144,11 @@ class APITests(TestCase):
             ),
             'error:unsupported-endpoint': dict(
                 js=None,
-                log='Unable to parse Datadog Agent JSON response: .*? \'error:unsupported-endpoint\'',
+                log='Unable to parse Datadog Agent JSON response: \'error:unsupported-endpoint\'',
             ),
             42: dict(  # int as key to trigger TypeError
                 js=None,
-                log='Unable to parse Datadog Agent JSON response: .*? 42',
+                log='Unable to parse Datadog Agent JSON response: 42',
             ),
             '{}': dict(js={}),
             '[]': dict(js=[]),

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -216,9 +216,9 @@ class TestTracingContext(BaseTestCase):
     def test_partial_flush(self):
         """
         When calling `Context.get`
-            When partial flushing is enabled
-            When we have just enough finished spans to flush
-                We return the finished spans
+        When partial flushing is enabled
+        When we have just enough finished spans to flush
+        We return the finished spans
         """
         tracer = get_dummy_tracer()
         ctx = Context()
@@ -255,9 +255,9 @@ class TestTracingContext(BaseTestCase):
     def test_partial_flush_too_many(self):
         """
         When calling `Context.get`
-            When partial flushing is enabled
-            When we have more than the minimum number of spans needed to flush
-                We return the finished spans
+        When partial flushing is enabled
+        When we have more than the minimum number of spans needed to flush
+        We return the finished spans
         """
         tracer = get_dummy_tracer()
         ctx = Context()
@@ -294,9 +294,9 @@ class TestTracingContext(BaseTestCase):
     def test_partial_flush_too_few(self):
         """
         When calling `Context.get`
-            When partial flushing is enabled
-            When we do not have enough finished spans to flush
-                We return no spans
+        When partial flushing is enabled
+        When we do not have enough finished spans to flush
+        We return no spans
         """
         tracer = get_dummy_tracer()
         ctx = Context()
@@ -327,9 +327,9 @@ class TestTracingContext(BaseTestCase):
     def test_partial_flush_remaining(self):
         """
         When calling `Context.get`
-            When partial flushing is enabled
-            When we have some unfinished spans
-                We keep the unfinished spans around
+        When partial flushing is enabled
+        When we have some unfinished spans
+        We keep the unfinished spans around
         """
         tracer = get_dummy_tracer()
         ctx = Context()

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -384,11 +384,11 @@ def test_sampling_rule_matches_exception():
     with mock.patch('ddtrace.sampler.log') as mock_log:
         assert rule.matches(span) is False
         mock_log.warning.assert_called_once_with(
-            '%r pattern %r failed with %r: %s',
+            '%r pattern %r failed with %r',
             rule,
             pattern,
             'test.span',
-            e,
+            exc_info=True,
         )
 
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -268,7 +268,7 @@ def test_sampling_rule_init():
             ('another.span', re.compile(r'test\.span|another\.span'), True),
             ('test.span', lambda name: 'span' in name, True),
             ('test.span', lambda name: 'span' not in name, False),
-            ('test.span', lambda name: 1/0, False),
+            ('test.span', lambda name: 1 / 0, False),
         ]
     ]
 )
@@ -282,24 +282,24 @@ def test_sampling_rule_matches_name(span, rule, expected):
         # DEV: Use sample_rate=1 to ensure SamplingRule._sample always returns True
         (create_span(service=service), SamplingRule(sample_rate=1, service=pattern), expected)
         for service, pattern, expected in [
-                ('my-service', SamplingRule.NO_RULE, True),
-                ('my-service', None, False),
-                (None, None, True),
-                (None, 'my-service', False),
-                (None, re.compile(r'my-service'), False),
-                (None, lambda service: 'service' in service, False),
-                ('my-service', 'my-service', True),
-                ('my-service', 'my_service', False),
-                ('my-service', re.compile(r'^my-'), True),
-                ('my_service', re.compile(r'^my[_-]'), True),
-                ('my-service', re.compile(r'^my_'), False),
-                ('my-service', re.compile(r'my-service'), True),
-                ('my-service', re.compile(r'my'), True),
-                ('my-service', re.compile(r'my-service|another-service'), True),
-                ('another-service', re.compile(r'my-service|another-service'), True),
-                ('my-service', lambda service: 'service' in service, True),
-                ('my-service', lambda service: 'service' not in service, False),
-                ('my-service', lambda service: 1/0, False),
+            ('my-service', SamplingRule.NO_RULE, True),
+            ('my-service', None, False),
+            (None, None, True),
+            (None, 'my-service', False),
+            (None, re.compile(r'my-service'), False),
+            (None, lambda service: 'service' in service, False),
+            ('my-service', 'my-service', True),
+            ('my-service', 'my_service', False),
+            ('my-service', re.compile(r'^my-'), True),
+            ('my_service', re.compile(r'^my[_-]'), True),
+            ('my-service', re.compile(r'^my_'), False),
+            ('my-service', re.compile(r'my-service'), True),
+            ('my-service', re.compile(r'my'), True),
+            ('my-service', re.compile(r'my-service|another-service'), True),
+            ('another-service', re.compile(r'my-service|another-service'), True),
+            ('my-service', lambda service: 'service' in service, True),
+            ('my-service', lambda service: 'service' not in service, False),
+            ('my-service', lambda service: 1 / 0, False),
         ]
     ]
 )

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -521,7 +521,7 @@ def test_excepthook():
 
     called = {}
 
-    def original(type, value, traceback):
+    def original(tp, value, traceback):
         called['yes'] = True
 
     sys.excepthook = original

--- a/tests/utils/span.py
+++ b/tests/utils/span.py
@@ -61,15 +61,15 @@ class TestSpan(Span):
 
     def matches(self, **kwargs):
         """
-        Helper function to check if this span's properties matches the expected
+        Helper function to check if this span's properties matches the expected.
 
         Example::
 
             span = TestSpan(span)
             span.matches(name='my.span', resource='GET /')
 
-        :param **kwargs: Property/Value pairs to evaluate on this span
-        :type **kwargs: dict
+        :param kwargs: Property/Value pairs to evaluate on this span
+        :type kwargs: dict
         :returns: True if the arguments passed match, False otherwise
         :rtype: bool
         """
@@ -123,8 +123,8 @@ class TestSpan(Span):
             span = TestSpan(span)
             span.assert_matches(name='my.span')
 
-        :param **kwargs: Property/Value pairs to evaluate on this span
-        :type **kwargs: dict
+        :param kwargs: Property/Value pairs to evaluate on this span
+        :type kwargs: dict
         :raises: AssertionError
         """
         for name, value in kwargs.items():
@@ -297,12 +297,12 @@ class TestSpanContainer(object):
         """
         Helper to filter current spans by provided parameters.
 
-        This function will yield all spans whose `TestSpan.matches` function return `True`
+        This function will yield all spans whose `TestSpan.matches` function return `True`.
 
-        :param *args: Positional arguments to pass to :meth:`tests.utils.span.TestSpan.matches`
-        :type *args: list
-        :param *kwargs: Keyword arguments to pass to :meth:`tests.utils.span.TestSpan.matches`
-        :type **kwargs: dict
+        :param args: Positional arguments to pass to :meth:`tests.utils.span.TestSpan.matches`
+        :type args: list
+        :param kwargs: Keyword arguments to pass to :meth:`tests.utils.span.TestSpan.matches`
+        :type kwargs: dict
         :returns: generator for the matched :class:`tests.utils.span.TestSpan`
         :rtype: generator
         """
@@ -318,12 +318,12 @@ class TestSpanContainer(object):
         """
         Find a single span matches the provided filter parameters.
 
-        This function will find the first span whose `TestSpan.matches` function return `True`
+        This function will find the first span whose `TestSpan.matches` function return `True`.
 
-        :param *args: Positional arguments to pass to :meth:`tests.utils.span.TestSpan.matches`
-        :type *args: list
-        :param *kwargs: Keyword arguments to pass to :meth:`tests.utils.span.TestSpan.matches`
-        :type **kwargs: dict
+        :param args: Positional arguments to pass to :meth:`tests.utils.span.TestSpan.matches`
+        :type args: list
+        :param kwargs: Keyword arguments to pass to :meth:`tests.utils.span.TestSpan.matches`
+        :type kwargs: dict
         :returns: The first matching span
         :rtype: :class:`tests.utils.span.TestSpan`
         """

--- a/tests/utils/tracer.py
+++ b/tests/utils/tracer.py
@@ -65,10 +65,10 @@ class DummyTracer(Tracer):
 
     def _update_writer(self):
         self.writer = DummyWriter(
-                hostname=self.writer.api.hostname,
-                port=self.writer.api.port,
-                filters=self.writer._filters,
-                priority_sampler=self.writer._priority_sampler,
+            hostname=self.writer.api.hostname,
+            port=self.writer.api.port,
+            filters=self.writer._filters,
+            priority_sampler=self.writer._priority_sampler,
         )
 
     def configure(self, *args, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -457,6 +457,7 @@ deps=
   flake8>=3.7,<=3.8
   flake8-blind-except
   flake8-builtins
+  flake8-logging-format
 commands=flake8 .
 basepython=python3.7
 
@@ -761,4 +762,6 @@ exclude=
   ddtrace/vendor/
 # Ignore:
 # A003: XXX is a python builtin, consider renaming the class attribute
-ignore = W504,A003
+# G201 Logging: .exception(...) should be used instead of .error(..., exc_info=True)
+ignore = W504,A003,G201
+enable-extensions=G

--- a/tox.ini
+++ b/tox.ini
@@ -455,10 +455,8 @@ ignore_outcome=true
 [testenv:flake8]
 deps=
   flake8>=3.7,<=3.8
-  flake8-quotes==1.0.0
 commands=flake8 .
 basepython=python3.7
-inline-quotes = '
 
 [falcon_autopatch]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -458,6 +458,9 @@ deps=
   flake8-blind-except
   flake8-builtins
   flake8-logging-format
+  flake8-rst-docstrings
+  # needed for some features from flake8-rst-docstrings
+  pygments
 commands=flake8 .
 basepython=python3.7
 
@@ -765,3 +768,5 @@ exclude=
 # G201 Logging: .exception(...) should be used instead of .error(..., exc_info=True)
 ignore = W504,A003,G201
 enable-extensions=G
+rst-roles = class,meth,obj,ref
+rst-directives = py:data

--- a/tox.ini
+++ b/tox.ini
@@ -456,6 +456,7 @@ ignore_outcome=true
 deps=
   flake8>=3.7,<=3.8
   flake8-blind-except
+  flake8-builtins
 commands=flake8 .
 basepython=python3.7
 
@@ -758,4 +759,6 @@ exclude=
   .eggs,*.egg,
   # We shouldn't lint our vendored dependencies
   ddtrace/vendor/
-ignore = W504
+# Ignore:
+# A003: XXX is a python builtin, consider renaming the class attribute
+ignore = W504,A003

--- a/tox.ini
+++ b/tox.ini
@@ -758,3 +758,4 @@ exclude=
   .eggs,*.egg,
   # We shouldn't lint our vendored dependencies
   ddtrace/vendor/
+ignore = W504

--- a/tox.ini
+++ b/tox.ini
@@ -455,6 +455,7 @@ ignore_outcome=true
 [testenv:flake8]
 deps=
   flake8>=3.7,<=3.8
+  flake8-blind-except
 commands=flake8 .
 basepython=python3.7
 

--- a/tox.ini
+++ b/tox.ini
@@ -457,6 +457,7 @@ deps=
   flake8>=3.7,<=3.8
   flake8-blind-except
   flake8-builtins
+  flake8-docstrings
   flake8-logging-format
   flake8-rst-docstrings
   # needed for some features from flake8-rst-docstrings
@@ -766,7 +767,8 @@ exclude=
 # Ignore:
 # A003: XXX is a python builtin, consider renaming the class attribute
 # G201 Logging: .exception(...) should be used instead of .error(..., exc_info=True)
-ignore = W504,A003,G201
+# We ignore most of the D errors because there are too many; the goal is to fix them eventually
+ignore = W504,A003,G201,D100,D101,D102,D103,D104,D105,D106,D107,D200,D202,D204,D205,D208,D210,D300,D400,D401,D403,D413
 enable-extensions=G
 rst-roles = class,meth,obj,ref
 rst-directives = py:data


### PR DESCRIPTION
## Remove quote enforcement

The current quote enforcement is a restrictive and annoying.

Furthermore, it arbitrary enforces single quotes whereas tools like black —
which are now standard in Python ecosystem — sticks to the Python widely used
double quotes.

## Add flake8-blind-except

Checks that no except statement is used without specifying an exception type.

## flake8: ignore no error

We only ignore W503 in favor of W504 to define where we put the line break
before binary operators.

## Add flake8-builtins

This makes sure we pick proper variable names.

## Add flake8-logging-format

This makes sure that we use a correct logging format in our log strings.

## Enable flake8-rst-docstrings

This fixes various RST directives that we got wrong and log format

## flake8: enable flake8-docstrings
