### PR TITLE
integrations: DD_SERVICE

### DIFF
--- a/ddtrace/commands/ddtrace_run.py
+++ b/ddtrace/commands/ddtrace_run.py
@@ -29,8 +29,8 @@ Available environment variables:
     DATADOG_PATCH_MODULES=module:patch,module:patch... e.g. boto:true,redis:false : override the modules patched for this execution of the program (default: none)
     DATADOG_TRACE_AGENT_HOSTNAME=localhost: override the address of the trace agent host that the default tracer will attempt to submit to  (default: localhost)
     DATADOG_TRACE_AGENT_PORT=8126: override the port that the default tracer will submit to (default: 8126)
-    DD_SERVICE : override the service name to be used for this program (default only for select web integrations)
-    DATADOG_PRIORITY_SAMPLING=true|false : (default: false): enables Priority Sampling.
+    DD_SERVICE: the service name to be used for this program (default only for select web frameworks)
+    DATADOG_PRIORITY_SAMPLING=true|false: (default: false): enables Priority Sampling.
 """  # noqa: E501
 
 

--- a/ddtrace/contrib/aiobotocore/patch.py
+++ b/ddtrace/contrib/aiobotocore/patch.py
@@ -27,7 +27,7 @@ def patch():
     setattr(aiobotocore.client, '_datadog_patch', True)
 
     wrapt.wrap_function_wrapper('aiobotocore.client', 'AioBaseClient._make_api_call', _wrapped_api_call)
-    Pin(service=config.get_service(default='aws'), app='aws').onto(aiobotocore.client.AioBaseClient)
+    Pin(service=config.service or "aws", app="aws").onto(aiobotocore.client.AioBaseClient)
 
 
 def unpatch():

--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -132,7 +132,7 @@ def trace_app(app, tracer, service='aiohttp-web'):
     # configure datadog settings
     app[CONFIG_KEY] = {
         'tracer': tracer,
-        'service': config.get_service(default=service),
+        'service': config._get_service(default=service),
         'distributed_tracing_enabled': True,
         'analytics_enabled': None,
         'analytics_sample_rate': 1.0,

--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -27,7 +27,7 @@ def patch():
 
         _w = wrapt.wrap_function_wrapper
         _w('aiohttp_jinja2', 'render_template', _trace_render_template)
-        Pin(app='aiohttp', service=config.get_service()).onto(aiohttp_jinja2)
+        Pin(app='aiohttp', service=config.service).onto(aiohttp_jinja2)
 
 
 def unpatch():

--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -16,7 +16,7 @@ try:
 
     # Default configuration
     config._add('algoliasearch', dict(
-        service_name=config.get_service(default=SERVICE_NAME),
+        service_name=config.service or SERVICE_NAME,
         collect_query_text=False
     ))
 except ImportError:

--- a/ddtrace/contrib/bottle/patch.py
+++ b/ddtrace/contrib/bottle/patch.py
@@ -19,7 +19,7 @@ def patch():
 def traced_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
 
-    service = config.get_service(default="bottle")
+    service = config._get_service(default="bottle")
 
     plugin = TracePlugin(service=service)
     instance.install(plugin)

--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -16,7 +16,7 @@ class TracePlugin(object):
     api = 2
 
     def __init__(self, service='bottle', tracer=None, distributed_tracing=True):
-        self.service = service
+        self.service = ddtrace.config.get_service(default=service)
         self.tracer = tracer or ddtrace.tracer
         self.distributed_tracing = distributed_tracing
 

--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -16,7 +16,7 @@ class TracePlugin(object):
     api = 2
 
     def __init__(self, service='bottle', tracer=None, distributed_tracing=True):
-        self.service = ddtrace.config.get_service(default=service)
+        self.service = ddtrace.config.service or service
         self.tracer = tracer or ddtrace.tracer
         self.distributed_tracing = distributed_tracing
 

--- a/ddtrace/contrib/celery/constants.py
+++ b/ddtrace/contrib/celery/constants.py
@@ -16,5 +16,5 @@ TASK_RETRY_REASON_KEY = 'celery.retry.reason'
 
 # Service info
 APP = 'celery'
-PRODUCER_SERVICE = config.get_service(default="celery-producer")
-WORKER_SERVICE = config.get_service(default="celery-worker")
+PRODUCER_SERVICE = config._get_service(default="celery-producer")
+WORKER_SERVICE = config._get_service(default="celery-worker")

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -31,7 +31,7 @@ log = get_logger(__name__)
 config._add(
     "django",
     dict(
-        service_name=config.get_service(default="django"),
+        service_name=config._get_service(default="django"),
         cache_service_name=get_env("django", "cache_service_name") or "django",
         database_service_name_prefix=get_env("django", "database_service_name_prefix", default=""),
         distributed_tracing_enabled=True,

--- a/ddtrace/contrib/falcon/patch.py
+++ b/ddtrace/contrib/falcon/patch.py
@@ -21,7 +21,7 @@ def patch():
 
 def traced_init(wrapped, instance, args, kwargs):
     mw = kwargs.pop('middleware', [])
-    service = config.get_service(default="falcon")
+    service = config._get_service(default="falcon")
     distributed_tracing = asbool(get_env('falcon', 'distributed_tracing', default=True))
 
     mw.insert(0, TraceMiddleware(tracer, service, distributed_tracing))

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -23,7 +23,7 @@ FLASK_VERSION = 'flask.version'
 # Configure default configuration
 config._add('flask', dict(
     # Flask service configuration
-    service_name=config.get_service(default="flask"),
+    service_name=config._get_service(default="flask"),
     app='flask',
 
     collect_view_args=True,

--- a/ddtrace/contrib/flask_cache/tracers.py
+++ b/ddtrace/contrib/flask_cache/tracers.py
@@ -17,7 +17,7 @@ from flask.ext.cache import Cache
 
 log = logging.Logger(__name__)
 
-DEFAULT_SERVICE = 'flask-cache'
+DEFAULT_SERVICE = config.get_service(default="flask-cache")
 
 # standard tags
 COMMAND_KEY = 'flask_cache.key'

--- a/ddtrace/contrib/flask_cache/tracers.py
+++ b/ddtrace/contrib/flask_cache/tracers.py
@@ -17,7 +17,7 @@ from flask.ext.cache import Cache
 
 log = logging.Logger(__name__)
 
-DEFAULT_SERVICE = config.get_service(default="flask-cache")
+DEFAULT_SERVICE = config.service or "flask-cache"
 
 # standard tags
 COMMAND_KEY = 'flask_cache.key'

--- a/ddtrace/contrib/grpc/patch.py
+++ b/ddtrace/contrib/grpc/patch.py
@@ -11,7 +11,7 @@ from .server_interceptor import create_server_interceptor
 
 
 config._add('grpc_server', dict(
-    service_name=config.get_service(default=constants.GRPC_SERVICE_SERVER),
+    service_name=config._get_service(default=constants.GRPC_SERVICE_SERVER),
     distributed_tracing_enabled=True,
 ))
 
@@ -19,8 +19,8 @@ config._add('grpc_server', dict(
 # compatibility but should change in future
 config._add('grpc', dict(
     service_name='{}-{}'.format(
-        config.get_service(), constants.GRPC_SERVICE_CLIENT
-    ) if config.get_service() else constants.GRPC_SERVICE_CLIENT,
+        config._get_service(), constants.GRPC_SERVICE_CLIENT
+    ) if config._get_service() else constants.GRPC_SERVICE_CLIENT,
     distributed_tracing_enabled=True,
 ))
 

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -22,7 +22,7 @@ from .utils import (
 
 # kombu default settings
 config._add('kombu', {
-    'service_name': config.get_service(get_env('kombu', 'service_name', default=DEFAULT_SERVICE)),
+    "service_name": config.get_service(get_env("kombu", "service_name", default=DEFAULT_SERVICE)),
 })
 
 propagator = HTTPPropagator()

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -1,5 +1,6 @@
 # 3p
 import kombu
+from ddtrace import config
 from ddtrace.vendor import wrapt
 
 # project
@@ -22,7 +23,7 @@ from .utils import (
 
 # kombu default settings
 config._add('kombu', {
-    'service_name': get_env('kombu', 'service_name', default=DEFAULT_SERVICE)
+    'service_name': config.get_service(get_env('kombu', 'service_name', default=DEFAULT_SERVICE)),
 })
 
 propagator = HTTPPropagator()

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -48,10 +48,16 @@ def patch():
     _w('kombu', 'Consumer.receive', traced_receive)
 
     # We do not provide a service for producer spans since they represent
-    # external service calls to another service.
+    # external calls to another service.
     # Instead the service should be inherited from the parent.
+    if config.service:
+        prod_service = None
+    # DEV: backwards-compatibility for users who set a kombu service
+    else:
+        prod_service = get_env("kombu", "service_name", default=DEFAULT_SERVICE)
+
     Pin(
-        service=None,
+        service=prod_service,
         app="kombu",
     ).onto(kombu.messaging.Producer)
 

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -21,6 +21,7 @@ from .utils import (
 )
 
 # kombu default settings
+
 config._add('kombu', {
     "service_name": config.service or get_env("kombu", "service_name", default=DEFAULT_SERVICE),
 })
@@ -45,9 +46,13 @@ def patch():
     # *  extracts/normalizes things like exchange
     _w('kombu', 'Producer._publish', traced_publish)
     _w('kombu', 'Consumer.receive', traced_receive)
+
+    # We do not provide a service for producer spans since they represent
+    # external service calls to another service.
+    # Instead the service should be inherited from the parent.
     Pin(
-        service=config.kombu['service_name'],
-        app='kombu'
+        service=None,
+        app="kombu",
     ).onto(kombu.messaging.Producer)
 
     Pin(

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -22,7 +22,7 @@ from .utils import (
 
 # kombu default settings
 config._add('kombu', {
-    "service_name": config.get_service(get_env("kombu", "service_name", default=DEFAULT_SERVICE)),
+    "service_name": config.service or get_env("kombu", "service_name", default=DEFAULT_SERVICE),
 })
 
 propagator = HTTPPropagator()

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -1,6 +1,5 @@
 # 3p
 import kombu
-from ddtrace import config
 from ddtrace.vendor import wrapt
 
 # project

--- a/ddtrace/contrib/mako/patch.py
+++ b/ddtrace/contrib/mako/patch.py
@@ -4,6 +4,7 @@ from mako.template import Template
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanTypes
 from ...pin import Pin
+from ...settings import config
 from ...utils.importlib import func_name
 from ...utils.wrappers import unwrap as _u
 from ...vendor.wrapt import wrap_function_wrapper as _w
@@ -16,7 +17,7 @@ def patch():
         return
     setattr(mako, '__datadog_patch', True)
 
-    Pin(service='mako', app='mako').onto(Template)
+    Pin(service=config.get_service(default='mako'), app='mako').onto(Template)
 
     _w(mako, 'template.Template.render', _wrap_render)
     _w(mako, 'template.Template.render_unicode', _wrap_render)

--- a/ddtrace/contrib/mako/patch.py
+++ b/ddtrace/contrib/mako/patch.py
@@ -17,7 +17,7 @@ def patch():
         return
     setattr(mako, '__datadog_patch', True)
 
-    Pin(service=config.get_service(default='mako'), app='mako').onto(Template)
+    Pin(service=config.service or "mako", app="mako").onto(Template)
 
     _w(mako, 'template.Template.render', _wrap_render)
     _w(mako, 'template.Template.render_unicode', _wrap_render)

--- a/ddtrace/contrib/molten/patch.py
+++ b/ddtrace/contrib/molten/patch.py
@@ -17,7 +17,7 @@ MOLTEN_VERSION = tuple(map(int, molten.__version__.split()[0].split('.')))
 
 # Configure default configuration
 config._add('molten', dict(
-    service_name=get_env('molten', 'service_name', default='molten'),
+    service_name=config.get_service(default=get_env('molten', 'service_name', default='molten')),
     app='molten',
     distributed_tracing=asbool(get_env('molten', 'distributed_tracing', default=True)),
 ))

--- a/ddtrace/contrib/molten/patch.py
+++ b/ddtrace/contrib/molten/patch.py
@@ -17,7 +17,7 @@ MOLTEN_VERSION = tuple(map(int, molten.__version__.split()[0].split('.')))
 
 # Configure default configuration
 config._add('molten', dict(
-    service_name=config.get_service(default=get_env('molten', 'service_name', default='molten')),
+    service_name=config.get_service(default=get_env("molten", "service_name", default="molten")),
     app='molten',
     distributed_tracing=asbool(get_env('molten', 'distributed_tracing', default=True)),
 ))

--- a/ddtrace/contrib/molten/patch.py
+++ b/ddtrace/contrib/molten/patch.py
@@ -17,7 +17,7 @@ MOLTEN_VERSION = tuple(map(int, molten.__version__.split()[0].split('.')))
 
 # Configure default configuration
 config._add('molten', dict(
-    service_name=config.get_service(default=get_env("molten", "service_name", default="molten")),
+    service_name=config.service or get_env("molten", "service_name", default="molten"),
     app='molten',
     distributed_tracing=asbool(get_env('molten', 'distributed_tracing', default=True)),
 ))

--- a/ddtrace/contrib/pylons/patch.py
+++ b/ddtrace/contrib/pylons/patch.py
@@ -31,7 +31,7 @@ def traced_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
 
     # set tracing options and create the TraceMiddleware
-    service = config.get_service(default="pylons")
+    service = config._get_service(default="pylons")
     distributed_tracing = asbool(get_env('pylons', 'distributed_tracing', default=True))
     Pin(service=service, tracer=tracer).onto(instance)
     traced_app = PylonsTraceMiddleware(instance, tracer, service=service, distributed_tracing=distributed_tracing)

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -28,7 +28,7 @@ def patch():
 
 def traced_init(wrapped, instance, args, kwargs):
     settings = kwargs.pop('settings', {})
-    service = config.get_service(default="pyramid")
+    service = config._get_service(default="pyramid")
     distributed_tracing = asbool(get_env('pyramid', 'distributed_tracing', default=True))
     # DEV: integration-specific analytics flag can be not set but still enabled
     # globally for web frameworks

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -13,7 +13,7 @@ from .connection import _wrap_send
 
 # requests default settings
 config._add('requests', {
-    "service_name": config.get_service(default=get_env("requests", "service_name", default=DEFAULT_SERVICE)),
+    'service_name': get_env('requests', 'service_name', default=DEFAULT_SERVICE),
     'distributed_tracing': asbool(get_env('requests', 'distributed_tracing', default=True)),
     'split_by_domain': asbool(get_env('requests', 'split_by_domain', default=False)),
 })

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -13,7 +13,7 @@ from .connection import _wrap_send
 
 # requests default settings
 config._add('requests', {
-    'service_name': get_env('requests', 'service_name', default=DEFAULT_SERVICE),
+    "service_name": config.get_service(default=get_env("requests", "service_name", default=DEFAULT_SERVICE)),
     'distributed_tracing': asbool(get_env('requests', 'distributed_tracing', default=True)),
     'split_by_domain': asbool(get_env('requests', 'split_by_domain', default=False)),
 })

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -18,7 +18,7 @@ def tracer_config(__init__, app, args, kwargs):
     # default settings
     settings = {
         'tracer': ddtrace.tracer,
-        'default_service': config.get_service("tornado-web"),
+        'default_service': config._get_service("tornado-web"),
         'distributed_tracing': True,
         'analytics_enabled': None
     }

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -31,7 +31,7 @@ class Config(object):
             get_env('trace', 'analytics_enabled', default=legacy_config_value)
         )
 
-        # DEV: we don't use `self.get_service()` here because {DD,DATADOG}_SERVICE and
+        # DEV: we don't use `self._get_service()` here because {DD,DATADOG}_SERVICE and
         # {DD,DATADOG}_SERVICE_NAME (deprecated) are distinct functionalities.
         self.service = get_env("service")
 
@@ -115,7 +115,7 @@ class Config(object):
         """
         return self._http.header_is_traced(header_name)
 
-    def get_service(self, default=None):
+    def _get_service(self, default=None):
         """
         Returns the globally configured service.
 

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -31,12 +31,11 @@ class Config(object):
             get_env('trace', 'analytics_enabled', default=legacy_config_value)
         )
 
-        self.env = get_env("env")
-        # get_env will get DD_SERVICE or DATADOG_SERVICE (deprecated)
-        # Note that we do not call self.get_service() here because we never
-        # supported {DD,DATADOG}_SERVICE_NAME for setting the service globally.
+        # DEV: we don't use `self.get_service()` here because {DD,DATADOG}_SERVICE and
+        # {DD,DATADOG}_SERVICE_NAME (deprecated) are distinct functionalities.
         self.service = get_env("service")
 
+        self.env = get_env("env")
         self.version = get_env("version")
         self.logs_injection = asbool(get_env("logs", "injection", default=False))
 
@@ -123,6 +122,9 @@ class Config(object):
         If a service is not configured globally, attempts to get the service
         using the legacy environment variables via ``get_service_legacy``
         else ``default`` is returned.
+
+        When support for {DD,DATADOG}_SERVICE_NAME is removed, all usages of
+        this method can be replaced with `config.service`.
 
         :param default: the default service to use if none is configured or
             found.

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -32,7 +32,11 @@ class Config(object):
         )
 
         self.env = get_env("env")
+        # get_env will get DD_SERVICE or DATADOG_SERVICE (deprecated)
+        # Note that we do not call self.get_service() here because we never
+        # supported {DD,DATADOG}_SERVICE_NAME for setting the service globally.
         self.service = get_env("service")
+
         self.version = get_env("version")
         self.logs_injection = asbool(get_env("logs", "injection", default=False))
 

--- a/ddtrace/utils/deprecation.py
+++ b/ddtrace/utils/deprecation.py
@@ -64,8 +64,11 @@ def deprecated(message="", version=None):
 
 
 def get_service_legacy(default=None):
-    """Helper to print out a warning if old service name environment variables
-    are used.
+    """Helper to get the old {DD,DATADOG}_SERVICE_NAME environment variables
+    and output a deprecation warning if they are defined.
+
+    Note that this helper should only be used for migrating integrations which
+    use the {DD,DATADOG}_SERVICE_NAME variables to the new DD_SERVICE variable.
 
     If the environment variables are not in use, no deprecation warning is
     produced and `default` is returned.
@@ -73,9 +76,11 @@ def get_service_legacy(default=None):
     for old_env_key in ["DD_SERVICE_NAME", "DATADOG_SERVICE_NAME"]:
         if old_env_key in os.environ:
             debtcollector.deprecate(
-                "'{}' is deprecated and will be removed in a future version. Please use DD_SERVICE instead.".format(
-                    old_env_key
-                )
+                (
+                    "'{}' is deprecated and will be removed in a future version. Please use DD_SERVICE instead. "
+                    "Refer to our release notes on Github: https://github.com/DataDog/dd-trace-py/releases/tag/v0.36.0 "
+                    "for the improvements being made for service names."
+                ).format(old_env_key)
             )
             return os.getenv(old_env_key)
 

--- a/tests/contrib/flask_cache/test.py
+++ b/tests/contrib/flask_cache/test.py
@@ -295,7 +295,7 @@ class TestFlaskCacheSettings(BaseTracerTestCase):
     TEST_MEMCACHED_PORT = MEMCACHED_CONFIG['port']
 
     def setUp(self):
-        super(FlaskCacheTest, self).setUp()
+        super(TestFlaskCacheSettings, self).setUp()
 
         # create the TracedCache instance for a Flask app
         Cache = get_traced_cache(self.tracer)

--- a/tests/contrib/jinja2/test_jinja2.py
+++ b/tests/contrib/jinja2/test_jinja2.py
@@ -7,13 +7,14 @@ import jinja2
 from ddtrace import Pin, config
 from ddtrace.contrib.jinja2 import patch, unpatch
 from tests.test_tracer import get_dummy_tracer
+from ...base import BaseTracerTestCase
 from ...utils import assert_is_measured, assert_is_not_measured
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 TMPL_DIR = os.path.join(TEST_DIR, 'templates')
 
 
-class Jinja2Test(unittest.TestCase):
+class Jinja2Test(BaseTracerTestCase):
     def setUp(self):
         patch()
         # prevent cache effects when using Template('code...')
@@ -128,3 +129,19 @@ class Jinja2Test(unittest.TestCase):
 
         for span in spans:
             assert span.service == 'web'
+
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_user_specified_service(self):
+        """
+        When a service name is specified by the user
+            The jinja integration should use it as the service name
+        """
+
+        loader = jinja2.loaders.FileSystemLoader(TMPL_DIR)
+        env = jinja2.Environment(loader=loader)
+        t = env.get_template("template.html")
+        assert t.render(name="Jinja") == "Message: Hello Jinja!"
+
+        spans = self.tracer.writer.pop()
+        for span in spans:
+            assert span.service == "mysvc"

--- a/tests/contrib/jinja2/test_jinja2.py
+++ b/tests/contrib/jinja2/test_jinja2.py
@@ -1,5 +1,4 @@
 import os.path
-import unittest
 
 # 3rd party
 import jinja2

--- a/tests/contrib/kombu/test.py
+++ b/tests/contrib/kombu/test.py
@@ -133,6 +133,10 @@ class TestKombuSettings(BaseTracerTestCase):
 
         patch()
 
+    def tearDown(self):
+        unpatch()
+        super(TestKombuSettings, self).tearDown()
+
     @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service(self):
         """
@@ -144,7 +148,7 @@ class TestKombuSettings(BaseTracerTestCase):
 
         # Callback is required
         def process_message(body, message):
-            pass
+            message.ack()
 
         self.producer.publish(to_publish,
                               exchange=task_queue.exchange,

--- a/tests/contrib/kombu/test.py
+++ b/tests/contrib/kombu/test.py
@@ -141,12 +141,17 @@ class TestKombuSettings(BaseTracerTestCase):
         """
         task_queue = kombu.Queue('tasks', kombu.Exchange('tasks'), routing_key='tasks')
         to_publish = {'hello': 'world'}
+
+        # Callback is required
+        def process_message(body, message):
+            pass
+
         self.producer.publish(to_publish,
                               exchange=task_queue.exchange,
                               routing_key=task_queue.routing_key,
                               declare=[task_queue])
 
-        with kombu.Consumer(self.conn, [task_queue], accept=['json'], callbacks=[]) as consumer:
+        with kombu.Consumer(self.conn, [task_queue], accept=['json'], callbacks=[process_message]) as consumer:
             Pin.override(consumer, tracer=self.tracer)
             self.conn.drain_events(timeout=2)
 

--- a/tests/contrib/kombu/test.py
+++ b/tests/contrib/kombu/test.py
@@ -141,12 +141,12 @@ class TestKombuSettings(BaseTracerTestCase):
     def test_user_specified_service(self):
         """
         When a service name is specified by the user
-            The kombu integration should use it as the service name
+            The kombu integration should use it as the service name for both
+            the producer and consumer spans.
         """
         task_queue = kombu.Queue('tasks', kombu.Exchange('tasks'), routing_key='tasks')
         to_publish = {'hello': 'world'}
 
-        # Callback is required
         def process_message(body, message):
             message.ack()
 
@@ -161,5 +161,41 @@ class TestKombuSettings(BaseTracerTestCase):
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 2)
+
+        # Since no parent span exists for the producer it will inherit the
+        # global service name.
         for span in spans:
             assert span.service == "mysvc"
+
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_user_specified_service_producer(self):
+        """
+        When a service name is specified by the user
+            When a parent span with a different service name is provided to the
+            producer
+                The producer should inherit the parent service name, not the
+                global service name.
+        """
+        task_queue = kombu.Queue('tasks', kombu.Exchange('tasks'), routing_key='tasks')
+        to_publish = {'hello': 'world'}
+
+        def process_message(body, message):
+            message.ack()
+
+        with self.tracer.trace("parent", service="parentsvc"):
+            self.producer.publish(to_publish,
+                                  exchange=task_queue.exchange,
+                                  routing_key=task_queue.routing_key,
+                                  declare=[task_queue])
+
+        with kombu.Consumer(self.conn, [task_queue], accept=['json'], callbacks=[process_message]) as consumer:
+            Pin.override(consumer, tracer=self.tracer)
+            self.conn.drain_events(timeout=2)
+
+        spans = self.get_spans()
+        self.assertEqual(len(spans), 3)
+        # Parent and producer spans should have parent service
+        assert spans[0].service == "parentsvc"
+        assert spans[1].service == "parentsvc"
+        # Consumer span should have global service
+        assert spans[2].service == "mysvc"

--- a/tests/contrib/mako/test_mako.py
+++ b/tests/contrib/mako/test_mako.py
@@ -1,5 +1,4 @@
 import os.path
-import unittest
 
 # 3rd party
 from mako.template import Template
@@ -10,13 +9,14 @@ from ddtrace import Pin
 from ddtrace.contrib.mako import patch, unpatch
 from ddtrace.compat import StringIO, to_unicode
 from tests.test_tracer import get_dummy_tracer
+from ...base import BaseTracerTestCase
 from ...utils import assert_is_measured
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 TMPL_DIR = os.path.join(TEST_DIR, 'templates')
 
 
-class MakoTest(unittest.TestCase):
+class MakoTest(BaseTracerTestCase):
     def setUp(self):
         patch()
         self.tracer = get_dummy_tracer()
@@ -83,3 +83,18 @@ class MakoTest(unittest.TestCase):
         self.assertEqual(spans[0].get_tag('mako.template_name'), template_name)
         self.assertEqual(spans[0].name, 'mako.template.render')
         self.assertEqual(spans[0].resource, template_name)
+
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_user_specified_service(self):
+        """
+        When a service name is specified by the user
+            The mako integration should use it as the service name
+        """
+        tmpl_lookup = TemplateLookup(directories=[TMPL_DIR])
+        t = tmpl_lookup.get_template('template.html')
+        self.assertEqual(t.render(name='mako'), 'Hello mako!\n')
+
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+
+        assert spans[0].service == "mysvc"

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -317,3 +317,14 @@ class TestMolten(BaseTracerTestCase):
         molten_client()
         spans = self.tracer.writer.pop()
         self.assertTrue(len(spans) > 0)
+
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_user_specified_service(self):
+        """
+        When a service name is specified by the user
+            The molten integration should use it as the service name
+        """
+        molten_client()
+        spans = self.tracer.writer.pop()
+        for span in spans:
+            assert span.service == "mysvc"

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -492,14 +492,3 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         self.assertEqual(len(spans), 1)
         s = spans[0]
         self.assertEqual(s.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
-
-    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_service(self):
-        """
-        When a service name is specified by the user
-            The requests integration should use it as the service name
-        """
-        self.session.get(URL_200)
-        spans = self.tracer.writer.pop()
-        self.assertEqual(len(spans), 1)
-        assert spans[0].service == "mysvc"

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -492,3 +492,14 @@ class TestRequests(BaseRequestTestCase, BaseTracerTestCase):
         self.assertEqual(len(spans), 1)
         s = spans[0]
         self.assertEqual(s.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
+
+    @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_user_specified_service(self):
+        """
+        When a service name is specified by the user
+            The requests integration should use it as the service name
+        """
+        self.session.get(URL_200)
+        spans = self.tracer.writer.pop()
+        self.assertEqual(len(spans), 1)
+        assert spans[0].service == "mysvc"

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -780,6 +780,34 @@ def test_tracer_with_env():
 class EnvTracerTestCase(BaseTracerTestCase):
     """Tracer test cases requiring environment variables.
     """
+    @run_in_subprocess(env_overrides=dict(DATADOG_SERVICE_NAME="mysvc"))
+    def test_service_name_legacy_DATADOG_SERVICE_NAME(self):
+        """
+        When DATADOG_SERVICE_NAME is provided
+            It should not be used by default
+            It should be used with config.get_service()
+        """
+        from ddtrace import config
+        assert config.service is None
+        with self.start_span("") as s:
+            s.assert_matches(service=None)
+        with self.start_span("", service=config.get_service()) as s:
+            s.assert_matches(service="mysvc")
+
+    @run_in_subprocess(env_overrides=dict(DD_SERVICE_NAME="mysvc"))
+    def test_service_name_legacy_DD_SERVICE_NAME(self):
+        """
+        When DD_SERVICE_NAME is provided
+            It should not be used by default
+            It should be used with config.get_service()
+        """
+        from ddtrace import config
+        assert config.service is None
+        with self.start_span("") as s:
+            s.assert_matches(service=None)
+        with self.start_span("", service=config.get_service()) as s:
+            s.assert_matches(service="mysvc")
+
     @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_service_name_env(self):
         span = self.start_span("")

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -785,13 +785,13 @@ class EnvTracerTestCase(BaseTracerTestCase):
         """
         When DATADOG_SERVICE_NAME is provided
             It should not be used by default
-            It should be used with config.get_service()
+            It should be used with config._get_service()
         """
         from ddtrace import config
         assert config.service is None
         with self.start_span("") as s:
             s.assert_matches(service=None)
-        with self.start_span("", service=config.get_service()) as s:
+        with self.start_span("", service=config._get_service()) as s:
             s.assert_matches(service="mysvc")
 
     @run_in_subprocess(env_overrides=dict(DD_SERVICE_NAME="mysvc"))
@@ -799,13 +799,13 @@ class EnvTracerTestCase(BaseTracerTestCase):
         """
         When DD_SERVICE_NAME is provided
             It should not be used by default
-            It should be used with config.get_service()
+            It should be used with config._get_service()
         """
         from ddtrace import config
         assert config.service is None
         with self.start_span("") as s:
             s.assert_matches(service=None)
-        with self.start_span("", service=config.get_service()) as s:
+        with self.start_span("", service=config._get_service()) as s:
             s.assert_matches(service="mysvc")
 
     @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))


### PR DESCRIPTION
This PR makes the following changes:

1. When `DD_SERVICE`/`config.service` is provided it is the default service name used by non-external-calling integrations. The expected behaviour when not using `DD_SERVICE`/`config.service` should remain as before.

2. Integrations that never used `{DD,DATADOG}_SERVICE_NAME` should use `config.service` instead of `config.get_service` since using the latter would introduce new functionality for integrations to use the old `{DD,DATADOG}_SERVICE_NAME`.

3. `config.get_service` refactored to `config._get_service`. This should be a private api used only in integrations which use `{DD,DATADOG}_SERVICE_NAME` in order to deprecate the usage.