### PR TITLE
Update error event handler name within SQLAlchemy engine

### DIFF
--- a/ddtrace/contrib/sqlalchemy/engine.py
+++ b/ddtrace/contrib/sqlalchemy/engine.py
@@ -67,7 +67,7 @@ class EngineTracer(object):
 
         listen(engine, 'before_cursor_execute', self._before_cur_exec)
         listen(engine, 'after_cursor_execute', self._after_cur_exec)
-        listen(engine, 'dbapi_error', self._dbapi_error)
+        listen(engine, 'handle_error', self._handle_db_error)
 
     def _before_cur_exec(self, conn, cursor, statement, *args):
         pin = Pin.get_from(self.engine)
@@ -107,7 +107,7 @@ class EngineTracer(object):
         finally:
             span.finish()
 
-    def _dbapi_error(self, conn, cursor, statement, *args):
+    def _handle_db_error(self, conn, cursor, statement, *args):
         pin = Pin.get_from(self.engine)
         if not pin or not pin.enabled():
             # don't trace the execution

--- a/ddtrace/contrib/sqlalchemy/engine.py
+++ b/ddtrace/contrib/sqlalchemy/engine.py
@@ -115,7 +115,7 @@ class EngineTracer(object):
         finally:
             span.finish()
 
-    def _handle_db_error(self, conn, cursor, statement, *args):
+    def _handle_db_error(self, *args):
         pin = Pin.get_from(self.engine)
         if not pin or not pin.enabled():
             # don't trace the execution


### PR DESCRIPTION
Resolves issue #841 (SQLAlchemy: ConnectionEvents.dbapi_error() event is deprecated)

**Background**
The `ddtrace` library's sqlalchemy engine currently listens for the `dbapi_error` event. This throws a deprecation warning within sqlalchemy, as mentioned in the above issue.

**Solution**
This PR changes the name of the event being listened for from `dbapi_error` to `handle_error`.

Reference to the new `handle_error` event within SQLAlchemy: https://docs.sqlalchemy.org/en/13/core/events.html#sqlalchemy.events.ConnectionEvents.handle_error