### PR TITLE
fix(tests,profiling): correct number of frames handling

### DIFF
--- a/tests/profile/collector/test_stack.py
+++ b/tests/profile/collector/test_stack.py
@@ -66,7 +66,7 @@ def test_collect_once():
     assert e.thread_id > 0
     # Thread name is None with gevent
     assert isinstance(e.thread_name, (str, type(None)))
-    assert len(e.frames) > 1
+    assert len(e.frames) >= 1
     assert e.frames[0][0].endswith(".py")
     assert e.frames[0][1] > 0
     assert isinstance(e.frames[0][2], str)


### PR DESCRIPTION
The number frames can actually be 1. In rare circumstances, the first event we
get can be e.g. catching the bootstrap of a thread which is only a frame like:
  [('/root/.pyenv/versions/2.7.17/lib/python2.7/threading.py', 774, '__bootstrap')]

In that case, the test was a little bit too strict.