### PR TITLE
Document how to propagate the tracer across celery tasks

### DIFF
--- a/ddtrace/contrib/celery/__init__.py
+++ b/ddtrace/contrib/celery/__init__.py
@@ -32,6 +32,32 @@ By default, reported service names are:
     * ``celery-producer`` when tasks are enqueued for processing
     * ``celery-worker`` when tasks are processed by a Celery process
 
+
+Distributed Tracing across celery tasks
+
+By default, ddtrace does not propagate trace_id when calling tasks, when you
+call ``apply_async()`` from your main application or from another celery task,
+the child task will be assigned a new trace.
+
+If you want to follow a trace across when you call a celery tasks, you will
+need to pass trace_id along to the child task. ddtrace currently don't have
+trace propagator for celery tasks, but you can use Celery-OpenTracing and
+ddtrace's opentracing support. To do this:
+
+1. Install ddtrace with opentracing support and Celery-OpenTracing:
+
+    pip install ddtrace[opentracing] Celery-OpenTracing
+
+2. Replace your Celery app with the version that comes with Celery-OpenTracing:
+
+    from celery_opentracing import CeleryTracing
+    from ddtrace.opentracer import set_global_tracer, Tracer
+
+    ddtracer = Tracer()
+    set_global_tracer(ddtracer)
+
+    app = CeleryTracing(app, tracer=ddtracer)
+
 """
 from ...utils.importlib import require_modules
 


### PR DESCRIPTION
We were having difficulties figuring out why celery tasks that was spawned from our Django apps aren't being traced from the originating Django request and I wasn't able to figure out how to do this with just ddtrace without having to write a custom propagator. It doesn't seem to be documented anywhere that the Celery integration doesn't propagate the trace down to called tasks. This PR documents what we did.

In the long run, it may make sense for ddtrace to implement support its own native celery propagator, but in the meantime, I found a way to do this by piggybacking on opentracing support and using an opentracing propagator.

Or ddtrace may have actually already supported propagation natively, and I have just missed how to do it, in which case, I'd welcome any advice on it as well.