### PR TITLE
Remove testing for aiobotocore 0.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,9 +27,9 @@ envlist =
     {py27,py34,py35,py36,py37}-test_utils
     {py27,py34,py35,py36,py37}-test_logging
 # Integrations environments
-    aiobotocore_contrib-py34-aiobotocore{02,03,04}
-    aiobotocore_contrib-{py35,py36}-aiobotocore{02,03,04,05,07,08,09,010}
-    # aiobotocore 0.2 and 0.4 do not work because they use async as a reserved keyword
+    aiobotocore_contrib-py34-aiobotocore{03,04}
+    aiobotocore_contrib-{py35,py36}-aiobotocore{03,04,05,07,08,09,010}
+    # aiobotocore 0.4 do not work because it uses async as a reserved keyword
     aiobotocore_contrib-py37-aiobotocore{03,05,07,08,09,010}
     # Python 3.7 needs at least aiohttp 2.3
     aiohttp_contrib-{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
@@ -156,8 +156,7 @@ deps =
     aiobotocore05: aiobotocore>=0.5,<0.6
     aiobotocore04: aiobotocore>=0.4,<0.5
     aiobotocore03: aiobotocore>=0.3,<0.4
-    aiobotocore02: aiobotocore>=0.2,<0.3
-    aiobotocore{02,03,04}-{py34}: typing
+    aiobotocore{03,04}-{py34}: typing
     aiopg012: aiopg>=0.12,<0.13
     aiopg015: aiopg>=0.15,<0.16
     aiopg: sqlalchemy


### PR DESCRIPTION
This version does not work anymore without some hack on its dependency. Since
it's 3 years old, does not support Python 3.7, etc, it's safe to remove it from
our test matrix.

Supersed #1145