### PR TITLE
core: Deprecate ddtrace.ext.AppTypes

### DIFF
--- a/ddtrace/ext/__init__.py
+++ b/ddtrace/ext/__init__.py
@@ -1,5 +1,8 @@
 from enum import Enum
 
+from ..vendor.debtcollector import removals
+from ..utils import removed_classproperty
+
 
 class SpanTypes(Enum):
     CACHE = "cache"
@@ -13,3 +16,22 @@ class SpanTypes(Enum):
     TEMPLATE = "template"
     WEB = "web"
     WORKER = "worker"
+
+
+@removals.removed_class("AppTypes")
+class AppTypes(object):
+    @removed_classproperty
+    def web(cls):
+        return SpanTypes.WEB
+
+    @removed_classproperty
+    def db(cls):
+        return "db"
+
+    @removed_classproperty
+    def cache(cls):
+        return SpanTypes.CACHE
+
+    @removed_classproperty
+    def worker(cls):
+        return SpanTypes.WORKER

--- a/ddtrace/ext/consul.py
+++ b/ddtrace/ext/consul.py
@@ -1,4 +1,8 @@
+from . import SpanTypes
+
 APP = 'consul'
+# [TODO] Deprecated, remove when we remove AppTypes
+APP_TYPE = SpanTypes.CACHE
 SERVICE = 'consul'
 
 CMD = 'consul.command'

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -1,3 +1,8 @@
+from . import SpanTypes
+
+# [TODO] Deprecated, remove when we remove AppTypes
+APP_TYPE = SpanTypes.SQL
+
 # tags
 QUERY = 'sql.query'   # the query text
 ROWS = 'sql.rows'     # number of rows returned by a query

--- a/ddtrace/utils/__init__.py
+++ b/ddtrace/utils/__init__.py
@@ -1,3 +1,5 @@
+from ..vendor import debtcollector
+
 # https://stackoverflow.com/a/26853961
 def merge_dicts(x, y):
     """Returns a copy of y merged into x."""
@@ -10,6 +12,20 @@ def get_module_name(module):
     """Returns a module's name or None if one cannot be found.
     Relevant PEP: https://www.python.org/dev/peps/pep-0451/
     """
-    if hasattr(module, '__spec__'):
+    if hasattr(module, "__spec__"):
         return module.__spec__.name
-    return getattr(module, '__name__', None)
+    return getattr(module, "__name__", None)
+
+
+# https://stackoverflow.com/a/7864317
+class classproperty(property):
+    def __get__(self, cls, owner):
+        return classmethod(self.fget).__get__(None, owner)()
+
+
+class removed_classproperty(property):
+    def __get__(self, cls, owner):
+        debtcollector.deprecate(
+            "Usage of ddtrace.ext.AppTypes is not longer supported, please use ddtrace.ext.SpanTypes"
+        )
+        return classmethod(self.fget).__get__(None, owner)()

--- a/ddtrace/utils/__init__.py
+++ b/ddtrace/utils/__init__.py
@@ -18,12 +18,7 @@ def get_module_name(module):
     return getattr(module, "__name__", None)
 
 
-# https://stackoverflow.com/a/7864317
-class classproperty(property):
-    def __get__(self, cls, owner):
-        return classmethod(self.fget).__get__(None, owner)()
-
-
+# Based on: https://stackoverflow.com/a/7864317
 class removed_classproperty(property):
     def __get__(self, cls, owner):
         debtcollector.deprecate(

--- a/ddtrace/utils/__init__.py
+++ b/ddtrace/utils/__init__.py
@@ -1,5 +1,6 @@
 from ..vendor import debtcollector
 
+
 # https://stackoverflow.com/a/26853961
 def merge_dicts(x, y):
     """Returns a copy of y merged into x."""


### PR DESCRIPTION
When upgrading `ddtrace` internally I noticed that an import of `ddtrace.ext.AppTypes` was failing because it was removed.

Instead we should add a deprecation warning so that we do not break anyone's applications.