### PR TITLE
core: Add support for DD_SERVICE

### DIFF
--- a/ddtrace/commands/ddtrace_run.py
+++ b/ddtrace/commands/ddtrace_run.py
@@ -29,10 +29,7 @@ Available environment variables:
     DATADOG_PATCH_MODULES=module:patch,module:patch... e.g. boto:true,redis:false : override the modules patched for this execution of the program (default: none)
     DATADOG_TRACE_AGENT_HOSTNAME=localhost: override the address of the trace agent host that the default tracer will attempt to submit to  (default: localhost)
     DATADOG_TRACE_AGENT_PORT=8126: override the port that the default tracer will submit to (default: 8126)
-    DATADOG_SERVICE_NAME : override the service name to be used for this program (no default)
-                           This value is passed through when setting up middleware for web framework integrations.
-                           (e.g. pylons, flask, django)
-                           For tracing without a web integration, prefer setting the service name in code.
+    DD_SERVICE : override the service name to be used for this program (default only for select web integrations)
     DATADOG_PRIORITY_SAMPLING=true|false : (default: false): enables Priority Sampling.
 """  # noqa: E501
 

--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -9,6 +9,7 @@ ORIGIN_KEY = '_dd.origin'
 HOSTNAME_KEY = '_dd.hostname'
 ENV_KEY = 'env'
 VERSION_KEY = 'version'
+SERVICE_KEY = 'service.name'
 SERVICE_VERSION_KEY = 'service.version'
 SPAN_MEASURED_KEY = '_dd.measured'
 

--- a/ddtrace/contrib/bottle/patch.py
+++ b/ddtrace/contrib/bottle/patch.py
@@ -1,5 +1,3 @@
-import os
-
 from .trace import TracePlugin
 
 import bottle

--- a/ddtrace/contrib/bottle/patch.py
+++ b/ddtrace/contrib/bottle/patch.py
@@ -4,6 +4,7 @@ from .trace import TracePlugin
 
 import bottle
 
+from ddtrace import config
 from ddtrace.vendor import wrapt
 
 
@@ -20,7 +21,7 @@ def patch():
 def traced_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
 
-    service = os.environ.get('DATADOG_SERVICE_NAME') or 'bottle'
+    service = config.get_service(default="bottle")
 
     plugin = TracePlugin(service=service)
     instance.install(plugin)

--- a/ddtrace/contrib/celery/constants.py
+++ b/ddtrace/contrib/celery/constants.py
@@ -1,4 +1,4 @@
-from os import getenv
+from ddtrace import config
 
 # Celery Context key
 CTX_KEY = '__dd_task_span'
@@ -16,7 +16,5 @@ TASK_RETRY_REASON_KEY = 'celery.retry.reason'
 
 # Service info
 APP = 'celery'
-# `getenv()` call must be kept for backward compatibility; we may remove it
-# later when we do a full migration to the `Config` class
-PRODUCER_SERVICE = getenv('DATADOG_SERVICE_NAME') or 'celery-producer'
-WORKER_SERVICE = getenv('DATADOG_SERVICE_NAME') or 'celery-worker'
+PRODUCER_SERVICE = config.get_service(default="celery-producer")
+WORKER_SERVICE = config.get_service(default="celery-worker")

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -32,7 +32,7 @@ log = get_logger(__name__)
 config._add(
     "django",
     dict(
-        service_name=os.environ.get("DD_SERVICE_NAME") or os.environ.get("DATADOG_SERVICE_NAME") or "django",
+        service_name=config.get_service(default="django"),
         cache_service_name=get_env("django", "cache_service_name") or "django",
         database_service_name_prefix=get_env("django", "database_service_name_prefix", default=""),
         distributed_tracing_enabled=True,

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -6,7 +6,6 @@ Django internals are instrumented via normal `patch()`.
 `django.apps.registry.Apps.populate` is patched to add instrumentation for any
 specific Django apps like Django Rest Framework (DRF).
 """
-import os
 import sys
 
 from inspect import isclass, isfunction

--- a/ddtrace/contrib/falcon/patch.py
+++ b/ddtrace/contrib/falcon/patch.py
@@ -1,9 +1,7 @@
-import os
-from ddtrace import config
-from ddtrace.vendor import wrapt
 import falcon
 
-from ddtrace import tracer
+from ddtrace import config, tracer
+from ddtrace.vendor import wrapt
 
 from .middleware import TraceMiddleware
 from ...utils.formats import asbool, get_env

--- a/ddtrace/contrib/falcon/patch.py
+++ b/ddtrace/contrib/falcon/patch.py
@@ -1,4 +1,5 @@
 import os
+from ddtrace import config
 from ddtrace.vendor import wrapt
 import falcon
 
@@ -22,7 +23,7 @@ def patch():
 
 def traced_init(wrapped, instance, args, kwargs):
     mw = kwargs.pop('middleware', [])
-    service = os.environ.get('DATADOG_SERVICE_NAME') or 'falcon'
+    service = config.get_service(default="falcon")
     distributed_tracing = asbool(get_env('falcon', 'distributed_tracing', default=True))
 
     mw.insert(0, TraceMiddleware(tracer, service, distributed_tracing))

--- a/ddtrace/contrib/flask/__init__.py
+++ b/ddtrace/contrib/flask/__init__.py
@@ -49,7 +49,7 @@ Configuration
 
    The service name reported for your Flask app.
 
-   Can also be configured via the ``DATADOG_SERVICE_NAME`` environment variable.
+   Can also be configured via the ``DD_SERVICE`` environment variable.
 
    Default: ``'flask'``
 

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -1,5 +1,3 @@
-import os
-
 import flask
 import werkzeug
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
@@ -25,8 +23,7 @@ FLASK_VERSION = 'flask.version'
 # Configure default configuration
 config._add('flask', dict(
     # Flask service configuration
-    # DEV: Environment variable 'DATADOG_SERVICE_NAME' used for backwards compatibility
-    service_name=os.environ.get('DATADOG_SERVICE_NAME') or 'flask',
+    service_name=config.get_service(default="flask"),
     app='flask',
 
     collect_view_args=True,

--- a/ddtrace/contrib/grpc/patch.py
+++ b/ddtrace/contrib/grpc/patch.py
@@ -1,5 +1,4 @@
 import grpc
-import os
 
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 from ddtrace import config, Pin
@@ -12,7 +11,7 @@ from .server_interceptor import create_server_interceptor
 
 
 config._add('grpc_server', dict(
-    service_name=os.environ.get('DATADOG_SERVICE_NAME', constants.GRPC_SERVICE_SERVER),
+    service_name=config.get_service(default=constants.GRPC_SERVICE_SERVER),
     distributed_tracing_enabled=True,
 ))
 
@@ -20,8 +19,8 @@ config._add('grpc_server', dict(
 # compatibility but should change in future
 config._add('grpc', dict(
     service_name='{}-{}'.format(
-        os.environ.get('DATADOG_SERVICE_NAME'), constants.GRPC_SERVICE_CLIENT
-    ) if os.environ.get('DATADOG_SERVICE_NAME') else constants.GRPC_SERVICE_CLIENT,
+        config.get_service(), constants.GRPC_SERVICE_CLIENT
+    ) if config.get_service() else constants.GRPC_SERVICE_CLIENT,
     distributed_tracing_enabled=True,
 ))
 

--- a/ddtrace/contrib/pylons/patch.py
+++ b/ddtrace/contrib/pylons/patch.py
@@ -1,4 +1,5 @@
 import os
+from ddtrace import config
 from ddtrace.vendor import wrapt
 import pylons.wsgiapp
 
@@ -31,7 +32,7 @@ def traced_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
 
     # set tracing options and create the TraceMiddleware
-    service = os.environ.get('DATADOG_SERVICE_NAME', 'pylons')
+    service = config.get_service(default="pylons")
     distributed_tracing = asbool(get_env('pylons', 'distributed_tracing', default=True))
     Pin(service=service, tracer=tracer).onto(instance)
     traced_app = PylonsTraceMiddleware(instance, tracer, service=service, distributed_tracing=distributed_tracing)

--- a/ddtrace/contrib/pylons/patch.py
+++ b/ddtrace/contrib/pylons/patch.py
@@ -1,4 +1,3 @@
-import os
 from ddtrace import config
 from ddtrace.vendor import wrapt
 import pylons.wsgiapp

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -10,6 +10,7 @@ from ...utils.formats import asbool, get_env
 import pyramid.config
 from pyramid.path import caller_package
 
+from ddtrace import config
 from ddtrace.vendor import wrapt
 
 DD_PATCH = '_datadog_patch'
@@ -29,7 +30,7 @@ def patch():
 
 def traced_init(wrapped, instance, args, kwargs):
     settings = kwargs.pop('settings', {})
-    service = os.environ.get('DATADOG_SERVICE_NAME') or 'pyramid'
+    service = config.get_service(default="pyramid")
     distributed_tracing = asbool(get_env('pyramid', 'distributed_tracing', default=True))
     # DEV: integration-specific analytics flag can be not set but still enabled
     # globally for web frameworks

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -1,5 +1,3 @@
-import os
-
 from .trace import trace_pyramid, DD_TWEEN_NAME
 from .constants import (
     SETTINGS_SERVICE, SETTINGS_DISTRIBUTED_TRACING,

--- a/ddtrace/contrib/tornado/__init__.py
+++ b/ddtrace/contrib/tornado/__init__.py
@@ -93,7 +93,7 @@ The available settings are:
 
 * ``default_service`` (default: `tornado-web`): set the service name used by the tracer. Usually
   this configuration must be updated with a meaningful name. Can also be configured via the
-  ``DATADOG_SERVICE_NAME`` environment variable.
+  ``DD_SERVICE`` environment variable.
 * ``tags`` (default: `{}`): set global tags that should be applied to all spans.
 * ``enabled`` (default: `True`): define if the tracer is enabled or not. If set to `false`, the
   code is still instrumented but no spans are sent to the APM agent.

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -1,5 +1,3 @@
-import os
-
 import ddtrace
 from ddtrace import config
 

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -1,6 +1,7 @@
 import os
 
 import ddtrace
+from ddtrace import config
 
 from tornado import template
 
@@ -19,7 +20,7 @@ def tracer_config(__init__, app, args, kwargs):
     # default settings
     settings = {
         'tracer': ddtrace.tracer,
-        'default_service': os.getenv('DATADOG_SERVICE_NAME', 'tornado-web'),
+        'default_service': config.get_service("tornado-web"),
         'distributed_tracing': True,
         'analytics_enabled': None
     }

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -32,6 +32,8 @@ class Config(object):
 
         self.env = get_env("env")
 
+        self.service = get_env("service")
+
         self.version = get_env("version")
 
         self.logs_injection = asbool(get_env("logs", "injection", default=False))

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 from ..internal.logger import get_logger
 from ..pin import Pin
+from ..utils.deprecation import get_service_legacy
 from ..utils.formats import asbool
 from ..utils.merge import deepmerge
 from .http import HttpConfig
@@ -31,11 +32,8 @@ class Config(object):
         )
 
         self.env = get_env("env")
-
         self.service = get_env("service")
-
         self.version = get_env("version")
-
         self.logs_injection = asbool(get_env("logs", "injection", default=False))
 
         self.report_hostname = asbool(
@@ -113,6 +111,9 @@ class Config(object):
         :rtype: bool
         """
         return self._http.header_is_traced(header_name)
+
+    def get_service(default=None):
+        return self.service if self.service is not None else get_service_legacy(default=default)
 
     def __repr__(self):
         cls = self.__class__

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -113,6 +113,18 @@ class Config(object):
         return self._http.header_is_traced(header_name)
 
     def get_service(self, default=None):
+        """
+        Returns the globally configured service.
+
+        If a service is not configured globally, attempts to get the service
+        using the legacy environment variables via ``get_service_legacy``
+        else ``default`` is returned.
+
+        :param default: the default service to use if none is configured or
+            found.
+        :type default: str
+        :rtype: str|None
+        """
         return self.service if self.service is not None else get_service_legacy(default=default)
 
     def __repr__(self):

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -112,7 +112,7 @@ class Config(object):
         """
         return self._http.header_is_traced(header_name)
 
-    def get_service(default=None):
+    def get_service(self, default=None):
         return self.service if self.service is not None else get_service_legacy(default=default)
 
     def __repr__(self):

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -6,7 +6,8 @@ import traceback
 from .compat import StringIO, stringify, iteritems, numeric_types, time_ns, is_integer
 from .constants import (
     NUMERIC_TAGS, MANUAL_DROP_KEY, MANUAL_KEEP_KEY,
-    VERSION_KEY, SERVICE_VERSION_KEY, SPAN_MEASURED_KEY
+    VERSION_KEY, SERVICE_VERSION_KEY, SPAN_MEASURED_KEY,
+    SERVICE_KEY,
 )
 from .ext import SpanTypes, errors, priority, net, http
 from .internal.logger import get_logger
@@ -207,6 +208,8 @@ class Span(object):
         elif key == MANUAL_DROP_KEY:
             self.context.sampling_priority = priority.USER_REJECT
             return
+        elif key == SERVICE_KEY:
+            self.service = value
         elif key == SERVICE_VERSION_KEY:
             # Also set the `version` tag to the same value
             # DEV: Note that we do no return, we want to set both

--- a/ddtrace/utils/deprecation.py
+++ b/ddtrace/utils/deprecation.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 
 from functools import wraps
@@ -59,3 +60,18 @@ def deprecated(message="", version=None):
         return wrapper
 
     return decorator
+
+
+def get_service_legacy(default=None):
+    """Helper to print out a warning if old service name environment variables
+    are used.
+
+    If the environment variables are not in use, no deprecation warning is
+    produced and `default` is returned.
+    """
+    for old_env_key in ["DD_SERVICE_NAME", "DATADOG_SERVICE_NAME"]:
+        if old_env_key in os.environ:
+            deprecation("'{}' is deprecated and will be removed in a future version. Please use DD_SERVICE instead.".format(old_env_key))
+            return os.getenv(old_env_key)
+
+    return default

--- a/ddtrace/utils/deprecation.py
+++ b/ddtrace/utils/deprecation.py
@@ -1,7 +1,8 @@
 import os
 import warnings
-
 from functools import wraps
+
+from ddtrace.vendor import debtcollector
 
 
 class RemovedInDDTrace10Warning(DeprecationWarning):
@@ -71,7 +72,7 @@ def get_service_legacy(default=None):
     """
     for old_env_key in ["DD_SERVICE_NAME", "DATADOG_SERVICE_NAME"]:
         if old_env_key in os.environ:
-            deprecation(
+            debtcollector.deprecate(
                 "'{}' is deprecated and will be removed in a future version. Please use DD_SERVICE instead.".format(
                     old_env_key
                 )

--- a/ddtrace/utils/deprecation.py
+++ b/ddtrace/utils/deprecation.py
@@ -71,7 +71,11 @@ def get_service_legacy(default=None):
     """
     for old_env_key in ["DD_SERVICE_NAME", "DATADOG_SERVICE_NAME"]:
         if old_env_key in os.environ:
-            deprecation("'{}' is deprecated and will be removed in a future version. Please use DD_SERVICE instead.".format(old_env_key))
+            deprecation(
+                "'{}' is deprecated and will be removed in a future version. Please use DD_SERVICE instead.".format(
+                    old_env_key
+                )
+            )
             return os.getenv(old_env_key)
 
     return default

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -565,10 +565,9 @@ The available environment variables for ``ddtrace-run`` are:
 * ``DD_VERSION`` (no default): Set an application's version e.g. ``1.2.3``, ``6c44da20``, ``2020.02.13``
 * ``DATADOG_TRACE_DEBUG=true|false`` (default: false): Enable debug logging in
   the tracer
-* ``DATADOG_SERVICE_NAME`` (no default): override the service name to be used
-  for this program. This value is passed through when setting up middleware for
-  web framework integrations (e.g. pylons, flask, django). For tracing without a
-  web integration, prefer setting the service name in code.
+* ``DD_SERVICE`` (no default): override the service name to be used for this
+  application. A default is provided for the bottle, flask, grpc, pyramid,
+  pylons, tornado, celery, django and falcon integrations.
 * ``DATADOG_PATCH_MODULES=module:patch,module:patch...`` e.g.
   ``boto:true,redis:false``: override the modules patched for this execution of
   the program (default: none)

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -45,6 +45,7 @@ class BaseTestCase(unittest.TestCase):
             "health_metrics_enabled",
             "env",
             "version",
+            "service",
         ]
 
         # Grab the current values of all keys

--- a/tests/commands/ddtrace_run_service.py
+++ b/tests/commands/ddtrace_run_service.py
@@ -1,5 +1,6 @@
 import os
 
 if __name__ == '__main__':
-    assert os.environ['DATADOG_SERVICE_NAME'] == 'my_test_service'
+    assert os.environ['DATADOG_SERVICE_NAME'] == 'my_test_service' or \
+           os.environ["DD_SERVICE"] == "my_test_service"
     print('Test success')

--- a/tests/commands/ddtrace_run_service.py
+++ b/tests/commands/ddtrace_run_service.py
@@ -1,6 +1,5 @@
 import os
 
-if __name__ == '__main__':
-    assert os.environ['DATADOG_SERVICE_NAME'] == 'my_test_service' or \
-           os.environ["DD_SERVICE"] == "my_test_service"
-    print('Test success')
+if __name__ == "__main__":
+    assert os.getenv("DATADOG_SERVICE_NAME") == "my_test_service" or os.getenv("DD_SERVICE") == "my_test_service"
+    print("Test success")

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -30,11 +30,21 @@ def inject_sitecustomize(path):
 
 
 class DdtraceRunTest(BaseTestCase):
-    def test_service_name_passthrough(self):
+    def test_service_name_passthrough_legacy(self):
         """
         $DATADOG_SERVICE_NAME gets passed through to the program
         """
         with self.override_env(dict(DATADOG_SERVICE_NAME='my_test_service')):
+            out = subprocess.check_output(
+                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_service.py']
+            )
+            assert out.startswith(b'Test success')
+
+    def test_service_name_passthrough(self):
+        """
+        $DD_SERVICE gets passed through to the program
+        """
+        with self.override_env(dict(DD_SERVICE='my_test_service')):
             out = subprocess.check_output(
                 ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_service.py']
             )

--- a/tests/subprocesstest.py
+++ b/tests/subprocesstest.py
@@ -16,7 +16,7 @@ SUBPROC_TEST_ENV_ATTR = '_subproc_test_env'
 SUBPROC_ENV_VAR = 'SUBPROCESS_TEST'
 
 
-def run_in_subprocess(*args, env_override=None):
+def run_in_subprocess(*args, **kwargs):
     """
     Marks a test case that is to be run in its own 'clean' interpreter instance.
 
@@ -58,13 +58,15 @@ def run_in_subprocess(*args, env_override=None):
     :param env_override: dict of environment variables to provide to the subprocess.
     :return:
     """
+    env_overrides = kwargs.get("env_overrides")
+
     def wrapper(obj):
         setattr(obj, SUBPROC_TEST_ATTR, True)
-        if env_override is not None:
-            setattr(obj, SUBPROC_TEST_ENV_ATTR, env_override)
+        if env_overrides is not None:
+            setattr(obj, SUBPROC_TEST_ENV_ATTR, env_overrides)
         return obj
 
-    # Support both @run_in_subprocess and @run_in_subprocess(env_override=...) usage
+    # Support both @run_in_subprocess and @run_in_subprocess(env_overrides=...) usage
     if len(args) == 1 and callable(args[0]):
         return wrapper(args[0])
     else:

--- a/tests/subprocesstest.py
+++ b/tests/subprocesstest.py
@@ -16,7 +16,7 @@ SUBPROC_TEST_ENV_ATTR = '_subproc_test_env'
 SUBPROC_ENV_VAR = 'SUBPROCESS_TEST'
 
 
-def run_in_subprocess(env_override=None):
+def run_in_subprocess(*args, env_override=None):
     """
     Marks a test case that is to be run in its own 'clean' interpreter instance.
 
@@ -63,7 +63,12 @@ def run_in_subprocess(env_override=None):
         if env_override is not None:
             setattr(obj, SUBPROC_TEST_ENV_ATTR, env_override)
         return obj
-    return wrapper
+
+    # Support both @run_in_subprocess and @run_in_subprocess(env_override=...) usage
+    if len(args) == 1 and callable(args[0]):
+        return wrapper(args[0])
+    else:
+        return wrapper
 
 
 class SubprocessTestCase(unittest.TestCase):

--- a/tests/subprocesstest.py
+++ b/tests/subprocesstest.py
@@ -12,15 +12,19 @@ import unittest
 
 
 SUBPROC_TEST_ATTR = '_subproc_test'
+SUBPROC_TEST_ENV_ATTR = '_subproc_test_env'
 SUBPROC_ENV_VAR = 'SUBPROCESS_TEST'
 
 
-def run_in_subprocess(obj):
+def run_in_subprocess(env_override=None):
     """
     Marks a test case that is to be run in its own 'clean' interpreter instance.
 
-    When applied to a TestCase class, each method will be run in a separate
-    interpreter instance.
+    When applied to a SubprocessTestCase class, each method will be run in a
+    separate interpreter instance.
+
+    When applied only to a method of a SubprocessTestCase, only the method
+    will be run in a separate interpreter instance.
 
     Usage on a class::
 
@@ -44,14 +48,22 @@ def run_in_subprocess(obj):
         class OtherTests(SubprocessTestCase):
             @run_in_subprocess
             def test_case(self):
+                # Run in subprocess
                 pass
 
+            def test_case(self):
+                # NOT run in subprocess
+                pass
 
-    :param obj: method or class to run in a separate python interpreter.
+    :param env_override: dict of environment variables to provide to the subprocess.
     :return:
     """
-    setattr(obj, SUBPROC_TEST_ATTR, True)
-    return obj
+    def wrapper(obj):
+        setattr(obj, SUBPROC_TEST_ATTR, True)
+        if env_override is not None:
+            setattr(obj, SUBPROC_TEST_ENV_ATTR, env_override)
+        return obj
+    return wrapper
 
 
 class SubprocessTestCase(unittest.TestCase):
@@ -63,7 +75,7 @@ class SubprocessTestCase(unittest.TestCase):
         # method is defined on another class.
         # A concrete case of this is a parent and child TestCase where the child
         # doesn't override a parent test method. The full_method_name we want
-        # is that of the child test method (even though it exists on the parent)
+        # is that of the child test method (even though it exists on the parent).
         modpath = test.__self__.__class__.__module__
         clsname = test.__self__.__class__.__name__
         testname = test.__name__
@@ -73,9 +85,11 @@ class SubprocessTestCase(unittest.TestCase):
     def _run_test_in_subprocess(self, result):
         full_testcase_name = self._full_method_name()
 
-        # copy the environment and include the special subprocess environment
-        # variable for the subprocess to detect
+        # Copy the environment and include the special subprocess environment
+        # variable for the subprocess to detect.
+        env_overrides = self._get_env_overrides()
         sp_test_env = os.environ.copy()
+        sp_test_env.update(env_overrides)
         sp_test_env[SUBPROC_ENV_VAR] = 'True'
         sp_test_cmd = ['python', '-m', 'unittest', full_testcase_name]
         sp = subprocess.Popen(
@@ -120,6 +134,16 @@ class SubprocessTestCase(unittest.TestCase):
             return True
 
         return False
+
+    def _get_env_overrides(self):
+        if hasattr(self, SUBPROC_TEST_ENV_ATTR):
+            return getattr(self, SUBPROC_TEST_ENV_ATTR)
+
+        test = getattr(self, self._testMethodName)
+        if hasattr(test, SUBPROC_TEST_ENV_ATTR):
+            return getattr(test, SUBPROC_TEST_ENV_ATTR)
+
+        return {}
 
     def run(self, result=None):
         if not self._is_subprocess_test():

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -31,14 +31,14 @@ def get_dummy_tracer():
 class EnvTracerTestCase(SubprocessTestCase, BaseTracerTestCase):
     """Tracer test cases requiring environment variables.
     """
-    @run_in_subprocess(env_override=dict(DD_SERVICE="mysvc"))
+    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_service_name_env(self):
         span = self.start_span("")
         span.assert_matches(
             service="mysvc",
         )
 
-    @run_in_subprocess(env_override=dict(DD_SERVICE="mysvc"))
+    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_service_name_env_global_config(self):
         # Global config should have higher precedence than the environment variable
         with self.override_global_config(dict(service="overridesvc")):

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -47,6 +47,16 @@ class TestConfig(BaseTestCase):
             config = Config()
             self.assertFalse(config.logs_injection)
 
+    def test_service(self):
+        # If none is provided the default should be ``None``
+        with self.override_env(dict()):
+            config = Config()
+            self.assertEqual(config.service, None)
+
+        with self.override_env(dict(DD_SERVICE="my-service")):
+            config = Config()
+            self.assertEqual(config.service, "my-service")
+
 
 class TestHttpConfig(BaseTestCase):
 


### PR DESCRIPTION
This PR introduces support for `DD_SERVICE` environment variable and `ddtrace.config.server`. It also adds support for OpenCensus service name configuration via `span.set_tag('service.name', 'mysvc')`.

Tests are added to confirm precedence in service name configuration.

### backwards compatibility
`{DD,DATADOG}_SERVICE_NAME` support is left in-place for the integrations that used it (django, flask, falcon, tornado, celery, pylons, pyramid, grpc). A helper deprecation function `get_service_legacy` is added to deal with deprecating the old variables.

### internal
In order to create robust tests for environment configuration, an addition was added to `run_in_subprocess` to support passing custom environment variables to the subprocess.