### PR TITLE
guard against missing botocore response metadata

### DIFF
--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -70,8 +70,14 @@ def patched_api_call(original_func, instance, args, kwargs):
         result = original_func(*args, **kwargs)
 
         response_meta = result['ResponseMetadata']
-        span.set_tag(http.STATUS_CODE, response_meta['HTTPStatusCode'])
-        span.set_tag('retry_attempts', response_meta['RetryAttempts'])
+
+        http_status_code = response_meta.get('HTTPStatusCode')
+        if http_status_code:
+            span.set_tag(http.STATUS_CODE, http_status_code)
+
+        retry_attempts = response_meta.get('RetryAttempts')
+        if retry_attempts:
+            span.set_tag('retry_attempts', retry_attempts)
 
         request_id = response_meta.get('RequestId')
         if request_id:

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -71,17 +71,14 @@ def patched_api_call(original_func, instance, args, kwargs):
 
         response_meta = result['ResponseMetadata']
 
-        http_status_code = response_meta.get('HTTPStatusCode')
-        if http_status_code:
-            span.set_tag(http.STATUS_CODE, http_status_code)
+        if 'HTTPStatusCode' in response_meta:
+            span.set_tag(http.STATUS_CODE, response_meta['HTTPStatusCode'])
 
-        retry_attempts = response_meta.get('RetryAttempts')
-        if retry_attempts:
-            span.set_tag('retry_attempts', retry_attempts)
+        if 'RetryAttempts' in response_meta:
+            span.set_tag('retry_attempts', response_meta['RetryAttempts'])
 
-        request_id = response_meta.get('RequestId')
-        if request_id:
-            span.set_tag('aws.requestid', request_id)
+        if 'RequestId' in response_meta:
+            span.set_tag('aws.requestid', response_meta['RequestId'])
 
         # set analytics sample rate
         span.set_tag(


### PR DESCRIPTION
ran into an issue with the botocore patching due to a missing `RetryAttempts` key in the aws response metadata.

will be running this through some tests tomorrow but since it's a sensible change thought i'd put it up as a PR now.

also seems like guarding against unset metadata was already thumbs up'd in the original PR, just missed these two - https://github.com/DataDog/dd-trace-py/pull/1248#discussion_r389036357.

can update here once we've run this on our end!