### PR TITLE
algoliasearch: prioritize DD_SERVICE

### DIFF
--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -16,7 +16,7 @@ try:
 
     # Default configuration
     config._add('algoliasearch', dict(
-        service_name=SERVICE_NAME,
+        service_name=config.get_service(default=SERVICE_NAME),
         collect_query_text=False
     ))
 except ImportError:

--- a/tests/contrib/algoliasearch/test.py
+++ b/tests/contrib/algoliasearch/test.py
@@ -1,5 +1,5 @@
 from ddtrace import config, patch_all
-from ddtrace.contrib.algoliasearch.patch import (patch, unpatch, algoliasearch_version)
+from ddtrace.contrib.algoliasearch.patch import patch, unpatch, algoliasearch_version
 from ddtrace.pin import Pin
 from tests.base import BaseTracerTestCase
 from ...utils import assert_is_measured
@@ -12,19 +12,15 @@ class AlgoliasearchTest(BaseTracerTestCase):
         # dummy values
         def search(self, query, args=None, request_options=None):
             return {
-                'hits': [
-                    {
-                        'dummy': 'dummy'
-                    }
-                ],
-                'processingTimeMS': 23,
-                'nbHits': 1,
-                'hitsPerPage': 20,
-                'exhaustiveNbHits': True,
-                'params': 'query=xxx',
-                'nbPages': 1,
-                'query': 'xxx',
-                'page': 0
+                "hits": [{"dummy": "dummy"}],
+                "processingTimeMS": 23,
+                "nbHits": 1,
+                "hitsPerPage": 20,
+                "exhaustiveNbHits": True,
+                "params": "query=xxx",
+                "nbPages": 1,
+                "query": "xxx",
+                "page": 0,
             }
 
         # Algolia search is a non free SaaS application, it isn't possible to add it to the
@@ -33,16 +29,18 @@ class AlgoliasearchTest(BaseTracerTestCase):
         if algoliasearch_version < (2, 0) and algoliasearch_version >= (1, 0):
             import algoliasearch
             import algoliasearch.index as index_module
+
             index_module.Index.search = search
-            client = algoliasearch.algoliasearch.Client('X', 'X')
+            client = algoliasearch.algoliasearch.Client("X", "X")
         else:
             import algoliasearch.search_index as index_module
             from algoliasearch.search_client import SearchClient
+
             index_module.SearchIndex.search = search
-            client = SearchClient.create('X', 'X')
+            client = SearchClient.create("X", "X")
 
         # use this index only to properly test stuff
-        self.index = client.init_index('test_index')
+        self.index = client.init_index("test_index")
 
     def patch_algoliasearch(self):
         patch()
@@ -51,7 +49,7 @@ class AlgoliasearchTest(BaseTracerTestCase):
     def tearDown(self):
         super(AlgoliasearchTest, self).tearDown()
         unpatch()
-        if hasattr(self, 'tracer'):
+        if hasattr(self, "tracer"):
             self.reset()
 
     def perform_search(self, query_text, query_args=None):
@@ -63,8 +61,7 @@ class AlgoliasearchTest(BaseTracerTestCase):
     def test_algoliasearch(self):
         self.patch_algoliasearch()
         self.perform_search(
-            'test search',
-            {'attributesToRetrieve': 'firstname,lastname', 'unsupportedTotallyNewArgument': 'ignore'}
+            "test search", {"attributesToRetrieve": "firstname,lastname", "unsupportedTotallyNewArgument": "ignore"}
         )
 
         spans = self.get_spans()
@@ -73,32 +70,31 @@ class AlgoliasearchTest(BaseTracerTestCase):
         assert len(spans) == 1
         span = spans[0]
         assert_is_measured(span)
-        assert span.service == 'algoliasearch'
-        assert span.name == 'algoliasearch.search'
+        assert span.service == "algoliasearch"
+        assert span.name == "algoliasearch.search"
         assert span.span_type is None
         assert span.error == 0
-        assert span.get_tag('query.args.attributes_to_retrieve') == 'firstname,lastname'
+        assert span.get_tag("query.args.attributes_to_retrieve") == "firstname,lastname"
         # Verify that adding new arguments to the search API will simply be ignored and not cause
         # errors
-        assert span.get_tag('query.args.unsupported_totally_new_argument') is None
-        assert span.get_metric('processing_time_ms') == 23
-        assert span.get_metric('number_of_hits') == 1
+        assert span.get_tag("query.args.unsupported_totally_new_argument") is None
+        assert span.get_metric("processing_time_ms") == 23
+        assert span.get_metric("number_of_hits") == 1
 
         # Verify query_text, which may contain sensitive data, is not passed along
         # unless the config value is appropriately set
-        assert span.get_tag('query.text') is None
+        assert span.get_tag("query.text") is None
 
     def test_algoliasearch_with_query_text(self):
         self.patch_algoliasearch()
         config.algoliasearch.collect_query_text = True
 
         self.perform_search(
-            'test search',
-            {'attributesToRetrieve': 'firstname,lastname', 'unsupportedTotallyNewArgument': 'ignore'}
+            "test search", {"attributesToRetrieve": "firstname,lastname", "unsupportedTotallyNewArgument": "ignore"}
         )
         spans = self.get_spans()
         span = spans[0]
-        assert span.get_tag('query.text') == 'test search'
+        assert span.get_tag("query.text") == "test search"
 
     def test_patch_unpatch(self):
         self.patch_algoliasearch()
@@ -106,7 +102,7 @@ class AlgoliasearchTest(BaseTracerTestCase):
         patch()
         patch()
 
-        self.perform_search('test search')
+        self.perform_search("test search")
 
         spans = self.get_spans()
         self.reset()
@@ -116,7 +112,7 @@ class AlgoliasearchTest(BaseTracerTestCase):
         # Test unpatch
         unpatch()
 
-        self.index.search('test search')
+        self.index.search("test search")
 
         spans = self.get_spans()
         self.reset()
@@ -126,7 +122,7 @@ class AlgoliasearchTest(BaseTracerTestCase):
         self.reset()
         patch()
 
-        self.index.search('test search')
+        self.index.search("test search")
 
         spans = self.get_spans()
         assert spans, spans
@@ -135,7 +131,7 @@ class AlgoliasearchTest(BaseTracerTestCase):
     def test_patch_all_auto_enable(self):
         patch_all()
         Pin.override(self.index, tracer=self.tracer)
-        self.perform_search('test search')
+        self.perform_search("test search")
 
         spans = self.get_spans()
         self.reset()
@@ -144,7 +140,23 @@ class AlgoliasearchTest(BaseTracerTestCase):
 
         unpatch()
 
-        self.perform_search('test search')
+        self.perform_search("test search")
 
         spans = self.get_spans()
         assert not spans, spans
+
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_user_specified_service(self):
+        """
+        When a service name is specified by the user
+            The algoliasearch integration should use it as the service name
+        """
+        patch_all()
+        Pin.override(self.index, tracer=self.tracer)
+        self.perform_search("test search")
+        spans = self.get_spans()
+        self.reset()
+        assert spans, spans
+        assert len(spans) == 1
+        assert spans[0].service == "mysvc"
+        unpatch()


### PR DESCRIPTION
The service precedence for `algoliasearch` is now: `DD_SERVICE`/`config.service` with a fallback to the original service name logic (`"algoliasearch"`).


I also black'd the tests.