### PR TITLE
logging: only use global setting for env, service and version

### DIFF
--- a/ddtrace/contrib/logging/patch.py
+++ b/ddtrace/contrib/logging/patch.py
@@ -2,7 +2,6 @@ import logging
 
 import ddtrace
 
-from ...constants import ENV_KEY, VERSION_KEY
 from ...utils.wrappers import unwrap as _u
 from ...vendor.wrapt import wrap_function_wrapper as _w
 
@@ -32,37 +31,11 @@ def _w_makeRecord(func, instance, args, kwargs):
     # Get the LogRecord instance for this log
     record = func(*args, **kwargs)
 
-    # Get the currently active span, if there is one
+    setattr(record, RECORD_ATTR_VERSION, ddtrace.config.version or "")
+    setattr(record, RECORD_ATTR_ENV, ddtrace.config.env or "")
+    setattr(record, RECORD_ATTR_SERVICE, ddtrace.config.service or "")
+
     span = _get_current_span(tracer=ddtrace.config.logging.tracer)
-
-    # Inject `dd.version`
-    # Order of precedence:
-    #   - `version` tag on the currently active span
-    #   - `config.version` config (`DD_VERSION` env)
-    #   - empty string
-    version = None
-    if span:
-        version = span.get_tag(VERSION_KEY)
-    version = version or ddtrace.config.version or RECORD_ATTR_VALUE_EMPTY
-    setattr(record, RECORD_ATTR_VERSION, version)
-
-    # Inject `dd.env`
-    # Order of precedence:
-    #   - `env` tag on the currently active span
-    #   - `config.env` config (`DD_ENV` env)
-    #   - empty string
-    env = None
-    if span:
-        env = span.get_tag(ENV_KEY)
-    env = env or ddtrace.config.env or RECORD_ATTR_VALUE_EMPTY
-    setattr(record, RECORD_ATTR_ENV, env)
-
-    service = ""
-    if span:
-        service = span.service or RECORD_ATTR_VALUE_EMPTY
-    setattr(record, RECORD_ATTR_SERVICE, service)
-
-    # Inject `dd.trace_id` and `dd.span_id`
     if span:
         setattr(record, RECORD_ATTR_TRACE_ID, span.trace_id)
         setattr(record, RECORD_ATTR_SPAN_ID, span.span_id)

--- a/tests/contrib/logging/test_logging.py
+++ b/tests/contrib/logging/test_logging.py
@@ -73,11 +73,10 @@ class LoggingTestCase(BaseTracerTestCase):
             output, span = capture_function_log(func)
             trace_id = 0
             span_id = 0
-            service = ""
+            service = ddtrace.config.service or ""
             if span:
                 trace_id = span.trace_id
                 span_id = span.span_id
-                service = span.service or ""
 
             assert output == "Hello! - dd.service={} dd.version={} dd.env={} dd.trace_id={} dd.span_id={}".format(
                 service, version, env, trace_id, span_id
@@ -123,11 +122,12 @@ class LoggingTestCase(BaseTracerTestCase):
             span.set_tag(VERSION_KEY, "manual.version")
             return span
 
-        self._test_logging(create_span=create_span, version="manual.version")
+        self._test_logging(create_span=create_span, version="")
 
         # Setting global config version and overriding with span specific value
+        # We always want the globals in the logs
         with self.override_global_config(dict(version="global.version", env="global.env")):
-            self._test_logging(create_span=create_span, version="manual.version", env="global.env")
+            self._test_logging(create_span=create_span, version="global.version", env="global.env")
 
     def test_log_trace_env(self):
         """
@@ -139,11 +139,12 @@ class LoggingTestCase(BaseTracerTestCase):
             span.set_tag(ENV_KEY, "manual.env")
             return span
 
-        self._test_logging(create_span=create_span, env="manual.env")
+        self._test_logging(create_span=create_span, env="")
 
         # Setting global config env and overriding with span specific value
+        # We always want the globals in the logs
         with self.override_global_config(dict(version="global.version", env="global.env")):
-            self._test_logging(create_span=create_span, version="global.version", env="manual.env")
+            self._test_logging(create_span=create_span, version="global.version", env="global.env")
 
     def test_log_no_trace(self):
         """


### PR DESCRIPTION
We wants logs into include only the globally configured values for `env`, `service` and `version`.