### PR TITLE
fix(tox): do not skip install for docs

### DIFF
--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -93,7 +93,7 @@ Migration from ddtrace<=0.33.0
 The Django integration provides automatic migration from enabling tracing using
 a middleware to the method consistent with our integrations. Application
 developers are encouraged to convert their configuration of the tracer to the
-later.
+latter.
 
 1. Remove ``'ddtrace.config.django'`` from ``INSTALLED_APPS`` in
    ``settings.py``.

--- a/docs/installation_quickstart.rst
+++ b/docs/installation_quickstart.rst
@@ -42,7 +42,7 @@ variable before starting your application and importing the library:
 
 .. list-table::
    :header-rows: 1
-   :widths: 1 1 2
+   :widths: 1 1 1 2
 
    * - Configuration Variable
      - Configuration Type
@@ -64,7 +64,7 @@ that you can use the Datadog tracer in your OpenTracing-compatible
 applications.
 
 Installation
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 
 Include OpenTracing with ``ddtrace``::
 
@@ -78,7 +78,7 @@ you have the following in ``setup.py``::
     ],
 
 Configuration
-^^^^^^^^^^^^^
+~~~~~~~~~~~~~
 
 The OpenTracing convention for initializing a tracer is to define an
 initialization method that will configure and instantiate a new tracer and

--- a/tox.ini
+++ b/tox.ini
@@ -509,8 +509,6 @@ commands=flake8 .
 basepython=python3.7
 
 [testenv:docs]
-commands_pre=
-skip_install=true
 deps = sphinx
 commands = sphinx-build -b html docs docs/_build/html
 basepython = python

--- a/tox.ini
+++ b/tox.ini
@@ -510,7 +510,7 @@ basepython=python3.7
 
 [testenv:docs]
 deps = sphinx
-commands = sphinx-build -b html docs docs/_build/html
+commands = sphinx-build -W -b html docs docs/_build/html
 basepython = python
 
 # do not use develop mode with celery as running multiple python versions within

--- a/tox.ini
+++ b/tox.ini
@@ -509,9 +509,13 @@ commands=flake8 .
 basepython=python3.7
 
 [testenv:docs]
-deps = sphinx
-commands = sphinx-build -W -b html docs docs/_build/html
-basepython = python
+commands_pre=
+extras=
+  opentracing
+deps=
+  sphinx
+commands=sphinx-build -W -b html docs docs/_build/html
+basepython=python
 
 # do not use develop mode with celery as running multiple python versions within
 # same job will cause problem for tests that use ddtrace-run


### PR DESCRIPTION
We need the package installed for `sphinx.ext.autodoc` to work. This PR also raises any warnings from sphinx as errors.