### PR TITLE
tests: Fix botocore py34 tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -187,6 +187,7 @@ deps =
     boto: boto
     boto: moto<1.0
     botocore: botocore
+    py34-botocore: PyYAML<5.3
     botocore: moto>=1.0,<2
     bottle11: bottle>=0.11,<0.12
     bottle12: bottle>=0.12,<0.13


### PR DESCRIPTION
PyYAML 5.3 dropped support for Python 3.4, we need 5.2 or lower