### PR TITLE
internal: move health metrics enabled to config

### DIFF
--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -34,6 +34,10 @@ class Config(object):
             get_env('trace', 'report_hostname', default=False)
         )
 
+        self.health_metrics_enabled = asbool(
+            get_env('trace', 'health_metrics_enabled', default=False)
+        )
+
     def __getattr__(self, name):
         if name not in self._config:
             self._config[name] = IntegrationConfig(self, name)

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -56,14 +56,17 @@ class BaseTestCase(unittest.TestCase):
         # DEV: Uses dict as interface but internally handled as attributes on Config instance
         analytics_enabled_original = ddtrace.config.analytics_enabled
         report_hostname_original = ddtrace.config.report_hostname
+        health_metrics_enabled_original = ddtrace.config.health_metrics_enabled
 
         ddtrace.config.analytics_enabled = values.get('analytics_enabled', analytics_enabled_original)
         ddtrace.config.report_hostname = values.get('report_hostname', report_hostname_original)
+        ddtrace.config.health_metrics_enabled = values.get('health_metrics_enabled', health_metrics_enabled_original)
         try:
             yield
         finally:
             ddtrace.config.analytics_enabled = analytics_enabled_original
             ddtrace.config.report_hostname = report_hostname_original
+            ddtrace.config.health_metrics_enabled = health_metrics_enabled_original
 
     @staticmethod
     @contextlib.contextmanager

--- a/tests/internal/test_writer.py
+++ b/tests/internal/test_writer.py
@@ -1,5 +1,4 @@
 import time
-from unittest import TestCase
 
 import pytest
 

--- a/tests/internal/test_writer.py
+++ b/tests/internal/test_writer.py
@@ -8,6 +8,7 @@ import mock
 from ddtrace.span import Span
 from ddtrace.api import API
 from ddtrace.internal.writer import AgentWriter, Q, Empty
+from ..base import BaseTestCase
 
 
 class RemoveAllFilter():
@@ -64,34 +65,36 @@ class FailingAPI(object):
         return [Exception('oops')]
 
 
-class AgentWriterTests(TestCase):
+class AgentWriterTests(BaseTestCase):
     N_TRACES = 11
 
     def create_worker(self, filters=None, api_class=DummyAPI, enable_stats=False):
-        self.dogstatsd = mock.Mock()
-        worker = AgentWriter(dogstatsd=self.dogstatsd, filters=filters)
-        worker._ENABLE_STATS = enable_stats
-        worker._STATS_EVERY_INTERVAL = 1
-        self.api = api_class()
-        worker.api = self.api
-        for i in range(self.N_TRACES):
-            worker.write([
-                Span(tracer=None, name='name', trace_id=i, span_id=j, parent_id=j - 1 or None)
-                for j in range(7)
-            ])
-        worker.stop()
-        worker.join()
-        return worker
+        with self.override_global_config(dict(health_metrics_enabled=enable_stats)):
+            self.dogstatsd = mock.Mock()
+            worker = AgentWriter(dogstatsd=self.dogstatsd, filters=filters)
+            worker._STATS_EVERY_INTERVAL = 1
+            self.api = api_class()
+            worker.api = self.api
+            for i in range(self.N_TRACES):
+                worker.write([
+                    Span(tracer=None, name='name', trace_id=i, span_id=j, parent_id=j - 1 or None)
+                    for j in range(7)
+                ])
+            worker.stop()
+            worker.join()
+            return worker
 
-    def test_recreate_stats(self):
-        worker = self.create_worker()
-        assert worker._ENABLE_STATS is False
-        new_worker = worker.recreate()
-        assert new_worker._ENABLE_STATS is False
+    def test_send_stats(self):
+        dogstatsd = mock.Mock()
+        worker = AgentWriter(dogstatsd=dogstatsd)
+        assert worker._send_stats is False
+        with self.override_global_config(dict(health_metrics_enabled=True)):
+            assert worker._send_stats is True
 
-        worker._ENABLE_STATS = True
-        new_worker = worker.recreate()
-        assert new_worker._ENABLE_STATS is True
+        worker = AgentWriter(dogstatsd=None)
+        assert worker._send_stats is False
+        with self.override_global_config(dict(health_metrics_enabled=True)):
+            assert worker._send_stats is False
 
     def test_filters_keep_all(self):
         filtr = KeepAllFilter()
@@ -124,7 +127,7 @@ class AgentWriterTests(TestCase):
 
     def test_no_dogstats(self):
         worker = self.create_worker()
-        assert worker._ENABLE_STATS is False
+        assert worker._send_stats is False
         assert [
         ] == self.dogstatsd.gauge.mock_calls
 


### PR DESCRIPTION
Move away from a private property to control whether health metrics are enabled and move to config API.

```python
from ddtrace import config
config.health_metrics_enabled = True
```

It is disabled by default for now.