### PR TITLE
aiohttp: prioritize DD_SERVICE

### DIFF
--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -132,7 +132,7 @@ def trace_app(app, tracer, service='aiohttp-web'):
     # configure datadog settings
     app[CONFIG_KEY] = {
         'tracer': tracer,
-        'service': service,
+        'service': config.get_service(default=service),
         'distributed_tracing_enabled': True,
         'analytics_enabled': None,
         'analytics_sample_rate': 1.0,

--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -1,3 +1,4 @@
+from ddtrace import config
 from ddtrace.vendor import wrapt
 
 from ...pin import Pin
@@ -26,7 +27,7 @@ def patch():
 
         _w = wrapt.wrap_function_wrapper
         _w('aiohttp_jinja2', 'render_template', _trace_render_template)
-        Pin(app='aiohttp', service=None).onto(aiohttp_jinja2)
+        Pin(app='aiohttp', service=config.get_service()).onto(aiohttp_jinja2)
 
 
 def unpatch():

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -19,6 +19,7 @@ class TestTraceMiddleware(TraceTestCase):
     Ensures that the trace Middleware creates root spans at
     the beginning of a request.
     """
+
     def enable_tracing(self):
         trace_app(self.app, self.tracer)
 
@@ -27,46 +28,46 @@ class TestTraceMiddleware(TraceTestCase):
     def test_handler(self):
         # it should create a root span when there is a handler hit
         # with the proper tags
-        request = yield from self.client.request('GET', '/')
+        request = yield from self.client.request("GET", "/")
         assert 200 == request.status
         text = yield from request.text()
-        assert 'What\'s tracing?' == text
+        assert "What's tracing?" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         assert 1 == len(traces)
         assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        assert 'aiohttp.request' == span.name
-        assert 'aiohttp-web' == span.service
-        assert 'web' == span.span_type
-        assert 'GET /' == span.resource
-        assert str(self.client.make_url('/')) == span.get_tag(http.URL)
-        assert 'GET' == span.get_tag('http.method')
+        assert "aiohttp.request" == span.name
+        assert "aiohttp-web" == span.service
+        assert "web" == span.span_type
+        assert "GET /" == span.resource
+        assert str(self.client.make_url("/")) == span.get_tag(http.URL)
+        assert "GET" == span.get_tag("http.method")
         assert_span_http_status_code(span, 200)
         assert 0 == span.error
 
     @asyncio.coroutine
-    def _test_param_handler(self, query_string=''):
+    def _test_param_handler(self, query_string=""):
         if query_string:
-            fqs = '?' + query_string
+            fqs = "?" + query_string
         else:
-            fqs = ''
+            fqs = ""
         # it should manage properly handlers with params
-        request = yield from self.client.request('GET', '/echo/team' + fqs)
+        request = yield from self.client.request("GET", "/echo/team" + fqs)
         assert 200 == request.status
         text = yield from request.text()
-        assert 'Hello team' == text
+        assert "Hello team" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         assert 1 == len(traces)
         assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        assert 'GET /echo/{name}' == span.resource
-        assert str(self.client.make_url('/echo/team')) == span.get_tag(http.URL)
+        assert "GET /echo/{name}" == span.resource
+        assert str(self.client.make_url("/echo/team")) == span.get_tag(http.URL)
         assert_span_http_status_code(span, 200)
-        if self.app[CONFIG_KEY].get('trace_query_string'):
+        if self.app[CONFIG_KEY].get("trace_query_string"):
             assert query_string == span.get_tag(http.QUERY_STRING)
         else:
             assert http.QUERY_STRING not in span.meta
@@ -77,32 +78,32 @@ class TestTraceMiddleware(TraceTestCase):
 
     @unittest_run_loop
     def test_query_string(self):
-        return self._test_param_handler('foo=bar')
+        return self._test_param_handler("foo=bar")
 
     @unittest_run_loop
     def test_query_string_duplicate_keys(self):
-        return self._test_param_handler('foo=bar&foo=baz&x=y')
+        return self._test_param_handler("foo=bar&foo=baz&x=y")
 
     @unittest_run_loop
     def test_param_handler_trace(self):
-        self.app[CONFIG_KEY]['trace_query_string'] = True
+        self.app[CONFIG_KEY]["trace_query_string"] = True
         return self._test_param_handler()
 
     @unittest_run_loop
     def test_query_string_trace(self):
-        self.app[CONFIG_KEY]['trace_query_string'] = True
-        return self._test_param_handler('foo=bar')
+        self.app[CONFIG_KEY]["trace_query_string"] = True
+        return self._test_param_handler("foo=bar")
 
     @unittest_run_loop
     def test_query_string_duplicate_keys_trace(self):
-        self.app[CONFIG_KEY]['trace_query_string'] = True
-        return self._test_param_handler('foo=bar&foo=baz&x=y')
+        self.app[CONFIG_KEY]["trace_query_string"] = True
+        return self._test_param_handler("foo=bar&foo=baz&x=y")
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_404_handler(self):
         # it should not pollute the resource space
-        request = yield from self.client.request('GET', '/404/not_found')
+        request = yield from self.client.request("GET", "/404/not_found")
         assert 404 == request.status
         # the trace is created
         traces = self.tracer.writer.pop_traces()
@@ -110,9 +111,9 @@ class TestTraceMiddleware(TraceTestCase):
         assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        assert '404' == span.resource
-        assert str(self.client.make_url('/404/not_found')) == span.get_tag(http.URL)
-        assert 'GET' == span.get_tag('http.method')
+        assert "404" == span.resource
+        assert str(self.client.make_url("/404/not_found")) == span.get_tag(http.URL)
+        assert "GET" == span.get_tag("http.method")
         assert_span_http_status_code(span, 404)
 
     @unittest_run_loop
@@ -122,13 +123,13 @@ class TestTraceMiddleware(TraceTestCase):
         When a server error occurs (uncaught exception)
             The span should be flagged as an error
         """
-        request = yield from self.client.request('GET', '/uncaught_server_error')
+        request = yield from self.client.request("GET", "/uncaught_server_error")
         assert request.status == 500
         traces = self.tracer.writer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 1
         span = traces[0][0]
-        assert span.get_tag('http.method') == 'GET'
+        assert span.get_tag("http.method") == "GET"
         assert_span_http_status_code(span, 500)
         assert span.error == 1
 
@@ -139,13 +140,13 @@ class TestTraceMiddleware(TraceTestCase):
         When a 5XX response code is returned
             The span should be flagged as an error
         """
-        request = yield from self.client.request('GET', '/caught_server_error')
+        request = yield from self.client.request("GET", "/caught_server_error")
         assert request.status == 503
         traces = self.tracer.writer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 1
         span = traces[0][0]
-        assert span.get_tag('http.method') == 'GET'
+        assert span.get_tag("http.method") == "GET"
         assert_span_http_status_code(span, 503)
         assert span.error == 1
 
@@ -153,10 +154,10 @@ class TestTraceMiddleware(TraceTestCase):
     @asyncio.coroutine
     def test_coroutine_chaining(self):
         # it should create a trace with multiple spans
-        request = yield from self.client.request('GET', '/chaining/')
+        request = yield from self.client.request("GET", "/chaining/")
         assert 200 == request.status
         text = yield from request.text()
-        assert 'OK' == text
+        assert "OK" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         assert 1 == len(traces)
@@ -165,17 +166,17 @@ class TestTraceMiddleware(TraceTestCase):
         handler = traces[0][1]
         coroutine = traces[0][2]
         # root span created in the middleware
-        assert 'aiohttp.request' == root.name
-        assert 'GET /chaining/' == root.resource
-        assert str(self.client.make_url('/chaining/')) == root.get_tag(http.URL)
-        assert 'GET' == root.get_tag('http.method')
+        assert "aiohttp.request" == root.name
+        assert "GET /chaining/" == root.resource
+        assert str(self.client.make_url("/chaining/")) == root.get_tag(http.URL)
+        assert "GET" == root.get_tag("http.method")
         assert_span_http_status_code(root, 200)
         # span created in the coroutine_chaining handler
-        assert 'aiohttp.coro_1' == handler.name
+        assert "aiohttp.coro_1" == handler.name
         assert root.span_id == handler.parent_id
         assert root.trace_id == handler.trace_id
         # span created in the coro_2 handler
-        assert 'aiohttp.coro_2' == coroutine.name
+        assert "aiohttp.coro_2" == coroutine.name
         assert handler.span_id == coroutine.parent_id
         assert root.trace_id == coroutine.trace_id
 
@@ -183,20 +184,20 @@ class TestTraceMiddleware(TraceTestCase):
     @asyncio.coroutine
     def test_static_handler(self):
         # it should create a trace with multiple spans
-        request = yield from self.client.request('GET', '/statics/empty.txt')
+        request = yield from self.client.request("GET", "/statics/empty.txt")
         assert 200 == request.status
         text = yield from request.text()
-        assert 'Static file\n' == text
+        assert "Static file\n" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         assert 1 == len(traces)
         assert 1 == len(traces[0])
         span = traces[0][0]
         # root span created in the middleware
-        assert 'aiohttp.request' == span.name
-        assert 'GET /statics' == span.resource
-        assert str(self.client.make_url('/statics/empty.txt')) == span.get_tag(http.URL)
-        assert 'GET' == span.get_tag('http.method')
+        assert "aiohttp.request" == span.name
+        assert "GET /statics" == span.resource
+        assert str(self.client.make_url("/statics/empty.txt")) == span.get_tag(http.URL)
+        assert "GET" == span.get_tag("http.method")
         assert_span_http_status_code(span, 200)
 
     @unittest_run_loop
@@ -220,7 +221,7 @@ class TestTraceMiddleware(TraceTestCase):
     @unittest_run_loop
     @asyncio.coroutine
     def test_exception(self):
-        request = yield from self.client.request('GET', '/exception')
+        request = yield from self.client.request("GET", "/exception")
         assert 500 == request.status
         yield from request.text()
 
@@ -230,14 +231,14 @@ class TestTraceMiddleware(TraceTestCase):
         assert 1 == len(spans)
         span = spans[0]
         assert 1 == span.error
-        assert 'GET /exception' == span.resource
-        assert 'error' == span.get_tag('error.msg')
-        assert 'Exception: error' in span.get_tag('error.stack')
+        assert "GET /exception" == span.resource
+        assert "error" == span.get_tag("error.msg")
+        assert "Exception: error" in span.get_tag("error.stack")
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_async_exception(self):
-        request = yield from self.client.request('GET', '/async_exception')
+        request = yield from self.client.request("GET", "/async_exception")
         assert 500 == request.status
         yield from request.text()
 
@@ -247,38 +248,38 @@ class TestTraceMiddleware(TraceTestCase):
         assert 1 == len(spans)
         span = spans[0]
         assert 1 == span.error
-        assert 'GET /async_exception' == span.resource
-        assert 'error' == span.get_tag('error.msg')
-        assert 'Exception: error' in span.get_tag('error.stack')
+        assert "GET /async_exception" == span.resource
+        assert "error" == span.get_tag("error.msg")
+        assert "Exception: error" in span.get_tag("error.stack")
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_wrapped_coroutine(self):
-        request = yield from self.client.request('GET', '/wrapped_coroutine')
+        request = yield from self.client.request("GET", "/wrapped_coroutine")
         assert 200 == request.status
         text = yield from request.text()
-        assert 'OK' == text
+        assert "OK" == text
 
         traces = self.tracer.writer.pop_traces()
         assert 1 == len(traces)
         spans = traces[0]
         assert 2 == len(spans)
         span = spans[0]
-        assert 'GET /wrapped_coroutine' == span.resource
+        assert "GET /wrapped_coroutine" == span.resource
         span = spans[1]
-        assert 'nested' == span.name
-        assert span.duration > 0.25, 'span.duration={0}'.format(span.duration)
+        assert "nested" == span.name
+        assert span.duration > 0.25, "span.duration={0}".format(span.duration)
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_distributed_tracing(self):
         # distributed tracing is enabled by default
         tracing_headers = {
-            'x-datadog-trace-id': '100',
-            'x-datadog-parent-id': '42',
+            "x-datadog-trace-id": "100",
+            "x-datadog-parent-id": "42",
         }
 
-        request = yield from self.client.request('GET', '/', headers=tracing_headers)
+        request = yield from self.client.request("GET", "/", headers=tracing_headers)
         assert 200 == request.status
         text = yield from request.text()
         assert "What's tracing?" == text
@@ -298,12 +299,12 @@ class TestTraceMiddleware(TraceTestCase):
         self.tracer.priority_sampler = RateSampler(0.1)
 
         tracing_headers = {
-            'x-datadog-trace-id': '100',
-            'x-datadog-parent-id': '42',
-            'x-datadog-sampling-priority': '1',
+            "x-datadog-trace-id": "100",
+            "x-datadog-parent-id": "42",
+            "x-datadog-sampling-priority": "1",
         }
 
-        request = yield from self.client.request('GET', '/', headers=tracing_headers)
+        request = yield from self.client.request("GET", "/", headers=tracing_headers)
         assert 200 == request.status
         text = yield from request.text()
         assert "What's tracing?" == text
@@ -323,12 +324,12 @@ class TestTraceMiddleware(TraceTestCase):
         self.tracer.priority_sampler = RateSampler(0.9)
 
         tracing_headers = {
-            'x-datadog-trace-id': '100',
-            'x-datadog-parent-id': '42',
-            'x-datadog-sampling-priority': '0',
+            "x-datadog-trace-id": "100",
+            "x-datadog-parent-id": "42",
+            "x-datadog-sampling-priority": "0",
         }
 
-        request = yield from self.client.request('GET', '/', headers=tracing_headers)
+        request = yield from self.client.request("GET", "/", headers=tracing_headers)
         assert 200 == request.status
         text = yield from request.text()
         assert "What's tracing?" == text
@@ -346,13 +347,13 @@ class TestTraceMiddleware(TraceTestCase):
     @asyncio.coroutine
     def test_distributed_tracing_disabled(self):
         # pass headers for distributed tracing
-        self.app['datadog_trace']['distributed_tracing_enabled'] = False
+        self.app["datadog_trace"]["distributed_tracing_enabled"] = False
         tracing_headers = {
-            'x-datadog-trace-id': '100',
-            'x-datadog-parent-id': '42',
+            "x-datadog-trace-id": "100",
+            "x-datadog-parent-id": "42",
         }
 
-        request = yield from self.client.request('GET', '/', headers=tracing_headers)
+        request = yield from self.client.request("GET", "/", headers=tracing_headers)
         assert 200 == request.status
         text = yield from request.text()
         assert "What's tracing?" == text
@@ -372,15 +373,15 @@ class TestTraceMiddleware(TraceTestCase):
 
         # activate distributed tracing
         tracing_headers = {
-            'x-datadog-trace-id': '100',
-            'x-datadog-parent-id': '42',
-            'x-datadog-sampling-priority': '0',
+            "x-datadog-trace-id": "100",
+            "x-datadog-parent-id": "42",
+            "x-datadog-sampling-priority": "0",
         }
 
-        request = yield from self.client.request('GET', '/sub_span', headers=tracing_headers)
+        request = yield from self.client.request("GET", "/sub_span", headers=tracing_headers)
         assert 200 == request.status
         text = yield from request.text()
-        assert 'OK' == text
+        assert "OK" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         assert 1 == len(traces)
@@ -413,23 +414,23 @@ class TestTraceMiddleware(TraceTestCase):
         assert outer_span.parent_id is None
         assert inner_span.parent_id is None
 
-        assert outer_span.name == 'aiohttp_op'
+        assert outer_span.name == "aiohttp_op"
 
         # with the right fields
-        assert 'aiohttp.request' == inner_span.name
-        assert 'aiohttp-web' == inner_span.service
-        assert 'web' == inner_span.span_type
-        assert 'GET /' == inner_span.resource
-        assert str(self.client.make_url('/')) == inner_span.get_tag(http.URL)
-        assert 'GET' == inner_span.get_tag('http.method')
+        assert "aiohttp.request" == inner_span.name
+        assert "aiohttp-web" == inner_span.service
+        assert "web" == inner_span.span_type
+        assert "GET /" == inner_span.resource
+        assert str(self.client.make_url("/")) == inner_span.get_tag(http.URL)
+        assert "GET" == inner_span.get_tag("http.method")
         assert_span_http_status_code(inner_span, 200)
         assert 0 == inner_span.error
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_parenting_200_dd(self):
-        with self.tracer.trace('aiohttp_op'):
-            request = yield from self.client.request('GET', '/')
+        with self.tracer.trace("aiohttp_op"):
+            request = yield from self.client.request("GET", "/")
             assert 200 == request.status
             text = yield from request.text()
 
@@ -441,10 +442,10 @@ class TestTraceMiddleware(TraceTestCase):
     @asyncio.coroutine
     def test_parenting_200_ot(self):
         """OpenTracing version of test_handler."""
-        ot_tracer = init_tracer('aiohttp_svc', self.tracer, scope_manager=AsyncioScopeManager())
+        ot_tracer = init_tracer("aiohttp_svc", self.tracer, scope_manager=AsyncioScopeManager())
 
-        with ot_tracer.start_active_span('aiohttp_op'):
-            request = yield from self.client.request('GET', '/')
+        with ot_tracer.start_active_span("aiohttp_op"):
+            request = yield from self.client.request("GET", "/")
             assert 200 == request.status
             text = yield from request.text()
 
@@ -456,21 +457,19 @@ class TestTraceMiddleware(TraceTestCase):
     @asyncio.coroutine
     def test_analytics_integration_enabled(self):
         """ Check trace has analytics sample rate set """
-        self.app['datadog_trace']['analytics_enabled'] = True
-        self.app['datadog_trace']['analytics_sample_rate'] = 0.5
-        request = yield from self.client.request('GET', '/template/')
+        self.app["datadog_trace"]["analytics_enabled"] = True
+        self.app["datadog_trace"]["analytics_sample_rate"] = 0.5
+        request = yield from self.client.request("GET", "/template/")
         yield from request.text()
 
         # Assert root span sets the appropriate metric
-        self.assert_structure(
-            dict(name='aiohttp.request', metrics={ANALYTICS_SAMPLE_RATE_KEY: 0.5})
-        )
+        self.assert_structure(dict(name="aiohttp.request", metrics={ANALYTICS_SAMPLE_RATE_KEY: 0.5}))
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_analytics_integration_default(self):
         """ Check trace has analytics sample rate set """
-        request = yield from self.client.request('GET', '/template/')
+        request = yield from self.client.request("GET", "/template/")
         yield from request.text()
 
         # Assert root span does not have the appropriate metric
@@ -481,8 +480,8 @@ class TestTraceMiddleware(TraceTestCase):
     @asyncio.coroutine
     def test_analytics_integration_disabled(self):
         """ Check trace has analytics sample rate set """
-        self.app['datadog_trace']['analytics_enabled'] = False
-        request = yield from self.client.request('GET', '/template/')
+        self.app["datadog_trace"]["analytics_enabled"] = False
+        request = yield from self.client.request("GET", "/template/")
         yield from request.text()
 
         # Assert root span does not have the appropriate metric

--- a/tests/contrib/aiohttp/test_request.py
+++ b/tests/contrib/aiohttp/test_request.py
@@ -17,6 +17,7 @@ class TestRequestTracing(TraceTestCase):
     """
     Ensures that the trace includes all traced components.
     """
+
     def enable_tracing(self):
         # enabled tracing:
         #   * middleware
@@ -33,7 +34,7 @@ class TestRequestTracing(TraceTestCase):
     def test_full_request(self):
         # it should create a root span when there is a handler hit
         # with the proper tags
-        request = yield from self.client.request('GET', '/template/')
+        request = yield from self.client.request("GET", "/template/")
         assert 200 == request.status
         yield from request.text()
         # the trace is created
@@ -45,22 +46,22 @@ class TestRequestTracing(TraceTestCase):
 
         template_span = traces[0][1]
         # request
-        assert 'aiohttp-web' == request_span.service
-        assert 'aiohttp.request' == request_span.name
-        assert 'GET /template/' == request_span.resource
+        assert "aiohttp-web" == request_span.service
+        assert "aiohttp.request" == request_span.name
+        assert "GET /template/" == request_span.resource
         # template
-        assert 'aiohttp-web' == template_span.service
-        assert 'aiohttp.template' == template_span.name
-        assert 'aiohttp.template' == template_span.resource
+        assert "aiohttp-web" == template_span.service
+        assert "aiohttp.template" == template_span.name
+        assert "aiohttp.template" == template_span.resource
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_multiple_full_request(self):
         # it should handle multiple requests using the same loop
         def make_requests():
-            url = self.client.make_url('/delayed/')
-            response = request.urlopen(str(url)).read().decode('utf-8')
-            assert 'Done' == response
+            url = self.client.make_url("/delayed/")
+            response = request.urlopen(str(url)).read().decode("utf-8")
+            assert "Done" == response
 
         # blocking call executed in different threads
         threads = [threading.Thread(target=make_requests) for _ in range(10)]
@@ -78,3 +79,23 @@ class TestRequestTracing(TraceTestCase):
         traces = self.tracer.writer.pop_traces()
         assert 10 == len(traces)
         assert 1 == len(traces[0])
+
+    @unittest_run_loop
+    @asyncio.coroutine
+    @TraceTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_user_specified_service(self):
+        """
+        When a service name is specified by the user
+            The aiohttp integration should use it as the service name
+        """
+        request = yield from self.client.request("GET", "/template/")
+        yield from request.text()
+        traces = self.tracer.writer.pop_traces()
+        assert 1 == len(traces)
+        assert 2 == len(traces[0])
+
+        request_span = traces[0][0]
+        assert request_span.service == "mysvc"
+
+        template_span = traces[0][1]
+        assert template_span.service == "mysvc"

--- a/tests/contrib/aiohttp/test_request_safety.py
+++ b/tests/contrib/aiohttp/test_request_safety.py
@@ -20,6 +20,7 @@ class TestAiohttpSafety(TraceTestCase):
     bad traces are produced but the ``Context`` object will not
     leak memory.
     """
+
     def enable_tracing(self):
         # aiohttp TestCase with the wrong context provider
         trace_app(self.app, self.tracer)
@@ -35,7 +36,7 @@ class TestAiohttpSafety(TraceTestCase):
     def test_full_request(self):
         # it should create a root span when there is a handler hit
         # with the proper tags
-        request = yield from self.client.request('GET', '/template/')
+        request = yield from self.client.request("GET", "/template/")
         assert 200 == request.status
         yield from request.text()
         # the trace is created
@@ -46,13 +47,13 @@ class TestAiohttpSafety(TraceTestCase):
         template_span = traces[0][1]
         # request
         assert_is_measured(request_span)
-        assert 'aiohttp-web' == request_span.service
-        assert 'aiohttp.request' == request_span.name
-        assert 'GET /template/' == request_span.resource
+        assert "aiohttp-web" == request_span.service
+        assert "aiohttp.request" == request_span.name
+        assert "GET /template/" == request_span.resource
         # template
-        assert 'aiohttp-web' == template_span.service
-        assert 'aiohttp.template' == template_span.name
-        assert 'aiohttp.template' == template_span.resource
+        assert "aiohttp-web" == template_span.service
+        assert "aiohttp.template" == template_span.name
+        assert "aiohttp.template" == template_span.resource
 
     @unittest_run_loop
     @asyncio.coroutine
@@ -63,8 +64,8 @@ class TestAiohttpSafety(TraceTestCase):
         # it should produce a wrong trace, but the Context must
         # be finished
         def make_requests():
-            url = self.client.make_url('/delayed/')
-            response = request.urlopen(str(url)).read().decode('utf-8')
+            url = self.client.make_url("/delayed/")
+            response = request.urlopen(str(url)).read().decode("utf-8")
             responses.append(response)
 
         # blocking call executed in different threads
@@ -78,7 +79,7 @@ class TestAiohttpSafety(TraceTestCase):
             yield from asyncio.sleep(0.001)
 
         for response in responses:
-            assert 'Done' == response
+            assert "Done" == response
 
         for t in threads:
             t.join()

--- a/tests/contrib/aiohttp/test_templates.py
+++ b/tests/contrib/aiohttp/test_templates.py
@@ -14,6 +14,7 @@ class TestTraceTemplate(TraceTestCase):
     """
     Ensures that the aiohttp_jinja2 library is properly traced.
     """
+
     def enable_tracing(self):
         patch()
         Pin.override(aiohttp_jinja2, tracer=self.tracer)
@@ -25,19 +26,19 @@ class TestTraceTemplate(TraceTestCase):
     @asyncio.coroutine
     def test_template_rendering(self):
         # it should trace a template rendering
-        request = yield from self.client.request('GET', '/template/')
+        request = yield from self.client.request("GET", "/template/")
         assert 200 == request.status
         text = yield from request.text()
-        assert 'OK' == text
+        assert "OK" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         assert 1 == len(traces)
         assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        assert 'aiohttp.template' == span.name
-        assert 'template' == span.span_type
-        assert '/template.jinja2' == span.get_tag('aiohttp.template')
+        assert "aiohttp.template" == span.name
+        assert "template" == span.span_type
+        assert "/template.jinja2" == span.get_tag("aiohttp.template")
         assert 0 == span.error
 
     @unittest_run_loop
@@ -45,19 +46,19 @@ class TestTraceTemplate(TraceTestCase):
     def test_template_rendering_filesystem(self):
         # it should trace a template rendering with a FileSystemLoader
         set_filesystem_loader(self.app)
-        request = yield from self.client.request('GET', '/template/')
+        request = yield from self.client.request("GET", "/template/")
         assert 200 == request.status
         text = yield from request.text()
-        assert 'OK' == text
+        assert "OK" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         assert 1 == len(traces)
         assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        assert 'aiohttp.template' == span.name
-        assert 'template' == span.span_type
-        assert '/template.jinja2' == span.get_tag('aiohttp.template')
+        assert "aiohttp.template" == span.name
+        assert "template" == span.span_type
+        assert "/template.jinja2" == span.get_tag("aiohttp.template")
         assert 0 == span.error
 
     @unittest_run_loop
@@ -65,45 +66,45 @@ class TestTraceTemplate(TraceTestCase):
     def test_template_rendering_package(self):
         # it should trace a template rendering with a PackageLoader
         set_package_loader(self.app)
-        request = yield from self.client.request('GET', '/template/')
+        request = yield from self.client.request("GET", "/template/")
         assert 200 == request.status
         text = yield from request.text()
-        assert 'OK' == text
+        assert "OK" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         assert 1 == len(traces)
         assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        assert 'aiohttp.template' == span.name
-        assert 'template' == span.span_type
-        assert 'templates/template.jinja2' == span.get_tag('aiohttp.template')
+        assert "aiohttp.template" == span.name
+        assert "template" == span.span_type
+        assert "templates/template.jinja2" == span.get_tag("aiohttp.template")
         assert 0 == span.error
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_template_decorator(self):
         # it should trace a template rendering
-        request = yield from self.client.request('GET', '/template_decorator/')
+        request = yield from self.client.request("GET", "/template_decorator/")
         assert 200 == request.status
         text = yield from request.text()
-        assert 'OK' == text
+        assert "OK" == text
         # the trace is created
         traces = self.tracer.writer.pop_traces()
         assert 1 == len(traces)
         assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        assert 'aiohttp.template' == span.name
-        assert 'template' == span.span_type
-        assert '/template.jinja2' == span.get_tag('aiohttp.template')
+        assert "aiohttp.template" == span.name
+        assert "template" == span.span_type
+        assert "/template.jinja2" == span.get_tag("aiohttp.template")
         assert 0 == span.error
 
     @unittest_run_loop
     @asyncio.coroutine
     def test_template_error(self):
         # it should trace a template rendering
-        request = yield from self.client.request('GET', '/template_error/')
+        request = yield from self.client.request("GET", "/template_error/")
         assert 500 == request.status
         yield from request.text()
         # the trace is created
@@ -112,9 +113,9 @@ class TestTraceTemplate(TraceTestCase):
         assert 1 == len(traces[0])
         span = traces[0][0]
         # with the right fields
-        assert 'aiohttp.template' == span.name
-        assert 'template' == span.span_type
-        assert '/error.jinja2' == span.get_tag('aiohttp.template')
+        assert "aiohttp.template" == span.name
+        assert "template" == span.span_type
+        assert "/error.jinja2" == span.get_tag("aiohttp.template")
         assert 1 == span.error
-        assert 'division by zero' == span.get_tag('error.msg')
-        assert 'ZeroDivisionError: division by zero' in span.get_tag('error.stack')
+        assert "division by zero" == span.get_tag("error.msg")
+        assert "ZeroDivisionError: division by zero" in span.get_tag("error.stack")

--- a/tests/contrib/aiohttp/utils.py
+++ b/tests/contrib/aiohttp/utils.py
@@ -11,6 +11,7 @@ class TraceTestCase(BaseTracerTestCase, AioHTTPTestCase):
     Base class that provides a valid ``aiohttp`` application with
     the async tracer.
     """
+
     def enable_tracing(self):
         pass
 


### PR DESCRIPTION
The service precedence for `aiohttp` is now: `DD_SERVICE`/`config.service` with a fallback to the original service (`"aiohttp-web"`).


I also black'd the tests for aiohttp.