### PR TITLE
fix: avoid context deadlock with logs injection enabled

### DIFF
--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -17,3 +17,5 @@ NUMERIC_TAGS = (ANALYTICS_SAMPLE_RATE_KEY, )
 
 MANUAL_DROP_KEY = 'manual.drop'
 MANUAL_KEEP_KEY = 'manual.keep'
+
+LOG_SPAN_KEY = '__datadog_log_span'

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 
-from .constants import HOSTNAME_KEY, SAMPLING_PRIORITY_KEY, ORIGIN_KEY
+from .constants import HOSTNAME_KEY, SAMPLING_PRIORITY_KEY, ORIGIN_KEY, LOG_SPAN_KEY
 from .internal.logger import get_logger
 from .internal import hostname
 from .settings import config
@@ -139,12 +139,13 @@ class Context(object):
             # some children. On the other hand, asynchronous web frameworks still expect
             # to close the root span after all the children.
             if span.tracer and span.tracer.log.isEnabledFor(logging.DEBUG) and span._parent is None:
+                extra = {LOG_SPAN_KEY: span}
                 unfinished_spans = [x for x in self._trace if not x.finished]
                 if unfinished_spans:
                     log.debug('Root span "%s" closed, but the trace has %d unfinished spans:',
-                              span.name, len(unfinished_spans))
+                              span.name, len(unfinished_spans), extra=extra)
                     for wrong_span in unfinished_spans:
-                        log.debug('\n%s', wrong_span.pprint())
+                        log.debug('\n%s', wrong_span.pprint(), extra=extra)
 
     def _is_sampled(self):
         return any(span.sampled for span in self._trace)

--- a/ddtrace/contrib/logging/patch.py
+++ b/ddtrace/contrib/logging/patch.py
@@ -35,7 +35,13 @@ def _w_makeRecord(func, instance, args, kwargs):
     setattr(record, RECORD_ATTR_ENV, ddtrace.config.env or "")
     setattr(record, RECORD_ATTR_SERVICE, ddtrace.config.service or "")
 
-    span = _get_current_span(tracer=ddtrace.config.logging.tracer)
+    # don't try to get the current span on the internal logger, can cause deadlocks
+    if getattr(record, "__from_DDLogger", False):
+        span = None
+        delattr(record, "__from_DDLogger")
+    else:
+        span = _get_current_span(tracer=ddtrace.config.logging.tracer)
+
     if span:
         setattr(record, RECORD_ATTR_TRACE_ID, span.trace_id)
         setattr(record, RECORD_ATTR_SPAN_ID, span.span_id)

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -75,17 +75,6 @@ class DDLogger(logging.Logger):
         # DEV: `DD_LOGGING_RATE_LIMIT=0` means to disable all rate limiting
         self.rate_limit = int(get_env("logging", "rate_limit", default=60))
 
-    def makeRecord(self, name, level, fn, lno, msg, args, exc_info, func=None, extra=None, sinfo=None):
-        """
-        Adds an extra attribute to our log records to make sure log injection doesn't
-        attempt to get the current span on an internal log, which can lead to a deadlock.
-        """
-        if extra is None:
-            extra = {}
-        extra["__from_DDLogger"] = True
-
-        return super(DDLogger, self).makeRecord(name, level, fn, lno, msg, args, exc_info, func, extra, sinfo)
-
     def handle(self, record):
         """
         Function used to call the handlers for a log line.

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -75,8 +75,7 @@ class DDLogger(logging.Logger):
         # DEV: `DD_LOGGING_RATE_LIMIT=0` means to disable all rate limiting
         self.rate_limit = int(get_env("logging", "rate_limit", default=60))
 
-    def makeRecord(self, name, level, fn, lno, msg, args, exc_info,
-                   func=None, extra=None, sinfo=None):
+    def makeRecord(self, name, level, fn, lno, msg, args, exc_info, func=None, extra=None, sinfo=None):
         """
         Adds an extra attribute to our log records to make sure log injection doesn't
         attempt to get the current span on an internal log, which can lead to a deadlock.

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -75,6 +75,18 @@ class DDLogger(logging.Logger):
         # DEV: `DD_LOGGING_RATE_LIMIT=0` means to disable all rate limiting
         self.rate_limit = int(get_env("logging", "rate_limit", default=60))
 
+    def makeRecord(self, name, level, fn, lno, msg, args, exc_info,
+                   func=None, extra=None, sinfo=None):
+        """
+        Adds an extra attribute to our log records to make sure log injection doesn't
+        attempt to get the current span on an internal log, which can lead to a deadlock.
+        """
+        if extra is None:
+            extra = {}
+        extra["__from_DDLogger"] = True
+
+        return super(DDLogger, self).makeRecord(name, level, fn, lno, msg, args, exc_info, func, extra, sinfo)
+
     def handle(self, record):
         """
         Function used to call the handlers for a log line.

--- a/tests/contrib/logging/test_logging.py
+++ b/tests/contrib/logging/test_logging.py
@@ -167,7 +167,7 @@ class LoggingTestCase(BaseTracerTestCase):
     def test_unfinished_child(self):
         """
         Check that closing a span with unfinished children correctly logs out
-        unfinished spans. See #1337 for more context.
+        unfinished spans.
         """
         # unfinished child spans only logged if tracer log level is debug
         self.tracer.log.setLevel(logging.DEBUG)

--- a/tests/contrib/logging/test_logging.py
+++ b/tests/contrib/logging/test_logging.py
@@ -24,9 +24,9 @@ def current_span(tracer=None):
     return tracer.current_span()
 
 
-def capture_function_log(func, fmt=DEFAULT_FORMAT, logger_arg=None):
+def capture_function_log(func, fmt=DEFAULT_FORMAT, logger_override=None):
     if logger_arg is not None:
-        logger_to_capture = logger_arg
+        logger_to_capture = logger_override
     else:
         logger_to_capture = logger
 

--- a/tests/contrib/logging/test_logging.py
+++ b/tests/contrib/logging/test_logging.py
@@ -25,7 +25,7 @@ def current_span(tracer=None):
 
 
 def capture_function_log(func, fmt=DEFAULT_FORMAT, logger_override=None):
-    if logger_arg is not None:
+    if logger_override is not None:
         logger_to_capture = logger_override
     else:
         logger_to_capture = logger

--- a/tests/contrib/logging/test_logging.py
+++ b/tests/contrib/logging/test_logging.py
@@ -182,6 +182,6 @@ class LoggingTestCase(BaseTracerTestCase):
         out, span = capture_function_log(parent.finish, logger_arg=context_logger)
 
         assert 'Root span "parent" closed, but the trace has 1 unfinished spans' in out
-        assert 'parent_id {}'.format(parent.span_id) in out
-        assert 'trace_id {}'.format(child.trace_id) in out
-        assert 'id {}'.format(child.span_id) in out
+        assert "parent_id {}".format(parent.span_id) in out
+        assert "trace_id {}".format(child.trace_id) in out
+        assert "id {}".format(child.span_id) in out

--- a/tests/contrib/logging/test_logging.py
+++ b/tests/contrib/logging/test_logging.py
@@ -169,9 +169,6 @@ class LoggingTestCase(BaseTracerTestCase):
         Check that closing a span with unfinished children correctly logs out
         unfinished spans. See #1337 for more context.
         """
-        parent = self.tracer.trace("parent")
-        child = self.tracer.trace("child")
-
         # unfinished child spans only logged if tracer log level is debug
         self.tracer.log.setLevel(logging.DEBUG)
 
@@ -179,6 +176,10 @@ class LoggingTestCase(BaseTracerTestCase):
         # so debug logging has to be enabled here as well.
         context_logger = logging.getLogger("ddtrace.context")
         context_logger.setLevel(logging.DEBUG)
+
+        # finish parent span without finishing child span
+        parent = self.tracer.trace("parent")
+        child = self.tracer.trace("child")
         out, span = capture_function_log(parent.finish, logger_arg=context_logger)
 
         assert 'Root span "parent" closed, but the trace has 1 unfinished spans' in out

--- a/tests/contrib/logging/test_logging.py
+++ b/tests/contrib/logging/test_logging.py
@@ -180,7 +180,7 @@ class LoggingTestCase(BaseTracerTestCase):
         # finish parent span without finishing child span
         parent = self.tracer.trace("parent")
         child = self.tracer.trace("child")
-        out, span = capture_function_log(parent.finish, logger_arg=context_logger)
+        out, span = capture_function_log(parent.finish, logger_override=context_logger)
 
         assert 'Root span "parent" closed, but the trace has 1 unfinished spans' in out
         assert "parent_id {}".format(parent.span_id) in out


### PR DESCRIPTION
resolves #1337. could also avoid adding the extra attribute to the record and say `if record.name.startswith("ddtrace")` in `_w_makeRecord` but that could miss some cases and hit a lot of false positives.

if folks are 👍 on this approach i can make `__from_DDLogger` a constant, look at tests, etc. haven't checked performance impact and am guessing there may be an easier way to do this