### PR TITLE
fix(tox): flake8 does not need to install ddtrace

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -490,6 +490,8 @@ commands=black --check .
 basepython=python3.7
 
 [testenv:flake8]
+commands_pre=
+skip_install=true
 deps=
   flake8>=3.7,<=3.8
   flake8-blind-except


### PR DESCRIPTION
This makes running flake8 in tox faster.