### PR TITLE
core: Add logs injection setting to Config

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -10,14 +10,13 @@ import logging
 
 from ddtrace.utils.formats import asbool, get_env
 from ddtrace.internal.logger import get_logger
-from ddtrace import constants
+from ddtrace import config, constants
 
-logs_injection = asbool(get_env("logs", "injection"))
 DD_LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] {}- %(message)s".format(
-    "[dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] " if logs_injection else ""
+    "[dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] " if config.logs_injection else ""
 )
 
-if logs_injection:
+if config.logs_injection:
     # immediately patch logging if trace id injected
     from ddtrace import patch
 
@@ -106,9 +105,6 @@ try:
 
     if opts:
         tracer.configure(**opts)
-
-    if logs_injection:
-        EXTRA_PATCHED_MODULES.update({"logging": True})
 
     if patch:
         update_patched_modules()

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -13,6 +13,7 @@ import threading
 from ddtrace.vendor.wrapt.importer import when_imported
 
 from .internal.logger import get_logger
+from .settings import config
 
 
 log = get_logger(__name__)
@@ -60,8 +61,8 @@ PATCH_MODULES = {
     'pylons': False,
     'pyramid': False,
 
-    # Standard library modules off by default
-    'logging': False,
+    # Auto-enable logging if the environment variable DD_LOGS_INJECTION is true
+    'logging': config.logs_injection,
 }
 
 _LOCK = threading.Lock()

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -30,6 +30,8 @@ class Config(object):
             get_env('trace', 'analytics_enabled', default=legacy_config_value)
         )
 
+        self.logs_injection = asbool(get_env("logs", "injection", default=False))
+
         self.report_hostname = asbool(
             get_env('trace', 'report_hostname', default=False)
         )

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -38,6 +38,15 @@ class TestConfig(BaseTestCase):
             config = Config()
             self.assertFalse(config.analytics_enabled)
 
+    def test_logs_injection(self):
+        with self.override_env(dict(DD_LOGS_INJECTION='True')):
+            config = Config()
+            self.assertTrue(config.logs_injection)
+
+        with self.override_env(dict(DD_LOGS_INJECTION='false')):
+            config = Config()
+            self.assertFalse(config.logs_injection)
+
 
 class TestHttpConfig(BaseTestCase):
 


### PR DESCRIPTION
This PR pulls out the logs injection setting stuff introduced coincidentally with #1211 and adds a simple test case.