### PR TITLE
core: common span types and revise language tag

### DIFF
--- a/ddtrace/contrib/aiobotocore/patch.py
+++ b/ddtrace/contrib/aiobotocore/patch.py
@@ -7,7 +7,7 @@ from aiobotocore.endpoint import ClientResponseContentProxy
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...pin import Pin
-from ...ext import http, aws
+from ...ext import SpanTypes, http, aws
 from ...compat import PYTHON_VERSION_INFO
 from ...utils.formats import deep_getattr
 from ...utils.wrappers import unwrap
@@ -79,7 +79,7 @@ def _wrapped_api_call(original_func, instance, args, kwargs):
 
     with pin.tracer.trace('{}.command'.format(endpoint_name),
                           service='{}.{}'.format(pin.service, endpoint_name),
-                          span_type=http.TYPE) as span:
+                          span_type=SpanTypes.HTTP) as span:
 
         if len(args) > 0:
             operation = args[0]

--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -3,7 +3,7 @@ import asyncio
 from ..asyncio import context_provider
 from ...compat import stringify
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import http
+from ...ext import SpanTypes, http
 from ...propagation.http import HTTPPropagator
 from ...settings import config
 
@@ -43,7 +43,7 @@ def trace_middleware(app, handler):
         request_span = tracer.trace(
             'aiohttp.request',
             service=service,
-            span_type=http.TYPE,
+            span_type=SpanTypes.WEB,
         )
 
         # Configure trace search sample rate

--- a/ddtrace/contrib/aiohttp/template.py
+++ b/ddtrace/contrib/aiohttp/template.py
@@ -2,7 +2,7 @@ import aiohttp_jinja2
 
 from ddtrace import Pin
 
-from ...ext import http
+from ...ext import SpanTypes
 
 
 def _trace_render_template(func, module, args, kwargs):
@@ -24,7 +24,6 @@ def _trace_render_template(func, module, args, kwargs):
     template_prefix = getattr(env.loader, 'package_path', '')
     template_meta = '{}/{}'.format(template_prefix, template_name)
 
-    with pin.tracer.trace('aiohttp.template') as span:
-        span.span_type = http.TEMPLATE
+    with pin.tracer.trace('aiohttp.template', span_type=SpanTypes.TEMPLATE) as span:
         span.set_meta('aiohttp.template', template_meta)
         return func(*args, **kwargs)

--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -5,7 +5,7 @@ from aiopg.utils import _ContextManager
 
 from .. import dbapi
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import sql
+from ...ext import SpanTypes, sql
 from ...pin import Pin
 from ...settings import config
 
@@ -28,8 +28,7 @@ class AIOTracedCursor(wrapt.ObjectProxy):
         service = pin.service
 
         with pin.tracer.trace(self._datadog_name, service=service,
-                              resource=resource) as s:
-            s.span_type = sql.TYPE
+                              resource=resource, span_type=SpanTypes.SQL) as s:
             s.set_tag(sql.QUERY, resource)
             s.set_tags(pin.tags)
             s.set_tags(extra_tags)

--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -7,7 +7,6 @@ DD_PATCH_ATTR = '_datadog_patch'
 
 SERVICE_NAME = 'algoliasearch'
 APP_NAME = 'algoliasearch'
-SEARCH_SPAN_TYPE = 'algoliasearch.search'
 
 try:
     import algoliasearch
@@ -101,7 +100,7 @@ def _patched_search(func, instance, wrapt_args, wrapt_kwargs):
     if not pin or not pin.enabled():
         return func(*wrapt_args, **wrapt_kwargs)
 
-    with pin.tracer.trace('algoliasearch.search', service=pin.service, span_type=SEARCH_SPAN_TYPE) as span:
+    with pin.tracer.trace('algoliasearch.search', service=pin.service) as span:
         if not span.sampled:
             return func(*wrapt_args, **wrapt_kwargs)
 

--- a/ddtrace/contrib/boto/patch.py
+++ b/ddtrace/contrib/boto/patch.py
@@ -5,14 +5,13 @@ import inspect
 from ddtrace import config
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...pin import Pin
-from ...ext import http, aws
+from ...ext import SpanTypes, http, aws
 from ...utils.wrappers import unwrap
 
 
 # Original boto client class
 _Boto_client = boto.connection.AWSQueryConnection
 
-SPAN_TYPE = 'boto'
 AWS_QUERY_ARGS_NAME = ('operation_name', 'params', 'path', 'verb')
 AWS_AUTH_ARGS_NAME = (
     'method',
@@ -68,7 +67,7 @@ def patched_query_request(original_func, instance, args, kwargs):
     with pin.tracer.trace(
         '{}.command'.format(endpoint_name),
         service='{}.{}'.format(pin.service, endpoint_name),
-        span_type=SPAN_TYPE,
+        span_type=SpanTypes.HTTP,
     ) as span:
 
         operation_name = None
@@ -136,7 +135,7 @@ def patched_auth_request(original_func, instance, args, kwargs):
     with pin.tracer.trace(
         '{}.command'.format(endpoint_name),
         service='{}.{}'.format(pin.service, endpoint_name),
-        span_type=SPAN_TYPE,
+        span_type=SpanTypes.HTTP,
     ) as span:
 
         if args:

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -9,7 +9,7 @@ import botocore.client
 # project
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...pin import Pin
-from ...ext import http, aws
+from ...ext import SpanTypes, http, aws
 from ...utils.formats import deep_getattr
 from ...utils.wrappers import unwrap
 
@@ -17,7 +17,6 @@ from ...utils.wrappers import unwrap
 # Original botocore client class
 _Botocore_client = botocore.client.BaseClient
 
-SPAN_TYPE = 'http'
 ARGS_NAME = ('action', 'params', 'path', 'verb')
 TRACED_ARGS = ['params', 'path', 'verb']
 
@@ -47,7 +46,7 @@ def patched_api_call(original_func, instance, args, kwargs):
 
     with pin.tracer.trace('{}.command'.format(endpoint_name),
                           service='{}.{}'.format(pin.service, endpoint_name),
-                          span_type=SPAN_TYPE) as span:
+                          span_type=SpanTypes.HTTP) as span:
 
         operation = None
         if args:

--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -6,11 +6,9 @@ import ddtrace
 
 # project
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import http
+from ...ext import SpanTypes, http
 from ...propagation.http import HTTPPropagator
 from ...settings import config
-
-SPAN_TYPE = 'web'
 
 
 class TracePlugin(object):
@@ -37,7 +35,9 @@ class TracePlugin(object):
                 if context.trace_id:
                     self.tracer.context_provider.activate(context)
 
-            with self.tracer.trace('bottle.request', service=self.service, resource=resource, span_type=SPAN_TYPE) as s:
+            with self.tracer.trace(
+                'bottle.request', service=self.service, resource=resource, span_type=SpanTypes.WEB
+            ) as s:
                 # set analytics sample rate with global config enabled
                 s.set_tag(
                     ANALYTICS_SAMPLE_RATE_KEY,

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -9,7 +9,7 @@ import cassandra.cluster
 # project
 from ...compat import stringify
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import net, cassandra as cassx, errors
+from ...ext import SpanTypes, net, cassandra as cassx, errors
 from ...internal.logger import get_logger
 from ...pin import Pin
 from ...settings import config
@@ -181,7 +181,7 @@ def traced_execute_async(func, instance, args, kwargs):
 def _start_span_and_set_tags(pin, query, session, cluster):
     service = pin.service
     tracer = pin.tracer
-    span = tracer.trace('cassandra.query', service=service, span_type=cassx.TYPE)
+    span = tracer.trace('cassandra.query', service=service, span_type=SpanTypes.CASSANDRA)
     _sanitize_query(span, query)
     span.set_tags(_extract_session_metas(session))     # FIXME[matt] do once?
     span.set_tags(_extract_cluster_metas(cluster))

--- a/ddtrace/contrib/celery/signals.py
+++ b/ddtrace/contrib/celery/signals.py
@@ -2,12 +2,12 @@ from ddtrace import Pin, config
 
 from celery import registry
 
+from ...ext import SpanTypes
 from ...internal.logger import get_logger
 from . import constants as c
 from .utils import tags_from_context, retrieve_task_id, attach_span, detach_span, retrieve_span
 
 log = get_logger(__name__)
-SPAN_TYPE = 'worker'
 
 
 def trace_prerun(*args, **kwargs):
@@ -28,7 +28,7 @@ def trace_prerun(*args, **kwargs):
 
     # propagate the `Span` in the current task Context
     service = config.celery['worker_service_name']
-    span = pin.tracer.trace(c.WORKER_ROOT_SPAN, service=service, resource=task.name, span_type=SPAN_TYPE)
+    span = pin.tracer.trace(c.WORKER_ROOT_SPAN, service=service, resource=task.name, span_type=SpanTypes.WORKER)
     attach_span(task, task_id, span)
 
 

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -3,7 +3,7 @@ Generic dbapi tracing code.
 """
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import sql
+from ...ext import SpanTypes, sql
 from ...internal.logger import get_logger
 from ...pin import Pin
 from ...settings import config
@@ -43,8 +43,7 @@ class TracedCursor(wrapt.ObjectProxy):
         if not pin or not pin.enabled():
             return method(*args, **kwargs)
         service = pin.service
-        with pin.tracer.trace(name, service=service, resource=resource) as s:
-            s.span_type = sql.TYPE
+        with pin.tracer.trace(name, service=service, resource=resource, span_type=SpanTypes.SQL) as s:
             # No reason to tag the query since it is set as the resource by the agent. See:
             # https://github.com/DataDog/datadog-trace-agent/blob/bda1ebbf170dd8c5879be993bdd4dbae70d10fda/obfuscate/sql.go#L232
             s.set_tags(pin.tags)

--- a/ddtrace/contrib/django/cache.py
+++ b/ddtrace/contrib/django/cache.py
@@ -2,6 +2,7 @@ from functools import wraps
 
 from django.conf import settings as django_settings
 
+from ...ext import SpanTypes
 from ...internal.logger import get_logger
 from .conf import settings, import_from_string
 from .utils import quantize_key_values, _resource_from_cache_prefix
@@ -24,7 +25,6 @@ TRACED_METHODS = [
 ]
 
 # standard tags
-TYPE = 'cache'
 CACHE_BACKEND = 'django.cache.backend'
 CACHE_COMMAND_KEY = 'django.cache.key'
 
@@ -54,7 +54,7 @@ def patch_cache(tracer):
         def wrapped(self, *args, **kwargs):
             # get the original function method
             method = getattr(self, DATADOG_NAMESPACE.format(method=method_name))
-            with tracer.trace('django.cache', span_type=TYPE, service=cache_service_name) as span:
+            with tracer.trace('django.cache', span_type=SpanTypes.CACHE, service=cache_service_name) as span:
                 # update the resource name and tag the cache backend
                 span.resource = _resource_from_cache_prefix(method_name, self)
                 cache_backend = '{}.{}'.format(self.__module__, self.__class__.__name__)

--- a/ddtrace/contrib/django/middleware.py
+++ b/ddtrace/contrib/django/middleware.py
@@ -5,7 +5,7 @@ from .utils import get_request_uri
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...contrib import func_name
-from ...ext import http
+from ...ext import SpanTypes, http
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
 from ...settings import config
@@ -126,7 +126,7 @@ class TraceMiddleware(InstrumentationMixin):
                 'django.request',
                 service=settings.DEFAULT_SERVICE,
                 resource='unknown',  # will be filled by process view
-                span_type=http.TYPE,
+                span_type=SpanTypes.WEB,
             )
 
             # set analytics sample rate

--- a/ddtrace/contrib/django/templates.py
+++ b/ddtrace/contrib/django/templates.py
@@ -2,7 +2,7 @@
 code to measure django template rendering.
 """
 # project
-from ...ext import http
+from ...ext import SpanTypes
 from ...internal.logger import get_logger
 
 # 3p
@@ -28,7 +28,7 @@ def patch_template(tracer):
     setattr(Template, RENDER_ATTR, Template.render)
 
     def traced_render(self, context):
-        with tracer.trace('django.template', span_type=http.TEMPLATE) as span:
+        with tracer.trace('django.template', span_type=SpanTypes.TEMPLATE) as span:
             try:
                 return Template._datadog_original_render(self, context)
             finally:

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -6,7 +6,7 @@ from .quantize import quantize
 
 from ...compat import urlencode
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import elasticsearch as metadata, http
+from ...ext import SpanTypes, elasticsearch as metadata, http
 from ...pin import Pin
 from ...utils.wrappers import unwrap as _u
 from ...settings import config
@@ -32,7 +32,7 @@ def _patch(elasticsearch):
         return
     setattr(elasticsearch, '_datadog_patch', True)
     _w(elasticsearch.transport, 'Transport.perform_request', _get_perform_request(elasticsearch))
-    Pin(service=metadata.SERVICE, app=metadata.APP).onto(elasticsearch.transport.Transport)
+    Pin(service=metadata.SERVICE).onto(elasticsearch.transport.Transport)
 
 
 def unpatch():
@@ -52,7 +52,7 @@ def _get_perform_request(elasticsearch):
         if not pin or not pin.enabled():
             return func(*args, **kwargs)
 
-        with pin.tracer.trace('elasticsearch.query') as span:
+        with pin.tracer.trace('elasticsearch.query', span_type=SpanTypes.ELASTICSEARCH) as span:
             # Don't instrument if the trace is not sampled
             if not span.sampled:
                 return func(*args, **kwargs)
@@ -62,7 +62,6 @@ def _get_perform_request(elasticsearch):
             body = kwargs.get('body')
 
             span.service = pin.service
-            span.span_type = metadata.TYPE
             span.set_tag(metadata.METHOD, method)
             span.set_tag(metadata.URL, url)
             span.set_tag(metadata.PARAMS, urlencode(params))

--- a/ddtrace/contrib/falcon/middleware.py
+++ b/ddtrace/contrib/falcon/middleware.py
@@ -1,6 +1,6 @@
 import sys
 
-from ddtrace.ext import http as httpx
+from ddtrace.ext import SpanTypes, http as httpx
 from ddtrace.http import store_request_headers, store_response_headers
 from ddtrace.propagation.http import HTTPPropagator
 
@@ -30,7 +30,7 @@ class TraceMiddleware(object):
         span = self.tracer.trace(
             'falcon.request',
             service=self.service,
-            span_type=httpx.TYPE,
+            span_type=SpanTypes.WEB,
         )
 
         # set analytics sample rate with global config enabled

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -1,5 +1,5 @@
 from ... import compat
-from ...ext import http, errors
+from ...ext import SpanTypes, http, errors
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
 from ...utils.deprecation import deprecated
@@ -112,7 +112,7 @@ class TraceMiddleware(object):
             g.flask_datadog_span = self.app._tracer.trace(
                 SPAN_NAME,
                 service=self.app._service,
-                span_type=http.TYPE,
+                span_type=SpanTypes.WEB,
             )
         except Exception:
             log.debug('flask: error tracing request', exc_info=True)
@@ -189,8 +189,7 @@ def _patch_render(tracer):
     _render = flask.templating._render
 
     def _traced_render(template, context, app):
-        with tracer.trace('flask.template') as span:
-            span.span_type = http.TEMPLATE
+        with tracer.trace('flask.template', span_type=SpanTypes.TEMPLATE) as span:
             span.set_tag('flask.template', template.name or 'string')
             return _render(template, context, app)
 

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -8,7 +8,7 @@ from ddtrace import compat
 from ddtrace import config, Pin
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import http
+from ...ext import SpanTypes, http
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
 from ...utils.wrappers import unwrap as _u
@@ -282,7 +282,7 @@ def traced_wsgi_app(pin, wrapped, instance, args, kwargs):
     #   POST /save
     # We will override this below in `traced_dispatch_request` when we have a `RequestContext` and possibly a url rule
     resource = u'{} {}'.format(request.method, request.path)
-    with pin.tracer.trace('flask.request', service=pin.service, resource=resource, span_type=http.TYPE) as s:
+    with pin.tracer.trace('flask.request', service=pin.service, resource=resource, span_type=SpanTypes.WEB) as s:
         # set analytics sample rate with global config enabled
         sample_rate = config.flask.get_analytics_sample_rate(use_global_config=True)
         if sample_rate is not None:
@@ -396,7 +396,7 @@ def traced_render_template(wrapped, instance, args, kwargs):
     if not pin or not pin.enabled():
         return wrapped(*args, **kwargs)
 
-    with pin.tracer.trace('flask.render_template', span_type=http.TEMPLATE):
+    with pin.tracer.trace('flask.render_template', span_type=SpanTypes.TEMPLATE):
         return wrapped(*args, **kwargs)
 
 
@@ -406,7 +406,7 @@ def traced_render_template_string(wrapped, instance, args, kwargs):
     if not pin or not pin.enabled():
         return wrapped(*args, **kwargs)
 
-    with pin.tracer.trace('flask.render_template_string', span_type=http.TEMPLATE):
+    with pin.tracer.trace('flask.render_template_string', span_type=SpanTypes.TEMPLATE):
         return wrapped(*args, **kwargs)
 
 

--- a/ddtrace/contrib/flask_cache/tracers.py
+++ b/ddtrace/contrib/flask_cache/tracers.py
@@ -8,6 +8,7 @@ import logging
 # project
 from .utils import _extract_conn_tags, _resource_from_cache_prefix
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
+from ...ext import SpanTypes
 from ...settings import config
 
 # 3rd party
@@ -16,7 +17,6 @@ from flask.ext.cache import Cache
 
 log = logging.Logger(__name__)
 
-TYPE = 'cache'
 DEFAULT_SERVICE = 'flask-cache'
 
 # standard tags
@@ -47,7 +47,7 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None):
             # create a new span
             s = self._datadog_tracer.trace(
                 cmd,
-                span_type=TYPE,
+                span_type=SpanTypes.CACHE,
                 service=self._datadog_service
             )
             # set span tags

--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -4,7 +4,7 @@ from ddtrace.vendor import wrapt
 
 from ddtrace import config
 from ddtrace.compat import to_unicode
-from ddtrace.ext import errors
+from ddtrace.ext import SpanTypes, errors
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -152,7 +152,7 @@ class _ClientInterceptor(
 
         span = tracer.trace(
             'grpc',
-            span_type='grpc',
+            span_type=SpanTypes.GRPC,
             service=self._pin.service,
             resource=client_call_details.method,
         )

--- a/ddtrace/contrib/grpc/server_interceptor.py
+++ b/ddtrace/contrib/grpc/server_interceptor.py
@@ -6,6 +6,7 @@ from ddtrace.ext import errors
 from ddtrace.compat import to_unicode
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
+from ...ext import SpanTypes
 from ...propagation.http import HTTPPropagator
 from . import constants
 from .utils import parse_method_path
@@ -64,7 +65,7 @@ class _TracedRpcMethodHandler(wrapt.ObjectProxy):
 
         span = tracer.trace(
             'grpc',
-            span_type='grpc',
+            span_type=SpanTypes.GRPC,
             service=self._pin.service,
             resource=self._handler_call_details.method,
         )

--- a/ddtrace/contrib/httplib/patch.py
+++ b/ddtrace/contrib/httplib/patch.py
@@ -4,7 +4,7 @@ from ddtrace.vendor import wrapt
 # Project
 from ...compat import PY2, httplib, parse
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import http as ext_http
+from ...ext import SpanTypes, http as ext_http
 from ...http import store_request_headers, store_response_headers
 from ...internal.logger import get_logger
 from ...pin import Pin
@@ -55,7 +55,7 @@ def _wrap_putrequest(func, instance, args, kwargs):
 
     try:
         # Create a new span and attach to this instance (so we can retrieve/update/close later on the response)
-        span = pin.tracer.trace(span_name, span_type=ext_http.TYPE)
+        span = pin.tracer.trace(span_name, span_type=SpanTypes.HTTP)
         setattr(instance, '_datadog_span', span)
 
         method, path = args[:2]

--- a/ddtrace/contrib/jinja2/patch.py
+++ b/ddtrace/contrib/jinja2/patch.py
@@ -3,7 +3,7 @@ from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
 
-from ...ext import http
+from ...ext import SpanTypes
 from ...utils.formats import get_env
 from ...pin import Pin
 from ...utils.wrappers import unwrap as _u
@@ -49,7 +49,7 @@ def _wrap_render(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     template_name = instance.name or DEFAULT_TEMPLATE_NAME
-    with pin.tracer.trace('jinja2.render', pin.service, span_type=http.TEMPLATE) as span:
+    with pin.tracer.trace('jinja2.render', pin.service, span_type=SpanTypes.TEMPLATE) as span:
         try:
             return wrapped(*args, **kwargs)
         finally:
@@ -67,7 +67,7 @@ def _wrap_compile(wrapped, instance, args, kwargs):
     else:
         template_name = kwargs.get('name', DEFAULT_TEMPLATE_NAME)
 
-    with pin.tracer.trace('jinja2.compile', pin.service, span_type=http.TEMPLATE) as span:
+    with pin.tracer.trace('jinja2.compile', pin.service, span_type=SpanTypes.TEMPLATE) as span:
         try:
             return wrapped(*args, **kwargs)
         finally:
@@ -81,7 +81,7 @@ def _wrap_load_template(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     template_name = kwargs.get('name', args[0])
-    with pin.tracer.trace('jinja2.load', pin.service, span_type=http.TEMPLATE) as span:
+    with pin.tracer.trace('jinja2.load', pin.service, span_type=SpanTypes.TEMPLATE) as span:
         template = None
         try:
             template = wrapped(*args, **kwargs)

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -4,7 +4,7 @@ from ddtrace.vendor import wrapt
 
 # project
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import kombu as kombux
+from ...ext import SpanTypes, kombu as kombux
 from ...pin import Pin
 from ...propagation.http import HTTPPropagator
 from ...settings import config
@@ -43,8 +43,8 @@ def patch():
     # *  defines defaults in its kwargs
     # *  potentially overrides kwargs with values from self
     # *  extracts/normalizes things like exchange
-    _w(kombux.TYPE, 'Producer._publish', traced_publish)
-    _w(kombux.TYPE, 'Consumer.receive', traced_receive)
+    _w('kombu', 'Producer._publish', traced_publish)
+    _w('kombu', 'Consumer.receive', traced_receive)
     Pin(
         service=config.kombu['service_name'],
         app='kombu'
@@ -78,7 +78,7 @@ def traced_receive(func, instance, args, kwargs):
     # only need to active the new context if something was propagated
     if context.trace_id:
         pin.tracer.context_provider.activate(context)
-    with pin.tracer.trace(kombux.RECEIVE_NAME, service=pin.service, span_type='kombu') as s:
+    with pin.tracer.trace(kombux.RECEIVE_NAME, service=pin.service, span_type=SpanTypes.WORKER) as s:
         # run the command
         exchange = message.delivery_info['exchange']
         s.resource = exchange
@@ -99,7 +99,7 @@ def traced_publish(func, instance, args, kwargs):
     if not pin or not pin.enabled():
         return func(*args, **kwargs)
 
-    with pin.tracer.trace(kombux.PUBLISH_NAME, service=pin.service, span_type='kombu') as s:
+    with pin.tracer.trace(kombux.PUBLISH_NAME, service=pin.service, span_type=SpanTypes.WORKER) as s:
         exchange_name = get_exchange_from_args(args)
         s.resource = exchange_name
         s.set_tag(kombux.EXCHANGE, exchange_name)

--- a/ddtrace/contrib/mako/patch.py
+++ b/ddtrace/contrib/mako/patch.py
@@ -1,7 +1,7 @@
 import mako
 from mako.template import Template
 
-from ...ext import http
+from ...ext import SpanTypes
 from ...pin import Pin
 from ...utils.importlib import func_name
 from ...utils.wrappers import unwrap as _u
@@ -38,7 +38,7 @@ def _wrap_render(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     template_name = instance.filename or DEFAULT_TEMPLATE_NAME
-    with pin.tracer.trace(func_name(wrapped), pin.service, span_type=http.TEMPLATE) as span:
+    with pin.tracer.trace(func_name(wrapped), pin.service, span_type=SpanTypes.TEMPLATE) as span:
         try:
             template = wrapped(*args, **kwargs)
             return template

--- a/ddtrace/contrib/molten/patch.py
+++ b/ddtrace/contrib/molten/patch.py
@@ -6,7 +6,7 @@ import molten
 from ... import Pin, config
 from ...compat import urlencode
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import http
+from ...ext import SpanTypes, http
 from ...propagation.http import HTTPPropagator
 from ...utils.formats import asbool, get_env
 from ...utils.importlib import func_name
@@ -82,7 +82,7 @@ def patch_app_call(wrapped, instance, args, kwargs):
         if context.trace_id:
             pin.tracer.context_provider.activate(context)
 
-    with pin.tracer.trace('molten.request', service=pin.service, resource=resource) as span:
+    with pin.tracer.trace('molten.request', service=pin.service, resource=resource, span_type=SpanTypes.WEB) as span:
         # set analytics sample rate with global config enabled
         span.set_tag(
             ANALYTICS_SAMPLE_RATE_KEY,

--- a/ddtrace/contrib/mongoengine/trace.py
+++ b/ddtrace/contrib/mongoengine/trace.py
@@ -17,7 +17,7 @@ class WrappedConnect(wrapt.ObjectProxy):
 
     def __init__(self, connect):
         super(WrappedConnect, self).__init__(connect)
-        ddtrace.Pin(service=mongox.TYPE, tracer=ddtrace.tracer).onto(self)
+        ddtrace.Pin(service=mongox.SERVICE, tracer=ddtrace.tracer).onto(self)
 
     def __call__(self, *args, **kwargs):
         client = self.__wrapped__(*args, **kwargs)

--- a/ddtrace/contrib/psycopg/connection.py
+++ b/ddtrace/contrib/psycopg/connection.py
@@ -5,9 +5,7 @@ Tracing utilities for the psycopg potgres client library.
 # stdlib
 import functools
 
-from ...ext import db
-from ...ext import net
-from ...ext import sql
+from ...ext import SpanTypes, db, net, sql
 from ...utils.deprecation import deprecated
 
 # 3p
@@ -44,12 +42,11 @@ class TracedCursor(cursor):
         if not self._datadog_tracer:
             return cursor.execute(self, query, vars)
 
-        with self._datadog_tracer.trace('postgres.query', service=self._datadog_service) as s:
+        with self._datadog_tracer.trace('postgres.query', service=self._datadog_service, span_type=SpanTypes.SQL) as s:
             if not s.sampled:
                 return super(TracedCursor, self).execute(query, vars)
 
             s.resource = query
-            s.span_type = sql.TYPE
             s.set_tags(self._datadog_tags)
             try:
                 return super(TracedCursor, self).execute(query, vars)

--- a/ddtrace/contrib/pylibmc/client.py
+++ b/ddtrace/contrib/pylibmc/client.py
@@ -8,8 +8,7 @@ import pylibmc
 # project
 import ddtrace
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import memcached
-from ...ext import net
+from ...ext import SpanTypes, memcached, net
 from ...internal.logger import get_logger
 from ...settings import config
 from .addrs import parse_addresses
@@ -136,8 +135,7 @@ class TracedClient(ObjectProxy):
             'memcached.cmd',
             service=pin.service,
             resource=cmd_name,
-            # TODO(Benjamin): set a better span type
-            span_type='cache')
+            span_type=SpanTypes.CACHE)
 
         try:
             self._tag_span(span)

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -8,7 +8,7 @@ from .constants import CONFIG_MIDDLEWARE
 
 from ...compat import reraise
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import http
+from ...ext import SpanTypes, http
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
 from ...settings import config as ddconfig
@@ -41,10 +41,9 @@ class PylonsTraceMiddleware(object):
             if context.trace_id:
                 self._tracer.context_provider.activate(context)
 
-        with self._tracer.trace('pylons.request', service=self._service) as span:
+        with self._tracer.trace('pylons.request', service=self._service, span_type=SpanTypes.WEB) as span:
             # Set the service in tracer.trace() as priority sampling requires it to be
             # set as early as possible when different services share one single agent.
-            span.span_type = http.TYPE
 
             # set analytics sample rate with global config enabled
             span.set_tag(

--- a/ddtrace/contrib/pymemcache/client.py
+++ b/ddtrace/contrib/pymemcache/client.py
@@ -15,7 +15,7 @@ from pymemcache.exceptions import (
 # project
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...compat import reraise
-from ...ext import net, memcached as memcachedx
+from ...ext import SpanTypes, net, memcached as memcachedx
 from ...internal.logger import get_logger
 from ...pin import Pin
 from ...settings import config
@@ -141,7 +141,7 @@ class WrappedClient(wrapt.ObjectProxy):
             memcachedx.CMD,
             service=p.service,
             resource=method_name,
-            span_type=memcachedx.TYPE,
+            span_type=SpanTypes.CACHE,
         ) as span:
             # set analytics sample rate
             span.set_tag(

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -6,7 +6,7 @@ from ddtrace.vendor import wrapt
 # project
 import ddtrace
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import http
+from ...ext import SpanTypes, http
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
 from ...settings import config
@@ -49,8 +49,7 @@ def trace_render(func, instance, args, kwargs):
         log.debug('No span found in request, will not be traced')
         return func(*args, **kwargs)
 
-    with span.tracer.trace('pyramid.render') as span:
-        span.span_type = http.TEMPLATE
+    with span.tracer.trace('pyramid.render', span_type=SpanTypes.TEMPLATE) as span:
         return func(*args, **kwargs)
 
 
@@ -71,7 +70,7 @@ def trace_tween_factory(handler, registry):
                 # only need to active the new context if something was propagated
                 if context.trace_id:
                     tracer.context_provider.activate(context)
-            with tracer.trace('pyramid.request', service=service, resource='404') as span:
+            with tracer.trace('pyramid.request', service=service, resource='404', span_type=SpanTypes.WEB) as span:
                 # Configure trace search sample rate
                 # DEV: pyramid is special case maintains separate configuration from config api
                 analytics_enabled = settings.get(SETTINGS_ANALYTICS_ENABLED)
@@ -100,7 +99,6 @@ def trace_tween_factory(handler, registry):
                     span.set_tag(http.STATUS_CODE, 500)
                     raise
                 finally:
-                    span.span_type = http.TYPE
                     # set request tags
                     span.set_tag(http.URL, request.path_url)
                     span.set_tag(http.METHOD, request.method)

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -6,7 +6,7 @@ from ddtrace.vendor import wrapt
 from ddtrace import config
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...pin import Pin
-from ...ext import redis as redisx
+from ...ext import SpanTypes, redis as redisx
 from ...utils.wrappers import unwrap
 from .util import format_command_args, _extract_conn_tags
 
@@ -62,7 +62,7 @@ def traced_execute_command(func, instance, args, kwargs):
     if not pin or not pin.enabled():
         return func(*args, **kwargs)
 
-    with pin.tracer.trace(redisx.CMD, service=pin.service, span_type=redisx.TYPE) as s:
+    with pin.tracer.trace(redisx.CMD, service=pin.service, span_type=SpanTypes.REDIS) as s:
         query = format_command_args(args)
         s.resource = query
         s.set_tag(redisx.RAWCMD, query)
@@ -96,8 +96,7 @@ def traced_execute_pipeline(func, instance, args, kwargs):
     cmds = [format_command_args(c) for c, _ in instance.command_stack]
     resource = '\n'.join(cmds)
     tracer = pin.tracer
-    with tracer.trace(redisx.CMD, resource=resource, service=pin.service) as s:
-        s.span_type = redisx.TYPE
+    with tracer.trace(redisx.CMD, resource=resource, service=pin.service, span_type=SpanTypes.REDIS) as s:
         s.set_tag(redisx.RAWCMD, resource)
         s.set_tags(_get_tags(instance))
         s.set_metric(redisx.PIPELINE_LEN, len(instance.command_stack))

--- a/ddtrace/contrib/rediscluster/patch.py
+++ b/ddtrace/contrib/rediscluster/patch.py
@@ -6,7 +6,7 @@ from ddtrace.vendor import wrapt
 from ddtrace import config
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...pin import Pin
-from ...ext import redis as redisx
+from ...ext import SpanTypes, redis as redisx
 from ...utils.wrappers import unwrap
 from ..redis.patch import traced_execute_command, traced_pipeline
 from ..redis.util import format_command_args
@@ -46,8 +46,7 @@ def traced_execute_pipeline(func, instance, args, kwargs):
     cmds = [format_command_args(c.args) for c in instance.command_stack]
     resource = '\n'.join(cmds)
     tracer = pin.tracer
-    with tracer.trace(redisx.CMD, resource=resource, service=pin.service) as s:
-        s.span_type = redisx.TYPE
+    with tracer.trace(redisx.CMD, resource=resource, service=pin.service, span_type=SpanTypes.REDIS) as s:
         s.set_tag(redisx.RAWCMD, resource)
         s.set_metric(redisx.PIPELINE_LEN, len(instance.command_stack))
 

--- a/ddtrace/contrib/requests/connection.py
+++ b/ddtrace/contrib/requests/connection.py
@@ -4,7 +4,7 @@ from ddtrace.http import store_request_headers, store_response_headers
 
 from ...compat import parse
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import http
+from ...ext import SpanTypes, http
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
 from .constants import DEFAULT_SERVICE
@@ -67,7 +67,7 @@ def _wrap_send(func, instance, args, kwargs):
         parsed_uri.fragment
     ))
 
-    with tracer.trace('requests.request', span_type=http.TYPE) as span:
+    with tracer.trace('requests.request', span_type=SpanTypes.HTTP) as span:
         # update the span service name before doing any action
         span.service = _extract_service_name(instance, span, hostname=hostname)
 

--- a/ddtrace/contrib/sqlalchemy/engine.py
+++ b/ddtrace/contrib/sqlalchemy/engine.py
@@ -18,8 +18,7 @@ from sqlalchemy.event import listen
 import ddtrace
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import sql as sqlx
-from ...ext import net as netx
+from ...ext import SpanTypes, sql as sqlx, net as netx
 from ...pin import Pin
 from ...settings import config
 
@@ -79,7 +78,7 @@ class EngineTracer(object):
         span = pin.tracer.trace(
             self.name,
             service=pin.service,
-            span_type=sqlx.TYPE,
+            span_type=SpanTypes.SQL,
             resource=statement,
         )
 

--- a/ddtrace/contrib/tornado/handlers.py
+++ b/ddtrace/contrib/tornado/handlers.py
@@ -3,7 +3,7 @@ from tornado.web import HTTPError
 from .constants import CONFIG_KEY, REQUEST_CONTEXT_KEY, REQUEST_SPAN_KEY
 from .stack_context import TracerStackContext
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import http
+from ...ext import SpanTypes, http
 from ...propagation.http import HTTPPropagator
 from ...settings import config
 
@@ -35,7 +35,7 @@ def execute(func, handler, args, kwargs):
         request_span = tracer.trace(
             'tornado.request',
             service=service,
-            span_type=http.TYPE
+            span_type=SpanTypes.WEB
         )
         # set analytics sample rate
         # DEV: tornado is special case maintains separate configuration from config api

--- a/ddtrace/contrib/tornado/template.py
+++ b/ddtrace/contrib/tornado/template.py
@@ -2,7 +2,7 @@ from tornado import template
 
 from ddtrace import Pin
 
-from ...ext import http
+from ...ext import SpanTypes
 
 
 def generate(func, renderer, args, kwargs):
@@ -24,8 +24,8 @@ def generate(func, renderer, args, kwargs):
         resource = template_name = renderer.name
 
     # trace the original call
-    with pin.tracer.trace('tornado.template', service=pin.service) as span:
-        span.span_type = http.TEMPLATE
-        span.resource = resource
+    with pin.tracer.trace(
+        'tornado.template', service=pin.service, resource=resource, span_type=SpanTypes.TEMPLATE
+    ) as span:
         span.set_meta('tornado.template_name', template_name)
         return func(*args, **kwargs)

--- a/ddtrace/contrib/vertica/patch.py
+++ b/ddtrace/contrib/vertica/patch.py
@@ -4,7 +4,7 @@ from ddtrace.vendor import wrapt
 
 import ddtrace
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...ext import db as dbx, sql
+from ...ext import SpanTypes, db as dbx
 from ...ext import net
 from ...internal.logger import get_logger
 from ...pin import Pin
@@ -71,28 +71,28 @@ config._add(
                 'routines': {
                     'execute': {
                         'operation_name': 'vertica.query',
-                        'span_type': sql.TYPE,
+                        'span_type': SpanTypes.SQL,
                         'span_start': execute_span_start,
                         'span_end': execute_span_end,
                     },
                     'copy': {
                         'operation_name': 'vertica.copy',
-                        'span_type': sql.TYPE,
+                        'span_type': SpanTypes.SQL,
                         'span_start': copy_span_start,
                     },
                     'fetchone': {
                         'operation_name': 'vertica.fetchone',
-                        'span_type': 'vertica',
+                        'span_type': SpanTypes.SQL,
                         'span_end': fetch_span_end,
                     },
                     'fetchall': {
                         'operation_name': 'vertica.fetchall',
-                        'span_type': 'vertica',
+                        'span_type': SpanTypes.SQL,
                         'span_end': fetch_span_end,
                     },
                     'nextset': {
                         'operation_name': 'vertica.nextset',
-                        'span_type': 'vertica',
+                        'span_type': SpanTypes.SQL,
                         'span_end': fetch_span_end,
                     },
                 },
@@ -198,10 +198,8 @@ def _install_routine(patch_routine, patch_class, patch_mod, config):
 
             operation_name = conf['operation_name']
             tracer = pin.tracer
-            with tracer.trace(operation_name, service=pin.service) as span:
+            with tracer.trace(operation_name, service=pin.service, span_type=conf.get('span_type')) as span:
                 span.set_tags(pin.tags)
-                if 'span_type' in conf:
-                    span.span_type = conf['span_type']
 
                 if 'span_start' in conf:
                     conf['span_start'](instance, span, conf, *args, **kwargs)

--- a/ddtrace/ext/__init__.py
+++ b/ddtrace/ext/__init__.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class SpanTypes(Enum):
+    CACHE = "cache"
+    CASSANDRA = "cassandra"
+    ELASTICSEARCH = "elasticsearch"
+    GRPC = "grpc"
+    HTTP = "http"
+    MONGODB = "mongodb"
+    REDIS = "redis"
+    SQL = "sql"
+    TEMPLATE = "template"
+    WEB = "web"
+    WORKER = "worker"

--- a/ddtrace/ext/cassandra.py
+++ b/ddtrace/ext/cassandra.py
@@ -1,7 +1,3 @@
-
-# the type of the spans
-TYPE = 'cassandra'
-
 # tags
 CLUSTER = 'cassandra.cluster'
 KEYSPACE = 'cassandra.keyspace'

--- a/ddtrace/ext/elasticsearch.py
+++ b/ddtrace/ext/elasticsearch.py
@@ -1,7 +1,4 @@
-TYPE = 'elasticsearch'
-SERVICE = 'elasticsearch'
-APP = 'elasticsearch'
-
+SERVICE = "elasticsearch"
 # standard tags
 URL = 'elasticsearch.url'
 METHOD = 'elasticsearch.method'

--- a/ddtrace/ext/http.py
+++ b/ddtrace/ext/http.py
@@ -7,9 +7,6 @@ span.set_tag(URL, '/user/home')
 span.set_tag(STATUS_CODE, 404)
 """
 
-# type of the spans
-TYPE = 'http'
-
 # tags
 URL = 'http.url'
 METHOD = 'http.method'

--- a/ddtrace/ext/kombu.py
+++ b/ddtrace/ext/kombu.py
@@ -1,5 +1,4 @@
-# type of the spans
-TYPE = 'kombu'
+SERVICE = 'kombu'
 
 # net extension
 VHOST = 'out.vhost'

--- a/ddtrace/ext/memcached.py
+++ b/ddtrace/ext/memcached.py
@@ -1,4 +1,3 @@
 CMD = 'memcached.command'
 SERVICE = 'memcached'
-TYPE = 'memcached'
 QUERY = 'memcached.query'

--- a/ddtrace/ext/mongo.py
+++ b/ddtrace/ext/mongo.py
@@ -1,5 +1,4 @@
-TYPE = 'mongodb'
-
+SERVICE = 'mongodb'
 COLLECTION = 'mongodb.collection'
 DB = 'mongodb.db'
 ROWS = 'mongodb.rows'

--- a/ddtrace/ext/redis.py
+++ b/ddtrace/ext/redis.py
@@ -2,9 +2,6 @@
 APP = 'redis'
 DEFAULT_SERVICE = 'redis'
 
-# type of the spans
-TYPE = 'redis'
-
 # net extension
 DB = 'out.redis_db'
 

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -1,6 +1,3 @@
-# the type of the spans
-TYPE = 'sql'
-
 # tags
 QUERY = 'sql.query'   # the query text
 ROWS = 'sql.rows'     # number of rows returned by a query

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -5,7 +5,7 @@ import traceback
 
 from .compat import StringIO, stringify, iteritems, numeric_types, time_ns
 from .constants import NUMERIC_TAGS, MANUAL_DROP_KEY, MANUAL_KEEP_KEY
-from .ext import errors, priority
+from .ext import SpanTypes, errors, priority
 from .internal.logger import get_logger
 
 
@@ -74,7 +74,7 @@ class Span(object):
         self.name = name
         self.service = service
         self.resource = resource or name
-        self.span_type = span_type
+        self.span_type = span_type.value if isinstance(span_type, SpanTypes) else span_type
 
         # tags / metatdata
         self.meta = {}

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -44,6 +44,14 @@ def _parse_dogstatsd_url(url):
         raise ValueError('Unknown scheme `%s` for DogStatsD URL `{}`'.format(parsed.scheme))
 
 
+_INTERNAL_APPLICATION_SPAN_TYPES = [
+    "custom",
+    "template",
+    "web",
+    "worker"
+]
+
+
 class Tracer(object):
     """
     Tracer is used to create, sample and submit spans that measure the
@@ -368,7 +376,8 @@ class Tracer(object):
                 context.sampling_priority = AUTO_KEEP if span.sampled else AUTO_REJECT
 
             # add tags to root span to correlate trace with runtime metrics
-            if self._runtime_worker:
+            # only applied to spans with types that are internal to applications
+            if self._runtime_worker and span.span_type in _INTERNAL_APPLICATION_SPAN_TYPES:
                 span.set_tag('language', 'python')
 
         # add common tags

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,17 @@ documentation][visualization docs].
 [visualization docs]: https://docs.datadoghq.com/tracing/visualization/
 """
 
+# psutil used to generate runtime metrics for tracer
+install_requires = [
+    'psutil>=5.0.0'
+]
+
+# include enum backport
+if sys.version_info[:2] < (3, 4):
+    install_requires.extend([
+        'enum34'
+    ])
+
 # Base `setup()` kwargs without any C-extension registering
 setup_kwargs = dict(
     name='ddtrace',
@@ -66,9 +77,7 @@ setup_kwargs = dict(
     long_description_content_type='text/markdown',
     license='BSD',
     packages=find_packages(exclude=['tests*']),
-    install_requires=[
-        'psutil>=5.0.0',
-    ],
+    install_requires=install_requires,
     extras_require={
         # users can include opentracing by having:
         # install_requires=['ddtrace[opentracing]', ...]

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -38,7 +38,7 @@ class TestTraceMiddleware(TraceTestCase):
         # with the right fields
         assert 'aiohttp.request' == span.name
         assert 'aiohttp-web' == span.service
-        assert 'http' == span.span_type
+        assert 'web' == span.span_type
         assert 'GET /' == span.resource
         assert str(self.client.make_url('/')) == span.get_tag(http.URL)
         assert 'GET' == span.get_tag('http.method')
@@ -417,7 +417,7 @@ class TestTraceMiddleware(TraceTestCase):
         # with the right fields
         assert 'aiohttp.request' == inner_span.name
         assert 'aiohttp-web' == inner_span.service
-        assert 'http' == inner_span.span_type
+        assert 'web' == inner_span.span_type
         assert 'GET /' == inner_span.resource
         assert str(self.client.make_url('/')) == inner_span.get_tag(http.URL)
         assert 'GET' == inner_span.get_tag('http.method')

--- a/tests/contrib/algoliasearch/test.py
+++ b/tests/contrib/algoliasearch/test.py
@@ -1,6 +1,5 @@
 from ddtrace import config, patch_all
-from ddtrace.contrib.algoliasearch.patch import (SEARCH_SPAN_TYPE, patch,
-                                                 unpatch, algoliasearch_version)
+from ddtrace.contrib.algoliasearch.patch import (patch, unpatch, algoliasearch_version)
 from ddtrace.pin import Pin
 from tests.base import BaseTracerTestCase
 
@@ -74,7 +73,7 @@ class AlgoliasearchTest(BaseTracerTestCase):
         span = spans[0]
         assert span.service == 'algoliasearch'
         assert span.name == 'algoliasearch.search'
-        assert span.span_type == SEARCH_SPAN_TYPE
+        assert span.span_type is None
         assert span.error == 0
         assert span.get_tag('query.args.attributes_to_retrieve') == 'firstname,lastname'
         # Verify that adding new arguments to the search API will simply be ignored and not cause

--- a/tests/contrib/boto/test.py
+++ b/tests/contrib/boto/test.py
@@ -59,7 +59,7 @@ class BotoTest(BaseTracerTestCase):
         self.assertEqual(span.service, 'test-boto-tracing.ec2')
         self.assertEqual(span.resource, 'ec2.runinstances')
         self.assertEqual(span.name, 'ec2.command')
-        self.assertEqual(span.span_type, 'boto')
+        self.assertEqual(span.span_type, 'http')
 
     @mock_ec2
     def test_analytics_enabled_with_rate(self):

--- a/tests/contrib/cassandra/test.py
+++ b/tests/contrib/cassandra/test.py
@@ -121,7 +121,7 @@ class CassandraBase(object):
         query = spans[0]
         assert query.service == self.TEST_SERVICE
         assert query.resource == self.TEST_QUERY
-        assert query.span_type == cassx.TYPE
+        assert query.span_type == 'cassandra'
 
         assert query.get_tag(cassx.KEYSPACE) == self.TEST_KEYSPACE
         assert query.get_tag(net.TARGET_PORT) == self.TEST_PORT
@@ -201,7 +201,7 @@ class CassandraBase(object):
 
         assert dd_span.service == self.TEST_SERVICE
         assert dd_span.resource == self.TEST_QUERY
-        assert dd_span.span_type == cassx.TYPE
+        assert dd_span.span_type == 'cassandra'
 
         assert dd_span.get_tag(cassx.KEYSPACE) == self.TEST_KEYSPACE
         assert dd_span.get_tag(net.TARGET_PORT) == self.TEST_PORT
@@ -259,7 +259,7 @@ class CassandraBase(object):
             query = spans[i]
             assert query.service == self.TEST_SERVICE
             assert query.resource == self.TEST_QUERY_PAGINATED
-            assert query.span_type == cassx.TYPE
+            assert query.span_type == 'cassandra'
 
             assert query.get_tag(cassx.KEYSPACE) == self.TEST_KEYSPACE
             assert query.get_tag(net.TARGET_PORT) == self.TEST_PORT

--- a/tests/contrib/django/test_middleware.py
+++ b/tests/contrib/django/test_middleware.py
@@ -40,7 +40,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         assert sp_request.get_tag(http.URL) == 'http://testserver/users/'
         assert sp_request.get_tag('django.user.is_authenticated') == 'False'
         assert sp_request.get_tag('http.method') == 'GET'
-        assert sp_request.span_type == 'http'
+        assert sp_request.span_type == 'web'
         assert sp_request.resource == 'tests.contrib.django.app.views.UserList'
         if config.django.trace_query_string:
             assert sp_request.get_tag(http.QUERY_STRING) == query_string
@@ -455,5 +455,5 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         assert sp_request.get_tag(http.URL) == 'http://testserver/unknown-url'
         assert sp_request.get_tag('django.user.is_authenticated') == 'False'
         assert sp_request.get_tag('http.method') == 'GET'
-        assert sp_request.span_type == 'http'
+        assert sp_request.span_type == 'web'
         assert sp_request.resource == 'django.views.defaults.page_not_found'

--- a/tests/contrib/djangorestframework/test_djangorestframework.py
+++ b/tests/contrib/djangorestframework/test_djangorestframework.py
@@ -37,7 +37,7 @@ class RestFrameworkTest(DjangoTraceTestCase):
         assert sp.name == 'django.request'
         assert sp.resource == 'tests.contrib.djangorestframework.app.views.UserViewSet'
         assert sp.error == 0
-        assert sp.span_type == 'http'
+        assert sp.span_type == 'web'
         assert sp.get_tag('http.status_code') == '500'
         assert sp.get_tag('error.msg') is None
 
@@ -54,7 +54,7 @@ class RestFrameworkTest(DjangoTraceTestCase):
         assert sp.name == 'django.request'
         assert sp.resource == 'tests.contrib.djangorestframework.app.views.UserViewSet'
         assert sp.error == 1
-        assert sp.span_type == 'http'
+        assert sp.span_type == 'web'
         assert sp.get_tag('http.method') == 'GET'
         assert sp.get_tag('http.status_code') == '500'
         assert sp.get_tag('error.msg') == 'Authentication credentials were not provided.'

--- a/tests/contrib/falcon/test_suite.py
+++ b/tests/contrib/falcon/test_suite.py
@@ -65,7 +65,7 @@ class FalconTestCase(object):
         else:
             assert httpx.QUERY_STRING not in span.meta
         assert span.parent_id is None
-        assert span.span_type == 'http'
+        assert span.span_type == 'web'
 
     def test_200_qs(self):
         return self.test_200('foo=bar')

--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -55,7 +55,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.service, 'flask')
         self.assertEqual(req_span.name, 'flask.request')
         self.assertEqual(req_span.resource, 'GET /')
-        self.assertEqual(req_span.span_type, 'http')
+        self.assertEqual(req_span.span_type, 'web')
         self.assertEqual(req_span.error, 0)
         self.assertIsNone(req_span.parent_id)
 
@@ -293,7 +293,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.name, 'flask.request')
         # Note: contains no query string
         self.assertEqual(req_span.resource, 'GET /')
-        self.assertEqual(req_span.span_type, 'http')
+        self.assertEqual(req_span.span_type, 'web')
         self.assertEqual(req_span.error, 0)
         self.assertIsNone(req_span.parent_id)
 
@@ -360,7 +360,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.service, 'flask')
         self.assertEqual(req_span.name, 'flask.request')
         self.assertEqual(req_span.resource, u'GET /üŋïĉóđē')
-        self.assertEqual(req_span.span_type, 'http')
+        self.assertEqual(req_span.span_type, 'web')
         self.assertEqual(req_span.error, 0)
         self.assertIsNone(req_span.parent_id)
 
@@ -420,7 +420,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.service, 'flask')
         self.assertEqual(req_span.name, 'flask.request')
         self.assertEqual(req_span.resource, 'GET 404')
-        self.assertEqual(req_span.span_type, 'http')
+        self.assertEqual(req_span.span_type, 'web')
         self.assertEqual(req_span.error, 0)
         self.assertIsNone(req_span.parent_id)
 
@@ -485,7 +485,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.service, 'flask')
         self.assertEqual(req_span.name, 'flask.request')
         self.assertEqual(req_span.resource, 'GET /not-found')
-        self.assertEqual(req_span.span_type, 'http')
+        self.assertEqual(req_span.span_type, 'web')
         self.assertEqual(req_span.error, 0)
         self.assertIsNone(req_span.parent_id)
 
@@ -562,7 +562,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.service, 'flask')
         self.assertEqual(req_span.name, 'flask.request')
         self.assertEqual(req_span.resource, 'GET /500')
-        self.assertEqual(req_span.span_type, 'http')
+        self.assertEqual(req_span.span_type, 'web')
         self.assertEqual(req_span.error, 1)
         self.assertIsNone(req_span.parent_id)
 
@@ -650,7 +650,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.service, 'flask')
         self.assertEqual(req_span.name, 'flask.request')
         self.assertEqual(req_span.resource, 'GET /501')
-        self.assertEqual(req_span.span_type, 'http')
+        self.assertEqual(req_span.span_type, 'web')
         self.assertEqual(req_span.error, 1)
         self.assertIsNone(req_span.parent_id)
 
@@ -762,7 +762,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.service, 'flask')
         self.assertEqual(req_span.name, 'flask.request')
         self.assertEqual(req_span.resource, 'GET /500')
-        self.assertEqual(req_span.span_type, 'http')
+        self.assertEqual(req_span.span_type, 'web')
         self.assertEqual(req_span.error, 1)
         self.assertIsNone(req_span.parent_id)
 

--- a/tests/contrib/flask_autopatch/test_flask_autopatch.py
+++ b/tests/contrib/flask_autopatch/test_flask_autopatch.py
@@ -76,7 +76,7 @@ class FlaskAutopatchTestCase(unittest.TestCase):
         self.assertEqual(req_span.service, 'test-flask')
         self.assertEqual(req_span.name, 'flask.request')
         self.assertEqual(req_span.resource, 'GET /')
-        self.assertEqual(req_span.span_type, 'http')
+        self.assertEqual(req_span.span_type, 'web')
         self.assertEqual(req_span.error, 0)
         self.assertIsNone(req_span.parent_id)
 

--- a/tests/contrib/flask_cache/test.py
+++ b/tests/contrib/flask_cache/test.py
@@ -4,7 +4,7 @@
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.ext import net
 from ddtrace.contrib.flask_cache import get_traced_cache
-from ddtrace.contrib.flask_cache.tracers import TYPE, CACHE_BACKEND
+from ddtrace.contrib.flask_cache.tracers import CACHE_BACKEND
 
 # 3rd party
 from flask import Flask
@@ -176,7 +176,7 @@ class FlaskCacheTest(BaseTracerTestCase):
         # test tags and attributes
         with self.cache._TracedCache__trace('flask_cache.cmd') as span:
             self.assertEqual(span.service, self.SERVICE)
-            self.assertEqual(span.span_type, TYPE)
+            self.assertEqual(span.span_type, 'cache')
             self.assertEqual(span.meta[CACHE_BACKEND], 'simple')
             self.assertTrue(net.TARGET_HOST not in span.meta)
             self.assertTrue(net.TARGET_PORT not in span.meta)
@@ -193,7 +193,7 @@ class FlaskCacheTest(BaseTracerTestCase):
         # test tags and attributes
         with cache._TracedCache__trace('flask_cache.cmd') as span:
             self.assertEqual(span.service, self.SERVICE)
-            self.assertEqual(span.span_type, TYPE)
+            self.assertEqual(span.span_type, 'cache')
             self.assertEqual(span.meta[CACHE_BACKEND], 'redis')
             self.assertEqual(span.meta[net.TARGET_HOST], 'localhost')
             self.assertEqual(span.meta[net.TARGET_PORT], self.TEST_REDIS_PORT)
@@ -210,7 +210,7 @@ class FlaskCacheTest(BaseTracerTestCase):
         # test tags and attributes
         with cache._TracedCache__trace('flask_cache.cmd') as span:
             self.assertEqual(span.service, self.SERVICE)
-            self.assertEqual(span.span_type, TYPE)
+            self.assertEqual(span.span_type, 'cache')
             self.assertEqual(span.meta[CACHE_BACKEND], 'memcached')
             self.assertEqual(span.meta[net.TARGET_HOST], '127.0.0.1')
             self.assertEqual(span.meta[net.TARGET_PORT], self.TEST_MEMCACHED_PORT)

--- a/tests/contrib/kombu/test.py
+++ b/tests/contrib/kombu/test.py
@@ -69,7 +69,7 @@ class TestKombuPatch(BaseTracerTestCase):
         consumer_span = spans[0]
         self.assertEqual(consumer_span.service, self.TEST_SERVICE)
         self.assertEqual(consumer_span.name, kombux.PUBLISH_NAME)
-        self.assertEqual(consumer_span.span_type, 'kombu')
+        self.assertEqual(consumer_span.span_type, 'worker')
         self.assertEqual(consumer_span.error, 0)
         self.assertEqual(consumer_span.get_tag('out.vhost'), '/')
         self.assertEqual(consumer_span.get_tag('out.host'), '127.0.0.1')
@@ -81,7 +81,7 @@ class TestKombuPatch(BaseTracerTestCase):
         producer_span = spans[1]
         self.assertEqual(producer_span.service, self.TEST_SERVICE)
         self.assertEqual(producer_span.name, kombux.RECEIVE_NAME)
-        self.assertEqual(producer_span.span_type, 'kombu')
+        self.assertEqual(producer_span.span_type, 'worker')
         self.assertEqual(producer_span.error, 0)
         self.assertEqual(producer_span.get_tag('kombu.exchange'), u'tasks')
         self.assertEqual(producer_span.get_tag('kombu.routing_key'), u'tasks')

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -48,6 +48,7 @@ class TestMolten(BaseTracerTestCase):
         span = spans[0]
         self.assertEqual(span.service, 'molten')
         self.assertEqual(span.name, 'molten.request')
+        self.assertEqual(span.span_type, 'web')
         self.assertEqual(span.resource, 'GET /hello/{name}/{age}')
         self.assertEqual(span.get_tag('http.method'), 'GET')
         self.assertEqual(span.get_tag(http.URL), 'http://127.0.0.1:8000/hello/Jim/24')

--- a/tests/contrib/mongoengine/test.py
+++ b/tests/contrib/mongoengine/test.py
@@ -192,7 +192,7 @@ class MongoEngineCore(object):
 class TestMongoEnginePatchConnectDefault(unittest.TestCase, MongoEngineCore):
     """Test suite with a global Pin for the connect function with the default configuration"""
 
-    TEST_SERVICE = mongox.TYPE
+    TEST_SERVICE = mongox.SERVICE
 
     def setUp(self):
         patch()
@@ -227,7 +227,7 @@ class TestMongoEnginePatchConnect(TestMongoEnginePatchConnectDefault):
 class TestMongoEnginePatchClientDefault(unittest.TestCase, MongoEngineCore):
     """Test suite with a Pin local to a specific client with default configuration"""
 
-    TEST_SERVICE = mongox.TYPE
+    TEST_SERVICE = mongox.SERVICE
 
     def setUp(self):
         patch()

--- a/tests/contrib/pylons/test_pylons.py
+++ b/tests/contrib/pylons/test_pylons.py
@@ -56,7 +56,7 @@ class PylonsTestCase(BaseTracerTestCase):
         assert span.get_tag(errors.ERROR_MSG) is None
         assert span.get_tag(errors.ERROR_TYPE) is None
         assert span.get_tag(errors.ERROR_STACK) is None
-        assert span.span_type == 'http'
+        assert span.span_type == 'web'
 
     def test_mw_exc_success(self):
         """Ensure exceptions can be properly handled by other middleware.

--- a/tests/contrib/pymemcache/test_client_mixin.py
+++ b/tests/contrib/pymemcache/test_client_mixin.py
@@ -6,8 +6,7 @@ import pymemcache
 from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.pymemcache.patch import patch, unpatch
-from ddtrace.ext import memcached as memcachedx
-from ddtrace.ext import net
+from ddtrace.ext import memcached as memcachedx, net
 from .utils import MockSocket
 
 from tests.test_tracer import get_dummy_tracer
@@ -38,7 +37,7 @@ class PymemcacheClientTestCaseMixin(unittest.TestCase):
             self.assertEqual(span.get_tag(net.TARGET_HOST), TEST_HOST)
             self.assertEqual(span.get_tag(net.TARGET_PORT), str(TEST_PORT))
             self.assertEqual(span.name, memcachedx.CMD)
-            self.assertEqual(span.span_type, memcachedx.TYPE)
+            self.assertEqual(span.span_type, 'cache')
             self.assertEqual(span.service, memcachedx.SERVICE)
             self.assertEqual(span.get_tag(memcachedx.QUERY), query)
             self.assertEqual(span.resource, resource)

--- a/tests/contrib/pymongo/test.py
+++ b/tests/contrib/pymongo/test.py
@@ -353,7 +353,7 @@ class TestPymongoTraceClient(unittest.TestCase, PymongoCore):
 class TestPymongoPatchDefault(unittest.TestCase, PymongoCore):
     """Test suite for pymongo with the default patched library"""
 
-    TEST_SERVICE = mongox.TYPE
+    TEST_SERVICE = mongox.SERVICE
 
     def setUp(self):
         patch()

--- a/tests/contrib/pyramid/utils.py
+++ b/tests/contrib/pyramid/utils.py
@@ -63,7 +63,7 @@ class PyramidTestCase(PyramidBase):
         assert s.service == 'foobar'
         assert s.resource == 'GET index'
         assert s.error == 0
-        assert s.span_type == 'http'
+        assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
         assert s.meta.get('http.status_code') == '200'
         assert s.meta.get(http.URL) == 'http://localhost/'
@@ -152,7 +152,7 @@ class PyramidTestCase(PyramidBase):
         assert s.service == 'foobar'
         assert s.resource == '404'
         assert s.error == 0
-        assert s.span_type == 'http'
+        assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
         assert s.meta.get('http.status_code') == '404'
         assert s.meta.get(http.URL) == 'http://localhost/404'
@@ -167,7 +167,7 @@ class PyramidTestCase(PyramidBase):
         assert s.service == 'foobar'
         assert s.resource == 'GET raise_redirect'
         assert s.error == 0
-        assert s.span_type == 'http'
+        assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
         assert s.meta.get('http.status_code') == '302'
         assert s.meta.get(http.URL) == 'http://localhost/redirect'
@@ -182,7 +182,7 @@ class PyramidTestCase(PyramidBase):
         assert s.service == 'foobar'
         assert s.resource == 'GET raise_no_content'
         assert s.error == 0
-        assert s.span_type == 'http'
+        assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
         assert s.meta.get('http.status_code') == '204'
         assert s.meta.get(http.URL) == 'http://localhost/nocontent'
@@ -200,7 +200,7 @@ class PyramidTestCase(PyramidBase):
         assert s.service == 'foobar'
         assert s.resource == 'GET exception'
         assert s.error == 1
-        assert s.span_type == 'http'
+        assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
         assert s.meta.get('http.status_code') == '500'
         assert s.meta.get(http.URL) == 'http://localhost/exception'
@@ -216,7 +216,7 @@ class PyramidTestCase(PyramidBase):
         assert s.service == 'foobar'
         assert s.resource == 'GET error'
         assert s.error == 1
-        assert s.span_type == 'http'
+        assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
         assert s.meta.get('http.status_code') == '500'
         assert s.meta.get(http.URL) == 'http://localhost/error'
@@ -236,7 +236,7 @@ class PyramidTestCase(PyramidBase):
         assert s.service == 'foobar'
         assert s.resource == 'GET json'
         assert s.error == 0
-        assert s.span_type == 'http'
+        assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
         assert s.meta.get('http.status_code') == '200'
         assert s.meta.get(http.URL) == 'http://localhost/json'
@@ -260,7 +260,7 @@ class PyramidTestCase(PyramidBase):
         assert s.service == 'foobar'
         assert s.resource == 'GET renderer'
         assert s.error == 0
-        assert s.span_type == 'http'
+        assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
         assert s.meta.get('http.status_code') == '200'
         assert s.meta.get(http.URL) == 'http://localhost/renderer'
@@ -282,7 +282,7 @@ class PyramidTestCase(PyramidBase):
         assert s.service == 'foobar'
         assert s.resource == '404'
         assert s.error == 1
-        assert s.span_type == 'http'
+        assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
         assert s.meta.get('http.status_code') == '404'
         assert s.meta.get(http.URL) == 'http://localhost/404/raise_exception'
@@ -354,7 +354,7 @@ class PyramidTestCase(PyramidBase):
         assert dd_span.service == 'foobar'
         assert dd_span.resource == 'GET index'
         assert dd_span.error == 0
-        assert dd_span.span_type == 'http'
+        assert dd_span.span_type == 'web'
         assert dd_span.meta.get('http.method') == 'GET'
         assert dd_span.meta.get('http.status_code') == '200'
         assert dd_span.meta.get(http.URL) == 'http://localhost/'

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -107,7 +107,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         assert s.get_tag(http.METHOD) == 'GET'
         assert s.get_tag(http.STATUS_CODE) == '200'
         assert s.error == 0
-        assert s.span_type == http.TYPE
+        assert s.span_type == 'http'
         assert http.QUERY_STRING not in s.meta
 
     def test_200_send(self):
@@ -124,7 +124,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         assert s.get_tag(http.METHOD) == 'GET'
         assert s.get_tag(http.STATUS_CODE) == '200'
         assert s.error == 0
-        assert s.span_type == http.TYPE
+        assert s.span_type == 'http'
 
     def test_200_query_string(self):
         # ensure query string is removed before adding url to metadata
@@ -140,7 +140,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         assert s.get_tag(http.STATUS_CODE) == '200'
         assert s.get_tag(http.URL) == URL_200
         assert s.error == 0
-        assert s.span_type == http.TYPE
+        assert s.span_type == 'http'
         assert s.get_tag(http.QUERY_STRING) == query_string
 
     def test_requests_module_200(self):
@@ -156,7 +156,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
             assert s.get_tag(http.METHOD) == 'GET'
             assert s.get_tag(http.STATUS_CODE) == '200'
             assert s.error == 0
-            assert s.span_type == http.TYPE
+            assert s.span_type == 'http'
 
     def test_post_500(self):
         out = self.session.post(URL_500)
@@ -370,7 +370,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         assert dd_span.get_tag(http.METHOD) == 'GET'
         assert dd_span.get_tag(http.STATUS_CODE) == '200'
         assert dd_span.error == 0
-        assert dd_span.span_type == http.TYPE
+        assert dd_span.span_type == 'http'
 
     def test_request_and_response_headers(self):
         # Disabled when not configured

--- a/tests/contrib/tornado/test_executor_decorator.py
+++ b/tests/contrib/tornado/test_executor_decorator.py
@@ -27,7 +27,7 @@ class TestTornadoExecutor(TornadoTestCase):
         request_span = traces[1][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '200' == request_span.get_tag('http.status_code')
@@ -58,7 +58,7 @@ class TestTornadoExecutor(TornadoTestCase):
         request_span = traces[1][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorSubmitHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '200' == request_span.get_tag('http.status_code')
@@ -88,7 +88,7 @@ class TestTornadoExecutor(TornadoTestCase):
         request_span = traces[1][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorExceptionHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '500' == request_span.get_tag('http.status_code')
@@ -125,7 +125,7 @@ class TestTornadoExecutor(TornadoTestCase):
         request_span = traces[1][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorCustomHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '200' == request_span.get_tag('http.status_code')
@@ -158,7 +158,7 @@ class TestTornadoExecutor(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorCustomArgsHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '500' == request_span.get_tag('http.status_code')

--- a/tests/contrib/tornado/test_tornado_template.py
+++ b/tests/contrib/tornado/test_tornado_template.py
@@ -25,7 +25,7 @@ class TestTornadoTemplate(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.TemplateHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '200' == request_span.get_tag('http.status_code')
@@ -72,7 +72,7 @@ class TestTornadoTemplate(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.TemplatePartialHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '200' == request_span.get_tag('http.status_code')
@@ -127,7 +127,7 @@ class TestTornadoTemplate(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.TemplateExceptionHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '500' == request_span.get_tag('http.status_code')

--- a/tests/contrib/tornado/test_tornado_web.py
+++ b/tests/contrib/tornado/test_tornado_web.py
@@ -30,7 +30,7 @@ class TestTornadoWeb(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.SuccessHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '200' == request_span.get_tag('http.status_code')
@@ -60,7 +60,7 @@ class TestTornadoWeb(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.NestedHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '200' == request_span.get_tag('http.status_code')
@@ -87,7 +87,7 @@ class TestTornadoWeb(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExceptionHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '500' == request_span.get_tag('http.status_code')
@@ -108,7 +108,7 @@ class TestTornadoWeb(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.HTTPExceptionHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '501' == request_span.get_tag('http.status_code')
@@ -129,7 +129,7 @@ class TestTornadoWeb(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.HTTPException500Handler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '500' == request_span.get_tag('http.status_code')
@@ -150,7 +150,7 @@ class TestTornadoWeb(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.SyncSuccessHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '200' == request_span.get_tag('http.status_code')
@@ -169,7 +169,7 @@ class TestTornadoWeb(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.SyncExceptionHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '500' == request_span.get_tag('http.status_code')
@@ -190,7 +190,7 @@ class TestTornadoWeb(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tornado.web.ErrorHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '404' == request_span.get_tag('http.status_code')
@@ -211,7 +211,7 @@ class TestTornadoWeb(TornadoTestCase):
         redirect_span = traces[0][0]
         assert 'tornado-web' == redirect_span.service
         assert 'tornado.request' == redirect_span.name
-        assert 'http' == redirect_span.span_type
+        assert 'web' == redirect_span.span_type
         assert 'tornado.web.RedirectHandler' == redirect_span.resource
         assert 'GET' == redirect_span.get_tag('http.method')
         assert '301' == redirect_span.get_tag('http.status_code')
@@ -221,7 +221,7 @@ class TestTornadoWeb(TornadoTestCase):
         success_span = traces[1][0]
         assert 'tornado-web' == success_span.service
         assert 'tornado.request' == success_span.name
-        assert 'http' == success_span.span_type
+        assert 'web' == success_span.span_type
         assert 'tests.contrib.tornado.web.app.SuccessHandler' == success_span.resource
         assert 'GET' == success_span.get_tag('http.method')
         assert '200' == success_span.get_tag('http.status_code')
@@ -241,7 +241,7 @@ class TestTornadoWeb(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tornado.web.StaticFileHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '200' == request_span.get_tag('http.status_code')
@@ -303,7 +303,7 @@ class TestTornadoWeb(TornadoTestCase):
 
         assert 'tornado-web' == dd_span.service
         assert 'tornado.request' == dd_span.name
-        assert 'http' == dd_span.span_type
+        assert 'web' == dd_span.span_type
         assert 'tests.contrib.tornado.web.app.SuccessHandler' == dd_span.resource
         assert 'GET' == dd_span.get_tag('http.method')
         assert '200' == dd_span.get_tag('http.status_code')
@@ -482,7 +482,7 @@ class TestCustomTornadoWeb(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.CustomDefaultHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '400' == request_span.get_tag('http.status_code')

--- a/tests/contrib/tornado/test_wrap_decorator.py
+++ b/tests/contrib/tornado/test_wrap_decorator.py
@@ -18,7 +18,7 @@ class TestTornadoWebWrapper(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.NestedWrapHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '200' == request_span.get_tag('http.status_code')
@@ -44,7 +44,7 @@ class TestTornadoWebWrapper(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.NestedExceptionWrapHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '500' == request_span.get_tag('http.status_code')
@@ -74,7 +74,7 @@ class TestTornadoWebWrapper(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.SyncNestedWrapHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '200' == request_span.get_tag('http.status_code')
@@ -100,7 +100,7 @@ class TestTornadoWebWrapper(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.SyncNestedExceptionWrapHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '500' == request_span.get_tag('http.status_code')
@@ -130,7 +130,7 @@ class TestTornadoWebWrapper(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorWrapHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '200' == request_span.get_tag('http.status_code')
@@ -157,7 +157,7 @@ class TestTornadoWebWrapper(TornadoTestCase):
         request_span = traces[0][0]
         assert 'tornado-web' == request_span.service
         assert 'tornado.request' == request_span.name
-        assert 'http' == request_span.span_type
+        assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorExceptionWrapHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
         assert '500' == request_span.get_tag('http.status_code')

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -6,7 +6,7 @@ from unittest.case import SkipTest
 from ddtrace.context import Context
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.span import Span
-from ddtrace.ext import errors, priority
+from ddtrace.ext import SpanTypes, errors, priority
 from .base import BaseTracerTestCase
 
 
@@ -167,6 +167,22 @@ class SpanTestCase(BaseTracerTestCase):
 
         else:
             assert 0, 'should have failed'
+
+    def test_span_type(self):
+        s = Span(tracer=None, name='test.span', service='s', resource='r', span_type=SpanTypes.WEB)
+        s.set_tag('a', '1')
+        s.set_meta('b', '2')
+        s.finish()
+
+        d = s.to_dict()
+        assert d
+        assert d['span_id'] == s.span_id
+        assert d['trace_id'] == s.trace_id
+        assert d['parent_id'] == s.parent_id
+        assert d['meta'] == {'a': '1', 'b': '2'}
+        assert d['type'] == 'web'
+        assert d['error'] == 0
+        assert type(d['error']) == int
 
     def test_span_to_dict(self):
         s = Span(tracer=None, name='test.span', service='s', resource='r')

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -494,16 +494,30 @@ class TracerTestCase(BaseTracerTestCase):
 
         self.assertIsNone(child.get_tag('language'))
 
-    def test_only_root_span_runtime(self):
+    def test_only_root_span_runtime_internal_span_types(self):
         self.tracer.configure(collect_metrics=True)
 
-        root = self.start_span('root')
-        context = root.context
-        child = self.start_span('child', child_of=context)
+        for span_type in ("custom", "template", "web", "worker"):
+            root = self.start_span('root', span_type=span_type)
+            context = root.context
+            child = self.start_span('child', child_of=context)
 
-        self.assertEqual(root.get_tag('language'), 'python')
+            self.assertEqual(root.get_tag('language'), 'python')
 
-        self.assertIsNone(child.get_tag('language'))
+            self.assertIsNone(child.get_tag('language'))
+
+    def test_only_root_span_runtime_external_span_types(self):
+        self.tracer.configure(collect_metrics=True)
+
+        for span_type in ("algoliasearch.search", "boto", "cache", "cassandra", "elasticsearch",
+                          "grpc", "kombu", "http", "memcached", "redis", "sql", "vertica"):
+            root = self.start_span('root', span_type=span_type)
+            context = root.context
+            child = self.start_span('child', child_of=context)
+
+            self.assertIsNone(root.get_tag('language'))
+
+            self.assertIsNone(child.get_tag('language'))
 
 
 def test_installed_excepthook():

--- a/tox.ini
+++ b/tox.ini
@@ -147,6 +147,8 @@ deps =
 # https://github.com/aio-libs/aiohttp/issues/2662
     yarl: yarl==0.18.0
     yarl10: yarl>=1.0,<1.1
+# backports
+    py27: enum34
 # integrations
     aiobotocore010: aiobotocore>=0.10,<0.11
     aiobotocore09: aiobotocore>=0.9,<0.10

--- a/tox.ini
+++ b/tox.ini
@@ -470,6 +470,69 @@ deps=
 commands=flake8 .
 basepython=python3.7
 
+# do not use develop mode with celery as running multiple python versions within
+# same job will cause problem for tests that use ddtrace-run
+[celery_contrib]
+usedevelop = False
+[testenv:celery_contrib-py27-celery31-redis210]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py34-celery31-redis210]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py35-celery31-redis210]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py36-celery31-redis210]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py27-celery40-redis210-kombu43]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py27-celery40-redis320-kombu44]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py27-celery41-redis210-kombu43]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py27-celery41-redis320-kombu44]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py34-celery40-redis210-kombu43]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py34-celery40-redis320-kombu44]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py34-celery41-redis210-kombu43]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py34-celery41-redis320-kombu44]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py35-celery40-redis210-kombu43]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py35-celery40-redis320-kombu44]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py35-celery41-redis210-kombu43]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py35-celery41-redis320-kombu44]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py36-celery40-redis210-kombu43]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py36-celery40-redis320-kombu44]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py36-celery41-redis210-kombu43]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py36-celery41-redis320-kombu44]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py27-celery42-redis210-kombu43]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py34-celery42-redis210-kombu43]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py35-celery42-redis210-kombu43]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py36-celery42-redis210-kombu43]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py27-celery43-redis320-kombu44]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py34-celery43-redis320-kombu44]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py35-celery43-redis320-kombu44]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py36-celery43-redis320-kombu44]
+usedevelop = {[celery_contrib]usedevelop}
+[testenv:celery_contrib-py37-celery43-redis320-kombu44]
+usedevelop = {[celery_contrib]usedevelop}
+
 [falcon_autopatch]
 setenv =
     DATADOG_SERVICE_NAME=my-falcon


### PR DESCRIPTION
This PR refactors the set of constant span types and revises the language tag such that it is only set for specific span types, closely following the Ruby tracer's implementation https://github.com/DataDog/dd-trace-rb/pull/848/.

For the most part, this PR replaces `TYPE` fields defined in integration-specific modules from `ddtrace.ext.*` into a single `enum` subclass `SpanTypes`.

The expected values for each integration have remained the same except for the following integrations:

- Use `SpanTypes.WEB` for request spans in the `aiohttp`, `django`, `falcon`, `flask`, `molten`, `pylons`, `pyramid`, `tornado` integrations
- Use `SpanTypes.HTTP` for spans in the `boto` integration
- Use `SpanTypes.WORKER` for spans in the `kombu` integration
- In cases where no common span type is currently identified, do not set the the span type (`algoliasearch`)

The language tag is set in https://github.com/DataDog/dd-trace-py/pull/1150/files#diff-ba5f6c17564de9d9f60424d8ddda624bR380