### PR TITLE
ci(wait): do not install ddtrace in the wait target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -476,6 +476,8 @@ commands =
     benchmarks: pytest --benchmark-only {posargs} tests/benchmark.py
 
 [testenv:wait]
+commands_pre=
+skip_install=true
 commands=python tests/wait-for-services.py {posargs}
 basepython=python
 deps=


### PR DESCRIPTION
We don't use ddtrace at all, we just run a Python script.