### PR TITLE
fix(profiling): allow to override options after load

### DIFF
--- a/ddtrace/profiling/exporter/http.py
+++ b/ddtrace/profiling/exporter/http.py
@@ -11,6 +11,7 @@ from ddtrace.vendor.six.moves import http_client
 from ddtrace.vendor.six.moves.urllib import parse as urlparse
 
 import ddtrace
+from ddtrace.profiling import _attr
 from ddtrace.profiling import _traceback
 from ddtrace.profiling import exporter
 from ddtrace.vendor import attr
@@ -58,10 +59,10 @@ class PprofHTTPExporter(pprof.PprofExporter):
     """PProf HTTP exporter."""
 
     endpoint = attr.ib(
-        default=os.getenv("DD_PROFILING_API_URL", "https://intake.profile.datadoghq.com/v1/input"), type=str
+        factory=_attr.from_env("DD_PROFILING_API_URL", "https://intake.profile.datadoghq.com/v1/input", str), type=str
     )
-    api_key = attr.ib(default=os.getenv("DD_PROFILING_API_KEY", ""), type=str)
-    timeout = attr.ib(default=os.getenv("DD_PROFILING_API_TIMEOUT", 10), type=float)
+    api_key = attr.ib(factory=_attr.from_env("DD_PROFILING_API_KEY", "", str), type=str)
+    timeout = attr.ib(factory=_attr.from_env("DD_PROFILING_API_TIMEOUT", 10, float), type=float)
 
     @staticmethod
     def _encode_multipart_formdata(fields, tags):

--- a/tests/profiling/exporter/test_http.py
+++ b/tests/profiling/exporter/test_http.py
@@ -186,6 +186,12 @@ def test_export_reset(endpoint_test_reset_server):
         assert isinstance(e, http_client.BadStatusLine)
 
 
+def test_default_from_env(monkeypatch):
+    monkeypatch.setenv("DD_PROFILING_API_KEY", "123")
+    exp = http.PprofHTTPExporter()
+    assert exp.api_key == "123"
+
+
 def test_get_tags():
     tags = http.PprofHTTPExporter()._get_tags("foobar")
     assert len(tags) == 7


### PR DESCRIPTION
Using default=os.getenv in attr attributes will make the default unchangeable
after the library is loaded.

Most options already leverage ddtrace.profiling._attr.from_env to avoid
this, but not the HTTP exporter.