### PR TITLE
vendor: fix debtcollector imports

### DIFF
--- a/ddtrace/vendor/debtcollector/_utils.py
+++ b/ddtrace/vendor/debtcollector/_utils.py
@@ -19,7 +19,7 @@ import inspect
 import types
 import warnings
 
-from ddtrace.vendor import six
+from .. import six
 
 try:
     _TYPE_TYPE = types.TypeType

--- a/ddtrace/vendor/debtcollector/_utils.py
+++ b/ddtrace/vendor/debtcollector/_utils.py
@@ -19,7 +19,7 @@ import inspect
 import types
 import warnings
 
-import six
+from ddtrace.vendor import six
 
 try:
     _TYPE_TYPE = types.TypeType

--- a/ddtrace/vendor/debtcollector/moves.py
+++ b/ddtrace/vendor/debtcollector/moves.py
@@ -16,8 +16,8 @@
 
 import inspect
 
-from ddtrace.vendor import six
-from ddtrace.vendor import wrapt
+from .. import six
+from .. import wrapt
 
 from . import _utils
 

--- a/ddtrace/vendor/debtcollector/removals.py
+++ b/ddtrace/vendor/debtcollector/removals.py
@@ -15,8 +15,8 @@
 import functools
 import inspect
 
-from ddtrace.vendor import six
-from ddtrace.vendor import wrapt
+from .. import six
+from .. import wrapt
 
 from . import _utils
 

--- a/ddtrace/vendor/debtcollector/renames.py
+++ b/ddtrace/vendor/debtcollector/renames.py
@@ -14,7 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from ddtrace.vendor import wrapt
+from .. import wrapt
 
 from . import _utils
 

--- a/ddtrace/vendor/debtcollector/updating.py
+++ b/ddtrace/vendor/debtcollector/updating.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from ddtrace.vendor import six
-from ddtrace.vendor import wrapt
+from .. import six
+from .. import wrapt
 if six.PY3:
     import inspect
     Parameter = inspect.Parameter


### PR DESCRIPTION
This adjustment had already been applied elsewhere in the vendored code but I had missed `ddtrace/vendor/debtcollector/_utils.py`. When I attempted to run it locally I got:

```
ModuleNotFoundError: No module named 'six'
```

I am not sure why this did not cause problems in CircleCI.