### PR TITLE
ci: requires virtualenv < 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -703,9 +703,9 @@ jobs:
         # list all executed test
       - run: jq -s ".[]|.testenvs|keys|.[]" /tmp/workspace/* | grep -v GLOB | sed 's/"//g' | sort | uniq | tee all_executed_tests
         # list all tests in tox.ini
-      - run: tox -l | grep -v "^wait$" | sort > all_tests
+      - run: tox -l | grep -v -E "^(wait$|\.)" | sort > all_tests
         # checks that all tests were executed
-      - run: diff all_tests all_executed_tests
+      - run: diff -u all_tests all_executed_tests
 
 
 requires_pre_test: &requires_pre_test

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 # versions.
 
 [tox]
+requires = virtualenv<20
 # Our various test environments. The py*-all tasks will run the core
 # library tests and all contrib tests with the latest library versions.
 # The others will test specific versions of libraries.


### PR DESCRIPTION
There's a regression in virtualenv >= 20 that makes one of the ddtrace-run +
Celery test to fails.

virtualenv now adds a site.py which modifies sys.path and breaks the PYTHONPATH
that is set by ddtrace-run.
