### PR TITLE
internal: Add global stats collector

### DIFF
--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -1,7 +1,7 @@
 import collections
 import logging
 
-from .stats import stats
+from . import stats
 from ..utils.formats import get_env
 
 
@@ -90,7 +90,7 @@ class DDLogger(logging.Logger):
         """
         # Record a stat for all error (or worse) logs
         if record.levelno >= logging.ERROR:
-            stats.error_log(record.name)
+            stats.get_stats().error_log(record.name)
 
         # If rate limiting has been disabled (`DD_LOGGING_RATE_LIMIT=0`) then apply no rate limit
         if not self.rate_limit:

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -1,6 +1,7 @@
 import collections
 import logging
 
+from .stats import stats
 from ..utils.formats import get_env
 
 
@@ -87,6 +88,10 @@ class DDLogger(logging.Logger):
         :param record: The log record being logged
         :type record: ``logging.LogRecord``
         """
+        # Record a stat for all error (or worse) logs
+        if record.levelno >= logging.ERROR:
+            stats.error_log(record.name)
+        
         # If rate limiting has been disabled (`DD_LOGGING_RATE_LIMIT=0`) then apply no rate limit
         if not self.rate_limit:
             super(DDLogger, self).handle(record)

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -90,7 +90,7 @@ class DDLogger(logging.Logger):
         """
         # Record a stat for all error (or worse) logs
         if record.levelno >= logging.ERROR:
-            stats.get_stats().error_log(record.name)
+            stats.error_log(record.name)
 
         # If rate limiting has been disabled (`DD_LOGGING_RATE_LIMIT=0`) then apply no rate limit
         if not self.rate_limit:

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -91,7 +91,7 @@ class DDLogger(logging.Logger):
         # Record a stat for all error (or worse) logs
         if record.levelno >= logging.ERROR:
             stats.error_log(record.name)
-        
+
         # If rate limiting has been disabled (`DD_LOGGING_RATE_LIMIT=0`) then apply no rate limit
         if not self.rate_limit:
             super(DDLogger, self).handle(record)

--- a/ddtrace/internal/stats.py
+++ b/ddtrace/internal/stats.py
@@ -92,7 +92,7 @@ class Stats(object):
         """
         Return and reset the current value of all counters
 
-        ..code-block:: python
+        ::
 
             from ddtrace.internal.stats import stats
 
@@ -100,7 +100,7 @@ class Stats(object):
             stats.span_started()
             stats.span_finished()
 
-            # Fetch all current metrics, resettting their internal values back to 0
+            # Fetch all current metrics, resetting their internal values back to 0
             for metric_name, metric_type, value, tags in stats.reset_values():
                 pass
 

--- a/ddtrace/internal/stats.py
+++ b/ddtrace/internal/stats.py
@@ -5,14 +5,15 @@ from ..utils.counter import Counter
 
 
 class Stats(object):
+    # Metric types
+    METRIC_TYPE_INCREMENT = 'increment'
+    METRIC_TYPE_GAUGE = 'gauge'
+
+    # Metric names
     SPANS_STARTED = 'datadog.tracer.spans.started'
-
     SPANS_FINISHED = 'datadog.tracer.spans.finished'
-
     ERROR_LOGS = 'datadog.tracer.log.errors'
-
     PATCH_ERROR = 'datadog.tracer.patch.error'
-
     PATCH_SUCCESS = 'datadog.tracer.patch.success'
 
     def __init__(self):
@@ -20,20 +21,20 @@ class Stats(object):
 
         self._last_values = collections.defaultdict(int)
         self._counters = collections.defaultdict(Counter)
-        self._one_time_stats = set()
 
     def span_started(self):
         """Increment the number of spans started"""
-        self._increment(self.SPANS_STARTED)
+        self._increment(self.SPANS_STARTED, self.METRIC_TYPE_INCREMENT)
 
     def span_finished(self):
         """Increment the number of spans finished"""
-        self._increment(self.SPANS_FINISHED)
+        self._increment(self.SPANS_FINISHED, self.METRIC_TYPE_INCREMENT)
 
     def error_log(self, logger_name):
         """Increment the number of error logs emitted"""
         self._increment(
             self.ERROR_LOGS,
+            self.METRIC_TYPE_INCREMENT,
             ('logger:{}'.format(logger_name), ),
         )
 
@@ -41,43 +42,46 @@ class Stats(object):
         """Increment the number of patching errors"""
         self._increment(
             self.PATCH_ERROR,
+            self.METRIC_TYPE_GAUGE,
             ('module:{}'.format(module_name), ),
-            one_time=True,
         )
 
     def patch_success(self, module_name):
         """Increment the number of patching successes"""
         self._increment(
             self.PATCH_SUCCESS,
+            self.METRIC_TYPE_GAUGE,
             ('module:{}'.format(module_name), ),
-            one_time=True,
         )
 
-    def _key(self, name, tags=None):
+    def _key(self, name, metric_type, tags=None):
+        # Tags must be `None` or a `tuple` (`list` is not hashable)
         if tags is not None:
             tags = tuple(tags)
-        return (name, tags)
+        return (name, metric_type, tags)
 
-    def _increment(self, name, tags=None, one_time=False):
+    def _increment(self, name, metric_type, tags=None):
         """Internal helper to increment a stats counter"""
-        key = self._key(name, tags)
+        key = self._key(name, metric_type, tags)
         self._counters[key].increment()
-        if one_time:
-            self._one_time_stats.add(key)
 
-    def _get_value(self, name, tags=None):
+    def _get_value(self, name, metric_type, tags=None):
         """Internal helper to get the current value of a counter since last check"""
-        key = self._key(name, tags)
+        key = self._key(name, metric_type, tags)
 
         # Get the current value and last value we saw
-        current_value = self._counters[key].value(no_lock=True)
+        val = self._counters[key].value(no_lock=True)
         last_value = self._last_values[key]
 
-        # Compute the change in value since last check
-        val = current_value - last_value
+        # For increments, only grab the difference between
+        #   last time we fetched and now
+        # For gauges, we always want the current total value
+        if metric_type is self.METRIC_TYPE_INCREMENT:
+            # Compute the change in value since last check
+            val = val - last_value
 
         # Store the current value for next time we fetch
-        self._last_values[key] = current_value
+        self._last_values[key] = val
         return val
 
     def reset_values(self):
@@ -86,34 +90,32 @@ class Stats(object):
 
         ::
 
-            from ddtrace.internal.stats import stats
+            from ddtrace.internal.stats import get_stats
+
+            # Get global stats instance
+            stats = stats.get_stats()
 
             # Increment counters
             stats.span_started()
             stats.span_finished()
 
             # Fetch all current metrics, resetting their internal values back to 0
-            for metric_name, value, tags in stats.reset_values():
+            for metric_name, metric_type, value, tags in stats.reset_values():
                 pass
 
-        :returns: List of ``(metric_name, value, tags)`` for each stat monitored
+        :returns: List of ``(metric_name, metric_type, value, tags)`` for each stat monitored
         :rtype: :obj:`list`
         """
         with self._read_lock:
             # Collect and reset all current counters
             values = []
-            for name, tags in self._counters.keys():
-                val = self._get_value(name, tags)
+            for name, metric_type, tags in self._counters.keys():
+                val = self._get_value(name, metric_type, tags)
+                # Convert tags to a list so we can add to default tags set on the dogstatsd client
                 if tags is not None:
                     tags = list(tags)
 
-                values.append((name, val, tags))
-
-            # Remove any one time keys
-            for key in self._one_time_stats:
-                del self._counters[key]
-                del self._last_values[key]
-            self._one_time_stats = set()
+                values.append((name, metric_type, val, tags))
 
             return values
 
@@ -124,8 +126,21 @@ class Stats(object):
         :param dogstatsd_client: A DogStatsd client to send metrics to
         :type dogstatsd_client: :class:`ddtrace.vendor.dogstatsd.DogStatsd`
         """
-        for metric, value, tags in self.reset_values():
-            dogstatsd_client.increment(metric, value, tags=tags)
+        for metric, metric_type, value, tags in self.reset_values():
+            getattr(dogstatsd_client, metric_type)(metric, value, tags=tags)
 
 
-stats = Stats()
+# Default global `Stats` instance
+# Get this from `ddtrace.internal.stats.get_stats`
+_stats = Stats()
+
+
+def get_stats():
+    """
+    Fetch the current global :class:`Stats` instance
+
+    :returns: Global :class:`Stats` instance
+    :rtype: :class:`Stats`
+    """
+    global _stats
+    return _stats

--- a/ddtrace/internal/stats.py
+++ b/ddtrace/internal/stats.py
@@ -109,10 +109,13 @@ class Stats(object):
         """
         with self._read_lock:
             # Collect and reset all current counters
-            values = [
-                (name, metric_type, self._get_value(name, metric_type, tags), tags)
-                for (name, metric_type, tags) in self._counters.keys()
-            ]
+            values = []
+            for name, metric_type, tags in self._counters.keys():
+                val = self._get_value(name, metric_type, tags)
+                if tags is not None:
+                    tags = list(tags)
+
+                values.append((name, metric_type, val, tags))
 
             # Remove any one time keys
             for key in self._one_time_stats:

--- a/ddtrace/internal/stats.py
+++ b/ddtrace/internal/stats.py
@@ -167,3 +167,38 @@ def get_stats():
     """
     global _stats
     return _stats
+
+
+def span_started():
+    """Increment the number of spans open"""
+    return get_stats().span_started()
+
+
+def span_finished():
+    """Decrement the number of spans open"""
+    return get_stats().span_finished()
+
+
+def error_log(logger_name):
+    """Increment the number of error logs emitted"""
+    return get_stats().error_log(logger_name)
+
+
+def patch_error(module_name):
+    """Increment the number of patching errors"""
+    return get_stats().patch_error(module_name)
+
+
+def patch_success(module_name):
+    """Increment the number of patching successes"""
+    return get_stats().patch_success(module_name)
+
+
+def report(dogstatsd_client):
+    """
+    Report all existing metrics to the provided dogstatsd client
+
+    :param dogstatsd_client: A DogStatsd client to send metrics to
+    :type dogstatsd_client: :class:`ddtrace.vendor.dogstatsd.DogStatsd`
+    """
+    return get_stats().report(dogstatsd_client)

--- a/ddtrace/internal/stats.py
+++ b/ddtrace/internal/stats.py
@@ -13,7 +13,7 @@ class Stats(object):
     def __init__(self):
         self._read_lock = threading.Lock()
 
-        self._number_of_reads = collections.defaultdict(int)
+        self._last_values = collections.defaultdict(int)
         self._values = collections.defaultdict(itertools.count)
         self._one_time_stats = set()
 
@@ -51,8 +51,12 @@ class Stats(object):
 
     def _get_value(self, name, tags=None):
         key = (name, tags)
-        val = next(self._values[key]) - self._number_of_reads[key]
-        self._number_of_reads[key] += 1
+
+        current_value = next(self._values[key])
+        last_value = self._last_values[key]
+
+        val = current_value - last_value
+        self._last_values[key] = current_value + 1
         return val
 
     def reset_values(self):
@@ -65,7 +69,7 @@ class Stats(object):
             # Remove any one time keys
             for key in self._one_time_stats:
                 del self._values[key]
-                del self._number_of_reads[key]
+                del self._last_values[key]
             self._one_time_stats = set()
 
             return values

--- a/ddtrace/internal/stats.py
+++ b/ddtrace/internal/stats.py
@@ -1,0 +1,74 @@
+import collections
+import itertools
+import threading
+
+
+class Stats(object):
+    SPANS_STARTED = 'datadog.tracer.spans.started'
+    SPANS_FINISHED = 'datadog.tracer.spans.finished'
+    ERROR_LOGS = 'datadog.tracer.log.errors'
+    PATCH_ERROR = 'datadog.tracer.patch.error'
+    PATCH_SUCCESS = 'datadog.tracer.patch.success'
+
+    def __init__(self):
+        self._read_lock = threading.Lock()
+
+        self._number_of_reads = collections.defaultdict(int)
+        self._values = collections.defaultdict(itertools.count)
+        self._one_time_stats = set()
+
+    def span_started(self):
+        self._increment(self.SPANS_STARTED)
+
+    def span_finished(self):
+        self._increment(self.SPANS_FINISHED)
+
+    def error_log(self, logger_name):
+        self._increment(
+            self.ERROR_LOGS,
+            ('logger:{}'.format(logger_name), ),
+        )
+
+    def patch_error(self, module_name):
+        self._increment(
+            self.PATCH_ERROR,
+            ('module:{}'.format(module_name), ),
+            one_time=True,
+        )
+
+    def patch_success(self, module_name):
+        self._increment(
+            self.PATCH_SUCCESS,
+            ('module:{}'.format(module_name), ),
+            one_time=True,
+        )
+
+    def _increment(self, name, tags=None, one_time=False):
+        key = (name, tags)
+        next(self._values[key])
+        if one_time:
+            self._one_time_stats.add(key)
+
+    def _get_value(self, name, tags=None):
+        key = (name, tags)
+        val = next(self._values[key]) - self._number_of_reads[key]
+        self._number_of_reads[key] += 1
+        return val
+
+    def reset_values(self):
+        with self._read_lock:
+            values = [
+                (name, self._get_value(name, tags), tags)
+                for (name, tags) in self._values.keys()
+            ]
+
+            # Remove any one time keys
+            for key in self._one_time_stats:
+                del self._values[key]
+                del self._number_of_reads[key]
+            self._one_time_stats = set()
+
+            return values
+
+
+stats = Stats()

--- a/ddtrace/internal/stats.py
+++ b/ddtrace/internal/stats.py
@@ -6,15 +6,15 @@ from ..utils.counter import Counter
 
 class Stats(object):
     # Metric types
-    METRIC_TYPE_INCREMENT = 'increment'
-    METRIC_TYPE_GAUGE = 'gauge'
-    METRIC_TYPE_HISTOGRAM = 'histogram'
+    METRIC_TYPE_INCREMENT = "increment"
+    METRIC_TYPE_GAUGE = "gauge"
+    METRIC_TYPE_HISTOGRAM = "histogram"
 
     # Metric names
-    SPANS_OPEN = 'datadog.tracer.spans.open'
-    ERROR_LOGS = 'datadog.tracer.log.errors'
-    PATCH_ERROR = 'datadog.tracer.patch.error'
-    PATCH_SUCCESS = 'datadog.tracer.patch.success'
+    SPANS_OPEN = "datadog.tracer.spans.open"
+    ERROR_LOGS = "datadog.tracer.log.errors"
+    PATCH_ERROR = "datadog.tracer.patch.error"
+    PATCH_SUCCESS = "datadog.tracer.patch.success"
 
     def __init__(self):
         self._read_lock = threading.Lock()
@@ -33,25 +33,19 @@ class Stats(object):
     def error_log(self, logger_name):
         """Increment the number of error logs emitted"""
         self._increment(
-            self.ERROR_LOGS,
-            self.METRIC_TYPE_INCREMENT,
-            ('logger:{}'.format(logger_name), ),
+            self.ERROR_LOGS, self.METRIC_TYPE_INCREMENT, ("logger:{}".format(logger_name),),
         )
 
     def patch_error(self, module_name):
         """Increment the number of patching errors"""
         self._increment(
-            self.PATCH_ERROR,
-            self.METRIC_TYPE_GAUGE,
-            ('module:{}'.format(module_name), ),
+            self.PATCH_ERROR, self.METRIC_TYPE_GAUGE, ("module:{}".format(module_name),),
         )
 
     def patch_success(self, module_name):
         """Increment the number of patching successes"""
         self._increment(
-            self.PATCH_SUCCESS,
-            self.METRIC_TYPE_GAUGE,
-            ('module:{}'.format(module_name), ),
+            self.PATCH_SUCCESS, self.METRIC_TYPE_GAUGE, ("module:{}".format(module_name),),
         )
 
     def _key(self, name, metric_type, tags=None):
@@ -137,7 +131,7 @@ class Stats(object):
             # Manually increment a "sum" counter for histograms
             # DEV: `<metric>.sum` histogram metric is disabled by default in the agent
             if metric_type is self.METRIC_TYPE_HISTOGRAM:
-                dogstatsd_client.increment('{}.total'.format(metric), value, tags=tags)
+                dogstatsd_client.increment("{}.total".format(metric), value, tags=tags)
 
 
 # Default global `Stats` instance

--- a/ddtrace/internal/stats.py
+++ b/ddtrace/internal/stats.py
@@ -6,19 +6,14 @@ from ..utils.counter import Counter
 
 class Stats(object):
     SPANS_STARTED = 'datadog.tracer.spans.started'
-    SPANS_STARTED_TYPE = 'increment'
 
     SPANS_FINISHED = 'datadog.tracer.spans.finished'
-    SPANS_FINISHED_TYPE = 'increment'
 
     ERROR_LOGS = 'datadog.tracer.log.errors'
-    ERROR_LOGS_TYPE = 'increment'
 
     PATCH_ERROR = 'datadog.tracer.patch.error'
-    PATCH_ERROR_TYPE = 'increment'
 
     PATCH_SUCCESS = 'datadog.tracer.patch.success'
-    PATCH_SUCCESS_TYPE = 'increment'
 
     def __init__(self):
         self._read_lock = threading.Lock()
@@ -29,17 +24,16 @@ class Stats(object):
 
     def span_started(self):
         """Increment the number of spans started"""
-        self._increment(self.SPANS_STARTED, self.SPANS_STARTED_TYPE)
+        self._increment(self.SPANS_STARTED)
 
     def span_finished(self):
         """Increment the number of spans finished"""
-        self._increment(self.SPANS_FINISHED, self.SPANS_FINISHED_TYPE)
+        self._increment(self.SPANS_FINISHED)
 
     def error_log(self, logger_name):
         """Increment the number of error logs emitted"""
         self._increment(
             self.ERROR_LOGS,
-            self.ERROR_LOGS_TYPE,
             ('logger:{}'.format(logger_name), ),
         )
 
@@ -47,7 +41,6 @@ class Stats(object):
         """Increment the number of patching errors"""
         self._increment(
             self.PATCH_ERROR,
-            self.PATCH_ERROR_TYPE,
             ('module:{}'.format(module_name), ),
             one_time=True,
         )
@@ -56,26 +49,25 @@ class Stats(object):
         """Increment the number of patching successes"""
         self._increment(
             self.PATCH_SUCCESS,
-            self.PATCH_SUCCESS_TYPE,
             ('module:{}'.format(module_name), ),
             one_time=True,
         )
 
-    def _key(self, name, metric_type, tags=None):
+    def _key(self, name, tags=None):
         if tags is not None:
             tags = tuple(tags)
-        return (name, metric_type, tags)
+        return (name, tags)
 
-    def _increment(self, name, metric_type, tags=None, one_time=False):
+    def _increment(self, name, tags=None, one_time=False):
         """Internal helper to increment a stats counter"""
-        key = self._key(name, metric_type, tags)
+        key = self._key(name, tags)
         self._counters[key].increment()
         if one_time:
             self._one_time_stats.add(key)
 
-    def _get_value(self, name, metric_type, tags=None):
+    def _get_value(self, name, tags=None):
         """Internal helper to get the current value of a counter since last check"""
-        key = self._key(name, metric_type, tags)
+        key = self._key(name, tags)
 
         # Get the current value and last value we saw
         current_value = self._counters[key].value(no_lock=True)
@@ -101,21 +93,21 @@ class Stats(object):
             stats.span_finished()
 
             # Fetch all current metrics, resetting their internal values back to 0
-            for metric_name, metric_type, value, tags in stats.reset_values():
+            for metric_name, value, tags in stats.reset_values():
                 pass
 
-        :returns: List of ``(metric_name, metric_type, value, tags)`` for each stat monitored
+        :returns: List of ``(metric_name, value, tags)`` for each stat monitored
         :rtype: :obj:`list`
         """
         with self._read_lock:
             # Collect and reset all current counters
             values = []
-            for name, metric_type, tags in self._counters.keys():
-                val = self._get_value(name, metric_type, tags)
+            for name, tags in self._counters.keys():
+                val = self._get_value(name, tags)
                 if tags is not None:
                     tags = list(tags)
 
-                values.append((name, metric_type, val, tags))
+                values.append((name, val, tags))
 
             # Remove any one time keys
             for key in self._one_time_stats:
@@ -132,13 +124,8 @@ class Stats(object):
         :param dogstatsd_client: A DogStatsd client to send metrics to
         :type dogstatsd_client: :class:`ddtrace.vendor.dogstatsd.DogStatsd`
         """
-        for metric, metric_type, value, tags in self.reset_values():
-            if metric_type == 'increment':
-                dogstatsd_client.increment(metric, value, tags=tags)
-            elif metric_type == 'gauge':
-                dogstatsd_client.gauge(metric, value, tags=tags)
-            elif metric_type == 'histogram':
-                dogstatsd_client.histogram(metric, value, tags=tags)
+        for metric, value, tags in self.reset_values():
+            dogstatsd_client.increment(metric, value, tags=tags)
 
 
 stats = Stats()

--- a/ddtrace/internal/stats.py
+++ b/ddtrace/internal/stats.py
@@ -1,78 +1,141 @@
 import collections
-import itertools
 import threading
+
+from ..utils.counter import Counter
 
 
 class Stats(object):
     SPANS_STARTED = 'datadog.tracer.spans.started'
+    SPANS_STARTED_TYPE = 'increment'
+
     SPANS_FINISHED = 'datadog.tracer.spans.finished'
+    SPANS_FINISHED_TYPE = 'increment'
+
     ERROR_LOGS = 'datadog.tracer.log.errors'
+    ERROR_LOGS_TYPE = 'increment'
+
     PATCH_ERROR = 'datadog.tracer.patch.error'
+    PATCH_ERROR_TYPE = 'increment'
+
     PATCH_SUCCESS = 'datadog.tracer.patch.success'
+    PATCH_SUCCESS_TYPE = 'increment'
 
     def __init__(self):
         self._read_lock = threading.Lock()
 
         self._last_values = collections.defaultdict(int)
-        self._values = collections.defaultdict(itertools.count)
+        self._counters = collections.defaultdict(Counter)
         self._one_time_stats = set()
 
     def span_started(self):
-        self._increment(self.SPANS_STARTED)
+        """Increment the number of spans started"""
+        self._increment(self.SPANS_STARTED, self.SPANS_STARTED_TYPE)
 
     def span_finished(self):
-        self._increment(self.SPANS_FINISHED)
+        """Increment the number of spans finished"""
+        self._increment(self.SPANS_FINISHED, self.SPANS_FINISHED_TYPE)
 
     def error_log(self, logger_name):
+        """Increment the number of error logs emitted"""
         self._increment(
             self.ERROR_LOGS,
+            self.ERROR_LOGS_TYPE,
             ('logger:{}'.format(logger_name), ),
         )
 
     def patch_error(self, module_name):
+        """Increment the number of patching errors"""
         self._increment(
             self.PATCH_ERROR,
+            self.PATCH_ERROR_TYPE,
             ('module:{}'.format(module_name), ),
             one_time=True,
         )
 
     def patch_success(self, module_name):
+        """Increment the number of patching successes"""
         self._increment(
             self.PATCH_SUCCESS,
+            self.PATCH_SUCCESS_TYPE,
             ('module:{}'.format(module_name), ),
             one_time=True,
         )
 
-    def _increment(self, name, tags=None, one_time=False):
-        key = (name, tags)
-        next(self._values[key])
+    def _key(self, name, metric_type, tags=None):
+        if tags is not None:
+            tags = tuple(tags)
+        return (name, metric_type, tags)
+
+    def _increment(self, name, metric_type, tags=None, one_time=False):
+        """Internal helper to increment a stats counter"""
+        key = self._key(name, metric_type, tags)
+        self._counters[key].increment()
         if one_time:
             self._one_time_stats.add(key)
 
-    def _get_value(self, name, tags=None):
-        key = (name, tags)
+    def _get_value(self, name, metric_type, tags=None):
+        """Internal helper to get the current value of a counter since last check"""
+        key = self._key(name, metric_type, tags)
 
-        current_value = next(self._values[key])
+        # Get the current value and last value we saw
+        current_value = self._counters[key].value(no_lock=True)
         last_value = self._last_values[key]
 
+        # Compute the change in value since last check
         val = current_value - last_value
-        self._last_values[key] = current_value + 1
+
+        # Store the current value for next time we fetch
+        self._last_values[key] = current_value
         return val
 
     def reset_values(self):
+        """
+        Return and reset the current value of all counters
+
+        ..code-block:: python
+
+            from ddtrace.internal.stats import stats
+
+            # Increment counters
+            stats.span_started()
+            stats.span_finished()
+
+            # Fetch all current metrics, resettting their internal values back to 0
+            for metric_name, metric_type, value, tags in stats.reset_values():
+                pass
+
+        :returns: List of ``(metric_name, metric_type, value, tags)`` for each stat monitored
+        :rtype: :obj:`list`
+        """
         with self._read_lock:
+            # Collect and reset all current counters
             values = [
-                (name, self._get_value(name, tags), tags)
-                for (name, tags) in self._values.keys()
+                (name, metric_type, self._get_value(name, metric_type, tags), tags)
+                for (name, metric_type, tags) in self._counters.keys()
             ]
 
             # Remove any one time keys
             for key in self._one_time_stats:
-                del self._values[key]
+                del self._counters[key]
                 del self._last_values[key]
             self._one_time_stats = set()
 
             return values
+
+    def report(self, dogstatsd_client):
+        """
+        Report all existing metrics to the provided dogstatsd client
+
+        :param dogstatsd_client: A DogStatsd client to send metrics to
+        :type dogstatsd_client: :class:`ddtrace.vendor.dogstatsd.DogStatsd`
+        """
+        for metric, metric_type, value, tags in self.reset_values():
+            if metric_type == 'increment':
+                dogstatsd_client.increment(metric, value, tags=tags)
+            elif metric_type == 'gauge':
+                dogstatsd_client.gauge(metric, value, tags=tags)
+            elif metric_type == 'histogram':
+                dogstatsd_client.histogram(metric, value, tags=tags)
 
 
 stats = Stats()

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -125,16 +125,6 @@ class AgentWriter(_worker.PeriodicWorkerThread):
                                            len(list(grouped_responses)),
                                            tags=['status:%d' % status])
 
-            # Report global stats
-            stats.report(self.dogstatsd)
-
-            # Statistics about the writer thread
-            if hasattr(time, 'thread_time'):
-                new_thread_time = time.thread_time()
-                diff = new_thread_time - self._last_thread_time
-                self._last_thread_time = new_thread_time
-                self.dogstatsd.histogram('datadog.tracer.writer.cpu_time', diff)
-
     def _histogram_with_total(self, name, value, tags=None):
         """Helper to add metric as a histogram and with a `.total` counter"""
         self.dogstatsd.histogram(name, value, tags=tags)
@@ -149,6 +139,16 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         finally:
             if not self._send_stats:
                 return
+
+            # Statistics about the writer thread
+            if hasattr(time, 'thread_time'):
+                new_thread_time = time.thread_time()
+                diff = new_thread_time - self._last_thread_time
+                self._last_thread_time = new_thread_time
+                self.dogstatsd.histogram('datadog.tracer.writer.cpu_time', diff)
+
+            # Report global stats
+            stats.report(self.dogstatsd)
 
             # Statistics about the rate at which spans are inserted in the queue
             dropped, enqueued, enqueued_lengths = self._trace_queue.reset_stats()

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -6,7 +6,7 @@ import time
 from .. import api
 from .. import _worker
 from ..internal.logger import get_logger
-from ..internal.stats import stats
+from ..internal import stats
 from ..settings import config
 from ..vendor import monotonic
 from ddtrace.vendor.six.moves.queue import Queue, Full, Empty
@@ -148,7 +148,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
                 self.dogstatsd.histogram('datadog.tracer.writer.cpu_time', diff)
 
             # Report global stats
-            stats.report(self.dogstatsd)
+            stats.get_stats().report(self.dogstatsd)
 
             # Statistics about the rate at which spans are inserted in the queue
             dropped, enqueued, enqueued_lengths = self._trace_queue.reset_stats()

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -157,7 +157,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
                 self.dogstatsd.histogram('datadog.tracer.writer.cpu_time', diff)
 
             # Report global stats
-            stats.get_stats().report(self.dogstatsd)
+            stats.report(self.dogstatsd)
 
             # Statistics about the rate at which spans are inserted in the queue
             dropped, enqueued, enqueued_lengths = self._trace_queue.reset_stats()

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -125,9 +125,8 @@ class AgentWriter(_worker.PeriodicWorkerThread):
                                            len(list(grouped_responses)),
                                            tags=['status:%d' % status])
 
-            # Send global stats
-            for stat, val, tags in stats.reset_values():
-                self.dogstatsd.gauge(stat, val, tags=tags)
+            # Report global stats
+            stats.report(self.dogstatsd)
 
             # Statistics about the writer thread
             if hasattr(time, 'thread_time'):

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -6,6 +6,7 @@ import time
 from .. import api
 from .. import _worker
 from ..internal.logger import get_logger
+from ..internal.stats import stats
 from ..settings import config
 from ..vendor import monotonic
 from ddtrace.vendor.six.moves.queue import Queue, Full, Empty
@@ -123,6 +124,10 @@ class AgentWriter(_worker.PeriodicWorkerThread):
                 self._histogram_with_total('datadog.tracer.api.responses',
                                            len(list(grouped_responses)),
                                            tags=['status:%d' % status])
+
+            # Send global stats
+            for stat, val, tags in stats.reset_values():
+                self.dogstatsd.gauge(stat, val, tags=tags)
 
             # Statistics about the writer thread
             if hasattr(time, 'thread_time'):

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -13,7 +13,7 @@ import threading
 from ddtrace.vendor.wrapt.importer import when_imported
 
 from .internal.logger import get_logger
-from .internal.stats import stats
+from .internal import stats
 
 
 log = get_logger(__name__)
@@ -93,7 +93,7 @@ def _on_import_factory(module, raise_errors=True):
         path = 'ddtrace.contrib.%s' % module
         imported_module = importlib.import_module(path)
         imported_module.patch()
-        stats.patch_success(module)
+        stats.get_stats().patch_success(module)
 
     return on_import
 
@@ -180,7 +180,7 @@ def _patch_module(module):
         try:
             imported_module = importlib.import_module(path)
             imported_module.patch()
-            stats.patch_success(module)
+            stats.get_stats().patch_success(module)
         except ImportError:
             # if the import fails, the integration is not available
             raise PatchException('integration not available')
@@ -189,7 +189,7 @@ def _patch_module(module):
             # that the library is not installed in the environment
             raise PatchException('module not installed')
         except Exception:
-            stats.patch_error(module)
+            stats.get_stats().patch_error(module)
             raise
 
         _PATCHED_MODULES.add(module)

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -13,6 +13,7 @@ import threading
 from ddtrace.vendor.wrapt.importer import when_imported
 
 from .internal.logger import get_logger
+from .internal.stats import stats
 
 
 log = get_logger(__name__)
@@ -178,6 +179,7 @@ def _patch_module(module):
         try:
             imported_module = importlib.import_module(path)
             imported_module.patch()
+            stats.patch_success(module)
         except ImportError:
             # if the import fails, the integration is not available
             raise PatchException('integration not available')
@@ -185,6 +187,9 @@ def _patch_module(module):
             # if patch() is not available in the module, it means
             # that the library is not installed in the environment
             raise PatchException('module not installed')
+        except Exception:
+            stats.patch_error(module)
+            raise
 
         _PATCHED_MODULES.add(module)
         return True

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -93,6 +93,7 @@ def _on_import_factory(module, raise_errors=True):
         path = 'ddtrace.contrib.%s' % module
         imported_module = importlib.import_module(path)
         imported_module.patch()
+        stats.patch_success(module)
 
     return on_import
 

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -93,7 +93,7 @@ def _on_import_factory(module, raise_errors=True):
         path = 'ddtrace.contrib.%s' % module
         imported_module = importlib.import_module(path)
         imported_module.patch()
-        stats.get_stats().patch_success(module)
+        stats.patch_success(module)
 
     return on_import
 
@@ -180,7 +180,7 @@ def _patch_module(module):
         try:
             imported_module = importlib.import_module(path)
             imported_module.patch()
-            stats.get_stats().patch_success(module)
+            stats.patch_success(module)
         except ImportError:
             # if the import fails, the integration is not available
             raise PatchException('integration not available')
@@ -189,7 +189,7 @@ def _patch_module(module):
             # that the library is not installed in the environment
             raise PatchException('module not installed')
         except Exception:
-            stats.get_stats().patch_error(module)
+            stats.patch_error(module)
             raise
 
         _PATCHED_MODULES.add(module)

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -108,7 +108,7 @@ class Span(object):
         self.finished = False
 
         # stats
-        stats.get_stats().span_started()
+        stats.span_started()
 
     @property
     def start(self):
@@ -139,7 +139,7 @@ class Span(object):
         if self.finished:
             return
         self.finished = True
-        stats.get_stats().span_finished()
+        stats.span_finished()
 
         if self.duration_ns is None:
             ft = time_ns() if finish_time is None else int(finish_time * 1e9)

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -7,6 +7,7 @@ from .compat import StringIO, stringify, iteritems, numeric_types, time_ns
 from .constants import NUMERIC_TAGS, MANUAL_DROP_KEY, MANUAL_KEEP_KEY
 from .ext import errors, priority
 from .internal.logger import get_logger
+from .internal.stats import stats
 
 
 log = get_logger(__name__)
@@ -100,6 +101,9 @@ class Span(object):
         # state
         self.finished = False
 
+        # stats
+        stats.span_started()
+
     @property
     def start(self):
         """The start timestamp in Unix epoch seconds."""
@@ -129,6 +133,7 @@ class Span(object):
         if self.finished:
             return
         self.finished = True
+        stats.span_finished()
 
         if self.duration_ns is None:
             ft = time_ns() if finish_time is None else int(finish_time * 1e9)

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -5,7 +5,7 @@ import traceback
 
 from .compat import StringIO, stringify, iteritems, numeric_types, time_ns
 from .constants import NUMERIC_TAGS, MANUAL_DROP_KEY, MANUAL_KEEP_KEY
-from .ext import errors, priority
+from .ext import SpanTypes, errors, priority
 from .internal import stats
 from .internal.logger import get_logger
 

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -6,8 +6,8 @@ import traceback
 from .compat import StringIO, stringify, iteritems, numeric_types, time_ns
 from .constants import NUMERIC_TAGS, MANUAL_DROP_KEY, MANUAL_KEEP_KEY
 from .ext import errors, priority
+from .internal import stats
 from .internal.logger import get_logger
-from .internal.stats import stats
 
 
 log = get_logger(__name__)
@@ -102,7 +102,7 @@ class Span(object):
         self.finished = False
 
         # stats
-        stats.span_started()
+        stats.get_stats().span_started()
 
     @property
     def start(self):
@@ -133,7 +133,7 @@ class Span(object):
         if self.finished:
             return
         self.finished = True
-        stats.span_finished()
+        stats.get_stats().span_finished()
 
         if self.duration_ns is None:
             ft = time_ns() if finish_time is None else int(finish_time * 1e9)

--- a/ddtrace/utils/counter.py
+++ b/ddtrace/utils/counter.py
@@ -5,7 +5,8 @@ import threading
 class Counter(object):
     """Thread safe counter class, keeps count of things
 
-    ..code-block:: python
+    ::
+
         from ddtrace.utils.counter import Counter
 
         counter = Counter()

--- a/ddtrace/utils/counter.py
+++ b/ddtrace/utils/counter.py
@@ -17,27 +17,30 @@ class Counter(object):
         for _ in range(10):
             counter.increment()
         counter.value()  # 11
+
+        counter.decrement()
+        counter.value()  # 10
     """
     def __init__(self):
         self._read_count = 0
-        self._counter = itertools.count()
+        self._increment = itertools.count()
+        self._decrement = itertools.count()
         self._read_lock = threading.Lock()
 
-    def increment(self, step=1):
-        """
-        Increment the counter
+    def increment(self):
+        """Increment the counter"""
+        next(self._increment)
 
-        :param step: The number of times to increment the counter (default: ``1``)
-        :type step: int
-        """
-        for _ in range(step):
-            next(self._counter)
+    def decrement(self):
+        """Increment the counter"""
+        next(self._decrement)
 
     def _value(self):
         """Return the current value of the counter"""
-        val = next(self._counter) - self._read_count
+        inc = next(self._increment) - self._read_count
+        dec = next(self._decrement) - self._read_count
         self._read_count += 1
-        return val
+        return inc - dec
 
     def value(self, no_lock=False):
         """

--- a/ddtrace/utils/counter.py
+++ b/ddtrace/utils/counter.py
@@ -1,0 +1,54 @@
+import itertools
+import threading
+
+
+class Counter(object):
+    """Thread safe counter class, keeps count of things
+
+    ..code-block:: python
+        from ddtrace.utils.counter import Counter
+
+        counter = Counter()
+
+        counter.increment()
+        counter.value()  # 1
+
+        for _ in range(10):
+            counter.increment()
+        counter.value()  # 11
+    """
+    def __init__(self):
+        self._read_count = 0
+        self._counter = itertools.count()
+        self._read_lock = threading.Lock()
+
+    def increment(self, times=1):
+        """
+        Increment the counter
+
+        :param times: The number of times to increment the counter (default: ``1``)
+        :type times: int
+        """
+        for _ in range(times):
+            next(self._counter)
+
+    def _value(self):
+        """Return the current value of the counter"""
+        val = next(self._counter) - self._read_count
+        self._read_count += 1
+        return val
+
+    def value(self, no_lock=False):
+        """
+        Return the current value of the counter
+
+        :param no_lock: Pass in :obj:`True` if you have acquired your own lock (default: :obj:`False`)
+        :type no_lock: :obj:`bool`
+        :rtype: :obj:`int`
+        :returns: The current value of this counter
+        """
+        if no_lock:
+            return self._value()
+
+        with self._read_lock:
+            return self._value()

--- a/ddtrace/utils/counter.py
+++ b/ddtrace/utils/counter.py
@@ -21,6 +21,7 @@ class Counter(object):
         counter.decrement()
         counter.value()  # 10
     """
+
     def __init__(self):
         self._read_count = 0
         self._increment = itertools.count()

--- a/ddtrace/utils/counter.py
+++ b/ddtrace/utils/counter.py
@@ -23,14 +23,14 @@ class Counter(object):
         self._counter = itertools.count()
         self._read_lock = threading.Lock()
 
-    def increment(self, times=1):
+    def increment(self, step=1):
         """
         Increment the counter
 
-        :param times: The number of times to increment the counter (default: ``1``)
-        :type times: int
+        :param step: The number of times to increment the counter (default: ``1``)
+        :type step: int
         """
-        for _ in range(times):
+        for _ in range(step):
             next(self._counter)
 
     def _value(self):

--- a/tests/internal/test_stats.py
+++ b/tests/internal/test_stats.py
@@ -18,8 +18,8 @@ def dogstatsd():
 
 def assert_values(stats_values, expected):
     assert len(stats_values) == len(expected)
-    actual = set(v[0:3] + (tuple(v[3]), ) for v in stats_values)
-    expected = set(v[0:3] + (tuple(v[3]), ) for v in expected)
+    actual = set(v[0:3] + (tuple(v[3]),) for v in stats_values)
+    expected = set(v[0:3] + (tuple(v[3]),) for v in expected)
     assert actual == expected
 
 
@@ -42,14 +42,14 @@ def test_stats_report_stats(stats, dogstatsd):
 
     assert dogstatsd.gauge.mock_calls == [mock.call("datadog.tracer.spans.open", 0, tags=None)]
     assert dogstatsd.increment.mock_calls == [
-        mock.call("datadog.tracer.log.errors", 1, tags=[("logger:ddtrace.tracer"),])
+        mock.call("datadog.tracer.log.errors", 1, tags=[("logger:ddtrace.tracer")])
     ]
 
     # Collect more stats
     stats.span_started()
-    stats.error_log('ddtrace.tracer')
-    stats.error_log('ddtrace.tracer')
-    stats.error_log('ddtrace.tracer')
+    stats.error_log("ddtrace.tracer")
+    stats.error_log("ddtrace.tracer")
+    stats.error_log("ddtrace.tracer")
 
     # Report stats
     dogstatsd.reset_mock()
@@ -58,7 +58,7 @@ def test_stats_report_stats(stats, dogstatsd):
     assert dogstatsd.gauge.mock_calls == [mock.call("datadog.tracer.spans.open", 1, tags=None)]
     # Diff between last report and this report
     assert dogstatsd.increment.mock_calls == [
-        mock.call("datadog.tracer.log.errors", 3, tags=[("logger:ddtrace.tracer"),])
+        mock.call("datadog.tracer.log.errors", 3, tags=[("logger:ddtrace.tracer")])
     ]
 
     # Add no more stats
@@ -70,7 +70,7 @@ def test_stats_report_stats(stats, dogstatsd):
     assert dogstatsd.gauge.mock_calls == [mock.call("datadog.tracer.spans.open", 1, tags=None)]
     # Diff between last report and this report
     assert dogstatsd.increment.mock_calls == [
-        mock.call("datadog.tracer.log.errors", 0, tags=[("logger:ddtrace.tracer"),])
+        mock.call("datadog.tracer.log.errors", 0, tags=[("logger:ddtrace.tracer")])
     ]
 
 
@@ -178,13 +178,16 @@ def test_stats_patching(stats):
     for module in ("flask", "urllib3"):
         stats.patch_error(module)
 
-    assert_values(stats.reset_values(), [
-        ("datadog.tracer.patch.success", "gauge", 1, ["module:django", ]),
-        ("datadog.tracer.patch.success", "gauge", 1, ["module:redis", ]),
-        ("datadog.tracer.patch.success", "gauge", 1, ["module:requests", ]),
-        ("datadog.tracer.patch.error", "gauge", 1, ["module:flask", ]),
-        ("datadog.tracer.patch.error", "gauge", 1, ["module:urllib3", ]),
-    ])
+    assert_values(
+        stats.reset_values(),
+        [
+            ("datadog.tracer.patch.success", "gauge", 1, ["module:django"]),
+            ("datadog.tracer.patch.success", "gauge", 1, ["module:redis"]),
+            ("datadog.tracer.patch.success", "gauge", 1, ["module:requests"]),
+            ("datadog.tracer.patch.error", "gauge", 1, ["module:flask"]),
+            ("datadog.tracer.patch.error", "gauge", 1, ["module:urllib3"]),
+        ],
+    )
 
     # Report again and they are gone
     assert stats.reset_values() == []

--- a/tests/internal/test_stats.py
+++ b/tests/internal/test_stats.py
@@ -16,10 +16,17 @@ def dogstatsd():
     return mock.Mock(spec=DogStatsd)
 
 
+def _convert_tags(val):
+    if val is None:
+        return None
+
+    return tuple(val)
+
+
 def assert_values(stats_values, expected):
     assert len(stats_values) == len(expected)
-    actual = set(v[0:3] + (tuple(v[3]),) for v in stats_values)
-    expected = set(v[0:3] + (tuple(v[3]),) for v in expected)
+    actual = set(v[0:3] + (_convert_tags(v[3]),) for v in stats_values)
+    expected = set(v[0:3] + (_convert_tags(v[3]),) for v in expected)
     assert actual == expected
 
 

--- a/tests/internal/test_stats.py
+++ b/tests/internal/test_stats.py
@@ -1,0 +1,190 @@
+import mock
+
+import pytest
+
+from ddtrace.internal.stats import Stats
+from ddtrace.vendor.dogstatsd import DogStatsd
+
+
+@pytest.fixture
+def stats():
+    return Stats()
+
+
+@pytest.fixture
+def dogstatsd():
+    return mock.Mock(spec=DogStatsd)
+
+
+def assert_values(stats_values, expected):
+    assert len(stats_values) == len(expected)
+    actual = set(v[0:3] + (tuple(v[3]), ) for v in stats_values)
+    expected = set(v[0:3] + (tuple(v[3]), ) for v in expected)
+    assert actual == expected
+
+
+def test_stats_report_no_stats(stats, dogstatsd):
+    stats.report(dogstatsd)
+
+    dogstatsd.gauge.assert_not_called()
+    dogstatsd.increment.assert_not_called()
+    dogstatsd.histogram.assert_not_called()
+
+
+def test_stats_report_stats(stats, dogstatsd):
+    # Collect some stats
+    stats.span_started()
+    stats.span_finished()
+    stats.error_log("ddtrace.tracer")
+
+    # Report stats
+    stats.report(dogstatsd)
+
+    assert dogstatsd.gauge.mock_calls == [mock.call("datadog.tracer.spans.open", 0, tags=None)]
+    assert dogstatsd.increment.mock_calls == [
+        mock.call("datadog.tracer.log.errors", 1, tags=[("logger:ddtrace.tracer"),])
+    ]
+
+    # Collect more stats
+    stats.span_started()
+    stats.error_log('ddtrace.tracer')
+    stats.error_log('ddtrace.tracer')
+    stats.error_log('ddtrace.tracer')
+
+    # Report stats
+    dogstatsd.reset_mock()
+    stats.report(dogstatsd)
+
+    assert dogstatsd.gauge.mock_calls == [mock.call("datadog.tracer.spans.open", 1, tags=None)]
+    # Diff between last report and this report
+    assert dogstatsd.increment.mock_calls == [
+        mock.call("datadog.tracer.log.errors", 3, tags=[("logger:ddtrace.tracer"),])
+    ]
+
+    # Add no more stats
+
+    # Report stats
+    dogstatsd.reset_mock()
+    stats.report(dogstatsd)
+
+    assert dogstatsd.gauge.mock_calls == [mock.call("datadog.tracer.spans.open", 1, tags=None)]
+    # Diff between last report and this report
+    assert dogstatsd.increment.mock_calls == [
+        mock.call("datadog.tracer.log.errors", 0, tags=[("logger:ddtrace.tracer"),])
+    ]
+
+
+def test_stats_reset_values(stats):
+    # No stats started
+    assert stats.reset_values() == []
+
+    # Collect some stats
+    stats.span_started()
+    stats.span_finished()
+    stats.error_log("ddtrace.tracer")
+
+    # Validate stats
+    values = stats.reset_values()
+    assert values == [
+        ("datadog.tracer.spans.open", "gauge", 0, None),
+        ("datadog.tracer.log.errors", "increment", 1, ["logger:ddtrace.tracer"]),
+    ]
+
+    # Collect more stats
+    stats.span_started()
+    stats.error_log("ddtrace.tracer")
+    stats.error_log("ddtrace.tracer")
+
+    # Validate stats
+    values = stats.reset_values()
+    assert values == [
+        ("datadog.tracer.spans.open", "gauge", 1, None),
+        ("datadog.tracer.log.errors", "increment", 2, ["logger:ddtrace.tracer"]),
+    ]
+
+    # Add no new stats
+
+    # Validate stats
+    values = stats.reset_values()
+    assert values == [
+        ("datadog.tracer.spans.open", "gauge", 1, None),
+        ("datadog.tracer.log.errors", "increment", 0, ["logger:ddtrace.tracer"]),
+    ]
+
+
+def test_stats_span_started_finished(stats):
+    # Open 5 spans
+    for _ in range(5):
+        stats.span_started()
+
+    assert stats.reset_values() == [
+        ("datadog.tracer.spans.open", "gauge", 5, None),
+    ]
+
+    # Close 2
+    stats.span_finished()
+    stats.span_finished()
+
+    assert stats.reset_values() == [
+        ("datadog.tracer.spans.open", "gauge", 3, None),
+    ]
+
+    # Open 5 more
+    for _ in range(5):
+        stats.span_started()
+
+    assert stats.reset_values() == [
+        ("datadog.tracer.spans.open", "gauge", 8, None),
+    ]
+
+    # Close all open spans
+    for _ in range(8):
+        stats.span_finished()
+
+    assert stats.reset_values() == [
+        ("datadog.tracer.spans.open", "gauge", 0, None),
+    ]
+
+
+def test_stats_error_log(stats):
+    # Assert when error logs occur
+    stats.error_log("ddtrace.tracer")
+    for _ in range(2):
+        stats.error_log("ddtrace.internal.writer")
+
+    assert stats.reset_values() == [
+        ("datadog.tracer.log.errors", "increment", 1, ["logger:ddtrace.tracer"]),
+        ("datadog.tracer.log.errors", "increment", 2, ["logger:ddtrace.internal.writer"]),
+    ]
+
+    # Assert when no new error logs occur
+    assert stats.reset_values() == [
+        ("datadog.tracer.log.errors", "increment", 0, ["logger:ddtrace.tracer"]),
+        ("datadog.tracer.log.errors", "increment", 0, ["logger:ddtrace.internal.writer"]),
+    ]
+
+    # Add more writer error logs
+    stats.error_log("ddtrace.internal.writer")
+    assert stats.reset_values() == [
+        ("datadog.tracer.log.errors", "increment", 0, ["logger:ddtrace.tracer"]),
+        ("datadog.tracer.log.errors", "increment", 1, ["logger:ddtrace.internal.writer"]),
+    ]
+
+
+def test_stats_patching(stats):
+    for module in ("django", "redis", "requests"):
+        stats.patch_success(module)
+
+    for module in ("flask", "urllib3"):
+        stats.patch_error(module)
+
+    assert_values(stats.reset_values(), [
+        ("datadog.tracer.patch.success", "gauge", 1, ["module:django", ]),
+        ("datadog.tracer.patch.success", "gauge", 1, ["module:redis", ]),
+        ("datadog.tracer.patch.success", "gauge", 1, ["module:requests", ]),
+        ("datadog.tracer.patch.error", "gauge", 1, ["module:flask", ]),
+        ("datadog.tracer.patch.error", "gauge", 1, ["module:urllib3", ]),
+    ])
+
+    # Report again and they are gone
+    assert stats.reset_values() == []

--- a/tests/internal/test_stats.py
+++ b/tests/internal/test_stats.py
@@ -84,11 +84,13 @@ def test_stats_reset_values(stats):
     stats.error_log("ddtrace.tracer")
 
     # Validate stats
-    values = stats.reset_values()
-    assert values == [
-        ("datadog.tracer.spans.open", "gauge", 0, None),
-        ("datadog.tracer.log.errors", "increment", 1, ["logger:ddtrace.tracer"]),
-    ]
+    assert_values(
+        stats.reset_values(),
+        [
+            ("datadog.tracer.spans.open", "gauge", 0, None),
+            ("datadog.tracer.log.errors", "increment", 1, ["logger:ddtrace.tracer"]),
+        ],
+    )
 
     # Collect more stats
     stats.span_started()
@@ -96,20 +98,24 @@ def test_stats_reset_values(stats):
     stats.error_log("ddtrace.tracer")
 
     # Validate stats
-    values = stats.reset_values()
-    assert values == [
-        ("datadog.tracer.spans.open", "gauge", 1, None),
-        ("datadog.tracer.log.errors", "increment", 2, ["logger:ddtrace.tracer"]),
-    ]
+    assert_values(
+        stats.reset_values(),
+        [
+            ("datadog.tracer.spans.open", "gauge", 1, None),
+            ("datadog.tracer.log.errors", "increment", 2, ["logger:ddtrace.tracer"]),
+        ],
+    )
 
     # Add no new stats
 
     # Validate stats
-    values = stats.reset_values()
-    assert values == [
-        ("datadog.tracer.spans.open", "gauge", 1, None),
-        ("datadog.tracer.log.errors", "increment", 0, ["logger:ddtrace.tracer"]),
-    ]
+    assert_values(
+        stats.reset_values(),
+        [
+            ("datadog.tracer.spans.open", "gauge", 1, None),
+            ("datadog.tracer.log.errors", "increment", 0, ["logger:ddtrace.tracer"]),
+        ],
+    )
 
 
 def test_stats_span_started_finished(stats):
@@ -152,23 +158,32 @@ def test_stats_error_log(stats):
     for _ in range(2):
         stats.error_log("ddtrace.internal.writer")
 
-    assert stats.reset_values() == [
-        ("datadog.tracer.log.errors", "increment", 1, ["logger:ddtrace.tracer"]),
-        ("datadog.tracer.log.errors", "increment", 2, ["logger:ddtrace.internal.writer"]),
-    ]
+    assert_values(
+        stats.reset_values(),
+        [
+            ("datadog.tracer.log.errors", "increment", 1, ["logger:ddtrace.tracer"]),
+            ("datadog.tracer.log.errors", "increment", 2, ["logger:ddtrace.internal.writer"]),
+        ],
+    )
 
     # Assert when no new error logs occur
-    assert stats.reset_values() == [
-        ("datadog.tracer.log.errors", "increment", 0, ["logger:ddtrace.tracer"]),
-        ("datadog.tracer.log.errors", "increment", 0, ["logger:ddtrace.internal.writer"]),
-    ]
+    assert_values(
+        stats.reset_values(),
+        [
+            ("datadog.tracer.log.errors", "increment", 0, ["logger:ddtrace.tracer"]),
+            ("datadog.tracer.log.errors", "increment", 0, ["logger:ddtrace.internal.writer"]),
+        ],
+    )
 
     # Add more writer error logs
     stats.error_log("ddtrace.internal.writer")
-    assert stats.reset_values() == [
-        ("datadog.tracer.log.errors", "increment", 0, ["logger:ddtrace.tracer"]),
-        ("datadog.tracer.log.errors", "increment", 1, ["logger:ddtrace.internal.writer"]),
-    ]
+    assert_values(
+        stats.reset_values(),
+        [
+            ("datadog.tracer.log.errors", "increment", 0, ["logger:ddtrace.tracer"]),
+            ("datadog.tracer.log.errors", "increment", 1, ["logger:ddtrace.internal.writer"]),
+        ],
+    )
 
 
 def test_stats_patching(stats):

--- a/tests/internal/test_writer.py
+++ b/tests/internal/test_writer.py
@@ -163,6 +163,7 @@ class AgentWriterTests(BaseTestCase):
         assert [
             mock.call('datadog.tracer.heartbeat', 1),
             mock.call('datadog.tracer.queue.max_length', 1000),
+            mock.call('datadog.tracer.spans.open', 0, tags=None),
         ] == self._sort_statsd_calls(self.dogstatsd.gauge.mock_calls)
 
         assert [
@@ -177,8 +178,6 @@ class AgentWriterTests(BaseTestCase):
             mock.call('datadog.tracer.queue.enqueued.spans', 77),
             mock.call('datadog.tracer.queue.enqueued.traces', 11),
             mock.call('datadog.tracer.shutdown'),
-            mock.call('datadog.tracer.spans.finished', 77, tags=None),
-            mock.call('datadog.tracer.spans.started', 77, tags=None),
         ] == self._sort_statsd_calls(self.dogstatsd.increment.mock_calls)
 
         histogram_calls = [
@@ -199,6 +198,7 @@ class AgentWriterTests(BaseTestCase):
         assert [
             mock.call('datadog.tracer.heartbeat', 1),
             mock.call('datadog.tracer.queue.max_length', 1000),
+            mock.call('datadog.tracer.spans.open', 0, tags=None),
         ] == self._sort_statsd_calls(self.dogstatsd.gauge.mock_calls)
 
         assert [
@@ -213,8 +213,6 @@ class AgentWriterTests(BaseTestCase):
             mock.call('datadog.tracer.queue.enqueued.spans', 77),
             mock.call('datadog.tracer.queue.enqueued.traces', 11),
             mock.call('datadog.tracer.shutdown'),
-            mock.call('datadog.tracer.spans.finished', 77, tags=None),
-            mock.call('datadog.tracer.spans.started', 77, tags=None),
         ] == self._sort_statsd_calls(self.dogstatsd.increment.mock_calls)
 
         histogram_calls = [

--- a/tests/internal/test_writer.py
+++ b/tests/internal/test_writer.py
@@ -6,6 +6,7 @@ import mock
 
 from ddtrace.span import Span
 from ddtrace.api import API
+from ddtrace.internal.stats import stats
 from ddtrace.internal.writer import AgentWriter, Q, Empty
 from ..base import BaseTestCase
 
@@ -66,6 +67,10 @@ class FailingAPI(object):
 
 class AgentWriterTests(BaseTestCase):
     N_TRACES = 11
+
+    def setUp(self):
+        stats.reset_values()
+        super(AgentWriterTests, self).setUp()
 
     def create_worker(self, filters=None, api_class=DummyAPI, enable_stats=False):
         with self.override_global_config(dict(health_metrics_enabled=enable_stats)):
@@ -189,7 +194,7 @@ class AgentWriterTests(BaseTestCase):
             mock.call('datadog.tracer.api.errors.total', 1, tags=None),
             mock.call('datadog.tracer.spans.started', 77, tags=None),
             mock.call('datadog.tracer.spans.finished', 77, tags=None),
-            mock.call('datadog.tracer.log.errors', 1, tags=('logger:ddtrace.internal.writer', )),
+            mock.call('datadog.tracer.log.errors', 1, tags=['logger:ddtrace.internal.writer', ]),
             mock.call('datadog.tracer.queue.dropped.traces', 0),
             mock.call('datadog.tracer.queue.enqueued.traces', 11),
             mock.call('datadog.tracer.queue.enqueued.spans', 77),

--- a/tests/internal/test_writer.py
+++ b/tests/internal/test_writer.py
@@ -141,8 +141,6 @@ class AgentWriterTests(BaseTestCase):
         self.create_worker(enable_stats=True)
         assert [
             mock.call('datadog.tracer.heartbeat', 1),
-            mock.call('datadog.tracer.spans.started', 77, tags=None),
-            mock.call('datadog.tracer.spans.finished', 77, tags=None),
             mock.call('datadog.tracer.queue.max_length', 1000),
         ] == self.dogstatsd.gauge.mock_calls
 
@@ -154,6 +152,8 @@ class AgentWriterTests(BaseTestCase):
             mock.call('datadog.tracer.api.requests.total', 11, tags=None),
             mock.call('datadog.tracer.api.errors.total', 0, tags=None),
             mock.call('datadog.tracer.api.responses.total', 11, tags=['status:200']),
+            mock.call('datadog.tracer.spans.started', 77, tags=None),
+            mock.call('datadog.tracer.spans.finished', 77, tags=None),
             mock.call('datadog.tracer.queue.dropped.traces', 0),
             mock.call('datadog.tracer.queue.enqueued.traces', 11),
             mock.call('datadog.tracer.queue.enqueued.spans', 77),
@@ -177,9 +177,6 @@ class AgentWriterTests(BaseTestCase):
         self.create_worker(api_class=FailingAPI, enable_stats=True)
         assert [
             mock.call('datadog.tracer.heartbeat', 1),
-            mock.call('datadog.tracer.spans.started', 77, tags=None),
-            mock.call('datadog.tracer.spans.finished', 77, tags=None),
-            mock.call('datadog.tracer.log.errors', 1, tags=('logger:ddtrace.internal.writer', )),
             mock.call('datadog.tracer.queue.max_length', 1000),
         ] == self.dogstatsd.gauge.mock_calls
 
@@ -190,6 +187,9 @@ class AgentWriterTests(BaseTestCase):
             mock.call('datadog.tracer.flush.traces_filtered.total', 0, tags=None),
             mock.call('datadog.tracer.api.requests.total', 1, tags=None),
             mock.call('datadog.tracer.api.errors.total', 1, tags=None),
+            mock.call('datadog.tracer.spans.started', 77, tags=None),
+            mock.call('datadog.tracer.spans.finished', 77, tags=None),
+            mock.call('datadog.tracer.log.errors', 1, tags=('logger:ddtrace.internal.writer', )),
             mock.call('datadog.tracer.queue.dropped.traces', 0),
             mock.call('datadog.tracer.queue.enqueued.traces', 11),
             mock.call('datadog.tracer.queue.enqueued.spans', 77),

--- a/tests/internal/test_writer.py
+++ b/tests/internal/test_writer.py
@@ -6,7 +6,6 @@ import mock
 
 from ddtrace.span import Span
 from ddtrace.api import API
-from ddtrace.internal.stats import stats
 from ddtrace.internal.writer import AgentWriter, Q, Empty
 from ..base import BaseTestCase
 

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 
 from ddtrace.utils.counter import Counter
@@ -27,3 +28,27 @@ def test_counter_decrement(counter):
         assert counter.value() == i
 
     assert counter.value() == -1000
+
+
+def test_counter_value_lock(counter):
+    lock = mock.MagicMock(wraps=counter._read_lock)
+    counter._read_lock = lock
+
+    counter.increment()
+
+    # Fetch the value using the built-in read lock
+    assert counter.value() == 1
+
+    # Assert that anything was called on "lock"
+    # DEV: We could assert that `__enter__` was called, but
+    #      we really just want to know "was this used at all"
+    assert lock.mock_calls
+
+    # Reset for the next validation
+    lock.reset_mock()
+
+    # Fetch the value without using the built-in read lock
+    assert counter.value(no_lock=True) == 1
+
+    # Assert nothing was called on the "lock"
+    assert not lock.mock_calls

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -1,0 +1,29 @@
+import pytest
+
+from ddtrace.utils.counter import Counter
+
+
+@pytest.fixture
+def counter():
+    return Counter()
+
+
+def test_counter_increment(counter):
+    for i in range(1, 1001):
+        counter.increment()
+
+        assert counter.value() == i
+
+    assert counter.value() == 1000
+
+
+def test_counter_decrement(counter):
+    for i in range(1, 1001):
+        counter.increment()
+    assert counter.value() == 1000
+
+    for i in range(999, -1001, -1):
+        counter.decrement()
+        assert counter.value() == i
+
+    assert counter.value() == -1000


### PR DESCRIPTION
**This PR supersedes #1136**

We want a way to collect metrics from all over the tracer, but aggregate and report once per-flush rather than reporting at the time the metric is incremented. The reason for this is to be able to effectively track things like "spans started" or "spans finished", something that will happen a lot, in the hot path of user's code. Aggregating together and reporting in a background thread when flushing is better.

This PR is still in progress, we need to add docstrings and test cases, but wanted to open to get general feedback on the approach.