### PR TITLE
fix(aiobotocore): add support for aiobotocore>=0.11.0

### DIFF
--- a/ddtrace/contrib/aiobotocore/patch.py
+++ b/ddtrace/contrib/aiobotocore/patch.py
@@ -3,7 +3,11 @@ from ddtrace.vendor import wrapt
 from ddtrace import config
 import aiobotocore.client
 
-from aiobotocore.endpoint import ClientResponseContentProxy
+try:
+    from aiobotocore.endpoint import ClientResponseContentProxy
+except ImportError:
+    # aiobotocore>=0.11.0
+    from aiobotocore._endpoint_helpers import ClientResponseContentProxy
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY, SPAN_MEASURED_KEY
 from ...pin import Pin

--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,9 @@ envlist =
     {py27,py34,py35,py36,py37,py38}-test_logging
 # Integrations environments
     aiobotocore_contrib-py34-aiobotocore{02,03,04}
-    aiobotocore_contrib-{py35,py36}-aiobotocore{02,03,04,05,07,08,09,010}
+    aiobotocore_contrib-{py35,py36}-aiobotocore{02,03,04,05,07,08,09,010,011,latest}
     # aiobotocore 0.2 and 0.4 do not work because they use async as a reserved keyword
-    aiobotocore_contrib-py{37,38}-aiobotocore{03,05,07,08,09,010}
+    aiobotocore_contrib-py{37,38}-aiobotocore{03,05,07,08,09,010,011,latest}
     # Python 3.7 needs at least aiohttp 2.3
     aiohttp_contrib-{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
     aiohttp_contrib-{py34,py35,py36,py37,py38}-aiohttp23-aiohttp_jinja015-yarl10
@@ -194,6 +194,8 @@ deps =
 # backports
     py27: enum34
 # integrations
+    aiobotocorelatest: aiobotocore>=0.11
+    aiobotocore011: aiobotocore>=0.11,<0.12
     aiobotocore010: aiobotocore>=0.10,<0.11
     aiobotocore09: aiobotocore>=0.9,<0.10
     aiobotocore08: aiobotocore>=0.8,<0.9


### PR DESCRIPTION
Fixes #1247 

https://github.com/aio-libs/aiobotocore/pull/744 moved `ClientResponseContentProxy` from `aiobotocore.endpoint` to `aiobotocore._endpoint_helpers`