### PR TITLE
fix(tests,profile): do not test the number of locking events

### DIFF
--- a/tests/profile/simple_program_fork.py
+++ b/tests/profile/simple_program_fork.py
@@ -37,18 +37,15 @@ if child_pid == 0:
 
     assert recorder is not parent_recorder
 
-    release_events_nb = len(recorder.events[cthreading.LockReleaseEvent])
-
     # Release it
     lock.release()
 
     # We don't track it
     assert test_lock_name not in set(e.lock_name for e in recorder.events[cthreading.LockReleaseEvent])
-    assert release_events_nb == len(recorder.events[cthreading.LockReleaseEvent])
 
     # We track this one though
     lock = threading.Lock()
-    test_lock_name = "simple_program_fork.py:50"
+    test_lock_name = "simple_program_fork.py:47"
     assert test_lock_name not in set(e.lock_name for e in recorder.events[cthreading.LockAcquireEvent])
     lock.acquire()
     assert test_lock_name in set(e.lock_name for e in recorder.events[cthreading.LockAcquireEvent])


### PR DESCRIPTION
This test can be false in Python 2.7 (at least) since it's possible that we
catch the profiler background thread using a lock — the Python 2 threading
module uses one.

Only do a check based on the lock name, that ought to be enough.