### PR TITLE
config: IntegrationConfig improvements

### DIFF
--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -1,62 +1,233 @@
 from copy import deepcopy
 
-from ..utils.attrdict import AttrDict
+from ..vendor import attr
 from ..utils.formats import asbool, get_env
 from .http import HttpConfig
 from .hooks import Hooks
 
 
-class IntegrationConfig(AttrDict):
+@attr.s
+class Setting(object):
+    """Setting represents a configuration setting which is defined by the
+    library and optionally overridden by the user.
     """
-    Integration specific configuration object.
 
-    This is what you will get when you do::
+    Undefined = object()
+
+    @attr.s
+    class Defined(object):
+        value = attr.ib()
+
+    class SettingKeyError(KeyError):
+        pass
+
+    _value = attr.ib(default=Undefined, validator=attr.validators.instance_of(Defined))
+    _default = attr.ib(init=False)
+
+    def __attrs_post_init__(self):
+        self._default = self._value
+
+    def set(self, value):
+        self._value = value
+        return value
+
+    def get(self):
+        if self._value is self.Undefined:
+            raise self.SettingKeyError()
+        return self._value.value
+
+    def reset(self):
+        self._value = self._default
+
+    def isdefined(self):
+        return self._value is not self.Undefined
+
+    def check(self, _type):
+        return isinstance(self._value, _type)
+
+
+class IntegrationConfig(object):
+    """
+    All internal methods/properties must be private (prefixed with _)
+
+    - Differentiation between library and user defined values
+    - Support for defaults
+    - User API is limited to reading/writing only settings that exist
+    - Awareness of whether a setting has been overridden by a user
+
+    Library API::
 
         from ddtrace import config
+        config._add("redis", dict(
+            service="redis",
+        ))
+        config.redis._get("service")
 
-        # This is an `IntegrationConfig`
-        config.flask
 
-        # `IntegrationConfig` supports both attribute and item accessors
-        config.flask['service_name'] = 'my-service-name'
-        config.flask.service_name = 'my-service-name'
+    User API::
+
+        from ddtrace import config
+        config.redis.service = "test"
+        config.redis.serivce = "test"  # throws exception!!
+
     """
+
+    class UserDefined(Setting.Defined):
+        pass
+
+    class LibDefined(Setting.Defined):
+        pass
+
+    class IntegrationConfigAttributeError(AttributeError):
+        pass
+
+    class IntegrationConfigKeyError(KeyError):
+        pass
+
+    @attr.s
+    class Dec(object):
+        """Used to declare a setting for an IntegrationConfig
+        """
+        default = attr.ib()
+        env_var = attr.ib(default=False, type=bool)
+        type = attr.ib(default=None)
+
+        def cast(self, val):
+            if self.type is None:
+                return val
+            elif self.type is bool:
+                return asbool(val)
+            elif self.type is float:
+                return float(val)
+
+            raise NotImplementedError("type {} not implemented".format(self.type))
+
     def __init__(self, global_config, name, *args, **kwargs):
-        """
-        :param global_config:
-        :type global_config: Config
-        :param args:
-        :param kwargs:
-        """
-        super(IntegrationConfig, self).__init__(*args, **kwargs)
+        self._global_config = global_config
+        self._name = name
+        self._settings = {}
+        self._hooks = Hooks()
+        self._http = HttpConfig()
 
-        # Set internal properties for this `IntegrationConfig`
-        # DEV: By-pass the `__setattr__` overrides from `AttrDict` to set real properties
-        object.__setattr__(self, 'global_config', global_config)
-        object.__setattr__(self, 'integration_name', name)
-        object.__setattr__(self, 'hooks', Hooks())
-        object.__setattr__(self, 'http', HttpConfig())
+        # Default integration settings
+        init_settings = dict(
+            analytics_enabled=self.Dec(False, type=bool, env_var=True),
+            analytics_sample_rate=self.Dec(1.0, type=float, env_var=True),
+            service_name=self.Dec(None),
+        )
+        init_settings.update(dict(*args, **kwargs))
 
-        # Set default analytics configuration, default is disabled
-        # DEV: Default to `None` which means do not set this key
-        # Inject environment variables for integration
-        analytics_enabled_env = get_env(name, 'analytics_enabled')
-        if analytics_enabled_env is not None:
-            analytics_enabled_env = asbool(analytics_enabled_env)
-        self.setdefault('analytics_enabled', analytics_enabled_env)
-        self.setdefault('analytics_sample_rate', float(get_env(name, 'analytics_sample_rate', default=1.0)))
+        # Defaults can be overridden by integration-specific configs
+        for (key, setting) in init_settings.items():
+            if not isinstance(setting, self.Dec):
+                setting = self.Dec(setting)
+
+            # First add the setting with the default.
+            self._add(key, setting.default)
+
+            # Then perform any environment variable lookups
+            if setting.env_var:
+                env_val = get_env(name, key)
+                if env_val is not None:
+                    self._set_user(key, setting.cast(env_val))
+
+    @property
+    def http(self):
+        return self._http
+
+    @property
+    def hooks(self):
+        return self._hooks
+
+    @property
+    def global_config(self):
+        return self._global_config
+
+    def copy(self):
+        return self
 
     def __deepcopy__(self, memodict=None):
-        new = IntegrationConfig(self.global_config, deepcopy(dict(self)))
-        new.hooks = deepcopy(self.hooks)
-        new.http = deepcopy(self.http)
+        new = IntegrationConfig(self._global_config, self._name, deepcopy(self._settings))
+        new._hooks = deepcopy(self._hooks)
+        new._http = deepcopy(self._http)
         return new
+
+    def __getitem__(self, key):
+        # implement Config()[] operator
+        if key not in self._settings:
+            raise self.IntegrationConfigKeyError("Setting {} does not exist".format(key))
+        return self._settings[key].get()
+
+    def __setitem__(self, key, value):
+        # implement Config()[] = operator
+        if key not in self._settings:
+            raise self.IntegrationConfigKeyError("Setting {} does not exist".format(key))
+        return self._set_user(key, value)
+
+    def __contains__(self, key):
+        # implement in operator
+        return key in self._settings
+
+    def __getattr__(self, key):
+        """
+        getattr is only called if the attribute does not exist
+        """
+        if key.startswith("_"):
+            return object.__getattribute__(self, key)
+
+        if key in self._settings:
+            return self._settings[key].get()
+
+        try:
+            return object.__getattribute__(self, key)
+        except AttributeError as e:
+            raise self.IntegrationConfigAttributeError(e)
+
+    def __setattr__(self, key, value):
+        if key.startswith("_"):
+            return object.__setattr__(self, key, value)
+        if key in self._settings:
+            return self._set_user(key, value)
+        else:
+            raise self.IntegrationConfigAttributeError("Setting for key {} does not exist".format(key))
+
+    def _add(self, key, value):
+        self._settings[key] = Setting(self.LibDefined(value))
+
+    def _reset(self):
+        for key in self._settings:
+            self._settings[key].reset()
+
+    def _set_user(self, key, value):
+        self._settings[key].set(self.UserDefined(value))
+        return value
+
+    def _is_user_defined(self, key):
+        return self._settings[key].check(IntegrationConfig.UserDefined)
+
+    def _is_lib_defined(self, key):
+        return self._settings[key].check(IntegrationConfig.LibDefined)
+
+    def items(self):
+        return [
+            (k, v.get()) for k, v in self._settings.items()
+        ]
+
+    def get(self, key, default=Setting.Undefined):
+        if key not in self._settings and default is not Setting.Undefined:
+            return default
+        return self._settings[key].get()
+
+    def update(self, other):
+        for k, v in other.items():
+            self._set_user(k, v)
+        return self
 
     @property
     def trace_query_string(self):
-        if self.http.trace_query_string is not None:
-            return self.http.trace_query_string
-        return self.global_config._http.trace_query_string
+        if self._http.trace_query_string is not None:
+            return self._http.trace_query_string
+        return self._global_config._http.trace_query_string
 
     def header_is_traced(self, header_name):
         """
@@ -66,18 +237,19 @@ class IntegrationConfig(AttrDict):
         :rtype: bool
         """
         return (
-            self.http.header_is_traced(header_name)
-            if self.http.is_header_tracing_configured
-            else self.global_config.header_is_traced(header_name)
+            self._http.header_is_traced(header_name)
+            if self._http.is_header_tracing_configured
+            else self._global_config.header_is_traced(header_name)
         )
 
     def _is_analytics_enabled(self, use_global_config):
-        # DEV: analytics flag can be None which should not be taken as
-        # enabled when global flag is disabled
-        if use_global_config and self.global_config.analytics_enabled:
-            return self.analytics_enabled is not False
+        if use_global_config and self._global_config.analytics_enabled:
+            # Allow users to override the global
+            if self._is_user_defined("analytics_enabled"):
+                return self.analytics_enabled
+            return True
         else:
-            return self.analytics_enabled is True
+            return self.analytics_enabled
 
     def get_analytics_sample_rate(self, use_global_config=False):
         """
@@ -86,12 +258,11 @@ class IntegrationConfig(AttrDict):
         configuration
         """
         if self._is_analytics_enabled(use_global_config):
-            analytics_sample_rate = getattr(self, 'analytics_sample_rate', None)
             # return True if attribute is None or attribute not found
-            if analytics_sample_rate is None:
+            if self.analytics_sample_rate is None:
                 return True
             # otherwise return rate
-            return analytics_sample_rate
+            return self.analytics_sample_rate
 
         # Use `None` as a way to say that it was not defined,
         #   `False` would mean `0` which is a different thing
@@ -99,5 +270,5 @@ class IntegrationConfig(AttrDict):
 
     def __repr__(self):
         cls = self.__class__
-        keys = ', '.join(self.keys())
-        return '{}.{}({})'.format(cls.__module__, cls.__name__, keys)
+        keys = ", ".join(["{}={}".format(k, v) for k, v in self._settings.items()])
+        return "{}.{}({})".format(cls.__module__, cls.__name__, keys)

--- a/ddtrace/utils/merge.py
+++ b/ddtrace/utils/merge.py
@@ -2,7 +2,6 @@
 def deepmerge(source, destination):
     """
     Merge the first provided ``dict`` into the second.
-
     :param dict source: The ``dict`` to merge into ``destination``
     :param dict destination: The ``dict`` that should get updated
     :rtype: dict

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -77,18 +77,16 @@ class BaseTestCase(SubprocessTestCase):
             >>> with self.override_config('flask', dict(service_name='test-service')):
                 # Your test
         """
-        options = getattr(ddtrace.config, integration)
+        settings = getattr(ddtrace.config, integration)
 
-        original = dict(
-            (key, options.get(key))
-            for key in values.keys()
-        )
+        # Set as user defined
+        for key, value in values.items():
+            settings[key] = value
 
-        options.update(values)
         try:
             yield
         finally:
-            options.update(original)
+            settings._reset()
 
     @staticmethod
     @contextlib.contextmanager

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -35,6 +35,9 @@ class BaseRequestTestCase(object):
     def tearDown(self):
         unpatch()
 
+        # Reset the config after each test run
+        config.requests._reset()
+
         super(BaseRequestTestCase, self).tearDown()
 
 

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -54,47 +54,25 @@ class GlobalConfigTestCase(TestCase):
         # ensure a global configuration is available in the `ddtrace` module
         assert isinstance(global_config, Config)
 
-    def test_settings_merge(self):
+    def test_settings_merge_library(self):
         """
         When calling `config._add()`
-            when existing settings exist
-                we do not overwrite the existing settings
+            When existing library settings exist
+                We do overwrite the existing library settings
         """
-        self.config.requests['split_by_domain'] = True
+        self.config._add('requests', dict(split_by_domain=True))
         self.config._add('requests', dict(split_by_domain=False))
-        assert self.config.requests['split_by_domain'] is True
-
-    def test_settings_overwrite(self):
-        """
-        When calling `config._add(..., merge=False)`
-            when existing settings exist
-                we overwrite the existing settings
-        """
-        self.config.requests['split_by_domain'] = True
-        self.config._add('requests', dict(split_by_domain=False), merge=False)
         assert self.config.requests['split_by_domain'] is False
 
-    def test_settings_merge_deep(self):
+    def test_settings_merge_user_library(self):
         """
         When calling `config._add()`
-            when existing "deep" settings exist
-                we do not overwrite the existing settings
+            When existing user settings exist
+                We do overwrite the existing library settings
         """
-        self.config.requests['a'] = dict(
-            b=dict(
-                c=True,
-            ),
-        )
-        self.config._add('requests', dict(
-            a=dict(
-                b=dict(
-                    c=False,
-                    d=True,
-                ),
-            ),
-        ))
-        assert self.config.requests['a']['b']['c'] is True
-        assert self.config.requests['a']['b']['d'] is True
+        self.config._add('requests', dict(split_by_domain=True))
+        self.config._add('requests', dict(split_by_domain=False))
+        assert self.config.requests['split_by_domain'] is False
 
     def test_settings_hook(self):
         """

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 
 from ddtrace import config
 from ddtrace.pin import Pin
-from ddtrace.settings import IntegrationConfig
 
 
 class InstanceConfigTestCase(TestCase):
@@ -99,32 +98,3 @@ class InstanceConfigTestCase(TestCase):
         cfg = config.get_from(instance)
         # it should have users updated value
         assert cfg['service_name'] == 'metrics'
-
-    def test_config_attr_and_key(self):
-        """
-        This is a regression test for when mixing attr attribute and key
-        access we would set the value of the attribute but not the key
-        """
-        integration_config = IntegrationConfig(config, 'test')
-
-        # Our key and attribute do not exist
-        self.assertFalse(hasattr(integration_config, 'distributed_tracing'))
-        self.assertNotIn('distributed_tracing', integration_config)
-
-        # Initially set and access
-        integration_config['distributed_tracing'] = True
-        self.assertTrue(integration_config['distributed_tracing'])
-        self.assertTrue(integration_config.get('distributed_tracing'))
-        self.assertTrue(integration_config.distributed_tracing)
-
-        # Override by key and access
-        integration_config['distributed_tracing'] = False
-        self.assertFalse(integration_config['distributed_tracing'])
-        self.assertFalse(integration_config.get('distributed_tracing'))
-        self.assertFalse(integration_config.distributed_tracing)
-
-        # Override by attr and access
-        integration_config.distributed_tracing = None
-        self.assertIsNone(integration_config['distributed_tracing'])
-        self.assertIsNone(integration_config.get('distributed_tracing'))
-        self.assertIsNone(integration_config.distributed_tracing)

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ddtrace.settings import Config, HttpConfig, IntegrationConfig
 
 from ..base import BaseTestCase
@@ -113,104 +115,223 @@ class TestHttpConfig(BaseTestCase):
         assert not http_config.header_is_traced(None)
 
 
+class TestIntegrationConfigCore(BaseTestCase):
+    def test_init_simple(self):
+        c = IntegrationConfig(None, "int", dict(key1="value1", key2="value2", key3=3,))
+        assert "key1" in c
+        assert "key2" in c
+        assert "key3" in c
+
+    def test_init_complex(self):
+        with self.override_env(dict(DD_INT_KEY1="DNE", DD_INT_KEY2="val2", DD_INT_KEY3="1.4")):
+            c = IntegrationConfig(None, "int", dict(
+                key1=IntegrationConfig.Dec("value1"),
+                key2=IntegrationConfig.Dec("value2", env_var=True),
+                key3=IntegrationConfig.Dec(2.3, env_var=True, type=float),
+            ))
+        assert "key1" in c
+        assert "key2" in c
+        assert "key3" in c
+
+        assert c.key1 == "value1"
+        assert c._is_lib_defined("key1")
+        assert c.key2 == "val2"
+        assert c._is_user_defined("key2")
+        assert c.key3 == 1.4
+        assert c._is_user_defined("key3")
+
+    def test_dot_operator_not_added(self):
+        """
+        When a config setting has not been added
+            It is an error to access it via dot notation.
+            It is an error to set it via dot notation.
+        """
+        c = IntegrationConfig(None, "int")
+
+        with pytest.raises(IntegrationConfig.IntegrationConfigAttributeError):
+            _ = c.key
+
+        with pytest.raises(IntegrationConfig.IntegrationConfigAttributeError):
+            c.key = object()
+
+        with pytest.raises(IntegrationConfig.IntegrationConfigAttributeError):
+            _ = c.key
+
+        assert "key" not in c
+
+    def test_index_operator_not_added(self):
+        """
+        When a config setting has not been added
+            It is an error to access it via index notation.
+            It is an error to set it via index notation.
+        """
+        c = IntegrationConfig(None, "int")
+
+        with pytest.raises(IntegrationConfig.IntegrationConfigKeyError):
+            _ = c["key"]
+
+        with pytest.raises(IntegrationConfig.IntegrationConfigKeyError):
+            c["key"] = object()
+
+        with pytest.raises(IntegrationConfig.IntegrationConfigKeyError):
+            _ = c["key"]
+
+    def test_index_operator(self):
+        c = IntegrationConfig(None, "int", dict(key="test",))
+        value = object()
+        c["key"] = value
+        assert "key" in c
+        assert c["key"] == value
+
+    def test_dot_operator_set(self):
+        c = IntegrationConfig(None, "int", dict(key="value"))
+        value = object()
+        c.key = value
+        assert "key" in c
+        assert c["key"] == value
+        assert c.key == value
+
+    def test_initializer_values(self):
+        """
+        When values are added via the initializer
+            They should be library defined.
+        """
+        c = IntegrationConfig(None, "int", dict(key1="value", key2="value",))
+
+        assert c._is_lib_defined("key1")
+        assert c._is_lib_defined("key2")
+
+    def test_add_values(self):
+        """
+        When values are added via the initializer
+            They should be library defined.
+        """
+        c = IntegrationConfig(None, "int", dict(key1="value",))
+
+        c._add("key2", "value")
+
+        assert c._is_lib_defined("key1")
+        assert c._is_lib_defined("key2")
+
+    def test_reset(self):
+        c = IntegrationConfig(None, "int", dict(key1="value",))
+        c.key1 = "different"
+        c._reset()
+        assert c.key1 == "value"
+
+    def test_items(self):
+        items = dict(key1="value", key2="value2")
+        c = IntegrationConfig(None, "int", items)
+        citems = c.items()
+        assert ("key1", "value") in citems
+        assert ("key2", "value2") in citems
+
+    def test_get(self):
+        c = IntegrationConfig(None, "int", dict(key1="value",))
+        assert c.get("key1") == "value"
+        assert c.get("dne", default=5) == 5
+
+    def test_mixed_access_attr(self):
+        c = IntegrationConfig(None, "int", dict(key1="value",))
+        c.key1 = "value2"
+        assert c["key1"] == "value2"
+        assert c.get("key1") == "value2"
+
+        c["key1"] = "value3"
+        assert c.key1 == "value3"
+        assert c.get("key1") == "value3"
+
+
 class TestIntegrationConfig(BaseTestCase):
     def setUp(self):
         self.config = Config()
-        self.integration_config = IntegrationConfig(self.config, 'test')
-
-    def test_is_a_dict(self):
-        assert isinstance(self.integration_config, dict)
-
-    def test_allow_item_access(self):
-        self.integration_config['setting'] = 'value'
-
-        # Can be accessed both as item and attr accessor
-        assert self.integration_config.setting == 'value'
-        assert self.integration_config['setting'] == 'value'
-
-    def test_allow_attr_access(self):
-        self.integration_config.setting = 'value'
-
-        # Can be accessed both as item and attr accessor
-        assert self.integration_config.setting == 'value'
-        assert self.integration_config['setting'] == 'value'
+        self.integration_config = IntegrationConfig(self.config, "test")
 
     def test_allow_both_access(self):
-        self.integration_config.setting = 'value'
-        assert self.integration_config['setting'] == 'value'
-        assert self.integration_config.setting == 'value'
+        self.integration_config._add("setting", None)
 
-        self.integration_config['setting'] = 'new-value'
-        assert self.integration_config.setting == 'new-value'
-        assert self.integration_config['setting'] == 'new-value'
+        self.integration_config.setting = "value"
+        assert self.integration_config["setting"] == "value"
+        assert self.integration_config.setting == "value"
+
+        self.integration_config["setting"] = "new-value"
+        assert self.integration_config.setting == "new-value"
+        assert self.integration_config["setting"] == "new-value"
 
     def test_allow_configuring_http(self):
-        self.integration_config.http.trace_headers('integration_header')
-        assert self.integration_config.http.header_is_traced('integration_header')
-        assert not self.integration_config.http.header_is_traced('other_header')
+        self.integration_config.http.trace_headers("integration_header")
+        assert self.integration_config.http.header_is_traced("integration_header")
+        assert not self.integration_config.http.header_is_traced("other_header")
 
     def test_allow_exist_both_global_and_integration_config(self):
-        self.config.trace_headers('global_header')
-        assert self.integration_config.header_is_traced('global_header')
+        self.config.trace_headers("global_header")
+        assert self.integration_config.header_is_traced("global_header")
 
-        self.integration_config.http.trace_headers('integration_header')
-        assert self.integration_config.header_is_traced('integration_header')
-        assert not self.integration_config.header_is_traced('global_header')
-        assert not self.config.header_is_traced('integration_header')
+        self.integration_config.http.trace_headers("integration_header")
+        assert self.integration_config.header_is_traced("integration_header")
+        assert not self.integration_config.header_is_traced("global_header")
+        assert not self.config.header_is_traced("integration_header")
 
     def test_environment_analytics_enabled(self):
-        # default
         self.assertFalse(self.config.analytics_enabled)
-        self.assertIsNone(self.config.foo.analytics_enabled)
 
-        with self.override_env(dict(DD_ANALYTICS_ENABLED='True')):
+        assert self.config.foo.analytics_enabled is False
+
+        with self.override_env(dict(DD_ANALYTICS_ENABLED="True")):
             config = Config()
             self.assertTrue(config.analytics_enabled)
-            self.assertIsNone(config.foo.analytics_enabled)
+            assert self.config.foo.analytics_enabled is False
+            assert not self.config.foo._is_user_defined("analytics_enabled")
 
-        with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED='True')):
+        with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED="True")):
             config = Config()
             self.assertTrue(config.foo.analytics_enabled)
             self.assertEqual(config.foo.analytics_sample_rate, 1.0)
+            assert config.foo._is_user_defined("analytics_enabled")
 
-        with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED='False')):
+        with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED="False")):
             config = Config()
             self.assertFalse(config.foo.analytics_enabled)
 
-        with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED='True', DD_FOO_ANALYTICS_SAMPLE_RATE='0.5')):
+        with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED="True", DD_FOO_ANALYTICS_SAMPLE_RATE="0.5")):
             config = Config()
             self.assertTrue(config.foo.analytics_enabled)
             self.assertEqual(config.foo.analytics_sample_rate, 0.5)
 
     def test_analytics_enabled_attribute(self):
         """" Confirm environment variable and kwargs are handled properly """
-        ic = IntegrationConfig(self.config, 'foo', analytics_enabled=True)
+        ic = IntegrationConfig(self.config, "foo", analytics_enabled=True)
         self.assertTrue(ic.analytics_enabled)
 
-        ic = IntegrationConfig(self.config, 'foo', analytics_enabled=False)
+        ic = IntegrationConfig(self.config, "foo", analytics_enabled=False)
         self.assertFalse(ic.analytics_enabled)
 
-        with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED='True')):
-            ic = IntegrationConfig(self.config, 'foo', analytics_enabled=False)
+        with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED="True")):
+            ic = IntegrationConfig(self.config, "foo")
+            ic.analytics_enabled = False
             self.assertFalse(ic.analytics_enabled)
 
     def test_get_analytics_sample_rate(self):
         """" Check method for accessing sample rate based on configuration """
-        ic = IntegrationConfig(self.config, 'foo', analytics_enabled=True, analytics_sample_rate=0.5)
+        ic = IntegrationConfig(self.config, "foo", analytics_enabled=True, analytics_sample_rate=0.5)
         self.assertEqual(ic.get_analytics_sample_rate(), 0.5)
 
-        ic = IntegrationConfig(self.config, 'foo', analytics_enabled=True)
+        ic = IntegrationConfig(self.config, "foo", analytics_enabled=True)
         self.assertEqual(ic.get_analytics_sample_rate(), 1.0)
 
-        ic = IntegrationConfig(self.config, 'foo', analytics_enabled=False)
+        ic = IntegrationConfig(self.config, "foo", analytics_enabled=True, analytics_sample_rate=None)
+        # uhhhhhhhh?
+        assert ic.get_analytics_sample_rate() is True
+
+        ic = IntegrationConfig(self.config, "foo", analytics_enabled=False)
         self.assertIsNone(ic.get_analytics_sample_rate())
 
-        with self.override_env(dict(DD_ANALYTICS_ENABLED='True')):
+        with self.override_env(dict(DD_ANALYTICS_ENABLED="True")):
             config = Config()
-            ic = IntegrationConfig(config, 'foo')
+            ic = IntegrationConfig(config, "foo")
             self.assertEqual(ic.get_analytics_sample_rate(use_global_config=True), 1.0)
 
-        with self.override_env(dict(DD_ANALYTICS_ENABLED='False')):
+        with self.override_env(dict(DD_ANALYTICS_ENABLED="False")):
             config = Config()
-            ic = IntegrationConfig(config, 'foo')
+            ic = IntegrationConfig(config, "foo")
             self.assertIsNone(ic.get_analytics_sample_rate(use_global_config=True))


### PR DESCRIPTION
This PR introduces a new `IntegrationConfig` class which addresses a few of the problems we have with the current `IntegrationConfig`.

## Problem 1: User-defined or library default?
One major problem we're facing in the library is that we can't tell if a value in an integration config object is set by us or by a user. This led us to very [hacky and confusing solutions](https://github.com/DataDog/dd-trace-py/blob/fcd791f6c996b5cd86144e7e9cf31e73d2fb713a/ddtrace/settings/integration.py#L74-L98) for trying to determine if something was overridden or not.

### Solution:
Using the internal API of an `IntegrationConfig` will set values as being *library-defined*.
Using the public API of an `IntegrationConfig` will set values as being *user-defined*.

For example:

```python
from ddtrace import config
# Internal usage
config._add("redis", dict(
    service="redis",
)

config.redis._is_user_defined("service")  # is False
config.redis.service = "mysvc"  # Public usage
config.redis._is_user_defined(key)  # is True
```

## Problem 2: Messy Configuration Specification
<img width="681" alt="image" src="https://user-images.githubusercontent.com/6321485/77593851-56afce00-6ecb-11ea-828e-20f19276f06b.png">
We do this or some variation of this for every integration. It's messy, inconsistent and unclear. We're also mixing user-defined configuration values and library defaults which results in a hard to understand precedence.

### Solution

```python
config._add('requests', {
    'service_name': config.Dec(DEFAULT_SERVICE, env_var=True),
    'distributed_tracing': config.Dec(True, env_var=True, type=bool),
    'split_by_domain': config.Dec(False, env_var=True, type=bool),
}
```

## Problem 3: Using undefined settings
In the old API it was perfectly acceptable for a user to set non-existent keys in the configuration.

### Solution

```python
from ddtrace import config
config._add('redis', dict(service="redis")
# ...
config.redis.servic3 = "mysvc"  # now throws AttributeError exception!!
```
Bonus points here if we can figure out how to link to our API documentation in the error message. 😄

## Problem 4: Setting values are not validated 

## Problem 5: Configuration initialization timing
Currently our configurations are typically defined at the top-level of `patch.py` for the respective integration. This "works" for us because we will have to import the `patch()` function from each integration when auto-patching or calling `patch_all()` which, as a side-effect, will run the configuration logic. In the mean-time a user can add configuration values which we have to store and then _merge_ later on when our configuration code gets run.

It would be nice to have a deterministic point in which the configuration will be "ready" for the user to override in code rather than having to deal with merging configuration objects.

## Breaking changes

None. The API remains the exact same.
