### PR TITLE
fix(ci): limit Werkzeug to <1 for old Flask version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -266,8 +266,11 @@ deps =
     falcon13: falcon>=1.3,<1.4
     falcon14: falcon>=1.4,<1.5
     flask09: flask>=0.9,<0.10
+    flask09: Werkzeug<1
     flask010: flask>=0.10,<0.11
+    flask010: Werkzeug<1
     flask011: flask>=0.11,<0.12
+    flask011: Werkzeug<1
     flask012: flask>=0.12,<0.13
     flask10: flask>=1.0,<1.1
     flaskcache012: flask_cache>=0.12,<0.13


### PR DESCRIPTION
The API changed in Werkzeug >= 1 and is not compatible with older Flask
version. Capping Werkzeug makes tests work again.