### PR TITLE
fix: do not build wheels on Python 3.4 + run test buildin wheels in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -696,6 +696,14 @@ jobs:
       - save_results
       - save_tox_cache
 
+  build_wheels:
+    <<: *machine_executor
+    steps:
+      - checkout
+      - *pyenv-set-global
+      - run: pip install cython
+      - run: scripts/build-dist
+
   deploy_master:
     # build the master branch releasing development docs and wheels
     <<: *machine_executor
@@ -805,6 +813,7 @@ workflows:
       - test_build_py36: *requires_pre_test
       - test_build_py35: *requires_pre_test
       - test_build_py27: *requires_pre_test
+      - build_wheels: *requires_pre_test
 
       # Integration test suites
       - aiobotocore: *requires_pre_test

--- a/scripts/build-dist
+++ b/scripts/build-dist
@@ -16,8 +16,11 @@ mkdir -p "$BUILD_DIR"
 build_script=$(cat <<'EOF'
 set -ex
 
+# This is used for pattern matching and excluding Python versions
+shopt -s extglob
+
 # Build linux wheels from the source distribution we created
-for PYBIN in /opt/python/*/bin;
+for PYBIN in /opt/python/!(cp34*)/bin;
 do
   "${PYBIN}/pip" wheel --no-deps /dd-trace-py/*.tar.gz -w /dd-trace-py
 done


### PR DESCRIPTION
Testing scripts/build-dist should make sure we don't break it when it's running
on post-commit.
