### PR TITLE
fix(ci): do not use the machine executor for deploy_docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -747,10 +747,9 @@ jobs:
 
   deploy_docs:
     # deploy official documentation
-    <<: *machine_executor
+    executor: python38
     steps:
       - checkout
-      - *pyenv-set-global
       - deploy_docs:
           s3_dir: *s3_dir_prod
 


### PR DESCRIPTION
We don't use Docker so a simple Python image should be fine.

Partial revert of 5e8b3c419994c183677073d1075f2966b25684b1
