### PR TITLE
core: safely deprecate ext type constants

### DIFF
--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -32,7 +32,7 @@ def _patch(elasticsearch):
         return
     setattr(elasticsearch, '_datadog_patch', True)
     _w(elasticsearch.transport, 'Transport.perform_request', _get_perform_request(elasticsearch))
-    Pin(service=metadata.SERVICE).onto(elasticsearch.transport.Transport)
+    Pin(service=metadata.SERVICE, app=metadata.APP).onto(elasticsearch.transport.Transport)
 
 
 def unpatch():

--- a/ddtrace/ext/cassandra.py
+++ b/ddtrace/ext/cassandra.py
@@ -1,3 +1,9 @@
+from . import SpanTypes
+
+# [TODO] Deprecated, remove when we remove AppTypes
+# the type of the spans
+TYPE = SpanTypes.CASSANDRA
+
 # tags
 CLUSTER = 'cassandra.cluster'
 KEYSPACE = 'cassandra.keyspace'

--- a/ddtrace/ext/elasticsearch.py
+++ b/ddtrace/ext/elasticsearch.py
@@ -1,4 +1,10 @@
-SERVICE = "elasticsearch"
+from . import SpanTypes
+
+# [TODO] Deprecated, remove when we remove AppTypes
+TYPE = SpanTypes.ELASTICSEARCH
+SERVICE = 'elasticsearch'
+APP = 'elasticsearch'
+
 # standard tags
 URL = 'elasticsearch.url'
 METHOD = 'elasticsearch.method'

--- a/ddtrace/ext/http.py
+++ b/ddtrace/ext/http.py
@@ -6,6 +6,11 @@ For example:
 span.set_tag(URL, '/user/home')
 span.set_tag(STATUS_CODE, 404)
 """
+from . import SpanTypes
+
+# [TODO] Deprecated, remove when we remove AppTypes
+# type of the spans
+TYPE = SpanTypes.HTTP
 
 # tags
 URL = 'http.url'

--- a/ddtrace/ext/kombu.py
+++ b/ddtrace/ext/kombu.py
@@ -1,3 +1,9 @@
+from . import SpanTypes
+
+# [TODO] Deprecated, remove when we remove AppTypes
+# type of the spans
+TYPE = SpanTypes.WORKER
+
 SERVICE = 'kombu'
 
 # net extension

--- a/ddtrace/ext/memcached.py
+++ b/ddtrace/ext/memcached.py
@@ -1,3 +1,8 @@
+from . import SpanTypes
+
+# [TODO] Deprecated, remove when we remove AppTypes
+TYPE = SpanTypes.CACHE
+
 CMD = 'memcached.command'
 SERVICE = 'memcached'
 QUERY = 'memcached.query'

--- a/ddtrace/ext/mongo.py
+++ b/ddtrace/ext/mongo.py
@@ -1,3 +1,8 @@
+from . import SpanTypes
+
+# [TODO] Deprecated, remove when we remove AppTypes
+TYPE = SpanTypes.MONGODB
+
 SERVICE = 'mongodb'
 COLLECTION = 'mongodb.collection'
 DB = 'mongodb.db'

--- a/ddtrace/ext/redis.py
+++ b/ddtrace/ext/redis.py
@@ -1,6 +1,12 @@
+from . import SpanTypes
+
 # defaults
 APP = 'redis'
 DEFAULT_SERVICE = 'redis'
+
+# [TODO] Deprecated, remove when we remove AppTypes
+# type of the spans
+TYPE = SpanTypes.REDIS
 
 # net extension
 DB = 'out.redis_db'

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -1,6 +1,7 @@
 from . import SpanTypes
 
 # [TODO] Deprecated, remove when we remove AppTypes
+TYPE = SpanTypes.SQL
 APP_TYPE = SpanTypes.SQL
 
 # tags


### PR DESCRIPTION
#1144 and #1150 removed `app_type` and reworked how span types were organized. While #1162 added back `ddtrace.ext.AppTypes` with deprecation warnings, several of the `ddtrace.ext.*` modules also contained `APP_TYPE` or `TYPE` attributes that need to also be restored and flagged for deprecation as to avoid breaking existing code.