### PR TITLE
encode python in the install_requires string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,11 +57,8 @@ documentation][visualization docs].
 """
 
 # psutil used to generate runtime metrics for tracer
-install_requires = ["psutil>=5.0.0"]
-
-# include enum backport
-if sys.version_info[:2] < (3, 4):
-    install_requires.extend(["enum34"])
+# enum34 is an enum backport for earlier versions of python
+install_requires = ["psutil>=5.0.0", "enum34; python_version<='3.4'"]
 
 # Base `setup()` kwargs without any C-extension registering
 setup_kwargs = dict(


### PR DESCRIPTION
This is breaking my build right now when I try to upgrade versions.

This could be because I'm using poetry which expects it to be encoded rather than an `if` condition. Not sure. But this seems to be how lots of packages do this specification in setup.py