### PR TITLE
chord(flake8,black): ignore W504 and E231 not respected by black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,79 @@ exclude = '''
     | bootstrap/
     | commands/
     | contrib/
+    (
+      aiobotocore
+      | aiohttp
+      | aiopg
+      | algoliasearch
+      | asyncio
+      | boto
+      | botocore
+      | bottle
+      | cassandra
+      | celery
+      | consul
+      | dbapi
+      | django/
+      (
+         __init__.py
+         | apps.py
+         | cache.py
+         | compat.py
+         | conf.py
+         | db.py
+         | patch.py
+         | restframework.py
+         | templates.py
+         | utils.py
+      )
+      | dogpile_cache
+      | elasticsearch
+      | falcon
+      | flask
+      | flask_cache
+      | futures
+      | gevent
+      | grpc/
+      (
+        __init__.py
+        | constants.py
+        | patch.py
+        | server_interceptor.py
+        | utils.py
+      )
+      | httplib
+      | jinja2
+      | kombu
+      | logging
+      | mako
+      | molten
+      | mongoengine
+      | mysql
+      | mysqldb
+      | psycopg
+      | pylibmc
+      | pylons
+      | pymemcache
+      | pymongo
+      | pymysql
+      | pyramid
+      | redis
+      | rediscluster
+      | requests/
+      (
+        __init__.py
+        | constants.py
+        | legacy.py
+        | patch.py
+        | session.py
+      )
+      | sqlalchemy
+      | sqlite3
+      | tornado
+      | util.py
+      | vertica
+    )
     | ext/
     | http/
     | internal/
@@ -29,5 +102,113 @@ exclude = '''
     | vendor/
   )
   | tests/
+  (
+    base
+    | benchmark.py
+    | commands
+    | contrib/
+    (
+      aiobotocore
+      | aiohttp
+      | aiopg
+      | algoliasearch
+      | asyncio
+      | boto
+      | botocore
+      | bottle
+      | cassandra
+      | celery
+      | config.py
+      | consul
+      | dbapi
+      | django
+      | djangorestframework
+      | elasticsearch
+      | falcon
+      | flask
+      | flask_autopatch
+      | flask_cache
+      | futures
+      | gevent
+      | grpc
+      | httplib
+      | jinja2
+      | kombu
+      | logging
+      | mako
+      | molten
+      | mongoengine
+      | mysql
+      | mysqldb
+      | patch.py
+      | psycopg
+      | pylibmc
+      | pylons
+      | pymemcache
+      | pymongo
+      | pymysql
+      | pyramid/
+      (
+        app/web.py
+        | __init__.py
+        | test_pyramid.py
+        | test_pyramid_autopatch.py
+      )
+      | redis
+      | rediscluster
+      | requests
+      | requests_gevent
+      | sqlalchemy
+      | sqlite3
+      | test_utils.py
+      | tornado
+      | vertica
+    )
+    | ddtrace_run.py
+    | internal/
+    (
+      runtime/
+      | test_context_manager.py
+      | test_hostname.py
+      | test_logger.py
+      | test_rate_limiter.py
+    )
+    | memory.py
+    | opentracer/
+    (
+      conftest.py
+      | test_dd_compatibility.py
+      | test_span.py
+      | test_span_context.py
+      | test_tracer_asyncio.py
+      | test_tracer_gevent.py
+      | test_tracer_tornado.py
+      | test_utils.py
+    )
+    | propagation/test_utils.py
+    | subprocesstest.py
+    | test_api.py
+    | test_compat.py
+    | test_context.py
+    | test_encoders.py
+    | test_filters.py
+    | test_global_config.py
+    | test_helpers.py
+    | test_hook.py
+    | test_instance_config.py
+    | test_integration.py
+    | test_payload.py
+    | test_pin.py
+    | test_sampler.py
+    | test_span.py
+    | test_tracer.py
+    | test_utils.py
+    | test_worker.py
+    | unit
+    | util.py
+    | utils
+    | vendor
+    | wait-for-services.py
+  )
 )
 '''

--- a/tests/contrib/dogpile_cache/test_tracing.py
+++ b/tests/contrib/dogpile_cache/test_tracing.py
@@ -17,8 +17,8 @@ def region(tracer):
     patch()
     # Setup a simple dogpile cache region for testing.
     # The backend is trivial so we can use memory to simplify test setup.
-    test_region = dogpile.cache.make_region(name='TestRegion')
-    test_region.configure('dogpile.cache.memory')
+    test_region = dogpile.cache.make_region(name="TestRegion")
+    test_region.configure("dogpile.cache.memory")
     Pin.override(dogpile.cache, tracer=tracer)
     return test_region
 
@@ -34,6 +34,7 @@ def single_cache(region):
     @region.cache_on_arguments()
     def fn(x):
         return x * 2
+
     return fn
 
 
@@ -74,13 +75,13 @@ def test_traces_get_or_create(tracer, single_cache):
     spans = traces[0]
     assert len(spans) == 1
     span = spans[0]
-    assert span.name == 'dogpile.cache'
-    assert span.resource == 'get_or_create'
-    assert span.meta['key'] == 'tests.contrib.dogpile_cache.test_tracing:fn|1'
-    assert span.meta['hit'] == 'False'
-    assert span.meta['expired'] == 'True'
-    assert span.meta['backend'] == 'MemoryBackend'
-    assert span.meta['region'] == 'TestRegion'
+    assert span.name == "dogpile.cache"
+    assert span.resource == "get_or_create"
+    assert span.meta["key"] == "tests.contrib.dogpile_cache.test_tracing:fn|1"
+    assert span.meta["hit"] == "False"
+    assert span.meta["expired"] == "True"
+    assert span.meta["backend"] == "MemoryBackend"
+    assert span.meta["region"] == "TestRegion"
 
     # Now the results should be cached.
     assert single_cache(1) == 2
@@ -89,13 +90,13 @@ def test_traces_get_or_create(tracer, single_cache):
     spans = traces[0]
     assert len(spans) == 1
     span = spans[0]
-    assert span.name == 'dogpile.cache'
-    assert span.resource == 'get_or_create'
-    assert span.meta['key'] == 'tests.contrib.dogpile_cache.test_tracing:fn|1'
-    assert span.meta['hit'] == 'True'
-    assert span.meta['expired'] == 'False'
-    assert span.meta['backend'] == 'MemoryBackend'
-    assert span.meta['region'] == 'TestRegion'
+    assert span.name == "dogpile.cache"
+    assert span.resource == "get_or_create"
+    assert span.meta["key"] == "tests.contrib.dogpile_cache.test_tracing:fn|1"
+    assert span.meta["hit"] == "True"
+    assert span.meta["expired"] == "False"
+    assert span.meta["backend"] == "MemoryBackend"
+    assert span.meta["region"] == "TestRegion"
 
 
 def test_traces_get_or_create_multi(tracer, multi_cache):
@@ -105,14 +106,13 @@ def test_traces_get_or_create_multi(tracer, multi_cache):
     spans = traces[0]
     assert len(spans) == 1
     span = spans[0]
-    assert span.meta['keys'] == (
-        "['tests.contrib.dogpile_cache.test_tracing:fn|2', " +
-        "'tests.contrib.dogpile_cache.test_tracing:fn|3']"
+    assert span.meta["keys"] == (
+        "['tests.contrib.dogpile_cache.test_tracing:fn|2', " + "'tests.contrib.dogpile_cache.test_tracing:fn|3']"
     )
-    assert span.meta['hit'] == 'False'
-    assert span.meta['expired'] == 'True'
-    assert span.meta['backend'] == 'MemoryBackend'
-    assert span.meta['region'] == 'TestRegion'
+    assert span.meta["hit"] == "False"
+    assert span.meta["expired"] == "True"
+    assert span.meta["backend"] == "MemoryBackend"
+    assert span.meta["region"] == "TestRegion"
 
     # Partial hit
     assert multi_cache(2, 4) == [4, 8]
@@ -121,14 +121,13 @@ def test_traces_get_or_create_multi(tracer, multi_cache):
     spans = traces[0]
     assert len(spans) == 1
     span = spans[0]
-    assert span.meta['keys'] == (
-        "['tests.contrib.dogpile_cache.test_tracing:fn|2', " +
-        "'tests.contrib.dogpile_cache.test_tracing:fn|4']"
+    assert span.meta["keys"] == (
+        "['tests.contrib.dogpile_cache.test_tracing:fn|2', " + "'tests.contrib.dogpile_cache.test_tracing:fn|4']"
     )
-    assert span.meta['hit'] == 'False'
-    assert span.meta['expired'] == 'True'
-    assert span.meta['backend'] == 'MemoryBackend'
-    assert span.meta['region'] == 'TestRegion'
+    assert span.meta["hit"] == "False"
+    assert span.meta["expired"] == "True"
+    assert span.meta["backend"] == "MemoryBackend"
+    assert span.meta["region"] == "TestRegion"
 
     # Full hit
     assert multi_cache(2, 4) == [4, 8]
@@ -137,14 +136,13 @@ def test_traces_get_or_create_multi(tracer, multi_cache):
     spans = traces[0]
     assert len(spans) == 1
     span = spans[0]
-    assert span.meta['keys'] == (
-        "['tests.contrib.dogpile_cache.test_tracing:fn|2', " +
-        "'tests.contrib.dogpile_cache.test_tracing:fn|4']"
+    assert span.meta["keys"] == (
+        "['tests.contrib.dogpile_cache.test_tracing:fn|2', " + "'tests.contrib.dogpile_cache.test_tracing:fn|4']"
     )
-    assert span.meta['hit'] == 'True'
-    assert span.meta['expired'] == 'False'
-    assert span.meta['backend'] == 'MemoryBackend'
-    assert span.meta['region'] == 'TestRegion'
+    assert span.meta["hit"] == "True"
+    assert span.meta["expired"] == "False"
+    assert span.meta["backend"] == "MemoryBackend"
+    assert span.meta["region"] == "TestRegion"
 
 
 class TestInnerFunctionCalls(object):
@@ -156,8 +154,8 @@ class TestInnerFunctionCalls(object):
 
     def test_calls_inner_functions_correctly(self, region, mocker):
         """ This ensures the get_or_create behavior of dogpile is not altered. """
-        spy_single_cache = mocker.spy(self, 'single_cache')
-        spy_multi_cache = mocker.spy(self, 'multi_cache')
+        spy_single_cache = mocker.spy(self, "single_cache")
+        spy_multi_cache = mocker.spy(self, "multi_cache")
 
         single_cache = region.cache_on_arguments()(self.single_cache)
         multi_cache = region.cache_multi_on_arguments()(self.multi_cache)

--- a/tests/contrib/pyramid/utils.py
+++ b/tests/contrib/pyramid/utils.py
@@ -19,6 +19,7 @@ from ...utils import assert_span_http_status_code
 
 class PyramidBase(BaseTracerTestCase):
     """Base Pyramid test application"""
+
     def setUp(self):
         super(PyramidBase, self).setUp()
         self.create_app()
@@ -27,7 +28,7 @@ class PyramidBase(BaseTracerTestCase):
         # get default settings or use what is provided
         settings = settings or self.get_settings()
         # always set the dummy tracer as a default tracer
-        settings.update({'datadog_tracer': self.tracer})
+        settings.update({"datadog_tracer": self.tracer})
 
         app, renderer = create_app(settings, self.instrument)
         self.app = webtest.TestApp(app)
@@ -42,37 +43,38 @@ class PyramidBase(BaseTracerTestCase):
 
 class PyramidTestCase(PyramidBase):
     """Pyramid TestCase that includes tests for automatic instrumentation"""
+
     instrument = True
 
     def get_settings(self):
         return {
-            'datadog_trace_service': 'foobar',
+            "datadog_trace_service": "foobar",
         }
 
-    def test_200(self, query_string=''):
+    def test_200(self, query_string=""):
         if query_string:
-            fqs = '?' + query_string
+            fqs = "?" + query_string
         else:
-            fqs = ''
-        res = self.app.get('/' + fqs, status=200)
-        assert b'idx' in res.body
+            fqs = ""
+        res = self.app.get("/" + fqs, status=200)
+        assert b"idx" in res.body
 
         writer = self.tracer.writer
         spans = writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == 'foobar'
-        assert s.resource == 'GET index'
+        assert s.service == "foobar"
+        assert s.resource == "GET index"
         assert s.error == 0
-        assert s.span_type == 'web'
-        assert s.meta.get('http.method') == 'GET'
+        assert s.span_type == "web"
+        assert s.meta.get("http.method") == "GET"
         assert_span_http_status_code(s, 200)
-        assert s.meta.get(http.URL) == 'http://localhost/'
+        assert s.meta.get(http.URL) == "http://localhost/"
         if config.pyramid.trace_query_string:
             assert s.meta.get(http.QUERY_STRING) == query_string
         else:
             assert http.QUERY_STRING not in s.meta
-        assert s.meta.get('pyramid.route.name') == 'index'
+        assert s.meta.get("pyramid.route.name") == "index"
 
         # ensure services are set correctly
         services = writer.pop_services()
@@ -80,11 +82,11 @@ class PyramidTestCase(PyramidBase):
         assert services == expected
 
     def test_200_query_string(self):
-        return self.test_200('foo=bar')
+        return self.test_200("foo=bar")
 
     def test_200_query_string_trace(self):
-        with self.override_http_config('pyramid', dict(trace_query_string=True)):
-            return self.test_200('foo=bar')
+        with self.override_http_config("pyramid", dict(trace_query_string=True)):
+            return self.test_200("foo=bar")
 
     def test_analytics_global_on_integration_default(self):
         """
@@ -93,12 +95,10 @@ class PyramidTestCase(PyramidBase):
                 We expect the root span to have the appropriate tag
         """
         with self.override_global_config(dict(analytics_enabled=True)):
-            res = self.app.get('/', status=200)
-            assert b'idx' in res.body
+            res = self.app.get("/", status=200)
+            assert b"idx" in res.body
 
-            self.assert_structure(
-                dict(name='pyramid.request', metrics={ANALYTICS_SAMPLE_RATE_KEY: 1.0}),
-            )
+            self.assert_structure(dict(name="pyramid.request", metrics={ANALYTICS_SAMPLE_RATE_KEY: 1.0}),)
 
     def test_analytics_global_on_integration_on(self):
         """
@@ -108,12 +108,10 @@ class PyramidTestCase(PyramidBase):
         """
         with self.override_global_config(dict(analytics_enabled=True)):
             self.override_settings(dict(datadog_analytics_enabled=True, datadog_analytics_sample_rate=0.5))
-            res = self.app.get('/', status=200)
-            assert b'idx' in res.body
+            res = self.app.get("/", status=200)
+            assert b"idx" in res.body
 
-            self.assert_structure(
-                dict(name='pyramid.request', metrics={ANALYTICS_SAMPLE_RATE_KEY: 0.5}),
-            )
+            self.assert_structure(dict(name="pyramid.request", metrics={ANALYTICS_SAMPLE_RATE_KEY: 0.5}),)
 
     def test_analytics_global_off_integration_default(self):
         """
@@ -122,8 +120,8 @@ class PyramidTestCase(PyramidBase):
                 We expect the root span to not include tag
         """
         with self.override_global_config(dict(analytics_enabled=False)):
-            res = self.app.get('/', status=200)
-            assert b'idx' in res.body
+            res = self.app.get("/", status=200)
+            assert b"idx" in res.body
 
             root = self.get_root_span()
             self.assertIsNone(root.get_metric(ANALYTICS_SAMPLE_RATE_KEY))
@@ -136,61 +134,59 @@ class PyramidTestCase(PyramidBase):
         """
         with self.override_global_config(dict(analytics_enabled=False)):
             self.override_settings(dict(datadog_analytics_enabled=True, datadog_analytics_sample_rate=0.5))
-            res = self.app.get('/', status=200)
-            assert b'idx' in res.body
+            res = self.app.get("/", status=200)
+            assert b"idx" in res.body
 
-            self.assert_structure(
-                dict(name='pyramid.request', metrics={ANALYTICS_SAMPLE_RATE_KEY: 0.5}),
-            )
+            self.assert_structure(dict(name="pyramid.request", metrics={ANALYTICS_SAMPLE_RATE_KEY: 0.5}),)
 
     def test_404(self):
-        self.app.get('/404', status=404)
+        self.app.get("/404", status=404)
 
         writer = self.tracer.writer
         spans = writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == 'foobar'
-        assert s.resource == '404'
+        assert s.service == "foobar"
+        assert s.resource == "404"
         assert s.error == 0
-        assert s.span_type == 'web'
-        assert s.meta.get('http.method') == 'GET'
+        assert s.span_type == "web"
+        assert s.meta.get("http.method") == "GET"
         assert_span_http_status_code(s, 404)
-        assert s.meta.get(http.URL) == 'http://localhost/404'
+        assert s.meta.get(http.URL) == "http://localhost/404"
 
     def test_302(self):
-        self.app.get('/redirect', status=302)
+        self.app.get("/redirect", status=302)
 
         writer = self.tracer.writer
         spans = writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == 'foobar'
-        assert s.resource == 'GET raise_redirect'
+        assert s.service == "foobar"
+        assert s.resource == "GET raise_redirect"
         assert s.error == 0
-        assert s.span_type == 'web'
-        assert s.meta.get('http.method') == 'GET'
+        assert s.span_type == "web"
+        assert s.meta.get("http.method") == "GET"
         assert_span_http_status_code(s, 302)
-        assert s.meta.get(http.URL) == 'http://localhost/redirect'
+        assert s.meta.get(http.URL) == "http://localhost/redirect"
 
     def test_204(self):
-        self.app.get('/nocontent', status=204)
+        self.app.get("/nocontent", status=204)
 
         writer = self.tracer.writer
         spans = writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == 'foobar'
-        assert s.resource == 'GET raise_no_content'
+        assert s.service == "foobar"
+        assert s.resource == "GET raise_no_content"
         assert s.error == 0
-        assert s.span_type == 'web'
-        assert s.meta.get('http.method') == 'GET'
+        assert s.span_type == "web"
+        assert s.meta.get("http.method") == "GET"
         assert_span_http_status_code(s, 204)
-        assert s.meta.get(http.URL) == 'http://localhost/nocontent'
+        assert s.meta.get(http.URL) == "http://localhost/nocontent"
 
     def test_exception(self):
         try:
-            self.app.get('/exception', status=500)
+            self.app.get("/exception", status=500)
         except ZeroDivisionError:
             pass
 
@@ -198,146 +194,145 @@ class PyramidTestCase(PyramidBase):
         spans = writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == 'foobar'
-        assert s.resource == 'GET exception'
+        assert s.service == "foobar"
+        assert s.resource == "GET exception"
         assert s.error == 1
-        assert s.span_type == 'web'
-        assert s.meta.get('http.method') == 'GET'
+        assert s.span_type == "web"
+        assert s.meta.get("http.method") == "GET"
         assert_span_http_status_code(s, 500)
-        assert s.meta.get(http.URL) == 'http://localhost/exception'
-        assert s.meta.get('pyramid.route.name') == 'exception'
+        assert s.meta.get(http.URL) == "http://localhost/exception"
+        assert s.meta.get("pyramid.route.name") == "exception"
 
     def test_500(self):
-        self.app.get('/error', status=500)
+        self.app.get("/error", status=500)
 
         writer = self.tracer.writer
         spans = writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == 'foobar'
-        assert s.resource == 'GET error'
+        assert s.service == "foobar"
+        assert s.resource == "GET error"
         assert s.error == 1
-        assert s.span_type == 'web'
-        assert s.meta.get('http.method') == 'GET'
+        assert s.span_type == "web"
+        assert s.meta.get("http.method") == "GET"
         assert_span_http_status_code(s, 500)
-        assert s.meta.get(http.URL) == 'http://localhost/error'
-        assert s.meta.get('pyramid.route.name') == 'error'
+        assert s.meta.get(http.URL) == "http://localhost/error"
+        assert s.meta.get("pyramid.route.name") == "error"
         assert type(s.error) == int
 
     def test_json(self):
-        res = self.app.get('/json', status=200)
+        res = self.app.get("/json", status=200)
         parsed = json.loads(compat.to_unicode(res.body))
-        assert parsed == {'a': 1}
+        assert parsed == {"a": 1}
 
         writer = self.tracer.writer
         spans = writer.pop()
         assert len(spans) == 2
         spans_by_name = {s.name: s for s in spans}
-        s = spans_by_name['pyramid.request']
-        assert s.service == 'foobar'
-        assert s.resource == 'GET json'
+        s = spans_by_name["pyramid.request"]
+        assert s.service == "foobar"
+        assert s.resource == "GET json"
         assert s.error == 0
-        assert s.span_type == 'web'
-        assert s.meta.get('http.method') == 'GET'
+        assert s.span_type == "web"
+        assert s.meta.get("http.method") == "GET"
         assert_span_http_status_code(s, 200)
-        assert s.meta.get(http.URL) == 'http://localhost/json'
-        assert s.meta.get('pyramid.route.name') == 'json'
+        assert s.meta.get(http.URL) == "http://localhost/json"
+        assert s.meta.get("pyramid.route.name") == "json"
 
-        s = spans_by_name['pyramid.render']
-        assert s.service == 'foobar'
+        s = spans_by_name["pyramid.render"]
+        assert s.service == "foobar"
         assert s.error == 0
-        assert s.span_type == 'template'
+        assert s.span_type == "template"
 
     def test_renderer(self):
-        self.app.get('/renderer', status=200)
-        assert self.renderer._received['request'] is not None
+        self.app.get("/renderer", status=200)
+        assert self.renderer._received["request"] is not None
 
-        self.renderer.assert_(foo='bar')
+        self.renderer.assert_(foo="bar")
         writer = self.tracer.writer
         spans = writer.pop()
         assert len(spans) == 2
         spans_by_name = {s.name: s for s in spans}
-        s = spans_by_name['pyramid.request']
-        assert s.service == 'foobar'
-        assert s.resource == 'GET renderer'
+        s = spans_by_name["pyramid.request"]
+        assert s.service == "foobar"
+        assert s.resource == "GET renderer"
         assert s.error == 0
-        assert s.span_type == 'web'
-        assert s.meta.get('http.method') == 'GET'
+        assert s.span_type == "web"
+        assert s.meta.get("http.method") == "GET"
         assert_span_http_status_code(s, 200)
-        assert s.meta.get(http.URL) == 'http://localhost/renderer'
-        assert s.meta.get('pyramid.route.name') == 'renderer'
+        assert s.meta.get(http.URL) == "http://localhost/renderer"
+        assert s.meta.get("pyramid.route.name") == "renderer"
 
-        s = spans_by_name['pyramid.render']
-        assert s.service == 'foobar'
+        s = spans_by_name["pyramid.render"]
+        assert s.service == "foobar"
         assert s.error == 0
-        assert s.span_type == 'template'
+        assert s.span_type == "template"
 
     def test_http_exception_response(self):
         with pytest.raises(HTTPException):
-            self.app.get('/404/raise_exception', status=404)
+            self.app.get("/404/raise_exception", status=404)
 
         writer = self.tracer.writer
         spans = writer.pop()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == 'foobar'
-        assert s.resource == '404'
+        assert s.service == "foobar"
+        assert s.resource == "404"
         assert s.error == 1
-        assert s.span_type == 'web'
-        assert s.meta.get('http.method') == 'GET'
+        assert s.span_type == "web"
+        assert s.meta.get("http.method") == "GET"
         assert_span_http_status_code(s, 404)
-        assert s.meta.get(http.URL) == 'http://localhost/404/raise_exception'
+        assert s.meta.get(http.URL) == "http://localhost/404/raise_exception"
 
     def test_insert_tween_if_needed_already_set(self):
-        settings = {'pyramid.tweens': 'ddtrace.contrib.pyramid:trace_tween_factory'}
+        settings = {"pyramid.tweens": "ddtrace.contrib.pyramid:trace_tween_factory"}
         insert_tween_if_needed(settings)
-        assert settings['pyramid.tweens'] == 'ddtrace.contrib.pyramid:trace_tween_factory'
+        assert settings["pyramid.tweens"] == "ddtrace.contrib.pyramid:trace_tween_factory"
 
     def test_insert_tween_if_needed_none(self):
-        settings = {'pyramid.tweens': ''}
+        settings = {"pyramid.tweens": ""}
         insert_tween_if_needed(settings)
-        assert settings['pyramid.tweens'] == ''
+        assert settings["pyramid.tweens"] == ""
 
     def test_insert_tween_if_needed_excview(self):
-        settings = {'pyramid.tweens': 'pyramid.tweens.excview_tween_factory'}
+        settings = {"pyramid.tweens": "pyramid.tweens.excview_tween_factory"}
         insert_tween_if_needed(settings)
         assert (
-            settings['pyramid.tweens'] ==
-            'ddtrace.contrib.pyramid:trace_tween_factory\npyramid.tweens.excview_tween_factory'
+            settings["pyramid.tweens"]
+            == "ddtrace.contrib.pyramid:trace_tween_factory\npyramid.tweens.excview_tween_factory"
         )
 
     def test_insert_tween_if_needed_excview_and_other(self):
-        settings = {'pyramid.tweens': 'a.first.tween\npyramid.tweens.excview_tween_factory\na.last.tween\n'}
+        settings = {"pyramid.tweens": "a.first.tween\npyramid.tweens.excview_tween_factory\na.last.tween\n"}
         insert_tween_if_needed(settings)
         assert (
-            settings['pyramid.tweens'] ==
-            'a.first.tween\n'
-            'ddtrace.contrib.pyramid:trace_tween_factory\n'
-            'pyramid.tweens.excview_tween_factory\n'
-            'a.last.tween\n')
+            settings["pyramid.tweens"] == "a.first.tween\n"
+            "ddtrace.contrib.pyramid:trace_tween_factory\n"
+            "pyramid.tweens.excview_tween_factory\n"
+            "a.last.tween\n"
+        )
 
     def test_insert_tween_if_needed_others(self):
-        settings = {'pyramid.tweens': 'a.random.tween\nand.another.one'}
+        settings = {"pyramid.tweens": "a.random.tween\nand.another.one"}
         insert_tween_if_needed(settings)
         assert (
-            settings['pyramid.tweens'] ==
-            'a.random.tween\nand.another.one\nddtrace.contrib.pyramid:trace_tween_factory'
+            settings["pyramid.tweens"] == "a.random.tween\nand.another.one\nddtrace.contrib.pyramid:trace_tween_factory"
         )
 
     def test_include_conflicts(self):
         # test that includes do not create conflicts
-        self.override_settings({'pyramid.includes': 'tests.contrib.pyramid.test_pyramid'})
-        self.app.get('/404', status=404)
+        self.override_settings({"pyramid.includes": "tests.contrib.pyramid.test_pyramid"})
+        self.app.get("/404", status=404)
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
 
     def test_200_ot(self):
         """OpenTracing version of test_200."""
-        ot_tracer = init_tracer('pyramid_svc', self.tracer)
+        ot_tracer = init_tracer("pyramid_svc", self.tracer)
 
-        with ot_tracer.start_active_span('pyramid_get'):
-            res = self.app.get('/', status=200)
-            assert b'idx' in res.body
+        with ot_tracer.start_active_span("pyramid_get"):
+            res = self.app.get("/", status=200)
+            assert b"idx" in res.body
 
         writer = self.tracer.writer
         spans = writer.pop()
@@ -349,14 +344,14 @@ class PyramidTestCase(PyramidBase):
         assert ot_span.parent_id is None
         assert dd_span.parent_id == ot_span.span_id
 
-        assert ot_span.name == 'pyramid_get'
-        assert ot_span.service == 'pyramid_svc'
+        assert ot_span.name == "pyramid_get"
+        assert ot_span.service == "pyramid_svc"
 
-        assert dd_span.service == 'foobar'
-        assert dd_span.resource == 'GET index'
+        assert dd_span.service == "foobar"
+        assert dd_span.resource == "GET index"
         assert dd_span.error == 0
-        assert dd_span.span_type == 'web'
-        assert dd_span.meta.get('http.method') == 'GET'
+        assert dd_span.span_type == "web"
+        assert dd_span.meta.get("http.method") == "GET"
         assert_span_http_status_code(dd_span, 200)
-        assert dd_span.meta.get(http.URL) == 'http://localhost/'
-        assert dd_span.meta.get('pyramid.route.name') == 'index'
+        assert dd_span.meta.get(http.URL) == "http://localhost/"
+        assert dd_span.meta.get("pyramid.route.name") == "index"

--- a/tests/internal/test_writer.py
+++ b/tests/internal/test_writer.py
@@ -10,7 +10,7 @@ from ddtrace.internal.writer import AgentWriter, Q, Empty
 from ..base import BaseTestCase
 
 
-class RemoveAllFilter():
+class RemoveAllFilter:
     def __init__(self):
         self.filtered_traces = 0
 
@@ -19,7 +19,7 @@ class RemoveAllFilter():
         return None
 
 
-class KeepAllFilter():
+class KeepAllFilter:
     def __init__(self):
         self.filtered_traces = 0
 
@@ -28,7 +28,7 @@ class KeepAllFilter():
         return trace
 
 
-class AddTagFilter():
+class AddTagFilter:
     def __init__(self, tag_name):
         self.tag_name = tag_name
         self.filtered_traces = 0
@@ -36,14 +36,14 @@ class AddTagFilter():
     def process_trace(self, trace):
         self.filtered_traces += 1
         for span in trace:
-            span.set_tag(self.tag_name, 'A value')
+            span.set_tag(self.tag_name, "A value")
         return trace
 
 
 class DummyAPI(API):
     def __init__(self):
         # Call API.__init__ to setup required properties
-        super(DummyAPI, self).__init__(hostname='localhost', port=8126)
+        super(DummyAPI, self).__init__(hostname="localhost", port=8126)
 
         self.traces = []
 
@@ -58,10 +58,9 @@ class DummyAPI(API):
 
 
 class FailingAPI(object):
-
     @staticmethod
     def send_traces(traces):
-        return [Exception('oops')]
+        return [Exception("oops")]
 
 
 class AgentWriterTests(BaseTestCase):
@@ -75,10 +74,9 @@ class AgentWriterTests(BaseTestCase):
             self.api = api_class()
             worker.api = self.api
             for i in range(self.N_TRACES):
-                worker.write([
-                    Span(tracer=None, name='name', trace_id=i, span_id=j, parent_id=j - 1 or None)
-                    for j in range(7)
-                ])
+                worker.write(
+                    [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(7)]
+                )
             worker.stop()
             worker.join()
             return worker
@@ -108,7 +106,7 @@ class AgentWriterTests(BaseTestCase):
         self.assertEqual(filtr.filtered_traces, self.N_TRACES)
 
     def test_filters_add_tag(self):
-        tag_name = 'Tag'
+        tag_name = "Tag"
         filtr = AddTagFilter(tag_name)
         self.create_worker([filtr])
         self.assertEqual(len(self.api.traces), self.N_TRACES)
@@ -127,72 +125,71 @@ class AgentWriterTests(BaseTestCase):
     def test_no_dogstats(self):
         worker = self.create_worker()
         assert worker._send_stats is False
-        assert [
-        ] == self.dogstatsd.gauge.mock_calls
+        assert [] == self.dogstatsd.gauge.mock_calls
 
     def test_dogstatsd(self):
         self.create_worker(enable_stats=True)
         assert [
-            mock.call('datadog.tracer.heartbeat', 1),
-            mock.call('datadog.tracer.queue.max_length', 1000),
+            mock.call("datadog.tracer.heartbeat", 1),
+            mock.call("datadog.tracer.queue.max_length", 1000),
         ] == self.dogstatsd.gauge.mock_calls
 
         assert [
-            mock.call('datadog.tracer.flushes'),
-            mock.call('datadog.tracer.flush.traces.total', 11, tags=None),
-            mock.call('datadog.tracer.flush.spans.total', 77, tags=None),
-            mock.call('datadog.tracer.flush.traces_filtered.total', 0, tags=None),
-            mock.call('datadog.tracer.api.requests.total', 11, tags=None),
-            mock.call('datadog.tracer.api.errors.total', 0, tags=None),
-            mock.call('datadog.tracer.api.responses.total', 11, tags=['status:200']),
-            mock.call('datadog.tracer.queue.dropped.traces', 0),
-            mock.call('datadog.tracer.queue.enqueued.traces', 11),
-            mock.call('datadog.tracer.queue.enqueued.spans', 77),
-            mock.call('datadog.tracer.shutdown'),
+            mock.call("datadog.tracer.flushes"),
+            mock.call("datadog.tracer.flush.traces.total", 11, tags=None),
+            mock.call("datadog.tracer.flush.spans.total", 77, tags=None),
+            mock.call("datadog.tracer.flush.traces_filtered.total", 0, tags=None),
+            mock.call("datadog.tracer.api.requests.total", 11, tags=None),
+            mock.call("datadog.tracer.api.errors.total", 0, tags=None),
+            mock.call("datadog.tracer.api.responses.total", 11, tags=["status:200"]),
+            mock.call("datadog.tracer.queue.dropped.traces", 0),
+            mock.call("datadog.tracer.queue.enqueued.traces", 11),
+            mock.call("datadog.tracer.queue.enqueued.spans", 77),
+            mock.call("datadog.tracer.shutdown"),
         ] == self.dogstatsd.increment.mock_calls
 
         histogram_calls = [
-            mock.call('datadog.tracer.flush.traces', 11, tags=None),
-            mock.call('datadog.tracer.flush.spans', 77, tags=None),
-            mock.call('datadog.tracer.flush.traces_filtered', 0, tags=None),
-            mock.call('datadog.tracer.api.requests', 11, tags=None),
-            mock.call('datadog.tracer.api.errors', 0, tags=None),
-            mock.call('datadog.tracer.api.responses', 11, tags=['status:200']),
+            mock.call("datadog.tracer.flush.traces", 11, tags=None),
+            mock.call("datadog.tracer.flush.spans", 77, tags=None),
+            mock.call("datadog.tracer.flush.traces_filtered", 0, tags=None),
+            mock.call("datadog.tracer.api.requests", 11, tags=None),
+            mock.call("datadog.tracer.api.errors", 0, tags=None),
+            mock.call("datadog.tracer.api.responses", 11, tags=["status:200"]),
         ]
-        if hasattr(time, 'thread_time'):
-            histogram_calls.append(mock.call('datadog.tracer.writer.cpu_time', mock.ANY))
+        if hasattr(time, "thread_time"):
+            histogram_calls.append(mock.call("datadog.tracer.writer.cpu_time", mock.ANY))
 
         assert histogram_calls == self.dogstatsd.histogram.mock_calls
 
     def test_dogstatsd_failing_api(self):
         self.create_worker(api_class=FailingAPI, enable_stats=True)
         assert [
-            mock.call('datadog.tracer.heartbeat', 1),
-            mock.call('datadog.tracer.queue.max_length', 1000),
+            mock.call("datadog.tracer.heartbeat", 1),
+            mock.call("datadog.tracer.queue.max_length", 1000),
         ] == self.dogstatsd.gauge.mock_calls
 
         assert [
-            mock.call('datadog.tracer.flushes'),
-            mock.call('datadog.tracer.flush.traces.total', 11, tags=None),
-            mock.call('datadog.tracer.flush.spans.total', 77, tags=None),
-            mock.call('datadog.tracer.flush.traces_filtered.total', 0, tags=None),
-            mock.call('datadog.tracer.api.requests.total', 1, tags=None),
-            mock.call('datadog.tracer.api.errors.total', 1, tags=None),
-            mock.call('datadog.tracer.queue.dropped.traces', 0),
-            mock.call('datadog.tracer.queue.enqueued.traces', 11),
-            mock.call('datadog.tracer.queue.enqueued.spans', 77),
-            mock.call('datadog.tracer.shutdown'),
+            mock.call("datadog.tracer.flushes"),
+            mock.call("datadog.tracer.flush.traces.total", 11, tags=None),
+            mock.call("datadog.tracer.flush.spans.total", 77, tags=None),
+            mock.call("datadog.tracer.flush.traces_filtered.total", 0, tags=None),
+            mock.call("datadog.tracer.api.requests.total", 1, tags=None),
+            mock.call("datadog.tracer.api.errors.total", 1, tags=None),
+            mock.call("datadog.tracer.queue.dropped.traces", 0),
+            mock.call("datadog.tracer.queue.enqueued.traces", 11),
+            mock.call("datadog.tracer.queue.enqueued.spans", 77),
+            mock.call("datadog.tracer.shutdown"),
         ] == self.dogstatsd.increment.mock_calls
 
         histogram_calls = [
-            mock.call('datadog.tracer.flush.traces', 11, tags=None),
-            mock.call('datadog.tracer.flush.spans', 77, tags=None),
-            mock.call('datadog.tracer.flush.traces_filtered', 0, tags=None),
-            mock.call('datadog.tracer.api.requests', 1, tags=None),
-            mock.call('datadog.tracer.api.errors', 1, tags=None),
+            mock.call("datadog.tracer.flush.traces", 11, tags=None),
+            mock.call("datadog.tracer.flush.spans", 77, tags=None),
+            mock.call("datadog.tracer.flush.traces_filtered", 0, tags=None),
+            mock.call("datadog.tracer.api.requests", 1, tags=None),
+            mock.call("datadog.tracer.api.errors", 1, tags=None),
         ]
-        if hasattr(time, 'thread_time'):
-            histogram_calls.append(mock.call('datadog.tracer.writer.cpu_time', mock.ANY))
+        if hasattr(time, "thread_time"):
+            histogram_calls.append(mock.call("datadog.tracer.writer.cpu_time", mock.ANY))
 
         assert histogram_calls == self.dogstatsd.histogram.mock_calls
 
@@ -203,9 +200,7 @@ def test_queue_full():
     q.put(2)
     q.put([3])
     q.put([4, 4])
-    assert (list(q.queue) == [[1], 2, [4, 4]] or
-            list(q.queue) == [[1], [4, 4], [3]] or
-            list(q.queue) == [[4, 4], 2, [3]])
+    assert list(q.queue) == [[1], 2, [4, 4]] or list(q.queue) == [[1], [4, 4], [3]] or list(q.queue) == [[4, 4], 2, [3]]
     assert q.dropped == 1
     assert q.accepted == 4
     assert q.accepted_lengths == 5

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -23,80 +23,77 @@ import pytest
 class TestTracerConfig(object):
     def test_config(self):
         """Test the configuration of the tracer"""
-        config = {'enabled': True}
-        tracer = Tracer(service_name='myservice', config=config)
+        config = {"enabled": True}
+        tracer = Tracer(service_name="myservice", config=config)
 
-        assert tracer._service_name == 'myservice'
+        assert tracer._service_name == "myservice"
         assert tracer._enabled is True
 
     def test_no_service_name(self):
         """A service_name should be generated if one is not provided."""
         tracer = Tracer()
-        assert tracer._service_name == 'pytest'
+        assert tracer._service_name == "pytest"
 
     def test_multiple_tracer_configs(self):
         """Ensure that a tracer config is a copy of the passed config."""
-        config = {'enabled': True}
+        config = {"enabled": True}
 
-        tracer1 = Tracer(service_name='serv1', config=config)
-        assert tracer1._service_name == 'serv1'
+        tracer1 = Tracer(service_name="serv1", config=config)
+        assert tracer1._service_name == "serv1"
 
-        config['enabled'] = False
-        tracer2 = Tracer(service_name='serv2', config=config)
+        config["enabled"] = False
+        tracer2 = Tracer(service_name="serv2", config=config)
 
         # Ensure tracer1's config was not mutated
-        assert tracer1._service_name == 'serv1'
+        assert tracer1._service_name == "serv1"
         assert tracer1._enabled is True
 
-        assert tracer2._service_name == 'serv2'
+        assert tracer2._service_name == "serv2"
         assert tracer2._enabled is False
 
     def test_invalid_config_key(self):
         """A config with an invalid key should raise a ConfigException."""
 
-        config = {'enabeld': False}
+        config = {"enabeld": False}
 
         # No debug flag should not raise an error
-        tracer = Tracer(service_name='mysvc', config=config)
+        tracer = Tracer(service_name="mysvc", config=config)
 
         # With debug flag should raise an error
-        config['debug'] = True
+        config["debug"] = True
         with pytest.raises(ConfigException) as ce_info:
             tracer = Tracer(config=config)
-            assert 'enabeld' in str(ce_info)
+            assert "enabeld" in str(ce_info)
             assert tracer is not None
 
         # Test with multiple incorrect keys
-        config['setttings'] = {}
+        config["setttings"] = {}
         with pytest.raises(ConfigException) as ce_info:
-            tracer = Tracer(service_name='mysvc', config=config)
-            assert ['enabeld', 'setttings'] in str(ce_info)
+            tracer = Tracer(service_name="mysvc", config=config)
+            assert ["enabeld", "setttings"] in str(ce_info)
             assert tracer is not None
 
     def test_global_tags(self):
         """Global tags should be passed from the opentracer to the tracer."""
         config = {
-            'global_tags': {
-                'tag1': 'value1',
-                'tag2': 2,
-            },
+            "global_tags": {"tag1": "value1", "tag2": 2,},
         }
 
-        tracer = Tracer(service_name='mysvc', config=config)
-        with tracer.start_span('myop') as span:
+        tracer = Tracer(service_name="mysvc", config=config)
+        with tracer.start_span("myop") as span:
             # global tags should be attached to generated all datadog spans
-            assert span._dd_span.get_tag('tag1') == 'value1'
-            assert span._dd_span.get_metric('tag2') == 2
+            assert span._dd_span.get_tag("tag1") == "value1"
+            assert span._dd_span.get_metric("tag2") == 2
 
-            with tracer.start_span('myop2') as span2:
-                assert span2._dd_span.get_tag('tag1') == 'value1'
-                assert span2._dd_span.get_metric('tag2') == 2
+            with tracer.start_span("myop2") as span2:
+                assert span2._dd_span.get_tag("tag1") == "value1"
+                assert span2._dd_span.get_metric("tag2") == 2
 
 
 class TestTracer(object):
     def test_start_span(self, ot_tracer, writer):
         """Start and finish a span."""
-        with ot_tracer.start_span('myop') as span:
+        with ot_tracer.start_span("myop") as span:
             pass
 
         # span should be finished when the context manager exits
@@ -108,16 +105,16 @@ class TestTracer(object):
     def test_start_span_references(self, ot_tracer, writer):
         """Start a span using references."""
 
-        with ot_tracer.start_span('one', references=[child_of()]):
+        with ot_tracer.start_span("one", references=[child_of()]):
             pass
 
         spans = writer.pop()
         assert spans[0].parent_id is None
 
-        root = ot_tracer.start_active_span('root')
+        root = ot_tracer.start_active_span("root")
         # create a child using a parent reference that is not the context parent
-        with ot_tracer.start_active_span('one'):
-            with ot_tracer.start_active_span('two', references=[child_of(root.span)]):
+        with ot_tracer.start_active_span("one"):
+            with ot_tracer.start_active_span("two", references=[child_of(root.span)]):
                 pass
         root.close()
 
@@ -127,9 +124,9 @@ class TestTracer(object):
     def test_start_span_custom_start_time(self, ot_tracer):
         """Start a span with a custom start time."""
         t = 100
-        with mock.patch('ddtrace.span.time_ns') as time:
+        with mock.patch("ddtrace.span.time_ns") as time:
             time.return_value = 102 * 1e9
-            with ot_tracer.start_span('myop', start_time=t) as span:
+            with ot_tracer.start_span("myop", start_time=t) as span:
                 pass
 
         assert span._dd_span.start == t
@@ -139,8 +136,8 @@ class TestTracer(object):
         """Start and finish a span using a span context as the child_of
         reference.
         """
-        with ot_tracer.start_span('myop') as span:
-            with ot_tracer.start_span('myop', child_of=span.context) as span2:
+        with ot_tracer.start_span("myop") as span:
+            with ot_tracer.start_span("myop", child_of=span.context) as span2:
                 pass
 
         # span should be finished when the context manager exits
@@ -155,36 +152,36 @@ class TestTracer(object):
 
     def test_start_span_with_tags(self, ot_tracer):
         """Create a span with initial tags."""
-        tags = {'key': 'value', 'key2': 'value2'}
-        with ot_tracer.start_span('myop', tags=tags) as span:
+        tags = {"key": "value", "key2": "value2"}
+        with ot_tracer.start_span("myop", tags=tags) as span:
             pass
 
-        assert span._dd_span.get_tag('key') == 'value'
-        assert span._dd_span.get_tag('key2') == 'value2'
+        assert span._dd_span.get_tag("key") == "value"
+        assert span._dd_span.get_tag("key2") == "value2"
 
     def test_start_span_with_resource_name_tag(self, ot_tracer):
         """Create a span with the tag to set the resource name"""
-        tags = {'resource.name': 'value', 'key2': 'value2'}
-        with ot_tracer.start_span('myop', tags=tags) as span:
+        tags = {"resource.name": "value", "key2": "value2"}
+        with ot_tracer.start_span("myop", tags=tags) as span:
             pass
 
         # Span resource name should be set to tag value, and should not get set as
         # a tag on the underlying span.
-        assert span._dd_span.resource == 'value'
-        assert span._dd_span.get_tag('resource.name') is None
+        assert span._dd_span.resource == "value"
+        assert span._dd_span.get_tag("resource.name") is None
 
         # Other tags are set as normal
-        assert span._dd_span.get_tag('key2') == 'value2'
+        assert span._dd_span.get_tag("key2") == "value2"
 
     def test_start_active_span_multi_child(self, ot_tracer, writer):
         """Start and finish multiple child spans.
         This should ensure that child spans can be created 2 levels deep.
         """
-        with ot_tracer.start_active_span('myfirstop') as scope1:
+        with ot_tracer.start_active_span("myfirstop") as scope1:
             time.sleep(0.009)
-            with ot_tracer.start_active_span('mysecondop') as scope2:
+            with ot_tracer.start_active_span("mysecondop") as scope2:
                 time.sleep(0.007)
-                with ot_tracer.start_active_span('mythirdop') as scope3:
+                with ot_tracer.start_active_span("mythirdop") as scope3:
                     time.sleep(0.005)
 
         # spans should be finished when the context manager exits
@@ -213,11 +210,11 @@ class TestTracer(object):
         This should test to ensure a parent can have multiple child spans at the
         same level.
         """
-        with ot_tracer.start_active_span('myfirstop') as scope1:
+        with ot_tracer.start_active_span("myfirstop") as scope1:
             time.sleep(0.009)
-            with ot_tracer.start_active_span('mysecondop') as scope2:
+            with ot_tracer.start_active_span("mysecondop") as scope2:
                 time.sleep(0.007)
-            with ot_tracer.start_active_span('mythirdop') as scope3:
+            with ot_tracer.start_active_span("mythirdop") as scope3:
                 time.sleep(0.005)
 
         # spans should be finished when the context manager exits
@@ -246,11 +243,11 @@ class TestTracer(object):
         Spans should be created without parents since there will be no call
         for the active span.
         """
-        root = ot_tracer.start_span('zero')
+        root = ot_tracer.start_span("zero")
 
-        with ot_tracer.start_span('one', child_of=root):
-            with ot_tracer.start_span('two', child_of=root):
-                with ot_tracer.start_span('three', child_of=root):
+        with ot_tracer.start_span("one", child_of=root):
+            with ot_tracer.start_span("two", child_of=root):
+                with ot_tracer.start_span("three", child_of=root):
                     pass
         root.finish()
 
@@ -261,20 +258,17 @@ class TestTracer(object):
         assert spans[1].parent_id is root._dd_span.span_id
         assert spans[2].parent_id is root._dd_span.span_id
         assert spans[3].parent_id is root._dd_span.span_id
-        assert (
-            spans[0].trace_id == spans[1].trace_id and
-            spans[1].trace_id == spans[2].trace_id
-        )
+        assert spans[0].trace_id == spans[1].trace_id and spans[1].trace_id == spans[2].trace_id
 
     def test_start_span_no_active_span(self, ot_tracer, writer):
         """Start spans without using a scope manager.
         Spans should be created without parents since there will be no call
         for the active span.
         """
-        with ot_tracer.start_span('one', ignore_active_span=True):
-            with ot_tracer.start_span('two', ignore_active_span=True):
+        with ot_tracer.start_span("one", ignore_active_span=True):
+            with ot_tracer.start_span("two", ignore_active_span=True):
                 pass
-            with ot_tracer.start_span('three', ignore_active_span=True):
+            with ot_tracer.start_span("three", ignore_active_span=True):
                 pass
 
         spans = writer.pop()
@@ -285,15 +279,15 @@ class TestTracer(object):
         assert spans[2].parent_id is None
         # and that each span is a new trace
         assert (
-            spans[0].trace_id != spans[1].trace_id and
-            spans[1].trace_id != spans[2].trace_id and
-            spans[0].trace_id != spans[2].trace_id
+            spans[0].trace_id != spans[1].trace_id
+            and spans[1].trace_id != spans[2].trace_id
+            and spans[0].trace_id != spans[2].trace_id
         )
 
     def test_start_active_span_child_finish_after_parent(self, ot_tracer, writer):
         """Start a child span and finish it after its parent."""
-        span1 = ot_tracer.start_active_span('one').span
-        span2 = ot_tracer.start_active_span('two').span
+        span1 = ot_tracer.start_active_span("one").span
+        span2 = ot_tracer.start_active_span("two").span
         span1.finish()
         time.sleep(0.005)
         span2.finish()
@@ -314,7 +308,7 @@ class TestTracer(object):
         event = threading.Event()
 
         def trace_one():
-            id = 11             # noqa: A001
+            id = 11  # noqa: A001
             with ot_tracer.start_active_span(str(id)):
                 id += 1
                 with ot_tracer.start_active_span(str(id)):
@@ -323,7 +317,7 @@ class TestTracer(object):
                         event.set()
 
         def trace_two():
-            id = 21             # noqa: A001
+            id = 21  # noqa: A001
             event.wait()
             with ot_tracer.start_active_span(str(id)):
                 id += 1
@@ -347,12 +341,12 @@ class TestTracer(object):
 
         # trace_one will finish before trace_two so its spans should be written
         # before the spans from trace_two, let's confirm this
-        assert spans[0].name == '11'
-        assert spans[1].name == '12'
-        assert spans[2].name == '13'
-        assert spans[3].name == '21'
-        assert spans[4].name == '22'
-        assert spans[5].name == '23'
+        assert spans[0].name == "11"
+        assert spans[1].name == "12"
+        assert spans[2].name == "13"
+        assert spans[3].name == "21"
+        assert spans[4].name == "22"
+        assert spans[5].name == "23"
 
         # next let's ensure that each span has the correct parent:
         # trace_one
@@ -366,61 +360,53 @@ class TestTracer(object):
 
         # finally we should ensure that the trace_ids are reasonable
         # trace_one
-        assert (
-            spans[0].trace_id == spans[1].trace_id and
-            spans[1].trace_id == spans[2].trace_id
-        )
+        assert spans[0].trace_id == spans[1].trace_id and spans[1].trace_id == spans[2].trace_id
         # traces should be independent
         assert spans[2].trace_id != spans[3].trace_id
         # trace_two
-        assert (
-            spans[3].trace_id == spans[4].trace_id and
-            spans[4].trace_id == spans[5].trace_id
-        )
+        assert spans[3].trace_id == spans[4].trace_id and spans[4].trace_id == spans[5].trace_id
 
     def test_start_active_span(self, ot_tracer, writer):
-        with ot_tracer.start_active_span('one') as scope:
+        with ot_tracer.start_active_span("one") as scope:
             pass
 
-        assert scope.span._dd_span.name == 'one'
+        assert scope.span._dd_span.name == "one"
         assert scope.span.finished
         spans = writer.pop()
         assert spans
 
     def test_start_active_span_finish_on_close(self, ot_tracer, writer):
-        with ot_tracer.start_active_span('one', finish_on_close=False) as scope:
+        with ot_tracer.start_active_span("one", finish_on_close=False) as scope:
             pass
 
-        assert scope.span._dd_span.name == 'one'
+        assert scope.span._dd_span.name == "one"
         assert not scope.span.finished
         spans = writer.pop()
         assert not spans
 
     def test_start_active_span_nested(self, ot_tracer):
         """Test the active span of multiple nested calls of start_active_span."""
-        with ot_tracer.start_active_span('one') as outer_scope:
+        with ot_tracer.start_active_span("one") as outer_scope:
             assert ot_tracer.active_span == outer_scope.span
-            with ot_tracer.start_active_span('two') as inner_scope:
+            with ot_tracer.start_active_span("two") as inner_scope:
                 assert ot_tracer.active_span == inner_scope.span
-                with ot_tracer.start_active_span(
-                    'three'
-                ) as innest_scope:  # why isn't it innest? innermost so verbose
+                with ot_tracer.start_active_span("three") as innest_scope:  # why isn't it innest? innermost so verbose
                     assert ot_tracer.active_span == innest_scope.span
-            with ot_tracer.start_active_span('two') as inner_scope:
+            with ot_tracer.start_active_span("two") as inner_scope:
                 assert ot_tracer.active_span == inner_scope.span
             assert ot_tracer.active_span == outer_scope.span
         assert ot_tracer.active_span is None
 
     def test_start_active_span_trace(self, ot_tracer, writer):
         """Test the active span of multiple nested calls of start_active_span."""
-        with ot_tracer.start_active_span('one') as outer_scope:
-            outer_scope.span.set_tag('outer', 2)
-            with ot_tracer.start_active_span('two') as inner_scope:
-                inner_scope.span.set_tag('inner', 3)
-            with ot_tracer.start_active_span('two') as inner_scope:
-                inner_scope.span.set_tag('inner', 3)
-                with ot_tracer.start_active_span('three') as innest_scope:
-                    innest_scope.span.set_tag('innerest', 4)
+        with ot_tracer.start_active_span("one") as outer_scope:
+            outer_scope.span.set_tag("outer", 2)
+            with ot_tracer.start_active_span("two") as inner_scope:
+                inner_scope.span.set_tag("inner", 3)
+            with ot_tracer.start_active_span("two") as inner_scope:
+                inner_scope.span.set_tag("inner", 3)
+                with ot_tracer.start_active_span("three") as innest_scope:
+                    innest_scope.span.set_tag("innerest", 4)
 
         spans = writer.pop()
 
@@ -474,9 +460,7 @@ class TestTracerSpanContextPropagation(object):
 
     def test_http_headers_baggage(self, ot_tracer):
         """extract should undo inject for http headers."""
-        span_ctx = SpanContext(
-            trace_id=123, span_id=456, baggage={'test': 4, 'test2': 'string'}
-        )
+        span_ctx = SpanContext(trace_id=123, span_id=456, baggage={"test": 4, "test2": "string"})
         carrier = {}
 
         ot_tracer.inject(span_ctx, Format.HTTP_HEADERS, carrier)
@@ -497,9 +481,7 @@ class TestTracerSpanContextPropagation(object):
 
     def test_text(self, ot_tracer):
         """extract should undo inject for http headers"""
-        span_ctx = SpanContext(
-            trace_id=123, span_id=456, baggage={'test': 4, 'test2': 'string'}
-        )
+        span_ctx = SpanContext(trace_id=123, span_id=456, baggage={"test": 4, "test2": "string"})
         carrier = {}
 
         ot_tracer.inject(span_ctx, Format.TEXT_MAP, carrier)
@@ -512,9 +494,7 @@ class TestTracerSpanContextPropagation(object):
 
     def test_corrupted_propagated_context(self, ot_tracer):
         """Corrupted context should raise a SpanContextCorruptedException."""
-        span_ctx = SpanContext(
-            trace_id=123, span_id=456, baggage={'test': 4, 'test2': 'string'}
-        )
+        span_ctx = SpanContext(trace_id=123, span_id=456, baggage={"test": 4, "test2": "string"})
         carrier = {}
 
         ot_tracer.inject(span_ctx, Format.TEXT_MAP, carrier)
@@ -530,12 +510,12 @@ class TestTracerSpanContextPropagation(object):
 
     def test_immutable_span_context(self, ot_tracer):
         """Span contexts should be immutable."""
-        with ot_tracer.start_span('root') as root:
+        with ot_tracer.start_span("root") as root:
             ctx_before = root.context
-            root.set_baggage_item('test', 2)
+            root.set_baggage_item("test", 2)
             assert ctx_before is not root.context
-            with ot_tracer.start_span('child') as level1:
-                with ot_tracer.start_span('child') as level2:
+            with ot_tracer.start_span("child") as level1:
+                with ot_tracer.start_span("child") as level2:
                     pass
         assert root.context is not level1.context
         assert level2.context is not level1.context
@@ -543,27 +523,27 @@ class TestTracerSpanContextPropagation(object):
 
     def test_inherited_baggage(self, ot_tracer):
         """Baggage should be inherited by child spans."""
-        with ot_tracer.start_active_span('root') as root:
+        with ot_tracer.start_active_span("root") as root:
             # this should be passed down to the child
-            root.span.set_baggage_item('root', 1)
-            root.span.set_baggage_item('root2', 1)
-            with ot_tracer.start_active_span('child') as level1:
-                level1.span.set_baggage_item('level1', 1)
-                with ot_tracer.start_active_span('child') as level2:
-                    level2.span.set_baggage_item('level2', 1)
+            root.span.set_baggage_item("root", 1)
+            root.span.set_baggage_item("root2", 1)
+            with ot_tracer.start_active_span("child") as level1:
+                level1.span.set_baggage_item("level1", 1)
+                with ot_tracer.start_active_span("child") as level2:
+                    level2.span.set_baggage_item("level2", 1)
         # ensure immutability
         assert level1.span.context is not root.span.context
         assert level2.span.context is not level1.span.context
 
         # level1 should have inherited the baggage of root
-        assert level1.span.get_baggage_item('root')
-        assert level1.span.get_baggage_item('root2')
+        assert level1.span.get_baggage_item("root")
+        assert level1.span.get_baggage_item("root2")
 
         # level2 should have inherited the baggage of both level1 and level2
-        assert level2.span.get_baggage_item('root')
-        assert level2.span.get_baggage_item('root2')
-        assert level2.span.get_baggage_item('level1')
-        assert level2.span.get_baggage_item('level2')
+        assert level2.span.get_baggage_item("root")
+        assert level2.span.get_baggage_item("root2")
+        assert level2.span.get_baggage_item("level1")
+        assert level2.span.get_baggage_item("level2")
 
 
 class TestTracerCompatibility(object):
@@ -574,14 +554,14 @@ class TestTracerCompatibility(object):
         by the underlying datadog tracer.
         """
         # a service name is required
-        tracer = Tracer('service')
-        with tracer.start_span('my_span') as span:
+        tracer = Tracer("service")
+        with tracer.start_span("my_span") as span:
             assert span._dd_span.service
 
 
 def test_set_global_tracer():
     """Sanity check for set_global_tracer"""
-    my_tracer = Tracer('service')
+    my_tracer = Tracer("service")
     set_global_tracer(my_tracer)
 
     assert opentracing.tracer is my_tracer

--- a/tests/propagation/test_http.py
+++ b/tests/propagation/test_http.py
@@ -19,61 +19,55 @@ class TestHttpPropagation(TestCase):
     def test_inject(self):
         tracer = get_dummy_tracer()
 
-        with tracer.trace('global_root_span') as span:
+        with tracer.trace("global_root_span") as span:
             span.context.sampling_priority = 2
-            span.context._dd_origin = 'synthetics'
+            span.context._dd_origin = "synthetics"
             headers = {}
             propagator = HTTPPropagator()
             propagator.inject(span.context, headers)
 
             assert int(headers[HTTP_HEADER_TRACE_ID]) == span.trace_id
             assert int(headers[HTTP_HEADER_PARENT_ID]) == span.span_id
-            assert (
-                int(headers[HTTP_HEADER_SAMPLING_PRIORITY]) ==
-                span.context.sampling_priority
-            )
-            assert (
-                headers[HTTP_HEADER_ORIGIN] ==
-                span.context._dd_origin
-            )
+            assert int(headers[HTTP_HEADER_SAMPLING_PRIORITY]) == span.context.sampling_priority
+            assert headers[HTTP_HEADER_ORIGIN] == span.context._dd_origin
 
     def test_extract(self):
         tracer = get_dummy_tracer()
 
         headers = {
-            'x-datadog-trace-id': '1234',
-            'x-datadog-parent-id': '5678',
-            'x-datadog-sampling-priority': '1',
-            'x-datadog-origin': 'synthetics',
+            "x-datadog-trace-id": "1234",
+            "x-datadog-parent-id": "5678",
+            "x-datadog-sampling-priority": "1",
+            "x-datadog-origin": "synthetics",
         }
 
         propagator = HTTPPropagator()
         context = propagator.extract(headers)
         tracer.context_provider.activate(context)
 
-        with tracer.trace('local_root_span') as span:
+        with tracer.trace("local_root_span") as span:
             assert span.trace_id == 1234
             assert span.parent_id == 5678
             assert span.context.sampling_priority == 1
-            assert span.context._dd_origin == 'synthetics'
+            assert span.context._dd_origin == "synthetics"
 
     def test_WSGI_extract(self):
         """Ensure we support the WSGI formatted headers as well."""
         tracer = get_dummy_tracer()
 
         headers = {
-            'HTTP_X_DATADOG_TRACE_ID': '1234',
-            'HTTP_X_DATADOG_PARENT_ID': '5678',
-            'HTTP_X_DATADOG_SAMPLING_PRIORITY': '1',
-            'HTTP_X_DATADOG_ORIGIN': 'synthetics',
+            "HTTP_X_DATADOG_TRACE_ID": "1234",
+            "HTTP_X_DATADOG_PARENT_ID": "5678",
+            "HTTP_X_DATADOG_SAMPLING_PRIORITY": "1",
+            "HTTP_X_DATADOG_ORIGIN": "synthetics",
         }
 
         propagator = HTTPPropagator()
         context = propagator.extract(headers)
         tracer.context_provider.activate(context)
 
-        with tracer.trace('local_root_span') as span:
+        with tracer.trace("local_root_span") as span:
             assert span.trace_id == 1234
             assert span.parent_id == 5678
             assert span.context.sampling_priority == 1
-            assert span.context._dd_origin == 'synthetics'
+            assert span.context._dd_origin == "synthetics"

--- a/tox.ini
+++ b/tox.ini
@@ -843,8 +843,9 @@ exclude=
 # Ignore:
 # A003: XXX is a python builtin, consider renaming the class attribute
 # G201 Logging: .exception(...) should be used instead of .error(..., exc_info=True)
+# E231,W503: not respected by black
 # We ignore most of the D errors because there are too many; the goal is to fix them eventually
-ignore = W504,A003,G201,D100,D101,D102,D103,D104,D105,D106,D107,D200,D202,D204,D205,D208,D210,D300,D400,D401,D403,D413
+ignore = W503,E231,A003,G201,D100,D101,D102,D103,D104,D105,D106,D107,D200,D202,D204,D205,D208,D210,D300,D400,D401,D403,D413
 enable-extensions=G
 rst-roles = class,meth,obj,ref
 rst-directives = py:data


### PR DESCRIPTION
black does not respect those error codes and therefore they should be ignored.

It does support W503 so that one should be included.
This patch therefore black-ifies the files that do not respect W503.