### PR TITLE
Pin multidict dependency for aiobotocore02 tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -157,6 +157,7 @@ deps =
     aiobotocore04: aiobotocore>=0.4,<0.5
     aiobotocore03: aiobotocore>=0.3,<0.4
     aiobotocore02: aiobotocore>=0.2,<0.3
+    aiobotocore02: multidict==4.5.2
     aiobotocore{02,03,04}-{py34}: typing
     aiopg012: aiopg>=0.12,<0.13
     aiopg015: aiopg>=0.15,<0.16


### PR DESCRIPTION
The new version of multidict released yesterday (4.6.0) causes failures in aiobotocore2 tests. Pinning version as a workaround. Note: I ran into this problem only once the build cache had been invalidated.

Signed-off-by: Alex Boten <aboten@lightstep.com>