### PR TITLE
internal: use debtcollector for keyword argument warnings

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -2,6 +2,7 @@ import functools
 import logging
 from os import environ, getpid
 
+from ddtrace.vendor import debtcollector
 
 from .constants import FILTERS_KEY, SAMPLE_RATE_METRIC_KEY
 from .ext import system
@@ -14,7 +15,7 @@ from .context import Context
 from .sampler import AllSampler, DatadogSampler, RateSampler, RateByServiceSampler
 from .span import Span
 from .utils.formats import get_env
-from .utils.deprecation import deprecated, warn
+from .utils.deprecation import deprecated, RemovedInDDTrace10Warning
 from .vendor.dogstatsd import DogStatsd
 from . import compat
 
@@ -162,6 +163,10 @@ class Tracer(object):
         return self._context_provider
 
     # TODO: deprecate this method and make sure users create a new tracer if they need different parameters
+    @debtcollector.removals.removed_kwarg("dogstatsd_host", "Use `dogstatsd_url` instead",
+                                          category=RemovedInDDTrace10Warning)
+    @debtcollector.removals.removed_kwarg("dogstatsd_port", "Use `dogstatsd_url` instead",
+                                          category=RemovedInDDTrace10Warning)
     def configure(self, enabled=None, hostname=None, port=None, uds_path=None, https=None,
                   sampler=None, context_provider=None, wrap_executor=None, priority_sampling=None,
                   settings=None, collect_metrics=None, dogstatsd_host=None, dogstatsd_port=None,
@@ -213,8 +218,6 @@ class Tracer(object):
 
         if dogstatsd_host is not None and dogstatsd_url is None:
             dogstatsd_url = 'udp://{}:{}'.format(dogstatsd_host, dogstatsd_port or self.DEFAULT_DOGSTATSD_PORT)
-            warn(('tracer.configure(): dogstatsd_host and dogstatsd_port are deprecated. '
-                  'Use dogstatsd_url={!r}').format(dogstatsd_url))
 
         if dogstatsd_url is not None:
             dogstatsd_kwargs = _parse_dogstatsd_url(dogstatsd_url)

--- a/ddtrace/vendor/__init__.py
+++ b/ddtrace/vendor/__init__.py
@@ -72,6 +72,18 @@ Notes:
   The source `monotonic.py` was added as `monotonic/__init__.py`
 
   No other changes were made
+
+debtcollector
+-------------
+
+Website: https://docs.openstack.org/debtcollector/latest/index.html
+Source: https://github.com/openstack/debtcollector
+Version: 1.22.0
+License: Apache License 2.0
+
+Notes:
+   Removed dependency on `pbr` and manually set `__version__`
+
 """
 
 # Initialize `ddtrace.vendor.datadog.base.log` logger with our custom rate limited logger

--- a/ddtrace/vendor/debtcollector/__init__.py
+++ b/ddtrace/vendor/debtcollector/__init__.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from . import _utils, moves, removals, renames, updating
+
+__version__ = "1.22.0"
+
+
+def deprecate(prefix, postfix=None, message=None,
+              version=None, removal_version=None,
+              stacklevel=3, category=DeprecationWarning):
+    """Helper to deprecate some thing using generated message format.
+
+    :param prefix: prefix string used as the prefix of the output message
+    :param postfix: postfix string used as the postfix of the output message
+    :param message: message string used as ending contents of the deprecate
+                    message
+    :param version: version string (represents the version this
+                    deprecation was created in)
+    :param removal_version: version string (represents the version this
+                            deprecation will be removed in); a string of '?'
+                            will denote this will be removed in some future
+                            unknown version
+    :param stacklevel: stacklevel used in the :func:`warnings.warn` function
+                       to locate where the users code is in the
+                       :func:`warnings.warn` call
+    :param category: the :mod:`warnings` category to use, defaults to
+                     :py:class:`DeprecationWarning` if not provided
+    """
+    out_message = _utils.generate_message(prefix, postfix=postfix,
+                                          version=version, message=message,
+                                          removal_version=removal_version)
+    _utils.deprecation(out_message, stacklevel=stacklevel,
+                       category=category)

--- a/ddtrace/vendor/debtcollector/_utils.py
+++ b/ddtrace/vendor/debtcollector/_utils.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+
+#    Copyright (C) 2015 Yahoo! Inc. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import functools
+import inspect
+import types
+import warnings
+
+import six
+
+try:
+    _TYPE_TYPE = types.TypeType
+except AttributeError:
+    _TYPE_TYPE = type
+
+
+# See: https://docs.python.org/2/library/__builtin__.html#module-__builtin__
+# and see https://docs.python.org/2/reference/executionmodel.html (and likely
+# others)...
+_BUILTIN_MODULES = ('builtins', '__builtin__', '__builtins__', 'exceptions')
+_enabled = True
+
+
+def deprecation(message, stacklevel=None, category=None):
+    """Warns about some type of deprecation that has been (or will be) made.
+
+    This helper function makes it easier to interact with the warnings module
+    by standardizing the arguments that the warning function receives so that
+    it is easier to use.
+
+    This should be used to emit warnings to users (users can easily turn these
+    warnings off/on, see https://docs.python.org/2/library/warnings.html
+    as they see fit so that the messages do not fill up the users logs with
+    warnings that they do not wish to see in production) about functions,
+    methods, attributes or other code that is deprecated and will be removed
+    in a future release (this is done using these warnings to avoid breaking
+    existing users of those functions, methods, code; which a library should
+    avoid doing by always giving at *least* N + 1 release for users to address
+    the deprecation warnings).
+    """
+    if not _enabled:
+        return
+    if category is None:
+        category = DeprecationWarning
+    if stacklevel is None:
+        warnings.warn(message, category=category)
+    else:
+        warnings.warn(message, category=category, stacklevel=stacklevel)
+
+
+def get_qualified_name(obj):
+    # Prefer the py3.x name (if we can get at it...)
+    try:
+        return (True, obj.__qualname__)
+    except AttributeError:
+        return (False, obj.__name__)
+
+
+def generate_message(prefix, postfix=None, message=None,
+                     version=None, removal_version=None):
+    """Helper to generate a common message 'style' for deprecation helpers."""
+    message_components = [prefix]
+    if version:
+        message_components.append(" in version '%s'" % version)
+    if removal_version:
+        if removal_version == "?":
+            message_components.append(" and will be removed in a future"
+                                      " version")
+        else:
+            message_components.append(" and will be removed in version '%s'"
+                                      % removal_version)
+    if postfix:
+        message_components.append(postfix)
+    if message:
+        message_components.append(": %s" % message)
+    return ''.join(message_components)
+
+
+def get_assigned(decorator):
+    """Helper to fix/workaround https://bugs.python.org/issue3445"""
+    if six.PY3:
+        return functools.WRAPPER_ASSIGNMENTS
+    else:
+        assigned = []
+        for attr_name in functools.WRAPPER_ASSIGNMENTS:
+            if hasattr(decorator, attr_name):
+                assigned.append(attr_name)
+        return tuple(assigned)
+
+
+def get_class_name(obj, fully_qualified=True):
+    """Get class name for object.
+
+    If object is a type, fully qualified name of the type is returned.
+    Else, fully qualified name of the type of the object is returned.
+    For builtin types, just name is returned.
+    """
+    if not isinstance(obj, six.class_types):
+        obj = type(obj)
+    try:
+        built_in = obj.__module__ in _BUILTIN_MODULES
+    except AttributeError:
+        pass
+    else:
+        if built_in:
+            return obj.__name__
+
+    if fully_qualified and hasattr(obj, '__module__'):
+        return '%s.%s' % (obj.__module__, obj.__name__)
+    else:
+        return obj.__name__
+
+
+def get_method_self(method):
+    """Gets the ``self`` object attached to this method (or none)."""
+    if not inspect.ismethod(method):
+        return None
+    try:
+        return six.get_method_self(method)
+    except AttributeError:
+        return None
+
+
+def get_callable_name(function):
+    """Generate a name from callable.
+
+    Tries to do the best to guess fully qualified callable name.
+    """
+    method_self = get_method_self(function)
+    if method_self is not None:
+        # This is a bound method.
+        if isinstance(method_self, six.class_types):
+            # This is a bound class method.
+            im_class = method_self
+        else:
+            im_class = type(method_self)
+        try:
+            parts = (im_class.__module__, function.__qualname__)
+        except AttributeError:
+            parts = (im_class.__module__, im_class.__name__, function.__name__)
+    elif inspect.ismethod(function) or inspect.isfunction(function):
+        # This could be a function, a static method, a unbound method...
+        try:
+            parts = (function.__module__, function.__qualname__)
+        except AttributeError:
+            if hasattr(function, 'im_class'):
+                # This is a unbound method, which exists only in python 2.x
+                im_class = function.im_class
+                parts = (im_class.__module__,
+                         im_class.__name__, function.__name__)
+            else:
+                parts = (function.__module__, function.__name__)
+    else:
+        im_class = type(function)
+        if im_class is _TYPE_TYPE:
+            im_class = function
+        try:
+            parts = (im_class.__module__, im_class.__qualname__)
+        except AttributeError:
+            parts = (im_class.__module__, im_class.__name__)
+    # When running under sphinx it appears this can be none? if so just
+    # don't include it...
+    mod, rest = (parts[0], parts[1:])
+    if not mod:
+        return '.'.join(rest)
+    else:
+        return '.'.join(parts)

--- a/ddtrace/vendor/debtcollector/moves.py
+++ b/ddtrace/vendor/debtcollector/moves.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+
+#    Copyright (C) 2015 Yahoo! Inc. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import inspect
+
+from ddtrace.vendor import six
+from ddtrace.vendor import wrapt
+
+from . import _utils
+
+_KIND_MOVED_PREFIX_TPL = "%s '%s' has moved to '%s'"
+_CLASS_MOVED_PREFIX_TPL = "Class '%s' has moved to '%s'"
+_MOVED_CALLABLE_POSTFIX = "()"
+_FUNC_MOVED_PREFIX_TPL = "Function '%s' has moved to '%s'"
+
+
+def _moved_decorator(kind, new_attribute_name, message=None,
+                     version=None, removal_version=None, stacklevel=3,
+                     attr_postfix=None, category=None):
+    """Decorates a method/property that was moved to another location."""
+
+    def decorator(f):
+        fully_qualified, old_attribute_name = _utils.get_qualified_name(f)
+        if attr_postfix:
+            old_attribute_name += attr_postfix
+
+        @wrapt.decorator
+        def wrapper(wrapped, instance, args, kwargs):
+            base_name = _utils.get_class_name(wrapped, fully_qualified=False)
+            if fully_qualified:
+                old_name = old_attribute_name
+            else:
+                old_name = ".".join((base_name, old_attribute_name))
+            new_name = ".".join((base_name, new_attribute_name))
+            prefix = _KIND_MOVED_PREFIX_TPL % (kind, old_name, new_name)
+            out_message = _utils.generate_message(
+                prefix, message=message,
+                version=version, removal_version=removal_version)
+            _utils.deprecation(out_message, stacklevel=stacklevel,
+                               category=category)
+            return wrapped(*args, **kwargs)
+
+        return wrapper(f)
+
+    return decorator
+
+
+def moved_function(new_func, old_func_name, old_module_name,
+                   message=None, version=None, removal_version=None,
+                   stacklevel=3, category=None):
+    """Deprecates a function that was moved to another location.
+
+    This generates a wrapper around ``new_func`` that will emit a deprecation
+    warning when called. The warning message will include the new location
+    to obtain the function from.
+    """
+    new_func_full_name = _utils.get_callable_name(new_func)
+    new_func_full_name += _MOVED_CALLABLE_POSTFIX
+    old_func_full_name = ".".join([old_module_name, old_func_name])
+    old_func_full_name += _MOVED_CALLABLE_POSTFIX
+    prefix = _FUNC_MOVED_PREFIX_TPL % (old_func_full_name, new_func_full_name)
+    out_message = _utils.generate_message(prefix,
+                                          message=message, version=version,
+                                          removal_version=removal_version)
+
+    @six.wraps(new_func, assigned=_utils.get_assigned(new_func))
+    def old_new_func(*args, **kwargs):
+        _utils.deprecation(out_message, stacklevel=stacklevel,
+                           category=category)
+        return new_func(*args, **kwargs)
+
+    old_new_func.__name__ = old_func_name
+    old_new_func.__module__ = old_module_name
+    return old_new_func
+
+
+class moved_read_only_property(object):
+    """Descriptor for read-only properties moved to another location.
+
+    This works like the ``@property`` descriptor but can be used instead to
+    provide the same functionality and also interact with the :mod:`warnings`
+    module to warn when a property is accessed, so that users of those
+    properties can know that a previously read-only property at a prior
+    location/name has moved to another location/name.
+
+    :param old_name: old attribute location/name
+    :param new_name: new attribute location/name
+    :param version: version string (represents the version this deprecation
+                    was created in)
+    :param removal_version: version string (represents the version this
+                            deprecation will be removed in); a string
+                            of '?' will denote this will be removed in
+                            some future unknown version
+    :param stacklevel: stacklevel used in the :func:`warnings.warn` function
+                       to locate where the users code is when reporting the
+                       deprecation call (the default being 3)
+    :param category: the :mod:`warnings` category to use, defaults to
+                     :py:class:`DeprecationWarning` if not provided
+    """
+
+    def __init__(self, old_name, new_name,
+                 version=None, removal_version=None,
+                 stacklevel=3, category=None):
+        self._old_name = old_name
+        self._new_name = new_name
+        self._message = _utils.generate_message(
+            "Read-only property '%s' has moved"
+            " to '%s'" % (self._old_name, self._new_name),
+            version=version, removal_version=removal_version)
+        self._stacklevel = stacklevel
+        self._category = category
+
+    def __get__(self, instance, owner):
+        _utils.deprecation(self._message,
+                           stacklevel=self._stacklevel,
+                           category=self._category)
+        # This handles the descriptor being applied on a
+        # instance or a class and makes both work correctly...
+        if instance is not None:
+            real_owner = instance
+        else:
+            real_owner = owner
+        return getattr(real_owner, self._new_name)
+
+
+def moved_method(new_method_name, message=None,
+                 version=None, removal_version=None, stacklevel=3,
+                 category=None):
+    """Decorates an *instance* method that was moved to another location."""
+    if not new_method_name.endswith(_MOVED_CALLABLE_POSTFIX):
+        new_method_name += _MOVED_CALLABLE_POSTFIX
+    return _moved_decorator('Method', new_method_name, message=message,
+                            version=version, removal_version=removal_version,
+                            stacklevel=stacklevel,
+                            attr_postfix=_MOVED_CALLABLE_POSTFIX,
+                            category=category)
+
+
+def moved_property(new_attribute_name, message=None,
+                   version=None, removal_version=None, stacklevel=3,
+                   category=None):
+    """Decorates an *instance* property that was moved to another location."""
+    return _moved_decorator('Property', new_attribute_name, message=message,
+                            version=version, removal_version=removal_version,
+                            stacklevel=stacklevel, category=category)
+
+
+def moved_class(new_class, old_class_name, old_module_name,
+                message=None, version=None, removal_version=None,
+                stacklevel=3, category=None):
+    """Deprecates a class that was moved to another location.
+
+    This creates a 'new-old' type that can be used for a
+    deprecation period that can be inherited from. This will emit warnings
+    when the old locations class is initialized, telling where the new and
+    improved location for the old class now is.
+    """
+
+    if not inspect.isclass(new_class):
+        _qual, type_name = _utils.get_qualified_name(type(new_class))
+        raise TypeError("Unexpected class type '%s' (expected"
+                        " class type only)" % type_name)
+
+    old_name = ".".join((old_module_name, old_class_name))
+    new_name = _utils.get_class_name(new_class)
+    prefix = _CLASS_MOVED_PREFIX_TPL % (old_name, new_name)
+    out_message = _utils.generate_message(
+        prefix, message=message, version=version,
+        removal_version=removal_version)
+
+    def decorator(f):
+
+        @six.wraps(f, assigned=_utils.get_assigned(f))
+        def wrapper(self, *args, **kwargs):
+            _utils.deprecation(out_message, stacklevel=stacklevel,
+                               category=category)
+            return f(self, *args, **kwargs)
+
+        return wrapper
+
+    old_class = type(old_class_name, (new_class,), {})
+    old_class.__module__ = old_module_name
+    old_class.__init__ = decorator(old_class.__init__)
+    return old_class

--- a/ddtrace/vendor/debtcollector/removals.py
+++ b/ddtrace/vendor/debtcollector/removals.py
@@ -1,0 +1,334 @@
+# Copyright 2014 Hewlett-Packard Development Company, L.P.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import functools
+import inspect
+
+from ddtrace.vendor import six
+from ddtrace.vendor import wrapt
+
+from . import _utils
+
+
+def _get_qualified_name(obj):
+    return _utils.get_qualified_name(obj)[1]
+
+
+def _fetch_first_result(fget, fset, fdel, apply_func, value_not_found=None):
+    """Fetch first non-none/empty result of applying ``apply_func``."""
+    for f in filter(None, (fget, fset, fdel)):
+        result = apply_func(f)
+        if result:
+            return result
+    return value_not_found
+
+
+class removed_property(object):
+    """Property descriptor that deprecates a property.
+
+    This works like the ``@property`` descriptor but can be used instead to
+    provide the same functionality and also interact with the :mod:`warnings`
+    module to warn when a property is accessed, set and/or deleted.
+
+    :param message: string used as ending contents of the deprecate message
+    :param version: version string (represents the version this deprecation
+                    was created in)
+    :param removal_version: version string (represents the version this
+                            deprecation will be removed in); a string
+                            of '?' will denote this will be removed in
+                            some future unknown version
+    :param stacklevel: stacklevel used in the :func:`warnings.warn` function
+                       to locate where the users code is when reporting the
+                       deprecation call (the default being 3)
+    :param category: the :mod:`warnings` category to use, defaults to
+                     :py:class:`DeprecationWarning` if not provided
+    """
+
+    # Message templates that will be turned into real messages as needed.
+    _PROPERTY_GONE_TPLS = {
+        'set': "Setting the '%s' property is deprecated",
+        'get': "Reading the '%s' property is deprecated",
+        'delete': "Deleting the '%s' property is deprecated",
+    }
+
+    def __init__(self, fget=None, fset=None, fdel=None, doc=None,
+                 stacklevel=3, category=DeprecationWarning,
+                 version=None, removal_version=None, message=None):
+        self.fset = fset
+        self.fget = fget
+        self.fdel = fdel
+        self.stacklevel = stacklevel
+        self.category = category
+        self.version = version
+        self.removal_version = removal_version
+        self.message = message
+        if doc is None and inspect.isfunction(fget):
+            doc = getattr(fget, '__doc__', None)
+        self._message_cache = {}
+        self.__doc__ = doc
+
+    def _fetch_message_from_cache(self, kind):
+        try:
+            out_message = self._message_cache[kind]
+        except KeyError:
+            prefix_tpl = self._PROPERTY_GONE_TPLS[kind]
+            prefix = prefix_tpl % _fetch_first_result(
+                self.fget, self.fset, self.fdel, _get_qualified_name,
+                value_not_found="???")
+            out_message = _utils.generate_message(
+                prefix, message=self.message, version=self.version,
+                removal_version=self.removal_version)
+            self._message_cache[kind] = out_message
+        return out_message
+
+    def __call__(self, fget, **kwargs):
+        self.fget = fget
+        self.message = kwargs.get('message', self.message)
+        self.version = kwargs.get('version', self.version)
+        self.removal_version = kwargs.get('removal_version',
+                                          self.removal_version)
+        self.stacklevel = kwargs.get('stacklevel', self.stacklevel)
+        self.category = kwargs.get('category', self.category)
+        self.__doc__ = kwargs.get('doc',
+                                  getattr(fget, '__doc__', self.__doc__))
+        # Regenerate all the messages...
+        self._message_cache.clear()
+        return self
+
+    def __delete__(self, obj):
+        if self.fdel is None:
+            raise AttributeError("can't delete attribute")
+        out_message = self._fetch_message_from_cache('delete')
+        _utils.deprecation(out_message, stacklevel=self.stacklevel,
+                           category=self.category)
+        self.fdel(obj)
+
+    def __set__(self, obj, value):
+        if self.fset is None:
+            raise AttributeError("can't set attribute")
+        out_message = self._fetch_message_from_cache('set')
+        _utils.deprecation(out_message, stacklevel=self.stacklevel,
+                           category=self.category)
+        self.fset(obj, value)
+
+    def __get__(self, obj, value):
+        if obj is None:
+            return self
+        if self.fget is None:
+            raise AttributeError("unreadable attribute")
+        out_message = self._fetch_message_from_cache('get')
+        _utils.deprecation(out_message, stacklevel=self.stacklevel,
+                           category=self.category)
+        return self.fget(obj)
+
+    def getter(self, fget):
+        o = type(self)(fget, self.fset, self.fdel, self.__doc__)
+        o.message = self.message
+        o.version = self.version
+        o.stacklevel = self.stacklevel
+        o.removal_version = self.removal_version
+        o.category = self.category
+        return o
+
+    def setter(self, fset):
+        o = type(self)(self.fget, fset, self.fdel, self.__doc__)
+        o.message = self.message
+        o.version = self.version
+        o.stacklevel = self.stacklevel
+        o.removal_version = self.removal_version
+        o.category = self.category
+        return o
+
+    def deleter(self, fdel):
+        o = type(self)(self.fget, self.fset, fdel, self.__doc__)
+        o.message = self.message
+        o.version = self.version
+        o.stacklevel = self.stacklevel
+        o.removal_version = self.removal_version
+        o.category = self.category
+        return o
+
+
+def remove(f=None, message=None, version=None, removal_version=None,
+           stacklevel=3, category=None):
+    """Decorates a function, method, or class to emit a deprecation warning
+
+    Due to limitations of the wrapt library (and python) itself, if this
+    is applied to subclasses of metaclasses then it likely will not work
+    as expected. More information can be found at bug #1520397 to see if
+    this situation affects your usage of this *universal* decorator, for
+    this specific scenario please use :py:func:`.removed_class` instead.
+
+    :param str message: A message to include in the deprecation warning
+    :param str version: Specify what version the removed function is present in
+    :param str removal_version: What version the function will be removed. If
+                                '?' is used this implies an undefined future
+                                version
+    :param int stacklevel: How many entries deep in the call stack before
+                           ignoring
+    :param type category: warnings message category (this defaults to
+                          ``DeprecationWarning`` when none is provided)
+    """
+    if f is None:
+        return functools.partial(remove, message=message,
+                                 version=version,
+                                 removal_version=removal_version,
+                                 stacklevel=stacklevel,
+                                 category=category)
+
+    @wrapt.decorator
+    def wrapper(f, instance, args, kwargs):
+        qualified, f_name = _utils.get_qualified_name(f)
+        if qualified:
+            if inspect.isclass(f):
+                prefix_pre = "Using class"
+                thing_post = ''
+            else:
+                prefix_pre = "Using function/method"
+                thing_post = '()'
+        if not qualified:
+            prefix_pre = "Using function/method"
+            base_name = None
+            if instance is None:
+                # Decorator was used on a class
+                if inspect.isclass(f):
+                    prefix_pre = "Using class"
+                    thing_post = ''
+                    module_name = _get_qualified_name(inspect.getmodule(f))
+                    if module_name == '__main__':
+                        f_name = _utils.get_class_name(
+                            f, fully_qualified=False)
+                    else:
+                        f_name = _utils.get_class_name(
+                            f, fully_qualified=True)
+                # Decorator was a used on a function
+                else:
+                    thing_post = '()'
+                    module_name = _get_qualified_name(inspect.getmodule(f))
+                    if module_name != '__main__':
+                        f_name = _utils.get_callable_name(f)
+            # Decorator was used on a classmethod or instancemethod
+            else:
+                thing_post = '()'
+                base_name = _utils.get_class_name(instance,
+                                                  fully_qualified=False)
+            if base_name:
+                thing_name = ".".join([base_name, f_name])
+            else:
+                thing_name = f_name
+        else:
+            thing_name = f_name
+        if thing_post:
+            thing_name += thing_post
+        prefix = prefix_pre + " '%s' is deprecated" % (thing_name)
+        out_message = _utils.generate_message(
+            prefix,
+            version=version,
+            removal_version=removal_version,
+            message=message)
+        _utils.deprecation(out_message,
+                           stacklevel=stacklevel, category=category)
+        return f(*args, **kwargs)
+    return wrapper(f)
+
+
+def removed_kwarg(old_name, message=None,
+                  version=None, removal_version=None, stacklevel=3,
+                  category=None):
+    """Decorates a kwarg accepting function to deprecate a removed kwarg."""
+
+    prefix = "Using the '%s' argument is deprecated" % old_name
+    out_message = _utils.generate_message(
+        prefix, postfix=None, message=message, version=version,
+        removal_version=removal_version)
+
+    @wrapt.decorator
+    def wrapper(f, instance, args, kwargs):
+        if old_name in kwargs:
+            _utils.deprecation(out_message,
+                               stacklevel=stacklevel, category=category)
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
+def removed_class(cls_name, replacement=None, message=None,
+                  version=None, removal_version=None, stacklevel=3,
+                  category=None):
+    """Decorates a class to denote that it will be removed at some point."""
+
+    def _wrap_it(old_init, out_message):
+
+        @six.wraps(old_init, assigned=_utils.get_assigned(old_init))
+        def new_init(self, *args, **kwargs):
+            _utils.deprecation(out_message, stacklevel=stacklevel,
+                               category=category)
+            return old_init(self, *args, **kwargs)
+
+        return new_init
+
+    def _check_it(cls):
+        if not inspect.isclass(cls):
+            _qual, type_name = _utils.get_qualified_name(type(cls))
+            raise TypeError("Unexpected class type '%s' (expected"
+                            " class type only)" % type_name)
+
+    def _cls_decorator(cls):
+        _check_it(cls)
+        out_message = _utils.generate_message(
+            "Using class '%s' (either directly or via inheritance)"
+            " is deprecated" % cls_name, postfix=None, message=message,
+            version=version, removal_version=removal_version)
+        cls.__init__ = _wrap_it(cls.__init__, out_message)
+        return cls
+
+    return _cls_decorator
+
+
+def removed_module(module, replacement=None, message=None,
+                   version=None, removal_version=None, stacklevel=3,
+                   category=None):
+    """Helper to be called inside a module to emit a deprecation warning
+
+    :param str replacment: A location (or information about) of any potential
+                           replacement for the removed module (if applicable)
+    :param str message: A message to include in the deprecation warning
+    :param str version: Specify what version the removed module is present in
+    :param str removal_version: What version the module will be removed. If
+                                '?' is used this implies an undefined future
+                                version
+    :param int stacklevel: How many entries deep in the call stack before
+                           ignoring
+    :param type category: warnings message category (this defaults to
+                          ``DeprecationWarning`` when none is provided)
+    """
+    if inspect.ismodule(module):
+        module_name = _get_qualified_name(module)
+    elif isinstance(module, six.string_types):
+        module_name = module
+    else:
+        _qual, type_name = _utils.get_qualified_name(type(module))
+        raise TypeError("Unexpected module type '%s' (expected string or"
+                        " module type only)" % type_name)
+    prefix = "The '%s' module usage is deprecated" % module_name
+    if replacement:
+        postfix = ", please use %s instead" % replacement
+    else:
+        postfix = None
+    out_message = _utils.generate_message(prefix,
+                                          postfix=postfix, message=message,
+                                          version=version,
+                                          removal_version=removal_version)
+    _utils.deprecation(out_message,
+                       stacklevel=stacklevel, category=category)

--- a/ddtrace/vendor/debtcollector/renames.py
+++ b/ddtrace/vendor/debtcollector/renames.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+#    Copyright (C) 2015 Yahoo! Inc. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from ddtrace.vendor import wrapt
+
+from . import _utils
+
+_KWARG_RENAMED_POSTFIX_TPL = ", please use the '%s' argument instead"
+_KWARG_RENAMED_PREFIX_TPL = "Using the '%s' argument is deprecated"
+
+
+def renamed_kwarg(old_name, new_name, message=None,
+                  version=None, removal_version=None, stacklevel=3,
+                  category=None, replace=False):
+    """Decorates a kwarg accepting function to deprecate a renamed kwarg."""
+
+    prefix = _KWARG_RENAMED_PREFIX_TPL % old_name
+    postfix = _KWARG_RENAMED_POSTFIX_TPL % new_name
+    out_message = _utils.generate_message(
+        prefix, postfix=postfix, message=message, version=version,
+        removal_version=removal_version)
+
+    @wrapt.decorator
+    def decorator(wrapped, instance, args, kwargs):
+        if old_name in kwargs:
+            _utils.deprecation(out_message,
+                               stacklevel=stacklevel, category=category)
+            if replace:
+                kwargs.setdefault(new_name, kwargs.pop(old_name))
+        return wrapped(*args, **kwargs)
+
+    return decorator

--- a/ddtrace/vendor/debtcollector/updating.py
+++ b/ddtrace/vendor/debtcollector/updating.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+#    Copyright (C) 2015 Yahoo! Inc. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from ddtrace.vendor import six
+from ddtrace.vendor import wrapt
+if six.PY3:
+    import inspect
+    Parameter = inspect.Parameter
+    Signature = inspect.Signature
+    get_signature = inspect.signature
+else:
+    # Provide an equivalent but use funcsigs instead...
+    import funcsigs
+    Parameter = funcsigs.Parameter
+    Signature = funcsigs.Signature
+    get_signature = funcsigs.signature
+
+from . import _utils
+
+_KWARG_UPDATED_POSTFIX_TPL = (', please update the code to explicitly set %s '
+                              'as the value')
+_KWARG_UPDATED_PREFIX_TPL = ('The %s argument is changing its default value '
+                             'to %s')
+
+
+def updated_kwarg_default_value(name, old_value, new_value, message=None,
+                                version=None, stacklevel=3,
+                                category=FutureWarning):
+
+    """Decorates a kwarg accepting function to change the default value"""
+
+    prefix = _KWARG_UPDATED_PREFIX_TPL % (name, new_value)
+    postfix = _KWARG_UPDATED_POSTFIX_TPL % old_value
+    out_message = _utils.generate_message(
+        prefix, postfix=postfix, message=message, version=version)
+
+    def decorator(f):
+        sig = get_signature(f)
+        varnames = list(six.iterkeys(sig.parameters))
+
+        @wrapt.decorator
+        def wrapper(wrapped, instance, args, kwargs):
+            explicit_params = set(
+                varnames[:len(args)] + list(kwargs.keys())
+            )
+            allparams = set(varnames)
+            default_params = set(allparams - explicit_params)
+            if name in default_params:
+                _utils.deprecation(out_message,
+                                   stacklevel=stacklevel, category=category)
+            return wrapped(*args, **kwargs)
+
+        return wrapper(f)
+
+    return decorator

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -457,7 +457,7 @@ class TracerTestCase(BaseTracerTestCase):
             # verify warnings triggered
             assert len(w) == 1
             assert issubclass(w[-1].category, ddtrace.utils.deprecation.RemovedInDDTrace10Warning)
-            assert 'Use dogstatsd_url' in str(w[-1].message)
+            assert 'Use `dogstatsd_url`' in str(w[-1].message)
 
     def test_configure_dogstatsd_host_port(self):
         with warnings.catch_warnings(record=True) as w:
@@ -466,9 +466,11 @@ class TracerTestCase(BaseTracerTestCase):
             assert self.tracer._dogstatsd_client.host == 'foo'
             assert self.tracer._dogstatsd_client.port == 1234
             # verify warnings triggered
-            assert len(w) == 1
-            assert issubclass(w[-1].category, ddtrace.utils.deprecation.RemovedInDDTrace10Warning)
-            assert 'Use dogstatsd_url' in str(w[-1].message)
+            assert len(w) == 2
+            assert issubclass(w[0].category, ddtrace.utils.deprecation.RemovedInDDTrace10Warning)
+            assert 'Use `dogstatsd_url`' in str(w[0].message)
+            assert issubclass(w[1].category, ddtrace.utils.deprecation.RemovedInDDTrace10Warning)
+            assert 'Use `dogstatsd_url`' in str(w[1].message)
 
     def test_configure_dogstatsd_url_host_port(self):
         self.tracer.configure(dogstatsd_url='foo:1234')


### PR DESCRIPTION
Vendor [debtcollector](https://github.com/openstack/debtcollector) and use it to deprecate keyword arguments instead of existing approach where a warning is generated within code.