### PR TITLE
add funcsigs backport to install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ documentation][visualization docs].
 # psutil used to generate runtime metrics for tracer
 # enum34 is an enum backport for earlier versions of python
 # funcsigs backport required for vendored debtcollector
-install_requires = ["psutil>=5.0.0", "enum34; python_version<'3.4'", "funcsigs; python_version<'3.3'"]
+install_requires = ["psutil>=5.0.0", "enum34; python_version<'3.4'", "funcsigs>=1.0.0;python_version=='2.7'"]
 
 # Base `setup()` kwargs without any C-extension registering
 setup_kwargs = dict(

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ documentation][visualization docs].
 
 # psutil used to generate runtime metrics for tracer
 # enum34 is an enum backport for earlier versions of python
-install_requires = ["psutil>=5.0.0", "enum34; python_version<'3.4'"]
+# funcsigs backport required for vendored debtcollector
+install_requires = ["psutil>=5.0.0", "enum34; python_version<'3.4'", "funcsigs; python_version<'3.3'"]
 
 # Base `setup()` kwargs without any C-extension registering
 setup_kwargs = dict(


### PR DESCRIPTION
Since 0.32.0, the vendored `debtcollector` depends on `funcsigs` before Python 3.3 but this had not been specified for installation at setup, causing an `ImportError` exception when importing `ddtrace` or running `ddtrace-run` on Python 2.7 if `funcsigs` had not been installed as a dependency of another library.