### PR TITLE
uWSGI Utility Function for Checking `enable-threads=true` Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,6 +643,12 @@ jobs:
           wait: rediscluster
           pattern: '^rediscluster_contrib-'
 
+  uwsgi:
+    executor: ddtrace_dev
+    steps:
+      - run_tox_scenario:
+          pattern: '^uwsgi_contrib-'
+
   vertica:
     executor: ddtrace_dev
     docker:
@@ -862,6 +868,7 @@ workflows:
       # tracer
       - tracer: *requires_pre_test
       - unit_tests: *requires_pre_test
+      - uwsgi: *requires_pre_test
       - vertica: *requires_pre_test
       - verify_all_tests_ran:
           requires:
@@ -928,6 +935,7 @@ workflows:
             - tracer
             - tornado
             - unit_tests
+            - uwsgi
             - vertica
       - deploy_master:
           requires:

--- a/ddtrace/utils/uwsgi.py
+++ b/ddtrace/utils/uwsgi.py
@@ -1,0 +1,30 @@
+import logging
+
+from ddtrace import _worker
+from ..internal.logger import get_logger
+
+logging.basicConfig(level=logging.DEBUG)
+
+log = get_logger(__name__)
+
+
+def check_threads_enabled():
+    """
+    This function is a helper used to confirm whether or not the traced application is 
+    running via uWSGI, and if so, to further confirm if the necessary config of `enable-threads`
+    has been set and that it's value is true.  Per uWSGI documentation, attempting to import the
+    module is a recommended way of checking whether or not the application is running under uWSGI:
+    https://uwsgi-docs.readthedocs.io/en/latest/PythonModule.html#uwsgi.opt - “Also useful
+    for detecting whether you’re actually running under uWSGI; if you attempt to import
+    uwsgi and receive an ImportError you’re not running under uWSGI.
+    """
+    try:
+        import uwsgi
+        if not uwsgi.opt.get('enable-threads'):
+            log.debug(
+                '--enable-threads not set but needs to be true in uwsgi config for ddtrace to run')
+        elif uwsgi.opt['enable-threads'] != True:
+            log.debug(
+                'enable-threads=true is required in uwsgi config for ddtrace to run')
+    except:
+        pass

--- a/ddtrace/utils/uwsgi.py
+++ b/ddtrace/utils/uwsgi.py
@@ -1,6 +1,4 @@
 import logging
-
-from ddtrace import _worker
 from ..internal.logger import get_logger
 
 logging.basicConfig(level=logging.DEBUG)
@@ -9,22 +7,28 @@ log = get_logger(__name__)
 
 
 def check_threads_enabled():
-    """
-    This function is a helper used to confirm whether or not the traced application is 
-    running via uWSGI, and if so, to further confirm if the necessary config of `enable-threads`
-    has been set and that it's value is true.  Per uWSGI documentation, attempting to import the
-    module is a recommended way of checking whether or not the application is running under uWSGI:
-    https://uwsgi-docs.readthedocs.io/en/latest/PythonModule.html#uwsgi.opt - “Also useful
-    for detecting whether you’re actually running under uWSGI; if you attempt to import
-    uwsgi and receive an ImportError you’re not running under uWSGI.
+    u"""
+    Check if uWSGI is in use and whether or not threads are enabled.
+
+    This function is a helper used to confirm whether or not the traced application is
+    running via uWSGI, and if so, to further confirm if the necessary config of ``enable-threads``
+    has been set and that it's value is true.  If uWSGI is in use, it will return True, otherwise
+    False.
+
+    Per uWSGI documentation, attempting to import the module is a recommended way of
+    checking whether or not the application is running under uWSGI:
+    `uWSGI Python Module Docs <https://uwsgi-docs.readthedocs.io/en/latest/PythonModule.html#uwsgi.opt>`
+        Also useful for detecting whether you’re actually running under uWSGI; if you attempt to import
+        uwsgi and receive an ImportError you’re not running under uWSGI.
     """
     try:
         import uwsgi
-        if not uwsgi.opt.get('enable-threads'):
+        if uwsgi.opt.get('enable-threads') is None:
             log.debug(
                 '--enable-threads not set but needs to be true in uwsgi config for ddtrace to run')
-        elif uwsgi.opt['enable-threads'] != True:
-            log.debug(
-                'enable-threads=true is required in uwsgi config for ddtrace to run')
-    except:
-        pass
+        elif uwsgi.opt['enable-threads'] is not True:
+            log.debug('enable-threads=true is required in uwsgi config for ddtrace to run')
+        elif uwsgi.opt['enable-threads']:
+            return True
+    except ImportError:
+        return False

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -78,7 +78,7 @@ API details of the decorator can be found here :py:meth:`ddtrace.Tracer.wrap`.
 Context Manager
 ^^^^^^^^^^^^^^^
 
-To trace an arbitrary block of code, you can use :py:meth:`ddtrace.Tracer.trace` 
+To trace an arbitrary block of code, you can use :py:meth:`ddtrace.Tracer.trace`
 that returns a :py:mod:`ddtrace.Span` which can be used as a context manager::
 
   # trace some interesting operation
@@ -125,18 +125,18 @@ Profiler
 
 Via module
 ----------
-To automatically profile your code, you can import the `ddprofile.auto` module.
+To automatically profile your code, you can import the `ddtrace.profile.auto` module.
 As soon as it is imported, it will start catching CPU profiling information on
 your behalf::
 
-  import ddprofile.auto
+  import ddtrace.profile.auto
 
 Via API
 ----------
 If you want to control which part of your code should be profiled, you can use
 the `ddtrace.profiler.Profiler` object::
 
-  import ddprofile.profiler
+  import ddtrace.profile.profiler
 
   prof = profiler.Profiler()
   prof.start()
@@ -160,11 +160,11 @@ When your process forks using `os.fork`, the profiler is stopped in the child
 process.
 
 For Python 3.7 and later on POSIX platforms, a new profiler will be started if
-you enabled the profiler via `pyddprofile` or `ddprofile.auto`.
+you enabled the profiler via `pyddprofile` or `ddtrace.profile.auto`.
 
 If you manually instrument the profiler, or if you rely on Python 3.6 or a
 non-POSIX platform and earlier version, you'll have to manually restart the
 profiler in your child.
 
-The global profiler instrumented by `pyddprofile` and `ddprofile.auto` can be
-started by calling `ddprofile.auto.start_profiler`.
+The global profiler instrumented by `pyddprofile` and `ddtrace.profile.auto` can be
+started by calling `ddtrace.profile.auto.start_profiler`.

--- a/tests/contrib/uwsgi/test_uwsgi.py
+++ b/tests/contrib/uwsgi/test_uwsgi.py
@@ -1,0 +1,11 @@
+import os
+import subprocess
+import shlex
+
+
+def test_uwsgi_threads_enabled():
+    command = "uwsgi --http :9090 --wsgi-file {} --log-master".format(
+        os.path.join(os.path.dirname(__file__), "uwsgi_threads.py")
+    )
+    out = subprocess.check_output(shlex.split(command))
+    assert b"Threads enabled" in out

--- a/tests/contrib/uwsgi/test_uwsgi.py
+++ b/tests/contrib/uwsgi/test_uwsgi.py
@@ -2,34 +2,30 @@ import os
 import subprocess
 import shlex
 
-current_dir = os.path.dirname(__file__)
+uwsgi_app = os.path.join(os.path.dirname(__file__), "uwsgi_threads.py")
+uwsgi_ini = os.path.join(os.path.dirname(__file__), "uwsgi.ini")
+
+
+def output(command):
+    return subprocess.check_output(shlex.split(command))
+
 
 def test_uwsgi_threads_enabled():
-    command = "uwsgi --http :9090 --wsgi-file {} --enable-threads --log-master".format(
-        os.path.join(current_dir, "uwsgi_threads.py")
-    )
-    out = subprocess.check_output(shlex.split(command))
-    assert b"threads support enabled" in out
+    cmd = "uwsgi --http :9090 --wsgi-file {} --enable-threads --log-master".format(uwsgi_app)
+    assert b"threads support enabled" in output(cmd)
 
 
 def test_uwsgi_threads_not_enabled():
-    command = "uwsgi --http :9090 --wsgi-file {} --log-master".format(
-        os.path.join(current_dir, "uwsgi_threads.py")
-    )
-    out = subprocess.check_output(shlex.split(command))
-    assert b"*** Python threads support is disabled" in out
+    cmd = "uwsgi --http :9090 --wsgi-file {} --log-master".format(uwsgi_app)
+    assert b"*** Python threads support is disabled" in output(cmd)
+
 
 def test_uwsgi_threads_not_set_in_tracer():
-    command = "uwsgi --http :9090 --wsgi-file {} --log-master".format(
-        os.path.join(current_dir, "uwsgi_threads.py")
-    )
-    out = subprocess.check_output(shlex.split(command))
-    assert b"--enable-threads not set" in out
+    cmd = "uwsgi --http :9090 --wsgi-file {} --log-master".format(uwsgi_app)
+    assert b"--enable-threads not set" in output(cmd)
+
 
 def test_uwsgi_threads_not_true_in_tracer():
-    command = "uwsgi --http :9090 --wsgi-file {} --ini {} --log-master".format(
-        os.path.join(current_dir, "uwsgi_threads.py"),
-        os.path.join(current_dir, "uwsgi.ini")
-    )
-    out = subprocess.check_output(shlex.split(command))
-    assert b"enable-threads=true is required" in out
+    cmd = "uwsgi --http :9090 --wsgi-file {} --ini {} --log-master".format(
+        uwsgi_app, uwsgi_ini)
+    assert b"enable-threads=true is required" in output(cmd)

--- a/tests/contrib/uwsgi/test_uwsgi.py
+++ b/tests/contrib/uwsgi/test_uwsgi.py
@@ -2,10 +2,34 @@ import os
 import subprocess
 import shlex
 
+current_dir = os.path.dirname(__file__)
 
 def test_uwsgi_threads_enabled():
-    command = "uwsgi --http :9090 --wsgi-file {} --log-master".format(
-        os.path.join(os.path.dirname(__file__), "uwsgi_threads.py")
+    command = "uwsgi --http :9090 --wsgi-file {} --enable-threads --log-master".format(
+        os.path.join(current_dir, "uwsgi_threads.py")
     )
     out = subprocess.check_output(shlex.split(command))
-    assert b"Threads enabled" in out
+    assert b"threads support enabled" in out
+
+
+def test_uwsgi_threads_not_enabled():
+    command = "uwsgi --http :9090 --wsgi-file {} --log-master".format(
+        os.path.join(current_dir, "uwsgi_threads.py")
+    )
+    out = subprocess.check_output(shlex.split(command))
+    assert b"*** Python threads support is disabled" in out
+
+def test_uwsgi_threads_not_set_in_tracer():
+    command = "uwsgi --http :9090 --wsgi-file {} --log-master".format(
+        os.path.join(current_dir, "uwsgi_threads.py")
+    )
+    out = subprocess.check_output(shlex.split(command))
+    assert b"--enable-threads not set" in out
+
+def test_uwsgi_threads_not_true_in_tracer():
+    command = "uwsgi --http :9090 --wsgi-file {} --ini {} --log-master".format(
+        os.path.join(current_dir, "uwsgi_threads.py"),
+        os.path.join(current_dir, "uwsgi.ini")
+    )
+    out = subprocess.check_output(shlex.split(command))
+    assert b"enable-threads=true is required" in out

--- a/tests/contrib/uwsgi/uwsgi.ini
+++ b/tests/contrib/uwsgi/uwsgi.ini
@@ -1,0 +1,3 @@
+[uwsgi]
+enable-threads = false
+

--- a/tests/contrib/uwsgi/uwsgi.ini
+++ b/tests/contrib/uwsgi/uwsgi.ini
@@ -1,3 +1,2 @@
 [uwsgi]
 enable-threads = false
-

--- a/tests/contrib/uwsgi/uwsgi_threads.py
+++ b/tests/contrib/uwsgi/uwsgi_threads.py
@@ -1,12 +1,20 @@
 # flake8: noqa
 # setup logging
 import logging
+import sys
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
 
+
+# import the uwsgi module test its function from within the test app
+# and ensure it can produce debug logs
+from ddtrace.utils import uwsgi
+uwsgi.check_threads_enabled()
 
 # import tracer which initializes thread workers
 from ddtrace import tracer
+
+# perhaps go with the basic sample app example and then use subprocess to send traces with curl
 
 
 # exit process

--- a/tests/contrib/uwsgi/uwsgi_threads.py
+++ b/tests/contrib/uwsgi/uwsgi_threads.py
@@ -14,10 +14,5 @@ uwsgi.check_threads_enabled()
 # import tracer which initializes thread workers
 from ddtrace import tracer
 
-# perhaps go with the basic sample app example and then use subprocess to send traces with curl
-
-
 # exit process
-import sys
-
 sys.exit(0)

--- a/tests/contrib/uwsgi/uwsgi_threads.py
+++ b/tests/contrib/uwsgi/uwsgi_threads.py
@@ -1,0 +1,15 @@
+# flake8: noqa
+# setup logging
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+# import tracer which initializes thread workers
+from ddtrace import tracer
+
+
+# exit process
+import sys
+
+sys.exit(0)

--- a/tox.ini
+++ b/tox.ini
@@ -131,6 +131,7 @@ envlist =
     tornado_contrib-{py27,py34,py35,py36,py37,py38}-tornado{40,41,42,43,44,45}
     tornado_contrib-py{37,38}-tornado{50,51,60}
     tornado_contrib-{py27}-tornado{40,41,42,43,44,45}-futures{30,31,32}
+    uwsgi_contrib-{py27,py34,py35,py36,py37,py38}-uwsgi{,19,20}
     vertica_contrib-{py27,py34,py35,py36,py37,py38}-vertica{060,070}
 # Opentracer
     {py27,py34,py35,py36,py37,py38}-opentracer
@@ -429,6 +430,9 @@ deps =
     tornado50: tornado>=5.0,<5.1
     tornado51: tornado>=5.1,<5.2
     tornado60: tornado>=6.0,<6.1
+    uwsgi19: uwsgi>=1.9,<2.0
+    uwsgi20: uwsgi>=2.0,<2.1
+    uwsgi: uwsgi>=2.0
     vertica060: vertica-python>=0.6.0,<0.7.0
     vertica070: vertica-python>=0.7.0,<0.8.0
     webtest: WebTest
@@ -500,6 +504,7 @@ commands =
     sqlalchemy_contrib: pytest {posargs} tests/contrib/sqlalchemy
     sqlite3_contrib: pytest {posargs} tests/contrib/sqlite3
     tornado_contrib: pytest {posargs} tests/contrib/tornado
+    uwsgi_contrib: pytest {posargs} tests/contrib/uwsgi
     vertica_contrib: pytest {posargs} tests/contrib/vertica/
 # run subsets of the tests for particular library versions
     ddtracerun: pytest {posargs} tests/commands/test_runner.py


### PR DESCRIPTION
Added uWSGI utility module and basic testing with minimal sample app file for uWSGI to run and a corresponding ini file for testing whether or not the debug log correctly addresses an absence or incorrect value for the `enable-threads` configuration necessary to run the tracer.