### PR TITLE
internal: use histogram and counters for metrics

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -107,24 +107,24 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         if self._send_stats:
             # Statistics about the queue length, size and number of spans
             self.dogstatsd.increment('datadog.tracer.flushes')
-            self.dogstatsd.histogram('datadog.tracer.flush.traces', traces_queue_length)
-            self.dogstatsd.histogram('datadog.tracer.flush.spans', traces_queue_spans)
+            self._histogram_with_total('datadog.tracer.flush.traces', traces_queue_length)
+            self._histogram_with_total('datadog.tracer.flush.spans', traces_queue_spans)
 
             # Statistics about the filtering
-            self.dogstatsd.histogram('datadog.tracer.flush.traces_filtered', traces_filtered)
+            self._histogram_with_total('datadog.tracer.flush.traces_filtered', traces_filtered)
 
             # Statistics about API
-            self.dogstatsd.histogram('datadog.tracer.api.requests', len(traces_responses))
-            self.dogstatsd.histogram('datadog.tracer.api.errors',
-                                     len(list(t for t in traces_responses
-                                              if isinstance(t, Exception))))
+            self._histogram_with_total('datadog.tracer.api.requests', len(traces_responses))
+
+            self._histogram_with_total('datadog.tracer.api.errors',
+                                       len(list(t for t in traces_responses if isinstance(t, Exception))))
             for status, grouped_responses in itertools.groupby(
                     sorted((t for t in traces_responses if not isinstance(t, Exception)),
                            key=lambda r: r.status),
                     key=lambda r: r.status):
-                self.dogstatsd.histogram('datadog.tracer.api.responses',
-                                         len(list(grouped_responses)),
-                                         tags=['status:%d' % status])
+                self._histogram_with_total('datadog.tracer.api.responses',
+                                           len(list(grouped_responses)),
+                                           tags=['status:%d' % status])
 
             # Statistics about the writer thread
             if hasattr(time, 'thread_time'):
@@ -132,6 +132,11 @@ class AgentWriter(_worker.PeriodicWorkerThread):
                 diff = new_thread_time - self._last_thread_time
                 self._last_thread_time = new_thread_time
                 self.dogstatsd.histogram('datadog.tracer.writer.cpu_time', diff)
+
+    def _histogram_with_total(self, name, value, tags=None):
+        """Helper to add metric as a histogram and with a `.total` counter"""
+        self.dogstatsd.histogram(name, value, tags=tags)
+        self.dogstatsd.increment('%s.total' % (name, ), value, tags=tags)
 
     def run_periodic(self):
         if self._send_stats:
@@ -146,9 +151,9 @@ class AgentWriter(_worker.PeriodicWorkerThread):
             # Statistics about the rate at which spans are inserted in the queue
             dropped, enqueued, enqueued_lengths = self._trace_queue.reset_stats()
             self.dogstatsd.gauge('datadog.tracer.queue.max_length', self._trace_queue.maxsize)
-            self.dogstatsd.histogram('datadog.tracer.queue.dropped.traces', dropped)
-            self.dogstatsd.histogram('datadog.tracer.queue.enqueued.traces', enqueued)
-            self.dogstatsd.histogram('datadog.tracer.queue.enqueued.spans', enqueued_lengths)
+            self.dogstatsd.increment('datadog.tracer.queue.dropped.traces', dropped)
+            self.dogstatsd.increment('datadog.tracer.queue.enqueued.traces', enqueued)
+            self.dogstatsd.increment('datadog.tracer.queue.enqueued.spans', enqueued_lengths)
 
     def on_shutdown(self):
         try:

--- a/tests/internal/test_writer.py
+++ b/tests/internal/test_writer.py
@@ -137,25 +137,29 @@ class AgentWriterTests(TestCase):
 
         assert [
             mock.call('datadog.tracer.flushes'),
+            mock.call('datadog.tracer.flush.traces.total', 11, tags=None),
+            mock.call('datadog.tracer.flush.spans.total', 77, tags=None),
+            mock.call('datadog.tracer.flush.traces_filtered.total', 0, tags=None),
+            mock.call('datadog.tracer.api.requests.total', 11, tags=None),
+            mock.call('datadog.tracer.api.errors.total', 0, tags=None),
+            mock.call('datadog.tracer.api.responses.total', 11, tags=['status:200']),
+            mock.call('datadog.tracer.queue.dropped.traces', 0),
+            mock.call('datadog.tracer.queue.enqueued.traces', 11),
+            mock.call('datadog.tracer.queue.enqueued.spans', 77),
             mock.call('datadog.tracer.shutdown'),
         ] == self.dogstatsd.increment.mock_calls
 
         histogram_calls = [
-            mock.call('datadog.tracer.flush.traces', 11),
-            mock.call('datadog.tracer.flush.spans', 77),
-            mock.call('datadog.tracer.flush.traces_filtered', 0),
-            mock.call('datadog.tracer.api.requests', 11),
-            mock.call('datadog.tracer.api.errors', 0),
+            mock.call('datadog.tracer.flush.traces', 11, tags=None),
+            mock.call('datadog.tracer.flush.spans', 77, tags=None),
+            mock.call('datadog.tracer.flush.traces_filtered', 0, tags=None),
+            mock.call('datadog.tracer.api.requests', 11, tags=None),
+            mock.call('datadog.tracer.api.errors', 0, tags=None),
             mock.call('datadog.tracer.api.responses', 11, tags=['status:200']),
         ]
         if hasattr(time, 'thread_time'):
             histogram_calls.append(mock.call('datadog.tracer.writer.cpu_time', mock.ANY))
 
-        histogram_calls += [
-            mock.call('datadog.tracer.queue.dropped.traces', 0),
-            mock.call('datadog.tracer.queue.enqueued.traces', 11),
-            mock.call('datadog.tracer.queue.enqueued.spans', 77),
-        ]
         assert histogram_calls == self.dogstatsd.histogram.mock_calls
 
     def test_dogstatsd_failing_api(self):
@@ -167,24 +171,27 @@ class AgentWriterTests(TestCase):
 
         assert [
             mock.call('datadog.tracer.flushes'),
+            mock.call('datadog.tracer.flush.traces.total', 11, tags=None),
+            mock.call('datadog.tracer.flush.spans.total', 77, tags=None),
+            mock.call('datadog.tracer.flush.traces_filtered.total', 0, tags=None),
+            mock.call('datadog.tracer.api.requests.total', 1, tags=None),
+            mock.call('datadog.tracer.api.errors.total', 1, tags=None),
+            mock.call('datadog.tracer.queue.dropped.traces', 0),
+            mock.call('datadog.tracer.queue.enqueued.traces', 11),
+            mock.call('datadog.tracer.queue.enqueued.spans', 77),
             mock.call('datadog.tracer.shutdown'),
         ] == self.dogstatsd.increment.mock_calls
 
         histogram_calls = [
-            mock.call('datadog.tracer.flush.traces', 11),
-            mock.call('datadog.tracer.flush.spans', 77),
-            mock.call('datadog.tracer.flush.traces_filtered', 0),
-            mock.call('datadog.tracer.api.requests', 1),
-            mock.call('datadog.tracer.api.errors', 1),
+            mock.call('datadog.tracer.flush.traces', 11, tags=None),
+            mock.call('datadog.tracer.flush.spans', 77, tags=None),
+            mock.call('datadog.tracer.flush.traces_filtered', 0, tags=None),
+            mock.call('datadog.tracer.api.requests', 1, tags=None),
+            mock.call('datadog.tracer.api.errors', 1, tags=None),
         ]
         if hasattr(time, 'thread_time'):
             histogram_calls.append(mock.call('datadog.tracer.writer.cpu_time', mock.ANY))
 
-        histogram_calls += [
-            mock.call('datadog.tracer.queue.dropped.traces', 0),
-            mock.call('datadog.tracer.queue.enqueued.traces', 11),
-            mock.call('datadog.tracer.queue.enqueued.spans', 77),
-        ]
         assert histogram_calls == self.dogstatsd.histogram.mock_calls
 
 


### PR DESCRIPTION
Sending as a histogram is great to get per-flush aggregation metrics, but we need to send as a counter as well to get the total number.

Histograms do support `.sum` aggregations but they must be enabled in the agent and are disabled by default. 