### PR TITLE
Prefer random.getrandbits on Python 3+, fall back to urandom implementation on 2

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -12,6 +12,12 @@ from .internal.logger import get_logger
 log = get_logger(__name__)
 
 
+if sys.version_info.major < 3:
+    _getrandbits = random.SystemRandom().getrandbits
+else:
+    _getrandbits = random.getrandbits
+
+
 class Span(object):
 
     __slots__ = [
@@ -383,9 +389,6 @@ class Span(object):
         )
 
 
-_SystemRandom = random.SystemRandom()
-
-
 def _new_id():
     """Generate a random trace_id or span_id"""
-    return _SystemRandom.getrandbits(64)
+    return _getrandbits(64)


### PR DESCRIPTION
This is a follow-up to a change originally made in https://github.com/DataDog/dd-trace-py/pull/940.

In #940, we started using a urandom-based implementation of `getrandbits` to work around a problem in Python 2. The downside of this plan is that the urandom implementation is around 15x-20x slower than the default implementation at `random.getrandbits`.

Instead of changing to the urandom implementation in all cases, this PR changes it so that we only fall back to the slower urandom implementation if we are actually in Python 2. Python 3 and above can continue using the fast version.

```
Python 3.7.5 (default, Nov 20 2019, 09:21:52) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.10.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import random                                                                                                                                                                                                                                                                                                         

In [2]: _getrandbits = random.SystemRandom().getrandbits                                                                                                                                                                                                                                                                      

In [3]: %timeit _getrandbits(64)                                                                                                                                                                                                                                                                                              
1.51 µs ± 6.31 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [4]: _getrandbits = random.getrandbits                                                                                                                                                                                                                                                                                     

In [5]: %timeit _getrandbits(64)                                                                                                                                                                                                                                                                                              
71.5 ns ± 0.694 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```