### PR TITLE
fix(profiling): ignore failure on shutdown

### DIFF
--- a/ddtrace/profiling/_periodic.py
+++ b/ddtrace/profiling/_periodic.py
@@ -100,9 +100,16 @@ class _GeventPeriodicThread(PeriodicThread):
             if sys is not None:
                 raise
         finally:
-            self.has_quit = True
-            del threading._active[self._tident]
-            PERIODIC_THREAD_IDS.remove(self.ident)
+            try:
+                self.has_quit = True
+                del threading._active[self._tident]
+                PERIODIC_THREAD_IDS.remove(self.ident)
+            except Exception:
+                # Exceptions might happen during interpreter shutdown.
+                # We're mimicking what `threading.Thread` does in daemon mode, we ignore them.
+                # See `threading.Thread._bootstrap` for details.
+                if sys is not None:
+                    raise
 
 
 def PeriodicRealThread(*args, **kwargs):


### PR DESCRIPTION
On interpreter shutdown, we can see this kind of errors:

Traceback (most recent call last):
  File "ddtrace/profiling/_periodic.py", line 104, in run
    del threading._active[self._tident]
TypeError: 'NoneType' object does not support item deletion

This changes the code to use the same try/except mechanism in the above block
to avoid logging those errors on shutdown.