### PR TITLE
core: remove unused app type

### DIFF
--- a/ddtrace/contrib/aiobotocore/patch.py
+++ b/ddtrace/contrib/aiobotocore/patch.py
@@ -23,7 +23,7 @@ def patch():
     setattr(aiobotocore.client, '_datadog_patch', True)
 
     wrapt.wrap_function_wrapper('aiobotocore.client', 'AioBaseClient._make_api_call', _wrapped_api_call)
-    Pin(service='aws', app='aws', app_type='web').onto(aiobotocore.client.AioBaseClient)
+    Pin(service='aws', app='aws').onto(aiobotocore.client.AioBaseClient)
 
 
 def unpatch():

--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -26,7 +26,7 @@ def patch():
 
         _w = wrapt.wrap_function_wrapper
         _w('aiohttp_jinja2', 'render_template', _trace_render_template)
-        Pin(app='aiohttp', service=None, app_type='web').onto(aiohttp_jinja2)
+        Pin(app='aiohttp', service=None).onto(aiohttp_jinja2)
 
 
 def unpatch():

--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -5,7 +5,7 @@ from aiopg.utils import _ContextManager
 
 from .. import dbapi
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import sql, AppTypes
+from ...ext import sql
 from ...pin import Pin
 from ...settings import config
 
@@ -77,7 +77,7 @@ class AIOTracedConnection(wrapt.ObjectProxy):
     def __init__(self, conn, pin=None, cursor_cls=AIOTracedCursor):
         super(AIOTracedConnection, self).__init__(conn)
         name = dbapi._get_vendor(conn)
-        db_pin = pin or Pin(service=name, app=name, app_type=AppTypes.db)
+        db_pin = pin or Pin(service=name, app=name)
         db_pin.onto(self)
         # wrapt requires prefix of `_self` for attributes that are only in the
         # proxy (since some of our source objects will use `__slots__`)

--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -1,4 +1,3 @@
-from ddtrace.ext import AppTypes
 from ddtrace.pin import Pin
 from ddtrace.settings import config
 from ddtrace.utils.wrappers import unwrap as _u
@@ -34,8 +33,7 @@ def patch():
     setattr(algoliasearch, '_datadog_patch', True)
 
     pin = Pin(
-        service=config.algoliasearch.service_name, app=APP_NAME,
-        app_type=AppTypes.db
+        service=config.algoliasearch.service_name, app=APP_NAME
     )
 
     if algoliasearch_version < (2, 0) and algoliasearch_version >= (1, 0):

--- a/ddtrace/contrib/boto/patch.py
+++ b/ddtrace/contrib/boto/patch.py
@@ -41,10 +41,10 @@ def patch():
     wrapt.wrap_function_wrapper(
         'boto.connection', 'AWSAuthConnection.make_request', patched_auth_request
     )
-    Pin(service='aws', app='aws', app_type='web').onto(
+    Pin(service='aws', app='aws').onto(
         boto.connection.AWSQueryConnection
     )
-    Pin(service='aws', app='aws', app_type='web').onto(
+    Pin(service='aws', app='aws').onto(
         boto.connection.AWSAuthConnection
     )
 

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -28,7 +28,7 @@ def patch():
     setattr(botocore.client, '_datadog_patch', True)
 
     wrapt.wrap_function_wrapper('botocore.client', 'BaseClient._make_api_call', patched_api_call)
-    Pin(service='aws', app='aws', app_type='web').onto(botocore.client.BaseClient)
+    Pin(service='aws', app='aws').onto(botocore.client.BaseClient)
 
 
 def unpatch():

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -32,7 +32,7 @@ def patch():
     """ patch will add tracing to the cassandra library. """
     setattr(cassandra.cluster.Cluster, 'connect',
             wrapt.FunctionWrapper(_connect, traced_connect))
-    Pin(service=SERVICE, app=SERVICE, app_type='db').onto(cassandra.cluster.Cluster)
+    Pin(service=SERVICE, app=SERVICE).onto(cassandra.cluster.Cluster)
 
 
 def unpatch():

--- a/ddtrace/contrib/celery/app.py
+++ b/ddtrace/contrib/celery/app.py
@@ -2,7 +2,6 @@ from celery import signals
 
 from ddtrace import Pin, config
 from ddtrace.pin import _DD_PIN_NAME
-from ddtrace.ext import AppTypes
 
 from .constants import APP
 from .signals import (
@@ -27,7 +26,6 @@ def patch_app(app, pin=None):
     pin = pin or Pin(
         service=config.celery['worker_service_name'],
         app=APP,
-        app_type=AppTypes.worker,
         _config=config.celery,
     )
     pin.onto(app)

--- a/ddtrace/contrib/consul/patch.py
+++ b/ddtrace/contrib/consul/patch.py
@@ -17,7 +17,7 @@ def patch():
         return
     setattr(consul, '__datadog_patch', True)
 
-    pin = Pin(service=consulx.SERVICE, app=consulx.APP, app_type=consulx.APP_TYPE)
+    pin = Pin(service=consulx.SERVICE, app=consulx.APP)
     pin.onto(consul.Consul.KV)
 
     for f_name in _KV_FUNCS:

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -3,7 +3,7 @@ Generic dbapi tracing code.
 """
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import AppTypes, sql
+from ...ext import sql
 from ...internal.logger import get_logger
 from ...pin import Pin
 from ...settings import config
@@ -155,7 +155,7 @@ class TracedConnection(wrapt.ObjectProxy):
         super(TracedConnection, self).__init__(conn)
         name = _get_vendor(conn)
         self._self_datadog_name = '{}.connection'.format(name)
-        db_pin = pin or Pin(service=name, app=name, app_type=AppTypes.db)
+        db_pin = pin or Pin(service=name, app=name)
         db_pin.onto(self)
         # wrapt requires prefix of `_self` for attributes that are only in the
         # proxy (since some of our source objects will use `__slots__`)

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -6,7 +6,7 @@ from .quantize import quantize
 
 from ...compat import urlencode
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import elasticsearch as metadata, http, AppTypes
+from ...ext import elasticsearch as metadata, http
 from ...pin import Pin
 from ...utils.wrappers import unwrap as _u
 from ...settings import config
@@ -32,7 +32,7 @@ def _patch(elasticsearch):
         return
     setattr(elasticsearch, '_datadog_patch', True)
     _w(elasticsearch.transport, 'Transport.perform_request', _get_perform_request(elasticsearch))
-    Pin(service=metadata.SERVICE, app=metadata.APP, app_type=AppTypes.db).onto(elasticsearch.transport.Transport)
+    Pin(service=metadata.SERVICE, app=metadata.APP).onto(elasticsearch.transport.Transport)
 
 
 def unpatch():

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -8,7 +8,6 @@ from ddtrace import compat
 from ddtrace import config, Pin
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import AppTypes
 from ...ext import http
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
@@ -29,7 +28,6 @@ config._add('flask', dict(
     # DEV: Environment variable 'DATADOG_SERVICE_NAME' used for backwards compatibility
     service_name=os.environ.get('DATADOG_SERVICE_NAME') or 'flask',
     app='flask',
-    app_type=AppTypes.web,
 
     collect_view_args=True,
     distributed_tracing_enabled=True,
@@ -70,8 +68,7 @@ def patch():
     # Attach service pin to `flask.app.Flask`
     Pin(
         service=config.flask['service_name'],
-        app=config.flask['app'],
-        app_type=config.flask['app_type'],
+        app=config.flask['app']
     ).onto(flask.Flask)
 
     # flask.app.Flask methods that have custom tracing (add metadata, wrap functions, etc)

--- a/ddtrace/contrib/httplib/patch.py
+++ b/ddtrace/contrib/httplib/patch.py
@@ -17,7 +17,7 @@ log = get_logger(__name__)
 
 
 def _wrap_init(func, instance, args, kwargs):
-    Pin(app='httplib', service=None, app_type=ext_http.TYPE).onto(instance)
+    Pin(app='httplib', service=None).onto(instance)
     return func(*args, **kwargs)
 
 

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -5,7 +5,6 @@ from ddtrace.vendor import wrapt
 # project
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...ext import kombu as kombux
-from ...ext import AppTypes
 from ...pin import Pin
 from ...propagation.http import HTTPPropagator
 from ...settings import config
@@ -48,14 +47,12 @@ def patch():
     _w(kombux.TYPE, 'Consumer.receive', traced_receive)
     Pin(
         service=config.kombu['service_name'],
-        app='kombu',
-        app_type=AppTypes.worker,
+        app='kombu'
     ).onto(kombu.messaging.Producer)
 
     Pin(
         service=config.kombu['service_name'],
-        app='kombu',
-        app_type=AppTypes.worker,
+        app='kombu'
     ).onto(kombu.messaging.Consumer)
 
 

--- a/ddtrace/contrib/mako/patch.py
+++ b/ddtrace/contrib/mako/patch.py
@@ -15,7 +15,7 @@ def patch():
         return
     setattr(mako, '__datadog_patch', True)
 
-    Pin(service='mako', app='mako', app_type=http.TEMPLATE).onto(Template)
+    Pin(service='mako', app='mako').onto(Template)
 
     _w(mako, 'template.Template.render', _wrap_render)
     _w(mako, 'template.Template.render_unicode', _wrap_render)

--- a/ddtrace/contrib/molten/patch.py
+++ b/ddtrace/contrib/molten/patch.py
@@ -6,7 +6,7 @@ import molten
 from ... import Pin, config
 from ...compat import urlencode
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import AppTypes, http
+from ...ext import http
 from ...propagation.http import HTTPPropagator
 from ...utils.formats import asbool, get_env
 from ...utils.importlib import func_name
@@ -19,7 +19,6 @@ MOLTEN_VERSION = tuple(map(int, molten.__version__.split()[0].split('.')))
 config._add('molten', dict(
     service_name=get_env('molten', 'service_name', 'molten'),
     app='molten',
-    app_type=AppTypes.web,
     distributed_tracing=asbool(get_env('molten', 'distributed_tracing', True)),
 ))
 
@@ -33,8 +32,7 @@ def patch():
 
     pin = Pin(
         service=config.molten['service_name'],
-        app=config.molten['app'],
-        app_type=config.molten['app_type'],
+        app=config.molten['app']
     )
 
     # add pin to module since many classes use __slots__

--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -5,7 +5,7 @@ import mysql.connector
 # project
 from ddtrace import Pin
 from ddtrace.contrib.dbapi import TracedConnection
-from ...ext import net, db, AppTypes
+from ...ext import net, db
 
 
 CONN_ATTR_BY_TAG = {
@@ -38,7 +38,7 @@ def _connect(func, instance, args, kwargs):
 def patch_conn(conn):
 
     tags = {t: getattr(conn, a) for t, a in CONN_ATTR_BY_TAG.items() if getattr(conn, a, '') != ''}
-    pin = Pin(service='mysql', app='mysql', app_type=AppTypes.db, tags=tags)
+    pin = Pin(service='mysql', app='mysql', tags=tags)
 
     # grab the metadata from the conn
     wrapped = TracedConnection(conn, pin=pin)

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -7,7 +7,7 @@ from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 from ddtrace import Pin
 from ddtrace.contrib.dbapi import TracedConnection
 
-from ...ext import net, db, AppTypes
+from ...ext import net, db
 from ...utils.wrappers import unwrap as _u
 
 KWPOS_BY_TAG = {
@@ -55,7 +55,7 @@ def patch_conn(conn, *args, **kwargs):
             for t, (k, p) in KWPOS_BY_TAG.items()
             if k in kwargs or len(args) > p}
     tags[net.TARGET_PORT] = conn.port
-    pin = Pin(service='mysql', app='mysql', app_type=AppTypes.db, tags=tags)
+    pin = Pin(service='mysql', app='mysql', tags=tags)
 
     # grab the metadata from the conn
     wrapped = TracedConnection(conn, pin=pin)

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -89,7 +89,6 @@ def patch_conn(conn, traced_conn_cls=Psycopg2TracedConnection):
     Pin(
         service='postgres',
         app='postgres',
-        app_type='db',
         tags=tags).onto(c)
 
     return c

--- a/ddtrace/contrib/pymemcache/patch.py
+++ b/ddtrace/contrib/pymemcache/patch.py
@@ -16,7 +16,7 @@ def patch():
 
     # Create a global pin with default configuration for our pymemcache clients
     Pin(
-        app=memcachedx.SERVICE, service=memcachedx.SERVICE, app_type=memcachedx.TYPE
+        app=memcachedx.SERVICE, service=memcachedx.SERVICE
     ).onto(pymemcache)
 
 

--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -10,7 +10,6 @@ from ddtrace.vendor.wrapt import ObjectProxy
 import ddtrace
 from ...compat import iteritems
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import AppTypes
 from ...ext import mongo as mongox
 from ...ext import net as netx
 from ...internal.logger import get_logger
@@ -62,7 +61,7 @@ class TracedMongoClient(ObjectProxy):
         client._topology = TracedTopology(client._topology)
 
         # Default Pin
-        ddtrace.Pin(service=mongox.TYPE, app=mongox.TYPE, app_type=AppTypes.db).onto(self)
+        ddtrace.Pin(service=mongox.TYPE, app=mongox.TYPE).onto(self)
 
     def __setddpin__(self, pin):
         pin.onto(self._topology)

--- a/ddtrace/contrib/pymysql/patch.py
+++ b/ddtrace/contrib/pymysql/patch.py
@@ -5,7 +5,7 @@ import pymysql
 # project
 from ddtrace import Pin
 from ddtrace.contrib.dbapi import TracedConnection
-from ...ext import net, db, AppTypes
+from ...ext import net, db
 
 CONN_ATTR_BY_TAG = {
     net.TARGET_HOST: 'host',
@@ -31,7 +31,7 @@ def _connect(func, instance, args, kwargs):
 
 def patch_conn(conn):
     tags = {t: getattr(conn, a, '') for t, a in CONN_ATTR_BY_TAG.items()}
-    pin = Pin(service='pymysql', app='pymysql', app_type=AppTypes.db, tags=tags)
+    pin = Pin(service='pymysql', app='pymysql', tags=tags)
 
     # grab the metadata from the conn
     wrapped = TracedConnection(conn, pin=pin)

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -6,7 +6,7 @@ from ddtrace.vendor import wrapt
 from ddtrace import config
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...pin import Pin
-from ...ext import AppTypes, redis as redisx
+from ...ext import redis as redisx
 from ...utils.wrappers import unwrap
 from .util import format_command_args, _extract_conn_tags
 
@@ -34,7 +34,7 @@ def patch():
         _w('redis', 'Redis.pipeline', traced_pipeline)
         _w('redis.client', 'Pipeline.execute', traced_execute_pipeline)
         _w('redis.client', 'Pipeline.immediate_execute_command', traced_execute_command)
-    Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP, app_type=AppTypes.db).onto(redis.StrictRedis)
+    Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP).onto(redis.StrictRedis)
 
 
 def unpatch():

--- a/ddtrace/contrib/rediscluster/patch.py
+++ b/ddtrace/contrib/rediscluster/patch.py
@@ -6,7 +6,7 @@ from ddtrace.vendor import wrapt
 from ddtrace import config
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...pin import Pin
-from ...ext import AppTypes, redis as redisx
+from ...ext import redis as redisx
 from ...utils.wrappers import unwrap
 from ..redis.patch import traced_execute_command, traced_pipeline
 from ..redis.util import format_command_args
@@ -23,7 +23,7 @@ def patch():
     _w('rediscluster', 'StrictRedisCluster.execute_command', traced_execute_command)
     _w('rediscluster', 'StrictRedisCluster.pipeline', traced_pipeline)
     _w('rediscluster', 'StrictClusterPipeline.execute', traced_execute_pipeline)
-    Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP, app_type=AppTypes.db).onto(rediscluster.StrictRedisCluster)
+    Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP).onto(rediscluster.StrictRedisCluster)
 
 
 def unpatch():

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -10,7 +10,6 @@ from ...utils.wrappers import unwrap as _u
 from .legacy import _distributed_tracing, _distributed_tracing_setter
 from .constants import DEFAULT_SERVICE
 from .connection import _wrap_send
-from ...ext import AppTypes
 
 # requests default settings
 config._add('requests', {
@@ -30,7 +29,6 @@ def patch():
     Pin(
         service=config.requests['service_name'],
         app='requests',
-        app_type=AppTypes.web,
         _config=config.requests,
     ).onto(requests.Session)
 

--- a/ddtrace/contrib/sqlalchemy/engine.py
+++ b/ddtrace/contrib/sqlalchemy/engine.py
@@ -63,8 +63,7 @@ class EngineTracer(object):
         Pin(
             app=self.vendor,
             tracer=tracer,
-            service=self.service,
-            app_type=sqlx.APP_TYPE,
+            service=self.service
         ).onto(engine)
 
         listen(engine, 'before_cursor_execute', self._before_cur_exec)

--- a/ddtrace/contrib/sqlite3/patch.py
+++ b/ddtrace/contrib/sqlite3/patch.py
@@ -5,7 +5,6 @@ from ddtrace.vendor import wrapt
 
 # project
 from ...contrib.dbapi import TracedConnection, TracedCursor, FetchTracedCursor
-from ...ext import AppTypes
 from ...pin import Pin
 from ...settings import config
 
@@ -32,7 +31,7 @@ def traced_connect(func, _, args, kwargs):
 
 def patch_conn(conn):
     wrapped = TracedSQLite(conn)
-    Pin(service='sqlite', app='sqlite', app_type=AppTypes.db).onto(wrapped)
+    Pin(service='sqlite', app='sqlite').onto(wrapped)
     return wrapped
 
 

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -53,4 +53,4 @@ def tracer_config(__init__, app, args, kwargs):
         tracer.set_tags(tags)
 
     # configure the PIN object for template rendering
-    ddtrace.Pin(app='tornado', service=service, app_type='web', tracer=tracer).onto(template)
+    ddtrace.Pin(app='tornado', service=service, tracer=tracer).onto(template)

--- a/ddtrace/contrib/vertica/patch.py
+++ b/ddtrace/contrib/vertica/patch.py
@@ -5,7 +5,7 @@ from ddtrace.vendor import wrapt
 import ddtrace
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...ext import db as dbx, sql
-from ...ext import net, AppTypes
+from ...ext import net
 from ...internal.logger import get_logger
 from ...pin import Pin
 from ...settings import config
@@ -46,7 +46,6 @@ def cursor_span_end(instance, cursor, _, conf, *args, **kwargs):
     pin = Pin(
         service=config.vertica['service_name'],
         app=APP,
-        app_type=AppTypes.db,
         tags=tags,
         _config=config.vertica['patch']['vertica_python.vertica.cursor.Cursor'],
     )
@@ -59,7 +58,6 @@ config._add(
     {
         'service_name': 'vertica',
         'app': 'vertica',
-        'app_type': 'db',
         'patch': {
             'vertica_python.vertica.connection.Connection': {
                 'routines': {
@@ -168,7 +166,6 @@ def _install_init(patch_item, patch_class, patch_mod, config):
         Pin(
             service=config['service_name'],
             app=config['app'],
-            app_type=config['app_type'],
             tags=config.get('tags', {}),
             tracer=config.get('tracer', ddtrace.tracer),
             _config=config['patch'][patch_item],

--- a/ddtrace/ext/__init__.py
+++ b/ddtrace/ext/__init__.py
@@ -1,5 +1,0 @@
-class AppTypes(object):
-    web = 'web'
-    db = 'db'
-    cache = 'cache'
-    worker = 'worker'

--- a/ddtrace/ext/consul.py
+++ b/ddtrace/ext/consul.py
@@ -1,7 +1,4 @@
-from . import AppTypes
-
 APP = 'consul'
-APP_TYPE = AppTypes.cache
 SERVICE = 'consul'
 
 CMD = 'consul.command'

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -1,9 +1,5 @@
-from ddtrace.ext import AppTypes
-
-
 # the type of the spans
 TYPE = 'sql'
-APP_TYPE = AppTypes.db
 
 # tags
 QUERY = 'sql.query'   # the query text

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -1,5 +1,7 @@
 import ddtrace
 
+from ddtrace.vendor import debtcollector
+
 from .internal.logger import get_logger
 from .vendor import wrapt
 
@@ -24,8 +26,9 @@ class Pin(object):
         >>> pin = Pin.override(conn, service='user-db')
         >>> conn = sqlite.connect('/tmp/image.db')
     """
-    __slots__ = ['app', 'app_type', 'tags', 'tracer', '_target', '_config', '_initialized']
+    __slots__ = ['app', 'tags', 'tracer', '_target', '_config', '_initialized']
 
+    @debtcollector.removals.removed_kwarg("app_type")
     def __init__(self, service, app=None, app_type=None, tags=None, tracer=None, _config=None):
         tracer = tracer or ddtrace.tracer
         self.app = app
@@ -100,6 +103,7 @@ class Pin(object):
         return pin
 
     @classmethod
+    @debtcollector.removals.removed_kwarg("app_type")
     def override(cls, obj, service=None, app=None, app_type=None, tags=None, tracer=None):
         """Override an object with the given attributes.
 
@@ -156,6 +160,7 @@ class Pin(object):
         except AttributeError:
             log.debug("can't remove pin from object. skipping", exc_info=True)
 
+    @debtcollector.removals.removed_kwarg("app_type")
     def clone(self, service=None, app=None, app_type=None, tags=None, tracer=None):
         """Return a clone of the pin with the given attributes replaced."""
         # do a shallow copy of Pin dicts

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -29,7 +29,6 @@ class Pin(object):
     def __init__(self, service, app=None, app_type=None, tags=None, tracer=None, _config=None):
         tracer = tracer or ddtrace.tracer
         self.app = app
-        self.app_type = app_type
         self.tags = tags
         self.tracer = tracer
         self._target = None
@@ -53,8 +52,8 @@ class Pin(object):
         super(Pin, self).__setattr__(name, value)
 
     def __repr__(self):
-        return 'Pin(service=%s, app=%s, app_type=%s, tags=%s, tracer=%s)' % (
-            self.service, self.app, self.app_type, self.tags, self.tracer)
+        return 'Pin(service=%s, app=%s, tags=%s, tracer=%s)' % (
+            self.service, self.app, self.tags, self.tracer)
 
     @staticmethod
     def _find(*objs):
@@ -121,7 +120,6 @@ class Pin(object):
         pin.clone(
             service=service,
             app=app,
-            app_type=app_type,
             tags=tags,
             tracer=tracer,
         ).onto(obj)
@@ -175,7 +173,6 @@ class Pin(object):
         return Pin(
             service=service or self.service,
             app=app or self.app,
-            app_type=app_type or self.app_type,
             tags=tags,
             tracer=tracer or self.tracer,  # do not clone the Tracer
             _config=config,

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -533,10 +533,6 @@ class Tracer(object):
     @deprecated(message='Manually setting service info is no longer necessary', version='1.0.0')
     def set_service_info(self, *args, **kwargs):
         """Set the information about the given service.
-
-        :param str service: the internal name of the service (e.g. acme_search, datadog_web)
-        :param str app: the off the shelf name of the application (e.g. rails, postgres, custom-app)
-        :param str app_type: the type of the application (e.g. db, web)
         """
         return
 

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -53,7 +53,6 @@ class TestSQLite(BaseTracerTestCase):
             db = sqlite3.connect(':memory:')
             pin = Pin.get_from(db)
             assert pin
-            self.assertEqual('db', pin.app_type)
             pin.clone(
                 service=service,
                 tracer=self.tracer).onto(db)
@@ -194,7 +193,6 @@ class TestSQLite(BaseTracerTestCase):
             db = sqlite3.connect(':memory:')
             pin = Pin.get_from(db)
             assert pin
-            self.assertEqual('db', pin.app_type)
             pin.clone(tracer=self.tracer).onto(db)
             cursor = db.execute(q)
             rows = cursor.fetchall()
@@ -213,7 +211,6 @@ class TestSQLite(BaseTracerTestCase):
                 db = sqlite3.connect(':memory:')
                 pin = Pin.get_from(db)
                 assert pin
-                self.assertEqual('db', pin.app_type)
                 pin.clone(tracer=self.tracer).onto(db)
                 cursor = db.execute(q)
                 rows = cursor.fetchall()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -277,21 +277,6 @@ class TestAPITransport(TestCase):
         for k, v in expected_headers.items():
             assert v == headers[k]
 
-    @mock.patch('ddtrace.api.httplib.HTTPConnection')
-    def test_send_presampler_headers_not_in_services(self, mocked_http):
-        # register some services and send them to the trace agent
-        services = [{
-            'client.service': {
-                'app': 'django',
-                'app_type': 'web',
-            },
-        }]
-
-        # make a call and retrieve the `conn` Mock object
-        self.api_msgpack.send_services(services)
-        request_call = mocked_http.return_value.request
-        assert request_call.call_count == 0
-
     def _send_traces_and_check(self, traces, nresponses=1):
         # test JSON encoder
         responses = self.api_json.send_traces(traces)
@@ -366,44 +351,6 @@ class TestAPITransport(TestCase):
         traces = [trace_1, trace_2]
 
         self._send_traces_and_check(traces)
-
-    def test_send_single_service(self):
-        # register some services and send them to the trace agent
-        services = [{
-            'client.service': {
-                'app': 'django',
-                'app_type': 'web',
-            },
-        }]
-
-        # test JSON encoder
-        response = self.api_json.send_services(services)
-        assert response is None
-
-        # test Msgpack encoder
-        response = self.api_msgpack.send_services(services)
-        assert response is None
-
-    def test_send_service_called_multiple_times(self):
-        # register some services and send them to the trace agent
-        services = [{
-            'backend': {
-                'app': 'django',
-                'app_type': 'web',
-            },
-            'database': {
-                'app': 'postgres',
-                'app_type': 'db',
-            },
-        }]
-
-        # test JSON encoder
-        response = self.api_json.send_services(services)
-        assert response is None
-
-        # test Msgpack encoder
-        response = self.api_msgpack.send_services(services)
-        assert response is None
 
 
 @skipUnless(


### PR DESCRIPTION
Since the deprecation of sending service info in #811, the library has kept the construct of an "app type" without it being used by any integration when creating spans. This PR removes any reference and deprecates the `app_type` slot in `Pin`.