### PR TITLE
rediscluster: Add support for v2.0.0

### DIFF
--- a/ddtrace/contrib/rediscluster/patch.py
+++ b/ddtrace/contrib/rediscluster/patch.py
@@ -12,6 +12,11 @@ from ..redis.patch import traced_execute_command, traced_pipeline
 from ..redis.util import format_command_args
 
 
+# DEV: In `2.0.0` `__version__` is a string and `VERSION` is a tuple,
+#      but in `1.x.x` `__version__` is a tuple annd `VERSION` does not exist
+REDISCLUSTER_VERSION = getattr(rediscluster, 'VERSION', rediscluster.__version__)
+
+
 def patch():
     """Patch the instrumented methods
     """
@@ -20,18 +25,30 @@ def patch():
     setattr(rediscluster, '_datadog_patch', True)
 
     _w = wrapt.wrap_function_wrapper
-    _w('rediscluster', 'StrictRedisCluster.execute_command', traced_execute_command)
-    _w('rediscluster', 'StrictRedisCluster.pipeline', traced_pipeline)
-    _w('rediscluster', 'StrictClusterPipeline.execute', traced_execute_pipeline)
-    Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP).onto(rediscluster.StrictRedisCluster)
+    if REDISCLUSTER_VERSION >= (2, 0, 0):
+        _w('rediscluster', 'StrictRedisCluster.execute_command', traced_execute_command)
+        _w('rediscluster', 'StrictRedisCluster.pipeline', traced_pipeline)
+        _w('rediscluster', 'StrictClusterPipeline.execute', traced_execute_pipeline)
+        Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP).onto(rediscluster.StrictRedisCluster)
+    else:
+        _w('rediscluster', 'RedisCluster.execute_command', traced_execute_command)
+        _w('rediscluster', 'RedisCluster.pipeline', traced_pipeline)
+        _w('rediscluster', 'ClusterPipeline.execute', traced_execute_pipeline)
+        Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP).onto(rediscluster.RedisCluster)
 
 
 def unpatch():
     if getattr(rediscluster, '_datadog_patch', False):
         setattr(rediscluster, '_datadog_patch', False)
-        unwrap(rediscluster.StrictRedisCluster, 'execute_command')
-        unwrap(rediscluster.StrictRedisCluster, 'pipeline')
-        unwrap(rediscluster.StrictClusterPipeline, 'execute')
+
+        if REDISCLUSTER_VERSION >= (2, 0, 0):
+            unwrap(rediscluster.RedisCluster, 'execute_command')
+            unwrap(rediscluster.RedisCluster, 'pipeline')
+            unwrap(rediscluster.ClusterPipeline, 'execute')
+        else:
+            unwrap(rediscluster.StrictRedisCluster, 'execute_command')
+            unwrap(rediscluster.StrictRedisCluster, 'pipeline')
+            unwrap(rediscluster.StrictClusterPipeline, 'execute')
 
 
 #

--- a/ddtrace/contrib/rediscluster/patch.py
+++ b/ddtrace/contrib/rediscluster/patch.py
@@ -26,15 +26,15 @@ def patch():
 
     _w = wrapt.wrap_function_wrapper
     if REDISCLUSTER_VERSION >= (2, 0, 0):
-        _w('rediscluster', 'StrictRedisCluster.execute_command', traced_execute_command)
-        _w('rediscluster', 'StrictRedisCluster.pipeline', traced_pipeline)
-        _w('rediscluster', 'StrictClusterPipeline.execute', traced_execute_pipeline)
-        Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP).onto(rediscluster.StrictRedisCluster)
-    else:
         _w('rediscluster', 'RedisCluster.execute_command', traced_execute_command)
         _w('rediscluster', 'RedisCluster.pipeline', traced_pipeline)
         _w('rediscluster', 'ClusterPipeline.execute', traced_execute_pipeline)
         Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP).onto(rediscluster.RedisCluster)
+    else:
+        _w('rediscluster', 'StrictRedisCluster.execute_command', traced_execute_command)
+        _w('rediscluster', 'StrictRedisCluster.pipeline', traced_pipeline)
+        _w('rediscluster', 'StrictClusterPipeline.execute', traced_execute_pipeline)
+        Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP).onto(rediscluster.StrictRedisCluster)
 
 
 def unpatch():

--- a/tests/contrib/rediscluster/test.py
+++ b/tests/contrib/rediscluster/test.py
@@ -3,6 +3,7 @@ import rediscluster
 
 from ddtrace import Pin
 from ddtrace.contrib.rediscluster.patch import patch, unpatch
+from ddtrace.contrib.rediscluster.patch import REDISCLUSTER_VERSION
 from ..config import REDISCLUSTER_CONFIG
 from ...test_tracer import get_dummy_tracer
 from ...base import BaseTracerTestCase
@@ -20,7 +21,10 @@ class TestRedisPatch(BaseTracerTestCase):
             {'host': self.TEST_HOST, 'port': int(port)}
             for port in self.TEST_PORTS.split(',')
         ]
-        return rediscluster.StrictRedisCluster(startup_nodes=startup_nodes)
+        if REDISCLUSTER_VERSION >= (2, 0, 0):
+            return rediscluster.RedisCluster(startup_nodes=startup_nodes)
+        else:
+            return rediscluster.StrictRedisCluster(startup_nodes=startup_nodes)
 
     def setUp(self):
         super(TestRedisPatch, self).setUp()

--- a/tox.ini
+++ b/tox.ini
@@ -109,7 +109,7 @@ envlist =
     pymysql_contrib-{py27,py34,py35,py36,py37}-pymysql{07,08,09}
     pyramid_contrib{,_autopatch}-{py27,py34,py35,py36,py37}-pyramid{17,18,19}-webtest
     redis_contrib-{py27,py34,py35,py36,py37}-redis{26,27,28,29,210,300}
-    rediscluster_contrib-{py27,py34,py35,py36,py37}-rediscluster{135,136}-redis210
+    rediscluster_contrib-{py27,py34,py35,py36,py37}-rediscluster{135,136,200,latest}-redis210
     requests_contrib{,_autopatch}-{py27,py34,py35,py36,py37}-requests{208,209,210,211,212,213,219}
     kombu_contrib-{py27,py34,py35,py36}-kombu{40,41,42}
     # Python 3.7 needs Kombu >= 4.2
@@ -363,6 +363,8 @@ deps =
     redis320: redis>=3.2.0,<3.3.0
     rediscluster135: redis-py-cluster>=1.3.5,<1.3.6
     rediscluster136: redis-py-cluster>=1.3.6,<1.3.7
+    rediscluster200: redis-py-cluster>=2.0.0,<2.1.0
+    redisclusterlatest: redis-py-cluster
     kombu44:  kombu>=4.4,<4.5
     kombu43:  kombu>=4.3,<4.4
     kombu42:  kombu>=4.2,<4.3


### PR DESCRIPTION
Fixes #1224

Version `2.0.0` dropped `Strict` from the name of properties.

This PR ensures we use the correct class names, and updates CI to test with latest version.