### PR TITLE
Adding B3 format support for propagation

### DIFF
--- a/ddtrace/propagation/b3.py
+++ b/ddtrace/propagation/b3.py
@@ -1,0 +1,95 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..context import Context
+from ..ext import priority
+
+
+class B3HTTPPropagator:
+    """b3 compatible propagator"""
+
+    SINGLE_HEADER_KEY = 'b3'
+    TRACE_ID_KEY = 'x-b3-traceid'
+    SPAN_ID_KEY = 'x-b3-spanid'
+    SAMPLED_KEY = 'x-b3-sampled'
+    FLAGS_KEY = 'x-b3-flags'
+    _SAMPLE_PROPAGATE_VALUES = set(['1', 'True', 'true', 'd'])
+
+    _SAMPLING_PRIORITY_MAP = {
+        priority.USER_REJECT: '0',
+        priority.AUTO_REJECT: '0',
+        priority.AUTO_KEEP: '1',
+        priority.USER_KEEP: '1',
+    }
+
+    def inject(self, span_context, headers):
+        sampled = '0'
+        if span_context.sampling_priority is not None:
+            sampled = self._SAMPLING_PRIORITY_MAP[span_context.sampling_priority]
+
+        headers[self.TRACE_ID_KEY] = format_trace_id(span_context.trace_id)
+        headers[self.SPAN_ID_KEY] = format_span_id(span_context.span_id)
+        headers[self.SAMPLED_KEY] = sampled
+
+    def extract(self, headers):
+        trace_id = '0'
+        span_id = '0'
+        sampled = '0'
+        flags = None
+
+        single_header = headers.get(self.SINGLE_HEADER_KEY)
+
+        if single_header:
+            # The b3 spec calls for the sampling state to be
+            # "deferred", which is unspecified. This concept does not
+            # translate to SpanContext, so we set it as recorded.
+            sampled = '1'
+            fields = single_header.split('-', 4)
+
+            if len(fields) == 1:
+                sampled = fields[0]
+            elif len(fields) == 2:
+                trace_id, span_id = fields
+            elif len(fields) == 3:
+                trace_id, span_id, sampled = fields
+            elif len(fields) == 4:
+                trace_id, span_id, sampled, _parent_span_id = fields
+            else:
+                return Context()
+        else:
+            trace_id = headers.get(self.TRACE_ID_KEY) or trace_id
+            span_id = headers.get(self.SPAN_ID_KEY) or span_id
+            sampled = headers.get(self.SAMPLED_KEY) or sampled
+            flags = headers.get(self.FLAGS_KEY) or flags
+
+        if sampled in self._SAMPLE_PROPAGATE_VALUES or flags == '1':
+            sampling_priority = priority.AUTO_KEEP
+        else:
+            sampling_priority = priority.AUTO_REJECT
+
+        return Context(
+            trace_id=int(trace_id, 16),
+            span_id=int(span_id, 16),
+            sampling_priority=sampling_priority,
+        )
+
+
+def format_trace_id(trace_id):
+    """Format the trace id according to b3 specification."""
+    return format(trace_id, '032x')
+
+
+def format_span_id(span_id):
+    """Format the span id according to b3 specification."""
+    return format(span_id, '016x')

--- a/ddtrace/propagation/datadog.py
+++ b/ddtrace/propagation/datadog.py
@@ -124,17 +124,13 @@ class DatadogHTTPPropagator(object):
                 _dd_origin=origin,
             )
         # If headers are invalid and cannot be parsed, return a new context and log the issue.
-        except Exception as error:
-            try:
-                log.debug(
-                    'invalid x-datadog-* headers, trace-id: %s, parent-id: %s, priority: %s, origin: %s, error: %s',
-                    headers.get(HTTP_HEADER_TRACE_ID, 0),
-                    headers.get(HTTP_HEADER_PARENT_ID, 0),
-                    headers.get(HTTP_HEADER_SAMPLING_PRIORITY),
-                    headers.get(HTTP_HEADER_ORIGIN, ''),
-                    error,
-                )
-            # We might fail on string formatting errors ; in that case only format the first error
-            except Exception:
-                log.debug(error)
+        except Exception:
+            log.debug(
+                'invalid x-datadog-* headers, trace-id: %s, parent-id: %s, priority: %s, origin: %s',
+                headers.get(HTTP_HEADER_TRACE_ID, 0),
+                headers.get(HTTP_HEADER_PARENT_ID, 0),
+                headers.get(HTTP_HEADER_SAMPLING_PRIORITY),
+                headers.get(HTTP_HEADER_ORIGIN, ''),
+                exc_info=True,
+            )
             return Context()

--- a/ddtrace/propagation/datadog.py
+++ b/ddtrace/propagation/datadog.py
@@ -1,0 +1,140 @@
+from ..context import Context
+from ..internal.logger import get_logger
+
+from .utils import get_wsgi_header
+
+log = get_logger(__name__)
+
+# HTTP headers one should set for distributed tracing.
+# These are cross-language (eg: Python, Go and other implementations should honor these)
+HTTP_HEADER_TRACE_ID = 'x-datadog-trace-id'
+HTTP_HEADER_PARENT_ID = 'x-datadog-parent-id'
+HTTP_HEADER_SAMPLING_PRIORITY = 'x-datadog-sampling-priority'
+HTTP_HEADER_ORIGIN = 'x-datadog-origin'
+
+
+# Note that due to WSGI spec we have to also check for uppercased and prefixed
+# versions of these headers
+POSSIBLE_HTTP_HEADER_TRACE_IDS = frozenset(
+    [HTTP_HEADER_TRACE_ID, get_wsgi_header(HTTP_HEADER_TRACE_ID)]
+)
+POSSIBLE_HTTP_HEADER_PARENT_IDS = frozenset(
+    [HTTP_HEADER_PARENT_ID, get_wsgi_header(HTTP_HEADER_PARENT_ID)]
+)
+POSSIBLE_HTTP_HEADER_SAMPLING_PRIORITIES = frozenset(
+    [HTTP_HEADER_SAMPLING_PRIORITY, get_wsgi_header(HTTP_HEADER_SAMPLING_PRIORITY)]
+)
+POSSIBLE_HTTP_HEADER_ORIGIN = frozenset(
+    [HTTP_HEADER_ORIGIN, get_wsgi_header(HTTP_HEADER_ORIGIN)]
+)
+
+
+def _extract_header_value(possible_header_names, headers, default=None):
+    for header, value in headers.items():
+        for header_name in possible_header_names:
+            if header.lower() == header_name.lower():
+                return value
+
+    return default
+
+
+class DatadogHTTPPropagator(object):
+    def inject(self, span_context, headers):
+        """Inject Context attributes that have to be propagated as HTTP headers.
+
+        Here is an example using `requests`::
+
+            import requests
+            from ddtrace.propagation.http import HTTPPropagator
+
+            def parent_call():
+                with tracer.trace('parent_span') as span:
+                    headers = {}
+                    propagator = HTTPPropagator()
+                    propagator.inject(span.context, headers)
+                    url = '<some RPC endpoint>'
+                    r = requests.get(url, headers=headers)
+
+        :param Context span_context: Span context to propagate.
+        :param dict headers: HTTP headers to extend with tracing attributes.
+        """
+        headers[HTTP_HEADER_TRACE_ID] = str(span_context.trace_id)
+        headers[HTTP_HEADER_PARENT_ID] = str(span_context.span_id)
+        # Propagate priority only if defined
+        if span_context.sampling_priority is not None:
+            headers[HTTP_HEADER_SAMPLING_PRIORITY] = str(span_context.sampling_priority)
+        # Propagate origin only if defined
+        if span_context._dd_origin is not None:
+            headers[HTTP_HEADER_ORIGIN] = str(span_context._dd_origin)
+
+    @staticmethod
+    def extract_trace_id(headers):
+        return int(
+            _extract_header_value(POSSIBLE_HTTP_HEADER_TRACE_IDS, headers, default=0)
+        )
+
+    @staticmethod
+    def extract_parent_span_id(headers):
+        return int(
+            _extract_header_value(POSSIBLE_HTTP_HEADER_PARENT_IDS, headers, default=0)
+        )
+
+    @staticmethod
+    def extract_sampling_priority(headers):
+        return _extract_header_value(POSSIBLE_HTTP_HEADER_SAMPLING_PRIORITIES, headers)
+
+    @staticmethod
+    def extract_origin(headers):
+        return _extract_header_value(POSSIBLE_HTTP_HEADER_ORIGIN, headers)
+
+    def extract(self, headers):
+        """Extract a Context from HTTP headers into a new Context.
+
+        Here is an example from a web endpoint::
+
+            from ddtrace.propagation.http import HTTPPropagator
+
+            def my_controller(url, headers):
+                propagator = HTTPPropagator()
+                context = propagator.extract(headers)
+                tracer.context_provider.activate(context)
+
+                with tracer.trace('my_controller') as span:
+                    span.set_meta('http.url', url)
+
+        :param dict headers: HTTP headers to extract tracing attributes.
+        :return: New `Context` with propagated attributes.
+        """
+        if not headers:
+            return Context()
+
+        try:
+            trace_id = DatadogHTTPPropagator.extract_trace_id(headers)
+            parent_span_id = DatadogHTTPPropagator.extract_parent_span_id(headers)
+            sampling_priority = DatadogHTTPPropagator.extract_sampling_priority(headers)
+            origin = DatadogHTTPPropagator.extract_origin(headers)
+
+            if sampling_priority is not None:
+                sampling_priority = int(sampling_priority)
+
+            return Context(
+                trace_id=trace_id,
+                span_id=parent_span_id,
+                sampling_priority=sampling_priority,
+                _dd_origin=origin,
+            )
+        # If headers are invalid and cannot be parsed, return a new context and log the issue.
+        except Exception as error:
+            try:
+                log.debug(
+                    'invalid x-datadog-* headers, trace-id: %s, parent-id: %s, priority: %s, origin: %s, error: %s',
+                    headers.get(HTTP_HEADER_TRACE_ID, 0),
+                    headers.get(HTTP_HEADER_PARENT_ID, 0),
+                    headers.get(HTTP_HEADER_SAMPLING_PRIORITY),
+                    headers.get(HTTP_HEADER_ORIGIN, ''),
+                    error,
+                )
+            # We might fail on string formatting errors ; in that case only format the first error
+            except Exception:
+                log.debug(error)
+            return Context()

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1,147 +1,28 @@
-from ..context import Context
-from ..internal.logger import get_logger
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from .utils import get_wsgi_header
+from .datadog import DatadogHTTPPropagator
 
-log = get_logger(__name__)
-
-# HTTP headers one should set for distributed tracing.
-# These are cross-language (eg: Python, Go and other implementations should honor these)
-HTTP_HEADER_TRACE_ID = 'x-datadog-trace-id'
-HTTP_HEADER_PARENT_ID = 'x-datadog-parent-id'
-HTTP_HEADER_SAMPLING_PRIORITY = 'x-datadog-sampling-priority'
-HTTP_HEADER_ORIGIN = 'x-datadog-origin'
-
-
-# Note that due to WSGI spec we have to also check for uppercased and prefixed
-# versions of these headers
-POSSIBLE_HTTP_HEADER_TRACE_IDS = frozenset(
-    [HTTP_HEADER_TRACE_ID, get_wsgi_header(HTTP_HEADER_TRACE_ID)]
-)
-POSSIBLE_HTTP_HEADER_PARENT_IDS = frozenset(
-    [HTTP_HEADER_PARENT_ID, get_wsgi_header(HTTP_HEADER_PARENT_ID)]
-)
-POSSIBLE_HTTP_HEADER_SAMPLING_PRIORITIES = frozenset(
-    [HTTP_HEADER_SAMPLING_PRIORITY, get_wsgi_header(HTTP_HEADER_SAMPLING_PRIORITY)]
-)
-POSSIBLE_HTTP_HEADER_ORIGIN = frozenset(
-    [HTTP_HEADER_ORIGIN, get_wsgi_header(HTTP_HEADER_ORIGIN)]
-)
+_PROGPAGATOR_FACTORY = DatadogHTTPPropagator
 
 
-class HTTPPropagator(object):
-    """A HTTP Propagator using HTTP headers as carrier."""
+def set_http_propagator_factory(factory):
+    """Sets the propagator factory to be used globally"""
+    global _PROGPAGATOR_FACTORY
+    _PROGPAGATOR_FACTORY = factory
 
-    def inject(self, span_context, headers):
-        """Inject Context attributes that have to be propagated as HTTP headers.
 
-        Here is an example using `requests`::
-
-            import requests
-            from ddtrace.propagation.http import HTTPPropagator
-
-            def parent_call():
-                with tracer.trace('parent_span') as span:
-                    headers = {}
-                    propagator = HTTPPropagator()
-                    propagator.inject(span.context, headers)
-                    url = '<some RPC endpoint>'
-                    r = requests.get(url, headers=headers)
-
-        :param Context span_context: Span context to propagate.
-        :param dict headers: HTTP headers to extend with tracing attributes.
-        """
-        headers[HTTP_HEADER_TRACE_ID] = str(span_context.trace_id)
-        headers[HTTP_HEADER_PARENT_ID] = str(span_context.span_id)
-        sampling_priority = span_context.sampling_priority
-        # Propagate priority only if defined
-        if sampling_priority is not None:
-            headers[HTTP_HEADER_SAMPLING_PRIORITY] = str(span_context.sampling_priority)
-        # Propagate origin only if defined
-        if span_context._dd_origin is not None:
-            headers[HTTP_HEADER_ORIGIN] = str(span_context._dd_origin)
-
-    @staticmethod
-    def extract_header_value(possible_header_names, headers, default=None):
-        for header, value in headers.items():
-            for header_name in possible_header_names:
-                if header.lower() == header_name.lower():
-                    return value
-
-        return default
-
-    @staticmethod
-    def extract_trace_id(headers):
-        return int(
-            HTTPPropagator.extract_header_value(
-                POSSIBLE_HTTP_HEADER_TRACE_IDS, headers, default=0,
-            )
-        )
-
-    @staticmethod
-    def extract_parent_span_id(headers):
-        return int(
-            HTTPPropagator.extract_header_value(
-                POSSIBLE_HTTP_HEADER_PARENT_IDS, headers, default=0,
-            )
-        )
-
-    @staticmethod
-    def extract_sampling_priority(headers):
-        return HTTPPropagator.extract_header_value(
-            POSSIBLE_HTTP_HEADER_SAMPLING_PRIORITIES, headers,
-        )
-
-    @staticmethod
-    def extract_origin(headers):
-        return HTTPPropagator.extract_header_value(
-            POSSIBLE_HTTP_HEADER_ORIGIN, headers,
-        )
-
-    def extract(self, headers):
-        """Extract a Context from HTTP headers into a new Context.
-
-        Here is an example from a web endpoint::
-
-            from ddtrace.propagation.http import HTTPPropagator
-
-            def my_controller(url, headers):
-                propagator = HTTPPropagator()
-                context = propagator.extract(headers)
-                tracer.context_provider.activate(context)
-
-                with tracer.trace('my_controller') as span:
-                    span.set_meta('http.url', url)
-
-        :param dict headers: HTTP headers to extract tracing attributes.
-        :return: New `Context` with propagated attributes.
-        """
-        if not headers:
-            return Context()
-
-        try:
-            trace_id = HTTPPropagator.extract_trace_id(headers)
-            parent_span_id = HTTPPropagator.extract_parent_span_id(headers)
-            sampling_priority = HTTPPropagator.extract_sampling_priority(headers)
-            origin = HTTPPropagator.extract_origin(headers)
-
-            if sampling_priority is not None:
-                sampling_priority = int(sampling_priority)
-
-            return Context(
-                trace_id=trace_id,
-                span_id=parent_span_id,
-                sampling_priority=sampling_priority,
-                _dd_origin=origin,
-            )
-        # If headers are invalid and cannot be parsed, return a new context and log the issue.
-        except Exception:
-            log.debug(
-                'invalid x-datadog-* headers, trace-id: %s, parent-id: %s, priority: %s, origin: %s',
-                headers.get(HTTP_HEADER_TRACE_ID, 0),
-                headers.get(HTTP_HEADER_PARENT_ID, 0),
-                headers.get(HTTP_HEADER_SAMPLING_PRIORITY),
-                headers.get(HTTP_HEADER_ORIGIN, ''),
-                exc_info=True,
-            )
-            return Context()
+def HTTPPropagator():
+    """Returns and instance of the configured propagator"""
+    return _PROGPAGATOR_FACTORY()

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -10,6 +10,7 @@ from .ext.priority import AUTO_REJECT, AUTO_KEEP
 from .internal.logger import get_logger
 from .internal.runtime import RuntimeTags, RuntimeWorker
 from .internal.writer import AgentWriter
+from .propagation.http import set_http_propagator_factory
 from .provider import DefaultContextProvider
 from .context import Context
 from .sampler import AllSampler, DatadogSampler, RateSampler, RateByServiceSampler
@@ -170,7 +171,7 @@ class Tracer(object):
     def configure(self, enabled=None, hostname=None, port=None, uds_path=None, https=None,
                   sampler=None, context_provider=None, wrap_executor=None, priority_sampling=None,
                   settings=None, collect_metrics=None, dogstatsd_host=None, dogstatsd_port=None,
-                  dogstatsd_url=None):
+                  dogstatsd_url=None, http_propagator=None):
         """
         Configure an existing Tracer the easy way.
         Allow to configure or reconfigure a Tracer instance.
@@ -194,6 +195,7 @@ class Tracer(object):
         :param str dogstatsd_host: Host for UDP connection to DogStatsD (deprecated: use dogstatsd_url)
         :param int dogstatsd_port: Port for UDP connection to DogStatsD (deprecated: use dogstatsd_url)
         :param str dogstatsd_url: URL for UDP or Unix socket connection to DogStatsD
+        :param class http_propagator: type of propagator to be used to distribute the tracing context.
         """
         if enabled is not None:
             self.enabled = enabled
@@ -267,6 +269,9 @@ class Tracer(object):
 
         if (collect_metrics is None and runtime_metrics_was_running) or collect_metrics:
             self._start_runtime_worker()
+
+        if http_propagator is not None:
+            set_http_propagator_factory(http_propagator)
 
     def start_span(self, name, child_of=None, service=None, resource=None, span_type=None):
         """

--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -3,7 +3,7 @@ from ddtrace.compat import PY2
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.flask.patch import flask_version
 from ddtrace.ext import http
-from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID, HTTP_HEADER_PARENT_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_TRACE_ID, HTTP_HEADER_PARENT_ID
 from flask import abort
 
 from . import BaseFlaskTestCase

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -4,7 +4,7 @@ from molten.testing import TestClient
 from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.ext import errors, http
-from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID, HTTP_HEADER_PARENT_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_TRACE_ID, HTTP_HEADER_PARENT_ID
 from ddtrace.contrib.molten import patch, unpatch
 from ddtrace.contrib.molten.patch import MOLTEN_VERSION
 

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -13,7 +13,7 @@ import ddtrace
 from ddtrace.ext.priority import AUTO_KEEP
 from ddtrace.opentracer import Tracer, set_global_tracer
 from ddtrace.opentracer.span_context import SpanContext
-from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_TRACE_ID
 from ddtrace.settings import ConfigException
 
 import mock

--- a/tests/propagation/test_http.py
+++ b/tests/propagation/test_http.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
 from tests.test_tracer import get_dummy_tracer
 
-from ddtrace.propagation.http import (
-    HTTPPropagator,
+from ddtrace.propagation.http import HTTPPropagator
+from ddtrace.propagation.datadog import (
     HTTP_HEADER_TRACE_ID,
     HTTP_HEADER_PARENT_ID,
     HTTP_HEADER_SAMPLING_PRIORITY,

--- a/tests/propagation/test_http_b3.py
+++ b/tests/propagation/test_http_b3.py
@@ -1,0 +1,54 @@
+from unittest import TestCase
+from tests.test_tracer import get_dummy_tracer
+
+from ddtrace.ext.priority import AUTO_REJECT, AUTO_KEEP
+from ddtrace.propagation.http import HTTPPropagator, set_http_propagator_factory
+from ddtrace.propagation.b3 import B3HTTPPropagator
+
+
+class TestB3HttpPropagation(TestCase):
+    def test_b3_inject(self):
+        tracer = get_dummy_tracer()
+        tracer.configure(http_propagator=B3HTTPPropagator)
+
+        with tracer.trace('global_root_span') as span:
+            headers = {}
+            set_http_propagator_factory(B3HTTPPropagator)
+            propagator = HTTPPropagator()
+            propagator.inject(span.context, headers)
+
+            assert int(headers[B3HTTPPropagator.TRACE_ID_KEY], 16) == span.trace_id
+            assert int(headers[B3HTTPPropagator.SPAN_ID_KEY], 16) == span.span_id
+            assert int(headers[B3HTTPPropagator.SAMPLED_KEY]) == 1
+
+    def test_b3_extract(self):
+        tracer = get_dummy_tracer()
+        tracer.configure(http_propagator=B3HTTPPropagator)
+
+        headers = {
+            'x-b3-traceid': '4d2',
+            'x-b3-spanid': '162e',
+            'x-b3-sampled': '1',
+        }
+
+        propagator = HTTPPropagator()
+        context = propagator.extract(headers)
+        tracer.context_provider.activate(context)
+
+        with tracer.trace('local_root_span') as span:
+            assert span.trace_id == 1234
+            assert span.parent_id == 5678
+            assert span.context.sampling_priority == AUTO_KEEP
+
+        headers = {
+            'x-b3-traceid': '4d2',
+            'x-b3-spanid': '162e',
+            'x-b3-sampled': '0',
+        }
+
+        propagator = HTTPPropagator()
+        context = propagator.extract(headers)
+        tracer.context_provider.activate(context)
+
+        with tracer.trace('local_root_span') as span:
+            assert span.context.sampling_priority == AUTO_REJECT


### PR DESCRIPTION
Adding support for propagating context information via B3 format (https://github.com/openzipkin/b3-propagation). As part of this change:

- refactored `HTTPPropagator` to act as a factory, returns `DatadogHTTPPropagator` by default
- adding `B3HTTPPropagator`
- adding http_propagator as a parameter to tracer configure `tracer.configure(http_propagator=B3HTTPPropagator)`

The work for supporting B3 format in context propagation was done in support of the OpenTelemetry auto-instrumentation work. https://github.com/lightstep/opentelemetry-auto-instr-python/commit/1c66a1a8fe8ea932c0ba095a5fde4b850874d75f

Signed-off-by: Alex Boten <aboten@lightstep.com>