### PR TITLE
fix(profiling): use formats.asbool to convert bool from env

### DIFF
--- a/ddtrace/profiling/collector/memory.py
+++ b/ddtrace/profiling/collector/memory.py
@@ -9,6 +9,7 @@ except ImportError:
 from ddtrace.profiling import _attr
 from ddtrace.profiling import collector
 from ddtrace.profiling import event
+from ddtrace.utils import formats
 from ddtrace.vendor import attr
 
 
@@ -31,7 +32,7 @@ class MemoryCollector(collector.PeriodicCollector, collector.CaptureSamplerColle
     _interval = attr.ib(default=0.1, repr=False)
 
     nframes = attr.ib(factory=_attr.from_env("DD_PROFILING_MAX_FRAMES", 64, int))
-    ignore_profiler = attr.ib(factory=_attr.from_env("DD_PROFILING_IGNORE_PROFILER", True, bool))
+    ignore_profiler = attr.ib(factory=_attr.from_env("DD_PROFILING_IGNORE_PROFILER", True, formats.asbool))
 
     def __attrs_post_init__(self):
         if sys.version_info[:2] <= (3, 5):

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -5,7 +5,6 @@ import logging
 import os
 import sys
 import threading
-from distutils import util
 
 from ddtrace import compat
 from ddtrace.profiling import _attr
@@ -13,6 +12,7 @@ from ddtrace.profiling import _periodic
 from ddtrace.profiling import collector
 from ddtrace.profiling import event
 from ddtrace.profiling.collector import _traceback
+from ddtrace.utils import formats
 from ddtrace.vendor import attr
 
 # NOTE: Do not use LOG here. This code runs under a real OS thread and is unable to acquire any lock of the `logging`
@@ -292,7 +292,7 @@ class StackCollector(collector.PeriodicCollector):
 
     max_time_usage_pct = attr.ib(factory=_attr.from_env("DD_PROFILING_MAX_TIME_USAGE_PCT", 2, float))
     nframes = attr.ib(factory=_attr.from_env("DD_PROFILING_MAX_FRAMES", 64, int))
-    ignore_profiler = attr.ib(factory=_attr.from_env("DD_PROFILING_IGNORE_PROFILER", True, bool))
+    ignore_profiler = attr.ib(factory=_attr.from_env("DD_PROFILING_IGNORE_PROFILER", True, formats.asbool))
     _thread_time = attr.ib(init=False, repr=False)
     _last_wall_time = attr.ib(init=False, repr=False)
 


### PR DESCRIPTION
Using the `bool` primitive will only work with 0 or 1, whereas we want to
support true/false strings.