### PR TITLE
Use DATADOG_SERVICE_NAME as default tornado name

### DIFF
--- a/ddtrace/contrib/tornado/__init__.py
+++ b/ddtrace/contrib/tornado/__init__.py
@@ -92,7 +92,8 @@ Tornado settings can be used to change some tracing configuration, like::
 The available settings are:
 
 * ``default_service`` (default: `tornado-web`): set the service name used by the tracer. Usually
-  this configuration must be updated with a meaningful name.
+  this configuration must be updated with a meaningful name. Can also be configured via the
+  ``DATADOG_SERVICE_NAME`` environment variable.
 * ``tags`` (default: `{}`): set global tags that should be applied to all spans.
 * ``enabled`` (default: `True`): define if the tracer is enabled or not. If set to `false`, the
   code is still instrumented but no spans are sent to the APM agent.

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -1,3 +1,5 @@
+import os
+
 import ddtrace
 
 from tornado import template
@@ -17,7 +19,7 @@ def tracer_config(__init__, app, args, kwargs):
     # default settings
     settings = {
         'tracer': ddtrace.tracer,
-        'default_service': 'tornado-web',
+        'default_service': os.environ.get('DATADOG_SERVICE_NAME', 'tornado-web'),
         'distributed_tracing': True,
         'analytics_enabled': None
     }

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -19,7 +19,7 @@ def tracer_config(__init__, app, args, kwargs):
     # default settings
     settings = {
         'tracer': ddtrace.tracer,
-        'default_service': os.environ.get('DATADOG_SERVICE_NAME', 'tornado-web'),
+        'default_service': os.getenv('DATADOG_SERVICE_NAME', 'tornado-web'),
         'distributed_tracing': True,
         'analytics_enabled': None
     }


### PR DESCRIPTION
allow user to set tornado's trace app name via the `DATADOG_SERVICE_NAME` environment variable. flask integration supports this behavior, doc language has been copied from flask to tornado.

this is a huge help so that a simple tornado integration doesn't require any changes to the tornado application setup.