### PR TITLE
fix: local docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
             - ./setup.py:/src/setup.py:ro
             - ./conftest.py:/src/conftest.py:ro
             - ./tox.ini:/src/tox.ini:ro
-            - ./docs:/src/docs:ro
+            - ./docs:/src/docs:rw
             - ./pyproject.toml:/src/pyproject.toml:ro
             - ./.ddtox:/src/.tox
             - ./scripts:/src/scripts


### PR DESCRIPTION
Running `scripts/ddtest tox -e docs` locally fails due to read only access to mounted volume.