### PR TITLE
core: fix new sampler defaults and add env variables to configure

### DIFF
--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -132,9 +132,9 @@ class DatadogSampler(BaseSampler):
         :type rate_limit: :obj:`int`
         """
         if default_sample_rate is None:
-            default_sample_rate = get_env('trace', 'sample_rate', default=self.DEFAULT_SAMPLE_RATE)
+            default_sample_rate = float(get_env('trace', 'sample_rate', default=self.DEFAULT_SAMPLE_RATE))
         if rate_limit is None:
-            rate_limit = get_env('trace', 'rate_limit', default=self.DEFAULT_RATE_LIMIT)
+            rate_limit = int(get_env('trace', 'rate_limit', default=self.DEFAULT_RATE_LIMIT))
 
         # Ensure rules is a list
         if not rules:

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -10,6 +10,7 @@ from .constants import SAMPLING_AGENT_DECISION, SAMPLING_RULE_DECISION, SAMPLING
 from .ext.priority import AUTO_KEEP, AUTO_REJECT
 from .internal.logger import get_logger
 from .internal.rate_limiter import RateLimiter
+from .utils.formats import get_env
 from .vendor import six
 
 log = get_logger(__name__)
@@ -115,8 +116,10 @@ class DatadogSampler(BaseSampler):
     __slots__ = ('default_sampler', 'limiter', 'rules')
 
     NO_RATE_LIMIT = -1
+    DEFAULT_RATE_LIMIT = 100
+    DEFAULT_SAMPLE_RATE = 1.0
 
-    def __init__(self, rules=None, default_sample_rate=1.0, rate_limit=NO_RATE_LIMIT):
+    def __init__(self, rules=None, default_sample_rate=None, rate_limit=None):
         """
         Constructor for DatadogSampler sampler
 
@@ -125,9 +128,14 @@ class DatadogSampler(BaseSampler):
         :param default_sample_rate: The default sample rate to apply if no rules matched (default: 1.0)
         :type default_sample_rate: float 0 <= X <= 1.0
         :param rate_limit: Global rate limit (traces per second) to apply to all traces regardless of the rules
-            applied to them, default is no rate limit
+            applied to them, (default: ``100``)
         :type rate_limit: :obj:`int`
         """
+        if default_sample_rate is None:
+            default_sample_rate = get_env('trace', 'sample_rate', default=self.DEFAULT_SAMPLE_RATE)
+        if rate_limit is None:
+            rate_limit = get_env('trace', 'rate_limit', default=self.DEFAULT_RATE_LIMIT)
+
         # Ensure rules is a list
         if not rules:
             rules = []

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -1,10 +1,10 @@
 import contextlib
-import os
 import sys
 import unittest
 
 import ddtrace
 
+from ..utils import override_env
 from ..utils.tracer import DummyTracer
 from ..utils.span import TestSpanContainer, TestSpan, NO_CHILDREN
 
@@ -25,26 +25,8 @@ class BaseTestCase(unittest.TestCase):
                     pass
     """
 
-    @staticmethod
-    @contextlib.contextmanager
-    def override_env(env):
-        """
-        Temporarily override ``os.environ`` with provided values::
-
-            >>> with self.override_env(dict(DATADOG_TRACE_DEBUG=True)):
-                # Your test
-        """
-        # Copy the full original environment
-        original = dict(os.environ)
-
-        # Update based on the passed in arguments
-        os.environ.update(env)
-        try:
-            yield
-        finally:
-            # Full clear the environment out and reset back to the original
-            os.environ.clear()
-            os.environ.update(original)
+    # Expose `override_env` as `self.override_env`
+    override_env = staticmethod(override_env)
 
     @staticmethod
     @contextlib.contextmanager

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -15,6 +15,7 @@ from ddtrace.sampler import DatadogSampler, SamplingRule
 from ddtrace.sampler import RateSampler, AllSampler, RateByServiceSampler
 from ddtrace.span import Span
 
+from .utils import override_env
 from .test_tracer import get_dummy_tracer
 
 
@@ -437,17 +438,31 @@ def test_datadog_sampler_init():
     sampler = DatadogSampler()
     assert sampler.rules == []
     assert isinstance(sampler.limiter, RateLimiter)
-    assert sampler.limiter.rate_limit == DatadogSampler.NO_RATE_LIMIT
+    assert sampler.limiter.rate_limit == DatadogSampler.DEFAULT_RATE_LIMIT
+    assert sampler.limiter.default_sample_rate == DatadogSampler.DEFAULT_SAMPLE_RATE
 
     # With rules
     rule = SamplingRule(sample_rate=1)
     sampler = DatadogSampler(rules=[rule])
     assert sampler.rules == [rule]
-    assert sampler.limiter.rate_limit == DatadogSampler.NO_RATE_LIMIT
+    assert sampler.limiter.rate_limit == DatadogSampler.DEFAULT_RATE_LIMIT
+    assert sampler.limiter.default_sample_rate == DatadogSampler.DEFAULT_SAMPLE_RATE
 
     # With rate limit
     sampler = DatadogSampler(rate_limit=10)
     assert sampler.limiter.rate_limit == 10
+    assert sampler.limiter.default_sample_rate == DatadogSampler.DEFAULT_SAMPLE_RATE
+
+    # With default_sample_rate
+    sampler = DatadogSampler(default_sample_rate=0.5)
+    assert sampler.limiter.rate_limit == DatadogSampler.DEFAULT_RATE_LIMIT
+    assert sampler.limiter.default_sample_rate == 0.5
+
+    # From env variables
+    with override_env(dict(DD_TRACE_SAAMPLE_RATE=0.5, DD_TRACE_RATE_LIMIT=10)):
+        sampler = DatadogSampler()
+        assert sampler.limiter.rate_limit == 10
+        assert sampler.limiter.default_sample_rate == 0.5
 
     # Invalid rules
     for val in (None, True, False, object(), 1, Exception()):

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -439,30 +439,30 @@ def test_datadog_sampler_init():
     assert sampler.rules == []
     assert isinstance(sampler.limiter, RateLimiter)
     assert sampler.limiter.rate_limit == DatadogSampler.DEFAULT_RATE_LIMIT
-    assert sampler.limiter.default_sample_rate == DatadogSampler.DEFAULT_SAMPLE_RATE
+    assert sampler.default_sampler.sample_rate == DatadogSampler.DEFAULT_SAMPLE_RATE
 
     # With rules
     rule = SamplingRule(sample_rate=1)
     sampler = DatadogSampler(rules=[rule])
     assert sampler.rules == [rule]
     assert sampler.limiter.rate_limit == DatadogSampler.DEFAULT_RATE_LIMIT
-    assert sampler.limiter.default_sample_rate == DatadogSampler.DEFAULT_SAMPLE_RATE
+    assert sampler.default_sampler.sample_rate == DatadogSampler.DEFAULT_SAMPLE_RATE
 
     # With rate limit
     sampler = DatadogSampler(rate_limit=10)
     assert sampler.limiter.rate_limit == 10
-    assert sampler.limiter.default_sample_rate == DatadogSampler.DEFAULT_SAMPLE_RATE
+    assert sampler.default_sampler.sample_rate == DatadogSampler.DEFAULT_SAMPLE_RATE
 
     # With default_sample_rate
     sampler = DatadogSampler(default_sample_rate=0.5)
     assert sampler.limiter.rate_limit == DatadogSampler.DEFAULT_RATE_LIMIT
-    assert sampler.limiter.default_sample_rate == 0.5
+    assert sampler.default_sampler.sample_rate == 0.5
 
     # From env variables
-    with override_env(dict(DD_TRACE_SAAMPLE_RATE=0.5, DD_TRACE_RATE_LIMIT=10)):
+    with override_env(dict(DD_TRACE_SAMPLE_RATE='0.5', DD_TRACE_RATE_LIMIT='10')):
         sampler = DatadogSampler()
         assert sampler.limiter.rate_limit == 10
-        assert sampler.limiter.default_sample_rate == 0.5
+        assert sampler.default_sampler.sample_rate == 0.5
 
     # Invalid rules
     for val in (None, True, False, object(), 1, Exception()):

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,23 @@
+import contextlib
+import os
+
+
+@contextlib.contextmanager
+def override_env(env):
+    """
+    Temporarily override ``os.environ`` with provided values::
+
+        >>> with self.override_env(dict(DATADOG_TRACE_DEBUG=True)):
+            # Your test
+    """
+    # Copy the full original environment
+    original = dict(os.environ)
+
+    # Update based on the passed in arguments
+    os.environ.update(env)
+    try:
+        yield
+    finally:
+        # Full clear the environment out and reset back to the original
+        os.environ.clear()
+        os.environ.update(original)


### PR DESCRIPTION
We want to ensure we have a sane default rate limit for the sampler.

As well, we want to allow people to use `DD_TRACE_SAMPLE_RATE` and `DD_TRACE_RATE_LIMIT` to configure these default values for the new sampler.