### PR TITLE
chore(ci): fix flake8 and pin pytest and readme_renderer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ commands:
       # DEV: `pyopenssl` needed until the following PR is released
       #      https://github.com/pypa/twine/pull/447
       # DEV: `wheel` is needed to run `bdist_wheel`
-      - run: pip install twine readme_renderer[md] pyopenssl wheel cython
+      - run: pip install twine readme_renderer[md]\<25.0 pyopenssl wheel cython
       # Ensure we didn't cache from previous runs
       - run: rm -rf build/ dist/
       # Manually build any extensions to ensure they succeed

--- a/tests/internal/runtime/utils.py
+++ b/tests/internal/runtime/utils.py
@@ -50,9 +50,9 @@ def cgroup_line_valid_test_cases():
 
     valid_test_cases = dict(
         (
-            ':'.join([id, ','.join(groups), path.format(container_id, pod_id)]),
+            ':'.join([id_, ','.join(groups), path.format(container_id, pod_id)]),
             CGroupInfo(
-                id=id,
+                id=id_,
                 groups=','.join(groups),
                 path=path.format(container_id, pod_id),
                 controllers=groups,
@@ -60,7 +60,7 @@ def cgroup_line_valid_test_cases():
                 pod_id=pod_id if '{1}' in path else None,
             )
         )
-        for path, id, groups, container_id, pod_id
+        for path, id_, groups, container_id, pod_id
         in itertools.product(paths, ids, controllers, container_ids, pod_ids)
     )
     # Dedupe test cases

--- a/tox.ini
+++ b/tox.ini
@@ -176,7 +176,7 @@ extras =
 deps =
     cython
     pdbpp
-    pytest>=3
+    pytest>=3,<5.4.0
     pytest-benchmark
     pytest-cov
     pytest-django


### PR DESCRIPTION
* fix(ci): pin pytest to avoid test failures
* chore: fix new flake8 warning about id
* fix(ci): pin readme_renderer since 25.0 dropped py34 support