### PR TITLE
fix(profiling/pprof): provide timestamp to export()

### DIFF
--- a/ddtrace/profiling/exporter/__init__.py
+++ b/ddtrace/profiling/exporter/__init__.py
@@ -10,10 +10,12 @@ class Exporter(object):
     """Exporter base class."""
 
     @staticmethod
-    def export(events):
+    def export(events, start_time_ns, end_time_ns):
         """Export events.
 
         :param events: List of events to export.
+        :param start_time_ns: The start time of recording.
+        :param end_time_ns: The end time of recording.
         """
         raise NotImplementedError
 
@@ -23,6 +25,6 @@ class NullExporter(Exporter):
     """Exporter that does nothing."""
 
     @staticmethod
-    def export(events):
+    def export(events, start_time_ns, end_time_ns):
         """Discard events."""
         pass

--- a/ddtrace/profiling/exporter/file.py
+++ b/ddtrace/profiling/exporter/file.py
@@ -12,15 +12,17 @@ class PprofFileExporter(pprof.PprofExporter):
     prefix = attr.ib()
     _increment = attr.ib(default=1, init=False, repr=False)
 
-    def export(self, events):
+    def export(self, events, start_time_ns, end_time_ns):
         """Export events to pprof file.
 
         The file name is based on the prefix passed to init. The process ID number and type of export is then added as a
         suffix.
 
         :param events: The event dictionary from a `ddtrace.profiling.recorder.Recorder`.
+        :param start_time_ns: The start time of recording.
+        :param end_time_ns: The end time of recording.
         """
-        profile = super(PprofFileExporter, self).export(events)
+        profile = super(PprofFileExporter, self).export(events, start_time_ns, end_time_ns)
         with gzip.open(self.prefix + (".%d.%d" % (os.getpid(), self._increment)), "wb") as f:
             f.write(profile.SerializeToString())
         self._increment += 1

--- a/tests/profiling/exporter/test_file.py
+++ b/tests/profiling/exporter/test_file.py
@@ -9,5 +9,5 @@ from ..exporter import test_pprof
 def test_export(tmp_path):
     filename = str(tmp_path / "pprof")
     exp = file.PprofFileExporter(filename)
-    exp.export(test_pprof.TEST_EVENTS)
+    exp.export(test_pprof.TEST_EVENTS, 0, 1)
     test_main.check_pprof_file(filename + "." + str(os.getpid()) + ".1")

--- a/tests/profiling/exporter/test_pprof.py
+++ b/tests/profiling/exporter/test_pprof.py
@@ -395,7 +395,7 @@ def test_ppprof_exporter():
     exp = pprof.PprofExporter()
     exp._get_program_name = mock.Mock()
     exp._get_program_name.return_value = "bonjour"
-    exports = exp.export(TEST_EVENTS)
+    exports = exp.export(TEST_EVENTS, 1, 7)
     if tracemalloc:
         if stack.FEATURES["stack-exceptions"]:
             filename = "test-pprof-exporter_tracemalloc+stack-exceptions.txt"
@@ -410,7 +410,7 @@ def test_ppprof_exporter():
 
 def test_pprof_exporter_empty():
     exp = pprof.PprofExporter()
-    export = exp.export({})
+    export = exp.export({}, 0, 1)
     assert len(export.sample) == 0
 
 
@@ -575,5 +575,5 @@ period_type {
   unit: 8
 }
 """ == str(
-            exp.export(events)
+            exp.export(events, 1, 2)
         )


### PR DESCRIPTION
Currently, the Exporters have to guess what the time range is for the provided
events.
This is not optimal in cases where we don't have any events — even if it
_should_ not happen in practice.

By forcing the caller of the exporter to provide the collection time range, we
can generate data that are actually more precise.