### PR TITLE
chore(ci): use system Python version for flake8 and black target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -521,7 +521,6 @@ commands_pre=
 skip_install=true
 deps=black
 commands=black --check .
-basepython=python3.7
 
 [testenv:flake8]
 commands_pre=
@@ -536,7 +535,6 @@ deps=
   # needed for some features from flake8-rst-docstrings
   pygments
 commands=flake8 .
-basepython=python3.7
 
 [testenv:docs]
 commands_pre=


### PR DESCRIPTION
We specify Python 3.7 as a base in tox whereas the target runs on Python 3.8 in
the CI. Use the CI Python version rather than the one specified here.
