### PR TITLE
fix(django): handle disallowed hosts

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -13,7 +13,6 @@ from inspect import isclass, isfunction
 
 from ddtrace import config, Pin
 from ddtrace.vendor import debtcollector, wrapt
-from ddtrace.compat import parse
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib import func_name, dbapi
 from ddtrace.ext import http, sql as sqlx, SpanTypes
@@ -394,21 +393,7 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
                 span.set_tag("http.route", route)
 
             # Set HTTP Request tags
-            # Build `http.url` tag value from request info
-            # DEV: We are explicitly omitting query strings since they may contain sensitive information
-            span.set_tag(
-                http.URL,
-                parse.urlunparse(
-                    parse.ParseResult(
-                        scheme=request.scheme,
-                        netloc=request.get_host(),  # this will include `host:port`
-                        path=request.path,
-                        params="",
-                        query="",
-                        fragment="",
-                    )
-                ),
-            )
+            span.set_tag(http.URL, utils.get_request_uri(request))
 
             response = func(*args, **kwargs)
 


### PR DESCRIPTION
Fixes #1231 

The new Django integration in `0.34.0` began using Django request's own methods to build the value for `http.url`. Unfortunately calling method threw an internal Django exception inside our patching code when a request host is not found in the `ALLOWED_HOSTS` setting.

This PR re-introduces `utils.get_request_uri()`  from `<0.34.0` and modifies it given the approach take in `0.34.0` but avoids throwing the exception by calling a different internal method for getting the request host. This latter modification only applies to `django>=1.19`.