### PR TITLE
core: Update default sampler to new DatadogSampler

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -6,6 +6,7 @@ import time
 from .. import api
 from .. import _worker
 from ..internal.logger import get_logger
+from ..sampler import BasePrioritySampler
 from ..settings import config
 from ..vendor import monotonic
 from ddtrace.vendor.six.moves.queue import Queue, Full, Empty
@@ -25,13 +26,14 @@ class AgentWriter(_worker.PeriodicWorkerThread):
 
     def __init__(self, hostname='localhost', port=8126, uds_path=None, https=False,
                  shutdown_timeout=DEFAULT_TIMEOUT,
-                 filters=None, priority_sampler=None,
+                 filters=None, sampler=None, priority_sampler=None,
                  dogstatsd=None):
         super(AgentWriter, self).__init__(interval=self.QUEUE_PROCESSING_INTERVAL,
                                           exit_timeout=shutdown_timeout,
                                           name=self.__class__.__name__)
         self._trace_queue = Q(maxsize=MAX_TRACES)
         self._filters = filters
+        self._sampler = sampler
         self._priority_sampler = priority_sampler
         self._last_error_ts = 0
         self.dogstatsd = dogstatsd
@@ -94,10 +96,17 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         for response in traces_responses:
             if isinstance(response, Exception) or response.status >= 400:
                 self._log_error_status(response)
-            elif self._priority_sampler:
+            elif self._priority_sampler or isinstance(self._sampler, BasePrioritySampler):
                 result_traces_json = response.get_json()
                 if result_traces_json and 'rate_by_service' in result_traces_json:
-                    self._priority_sampler.set_sample_rate_by_service(result_traces_json['rate_by_service'])
+                    if self._priority_sampler:
+                        self._priority_sampler.update_rate_by_service_sample_rates(
+                            result_traces_json['rate_by_service'],
+                        )
+                    if isinstance(self._sampler, BasePrioritySampler):
+                        self._sampler.update_rate_by_service_sample_rates(
+                            result_traces_json['rate_by_service'],
+                        )
 
         # Dump statistics
         # NOTE: Do not use the buffering of dogstatsd as it's not thread-safe

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -131,7 +131,7 @@ class DatadogSampler(BaseSampler, BasePrioritySampler):
 
         :param rules: List of :class:`SamplingRule` rules to apply to the root span of every trace, default no rules
         :type rules: :obj:`list` of :class:`SamplingRule`
-        :param default_sample_rate: The default sample rate to apply if no rules matched (default: ``1.0``)
+        :param default_sample_rate: The default sample rate to apply if no rules matched (default: ``None``/Use :class:`RateByServiceSampler` only)
         :type default_sample_rate: float 0 <= X <= 1.0
         :param rate_limit: Global rate limit (traces per second) to apply to all traces regardless of the rules
             applied to them, (default: ``100``)

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -131,7 +131,8 @@ class DatadogSampler(BaseSampler, BasePrioritySampler):
 
         :param rules: List of :class:`SamplingRule` rules to apply to the root span of every trace, default no rules
         :type rules: :obj:`list` of :class:`SamplingRule`
-        :param default_sample_rate: The default sample rate to apply if no rules matched (default: ``None``/Use :class:`RateByServiceSampler` only)
+        :param default_sample_rate: The default sample rate to apply if no rules matched (default: ``None`` /
+            Use :class:`RateByServiceSampler` only)
         :type default_sample_rate: float 0 <= X <= 1.0
         :param rate_limit: Global rate limit (traces per second) to apply to all traces regardless of the rules
             applied to them, (default: ``100``)

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -12,7 +12,7 @@ from .internal.runtime import RuntimeTags, RuntimeWorker
 from .internal.writer import AgentWriter
 from .provider import DefaultContextProvider
 from .context import Context
-from .sampler import AllSampler, DatadogSampler, RateSampler, RateByServiceSampler
+from .sampler import BaseSampler, DatadogSampler, RateSampler, RateByServiceSampler
 from .span import Span
 from .utils.formats import get_env
 from .utils.deprecation import deprecated, RemovedInDDTrace10Warning
@@ -114,7 +114,7 @@ class Tracer(object):
             port=port,
             https=https,
             uds_path=uds_path,
-            sampler=AllSampler(),
+            sampler=DatadogSampler(),
             context_provider=DefaultContextProvider(),
             dogstatsd_url=dogstatsd_url,
         )
@@ -229,7 +229,7 @@ class Tracer(object):
             self._dogstatsd_client = DogStatsd(**dogstatsd_kwargs)
 
         if hostname is not None or port is not None or uds_path is not None or https is not None or \
-                filters is not None or priority_sampling is not None:
+                filters is not None or priority_sampling is not None or sampler is not None:
             # Preserve hostname and port when overriding filters or priority sampling
             # This is clumsy and a good reason to get rid of this configure() API
             if hasattr(self, 'writer') and hasattr(self.writer, 'api'):
@@ -247,6 +247,7 @@ class Tracer(object):
                 uds_path=uds_path,
                 https=https,
                 filters=filters,
+                sampler=self.sampler,
                 priority_sampler=self.priority_sampler,
                 dogstatsd=self._dogstatsd_client,
             )

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -12,7 +12,7 @@ from .internal.runtime import RuntimeTags, RuntimeWorker
 from .internal.writer import AgentWriter
 from .provider import DefaultContextProvider
 from .context import Context
-from .sampler import BaseSampler, DatadogSampler, RateSampler, RateByServiceSampler
+from .sampler import DatadogSampler, RateSampler, RateByServiceSampler
 from .span import Span
 from .utils.formats import get_env
 from .utils.deprecation import deprecated, RemovedInDDTrace10Warning

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -371,6 +371,8 @@ class Tracer(object):
                         context.sampling_priority = AUTO_REJECT
             else:
                 context.sampling_priority = AUTO_KEEP if span.sampled else AUTO_REJECT
+                # We must always mark the span as sampled so it is forwarded to the agent
+                span.sampled = True
 
             # add tags to root span to correlate trace with runtime metrics
             # only applied to spans with types that are internal to applications

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -658,9 +658,9 @@ def test_datadog_sampler_sample_rules(mock_is_allowed, dummy_tracer):
         assert sampler.sample(span) is True
         assert span._context.sampling_priority is AUTO_KEEP
         assert span.sampled is True
-        mock_is_allowed.assert_called_once()
+        mock_is_allowed.assert_not_called()
         sampler.default_sampler.sample.assert_called_once_with(span)
-        assert_sampling_decision_tags(span, agent=1, limit=1)
+        assert_sampling_decision_tags(span, agent=1)
 
         [r.matches.assert_called_once_with(span) for r in rules]
         [r.sample.assert_not_called() for r in rules]
@@ -705,8 +705,7 @@ def test_datadog_sampler_tracer(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    # TODO: Remove `priority_sampling=False` when we remove fallback
-    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
+    dummy_tracer.configure(sampler=sampler_spy)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -717,8 +716,9 @@ def test_datadog_sampler_tracer(dummy_tracer):
         rule_spy.sample.assert_called_once_with(span)
         limiter_spy.is_allowed.assert_called_once_with()
 
-        # We know it was sampled because we have a sample rate of 1.0
+        # It must always mark it as sampled
         assert span.sampled is True
+        # We know it was sampled because we have a sample rate of 1.0
         assert span._context.sampling_priority is AUTO_KEEP
         assert_sampling_decision_tags(span, rule=1.0)
 
@@ -734,8 +734,7 @@ def test_datadog_sampler_tracer_rate_limited(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    # TODO: Remove `priority_sampling=False` when we remove fallback
-    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
+    dummy_tracer.configure(sampler=sampler_spy)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -746,8 +745,8 @@ def test_datadog_sampler_tracer_rate_limited(dummy_tracer):
         rule_spy.sample.assert_called_once_with(span)
         limiter_spy.is_allowed.assert_called_once_with()
 
-        # We know it was not sampled because of our limiter
-        assert span.sampled is False
+        # We must always mark the span as sampled
+        assert span.sampled is True
         assert span._context.sampling_priority is AUTO_REJECT
         assert_sampling_decision_tags(span, rule=1.0, limit=None)
 
@@ -762,8 +761,7 @@ def test_datadog_sampler_tracer_rate_0(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    # TODO: Remove `priority_sampling=False` when we remove fallback
-    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
+    dummy_tracer.configure(sampler=sampler_spy)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -774,8 +772,9 @@ def test_datadog_sampler_tracer_rate_0(dummy_tracer):
         rule_spy.sample.assert_called_once_with(span)
         limiter_spy.is_allowed.assert_not_called()
 
+        # It must always mark it as sampled
+        assert span.sampled is True
         # We know it was not sampled because we have a sample rate of 0.0
-        assert span.sampled is False
         assert span._context.sampling_priority is AUTO_REJECT
         assert_sampling_decision_tags(span, rule=0)
 
@@ -790,8 +789,7 @@ def test_datadog_sampler_tracer_child(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    # TODO: Remove `priority_sampling=False` when we remove fallback
-    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
+    dummy_tracer.configure(sampler=sampler_spy)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -824,8 +822,7 @@ def test_datadog_sampler_tracer_start_span(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    # TODO: Remove `priority_sampling=False` when we remove fallback
-    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
+    dummy_tracer.configure(sampler=sampler_spy)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -837,8 +834,9 @@ def test_datadog_sampler_tracer_start_span(dummy_tracer):
     rule_spy.sample.assert_called_once_with(span)
     limiter_spy.is_allowed.assert_called_once_with()
 
-    # We know it was sampled because we have a sample rate of 1.0
+    # It must always mark it as sampled
     assert span.sampled is True
+    # We know it was sampled because we have a sample rate of 1.0
     assert span._context.sampling_priority is AUTO_KEEP
     assert_sampling_decision_tags(span, rule=1.0)
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -151,7 +151,7 @@ class RateByServiceSamplerTest(unittest.TestCase):
             deviation = abs(samples_with_high_priority - (iterations * sample_rate)) / (iterations * sample_rate)
             assert deviation < 0.05, 'Deviation too high %f with sample_rate %f' % (deviation, sample_rate)
 
-    def test_set_sample_rate_by_service(self):
+    def test_update_rate_by_service_sample_rates(self):
         cases = [
             {
                 'service:,env:': 1,
@@ -173,7 +173,7 @@ class RateByServiceSamplerTest(unittest.TestCase):
         tracer.configure(sampler=AllSampler())
         priority_sampler = tracer.priority_sampler
         for case in cases:
-            priority_sampler.set_sample_rate_by_service(case)
+            priority_sampler.update_rate_by_service_sample_rates(case)
             rates = {}
             for k, v in iteritems(priority_sampler._by_service_samplers):
                 rates[k] = v.sample_rate
@@ -182,7 +182,7 @@ class RateByServiceSamplerTest(unittest.TestCase):
         # works as well as key insertion (and doing this both ways ensures we trigger both cases)
         cases.reverse()
         for case in cases:
-            priority_sampler.set_sample_rate_by_service(case)
+            priority_sampler.update_rate_by_service_sample_rates(case)
             rates = {}
             for k, v in iteritems(priority_sampler._by_service_samplers):
                 rates[k] = v.sample_rate
@@ -439,29 +439,31 @@ def test_datadog_sampler_init():
     assert sampler.rules == []
     assert isinstance(sampler.limiter, RateLimiter)
     assert sampler.limiter.rate_limit == DatadogSampler.DEFAULT_RATE_LIMIT
-    assert sampler.default_sampler.sample_rate == DatadogSampler.DEFAULT_SAMPLE_RATE
+    assert isinstance(sampler.default_sampler, RateByServiceSampler)
 
     # With rules
     rule = SamplingRule(sample_rate=1)
     sampler = DatadogSampler(rules=[rule])
     assert sampler.rules == [rule]
     assert sampler.limiter.rate_limit == DatadogSampler.DEFAULT_RATE_LIMIT
-    assert sampler.default_sampler.sample_rate == DatadogSampler.DEFAULT_SAMPLE_RATE
+    assert isinstance(sampler.default_sampler, RateByServiceSampler)
 
     # With rate limit
     sampler = DatadogSampler(rate_limit=10)
     assert sampler.limiter.rate_limit == 10
-    assert sampler.default_sampler.sample_rate == DatadogSampler.DEFAULT_SAMPLE_RATE
+    assert isinstance(sampler.default_sampler, RateByServiceSampler)
 
     # With default_sample_rate
     sampler = DatadogSampler(default_sample_rate=0.5)
     assert sampler.limiter.rate_limit == DatadogSampler.DEFAULT_RATE_LIMIT
+    assert isinstance(sampler.default_sampler, SamplingRule)
     assert sampler.default_sampler.sample_rate == 0.5
 
     # From env variables
     with override_env(dict(DD_TRACE_SAMPLE_RATE='0.5', DD_TRACE_RATE_LIMIT='10')):
         sampler = DatadogSampler()
         assert sampler.limiter.rate_limit == 10
+        assert isinstance(sampler.default_sampler, SamplingRule)
         assert sampler.default_sampler.sample_rate == 0.5
 
     # Invalid rules
@@ -477,35 +479,32 @@ def test_datadog_sampler_init():
     assert sampler.rules == [rule_1, rule_2, rule_3]
 
 
-@mock.patch('ddtrace.internal.rate_limiter.RateLimiter.is_allowed')
-def test_datadog_sampler_sample_no_rules(mock_is_allowed, dummy_tracer):
+@mock.patch('ddtrace.sampler.RateByServiceSampler.sample')
+def test_datadog_sampler_sample_no_rules(mock_sample, dummy_tracer):
     sampler = DatadogSampler()
     span = create_span(tracer=dummy_tracer)
 
-    # Default SamplingRule(sample_rate=1.0) is applied
-    #   No priority sampler configured
+    # Default RateByServiceSampler() is applied
     #   No rules configured
-    # RateLimiter is allowed, it is sampled
-    mock_is_allowed.return_value = True
+    #   No global rate limit
+    #   No rate limit configured
+    # RateByServiceSampler.sample(span) returns True
+    mock_sample.return_value = True
     assert sampler.sample(span) is True
     assert span._context.sampling_priority is AUTO_KEEP
     assert span.sampled is True
-    assert_sampling_decision_tags(span, rule=1.0, limit=1.0)
-    mock_is_allowed.assert_called_once_with()
-    mock_is_allowed.reset_mock()
 
     span = create_span(tracer=dummy_tracer)
 
-    # Default SamplingRule(sample_rate=1.0) is applied
-    #   No priority sampler configured
+    # Default RateByServiceSampler() is applied
     #   No rules configured
-    # RateLimit not allowed, it is not sampled
-    mock_is_allowed.return_value = False
+    #   No global rate limit
+    #   No rate limit configured
+    # RateByServiceSampler.sample(span) returns False
+    mock_sample.return_value = False
     assert sampler.sample(span) is False
     assert span._context.sampling_priority is AUTO_REJECT
     assert span.sampled is False
-    assert_sampling_decision_tags(span, rule=1.0, limit=1.0)
-    mock_is_allowed.assert_called_once_with()
 
 
 @mock.patch('ddtrace.internal.rate_limiter.RateLimiter.is_allowed')
@@ -519,8 +518,6 @@ def test_datadog_sampler_sample_rules(mock_is_allowed, dummy_tracer):
         mock.Mock(spec=SamplingRule),
     ]
     sampler = DatadogSampler(rules=rules)
-    sampler.default_sampler = mock.Mock(spec=SamplingRule)
-    sampler.default_sampler.return_value = True
 
     # Reset all of our mocks
     @contextlib.contextmanager
@@ -530,8 +527,11 @@ def test_datadog_sampler_sample_rules(mock_is_allowed, dummy_tracer):
             for rule in rules:
                 rule.reset_mock()
                 rule.sample_rate = 0.5
-            sampler.default_sampler.reset_mock()
-            sampler.default_sampler.sample_rate = 1.0
+
+            default_rule = SamplingRule(sample_rate=1.0)
+            sampler.default_sampler = mock.Mock(spec=SamplingRule, wraps=default_rule)
+            # Mock has lots of problems with mocking/wrapping over class properties
+            sampler.default_sampler.sample_rate = default_rule.sample_rate
 
         reset()  # Reset before, just in case
         try:
@@ -639,6 +639,61 @@ def test_datadog_sampler_sample_rules(mock_is_allowed, dummy_tracer):
         rules[2].matches.assert_not_called()
         rules[2].sample.assert_not_called()
 
+    # No rules match and RateByServiceSampler is used
+    #   All rules SamplingRule.matches are called
+    #   Priority sampler's `sample` method is called
+    #   Result of priority sampler is returned
+    #   Rate limiter is not called
+    with reset_mocks():
+        span = create_span(tracer=dummy_tracer)
+
+        # Configure mock priority sampler
+        priority_sampler = RateByServiceSampler()
+        sampler.default_sampler = mock.Mock(spec=RateByServiceSampler, wraps=priority_sampler)
+
+        for rule in rules:
+            rule.matches.return_value = False
+            rule.sample.return_value = False
+
+        assert sampler.sample(span) is True
+        assert span._context.sampling_priority is AUTO_KEEP
+        assert span.sampled is True
+        mock_is_allowed.assert_called_once()
+        sampler.default_sampler.sample.assert_called_once_with(span)
+        assert_sampling_decision_tags(span, agent=1, limit=1)
+
+        [r.matches.assert_called_once_with(span) for r in rules]
+        [r.sample.assert_not_called() for r in rules]
+
+    # No rules match and priority sampler is defined
+    #   All rules SamplingRule.matches are called
+    #   Priority sampler's `sample` method is called
+    #   Result of priority sampler is returned
+    #   Rate limiter is not called
+    with reset_mocks():
+        span = create_span(tracer=dummy_tracer)
+
+        # Configure mock priority sampler
+        priority_sampler = RateByServiceSampler()
+        for rate_sampler in priority_sampler._by_service_samplers.values():
+            rate_sampler.set_sample_rate(0)
+
+        sampler.default_sampler = mock.Mock(spec=RateByServiceSampler, wraps=priority_sampler)
+
+        for rule in rules:
+            rule.matches.return_value = False
+            rule.sample.return_value = False
+
+        assert sampler.sample(span) is False
+        assert span._context.sampling_priority is AUTO_REJECT
+        assert span.sampled is False
+        mock_is_allowed.assert_not_called()
+        sampler.default_sampler.sample.assert_called_once_with(span)
+        assert_sampling_decision_tags(span, agent=0)
+
+        [r.matches.assert_called_once_with(span) for r in rules]
+        [r.sample.assert_not_called() for r in rules]
+
 
 def test_datadog_sampler_tracer(dummy_tracer):
     rule = SamplingRule(sample_rate=1.0, name='test.span')
@@ -650,7 +705,8 @@ def test_datadog_sampler_tracer(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    dummy_tracer.configure(sampler=sampler_spy)
+    # TODO: Remove `priority_sampling=False` when we remove fallback
+    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -678,7 +734,8 @@ def test_datadog_sampler_tracer_rate_limited(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    dummy_tracer.configure(sampler=sampler_spy)
+    # TODO: Remove `priority_sampling=False` when we remove fallback
+    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -705,7 +762,8 @@ def test_datadog_sampler_tracer_rate_0(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    dummy_tracer.configure(sampler=sampler_spy)
+    # TODO: Remove `priority_sampling=False` when we remove fallback
+    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -732,7 +790,8 @@ def test_datadog_sampler_tracer_child(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    dummy_tracer.configure(sampler=sampler_spy)
+    # TODO: Remove `priority_sampling=False` when we remove fallback
+    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -765,7 +824,8 @@ def test_datadog_sampler_tracer_start_span(dummy_tracer):
     sampler.limiter = limiter_spy
     sampler_spy = mock.Mock(spec=sampler, wraps=sampler)
 
-    dummy_tracer.configure(sampler=sampler_spy)
+    # TODO: Remove `priority_sampling=False` when we remove fallback
+    dummy_tracer.configure(sampler=sampler_spy, priority_sampling=False)
 
     assert dummy_tracer.sampler is sampler_spy
 
@@ -781,3 +841,41 @@ def test_datadog_sampler_tracer_start_span(dummy_tracer):
     assert span.sampled is True
     assert span._context.sampling_priority is AUTO_KEEP
     assert_sampling_decision_tags(span, rule=1.0)
+
+
+def test_datadog_sampler_update_rate_by_service_sample_rates(dummy_tracer):
+    cases = [
+        {
+            'service:,env:': 1,
+        },
+        {
+            'service:,env:': 1,
+            'service:mcnulty,env:dev': 0.33,
+            'service:postgres,env:dev': 0.7,
+        },
+        {
+            'service:,env:': 1,
+            'service:mcnulty,env:dev': 0.25,
+            'service:postgres,env:dev': 0.5,
+            'service:redis,env:prod': 0.75,
+        },
+    ]
+
+    # By default sampler sets it's default sampler to RateByServiceSampler
+    sampler = DatadogSampler()
+    for case in cases:
+        sampler.update_rate_by_service_sample_rates(case)
+        rates = {}
+        for k, v in iteritems(sampler.default_sampler._by_service_samplers):
+            rates[k] = v.sample_rate
+        assert case == rates, '%s != %s' % (case, rates)
+
+    # It's important to also test in reverse mode for we want to make sure key deletion
+    # works as well as key insertion (and doing this both ways ensures we trigger both cases)
+    cases.reverse()
+    for case in cases:
+        sampler.update_rate_by_service_sample_rates(case)
+        rates = {}
+        for k, v in iteritems(sampler.default_sampler._by_service_samplers):
+            rates[k] = v.sample_rate
+        assert case == rates, '%s != %s' % (case, rates)


### PR DESCRIPTION
We have made a change to ensure that, if no explicitly defined rules match and no global sample rate is defined, we continue to use a `RateByServiceSampler`.

I tried to unify the logic here a bit more to make it easier to drop in a `DatadogSampler` as the default without needing to rely on configuring/passing priority samplers around, hopefully it makes it more clear.

How people can utilize this new sampler:

1) Set `DD_TRACE_SAMPLE_RATE=` env variable to set a global rate limit
  a) this will by-pass the `RateByServiceSampler`
2) Configure and pass in the sampler manually:

```python
from ddtrace import tracer
from ddtrace.sampler import DatadogSampler

tracer.configure(sampler=DatadogSampler(sample_rate=1.0, rules=[ ... ], rate_limit=100))
```