### PR TITLE
not install enum34 for Python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ documentation][visualization docs].
 
 # psutil used to generate runtime metrics for tracer
 # enum34 is an enum backport for earlier versions of python
-install_requires = ["psutil>=5.0.0", "enum34; python_version<='3.4'"]
+install_requires = ["psutil>=5.0.0", "enum34; python_version<'3.4'"]
 
 # Base `setup()` kwargs without any C-extension registering
 setup_kwargs = dict(


### PR DESCRIPTION
Small modification to avoid install `enum34` backport for Python 3.4 after move to environment markers with #1174.