### PR TITLE
Allow Profiler to finish upload data in the background when stopped

### DIFF
--- a/ddtrace/profiling/_service.py
+++ b/ddtrace/profiling/_service.py
@@ -1,0 +1,38 @@
+import enum
+
+from ddtrace.vendor import attr
+
+
+class ServiceStatus(enum.Enum):
+    """A Service status."""
+
+    STOPPED = "stopped"
+    RUNNING = "running"
+
+
+@attr.s
+class Service(object):
+    """A service that can be started or stopped."""
+
+    status = attr.ib(default=ServiceStatus.STOPPED, type=ServiceStatus, init=False)
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return self.stop()
+
+    def start(self):
+        """Start the service."""
+        if self.status == ServiceStatus.RUNNING:
+            raise RuntimeError("%s is already running" % self.__class__.__name__)
+        self.status = ServiceStatus.RUNNING
+
+    def stop(self):
+        """Stop the service."""
+        self.status = ServiceStatus.STOPPED
+
+    @staticmethod
+    def join(timeout=None):
+        """Join the service once stopped."""

--- a/ddtrace/profiling/collector/__init__.py
+++ b/ddtrace/profiling/collector/__init__.py
@@ -55,6 +55,10 @@ class Collector(object):
         """Stop collecting profiles."""
         self.status = CollectorStatus.STOPPED
 
+    @staticmethod
+    def join():
+        """Join the collector."""
+
 
 @attr.s(slots=True)
 class PeriodicCollector(Collector):
@@ -87,11 +91,11 @@ class PeriodicCollector(Collector):
 
     def stop(self):
         """Stop the periodic collector."""
-        if self._worker:
-            self._worker.stop()
-            self._worker.join()
-            self._worker = None
+        self._worker.stop()
         super(PeriodicCollector, self).stop()
+
+    def join(self, timeout=None):
+        self._worker.join(timeout)
 
     def collect(self):
         """Collect events and push them into the recorder."""

--- a/ddtrace/profiling/collector/__init__.py
+++ b/ddtrace/profiling/collector/__init__.py
@@ -1,109 +1,28 @@
 # -*- encoding: utf-8 -*-
-import abc
-
-from ddtrace.vendor import six
-
 from ddtrace.profiling import _attr
 from ddtrace.profiling import _periodic
+from ddtrace.profiling import _service
 from ddtrace.vendor import attr
 
 
-# This ought to use `enum.Enum`, but since it's not available in Python 2, we just use a dumb class.
-@attr.s(repr=False)
-class CollectorStatus(object):
-    """A Collector status."""
-
-    status = attr.ib()
-
-    def __repr__(self):
-        return self.status.upper()
-
-
-CollectorStatus.STOPPED = CollectorStatus("stopped")
-CollectorStatus.RUNNING = CollectorStatus("running")
-
-
-@six.add_metaclass(abc.ABCMeta)
-@attr.s(slots=True)
-class Collector(object):
+@attr.s
+class Collector(_service.Service):
     """A profile collector."""
 
     recorder = attr.ib()
-    status = attr.ib(default=CollectorStatus.STOPPED, type=CollectorStatus, repr=False, init=False)
-
-    def __enter__(self):
-        self.start()
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        return self.stop()
-
-    @staticmethod
-    def _init():
-        pass
-
-    @abc.abstractmethod
-    def start(self):
-        """Start collecting profiles."""
-        if self.status == CollectorStatus.RUNNING:
-            raise RuntimeError("Collector is already running")
-        self.status = CollectorStatus.RUNNING
-        self._init()
-
-    @abc.abstractmethod
-    def stop(self):
-        """Stop collecting profiles."""
-        self.status = CollectorStatus.STOPPED
-
-    @staticmethod
-    def join():
-        """Join the collector."""
 
 
 @attr.s(slots=True)
-class PeriodicCollector(Collector):
+class PeriodicCollector(Collector, _periodic.PeriodicService):
     """A collector that needs to run periodically."""
 
-    _real_thread = False
-
-    _interval = attr.ib(repr=False)
-    _worker = attr.ib(default=None, init=False, repr=False)
-
-    def start(self):
-        """Start the periodic collector."""
-        super(PeriodicCollector, self).start()
-        periodic_thread_class = _periodic.PeriodicRealThread if self._real_thread else _periodic.PeriodicThread
-        self._worker = periodic_thread_class(
-            self.interval, target=self.collect, name="%s:%s" % (__name__, self.__class__.__name__)
-        )
-        self._worker.start()
-
-    @property
-    def interval(self):
-        return self._interval
-
-    @interval.setter
-    def interval(self, value):
-        self._interval = value
-        # Update the interval of the PeriodicThread based on ours
-        if self._worker:
-            self._worker.interval = value
-
-    def stop(self):
-        """Stop the periodic collector."""
-        self._worker.stop()
-        super(PeriodicCollector, self).stop()
-
-    def join(self, timeout=None):
-        self._worker.join(timeout)
-
-    def collect(self):
+    def periodic(self):
         """Collect events and push them into the recorder."""
-        for events in self._collect():
+        for events in self.collect():
             self.recorder.push_events(events)
 
     @staticmethod
-    def _collect():
+    def collect():
         """Collect the actual data.
 
         :return: A list of sample list to push in the recorder.

--- a/ddtrace/profiling/collector/memory.py
+++ b/ddtrace/profiling/collector/memory.py
@@ -55,9 +55,9 @@ class MemoryCollector(collector.PeriodicCollector, collector.CaptureSamplerColle
     def stop(self):
         if tracemalloc is not None:
             tracemalloc.stop()
-        super(MemoryCollector, self).stop()
+            super(MemoryCollector, self).stop()
 
-    def _collect(self):
+    def collect(self):
         try:
             snapshot = tracemalloc.take_snapshot()
         except RuntimeError:

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -301,15 +301,16 @@ class StackCollector(collector.PeriodicCollector):
         if value <= 0 or value > 100:
             raise ValueError("Max time usage percent must be greater than 0 and smaller or equal to 100")
 
-    def _init(self):
+    def start(self):
         self._thread_time = ThreadTime()
         self._last_wall_time = compat.monotonic_ns()
+        super(StackCollector, self).start()
 
     def _compute_new_interval(self, used_wall_time_ns):
         interval = (used_wall_time_ns / (self.max_time_usage_pct / 100.0)) - used_wall_time_ns
         return max(interval / 1e9, self.MIN_INTERVAL_TIME)
 
-    def _collect(self):
+    def collect(self):
         # Compute wall time
         now = compat.monotonic_ns()
         wall_time = now - self._last_wall_time

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -102,7 +102,7 @@ class Profiler(object):
 
         This stops all the collectors and schedulers, waiting for them to finish their operations.
 
-        :param flush: Flush the event before stopping.
+        :param flush: Wait for the flush of the remaining events before stopping.
         """
         for col in reversed(self.collectors):
             col.stop()
@@ -111,6 +111,10 @@ class Profiler(object):
             col.join()
 
         for s in reversed(self.schedulers):
-            s.stop(flush=flush)
+            s.stop()
+
+        if flush:
+            for s in reversed(self.schedulers):
+                s.join()
 
         self.status = ProfilerStatus.STOPPED

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -107,6 +107,9 @@ class Profiler(object):
         for col in reversed(self.collectors):
             col.stop()
 
+        for col in reversed(self.collectors):
+            col.join()
+
         for s in reversed(self.schedulers):
             s.stop(flush=flush)
 

--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -12,45 +12,20 @@ LOG = logging.getLogger(__name__)
 
 
 @attr.s
-class Scheduler(object):
+class Scheduler(_periodic.PeriodicService):
     """Schedule export of recorded data."""
 
     recorder = attr.ib()
     exporters = attr.ib()
-    interval = attr.ib(factory=_attr.from_env("DD_PROFILING_UPLOAD_INTERVAL", 60, float))
-    _periodic = attr.ib(init=False, default=None)
+    _interval = attr.ib(factory=_attr.from_env("DD_PROFILING_UPLOAD_INTERVAL", 60, float))
     _last_export = attr.ib(init=False, default=None)
-
-    def __enter__(self):
-        self.start()
-        return self
 
     def start(self):
         """Start the scheduler."""
-        self._periodic = _periodic.PeriodicThread(
-            self.interval, self.flush, name="%s:%s" % (__name__, self.__class__.__name__)
-        )
         LOG.debug("Starting scheduler")
+        super(Scheduler, self).start()
         self._last_export = compat.time_ns()
-        self._periodic.start()
         LOG.debug("Scheduler started")
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        return self.stop()
-
-    def stop(self, flush=True):
-        """Stop the scheduler.
-
-        :param flush: Whetever to do a final flush.
-        """
-        LOG.debug("Stopping scheduler")
-        if self._periodic:
-            self._periodic.stop()
-            self._periodic.join()
-            self._periodic = None
-        if flush:
-            self.flush()
-        LOG.debug("Scheduler stopped")
 
     def flush(self):
         """Flush events from recorder to exporters."""
@@ -67,3 +42,6 @@ class Scheduler(object):
                     LOG.error("Unable to export %d events: %s", total_events, _traceback.format_exception(e))
                 except Exception:
                     LOG.exception("Error while exporting %d events", total_events)
+
+    periodic = flush
+    on_shutdown = flush

--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -55,14 +55,15 @@ class Scheduler(object):
     def flush(self):
         """Flush events from recorder to exporters."""
         LOG.debug("Flushing events")
-        events = self.recorder.reset()
-        start = self._last_export
-        self._last_export = compat.time_ns()
-        total_events = sum(len(v) for v in events.values())
-        for exp in self.exporters:
-            try:
-                exp.export(events, start, self._last_export)
-            except exporter.ExportError as e:
-                LOG.error("Unable to export %d events: %s", total_events, _traceback.format_exception(e))
-            except Exception:
-                LOG.exception("Error while exporting %d events", total_events)
+        if self.exporters:
+            events = self.recorder.reset()
+            start = self._last_export
+            self._last_export = compat.time_ns()
+            total_events = sum(len(v) for v in events.values())
+            for exp in self.exporters:
+                try:
+                    exp.export(events, start, self._last_export)
+                except exporter.ExportError as e:
+                    LOG.error("Unable to export %d events: %s", total_events, _traceback.format_exception(e))
+                except Exception:
+                    LOG.exception("Error while exporting %d events", total_events)

--- a/tests/profiling/collector/test_collector.py
+++ b/tests/profiling/collector/test_collector.py
@@ -1,29 +1,9 @@
 import time
 
-import mock
-
 import pytest
 
 from ddtrace.profiling import collector
 from ddtrace.profiling import recorder
-
-
-def test_collector_status():
-    assert repr(collector.CollectorStatus.STOPPED) == "STOPPED"
-    assert repr(collector.CollectorStatus.RUNNING) == "RUNNING"
-
-
-def _test_collector_status(collector_class):
-    r = recorder.Recorder()
-    c = collector_class(r)
-    assert c.status == collector.CollectorStatus.STOPPED
-    with mock.patch("ddtrace.compat.time_ns") as time_ns:
-        time_ns.return_value = 123
-        c.start()
-    assert c.status == collector.CollectorStatus.RUNNING
-    c.stop()
-    assert c.status == collector.CollectorStatus.STOPPED
-    return r, c
 
 
 def _test_collector_collect(collector, event_type, fn=None, **kwargs):

--- a/tests/profiling/collector/test_collector.py
+++ b/tests/profiling/collector/test_collector.py
@@ -46,6 +46,19 @@ def _test_repr(collector_class, s):
     assert repr(collector_class(r)) == s
 
 
+def _test_restart(collector, **kwargs):
+    r = recorder.Recorder()
+    c = collector(r, **kwargs)
+    c.start()
+    c.stop()
+    c.join()
+    c.start()
+    with pytest.raises(RuntimeError):
+        c.start()
+    c.stop()
+    c.join()
+
+
 def test_dynamic_interval():
     r = recorder.Recorder()
     c = collector.PeriodicCollector(recorder=r, interval=1)

--- a/tests/profiling/collector/test_memory.py
+++ b/tests/profiling/collector/test_memory.py
@@ -56,14 +56,16 @@ def test_max_capture_over():
 def _test_memory_ignore(ignore):
     r = recorder.Recorder()
     # Start a stack collector so it allocates memory
-    with stack.StackCollector(r):
+    with stack.StackCollector(r) as sc:
         r = recorder.Recorder()
         c = memory.MemoryCollector(r, ignore_profiler=ignore, capture_pct=100)
-        with c:
+        with c as mc:
             while not r.events[memory.MemorySampleEvent]:
                 _ = _alloc()
                 # Allow gevent to switch to the memory collector thread
                 time.sleep(0)
+    sc.join()
+    mc.join()
     events = r.events[memory.MemorySampleEvent]
     files = {frame.filename for event in events for trace in event.snapshot.traces for frame in trace.traceback}
     return files

--- a/tests/profiling/collector/test_memory.py
+++ b/tests/profiling/collector/test_memory.py
@@ -27,6 +27,11 @@ def test_collect():
 
 
 @pytest.mark.skipif(tracemalloc is None, reason="tracemalloc is unavailable")
+def test_restart():
+    test_collector._test_restart(memory.MemoryCollector)
+
+
+@pytest.mark.skipif(tracemalloc is None, reason="tracemalloc is unavailable")
 def test_status():
     test_collector._test_collector_status(memory.MemoryCollector)
 

--- a/tests/profiling/collector/test_service.py
+++ b/tests/profiling/collector/test_service.py
@@ -1,0 +1,14 @@
+from ddtrace.profiling import _service
+
+
+def test_service_status():
+    s = _service.Service()
+    assert s.status == _service.ServiceStatus.STOPPED
+    s.start()
+    assert s.status == _service.ServiceStatus.RUNNING
+    s.stop()
+    assert s.status == _service.ServiceStatus.STOPPED
+    s.start()
+    assert s.status == _service.ServiceStatus.RUNNING
+    s.stop()
+    assert s.status == _service.ServiceStatus.STOPPED

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -11,14 +11,11 @@ from ddtrace.profiling.collector import threading as collector_threading
 from . import test_collector
 
 
-def test_status():
-    test_collector._test_collector_status(collector_threading.LockCollector)
-
-
 def test_repr():
     test_collector._test_repr(
         collector_threading.LockCollector,
-        "LockCollector(recorder=Recorder(max_size=49152), capture_pct=5.0, nframes=64)",
+        "LockCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
+        "recorder=Recorder(max_size=49152), capture_pct=5.0, nframes=64)",
     )
 
 
@@ -65,13 +62,13 @@ def test_lock_acquire_events():
     assert len(r.events[collector_threading.LockAcquireEvent]) == 1
     assert len(r.events[collector_threading.LockReleaseEvent]) == 0
     event = r.events[collector_threading.LockAcquireEvent][0]
-    assert event.lock_name == "test_threading.py:63"
+    assert event.lock_name == "test_threading.py:60"
     assert event.thread_id == _thread.get_ident()
     assert event.wait_time_ns > 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[0] == (__file__, 64, "test_lock_acquire_events")
+    assert event.frames[0] == (__file__, 61, "test_lock_acquire_events")
     assert event.sampling_pct == 100
 
 
@@ -85,13 +82,13 @@ def test_lock_release_events():
     assert len(r.events[collector_threading.LockAcquireEvent]) == 1
     assert len(r.events[collector_threading.LockReleaseEvent]) == 1
     event = r.events[collector_threading.LockReleaseEvent][0]
-    assert event.lock_name == "test_threading.py:81"
+    assert event.lock_name == "test_threading.py:78"
     assert event.thread_id == _thread.get_ident()
     assert event.locked_for_ns >= 0.1
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[0] == (__file__, 84, "test_lock_release_events")
+    assert event.frames[0] == (__file__, 81, "test_lock_release_events")
     assert event.sampling_pct == 100
 
 

--- a/tests/profiling/compat_program.py
+++ b/tests/profiling/compat_program.py
@@ -4,7 +4,7 @@ import time
 import ddtrace.profile.auto  # noqa
 
 from ddtrace.profile import bootstrap
-from ddtrace.profile import collector
+from ddtrace.profile import collector  # noqa
 from ddtrace.profile.collector import stack
 
 for running_collector in bootstrap.profiler.collectors:
@@ -15,7 +15,6 @@ else:
 
 
 print("hello world")
-assert running_collector.status == collector.CollectorStatus.RUNNING
 print(running_collector.interval)
 
 t0 = time.time()

--- a/tests/profiling/simple_program.py
+++ b/tests/profiling/simple_program.py
@@ -1,8 +1,8 @@
 import sys
 import time
 
+from ddtrace.profiling import _service
 from ddtrace.profiling import bootstrap
-from ddtrace.profiling import collector
 from ddtrace.profiling.collector import stack
 
 for running_collector in bootstrap.profiler.collectors:
@@ -13,7 +13,7 @@ else:
 
 
 print("hello world")
-assert running_collector.status == collector.CollectorStatus.RUNNING
+assert running_collector.status == _service.ServiceStatus.RUNNING
 print(running_collector.interval)
 
 t0 = time.time()

--- a/tests/profiling/test_accuracy.py
+++ b/tests/profiling/test_accuracy.py
@@ -75,7 +75,7 @@ def test_accuracy(monkeypatch):
     p = profiler.Profiler()
     p.start()
     spend_16()
-    p.stop(flush=False)
+    p.stop()
     recorder = list(p.recorders)[0]
     # First index is the stack position, second is the function name
     time_spent_ns = collections.defaultdict(lambda: collections.defaultdict(lambda: 0))

--- a/tests/profiling/test_periodic.py
+++ b/tests/profiling/test_periodic.py
@@ -1,6 +1,8 @@
 import os
 import threading
 
+import pytest
+
 from ddtrace.profiling import _periodic
 
 
@@ -62,3 +64,27 @@ def test_periodic_real_thread_name():
     assert t in threading.enumerate()
     t.stop()
     t.join()
+
+
+def test_periodic_service_start_stop():
+    t = _periodic.PeriodicService(1)
+    t.start()
+    with pytest.raises(RuntimeError):
+        t.start()
+    t.stop()
+    t.join()
+    t.stop()
+    t.stop()
+    t.join()
+    t.join()
+
+
+def test_periodic_join_stop_no_start():
+    t = _periodic.PeriodicService(1)
+    t.join()
+    t.stop()
+    t.join()
+    t = _periodic.PeriodicService(1)
+    t.stop()
+    t.join()
+    t.stop()

--- a/tests/profiling/test_periodic.py
+++ b/tests/profiling/test_periodic.py
@@ -1,18 +1,19 @@
 import os
 import threading
 
-import pytest
-
 from ddtrace.profiling import _periodic
 
 
-def _test_periodic(thread_class):
+def test_periodic():
     x = {"OK": False}
 
     def _run_periodic():
         x["OK"] = True
 
-    t = thread_class(0.001, _run_periodic)
+    def _on_shutdown():
+        x["DOWN"] = True
+
+    t = _periodic.PeriodicRealThread(0.001, _run_periodic, on_shutdown=_on_shutdown)
     t.start()
     assert t.ident in _periodic.PERIODIC_THREAD_IDS
     while not x["OK"]:
@@ -20,16 +21,36 @@ def _test_periodic(thread_class):
     t.stop()
     t.join()
     assert x["OK"]
+    assert x["DOWN"]
     assert len(_periodic.PERIODIC_THREAD_IDS) == 0
 
 
-@pytest.mark.skipif(os.getenv("DD_PROFILE_TEST_GEVENT", False), reason="gevent threads are not running in parallel")
-def test_periodic_thread():
-    return _test_periodic(_periodic.PeriodicThread)
+def test_periodic_error():
+    x = {"OK": False}
+
+    def _run_periodic():
+        x["OK"] = True
+        raise ValueError
+
+    def _on_shutdown():
+        x["DOWN"] = True
+
+    t = _periodic.PeriodicRealThread(0.001, _run_periodic, on_shutdown=_on_shutdown)
+    t.start()
+    assert t.ident in _periodic.PERIODIC_THREAD_IDS
+    while not x["OK"]:
+        pass
+    t.stop()
+    t.join()
+    assert "DOWN" not in x
+    assert len(_periodic.PERIODIC_THREAD_IDS) == 0
 
 
-def test_periodic_real_thread():
-    return _test_periodic(_periodic.PeriodicRealThread)
+def test_gevent_class():
+    if os.getenv("DD_PROFILE_TEST_GEVENT", False):
+        assert isinstance(_periodic.PeriodicRealThread(1, sum), _periodic._GeventPeriodicThread)
+    else:
+        assert isinstance(_periodic.PeriodicRealThread(1, sum), _periodic.PeriodicThread)
 
 
 def test_periodic_real_thread_name():

--- a/tests/profiling/test_scheduler.py
+++ b/tests/profiling/test_scheduler.py
@@ -24,5 +24,5 @@ def test_thread_name():
     exp = exporter.NullExporter()
     s = scheduler.Scheduler(r, [exp])
     s.start()
-    assert s._periodic.name == "ddtrace.profiling.scheduler:Scheduler"
+    assert s._worker.name == "ddtrace.profiling.scheduler:Scheduler"
     s.stop()


### PR DESCRIPTION
## feat(profiling/periodic): allow to call a shutdown function


## feat(profiling): do not reset event list of no exporter configured


## feat(profiling): allow to stop/join collectors in 2 steps

This should make the Profiler slightly faster to stop.

## refactor: introduce Service class

This introduces a new class Service that describes a Service that can be
started, stopped and joined.

The Service tracks its own status in order to avoid starting twice the same
service.

The collectors are now inheriting from this common class as they all provide a
startable/stoppable service.

## refactor(scheduler): leverage PeriodicService class

This changes the Scheduler class to leverage the PeriodicService class.

It also makes sure the Scheduler always flush on exit.

The Profiler is now responsible for joining or not the Scheduler if it wants to
block on the last upload before returning from its `stop` method.
