### PR TITLE
Update _dd.measured support

### DIFF
--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -7,7 +7,7 @@ from ddtrace.compat import to_unicode
 from ddtrace.ext import SpanTypes, errors
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
-from ...constants import ANALYTICS_SAMPLE_RATE_KEY, SPAN_MEASURED_KEY
+from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from . import constants
 from .utils import parse_method_path
 
@@ -154,7 +154,6 @@ class _ClientInterceptor(
         span = tracer.trace(
             "grpc", span_type=SpanTypes.GRPC, service=self._pin.service, resource=client_call_details.method,
         )
-        span.set_tag(SPAN_MEASURED_KEY)
 
         # tags for method details
         method_path = client_call_details.method

--- a/ddtrace/contrib/httplib/patch.py
+++ b/ddtrace/contrib/httplib/patch.py
@@ -3,7 +3,7 @@ from ddtrace.vendor import wrapt
 
 # Project
 from ...compat import PY2, httplib, parse
-from ...constants import ANALYTICS_SAMPLE_RATE_KEY, SPAN_MEASURED_KEY
+from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...ext import SpanTypes, http as ext_http
 from ...http import store_request_headers, store_response_headers
 from ...internal.logger import get_logger
@@ -56,7 +56,6 @@ def _wrap_putrequest(func, instance, args, kwargs):
     try:
         # Create a new span and attach to this instance (so we can retrieve/update/close later on the response)
         span = pin.tracer.trace(span_name, span_type=SpanTypes.HTTP)
-        span.set_tag(SPAN_MEASURED_KEY)
         setattr(instance, '_datadog_span', span)
 
         method, path = args[:2]

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -4,7 +4,7 @@ import sys
 import ddtrace
 
 from ..subprocesstest import SubprocessTestCase
-from ..utils import override_env
+from ..utils import override_env, assert_is_not_measured, assert_is_measured
 from ..utils.tracer import DummyTracer
 from ..utils.span import TestSpanContainer, TestSpan, NO_CHILDREN
 
@@ -27,6 +27,10 @@ class BaseTestCase(SubprocessTestCase):
 
     # Expose `override_env` as `self.override_env`
     override_env = staticmethod(override_env)
+
+    assert_is_measured = staticmethod(assert_is_measured)
+
+    assert_is_not_measured = staticmethod(assert_is_not_measured)
 
     @staticmethod
     @contextlib.contextmanager

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -10,7 +10,6 @@ from ddtrace.ext import errors
 from ddtrace import Pin
 
 from ...base import BaseTracerTestCase
-from ...utils import assert_is_measured
 
 from .hello_pb2 import HelloRequest, HelloReply
 from .hello_pb2_grpc import add_HelloServicer_to_server, HelloStub, HelloServicer
@@ -64,7 +63,7 @@ class GrpcTestCase(BaseTracerTestCase):
         self._server.stop(0)
 
     def _check_client_span(self, span, service, method_name, method_kind):
-        assert_is_measured(span)
+        self.assert_is_not_measured(span)
         assert span.name == 'grpc'
         assert span.resource == '/helloworld.Hello/{}'.format(method_name)
         assert span.service == service
@@ -80,7 +79,7 @@ class GrpcTestCase(BaseTracerTestCase):
         assert span.get_tag('grpc.port') == '50531'
 
     def _check_server_span(self, span, service, method_name, method_kind):
-        assert_is_measured(span)
+        self.assert_is_measured(span)
         assert span.name == 'grpc'
         assert span.resource == '/helloworld.Hello/{}'.format(method_name)
         assert span.service == service

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -18,7 +18,7 @@ from tests.opentracer.utils import init_tracer
 
 from ...base import BaseTracerTestCase
 from ...util import override_global_tracer
-from ...utils import assert_span_http_status_code, assert_is_measured
+from ...utils import assert_span_http_status_code
 
 if PY2:
     from urllib2 import urlopen, build_opener, Request
@@ -149,7 +149,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         spans = self.tracer.writer.pop()
         self.assertEqual(len(spans), 1)
         span = spans[0]
-        assert_is_measured(span)
+        self.assert_is_not_measured(span)
         self.assertEqual(span.span_type, 'http')
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
@@ -187,7 +187,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         spans = self.tracer.writer.pop()
         self.assertEqual(len(spans), 1)
         span = spans[0]
-        assert_is_measured(span)
+        self.assert_is_not_measured(span)
         self.assertEqual(span.span_type, 'http')
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
@@ -212,7 +212,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         spans = self.tracer.writer.pop()
         self.assertEqual(len(spans), 1)
         span = spans[0]
-        assert_is_measured(span)
+        self.assert_is_not_measured(span)
         self.assertEqual(span.span_type, 'http')
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
@@ -236,7 +236,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         spans = self.tracer.writer.pop()
         self.assertEqual(len(spans), 1)
         span = spans[0]
-        assert_is_measured(span)
+        self.assert_is_not_measured(span)
         self.assertEqual(span.span_type, 'http')
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
@@ -266,7 +266,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         spans = self.tracer.writer.pop()
         self.assertEqual(len(spans), 1)
         span = spans[0]
-        assert_is_measured(span)
+        self.assert_is_not_measured(span)
         self.assertEqual(span.span_type, 'http')
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
@@ -296,7 +296,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         spans = self.tracer.writer.pop()
         self.assertEqual(len(spans), 1)
         span = spans[0]
-        assert_is_measured(span)
+        self.assert_is_not_measured(span)
         self.assertEqual(span.span_type, 'http')
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
@@ -381,7 +381,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         spans = self.tracer.writer.pop()
         self.assertEqual(len(spans), 1)
         span = spans[0]
-        assert_is_measured(span)
+        self.assert_is_not_measured(span)
         self.assertEqual(span.span_type, 'http')
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
@@ -406,7 +406,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         spans = self.tracer.writer.pop()
         self.assertEqual(len(spans), 1)
         span = spans[0]
-        assert_is_measured(span)
+        self.assert_is_not_measured(span)
         self.assertEqual(span.span_type, 'http')
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
@@ -432,7 +432,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         spans = self.tracer.writer.pop()
         self.assertEqual(len(spans), 1)
         span = spans[0]
-        assert_is_measured(span)
+        self.assert_is_not_measured(span)
         self.assertEqual(span.span_type, 'http')
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
@@ -457,7 +457,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         spans = self.tracer.writer.pop()
         self.assertEqual(len(spans), 1)
         span = spans[0]
-        assert_is_measured(span)
+        self.assert_is_not_measured(span)
         self.assertEqual(span.span_type, 'http')
         self.assertIsNone(span.service)
         self.assertEqual(span.name, self.SPAN_NAME)
@@ -489,7 +489,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, BaseTracerTestCase):
         self.assertEqual(ot_span.service, 'my_svc')
         self.assertEqual(ot_span.name, 'ot_span')
 
-        assert_is_measured(dd_span)
+        self.assert_is_not_measured(dd_span)
         self.assertEqual(dd_span.span_type, 'http')
         self.assertEqual(dd_span.name, self.SPAN_NAME)
         self.assertEqual(dd_span.error, 0)
@@ -562,7 +562,7 @@ if PY2:
             spans = self.tracer.writer.pop()
             self.assertEqual(len(spans), 1)
             span = spans[0]
-            assert_is_measured(span)
+            self.assert_is_not_measured(span)
             self.assertEqual(span.span_type, 'http')
             self.assertIsNone(span.service)
             self.assertEqual(span.name, 'httplib.request')
@@ -587,7 +587,7 @@ if PY2:
             spans = self.tracer.writer.pop()
             self.assertEqual(len(spans), 1)
             span = spans[0]
-            assert_is_measured(span)
+            self.assert_is_not_measured(span)
             self.assertEqual(span.span_type, 'http')
             self.assertIsNone(span.service)
             self.assertEqual(span.name, 'httplib.request')

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -15,7 +15,7 @@ def assert_is_measured(span):
 def assert_is_not_measured(span):
     """Assert that the span does not set _dd.measured"""
     assert SPAN_MEASURED_KEY not in span.meta
-    if SPAN_MEASURED_KEY in span.meta:
+    if SPAN_MEASURED_KEY in span.metrics:
         assert span.get_metric(SPAN_MEASURED_KEY) == 0
     else:
         assert SPAN_MEASURED_KEY not in span.metrics

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -18,7 +18,7 @@ def assert_is_not_measured(span):
     if SPAN_MEASURED_KEY in span.meta:
         assert span.get_metric(SPAN_MEASURED_KEY) == 0
     else:
-        assert SPAN_MEASURED_KEY not in span.meta
+        assert SPAN_MEASURED_KEY not in span.metrics
 
 
 def assert_span_http_status_code(span, code):


### PR DESCRIPTION
For some of our integrations, which represent external service calls, applying the `_dd.measured` tag does not make sense by default. This PR removes those instances.