### PR TITLE
ci(tox): do not install ddtrace for running black

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -491,6 +491,8 @@ deps=
 ignore_outcome=true
 
 [testenv:black]
+commands_pre=
+skip_install=true
 deps=black
 commands=black --check .
 basepython=python3.7


### PR DESCRIPTION
This is a follow-up of #1200, doing the same thing for black.