### PR TITLE
aiobotocore: pin to <1.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,9 @@ envlist =
     {py27,py35,py36,py37,py38}-test_utils
     {py27,py35,py36,py37,py38}-test_logging
 # Integrations environments
-    aiobotocore_contrib-{py35,py36}-aiobotocore{02,03,04,05,07,08,09,010,011,latest}
+    aiobotocore_contrib-{py35,py36}-aiobotocore{02,03,04,05,07,08,09,010,011,012}
     # aiobotocore 0.2 and 0.4 do not work because they use async as a reserved keyword
-    aiobotocore_contrib-py{37,38}-aiobotocore{03,05,07,08,09,010,011,latest}
+    aiobotocore_contrib-py{37,38}-aiobotocore{03,05,07,08,09,010,011,012}
     # Python 3.7 needs at least aiohttp 2.3
     aiohttp_contrib-{py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
     aiohttp_contrib-{py35,py36,py37,py38}-aiohttp23-aiohttp_jinja015-yarl10
@@ -199,7 +199,8 @@ deps =
 # backports
     py27: enum34
 # integrations
-    aiobotocorelatest: aiobotocore>=0.11
+    # aiobotocore: aiobotocore>=1.0 not yet supported
+    aiobotocore012: aiobotocore>=0.12,<0.13
     aiobotocore011: aiobotocore>=0.11,<0.12
     aiobotocore010: aiobotocore>=0.10,<0.11
     aiobotocore09: aiobotocore>=0.9,<0.10

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,9 @@ envlist =
     {py27,py35,py36,py37,py38}-test_utils
     {py27,py35,py36,py37,py38}-test_logging
 # Integrations environments
-    aiobotocore_contrib-{py35,py36}-aiobotocore{02,03,04,05,07,08,09,010,011,012}
+    # aiobotocore dropped Python 3.5 support in 0.12
+    aiobotocore_contrib-{py35}-aiobotocore{02,03,04,05,07,08,09,010,011}
+    aiobotocore_contrib-{py36}-aiobotocore{02,03,04,05,07,08,09,010,011,012}
     # aiobotocore 0.2 and 0.4 do not work because they use async as a reserved keyword
     aiobotocore_contrib-py{37,38}-aiobotocore{03,05,07,08,09,010,011,012}
     # Python 3.7 needs at least aiohttp 2.3


### PR DESCRIPTION
[aiobotocore went 1.0](https://github.com/aio-libs/aiobotocore/releases/tag/1.0.0) with some breaking changes. We don't yet support this functionality (or at least our tests don't). Pin it for now. 