### PR TITLE
Ensure DD_SERVICE is not used for external integrations

### DIFF
--- a/ddtrace/contrib/grpc/patch.py
+++ b/ddtrace/contrib/grpc/patch.py
@@ -15,6 +15,8 @@ config._add('grpc_server', dict(
     distributed_tracing_enabled=True,
 ))
 
+# TODO[tbutt]: keeping name for client config unchanged to maintain backwards
+# compatibility but should change in future
 config._add('grpc', dict(
     service_name='{}-{}'.format(
         config.get_service(), constants.GRPC_SERVICE_CLIENT

--- a/ddtrace/contrib/grpc/patch.py
+++ b/ddtrace/contrib/grpc/patch.py
@@ -15,8 +15,6 @@ config._add('grpc_server', dict(
     distributed_tracing_enabled=True,
 ))
 
-# TODO[tbutt]: keeping name for client config unchanged to maintain backwards
-# compatibility but should change in future
 config._add('grpc', dict(
     service_name='{}-{}'.format(
         config.get_service(), constants.GRPC_SERVICE_CLIENT

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -1,15 +1,15 @@
 import contextlib
 import sys
-import unittest
 
 import ddtrace
 
+from ..subprocesstest import SubprocessTestCase
 from ..utils import override_env
 from ..utils.tracer import DummyTracer
 from ..utils.span import TestSpanContainer, TestSpan, NO_CHILDREN
 
 
-class BaseTestCase(unittest.TestCase):
+class BaseTestCase(SubprocessTestCase):
     """
     BaseTestCase extends ``unittest.TestCase`` to provide some useful helpers/assertions
 

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -4,7 +4,6 @@ import unittest
 
 import ddtrace
 
-from ..subprocesstest import SubprocessTestCase
 from ..utils import override_env
 from ..utils.tracer import DummyTracer
 from ..utils.span import TestSpanContainer, TestSpan, NO_CHILDREN
@@ -134,7 +133,7 @@ class BaseTestCase(unittest.TestCase):
 override_config = BaseTestCase.override_config
 
 
-class BaseTracerTestCase(SubprocessTestCase, TestSpanContainer, BaseTestCase):
+class BaseTracerTestCase(TestSpanContainer, BaseTestCase):
     """
     BaseTracerTestCase is a base test case for when you need access to a dummy tracer and span assertions
     """

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -4,6 +4,7 @@ import unittest
 
 import ddtrace
 
+from ..subprocesstest import SubprocessTestCase
 from ..utils import override_env
 from ..utils.tracer import DummyTracer
 from ..utils.span import TestSpanContainer, TestSpan, NO_CHILDREN
@@ -133,7 +134,7 @@ class BaseTestCase(unittest.TestCase):
 override_config = BaseTestCase.override_config
 
 
-class BaseTracerTestCase(TestSpanContainer, BaseTestCase):
+class BaseTracerTestCase(SubprocessTestCase, TestSpanContainer, BaseTestCase):
     """
     BaseTracerTestCase is a base test case for when you need access to a dummy tracer and span assertions
     """

--- a/tests/contrib/aiopg/test.py
+++ b/tests/contrib/aiopg/test.py
@@ -16,6 +16,7 @@ from tests.opentracer.utils import init_tracer
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.test_tracer import get_dummy_tracer
 from tests.contrib.asyncio.utils import AsyncioTestCase, mark_asyncio
+from ...subprocesstest import run_in_subprocess
 from ...utils import assert_is_measured
 
 
@@ -197,6 +198,26 @@ class AiopgTestCase(AsyncioTestCase):
         spans = writer.pop()
         assert spans, spans
         assert len(spans) == 1
+
+    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_user_specified_service(self):
+        """
+        When a user specifies a service for the app
+            The aiopg integration should not use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+        assert config.service == "mysvc"
+
+        conn = yield from aiopg.connect(**POSTGRES_CONFIG)
+        Pin.get_from(conn).clone(tracer=self.tracer).onto(conn)
+        yield from (yield from conn.cursor()).execute('select \'blah\'')
+        conn.close()
+
+        spans = self.get_spans()
+        assert spans, spans
+        assert len(spans) == 1
+        assert spans[0].service != "mysvc"
 
 
 class AiopgAnalyticsTestCase(AiopgTestCase):

--- a/tests/contrib/cassandra/test.py
+++ b/tests/contrib/cassandra/test.py
@@ -483,6 +483,10 @@ class TestCassandraConfig(SubprocessTestCase):
         When a user specifies a service for the app
             The cassandra integration should not use it.
         """
+        # Ensure that the service name was configured
+        from ddtrace import config
+        assert config.service == "mysvc"
+
         self.session.execute(self.TEST_QUERY)
         spans = self.tracer.writer.pop()
         assert spans

--- a/tests/contrib/cassandra/test.py
+++ b/tests/contrib/cassandra/test.py
@@ -19,7 +19,7 @@ from ddtrace import config, Pin
 from tests.contrib.config import CASSANDRA_CONFIG
 from tests.opentracer.utils import init_tracer
 from tests.test_tracer import get_dummy_tracer
-from ...subprocesstest import SubprocessTestCase, run_in_subprocess
+from ...base import BaseTracerTestCase
 from ...utils import assert_is_measured
 
 # Oftentimes our tests fails because Cassandra connection timeouts during keyspace drop. Slowness in keyspace drop
@@ -462,7 +462,7 @@ def test_backwards_compat_get_traced_cassandra():
     session.execute('drop table if exists test.person')
 
 
-class TestCassandraConfig(SubprocessTestCase):
+class TestCassandraConfig(BaseTracerTestCase):
     """
     Test various configurations of the Cassandra integration.
     """
@@ -477,7 +477,7 @@ class TestCassandraConfig(SubprocessTestCase):
         Pin.get_from(self.cluster).clone(tracer=self.tracer).onto(self.cluster)
         self.session = self.cluster.connect(self.TEST_KEYSPACE)
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service(self):
         """
         When a user specifies a service for the app

--- a/tests/contrib/elasticsearch/test.py
+++ b/tests/contrib/elasticsearch/test.py
@@ -12,8 +12,9 @@ from ddtrace.contrib.elasticsearch.patch import patch, unpatch
 # testing
 from tests.opentracer.utils import init_tracer
 from ..config import ELASTICSEARCH_CONFIG
-from ...test_tracer import get_dummy_tracer
 from ...base import BaseTracerTestCase
+from ...subprocesstest import SubprocessTestCase, run_in_subprocess
+from ...test_tracer import get_dummy_tracer
 from ...utils import assert_span_http_status_code, assert_is_measured
 
 
@@ -197,7 +198,7 @@ class ElasticsearchTest(unittest.TestCase):
         assert dd_span.resource == 'PUT /%s' % self.ES_INDEX
 
 
-class ElasticsearchPatchTest(BaseTracerTestCase):
+class ElasticsearchPatchTest(SubprocessTestCase, BaseTracerTestCase):
     """
     Elasticsearch integration test suite.
     Need a running ElasticSearch.
@@ -391,3 +392,16 @@ class ElasticsearchPatchTest(BaseTracerTestCase):
         self.reset()
         assert spans, spans
         assert len(spans) == 1
+
+    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_user_specified_service(self):
+        """
+        When a user specifies a service for the app
+            The elasticsearch integration should not use it.
+        """
+        self.es.indices.create(index=self.ES_INDEX, ignore=400)
+        Pin(service="es", tracer=self.tracer).onto(self.es.transport)
+        spans = self.get_spans()
+        self.reset()
+        assert len(spans) == 1
+        assert spans[0].service != "mysvc"

--- a/tests/contrib/elasticsearch/test.py
+++ b/tests/contrib/elasticsearch/test.py
@@ -13,7 +13,7 @@ from ddtrace.contrib.elasticsearch.patch import patch, unpatch
 from tests.opentracer.utils import init_tracer
 from ..config import ELASTICSEARCH_CONFIG
 from ...base import BaseTracerTestCase
-from ...subprocesstest import SubprocessTestCase, run_in_subprocess
+from ...subprocesstest import run_in_subprocess
 from ...test_tracer import get_dummy_tracer
 from ...utils import assert_span_http_status_code, assert_is_measured
 
@@ -198,7 +198,7 @@ class ElasticsearchTest(unittest.TestCase):
         assert dd_span.resource == 'PUT /%s' % self.ES_INDEX
 
 
-class ElasticsearchPatchTest(SubprocessTestCase, BaseTracerTestCase):
+class ElasticsearchPatchTest(BaseTracerTestCase):
     """
     Elasticsearch integration test suite.
     Need a running ElasticSearch.
@@ -399,6 +399,10 @@ class ElasticsearchPatchTest(SubprocessTestCase, BaseTracerTestCase):
         When a user specifies a service for the app
             The elasticsearch integration should not use it.
         """
+        # Ensure that the service name was configured
+        from ddtrace import config
+        assert config.service == "mysvc"
+
         self.es.indices.create(index=self.ES_INDEX, ignore=400)
         Pin(service="es", tracer=self.tracer).onto(self.es.transport)
         spans = self.get_spans()

--- a/tests/contrib/elasticsearch/test.py
+++ b/tests/contrib/elasticsearch/test.py
@@ -13,7 +13,6 @@ from ddtrace.contrib.elasticsearch.patch import patch, unpatch
 from tests.opentracer.utils import init_tracer
 from ..config import ELASTICSEARCH_CONFIG
 from ...base import BaseTracerTestCase
-from ...subprocesstest import run_in_subprocess
 from ...test_tracer import get_dummy_tracer
 from ...utils import assert_span_http_status_code, assert_is_measured
 
@@ -393,7 +392,7 @@ class ElasticsearchPatchTest(BaseTracerTestCase):
         assert spans, spans
         assert len(spans) == 1
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service(self):
         """
         When a user specifies a service for the app

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -11,7 +11,6 @@ from ddtrace import Pin
 
 from ...base import BaseTracerTestCase
 from ...utils import assert_is_measured
-from ...subprocesstest import run_in_subprocess
 
 from .hello_pb2 import HelloRequest, HelloReply
 from .hello_pb2_grpc import add_HelloServicer_to_server, HelloStub, HelloServicer
@@ -442,7 +441,7 @@ class GrpcTestCase(BaseTracerTestCase):
         assert 'Traceback' in server_span.get_tag(errors.ERROR_STACK)
         assert 'grpc.StatusCode.RESOURCE_EXHAUSTED' in server_span.get_tag(errors.ERROR_STACK)
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_server_service_name(self):
         """
         When a service name is specified by the user

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -11,7 +11,7 @@ from ddtrace import Pin
 
 from ...base import BaseTracerTestCase
 from ...utils import assert_is_measured
-from ...subprocesstest import run_in_subprocess
+from ...subprocesstest import SubprocessTestCase, run_in_subprocess
 
 from .hello_pb2 import HelloRequest, HelloReply
 from .hello_pb2_grpc import add_HelloServicer_to_server, HelloStub, HelloServicer
@@ -20,7 +20,7 @@ _GRPC_PORT = 50531
 _GRPC_VERSION = tuple([int(i) for i in _GRPC_VERSION.split('.')])
 
 
-class GrpcTestCase(BaseTracerTestCase):
+class GrpcTestCase(SubprocessTestCase, BaseTracerTestCase):
     def setUp(self):
         super(GrpcTestCase, self).setUp()
         patch()

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -11,7 +11,7 @@ from ddtrace import Pin
 
 from ...base import BaseTracerTestCase
 from ...utils import assert_is_measured
-from ...subprocesstest import SubprocessTestCase, run_in_subprocess
+from ...subprocesstest import run_in_subprocess
 
 from .hello_pb2 import HelloRequest, HelloReply
 from .hello_pb2_grpc import add_HelloServicer_to_server, HelloStub, HelloServicer
@@ -20,7 +20,7 @@ _GRPC_PORT = 50531
 _GRPC_VERSION = tuple([int(i) for i in _GRPC_VERSION.split('.')])
 
 
-class GrpcTestCase(SubprocessTestCase, BaseTracerTestCase):
+class GrpcTestCase(BaseTracerTestCase):
     def setUp(self):
         super(GrpcTestCase, self).setUp()
         patch()
@@ -449,6 +449,10 @@ class GrpcTestCase(SubprocessTestCase, BaseTracerTestCase):
             It should be used for grpc server spans
             It should be included in grpc client spans
         """
+        # Ensure that the service name was configured
+        from ddtrace import config
+        assert config.service == "mysvc"
+
         channel1 = grpc.insecure_channel('localhost:%d' % (_GRPC_PORT))
         stub1 = HelloStub(channel1)
         stub1.SayHello(HelloRequest(name="test"))

--- a/tests/contrib/mongoengine/test.py
+++ b/tests/contrib/mongoengine/test.py
@@ -1,6 +1,5 @@
 # stdib
 import time
-import unittest
 
 # 3p
 import mongoengine

--- a/tests/contrib/mongoengine/test.py
+++ b/tests/contrib/mongoengine/test.py
@@ -14,8 +14,7 @@ from ddtrace.ext import mongo as mongox
 # testing
 from tests.opentracer.utils import init_tracer
 from ..config import MONGO_CONFIG
-from ...base import override_config
-from ...subprocesstest import SubprocessTestCase, run_in_subprocess
+from ...base import BaseTracerTestCase, override_config
 from ...test_tracer import get_dummy_tracer
 from ...utils import assert_is_measured
 
@@ -197,7 +196,7 @@ class MongoEngineCore(object):
             assert len(spans) == 1
             assert spans[0].get_metric(ANALYTICS_SAMPLE_RATE_KEY) == 1.0
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service(self):
         """
         When a user specifies a service for the app
@@ -214,7 +213,7 @@ class MongoEngineCore(object):
         assert spans[0].service != "mysvc"
 
 
-class TestMongoEnginePatchConnectDefault(SubprocessTestCase, MongoEngineCore):
+class TestMongoEnginePatchConnectDefault(BaseTracerTestCase, MongoEngineCore):
     """Test suite with a global Pin for the connect function with the default configuration"""
 
     TEST_SERVICE = mongox.SERVICE
@@ -249,7 +248,7 @@ class TestMongoEnginePatchConnect(TestMongoEnginePatchConnectDefault):
         return tracer
 
 
-class TestMongoEnginePatchClientDefault(SubprocessTestCase, MongoEngineCore):
+class TestMongoEnginePatchClientDefault(BaseTracerTestCase, MongoEngineCore):
     """Test suite with a Pin local to a specific client with default configuration"""
 
     TEST_SERVICE = mongox.SERVICE

--- a/tests/contrib/mysql/test_mysql.py
+++ b/tests/contrib/mysql/test_mysql.py
@@ -383,7 +383,7 @@ class MySQLCore(object):
         conn, tracer = self._get_conn_tracer()
         writer = tracer.writer
         cursor = conn.cursor()
-        cursor.execute('SELECT 1')
+        cursor.execute("SELECT 1")
         rows = cursor.fetchall()
         assert len(rows) == 1
         spans = writer.pop()

--- a/tests/contrib/mysql/test_mysql.py
+++ b/tests/contrib/mysql/test_mysql.py
@@ -10,7 +10,6 @@ from ddtrace.contrib.mysql.patch import patch, unpatch
 from tests.contrib.config import MYSQL_CONFIG
 from tests.opentracer.utils import init_tracer
 from ...base import BaseTracerTestCase
-from ...subprocesstest import run_in_subprocess
 from ...util import assert_dict_issuperset
 from ...utils import assert_is_measured
 
@@ -370,7 +369,7 @@ class MySQLCore(object):
             span = spans[0]
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service(self):
         """
         When a user specifies a service for the app

--- a/tests/contrib/mysql/test_mysql.py
+++ b/tests/contrib/mysql/test_mysql.py
@@ -10,6 +10,7 @@ from ddtrace.contrib.mysql.patch import patch, unpatch
 from tests.contrib.config import MYSQL_CONFIG
 from tests.opentracer.utils import init_tracer
 from ...base import BaseTracerTestCase
+from ...subprocesstest import run_in_subprocess
 from ...util import assert_dict_issuperset
 from ...utils import assert_is_measured
 
@@ -368,6 +369,26 @@ class MySQLCore(object):
             self.assertEqual(len(spans), 1)
             span = spans[0]
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
+
+    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_user_specified_service(self):
+        """
+        When a user specifies a service for the app
+            The mysql integration should not use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+        assert config.service == "mysvc"
+
+        conn, tracer = self._get_conn_tracer()
+        writer = tracer.writer
+        cursor = conn.cursor()
+        cursor.execute('SELECT 1')
+        rows = cursor.fetchall()
+        assert len(rows) == 1
+        spans = writer.pop()
+
+        assert spans[0].service != "mysvc"
 
 
 class TestMysqlPatch(MySQLCore, BaseTracerTestCase):

--- a/tests/contrib/mysqldb/test_mysql.py
+++ b/tests/contrib/mysqldb/test_mysql.py
@@ -7,7 +7,6 @@ from ddtrace.contrib.mysqldb.patch import patch, unpatch
 from tests.opentracer.utils import init_tracer
 from ..config import MYSQL_CONFIG
 from ...base import BaseTracerTestCase
-from ...subprocesstest import run_in_subprocess
 from ...util import assert_dict_issuperset
 from ...utils import assert_is_measured
 
@@ -420,7 +419,7 @@ class MySQLCore(object):
             span = spans[0]
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service(self):
         """
         When a user specifies a service for the app

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -18,7 +18,6 @@ from ddtrace import Pin
 from tests.opentracer.utils import init_tracer
 from tests.contrib.config import POSTGRES_CONFIG
 from ...base import BaseTracerTestCase
-from ...subprocesstest import run_in_subprocess
 from ...utils import assert_is_measured
 from ...utils.tracer import DummyTracer
 
@@ -330,7 +329,7 @@ class PsycopgCore(BaseTracerTestCase):
             span = spans[0]
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service(self):
         """
         When a user specifies a service for the app

--- a/tests/contrib/pylibmc/test.py
+++ b/tests/contrib/pylibmc/test.py
@@ -16,7 +16,7 @@ from ddtrace.ext import memcached
 from ...opentracer.utils import init_tracer
 from ...contrib.config import MEMCACHED_CONFIG as cfg
 from ...base import BaseTracerTestCase
-from ...subprocesstest import SubprocessTestCase, run_in_subprocess
+from ...subprocesstest import run_in_subprocess
 from ...utils import assert_is_measured
 
 
@@ -242,6 +242,10 @@ class PylibmcCore(object):
         When a user specifies a service for the app
             The pylibmc integration should not use it.
         """
+        # Ensure that the service name was configured
+        from ddtrace import config
+        assert config.service == "mysvc"
+
         client, tracer = self.get_client()
         client.set('a', 'crow')
         spans = self.get_spans()
@@ -249,7 +253,7 @@ class PylibmcCore(object):
         assert spans[0].service != "mysvc"
 
 
-class TestPylibmcLegacy(SubprocessTestCase, BaseTracerTestCase, PylibmcCore):
+class TestPylibmcLegacy(BaseTracerTestCase, PylibmcCore):
     """Test suite for the tracing of pylibmc with the legacy TracedClient interface"""
 
     TEST_SERVICE = 'mc-legacy'

--- a/tests/contrib/pylibmc/test.py
+++ b/tests/contrib/pylibmc/test.py
@@ -16,7 +16,6 @@ from ddtrace.ext import memcached
 from ...opentracer.utils import init_tracer
 from ...contrib.config import MEMCACHED_CONFIG as cfg
 from ...base import BaseTracerTestCase
-from ...subprocesstest import run_in_subprocess
 from ...utils import assert_is_measured
 
 
@@ -236,7 +235,7 @@ class PylibmcCore(object):
         finally:
             tracer.enabled = True
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service(self):
         """
         When a user specifies a service for the app

--- a/tests/contrib/pymemcache/test_client.py
+++ b/tests/contrib/pymemcache/test_client.py
@@ -16,7 +16,6 @@ from ddtrace.contrib.pymemcache.patch import patch, unpatch
 from .utils import MockSocket, _str
 from .test_client_mixin import PymemcacheClientTestCaseMixin, TEST_HOST, TEST_PORT
 from ...base import BaseTracerTestCase
-from ...subprocesstest import run_in_subprocess
 
 from tests.test_tracer import get_dummy_tracer
 
@@ -321,7 +320,7 @@ class PymemcacheClientConfiguration(BaseTracerTestCase):
 
         self.assertEqual(spans[0].service, 'mysvc2')
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service(self):
         """
         When a user specifies a service for the app

--- a/tests/contrib/pymemcache/test_client.py
+++ b/tests/contrib/pymemcache/test_client.py
@@ -8,7 +8,6 @@ from pymemcache.exceptions import (
     MemcacheIllegalInputError,
 )
 import pytest
-import unittest
 from ddtrace.vendor import wrapt
 
 # project
@@ -16,7 +15,8 @@ from ddtrace import Pin
 from ddtrace.contrib.pymemcache.patch import patch, unpatch
 from .utils import MockSocket, _str
 from .test_client_mixin import PymemcacheClientTestCaseMixin, TEST_HOST, TEST_PORT
-from ...subprocesstest import SubprocessTestCase, run_in_subprocess
+from ...base import BaseTracerTestCase
+from ...subprocesstest import run_in_subprocess
 
 from tests.test_tracer import get_dummy_tracer
 
@@ -273,7 +273,7 @@ class PymemcacheHashClientTestCase(PymemcacheClientTestCaseMixin):
         self.check_spans(2, ['add', 'delete'], ['add key', 'delete key'])
 
 
-class PymemcacheClientConfiguration(SubprocessTestCase):
+class PymemcacheClientConfiguration(BaseTracerTestCase):
     """Ensure that pymemache can be configured properly."""
 
     def setUp(self):
@@ -327,6 +327,10 @@ class PymemcacheClientConfiguration(SubprocessTestCase):
         When a user specifies a service for the app
             The pymemcache integration should not use it.
         """
+        # Ensure that the service name was configured
+        from ddtrace import config
+        assert config.service == "mysvc"
+
         client = self.make_client([b"STORED\r\n", b"VALUE key 0 5\r\nvalue\r\nEND\r\n"])
         client.set(b"key", b"value", noreply=False)
 

--- a/tests/contrib/pymongo/test.py
+++ b/tests/contrib/pymongo/test.py
@@ -15,7 +15,6 @@ from ddtrace.contrib.pymongo.patch import patch, unpatch
 from tests.opentracer.utils import init_tracer
 from ..config import MONGO_CONFIG
 from ...base import BaseTracerTestCase, override_config
-from ...subprocesstest import run_in_subprocess
 from ...test_tracer import get_dummy_tracer
 from ...utils import assert_is_measured
 
@@ -449,7 +448,7 @@ class TestPymongoPatchConfigured(BaseTracerTestCase, PymongoCore):
         assert spans, spans
         assert len(spans) == 1
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service(self):
         """
         When a user specifies a service for the app

--- a/tests/contrib/pymongo/test.py
+++ b/tests/contrib/pymongo/test.py
@@ -459,9 +459,10 @@ class TestPymongoPatchConfigured(BaseTracerTestCase, PymongoCore):
         from ddtrace import config
         assert config.service == "mysvc"
 
+        tracer = get_dummy_tracer()
         client = pymongo.MongoClient(port=MONGO_CONFIG["port"])
-        Pin.get_from(client).clone(tracer=self.tracer).onto(client)
+        Pin.get_from(client).clone(tracer=tracer).onto(client)
         client["testdb"].drop_collection("whatever")
-        spans = self.get_spans()
+        spans = tracer.writer.pop()
         assert len(spans) == 1
         assert spans[0].service != "mysvc"

--- a/tests/contrib/redis/test.py
+++ b/tests/contrib/redis/test.py
@@ -10,6 +10,7 @@ from tests.opentracer.utils import init_tracer
 from ..config import REDIS_CONFIG
 from ...test_tracer import get_dummy_tracer
 from ...base import BaseTracerTestCase
+from ...subprocesstest import run_in_subprocess
 from ...utils import assert_is_measured
 
 
@@ -229,3 +230,19 @@ class TestRedisPatch(BaseTracerTestCase):
         assert dd_span.get_tag('redis.raw_command') == u'GET cheese'
         assert dd_span.get_metric('redis.args_length') == 2
         assert dd_span.resource == 'GET cheese'
+
+    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_user_specified_service(self):
+        """
+        When a user specifies a service for the app
+            The redis integration should not use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+        assert config.service == "mysvc"
+
+        self.r.get("cheese")
+        spans = self.get_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.service != "mysvc"

--- a/tests/contrib/redis/test.py
+++ b/tests/contrib/redis/test.py
@@ -10,7 +10,6 @@ from tests.opentracer.utils import init_tracer
 from ..config import REDIS_CONFIG
 from ...test_tracer import get_dummy_tracer
 from ...base import BaseTracerTestCase
-from ...subprocesstest import run_in_subprocess
 from ...utils import assert_is_measured
 
 
@@ -231,7 +230,7 @@ class TestRedisPatch(BaseTracerTestCase):
         assert dd_span.get_metric('redis.args_length') == 2
         assert dd_span.resource == 'GET cheese'
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service(self):
         """
         When a user specifies a service for the app

--- a/tests/contrib/rediscluster/test.py
+++ b/tests/contrib/rediscluster/test.py
@@ -6,7 +6,6 @@ from ddtrace.contrib.rediscluster.patch import patch, unpatch
 from ddtrace.contrib.rediscluster.patch import REDISCLUSTER_VERSION
 from ..config import REDISCLUSTER_CONFIG
 from ...base import BaseTracerTestCase
-from ...subprocesstest import run_in_subprocess
 from ...test_tracer import get_dummy_tracer
 from ...utils import assert_is_measured
 
@@ -109,7 +108,7 @@ class TestRedisPatch(BaseTracerTestCase):
         assert spans, spans
         assert len(spans) == 1
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service(self):
         """
         When a user specifies a service for the app

--- a/tests/contrib/rediscluster/test.py
+++ b/tests/contrib/rediscluster/test.py
@@ -113,7 +113,7 @@ class TestRedisPatch(BaseTracerTestCase):
     def test_user_specified_service(self):
         """
         When a user specifies a service for the app
-            The rediscluser integration should not use it.
+            The rediscluster integration should not use it.
         """
         # Ensure that the service name was configured
         from ddtrace import config

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -13,7 +13,6 @@ from ddtrace.ext import errors
 # testing
 from tests.opentracer.utils import init_tracer
 from ...base import BaseTracerTestCase
-from ...subprocesstest import run_in_subprocess
 from ...utils import assert_is_measured, assert_is_not_measured
 
 
@@ -335,7 +334,7 @@ class TestSQLite(BaseTracerTestCase):
             span = spans[0]
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service(self):
         """
         When a user specifies a service for the app

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -13,6 +13,7 @@ from ddtrace.ext import errors
 # testing
 from tests.opentracer.utils import init_tracer
 from ...base import BaseTracerTestCase
+from ...subprocesstest import run_in_subprocess
 from ...utils import assert_is_measured, assert_is_not_measured
 
 
@@ -333,3 +334,24 @@ class TestSQLite(BaseTracerTestCase):
             self.assertEqual(len(spans), 1)
             span = spans[0]
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
+
+    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_user_specified_service(self):
+        """
+        When a user specifies a service for the app
+            The sqlite3 integration should not use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+        assert config.service == "mysvc"
+
+        q = "select * from sqlite_master"
+        connection = self._given_a_traced_connection(self.tracer)
+        cursor = connection.execute(q)
+        cursor.fetchall()
+
+        spans = self.get_spans()
+
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        assert span.service != "mysvc"

--- a/tests/contrib/vertica/test_vertica.py
+++ b/tests/contrib/vertica/test_vertica.py
@@ -15,7 +15,6 @@ from tests.base import BaseTracerTestCase
 from tests.contrib.config import VERTICA_CONFIG
 from tests.opentracer.utils import init_tracer
 from tests.test_tracer import get_dummy_tracer
-from ...subprocesstest import run_in_subprocess
 from ...utils import assert_is_measured
 
 TEST_TABLE = 'test_table'

--- a/tests/subprocesstest.py
+++ b/tests/subprocesstest.py
@@ -74,7 +74,7 @@ def run_in_subprocess(*args, **kwargs):
 
 
 class SubprocessTestCase(unittest.TestCase):
-    run_in_subprocess = run_in_subprocess
+    run_in_subprocess = staticmethod(run_in_subprocess)
 
     def _full_method_name(self):
         test = getattr(self, self._testMethodName)

--- a/tests/subprocesstest.py
+++ b/tests/subprocesstest.py
@@ -74,6 +74,8 @@ def run_in_subprocess(*args, **kwargs):
 
 
 class SubprocessTestCase(unittest.TestCase):
+    run_in_subprocess = run_in_subprocess
+
     def _full_method_name(self):
         test = getattr(self, self._testMethodName)
         # DEV: we have to use the internal self reference of the bound test

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -776,7 +776,7 @@ def test_tracer_with_env():
             assert span.get_tag(ENV_KEY) == 'config.env'
 
 
-class EnvTracerTestCase(BaseTracerTestCase):
+class EnvTracerTestCase(SubprocessTestCase, BaseTracerTestCase):
     """Tracer test cases requiring environment variables.
     """
     @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -776,7 +776,7 @@ def test_tracer_with_env():
             assert span.get_tag(ENV_KEY) == 'config.env'
 
 
-class EnvTracerTestCase(SubprocessTestCase, BaseTracerTestCase):
+class EnvTracerTestCase(BaseTracerTestCase):
     """Tracer test cases requiring environment variables.
     """
     @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -17,7 +17,7 @@ from ddtrace.ext import system
 from ddtrace.context import Context
 from ddtrace.constants import VERSION_KEY, ENV_KEY
 
-from tests.subprocesstest import SubprocessTestCase, run_in_subprocess
+from tests.subprocesstest import run_in_subprocess
 from .base import BaseTracerTestCase
 from .util import override_global_tracer
 from .utils.tracer import DummyTracer
@@ -776,7 +776,7 @@ def test_tracer_with_env():
             assert span.get_tag(ENV_KEY) == 'config.env'
 
 
-class EnvTracerTestCase(SubprocessTestCase, BaseTracerTestCase):
+class EnvTracerTestCase(BaseTracerTestCase):
     """Tracer test cases requiring environment variables.
     """
     @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))


### PR DESCRIPTION
This PR is part 1 of 2 where we confirm the behaviour of service names: we want only non-external integrations to use `DD_SERVICE` (or `config.service`).

The second PR will add assertions that non-external integrations all use DD_SERVICE if it is specified by the user.