### PR TITLE
feat(profiling): add the pip install when recompilation is needed

### DIFF
--- a/ddtrace/profiling/__init__.py
+++ b/ddtrace/profiling/__init__.py
@@ -6,7 +6,11 @@ from ddtrace.profiling import _build
 
 
 def _not_compatible_abi():
-    raise ImportError("Python ABI is not compatible, you need to recompile this module")
+    raise ImportError(
+        "Python ABI is not compatible, you need to recompile this module.\n"
+        "Reinstall it with the following command:\n"
+        "  pip install --no-binary ddtrace ddtrace[profiling]"
+    )
 
 
 if (3, 7) < _build.compiled_with <= (3, 7, 3):


### PR DESCRIPTION
If an incompatible ABI is detected, users are usually lost and don't know what
to do.
Indicate the command to use to install and compile this module.
