### PR TITLE
ci(tox): remove useless basepython specifiers

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -143,12 +143,6 @@ envlist =
 #      https://stackoverflow.com/questions/57459123/why-do-i-need-to-run-tox-twice-to-test-a-python-package-with-c-extension
 commands_pre={envpython} {toxinidir}/setup.py develop
 usedevelop = True
-basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
 
 deps =
     pdbpp


### PR DESCRIPTION
https://tox.readthedocs.io/en/latest/example/general.html#basepython-defaults-overriding

```
basepython defaults, overriding
For any pyXY test environment name the underlying pythonX.Y executable will be searched in your system PATH.
```