### PR TITLE
bottle: fix status code for responses

### DIFF
--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -62,11 +62,13 @@ class TracePlugin(object):
                     code = 500
                     raise
                 finally:
-                    if code or isinstance(result, HTTPResponse):
-                        response_code = code or result.status_code
+                    if isinstance(result, HTTPResponse):
+                        response_code = result.status_code
+                    elif code:
+                        response_code = code
                     else:
-                        # FIXME: thread-local bottle response has not yet been
-                        # updated so this will be default or last values
+                        # bottle local response has not yet been updated so this
+                        # will be default
                         response_code = response.status_code
 
                     if 500 <= response_code < 600:

--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -1,5 +1,5 @@
 # 3p
-from bottle import response, request, HTTPError
+from bottle import request, HTTPError, HTTPResponse
 
 # stdlib
 import ddtrace
@@ -46,10 +46,13 @@ class TracePlugin(object):
 
                 code = 0
                 try:
-                    return callback(*args, **kwargs)
-                except HTTPError as e:
+                    response = callback(*args, **kwargs)
+                    return response
+                except (HTTPError, HTTPResponse) as e:
                     # you can interrupt flows using abort(status_code, 'message')...
                     # we need to respect the defined status_code.
+                    # we also need to handle when response is raised as is the
+                    # case with a 4xx status
                     code = e.status_code
                     raise
                 except Exception:


### PR DESCRIPTION
This PR is a fix for #1156. 

The integration currently does not support handle when a `HTTPResponse` is raised, whereas we only had handled `HTTPError` exceptions.

While fixing exception handling, I also found that the handling of the response in the wrapping function was not pulling out the correct status code for the response being returned. The code had been using the current value of `bottle.response` but this had not yet been bound to the response from the callback. We should use the return value of the callback to set the span tag for HTTP status. When a route function returns a `str`, we continue using the default response status.