### PR TITLE
span: handle non-string tag keys

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -3,6 +3,7 @@ import random
 import sys
 import traceback
 
+from .vendor import six
 from .compat import StringIO, stringify, iteritems, numeric_types, time_ns, is_integer
 from .constants import (
     NUMERIC_TAGS, MANUAL_DROP_KEY, MANUAL_KEEP_KEY,
@@ -169,7 +170,7 @@ class Span(object):
         :type value: ``stringify``-able value
         """
 
-        if not isinstance(key, str):
+        if not isinstance(key, six.string_types):
             log.warning("Ignoring tag pair %s:%s. Key must be a string.", key, value)
             return
 

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -159,10 +159,20 @@ class Span(object):
                         log.exception('error recording finished trace')
 
     def set_tag(self, key, value=None):
-        """ Set the given key / value tag pair on the span. Keys and values
-            must be strings (or stringable). If a casting error occurs, it will
-            be ignored.
+        """Set a tag key/value pair on the span.
+
+        Keys must be strings, values must be ``stringify``-able.
+
+        :param key: Key to use for the tag
+        :type key: str
+        :param value: Value to assign for the tag
+        :type value: ``stringify``-able value
         """
+
+        if not isinstance(key, str):
+            log.warning("Ignoring tag pair %s:%s. Key must be a string.", key, value)
+            return
+
         # Special case, force `http.status_code` as a string
         # DEV: `http.status_code` *has* to be in `meta` for metrics
         #   calculated in the trace agent
@@ -170,20 +180,20 @@ class Span(object):
             value = str(value)
 
         # Determine once up front
-        is_an_int = is_integer(value)
+        val_is_an_int = is_integer(value)
 
         # Explicitly try to convert expected integers to `int`
         # DEV: Some integrations parse these values from strings, but don't call `int(value)` themselves
         INT_TYPES = (net.TARGET_PORT, )
-        if key in INT_TYPES and not is_an_int:
+        if key in INT_TYPES and not val_is_an_int:
             try:
                 value = int(value)
-                is_an_int = True
+                val_is_an_int = True
             except (ValueError, TypeError):
                 pass
 
         # Set integers that are less than equal to 2^53 as metrics
-        if is_an_int and abs(value) <= 2 ** 53:
+        if val_is_an_int and abs(value) <= 2 ** 53:
             self.set_metric(key, value)
             return
 
@@ -198,7 +208,7 @@ class Span(object):
                 # DEV: `set_metric` will try to cast to `float()` for us
                 self.set_metric(key, value)
             except (TypeError, ValueError):
-                log.debug('error setting numeric metric %s:%s', key, value)
+                log.warning("error setting numeric metric %s:%s", key, value)
 
             return
 
@@ -227,7 +237,7 @@ class Span(object):
             if key in self.metrics:
                 del self.metrics[key]
         except Exception:
-            log.debug('error setting tag %s, ignoring it', key, exc_info=True)
+            log.warning("error setting tag %s, ignoring it", key, exc_info=True)
 
     def _remove_tag(self, key):
         if key in self.meta:

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -487,3 +487,20 @@ def test_set_tag_measured_change_value():
 
     s.set_tag(SPAN_MEASURED_KEY)
     assert_is_measured(s)
+
+
+@mock.patch('ddtrace.span.log')
+def test_span_key(span_log):
+    # Span tag keys must be strings
+    s = Span(tracer=None, name="test.span")
+
+    s.set_tag(123, True)
+    span_log.warning.assert_called_once_with("Ignoring tag pair %s:%s. Key must be a string.", 123, True)
+    assert s.get_tag(123) is None
+    assert s.get_tag("123") is None
+
+    span_log.reset_mock()
+
+    s.set_tag(None, "val")
+    span_log.warning.assert_called_once_with("Ignoring tag pair %s:%s. Key must be a string.", None, "val")
+    assert s.get_tag(123.32) is None


### PR DESCRIPTION
As I found out the hard way: setting a non-string key tag (eg: `span.set_tag(1, "value")`) will result in the span being dropped at the agent:

```bash
2020-04-07 21:26:21 UTC | TRACE | ERROR | (pkg/trace/api/api.go:379 in handleTraces) | Cannot decode v0.4 traces payload: msgp: attempted to decode type "int" with method for "str"
```

This PR adds the functionality of logging a warning and aborting the operation when this occurs.