### PR TITLE
core: ensure http.status_code is always set as str on meta

### DIFF
--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -135,7 +135,7 @@ class TraceMiddleware(object):
         if not span or not span.sampled:
             return
 
-        code = span.get_metric(http.STATUS_CODE) or 0
+        code = span.get_tag(http.STATUS_CODE) or 0
         try:
             code = int(code)
         except Exception:

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -153,13 +153,18 @@ class Span(object):
             must be strings (or stringable). If a casting error occurs, it will
             be ignored.
         """
+        # Special case, force `http.status_code` as a string
+        # DEV: `http.status_code` *has* to be in `meta` for metrics
+        #   calculated in the trace agent
+        if key == http.STATUS_CODE:
+            value = str(value)
 
         # Determine once up front
         is_an_int = is_integer(value)
 
         # Explicitly try to convert expected integers to `int`
         # DEV: Some integrations parse these values from strings, but don't call `int(value)` themselves
-        INT_TYPES = (net.TARGET_PORT, http.STATUS_CODE)
+        INT_TYPES = (net.TARGET_PORT, )
         if key in INT_TYPES and not is_an_int:
             try:
                 value = int(value)

--- a/tests/contrib/aiobotocore/py35/test.py
+++ b/tests/contrib/aiobotocore/py35/test.py
@@ -5,6 +5,7 @@ from ddtrace.contrib.aiobotocore.patch import patch, unpatch
 from ..utils import aiobotocore_client
 from ...asyncio.utils import AsyncioTestCase, mark_asyncio
 from ....test_tracer import get_dummy_tracer
+from ....utils import assert_span_http_status_code
 
 
 class AIOBotocoreTest(AsyncioTestCase):
@@ -45,13 +46,13 @@ class AIOBotocoreTest(AsyncioTestCase):
 
             span = traces[0][0]
             assert span.get_tag('aws.operation') == 'GetObject'
-            assert span.get_metric('http.status_code') == 200
+            assert_span_http_status_code(span, 200)
             assert span.service == 'aws.s3'
             assert span.resource == 's3.getobject'
 
             read_span = traces[1][0]
             assert read_span.get_tag('aws.operation') == 'GetObject'
-            assert read_span.get_metric('http.status_code') == 200
+            assert_span_http_status_code(read_span, 200)
             assert read_span.service == 'aws.s3'
             assert read_span.resource == 's3.getobject'
             assert read_span.name == 's3.command.read'
@@ -64,7 +65,7 @@ class AIOBotocoreTest(AsyncioTestCase):
 
             span = traces[0][0]
             assert span.get_tag('aws.operation') == 'GetObject'
-            assert span.get_metric('http.status_code') == 200
+            assert_span_http_status_code(span, 200)
             assert span.service == 'aws.s3'
             assert span.resource == 's3.getobject'
             assert span.name == 's3.command'

--- a/tests/contrib/aiobotocore/test.py
+++ b/tests/contrib/aiobotocore/test.py
@@ -9,6 +9,7 @@ from ddtrace.compat import stringify
 from .utils import aiobotocore_client
 from ..asyncio.utils import AsyncioTestCase, mark_asyncio
 from ...test_tracer import get_dummy_tracer
+from ...utils import assert_span_http_status_code
 
 
 class AIOBotocoreTest(AsyncioTestCase):
@@ -36,7 +37,7 @@ class AIOBotocoreTest(AsyncioTestCase):
         self.assertEqual(span.get_tag('aws.agent'), 'aiobotocore')
         self.assertEqual(span.get_tag('aws.region'), 'us-west-2')
         self.assertEqual(span.get_tag('aws.operation'), 'DescribeInstances')
-        self.assertEqual(span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.get_metric('retry_attempts'), 0)
         self.assertEqual(span.service, 'aws.ec2')
         self.assertEqual(span.resource, 'ec2.describeinstances')
@@ -70,7 +71,7 @@ class AIOBotocoreTest(AsyncioTestCase):
         span = traces[0][0]
 
         self.assertEqual(span.get_tag('aws.operation'), 'ListBuckets')
-        self.assertEqual(span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.service, 'aws.s3')
         self.assertEqual(span.resource, 's3.listbuckets')
         self.assertEqual(span.name, 's3.command')
@@ -87,7 +88,7 @@ class AIOBotocoreTest(AsyncioTestCase):
         assert spans
         self.assertEqual(len(spans), 2)
         self.assertEqual(spans[0].get_tag('aws.operation'), 'CreateBucket')
-        self.assertEqual(spans[0].get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(spans[0], 200)
         self.assertEqual(spans[0].service, 'aws.s3')
         self.assertEqual(spans[0].resource, 's3.createbucket')
         self.assertEqual(spans[1].get_tag('aws.operation'), 'PutObject')
@@ -136,14 +137,14 @@ class AIOBotocoreTest(AsyncioTestCase):
 
         span = traces[0][0]
         self.assertEqual(span.get_tag('aws.operation'), 'GetObject')
-        self.assertEqual(span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.service, 'aws.s3')
         self.assertEqual(span.resource, 's3.getobject')
 
         if pre_08:
             read_span = traces[1][0]
             self.assertEqual(read_span.get_tag('aws.operation'), 'GetObject')
-            self.assertEqual(read_span.get_metric('http.status_code'), 200)
+            assert_span_http_status_code(read_span, 200)
             self.assertEqual(read_span.service, 'aws.s3')
             self.assertEqual(read_span.resource, 's3.getobject')
             self.assertEqual(read_span.name, 's3.command.read')
@@ -163,7 +164,7 @@ class AIOBotocoreTest(AsyncioTestCase):
         span = traces[0][0]
         self.assertEqual(span.get_tag('aws.region'), 'us-west-2')
         self.assertEqual(span.get_tag('aws.operation'), 'ListQueues')
-        self.assertEqual(span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.service, 'aws.sqs')
         self.assertEqual(span.resource, 'sqs.listqueues')
 
@@ -179,7 +180,7 @@ class AIOBotocoreTest(AsyncioTestCase):
         span = traces[0][0]
         self.assertEqual(span.get_tag('aws.region'), 'us-west-2')
         self.assertEqual(span.get_tag('aws.operation'), 'ListStreams')
-        self.assertEqual(span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.service, 'aws.kinesis')
         self.assertEqual(span.resource, 'kinesis.liststreams')
 
@@ -196,7 +197,7 @@ class AIOBotocoreTest(AsyncioTestCase):
         span = traces[0][0]
         self.assertEqual(span.get_tag('aws.region'), 'us-west-2')
         self.assertEqual(span.get_tag('aws.operation'), 'ListFunctions')
-        self.assertEqual(span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.service, 'aws.lambda')
         self.assertEqual(span.resource, 'lambda.listfunctions')
 
@@ -212,7 +213,7 @@ class AIOBotocoreTest(AsyncioTestCase):
         span = traces[0][0]
         self.assertEqual(span.get_tag('aws.region'), 'us-west-2')
         self.assertEqual(span.get_tag('aws.operation'), 'ListKeys')
-        self.assertEqual(span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.service, 'aws.kms')
         self.assertEqual(span.resource, 'kms.listkeys')
         # checking for protection on STS against security leak
@@ -264,7 +265,7 @@ class AIOBotocoreTest(AsyncioTestCase):
         self.assertEqual(dd_span.get_tag('aws.agent'), 'aiobotocore')
         self.assertEqual(dd_span.get_tag('aws.region'), 'us-west-2')
         self.assertEqual(dd_span.get_tag('aws.operation'), 'DescribeInstances')
-        self.assertEqual(dd_span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(dd_span, 200)
         self.assertEqual(dd_span.get_metric('retry_attempts'), 0)
         self.assertEqual(dd_span.service, 'aws.ec2')
         self.assertEqual(dd_span.resource, 'ec2.describeinstances')
@@ -305,13 +306,13 @@ class AIOBotocoreTest(AsyncioTestCase):
         self.assertEqual(ot_inner_span2.parent_id, ot_outer_span.span_id)
 
         self.assertEqual(dd_span.get_tag('aws.operation'), 'ListBuckets')
-        self.assertEqual(dd_span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(dd_span, 200)
         self.assertEqual(dd_span.service, 'aws.s3')
         self.assertEqual(dd_span.resource, 's3.listbuckets')
         self.assertEqual(dd_span.name, 's3.command')
 
         self.assertEqual(dd_span2.get_tag('aws.operation'), 'ListBuckets')
-        self.assertEqual(dd_span2.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(dd_span2, 200)
         self.assertEqual(dd_span2.service, 'aws.s3')
         self.assertEqual(dd_span2.resource, 's3.listbuckets')
         self.assertEqual(dd_span2.name, 's3.command')

--- a/tests/contrib/aiobotocore/test.py
+++ b/tests/contrib/aiobotocore/test.py
@@ -3,7 +3,6 @@ from botocore.errorfactory import ClientError
 
 from ddtrace.contrib.aiobotocore.patch import patch, unpatch
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
-from ddtrace.ext import http
 from ddtrace.compat import stringify
 
 from .utils import aiobotocore_client

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -11,6 +11,7 @@ from opentracing.scope_managers.asyncio import AsyncioScopeManager
 from tests.opentracer.utils import init_tracer
 from .utils import TraceTestCase
 from .app.web import setup_app, noop_middleware
+from ...utils import assert_span_http_status_code
 
 
 class TestTraceMiddleware(TraceTestCase):
@@ -42,7 +43,7 @@ class TestTraceMiddleware(TraceTestCase):
         assert 'GET /' == span.resource
         assert str(self.client.make_url('/')) == span.get_tag(http.URL)
         assert 'GET' == span.get_tag('http.method')
-        assert 200 == span.get_metric('http.status_code')
+        assert_span_http_status_code(span, 200)
         assert 0 == span.error
 
     @asyncio.coroutine
@@ -64,7 +65,7 @@ class TestTraceMiddleware(TraceTestCase):
         # with the right fields
         assert 'GET /echo/{name}' == span.resource
         assert str(self.client.make_url('/echo/team')) == span.get_tag(http.URL)
-        assert 200 == span.get_metric('http.status_code')
+        assert_span_http_status_code(span, 200)
         if self.app[CONFIG_KEY].get('trace_query_string'):
             assert query_string == span.get_tag(http.QUERY_STRING)
         else:
@@ -112,7 +113,7 @@ class TestTraceMiddleware(TraceTestCase):
         assert '404' == span.resource
         assert str(self.client.make_url('/404/not_found')) == span.get_tag(http.URL)
         assert 'GET' == span.get_tag('http.method')
-        assert 404 == span.get_metric('http.status_code')
+        assert_span_http_status_code(span, 404)
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -128,7 +129,7 @@ class TestTraceMiddleware(TraceTestCase):
         assert len(traces[0]) == 1
         span = traces[0][0]
         assert span.get_tag('http.method') == 'GET'
-        assert span.get_metric('http.status_code') == 500
+        assert_span_http_status_code(span, 500)
         assert span.error == 1
 
     @unittest_run_loop
@@ -145,7 +146,7 @@ class TestTraceMiddleware(TraceTestCase):
         assert len(traces[0]) == 1
         span = traces[0][0]
         assert span.get_tag('http.method') == 'GET'
-        assert span.get_metric('http.status_code') == 503
+        assert_span_http_status_code(span, 503)
         assert span.error == 1
 
     @unittest_run_loop
@@ -168,7 +169,7 @@ class TestTraceMiddleware(TraceTestCase):
         assert 'GET /chaining/' == root.resource
         assert str(self.client.make_url('/chaining/')) == root.get_tag(http.URL)
         assert 'GET' == root.get_tag('http.method')
-        assert 200 == root.get_metric('http.status_code')
+        assert_span_http_status_code(root, 200)
         # span created in the coroutine_chaining handler
         assert 'aiohttp.coro_1' == handler.name
         assert root.span_id == handler.parent_id
@@ -196,7 +197,7 @@ class TestTraceMiddleware(TraceTestCase):
         assert 'GET /statics' == span.resource
         assert str(self.client.make_url('/statics/empty.txt')) == span.get_tag(http.URL)
         assert 'GET' == span.get_tag('http.method')
-        assert 200 == span.get_metric('http.status_code')
+        assert_span_http_status_code(span, 200)
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -421,7 +422,7 @@ class TestTraceMiddleware(TraceTestCase):
         assert 'GET /' == inner_span.resource
         assert str(self.client.make_url('/')) == inner_span.get_tag(http.URL)
         assert 'GET' == inner_span.get_tag('http.method')
-        assert 200 == inner_span.get_metric('http.status_code')
+        assert_span_http_status_code(inner_span, 200)
         assert 0 == inner_span.error
 
     @unittest_run_loop

--- a/tests/contrib/boto/test.py
+++ b/tests/contrib/boto/test.py
@@ -18,6 +18,7 @@ from ddtrace.ext import http
 from unittest import skipUnless
 from tests.opentracer.utils import init_tracer
 from ...base import BaseTracerTestCase
+from ...utils import assert_span_http_status_code
 
 
 class BotoTest(BaseTracerTestCase):
@@ -41,7 +42,7 @@ class BotoTest(BaseTracerTestCase):
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertEqual(span.get_tag('aws.operation'), 'DescribeInstances')
-        self.assertEqual(span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.get_tag(http.METHOD), 'POST')
         self.assertEqual(span.get_tag('aws.region'), 'us-west-2')
         self.assertIsNone(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY))
@@ -53,7 +54,7 @@ class BotoTest(BaseTracerTestCase):
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertEqual(span.get_tag('aws.operation'), 'RunInstances')
-        self.assertEqual(span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.get_tag(http.METHOD), 'POST')
         self.assertEqual(span.get_tag('aws.region'), 'us-west-2')
         self.assertEqual(span.service, 'test-boto-tracing.ec2')
@@ -107,7 +108,7 @@ class BotoTest(BaseTracerTestCase):
         assert spans
         self.assertEqual(len(spans), 1)
         span = spans[0]
-        self.assertEqual(span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.get_tag(http.METHOD), 'GET')
         self.assertEqual(span.get_tag('aws.operation'), 'get_all_buckets')
 
@@ -117,7 +118,7 @@ class BotoTest(BaseTracerTestCase):
         assert spans
         self.assertEqual(len(spans), 1)
         span = spans[0]
-        self.assertEqual(span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.get_tag(http.METHOD), 'PUT')
         self.assertEqual(span.get_tag('path'), '/')
         self.assertEqual(span.get_tag('aws.operation'), 'create_bucket')
@@ -128,7 +129,7 @@ class BotoTest(BaseTracerTestCase):
         assert spans
         self.assertEqual(len(spans), 1)
         span = spans[0]
-        self.assertEqual(span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.get_tag(http.METHOD), 'HEAD')
         self.assertEqual(span.get_tag('aws.operation'), 'head_bucket')
         self.assertEqual(span.service, 'test-boto-tracing.s3')
@@ -161,7 +162,7 @@ class BotoTest(BaseTracerTestCase):
         # create bucket
         self.assertEqual(len(spans), 3)
         self.assertEqual(spans[0].get_tag('aws.operation'), 'create_bucket')
-        self.assertEqual(spans[0].get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(spans[0], 200)
         self.assertEqual(spans[0].service, 'test-boto-tracing.s3')
         self.assertEqual(spans[0].resource, 's3.put')
         # get bucket
@@ -215,7 +216,7 @@ class BotoTest(BaseTracerTestCase):
         assert spans
         self.assertEqual(len(spans), 2)
         span = spans[0]
-        self.assertEqual(span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.get_tag(http.METHOD), 'GET')
         self.assertEqual(span.get_tag('aws.region'), 'us-east-2')
         self.assertEqual(span.get_tag('aws.operation'), 'list_functions')
@@ -285,7 +286,7 @@ class BotoTest(BaseTracerTestCase):
 
         self.assertEqual(ot_span.resource, 'ot_span')
         self.assertEqual(dd_span.get_tag('aws.operation'), 'DescribeInstances')
-        self.assertEqual(dd_span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(dd_span, 200)
         self.assertEqual(dd_span.get_tag(http.METHOD), 'POST')
         self.assertEqual(dd_span.get_tag('aws.region'), 'us-west-2')
 
@@ -301,7 +302,7 @@ class BotoTest(BaseTracerTestCase):
         self.assertEqual(dd_span.parent_id, ot_span.span_id)
 
         self.assertEqual(dd_span.get_tag('aws.operation'), 'RunInstances')
-        self.assertEqual(dd_span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(dd_span, 200)
         self.assertEqual(dd_span.get_tag(http.METHOD), 'POST')
         self.assertEqual(dd_span.get_tag('aws.region'), 'us-west-2')
         self.assertEqual(dd_span.service, 'test-boto-tracing.ec2')

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -6,7 +6,6 @@ from moto import mock_s3, mock_ec2, mock_lambda, mock_sqs, mock_kinesis, mock_km
 from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.botocore.patch import patch, unpatch
-from ddtrace.ext import http
 from ddtrace.compat import stringify
 
 # testing

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -12,6 +12,7 @@ from ddtrace.compat import stringify
 # testing
 from tests.opentracer.utils import init_tracer
 from ...base import BaseTracerTestCase
+from ...utils import assert_span_http_status_code
 
 
 class BotocoreTest(BaseTracerTestCase):
@@ -46,7 +47,7 @@ class BotocoreTest(BaseTracerTestCase):
         self.assertEqual(span.get_tag('aws.agent'), 'botocore')
         self.assertEqual(span.get_tag('aws.region'), 'us-west-2')
         self.assertEqual(span.get_tag('aws.operation'), 'DescribeInstances')
-        self.assertEqual(span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.get_metric('retry_attempts'), 0)
         self.assertEqual(span.service, 'test-botocore-tracing.ec2')
         self.assertEqual(span.resource, 'ec2.describeinstances')
@@ -82,7 +83,7 @@ class BotocoreTest(BaseTracerTestCase):
         span = spans[0]
         self.assertEqual(len(spans), 2)
         self.assertEqual(span.get_tag('aws.operation'), 'ListBuckets')
-        self.assertEqual(span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.service, 'test-botocore-tracing.s3')
         self.assertEqual(span.resource, 's3.listbuckets')
 
@@ -110,7 +111,7 @@ class BotocoreTest(BaseTracerTestCase):
         span = spans[0]
         self.assertEqual(len(spans), 2)
         self.assertEqual(span.get_tag('aws.operation'), 'CreateBucket')
-        self.assertEqual(span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.service, 'test-botocore-tracing.s3')
         self.assertEqual(span.resource, 's3.createbucket')
         self.assertEqual(spans[1].get_tag('aws.operation'), 'PutObject')
@@ -133,7 +134,7 @@ class BotocoreTest(BaseTracerTestCase):
         self.assertEqual(len(spans), 1)
         self.assertEqual(span.get_tag('aws.region'), 'us-east-1')
         self.assertEqual(span.get_tag('aws.operation'), 'ListQueues')
-        self.assertEqual(span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.service, 'test-botocore-tracing.sqs')
         self.assertEqual(span.resource, 'sqs.listqueues')
 
@@ -150,7 +151,7 @@ class BotocoreTest(BaseTracerTestCase):
         self.assertEqual(len(spans), 1)
         self.assertEqual(span.get_tag('aws.region'), 'us-east-1')
         self.assertEqual(span.get_tag('aws.operation'), 'ListStreams')
-        self.assertEqual(span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.service, 'test-botocore-tracing.kinesis')
         self.assertEqual(span.resource, 'kinesis.liststreams')
 
@@ -192,7 +193,7 @@ class BotocoreTest(BaseTracerTestCase):
         self.assertEqual(len(spans), 1)
         self.assertEqual(span.get_tag('aws.region'), 'us-east-1')
         self.assertEqual(span.get_tag('aws.operation'), 'ListFunctions')
-        self.assertEqual(span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.service, 'test-botocore-tracing.lambda')
         self.assertEqual(span.resource, 'lambda.listfunctions')
 
@@ -209,7 +210,7 @@ class BotocoreTest(BaseTracerTestCase):
         self.assertEqual(len(spans), 1)
         self.assertEqual(span.get_tag('aws.region'), 'us-east-1')
         self.assertEqual(span.get_tag('aws.operation'), 'ListKeys')
-        self.assertEqual(span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.service, 'test-botocore-tracing.kms')
         self.assertEqual(span.resource, 'kms.listkeys')
 
@@ -242,7 +243,7 @@ class BotocoreTest(BaseTracerTestCase):
         self.assertEqual(dd_span.get_tag('aws.agent'), 'botocore')
         self.assertEqual(dd_span.get_tag('aws.region'), 'us-west-2')
         self.assertEqual(dd_span.get_tag('aws.operation'), 'DescribeInstances')
-        self.assertEqual(dd_span.get_metric(http.STATUS_CODE), 200)
+        assert_span_http_status_code(dd_span, 200)
         self.assertEqual(dd_span.get_metric('retry_attempts'), 0)
         self.assertEqual(dd_span.service, 'test-botocore-tracing.ec2')
         self.assertEqual(dd_span.resource, 'ec2.describeinstances')

--- a/tests/contrib/bottle/test.py
+++ b/tests/contrib/bottle/test.py
@@ -4,6 +4,7 @@ import webtest
 
 from tests.opentracer.utils import init_tracer
 from ...base import BaseTracerTestCase
+from ...utils import assert_span_http_status_code
 
 from ddtrace import compat
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -58,7 +59,7 @@ class TraceBottleTest(BaseTracerTestCase):
         assert s.service == 'bottle-app'
         assert s.span_type == 'web'
         assert s.resource == 'GET /hi/<name>'
-        assert s.get_metric('http.status_code') == 200
+        assert_span_http_status_code(s, 200)
         assert s.get_tag('http.method') == 'GET'
         assert s.get_tag(http.URL) == 'http://localhost:80/hi/dougie'
         if ddtrace.config.bottle.trace_query_string:
@@ -99,7 +100,7 @@ class TraceBottleTest(BaseTracerTestCase):
         assert len(spans) == 1
         s = spans[0]
         assert s.resource == 'GET /2xx'
-        assert s.get_metric('http.status_code') == 202
+        assert_span_http_status_code(s, 202)
         assert s.error == 0
 
     def test_400_return(self):
@@ -120,7 +121,7 @@ class TraceBottleTest(BaseTracerTestCase):
         assert s.name == 'bottle.request'
         assert s.service == 'bottle-app'
         assert s.resource == 'GET /400_return'
-        assert s.get_metric('http.status_code') == 400
+        assert_span_http_status_code(s, 400)
         assert s.get_tag('http.method') == 'GET'
         assert s.get_tag(http.URL) == 'http://localhost:80/400_return'
         assert s.error == 0
@@ -143,7 +144,7 @@ class TraceBottleTest(BaseTracerTestCase):
         assert s.name == 'bottle.request'
         assert s.service == 'bottle-app'
         assert s.resource == 'GET /400_raise'
-        assert s.get_metric('http.status_code') == 400
+        assert_span_http_status_code(s, 400)
         assert s.get_tag('http.method') == 'GET'
         assert s.get_tag(http.URL) == 'http://localhost:80/400_raise'
         assert s.error == 1
@@ -166,7 +167,7 @@ class TraceBottleTest(BaseTracerTestCase):
         assert s.name == 'bottle.request'
         assert s.service == 'bottle-app'
         assert s.resource == 'GET /hi'
-        assert s.get_metric('http.status_code') == 500
+        assert_span_http_status_code(s, 500)
         assert s.get_tag('http.method') == 'GET'
         assert s.get_tag(http.URL) == 'http://localhost:80/hi'
         assert s.error == 1
@@ -233,7 +234,7 @@ class TraceBottleTest(BaseTracerTestCase):
         assert s.name == 'bottle.request'
         assert s.service == 'bottle-app'
         assert s.resource == 'GET /hi'
-        assert s.get_metric('http.status_code') == 420
+        assert_span_http_status_code(s, 420)
         assert s.get_tag('http.method') == 'GET'
         assert s.get_tag(http.URL) == 'http://localhost:80/hi'
 
@@ -254,7 +255,7 @@ class TraceBottleTest(BaseTracerTestCase):
         assert s.name == 'bottle.request'
         assert s.service == 'bottle-app'
         assert s.resource == 'GET /home/'
-        assert s.get_metric('http.status_code') == 200
+        assert_span_http_status_code(s, 200)
         assert s.get_tag('http.method') == 'GET'
         assert s.get_tag(http.URL) == 'http://localhost:80/home/'
 
@@ -404,7 +405,7 @@ class TraceBottleTest(BaseTracerTestCase):
         assert dd_span.name == 'bottle.request'
         assert dd_span.service == 'bottle-app'
         assert dd_span.resource == 'GET /hi/<name>'
-        assert dd_span.get_metric('http.status_code') == 200
+        assert_span_http_status_code(dd_span, 200)
         assert dd_span.get_tag('http.method') == 'GET'
         assert dd_span.get_tag(http.URL) == 'http://localhost:80/hi/dougie'
 

--- a/tests/contrib/bottle/test_autopatch.py
+++ b/tests/contrib/bottle/test_autopatch.py
@@ -4,6 +4,7 @@ import webtest
 
 from unittest import TestCase
 from tests.test_tracer import get_dummy_tracer
+from ...utils import assert_span_http_status_code
 
 from ddtrace import compat
 
@@ -48,7 +49,7 @@ class TraceBottleTest(TestCase):
         assert s.name == 'bottle.request'
         assert s.service == 'bottle-app'
         assert s.resource == 'GET /hi/<name>'
-        assert s.get_metric('http.status_code') == 200
+        assert_span_http_status_code(s, 200)
         assert s.get_tag('http.method') == 'GET'
 
         services = self.tracer.writer.pop_services()
@@ -73,7 +74,7 @@ class TraceBottleTest(TestCase):
         assert s.name == 'bottle.request'
         assert s.service == 'bottle-app'
         assert s.resource == 'GET /hi'
-        assert s.get_metric('http.status_code') == 500
+        assert_span_http_status_code(s, 500)
         assert s.get_tag('http.method') == 'GET'
 
     def test_bottle_global_tracer(self):
@@ -93,5 +94,5 @@ class TraceBottleTest(TestCase):
         assert s.name == 'bottle.request'
         assert s.service == 'bottle-app'
         assert s.resource == 'GET /home/'
-        assert s.get_metric('http.status_code') == 200
+        assert_span_http_status_code(s, 200)
         assert s.get_tag('http.method') == 'GET'

--- a/tests/contrib/bottle/test_distributed.py
+++ b/tests/contrib/bottle/test_distributed.py
@@ -6,6 +6,7 @@ from ddtrace import compat
 from ddtrace.contrib.bottle import TracePlugin
 
 from ...base import BaseTracerTestCase
+from ...utils import assert_span_http_status_code
 
 SERVICE = 'bottle-app'
 
@@ -56,7 +57,7 @@ class TraceBottleDistributedTest(BaseTracerTestCase):
         assert s.name == 'bottle.request'
         assert s.service == 'bottle-app'
         assert s.resource == 'GET /hi/<name>'
-        assert s.get_metric('http.status_code') == 200
+        assert_span_http_status_code(s, 200)
         assert s.get_tag('http.method') == 'GET'
         # check distributed headers
         assert 123 == s.trace_id
@@ -83,7 +84,7 @@ class TraceBottleDistributedTest(BaseTracerTestCase):
         assert s.name == 'bottle.request'
         assert s.service == 'bottle-app'
         assert s.resource == 'GET /hi/<name>'
-        assert s.get_metric('http.status_code') == 200
+        assert_span_http_status_code(s, 200)
         assert s.get_tag('http.method') == 'GET'
         # check distributed headers
         assert 123 != s.trace_id

--- a/tests/contrib/django/test_middleware.py
+++ b/tests/contrib/django/test_middleware.py
@@ -12,6 +12,7 @@ from ddtrace.ext import errors, http
 from tests.opentracer.utils import init_tracer
 from .compat import reverse
 from .utils import DjangoTraceTestCase, override_ddtrace_settings
+from ...utils import assert_span_http_status_code
 
 
 class DjangoMiddlewareTest(DjangoTraceTestCase):
@@ -36,7 +37,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         sp_database = spans[2]
         assert sp_database.get_tag('django.db.vendor') == 'sqlite'
         assert sp_template.get_tag('django.template_name') == 'users_list.html'
-        assert sp_request.get_metric('http.status_code') == 200
+        assert_span_http_status_code(sp_request, 200)
         assert sp_request.get_tag(http.URL) == 'http://testserver/users/'
         assert sp_request.get_tag('django.user.is_authenticated') == 'False'
         assert sp_request.get_tag('http.method') == 'GET'
@@ -205,7 +206,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.get_metric('http.status_code') == 403
+        assert_span_http_status_code(span, 403)
         assert span.get_tag(http.URL) == 'http://testserver/fail-view/'
         assert span.resource == 'tests.contrib.django.app.views.ForbiddenView'
 
@@ -219,7 +220,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.get_metric('http.status_code') == 200
+        assert_span_http_status_code(span, 200)
         assert span.get_tag(http.URL) == 'http://testserver/fn-view/'
         assert span.resource == 'tests.contrib.django.app.views.function_view'
 
@@ -234,7 +235,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         assert len(spans) == 1
         span = spans[0]
         assert span.error == 1
-        assert span.get_metric('http.status_code') == 500
+        assert_span_http_status_code(span, 500)
         assert span.get_tag(http.URL) == 'http://testserver/error-500/'
         assert span.resource == 'tests.contrib.django.app.views.error_500'
         assert 'Error 500' in span.get_tag('error.stack')
@@ -249,7 +250,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.get_metric('http.status_code') == 200
+        assert_span_http_status_code(span, 200)
         assert span.get_tag(http.URL) == 'http://testserver/feed-view/'
         assert span.resource == 'tests.contrib.django.app.views.FeedView'
 
@@ -263,7 +264,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.get_metric('http.status_code') == 200
+        assert_span_http_status_code(span, 200)
         assert span.get_tag(http.URL) == 'http://testserver/partial-view/'
         assert span.resource == 'partial'
 
@@ -277,7 +278,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.get_metric('http.status_code') == 200
+        assert_span_http_status_code(span, 200)
         assert span.get_tag(http.URL) == 'http://testserver/lambda-view/'
         assert span.resource == 'tests.contrib.django.app.views.<lambda>'
 
@@ -300,7 +301,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         spans = self.tracer.writer.pop()
         assert len(spans) == 3
         sp_request = spans[0]
-        assert sp_request.get_metric('http.status_code') == 200
+        assert_span_http_status_code(sp_request, 200)
         assert sp_request.get_tag('django.user.is_authenticated') is None
 
     def test_middleware_propagation(self):
@@ -425,7 +426,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
 
         assert sp_database.get_tag('django.db.vendor') == 'sqlite'
         assert sp_template.get_tag('django.template_name') == 'users_list.html'
-        assert sp_request.get_metric('http.status_code') == 200
+        assert_span_http_status_code(sp_request, 200)
         assert sp_request.get_tag(http.URL) == 'http://testserver/users/'
         assert sp_request.get_tag('django.user.is_authenticated') == 'False'
         assert sp_request.get_tag('http.method') == 'GET'
@@ -451,7 +452,7 @@ class DjangoMiddlewareTest(DjangoTraceTestCase):
         assert sp_template.get_tag('django.template_name') == 'unknown'
 
         # Request
-        assert sp_request.get_metric('http.status_code') == 404
+        assert_span_http_status_code(sp_request, 404)
         assert sp_request.get_tag(http.URL) == 'http://testserver/unknown-url'
         assert sp_request.get_tag('django.user.is_authenticated') == 'False'
         assert sp_request.get_tag('http.method') == 'GET'

--- a/tests/contrib/djangorestframework/test_djangorestframework.py
+++ b/tests/contrib/djangorestframework/test_djangorestframework.py
@@ -3,6 +3,7 @@ from django.apps import apps
 from unittest import skipIf
 
 from tests.contrib.django.utils import DjangoTraceTestCase
+from ...utils import assert_span_http_status_code
 
 
 @skipIf(django.VERSION < (1, 10), 'requires django version >= 1.10')
@@ -38,7 +39,7 @@ class RestFrameworkTest(DjangoTraceTestCase):
         assert sp.resource == 'tests.contrib.djangorestframework.app.views.UserViewSet'
         assert sp.error == 0
         assert sp.span_type == 'web'
-        assert sp.get_metric('http.status_code') == 500
+        assert_span_http_status_code(sp, 500)
         assert sp.get_tag('error.msg') is None
 
     def test_trace_exceptions(self):
@@ -56,6 +57,6 @@ class RestFrameworkTest(DjangoTraceTestCase):
         assert sp.error == 1
         assert sp.span_type == 'web'
         assert sp.get_tag('http.method') == 'GET'
-        assert sp.get_metric('http.status_code') == 500
+        assert_span_http_status_code(sp, 500)
         assert sp.get_tag('error.msg') == 'Authentication credentials were not provided.'
         assert 'NotAuthenticated' in sp.get_tag('error.stack')

--- a/tests/contrib/elasticsearch/test.py
+++ b/tests/contrib/elasticsearch/test.py
@@ -14,6 +14,7 @@ from tests.opentracer.utils import init_tracer
 from ..config import ELASTICSEARCH_CONFIG
 from ...test_tracer import get_dummy_tracer
 from ...base import BaseTracerTestCase
+from ...utils import assert_span_http_status_code
 
 
 class ElasticsearchTest(unittest.TestCase):
@@ -131,7 +132,7 @@ class ElasticsearchTest(unittest.TestCase):
             spans = writer.pop()
             assert spans
             span = spans[0]
-            assert span.get_metric(http.STATUS_CODE) == 404
+            assert_span_http_status_code(span, 404)
 
         # Raise error 400, the index 10 is created twice
         try:
@@ -142,7 +143,7 @@ class ElasticsearchTest(unittest.TestCase):
             spans = writer.pop()
             assert spans
             span = spans[-1]
-            assert span.get_metric(http.STATUS_CODE) == 400
+            assert_span_http_status_code(span, 400)
 
         # Drop the index, checking it won't raise exception on success or failure
         es.indices.delete(index=self.ES_INDEX, ignore=[400, 404])

--- a/tests/contrib/falcon/test_suite.py
+++ b/tests/contrib/falcon/test_suite.py
@@ -3,6 +3,7 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.ext import errors as errx, http as httpx
 
 from tests.opentracer.utils import init_tracer
+from ...utils import assert_span_http_status_code
 
 
 class FalconTestCase(object):
@@ -21,7 +22,7 @@ class FalconTestCase(object):
         assert span.name == 'falcon.request'
         assert span.service == self._service
         assert span.resource == 'GET 404'
-        assert span.get_metric(httpx.STATUS_CODE) == 404
+        assert_span_http_status_code(span, 404)
         assert span.get_tag(httpx.URL) == 'http://falconframework.org/fake_endpoint'
         assert httpx.QUERY_STRING not in span.meta
         assert span.parent_id is None
@@ -41,7 +42,7 @@ class FalconTestCase(object):
         assert span.name == 'falcon.request'
         assert span.service == self._service
         assert span.resource == 'GET tests.contrib.falcon.app.resources.ResourceException'
-        assert span.get_metric(httpx.STATUS_CODE) == 500
+        assert_span_http_status_code(span, 500)
         assert span.get_tag(httpx.URL) == 'http://falconframework.org/exception'
         assert span.parent_id is None
 
@@ -57,7 +58,7 @@ class FalconTestCase(object):
         assert span.name == 'falcon.request'
         assert span.service == self._service
         assert span.resource == 'GET tests.contrib.falcon.app.resources.Resource200'
-        assert span.get_metric(httpx.STATUS_CODE) == 200
+        assert_span_http_status_code(span, 200)
         fqs = ('?' + query_string) if query_string else ''
         assert span.get_tag(httpx.URL) == 'http://falconframework.org/200' + fqs
         if config.falcon.trace_query_string:
@@ -154,7 +155,7 @@ class FalconTestCase(object):
         assert span.name == 'falcon.request'
         assert span.service == self._service
         assert span.resource == 'POST tests.contrib.falcon.app.resources.Resource201'
-        assert span.get_metric(httpx.STATUS_CODE) == 201
+        assert_span_http_status_code(span, 201)
         assert span.get_tag(httpx.URL) == 'http://falconframework.org/201'
         assert span.parent_id is None
 
@@ -170,7 +171,7 @@ class FalconTestCase(object):
         assert span.name == 'falcon.request'
         assert span.service == self._service
         assert span.resource == 'GET tests.contrib.falcon.app.resources.Resource500'
-        assert span.get_metric(httpx.STATUS_CODE) == 500
+        assert_span_http_status_code(span, 500)
         assert span.get_tag(httpx.URL) == 'http://falconframework.org/500'
         assert span.parent_id is None
 
@@ -185,7 +186,7 @@ class FalconTestCase(object):
         assert span.name == 'falcon.request'
         assert span.service == self._service
         assert span.resource == 'GET tests.contrib.falcon.app.resources.ResourceNotFound'
-        assert span.get_metric(httpx.STATUS_CODE) == 404
+        assert_span_http_status_code(span, 404)
         assert span.get_tag(httpx.URL) == 'http://falconframework.org/not_found'
         assert span.parent_id is None
 
@@ -200,7 +201,7 @@ class FalconTestCase(object):
         span = traces[0][0]
         assert span.name == 'falcon.request'
         assert span.service == self._service
-        assert span.get_metric(httpx.STATUS_CODE) == 404
+        assert_span_http_status_code(span, 404)
         assert span.get_tag(errx.ERROR_TYPE) is None
         assert span.parent_id is None
 
@@ -229,7 +230,7 @@ class FalconTestCase(object):
         assert dd_span.name == 'falcon.request'
         assert dd_span.service == self._service
         assert dd_span.resource == 'GET tests.contrib.falcon.app.resources.Resource200'
-        assert dd_span.get_metric(httpx.STATUS_CODE) == 200
+        assert_span_http_status_code(dd_span, 200)
         assert dd_span.get_tag(httpx.URL) == 'http://falconframework.org/200'
 
     def test_falcon_request_hook(self):

--- a/tests/contrib/flask/test_errorhandler.py
+++ b/tests/contrib/flask/test_errorhandler.py
@@ -1,6 +1,7 @@
 import flask
 
 from . import BaseFlaskTestCase
+from ...utils import assert_span_http_status_code
 
 
 class FlaskErrorhandlerTestCase(BaseFlaskTestCase):
@@ -23,7 +24,7 @@ class FlaskErrorhandlerTestCase(BaseFlaskTestCase):
 
         # flask.request span
         self.assertEqual(req_span.error, 0)
-        self.assertEqual(req_span.get_metric('http.status_code'), 404)
+        assert_span_http_status_code(req_span, 404)
         self.assertIsNone(req_span.get_tag('flask.endpoint'))
         self.assertIsNone(req_span.get_tag('flask.url_rule'))
 
@@ -68,7 +69,8 @@ class FlaskErrorhandlerTestCase(BaseFlaskTestCase):
 
         # flask.request span
         self.assertEqual(req_span.error, 1)
-        self.assertEqual(req_span.get_metric('http.status_code'), 500)
+
+        assert_span_http_status_code(req_span, 500)
         self.assertEqual(req_span.get_tag('flask.endpoint'), 'endpoint_500')
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/500')
 
@@ -128,7 +130,7 @@ class FlaskErrorhandlerTestCase(BaseFlaskTestCase):
 
         # flask.request span
         self.assertEqual(req_span.error, 0)
-        self.assertEqual(req_span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(req_span, 200)
         self.assertEqual(req_span.get_tag('flask.endpoint'), 'endpoint_500')
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/500')
 
@@ -191,7 +193,7 @@ class FlaskErrorhandlerTestCase(BaseFlaskTestCase):
 
         # flask.request span
         self.assertEqual(req_span.error, 1)
-        self.assertEqual(req_span.get_metric('http.status_code'), 500)
+        assert_span_http_status_code(req_span, 500)
         self.assertEqual(req_span.get_tag('flask.endpoint'), 'endpoint_error')
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/error')
 
@@ -258,7 +260,7 @@ class FlaskErrorhandlerTestCase(BaseFlaskTestCase):
 
         # flask.request span
         self.assertEqual(req_span.error, 0)
-        self.assertEqual(req_span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(req_span, 200)
         self.assertEqual(req_span.get_tag('flask.endpoint'), 'endpoint_error')
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/error')
 

--- a/tests/contrib/flask/test_hooks.py
+++ b/tests/contrib/flask/test_hooks.py
@@ -2,6 +2,7 @@ from flask import Blueprint
 
 from ddtrace.ext import http
 from . import BaseFlaskTestCase
+from ...utils import assert_span_http_status_code
 
 
 class FlaskHookTestCase(BaseFlaskTestCase):
@@ -81,7 +82,7 @@ class FlaskHookTestCase(BaseFlaskTestCase):
         self.assertEqual(root.get_tag('flask.endpoint'), 'index')
         self.assertEqual(root.get_tag('flask.url_rule'), '/')
         self.assertEqual(root.get_tag('http.method'), 'GET')
-        self.assertEqual(root.get_metric('http.status_code'), 401)
+        assert_span_http_status_code(root, 401)
         self.assertEqual(root.get_tag(http.URL), 'http://localhost/')
 
         # Assert hook span
@@ -182,7 +183,7 @@ class FlaskHookTestCase(BaseFlaskTestCase):
         parent = self.find_span_parent(spans, span)
 
         # Assert root span
-        self.assertEqual(root.get_metric('http.status_code'), 401)
+        assert_span_http_status_code(root, 401)
 
         # Assert hook span
         self.assertEqual(span.service, 'flask')

--- a/tests/contrib/flask/test_middleware.py
+++ b/tests/contrib/flask/test_middleware.py
@@ -11,6 +11,7 @@ from ddtrace.ext import http, errors
 from tests.opentracer.utils import init_tracer
 from .web import create_app
 from ...test_tracer import get_dummy_tracer
+from ...utils import assert_span_http_status_code
 
 
 class TestFlask(TestCase):
@@ -110,7 +111,7 @@ class TestFlask(TestCase):
         assert s.start >= start
         assert s.duration <= end - start
         assert s.error == 0
-        assert s.metrics.get(http.STATUS_CODE) == 200
+        assert_span_http_status_code(s, 200)
         assert s.meta.get(http.METHOD) == 'GET'
 
         services = self.tracer.writer.pop_services()
@@ -137,7 +138,7 @@ class TestFlask(TestCase):
         assert s.start >= start
         assert s.duration <= end - start
         assert s.error == 0
-        assert s.metrics.get(http.STATUS_CODE) == 200
+        assert_span_http_status_code(s, 200)
         assert s.meta.get(http.METHOD) == 'GET'
 
         t = by_name['flask.template']
@@ -165,7 +166,7 @@ class TestFlask(TestCase):
         assert s.start >= start
         assert s.duration <= end - start
         assert s.error == 0
-        assert s.metrics.get(http.STATUS_CODE) == 202
+        assert_span_http_status_code(s, 202)
         assert s.meta.get(http.METHOD) == 'GET'
 
     def test_template_err(self):
@@ -189,7 +190,7 @@ class TestFlask(TestCase):
         assert s.start >= start
         assert s.duration <= end - start
         assert s.error == 1
-        assert s.get_metric(http.STATUS_CODE) == 500
+        assert_span_http_status_code(s, 500)
         assert s.meta.get(http.METHOD) == 'GET'
 
     def test_template_render_err(self):
@@ -213,7 +214,7 @@ class TestFlask(TestCase):
         assert s.start >= start
         assert s.duration <= end - start
         assert s.error == 1
-        assert s.get_metric(http.STATUS_CODE) == 500
+        assert_span_http_status_code(s, 500)
         assert s.meta.get(http.METHOD) == 'GET'
         t = by_name['flask.template']
         assert t.get_tag('flask.template') == 'render_err.html'
@@ -239,7 +240,7 @@ class TestFlask(TestCase):
         assert s.resource == 'error'
         assert s.start >= start
         assert s.duration <= end - start
-        assert s.get_metric(http.STATUS_CODE) == 500
+        assert_span_http_status_code(s, 500)
         assert s.meta.get(http.METHOD) == 'GET'
 
     def test_fatal(self):
@@ -264,7 +265,7 @@ class TestFlask(TestCase):
         assert s.resource == 'fatal'
         assert s.start >= start
         assert s.duration <= end - start
-        assert s.get_metric(http.STATUS_CODE) == 500
+        assert_span_http_status_code(s, 500)
         assert s.meta.get(http.METHOD) == 'GET'
         assert 'ZeroDivisionError' in s.meta.get(errors.ERROR_TYPE), s.meta
         assert 'by zero' in s.meta.get(errors.ERROR_MSG)
@@ -289,7 +290,7 @@ class TestFlask(TestCase):
         assert s.start >= start
         assert s.duration <= end - start
         assert s.error == 0
-        assert s.get_metric(http.STATUS_CODE) == 200
+        assert_span_http_status_code(s, 200)
         assert s.meta.get(http.METHOD) == 'GET'
         assert s.meta.get(http.URL) == u'http://localhost/üŋïĉóđē'
 
@@ -311,7 +312,7 @@ class TestFlask(TestCase):
         assert s.start >= start
         assert s.duration <= end - start
         assert s.error == 0
-        assert s.get_metric(http.STATUS_CODE) == 404
+        assert_span_http_status_code(s, 404)
         assert s.meta.get(http.METHOD) == 'GET'
         assert s.meta.get(http.URL) == u'http://localhost/404/üŋïĉóđē'
 
@@ -348,7 +349,7 @@ class TestFlask(TestCase):
         assert s.service == 'test.flask.service'
         assert s.resource == 'overridden'
         assert s.error == 0
-        assert s.get_metric(http.STATUS_CODE) == 200
+        assert_span_http_status_code(s, 200)
         assert s.meta.get(http.METHOD) == 'GET'
 
     def test_success_200_ot(self):
@@ -382,5 +383,5 @@ class TestFlask(TestCase):
         assert dd_span.start >= start
         assert dd_span.duration <= end - start
         assert dd_span.error == 0
-        assert dd_span.get_metric(http.STATUS_CODE) == 200
+        assert_span_http_status_code(dd_span, 200)
         assert dd_span.meta.get(http.METHOD) == 'GET'

--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -7,6 +7,7 @@ from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID, HTTP_HEADER_PARENT_ID
 from flask import abort
 
 from . import BaseFlaskTestCase
+from ...utils import assert_span_http_status_code
 
 
 base_exception_name = 'builtins.Exception'
@@ -64,7 +65,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/')
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/')
-        self.assertEqual(req_span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(req_span, 200)
         assert http.QUERY_STRING not in req_span.meta
 
         # Handler span
@@ -299,7 +300,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
         # Note: contains no query string
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/')
-        self.assertEqual(req_span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(req_span, 200)
 
         # Handler span
         handler_span = spans[4]
@@ -359,7 +360,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.get_tag('flask.url_rule'), u'/üŋïĉóđē')
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
         self.assertEqual(req_span.get_tag(http.URL), u'http://localhost/üŋïĉóđē')
-        self.assertEqual(req_span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(req_span, 200)
 
         # Handler span
         handler_span = spans[4]
@@ -412,7 +413,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         # Request tags
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/not-found')
-        self.assertEqual(req_span.get_metric('http.status_code'), 404)
+        assert_span_http_status_code(req_span, 404)
 
         # Dispatch span
         dispatch_span = spans[3]
@@ -473,7 +474,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         # Request tags
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/not-found')
-        self.assertEqual(req_span.get_metric('http.status_code'), 404)
+        assert_span_http_status_code(req_span, 404)
         self.assertEqual(req_span.get_tag('flask.endpoint'), 'not_found')
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/not-found')
 
@@ -545,7 +546,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         # Request tags
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/500')
-        self.assertEqual(req_span.get_metric('http.status_code'), 500)
+        assert_span_http_status_code(req_span, 500)
         self.assertEqual(req_span.get_tag('flask.endpoint'), 'fivehundred')
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/500')
 
@@ -628,7 +629,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         # Request tags
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/501')
-        self.assertEqual(req_span.get_metric('http.status_code'), 501)
+        assert_span_http_status_code(req_span, 501)
         self.assertEqual(req_span.get_tag('flask.endpoint'), 'fivehundredone')
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/501')
 
@@ -735,7 +736,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         # Request tags
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/500')
-        self.assertEqual(req_span.get_metric('http.status_code'), 500)
+        assert_span_http_status_code(req_span, 500)
         self.assertEqual(req_span.get_tag('flask.endpoint'), 'fivehundred')
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/500')
 

--- a/tests/contrib/flask/test_static.py
+++ b/tests/contrib/flask/test_static.py
@@ -1,6 +1,7 @@
 from ddtrace.ext import http
 
 from . import BaseFlaskTestCase
+from ...utils import assert_span_http_status_code
 
 
 class FlaskStaticFileTestCase(BaseFlaskTestCase):
@@ -29,7 +30,7 @@ class FlaskStaticFileTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.get_tag('flask.endpoint'), 'static')
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/static/<path:filename>')
         self.assertEqual(req_span.get_tag('flask.view_args.filename'), 'test.txt')
-        self.assertEqual(req_span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(req_span, 200)
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/static/test.txt')
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
 
@@ -70,7 +71,7 @@ class FlaskStaticFileTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.get_tag('flask.endpoint'), 'static')
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/static/<path:filename>')
         self.assertEqual(req_span.get_tag('flask.view_args.filename'), 'unknown-file')
-        self.assertEqual(req_span.get_metric('http.status_code'), 404)
+        assert_span_http_status_code(req_span, 404)
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/static/unknown-file')
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
 

--- a/tests/contrib/flask/test_views.py
+++ b/tests/contrib/flask/test_views.py
@@ -4,6 +4,7 @@ from ddtrace.compat import PY2
 from ddtrace.ext import http
 
 from . import BaseFlaskTestCase
+from ...utils import assert_span_http_status_code
 
 
 base_exception_name = 'builtins.Exception'
@@ -40,7 +41,7 @@ class FlaskViewTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/hello/<name>')
         self.assertEqual(req_span.get_tag('flask.view_args.name'), 'flask')
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
-        self.assertEqual(req_span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(req_span, 200)
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/hello/flask')
 
         # tests.contrib.flask.test_views.hello
@@ -77,7 +78,7 @@ class FlaskViewTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/hello/<name>')
         self.assertEqual(req_span.get_tag('flask.view_args.name'), 'flask')
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
-        self.assertEqual(req_span.get_metric('http.status_code'), 500)
+        assert_span_http_status_code(req_span, 500)
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/hello/flask')
 
         # flask.dispatch_request
@@ -119,7 +120,7 @@ class FlaskViewTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/hello/<name>')
         self.assertEqual(req_span.get_tag('flask.view_args.name'), 'flask')
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
-        self.assertEqual(req_span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(req_span, 200)
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/hello/flask')
 
         # tests.contrib.flask.test_views.hello
@@ -154,7 +155,7 @@ class FlaskViewTestCase(BaseFlaskTestCase):
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/hello/<name>')
         self.assertEqual(req_span.get_tag('flask.view_args.name'), 'flask')
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
-        self.assertEqual(req_span.get_metric('http.status_code'), 500)
+        assert_span_http_status_code(req_span, 500)
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/hello/flask')
 
         # flask.dispatch_request

--- a/tests/contrib/flask_autopatch/test_flask_autopatch.py
+++ b/tests/contrib/flask_autopatch/test_flask_autopatch.py
@@ -83,7 +83,8 @@ class FlaskAutopatchTestCase(unittest.TestCase):
 
         # Request tags
         self.assertEqual(
-            set(['flask.version', 'http.url', 'http.method', 'flask.endpoint', 'flask.url_rule']),
+            set(['flask.version', 'http.url', 'http.method', 'http.status_code',
+                 'flask.endpoint', 'flask.url_rule']),
             set(req_span.meta.keys()),
         )
         self.assertEqual(req_span.get_tag('flask.endpoint'), 'index')

--- a/tests/contrib/flask_autopatch/test_flask_autopatch.py
+++ b/tests/contrib/flask_autopatch/test_flask_autopatch.py
@@ -8,6 +8,7 @@ from ddtrace.ext import http
 from ddtrace import Pin
 
 from ...test_tracer import get_dummy_tracer
+from ...utils import assert_span_http_status_code
 
 
 class FlaskAutopatchTestCase(unittest.TestCase):
@@ -89,7 +90,7 @@ class FlaskAutopatchTestCase(unittest.TestCase):
         self.assertEqual(req_span.get_tag('flask.url_rule'), '/')
         self.assertEqual(req_span.get_tag('http.method'), 'GET')
         self.assertEqual(req_span.get_tag(http.URL), 'http://localhost/')
-        self.assertEqual(req_span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(req_span, 200)
 
         # Handler span
         handler_span = spans[4]

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -18,6 +18,7 @@ from tests.opentracer.utils import init_tracer
 
 from ...base import BaseTracerTestCase
 from ...util import override_global_tracer
+from ...utils import assert_span_http_status_code
 
 if PY2:
     from urllib2 import urlopen, build_opener, Request
@@ -154,7 +155,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         self.assertEqual(span.error, 0)
         assert span.get_tag('http.method') == 'GET'
         assert span.get_tag('http.url') == URL_200
-        assert span.get_metric('http.status_code') == 200
+        assert_span_http_status_code(span, 200)
         if config.httplib.trace_query_string:
             assert span.get_tag(http.QUERY_STRING) == query_string
         else:
@@ -190,7 +191,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         self.assertEqual(span.name, self.SPAN_NAME)
         self.assertEqual(span.error, 0)
         assert span.get_tag('http.method') == 'GET'
-        assert span.get_metric('http.status_code') == 200
+        assert_span_http_status_code(span, 200)
         assert span.get_tag('http.url') == 'https://httpbin.org/status/200'
 
     def test_httplib_request_post_request(self):
@@ -214,7 +215,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         self.assertEqual(span.name, self.SPAN_NAME)
         self.assertEqual(span.error, 0)
         assert span.get_tag('http.method') == 'POST'
-        assert span.get_metric('http.status_code') == 200
+        assert_span_http_status_code(span, 200)
         assert span.get_tag('http.url') == URL_200
 
     def test_httplib_request_get_request_query_string(self):
@@ -237,7 +238,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         self.assertEqual(span.name, self.SPAN_NAME)
         self.assertEqual(span.error, 0)
         assert span.get_tag('http.method') == 'GET'
-        assert span.get_metric('http.status_code') == 200
+        assert_span_http_status_code(span, 200)
         assert span.get_tag('http.url') == URL_200
 
     def test_httplib_request_500_request(self):
@@ -266,7 +267,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         self.assertEqual(span.name, self.SPAN_NAME)
         self.assertEqual(span.error, 1)
         self.assertEqual(span.get_tag('http.method'), 'GET')
-        self.assertEqual(span.get_metric('http.status_code'), 500)
+        assert_span_http_status_code(span, 500)
         self.assertEqual(span.get_tag('http.url'), URL_500)
 
     def test_httplib_request_non_200_request(self):
@@ -295,7 +296,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         self.assertEqual(span.name, self.SPAN_NAME)
         self.assertEqual(span.error, 0)
         self.assertEqual(span.get_tag('http.method'), 'GET')
-        self.assertEqual(span.get_metric('http.status_code'), 404)
+        assert_span_http_status_code(span, 404)
         self.assertEqual(span.get_tag('http.url'), URL_404)
 
     def test_httplib_request_get_request_disabled(self):
@@ -379,7 +380,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         self.assertEqual(span.name, self.SPAN_NAME)
         self.assertEqual(span.error, 0)
         self.assertEqual(span.get_tag('http.method'), 'GET')
-        self.assertEqual(span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.get_tag('http.url'), URL_200)
 
     def test_urllib_request_https(self):
@@ -403,7 +404,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         self.assertEqual(span.name, self.SPAN_NAME)
         self.assertEqual(span.error, 0)
         self.assertEqual(span.get_tag('http.method'), 'GET')
-        self.assertEqual(span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.get_tag('http.url'), 'https://httpbin.org/status/200')
 
     def test_urllib_request_object(self):
@@ -428,7 +429,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         self.assertEqual(span.name, self.SPAN_NAME)
         self.assertEqual(span.error, 0)
         self.assertEqual(span.get_tag('http.method'), 'GET')
-        self.assertEqual(span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.get_tag('http.url'), URL_200)
 
     def test_urllib_request_opener(self):
@@ -452,7 +453,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         self.assertEqual(span.name, self.SPAN_NAME)
         self.assertEqual(span.error, 0)
         self.assertEqual(span.get_tag('http.method'), 'GET')
-        self.assertEqual(span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.get_tag('http.url'), URL_200)
 
     def test_httplib_request_get_request_ot(self):
@@ -482,7 +483,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         self.assertEqual(dd_span.name, self.SPAN_NAME)
         self.assertEqual(dd_span.error, 0)
         assert dd_span.get_tag('http.method') == 'GET'
-        assert dd_span.get_metric('http.status_code') == 200
+        assert_span_http_status_code(dd_span, 200)
         assert dd_span.get_tag('http.url') == URL_200
 
     def test_analytics_default(self):
@@ -555,7 +556,7 @@ if PY2:
             self.assertEqual(span.name, 'httplib.request')
             self.assertEqual(span.error, 0)
             self.assertEqual(span.get_tag('http.method'), 'GET')
-            self.assertEqual(span.get_metric('http.status_code'), 200)
+            assert_span_http_status_code(span, 200)
             self.assertEqual(span.get_tag('http.url'), URL_200)
 
         def test_urllib_request_https(self):
@@ -579,5 +580,5 @@ if PY2:
             self.assertEqual(span.name, 'httplib.request')
             self.assertEqual(span.error, 0)
             self.assertEqual(span.get_tag('http.method'), 'GET')
-            self.assertEqual(span.get_metric('http.status_code'), 200)
+            assert_span_http_status_code(span, 200)
             self.assertEqual(span.get_tag('http.url'), 'https://httpbin.org/status/200')

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -9,6 +9,7 @@ from ddtrace.contrib.molten import patch, unpatch
 from ddtrace.contrib.molten.patch import MOLTEN_VERSION
 
 from ...base import BaseTracerTestCase
+from ...utils import assert_span_http_status_code
 
 
 # NOTE: Type annotations required by molten otherwise parameters cannot be coerced
@@ -52,7 +53,7 @@ class TestMolten(BaseTracerTestCase):
         self.assertEqual(span.resource, 'GET /hello/{name}/{age}')
         self.assertEqual(span.get_tag('http.method'), 'GET')
         self.assertEqual(span.get_tag(http.URL), 'http://127.0.0.1:8000/hello/Jim/24')
-        self.assertEqual(span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(span, 200)
         assert http.QUERY_STRING not in span.meta
 
         # See test_resources below for specifics of this difference
@@ -81,7 +82,7 @@ class TestMolten(BaseTracerTestCase):
         self.assertEqual(span.resource, 'GET /hello/{name}/{age}')
         self.assertEqual(span.get_tag('http.method'), 'GET')
         self.assertEqual(span.get_tag(http.URL), 'http://127.0.0.1:8000/hello/Jim/24')
-        self.assertEqual(span.get_metric('http.status_code'), 200)
+        assert_span_http_status_code(span, 200)
         self.assertEqual(span.get_tag(http.QUERY_STRING), 'foo=bar')
 
     def test_analytics_global_on_integration_default(self):
@@ -168,7 +169,7 @@ class TestMolten(BaseTracerTestCase):
         self.assertEqual(span.resource, 'GET 404')
         self.assertEqual(span.get_tag(http.URL), 'http://127.0.0.1:8000/goodbye')
         self.assertEqual(span.get_tag('http.method'), 'GET')
-        self.assertEqual(span.get_metric('http.status_code'), 404)
+        assert_span_http_status_code(span, 404)
 
     def test_route_exception(self):
         def route_error() -> str:

--- a/tests/contrib/pylons/test_pylons.py
+++ b/tests/contrib/pylons/test_pylons.py
@@ -174,7 +174,7 @@ class PylonsTestCase(BaseTracerTestCase):
 
         assert span.service == 'web'
         assert span.resource == 'root.index'
-        assert span.metrics.get(http.STATUS_CODE) == 200
+        assert_span_http_status_code(span, 200)
         if config.pylons.trace_query_string:
             assert span.meta.get(http.QUERY_STRING) == query_string
         else:
@@ -264,7 +264,7 @@ class PylonsTestCase(BaseTracerTestCase):
 
         assert request.service == 'web'
         assert request.resource == 'root.render'
-        assert request.metrics.get(http.STATUS_CODE) == 200
+        assert_span_http_status_code(request, 200)
         assert request.error == 0
 
         assert template.service == 'web'
@@ -284,7 +284,7 @@ class PylonsTestCase(BaseTracerTestCase):
 
         assert request.service == 'web'
         assert request.resource == 'root.render_exception'
-        assert request.metrics.get(http.STATUS_CODE) == 500
+        assert_span_http_status_code(request, 500)
         assert request.error == 1
 
         assert template.service == 'web'
@@ -424,6 +424,6 @@ class PylonsTestCase(BaseTracerTestCase):
 
         assert dd_span.service == 'web'
         assert dd_span.resource == 'root.index'
-        assert dd_span.metrics.get(http.STATUS_CODE) == 200
+        assert_span_http_status_code(dd_span, 200)
         assert dd_span.meta.get(http.URL) == 'http://localhost:80/'
         assert dd_span.error == 0

--- a/tests/contrib/pylons/test_pylons.py
+++ b/tests/contrib/pylons/test_pylons.py
@@ -12,6 +12,7 @@ from ddtrace.contrib.pylons import PylonsTraceMiddleware
 
 from tests.opentracer.utils import init_tracer
 from ...base import BaseTracerTestCase
+from ...utils import assert_span_http_status_code
 
 
 class PylonsTestCase(BaseTracerTestCase):
@@ -51,7 +52,7 @@ class PylonsTestCase(BaseTracerTestCase):
         assert span.resource == 'root.raise_exception'
         assert span.error == 0
         assert span.get_tag(http.URL) == 'http://localhost:80/raise_exception'
-        assert span.get_metric('http.status_code') == 200
+        assert_span_http_status_code(span, 200)
         assert http.QUERY_STRING not in span.meta
         assert span.get_tag(errors.ERROR_MSG) is None
         assert span.get_tag(errors.ERROR_TYPE) is None
@@ -81,7 +82,7 @@ class PylonsTestCase(BaseTracerTestCase):
         assert span.resource == 'None.None'
         assert span.error == 0
         assert span.get_tag(http.URL) == 'http://localhost:80/'
-        assert span.get_metric('http.status_code') == 200
+        assert_span_http_status_code(span, 200)
         assert span.get_tag(errors.ERROR_MSG) is None
         assert span.get_tag(errors.ERROR_TYPE) is None
         assert span.get_tag(errors.ERROR_STACK) is None
@@ -109,7 +110,7 @@ class PylonsTestCase(BaseTracerTestCase):
         assert span.resource == 'None.None'
         assert span.error == 1
         assert span.get_tag(http.URL) == 'http://localhost:80/'
-        assert span.get_metric('http.status_code') == 500
+        assert_span_http_status_code(span, 500)
         assert span.get_tag(errors.ERROR_MSG) == 'Middleware exception'
         assert span.get_tag(errors.ERROR_TYPE) == 'exceptions.Exception'
         assert span.get_tag(errors.ERROR_STACK)
@@ -131,7 +132,7 @@ class PylonsTestCase(BaseTracerTestCase):
         assert span.resource == 'root.raise_exception'
         assert span.error == 0
         assert span.get_tag(http.URL) == 'http://localhost:80/raise_exception'
-        assert span.get_metric('http.status_code') == 200
+        assert_span_http_status_code(span, 200)
         assert span.get_tag(errors.ERROR_MSG) is None
         assert span.get_tag(errors.ERROR_TYPE) is None
         assert span.get_tag(errors.ERROR_STACK) is None
@@ -153,7 +154,7 @@ class PylonsTestCase(BaseTracerTestCase):
         assert span.resource == 'root.raise_exception'
         assert span.error == 0
         assert span.get_tag(http.URL) == 'http://localhost:80/raise_exception'
-        assert span.get_metric('http.status_code') == 404
+        assert_span_http_status_code(span, 404)
         assert span.get_tag(errors.ERROR_MSG) is None
         assert span.get_tag(errors.ERROR_TYPE) is None
         assert span.get_tag(errors.ERROR_STACK) is None
@@ -305,7 +306,7 @@ class PylonsTestCase(BaseTracerTestCase):
         assert span.service == 'web'
         assert span.resource == 'root.raise_exception'
         assert span.error == 1
-        assert span.get_metric('http.status_code') == 500
+        assert_span_http_status_code(span, 500)
         assert span.get_tag('error.msg') == 'Ouch!'
         assert span.get_tag(http.URL) == 'http://localhost:80/raise_exception'
         assert 'Exception: Ouch!' in span.get_tag('error.stack')
@@ -322,7 +323,7 @@ class PylonsTestCase(BaseTracerTestCase):
         assert span.service == 'web'
         assert span.resource == 'root.raise_wrong_code'
         assert span.error == 1
-        assert span.get_metric('http.status_code') == 500
+        assert_span_http_status_code(span, 500)
         assert span.meta.get(http.URL) == 'http://localhost:80/raise_wrong_code'
         assert span.get_tag('error.msg') == 'Ouch!'
         assert 'Exception: Ouch!' in span.get_tag('error.stack')
@@ -339,7 +340,7 @@ class PylonsTestCase(BaseTracerTestCase):
         assert span.service == 'web'
         assert span.resource == 'root.raise_custom_code'
         assert span.error == 1
-        assert span.get_metric('http.status_code') == 512
+        assert_span_http_status_code(span, 512)
         assert span.meta.get(http.URL) == 'http://localhost:80/raise_custom_code'
         assert span.get_tag('error.msg') == 'Ouch!'
         assert 'Exception: Ouch!' in span.get_tag('error.stack')
@@ -356,7 +357,7 @@ class PylonsTestCase(BaseTracerTestCase):
         assert span.service == 'web'
         assert span.resource == 'root.raise_code_method'
         assert span.error == 1
-        assert span.get_metric('http.status_code') == 500
+        assert_span_http_status_code(span, 500)
         assert span.meta.get(http.URL) == 'http://localhost:80/raise_code_method'
         assert span.get_tag('error.msg') == 'Ouch!'
 

--- a/tests/contrib/pyramid/utils.py
+++ b/tests/contrib/pyramid/utils.py
@@ -14,6 +14,7 @@ from .app import create_app
 
 from ...opentracer.utils import init_tracer
 from ...base import BaseTracerTestCase
+from ...utils import assert_span_http_status_code
 
 
 class PyramidBase(BaseTracerTestCase):
@@ -65,7 +66,7 @@ class PyramidTestCase(PyramidBase):
         assert s.error == 0
         assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
-        assert s.metrics.get('http.status_code') == 200
+        assert_span_http_status_code(s, 200)
         assert s.meta.get(http.URL) == 'http://localhost/'
         if config.pyramid.trace_query_string:
             assert s.meta.get(http.QUERY_STRING) == query_string
@@ -154,7 +155,7 @@ class PyramidTestCase(PyramidBase):
         assert s.error == 0
         assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
-        assert s.metrics.get('http.status_code') == 404
+        assert_span_http_status_code(s, 404)
         assert s.meta.get(http.URL) == 'http://localhost/404'
 
     def test_302(self):
@@ -169,7 +170,7 @@ class PyramidTestCase(PyramidBase):
         assert s.error == 0
         assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
-        assert s.metrics.get('http.status_code') == 302
+        assert_span_http_status_code(s, 302)
         assert s.meta.get(http.URL) == 'http://localhost/redirect'
 
     def test_204(self):
@@ -184,7 +185,7 @@ class PyramidTestCase(PyramidBase):
         assert s.error == 0
         assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
-        assert s.metrics.get('http.status_code') == 204
+        assert_span_http_status_code(s, 204)
         assert s.meta.get(http.URL) == 'http://localhost/nocontent'
 
     def test_exception(self):
@@ -202,7 +203,7 @@ class PyramidTestCase(PyramidBase):
         assert s.error == 1
         assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
-        assert s.metrics.get('http.status_code') == 500
+        assert_span_http_status_code(s, 500)
         assert s.meta.get(http.URL) == 'http://localhost/exception'
         assert s.meta.get('pyramid.route.name') == 'exception'
 
@@ -218,7 +219,7 @@ class PyramidTestCase(PyramidBase):
         assert s.error == 1
         assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
-        assert s.metrics.get('http.status_code') == 500
+        assert_span_http_status_code(s, 500)
         assert s.meta.get(http.URL) == 'http://localhost/error'
         assert s.meta.get('pyramid.route.name') == 'error'
         assert type(s.error) == int
@@ -238,7 +239,7 @@ class PyramidTestCase(PyramidBase):
         assert s.error == 0
         assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
-        assert s.metrics.get('http.status_code') == 200
+        assert_span_http_status_code(s, 200)
         assert s.meta.get(http.URL) == 'http://localhost/json'
         assert s.meta.get('pyramid.route.name') == 'json'
 
@@ -262,7 +263,7 @@ class PyramidTestCase(PyramidBase):
         assert s.error == 0
         assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
-        assert s.metrics.get('http.status_code') == 200
+        assert_span_http_status_code(s, 200)
         assert s.meta.get(http.URL) == 'http://localhost/renderer'
         assert s.meta.get('pyramid.route.name') == 'renderer'
 
@@ -284,7 +285,7 @@ class PyramidTestCase(PyramidBase):
         assert s.error == 1
         assert s.span_type == 'web'
         assert s.meta.get('http.method') == 'GET'
-        assert s.metrics.get('http.status_code') == 404
+        assert_span_http_status_code(s, 404)
         assert s.meta.get(http.URL) == 'http://localhost/404/raise_exception'
 
     def test_insert_tween_if_needed_already_set(self):
@@ -356,6 +357,6 @@ class PyramidTestCase(PyramidBase):
         assert dd_span.error == 0
         assert dd_span.span_type == 'web'
         assert dd_span.meta.get('http.method') == 'GET'
-        assert dd_span.metrics.get('http.status_code') == 200
+        assert_span_http_status_code(dd_span, 200)
         assert dd_span.meta.get(http.URL) == 'http://localhost/'
         assert dd_span.meta.get('pyramid.route.name') == 'index'

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -13,6 +13,7 @@ from tests.opentracer.utils import init_tracer
 
 from ...base import BaseTracerTestCase
 from ...util import override_global_tracer
+from ...utils import assert_span_http_status_code
 
 # socket name comes from https://english.stackexchange.com/a/44048
 SOCKET = 'httpbin.org'
@@ -73,7 +74,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
             assert len(spans) == 1
             s = spans[0]
             assert s.get_tag(http.METHOD) == 'GET'
-            assert s.get_metric(http.STATUS_CODE) == 200
+            assert_span_http_status_code(s, 200)
 
     def test_untraced_request(self):
         # ensure the unpatch removes tracing
@@ -105,7 +106,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         assert len(spans) == 1
         s = spans[0]
         assert s.get_tag(http.METHOD) == 'GET'
-        assert s.get_metric(http.STATUS_CODE) == 200
+        assert_span_http_status_code(s, 200)
         assert s.error == 0
         assert s.span_type == 'http'
         assert http.QUERY_STRING not in s.meta
@@ -122,7 +123,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         assert len(spans) == 1
         s = spans[0]
         assert s.get_tag(http.METHOD) == 'GET'
-        assert s.get_metric(http.STATUS_CODE) == 200
+        assert_span_http_status_code(s, 200)
         assert s.error == 0
         assert s.span_type == 'http'
 
@@ -137,7 +138,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         assert len(spans) == 1
         s = spans[0]
         assert s.get_tag(http.METHOD) == 'GET'
-        assert s.get_metric(http.STATUS_CODE) == 200
+        assert_span_http_status_code(s, 200)
         assert s.get_tag(http.URL) == URL_200
         assert s.error == 0
         assert s.span_type == 'http'
@@ -154,7 +155,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
             assert len(spans) == 1
             s = spans[0]
             assert s.get_tag(http.METHOD) == 'GET'
-            assert s.get_metric(http.STATUS_CODE) == 200
+            assert_span_http_status_code(s, 200)
             assert s.error == 0
             assert s.span_type == 'http'
 
@@ -166,7 +167,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         assert len(spans) == 1
         s = spans[0]
         assert s.get_tag(http.METHOD) == 'POST'
-        assert s.get_metric(http.STATUS_CODE) == 500
+        assert_span_http_status_code(s, 500)
         assert s.error == 1
 
     def test_non_existant_url(self):
@@ -195,7 +196,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         assert len(spans) == 1
         s = spans[0]
         assert s.get_tag(http.METHOD) == 'GET'
-        assert s.get_metric(http.STATUS_CODE) == 500
+        assert_span_http_status_code(s, 500)
         assert s.error == 1
 
     def test_default_service_name(self):
@@ -368,7 +369,7 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         assert ot_span.service == 'requests_svc'
 
         assert dd_span.get_tag(http.METHOD) == 'GET'
-        assert dd_span.get_metric(http.STATUS_CODE) == 200
+        assert_span_http_status_code(dd_span, 200)
         assert dd_span.error == 0
         assert dd_span.span_type == 'http'
 

--- a/tests/contrib/tornado/test_executor_decorator.py
+++ b/tests/contrib/tornado/test_executor_decorator.py
@@ -6,6 +6,7 @@ from ddtrace.ext import http
 from tornado import version_info
 
 from .utils import TornadoTestCase
+from ...utils import assert_span_http_status_code
 
 
 class TestTornadoExecutor(TornadoTestCase):
@@ -30,7 +31,7 @@ class TestTornadoExecutor(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/executor_handler/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
         assert request_span.duration >= 0.05
@@ -61,7 +62,7 @@ class TestTornadoExecutor(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorSubmitHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/executor_submit_handler/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
         assert request_span.duration >= 0.05
@@ -91,7 +92,7 @@ class TestTornadoExecutor(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorExceptionHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 500 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 500)
         assert self.get_url('/executor_exception/') == request_span.get_tag(http.URL)
         assert 1 == request_span.error
         assert 'Ouch!' == request_span.get_tag('error.msg')
@@ -128,7 +129,7 @@ class TestTornadoExecutor(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorCustomHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/executor_custom_handler/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
         assert request_span.duration >= 0.05
@@ -161,7 +162,7 @@ class TestTornadoExecutor(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorCustomArgsHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 500 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 500)
         assert self.get_url('/executor_custom_args_handler/') == request_span.get_tag(http.URL)
         assert 1 == request_span.error
         assert 'cannot combine positional and keyword args' == request_span.get_tag('error.msg')

--- a/tests/contrib/tornado/test_tornado_template.py
+++ b/tests/contrib/tornado/test_tornado_template.py
@@ -3,6 +3,7 @@ from tornado import template
 import pytest
 
 from .utils import TornadoTestCase
+from ...utils import assert_span_http_status_code
 
 from ddtrace.ext import http
 
@@ -28,7 +29,7 @@ class TestTornadoTemplate(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.TemplateHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/template/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
 
@@ -75,7 +76,7 @@ class TestTornadoTemplate(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.TemplatePartialHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/template_partial/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
 
@@ -130,7 +131,7 @@ class TestTornadoTemplate(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.TemplateExceptionHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 500 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 500)
         assert self.get_url('/template_exception/') == request_span.get_tag(http.URL)
         assert 1 == request_span.error
         assert 'ModuleThatDoesNotExist' in request_span.get_tag('error.msg')

--- a/tests/contrib/tornado/test_tornado_web.py
+++ b/tests/contrib/tornado/test_tornado_web.py
@@ -8,6 +8,7 @@ import pytest
 import tornado
 
 from tests.opentracer.utils import init_tracer
+from ...utils import assert_span_http_status_code
 
 
 class TestTornadoWeb(TornadoTestCase):
@@ -33,7 +34,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.SuccessHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/success/') == request_span.get_tag(http.URL)
         if config.tornado.trace_query_string:
             assert query_string == request_span.get_tag(http.QUERY_STRING)
@@ -63,7 +64,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.NestedHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/nested/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
         # check nested span
@@ -90,7 +91,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExceptionHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 500 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 500)
         assert self.get_url('/exception/') == request_span.get_tag(http.URL)
         assert 1 == request_span.error
         assert 'Ouch!' == request_span.get_tag('error.msg')
@@ -111,7 +112,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.HTTPExceptionHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 501 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 501)
         assert self.get_url('/http_exception/') == request_span.get_tag(http.URL)
         assert 1 == request_span.error
         assert 'HTTP 501: Not Implemented (unavailable)' == request_span.get_tag('error.msg')
@@ -132,7 +133,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.HTTPException500Handler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 500 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 500)
         assert self.get_url('/http_exception_500/') == request_span.get_tag(http.URL)
         assert 1 == request_span.error
         assert 'HTTP 500: Server Error (server error)' == request_span.get_tag('error.msg')
@@ -153,7 +154,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.SyncSuccessHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/sync_success/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
 
@@ -172,7 +173,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.SyncExceptionHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 500 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 500)
         assert self.get_url('/sync_exception/') == request_span.get_tag(http.URL)
         assert 1 == request_span.error
         assert 'Ouch!' == request_span.get_tag('error.msg')
@@ -193,7 +194,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tornado.web.ErrorHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 404 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 404)
         assert self.get_url('/does_not_exist/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
 
@@ -214,7 +215,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert 'web' == redirect_span.span_type
         assert 'tornado.web.RedirectHandler' == redirect_span.resource
         assert 'GET' == redirect_span.get_tag('http.method')
-        assert 301 == redirect_span.get_metric('http.status_code')
+        assert_span_http_status_code(redirect_span, 301)
         assert self.get_url('/redirect/') == redirect_span.get_tag(http.URL)
         assert 0 == redirect_span.error
 
@@ -224,7 +225,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert 'web' == success_span.span_type
         assert 'tests.contrib.tornado.web.app.SuccessHandler' == success_span.resource
         assert 'GET' == success_span.get_tag('http.method')
-        assert 200 == success_span.get_metric('http.status_code')
+        assert_span_http_status_code(success_span, 200)
         assert self.get_url('/success/') == success_span.get_tag(http.URL)
         assert 0 == success_span.error
 
@@ -244,7 +245,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tornado.web.StaticFileHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/statics/empty.txt') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
 
@@ -266,7 +267,7 @@ class TestTornadoWeb(TornadoTestCase):
 
         # simple sanity check on the span
         assert 'tornado.request' == request_span.name
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/success/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
 
@@ -306,7 +307,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert 'web' == dd_span.span_type
         assert 'tests.contrib.tornado.web.app.SuccessHandler' == dd_span.resource
         assert 'GET' == dd_span.get_tag('http.method')
-        assert 200 == dd_span.get_metric('http.status_code')
+        assert_span_http_status_code(dd_span, 200)
         assert self.get_url('/success/') == dd_span.get_tag(http.URL)
         assert 0 == dd_span.error
 
@@ -448,7 +449,7 @@ class TestNoPropagationTornadoWeb(TornadoTestCase):
 
         # simple sanity check on the span
         assert 'tornado.request' == request_span.name
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/success/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
 
@@ -485,6 +486,6 @@ class TestCustomTornadoWeb(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.CustomDefaultHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 400 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 400)
         assert self.get_url('/custom_handler/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error

--- a/tests/contrib/tornado/test_wrap_decorator.py
+++ b/tests/contrib/tornado/test_wrap_decorator.py
@@ -1,6 +1,7 @@
 from ddtrace.ext import http
 
 from .utils import TornadoTestCase
+from ...utils import assert_span_http_status_code
 
 
 class TestTornadoWebWrapper(TornadoTestCase):
@@ -21,7 +22,7 @@ class TestTornadoWebWrapper(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.NestedWrapHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/nested_wrap/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
         # check nested span
@@ -47,7 +48,7 @@ class TestTornadoWebWrapper(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.NestedExceptionWrapHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 500 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 500)
         assert self.get_url('/nested_exception_wrap/') == request_span.get_tag(http.URL)
         assert 1 == request_span.error
         assert 'Ouch!' == request_span.get_tag('error.msg')
@@ -77,7 +78,7 @@ class TestTornadoWebWrapper(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.SyncNestedWrapHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/sync_nested_wrap/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
         # check nested span
@@ -103,7 +104,7 @@ class TestTornadoWebWrapper(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.SyncNestedExceptionWrapHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 500 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 500)
         assert self.get_url('/sync_nested_exception_wrap/') == request_span.get_tag(http.URL)
         assert 1 == request_span.error
         assert 'Ouch!' == request_span.get_tag('error.msg')
@@ -133,7 +134,7 @@ class TestTornadoWebWrapper(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorWrapHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 200 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 200)
         assert self.get_url('/executor_wrap_handler/') == request_span.get_tag(http.URL)
         assert 0 == request_span.error
         # check nested span in the executor
@@ -160,7 +161,7 @@ class TestTornadoWebWrapper(TornadoTestCase):
         assert 'web' == request_span.span_type
         assert 'tests.contrib.tornado.web.app.ExecutorExceptionWrapHandler' == request_span.resource
         assert 'GET' == request_span.get_tag('http.method')
-        assert 500 == request_span.get_metric('http.status_code')
+        assert_span_http_status_code(request_span, 500)
         assert self.get_url('/executor_wrap_exception/') == request_span.get_tag(http.URL)
         assert 1 == request_span.error
         assert 'Ouch!' == request_span.get_tag('error.msg')

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,6 +1,15 @@
 import contextlib
 import os
 
+from ddtrace.ext import http
+
+
+def assert_span_http_status_code(span, code):
+    """Assert on the span's 'http.status_code' tag"""
+    tag = span.get_tag(http.STATUS_CODE)
+    code = str(code)
+    assert tag == code, "%r != %r" % (tag, code)
+
 
 @contextlib.contextmanager
 def override_env(env):


### PR DESCRIPTION
Due to the way the trace agent computes metrics/tags with `meta['http.status_code']` we need to ensure that `http.status_code` tag is always set as a string on `meta` instead of `metrics`.