### PR TITLE
core: change DatadogSampler defaults

### DIFF
--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -112,14 +112,11 @@ class DatadogSampler(BaseSampler):
     """
     This sampler is currently in ALPHA and it's API may change at any time, use at your own risk.
     """
-    # TODO: Remove '_priority_sampler' when we no longer use the fallback
-    __slots__ = ('default_sampler', 'rules', '_priority_sampler')
+    __slots__ = ('default_sampler', 'limiter', 'rules')
 
-    DEFAULT_RATE_LIMIT = 100
     NO_RATE_LIMIT = -1
 
-    # TODO: Remove _priority_sampler=None when we no longer use the fallback
-    def __init__(self, rules=None, default_sample_rate=1.0, rate_limit=DEFAULT_RATE_LIMIT, _priority_sampler=None):
+    def __init__(self, rules=None, default_sample_rate=1.0, rate_limit=NO_RATE_LIMIT):
         """
         Constructor for DatadogSampler sampler
 
@@ -128,7 +125,7 @@ class DatadogSampler(BaseSampler):
         :param default_sample_rate: The default sample rate to apply if no rules matched (default: 1.0)
         :type default_sample_rate: float 0 <= X <= 1.0
         :param rate_limit: Global rate limit (traces per second) to apply to all traces regardless of the rules
-            applied to them, default 100 traces per second
+            applied to them, default is no rate limit
         :type rate_limit: :obj:`int`
         """
         # Ensure rules is a list
@@ -144,9 +141,6 @@ class DatadogSampler(BaseSampler):
         # Configure rate limiter
         self.limiter = RateLimiter(rate_limit)
         self.default_sampler = SamplingRule(sample_rate=default_sample_rate)
-
-        # TODO: Remove when we no longer use the fallback
-        self._priority_sampler = _priority_sampler
 
     def _set_priority(self, span, priority):
         if span._context:
@@ -173,16 +167,7 @@ class DatadogSampler(BaseSampler):
                 matching_rule = rule
                 break
         else:
-            # No rule matches, fallback to priority sampling if set
-            if self._priority_sampler:
-                if self._priority_sampler.sample(span):
-                    self._set_priority(span, AUTO_KEEP)
-                    return True
-                else:
-                    self._set_priority(span, AUTO_REJECT)
-                    return False
-
-            # No rule matches, no priority sampler, use the default sampler
+            # No rule matches, use the default sampler
             matching_rule = self.default_sampler
 
         # Sample with the matching sampling rule

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -212,10 +212,6 @@ class Tracer(object):
         if sampler is not None:
             self.sampler = sampler
 
-        # TODO: Remove when we remove the fallback to priority sampling
-        if isinstance(self.sampler, DatadogSampler):
-            self.sampler._priority_sampler = self.priority_sampler
-
         if dogstatsd_host is not None and dogstatsd_url is None:
             dogstatsd_url = 'udp://{}:{}'.format(dogstatsd_host, dogstatsd_port or self.DEFAULT_DOGSTATSD_PORT)
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -437,13 +437,13 @@ def test_datadog_sampler_init():
     sampler = DatadogSampler()
     assert sampler.rules == []
     assert isinstance(sampler.limiter, RateLimiter)
-    assert sampler.limiter.rate_limit == DatadogSampler.DEFAULT_RATE_LIMIT
+    assert sampler.limiter.rate_limit == DatadogSampler.NO_RATE_LIMIT
 
     # With rules
     rule = SamplingRule(sample_rate=1)
     sampler = DatadogSampler(rules=[rule])
     assert sampler.rules == [rule]
-    assert sampler.limiter.rate_limit == DatadogSampler.DEFAULT_RATE_LIMIT
+    assert sampler.limiter.rate_limit == DatadogSampler.NO_RATE_LIMIT
 
     # With rate limit
     sampler = DatadogSampler(rate_limit=10)
@@ -624,76 +624,6 @@ def test_datadog_sampler_sample_rules(mock_is_allowed, dummy_tracer):
         rules[2].matches.assert_not_called()
         rules[2].sample.assert_not_called()
 
-    # No rules match and priority sampler is defined
-    #   All rules SamplingRule.matches are called
-    #   Priority sampler's `sample` method is called
-    #   Result of priority sampler is returned
-    #   Rate limiter is not called
-    # TODO: Remove this case when we remove fallback to priority sampling
-    with reset_mocks():
-        span = create_span(tracer=dummy_tracer)
-
-        # Configure mock priority sampler
-        priority_sampler = RateByServiceSampler()
-        for rate_sampler in priority_sampler._by_service_samplers.values():
-            rate_sampler.set_sample_rate(1)
-
-        spy_sampler = mock.Mock(spec=RateByServiceSampler, wraps=priority_sampler)
-        sampler._priority_sampler = spy_sampler
-
-        for rule in rules:
-            rule.matches.return_value = False
-            rule.sample.return_value = False
-
-        assert sampler.sample(span) is True
-        assert span._context.sampling_priority is AUTO_KEEP
-        assert span.sampled is True
-        mock_is_allowed.assert_not_called()
-        sampler.default_sampler.sample.assert_not_called()
-        spy_sampler.sample.assert_called_once_with(span)
-        assert_sampling_decision_tags(span, agent=1)
-
-        [r.matches.assert_called_once_with(span) for r in rules]
-        [r.sample.assert_not_called() for r in rules]
-
-        # Reset priority sampler property
-        sampler._priority_sampler = None
-
-    # No rules match and priority sampler is defined
-    #   All rules SamplingRule.matches are called
-    #   Priority sampler's `sample` method is called
-    #   Result of priority sampler is returned
-    #   Rate limiter is not called
-    # TODO: Remove this case when we remove fallback to priority sampling
-    with reset_mocks():
-        span = create_span(tracer=dummy_tracer)
-
-        # Configure mock priority sampler
-        priority_sampler = RateByServiceSampler()
-        for rate_sampler in priority_sampler._by_service_samplers.values():
-            rate_sampler.set_sample_rate(0)
-
-        spy_sampler = mock.Mock(spec=RateByServiceSampler, wraps=priority_sampler)
-        sampler._priority_sampler = spy_sampler
-
-        for rule in rules:
-            rule.matches.return_value = False
-            rule.sample.return_value = False
-
-        assert sampler.sample(span) is False
-        assert span._context.sampling_priority is AUTO_REJECT
-        assert span.sampled is False
-        mock_is_allowed.assert_not_called()
-        sampler.default_sampler.sample.assert_not_called()
-        spy_sampler.sample.assert_called_once_with(span)
-        assert_sampling_decision_tags(span, agent=0)
-
-        [r.matches.assert_called_once_with(span) for r in rules]
-        [r.sample.assert_not_called() for r in rules]
-
-        # Reset priority sampler property
-        sampler._priority_sampler = None
-
 
 def test_datadog_sampler_tracer(dummy_tracer):
     rule = SamplingRule(sample_rate=1.0, name='test.span')
@@ -705,8 +635,7 @@ def test_datadog_sampler_tracer(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    # TODO: Remove `priority_sampling=False` when we remove fallback
-    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
+    dummy_tracer.configure(sampler=sampler_spy)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -734,8 +663,7 @@ def test_datadog_sampler_tracer_rate_limited(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    # TODO: Remove `priority_sampling=False` when we remove fallback
-    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
+    dummy_tracer.configure(sampler=sampler_spy)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -762,8 +690,7 @@ def test_datadog_sampler_tracer_rate_0(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    # TODO: Remove `priority_sampling=False` when we remove fallback
-    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
+    dummy_tracer.configure(sampler=sampler_spy)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -790,8 +717,7 @@ def test_datadog_sampler_tracer_child(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    # TODO: Remove `priority_sampling=False` when we remove fallback
-    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
+    dummy_tracer.configure(sampler=sampler_spy)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -824,8 +750,7 @@ def test_datadog_sampler_tracer_start_span(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    # TODO: Remove `priority_sampling=False` when we remove fallback
-    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
+    dummy_tracer.configure(sampler=sampler_spy)
 
     assert dummy_tracer.sampler is sampler_spy
 


### PR DESCRIPTION
Right now the defaults are:

1) Fallback to the "rate by service" sampler whenever no matching rule is found
2) 100 traces sampled per second max

With these defaults:

1) 100% of all traces
2) No rate limit