### PR TITLE
tests: fix botocore tests on py3.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -188,6 +188,7 @@ deps =
     boto: moto<1.0
     botocore: botocore
     py34-botocore: PyYAML<5.3
+    py34-botocore: jsonpatch<1.25
     botocore: moto>=1.0,<2
     bottle11: bottle>=0.11,<0.12
     bottle12: bottle>=0.12,<0.13


### PR DESCRIPTION
`jsonpatch==1.25` removed support for Python 3.4.