### PR TITLE
ci: make sure we install cython for deploy_dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -649,7 +649,7 @@ jobs:
       - checkout
       - setup_tox
       - run: sudo apt-get -y install rake
-      - run: pip install tox mkwheelhouse awscli
+      - run: pip install tox mkwheelhouse awscli cython
       - run: tox -e docs
       - run: S3_DIR=trace-dev rake release:docs
       - run: S3_DIR=trace-dev rake release:wheel


### PR DESCRIPTION
Latest build on `master` has failed at `deploy_dev` because `cython` wasn't installed.