### PR TITLE
fix(encoding): always return bytes when decoding

### DIFF
--- a/ddtrace/encoding.py
+++ b/ddtrace/encoding.py
@@ -83,7 +83,9 @@ class MsgpackEncoder(_EncoderBase):
 
     @staticmethod
     def decode(data):
-        return msgpack.unpackb(data)
+        if msgpack.version[:2] < (0, 6):
+            return msgpack.unpackb(data)
+        return msgpack.unpackb(data, raw=True)
 
     @staticmethod
     def join_encoded(objs):


### PR DESCRIPTION
msgpack 1.0.0 has a different default behaviour which returns string rather
than bytes. Keep it to bytes by default for all versions.

Note that this is only used in testing anyway.