### PR TITLE
ci: test profiler on Python 3.9

### DIFF
--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -228,6 +228,11 @@ IF UNAME_SYSNAME != "Windows" and PY_MAJOR_VERSION >= 3 and PY_MINOR_VERSION >= 
                 pyinterpreters interpreters
 
             cdef extern _PyRuntimeState _PyRuntime
+
+        IF PY_MINOR_VERSION >= 9:
+            # Needed for accessing _PyGC_FINALIZED when we build with -DPy_BUILD_CORE
+            cdef extern from "<internal/pycore_gc.h>":
+                pass
 ELSE:
     from cpython.ref cimport Py_DECREF
 

--- a/tests/profiling/exporter/test_pprof.py
+++ b/tests/profiling/exporter/test_pprof.py
@@ -446,8 +446,8 @@ def test_ppprof_memory_exporter():
             (32, (("<stdin>", 1),)),
             (24, (("<unknown>", 0),)),
         ]
-
-    else:
+    elif sys.version_info.major <= 3 and sys.version_info.minor < 9:
+        # Python before 3.9 does not support number of frames
         traces = [
             (0, 45, (("<unknown>", 0),)),
             (0, 64, (("<stdin>", 1),)),
@@ -456,6 +456,16 @@ def test_ppprof_memory_exporter():
             (0, 32, (("<unknown>", 0),)),
             (0, 32, (("<stdin>", 1),)),
             (0, 24, (("<unknown>", 0),)),
+        ]
+    else:
+        traces = [
+            (0, 45, (("<unknown>", 0),), 1),
+            (0, 64, (("<stdin>", 1),), 1),
+            (0, 8224, (("<unknown>", 0),), 1),
+            (0, 144, (("<unknown>", 0),), 1),
+            (0, 32, (("<unknown>", 0),), 1),
+            (0, 32, (("<stdin>", 1),), 1),
+            (0, 24, (("<unknown>", 0),), 1),
         ]
     events = {
         memory.MemorySampleEvent: [

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,8 @@ envlist =
     black
     wait
     {py27,py35,py36,py37,py38}-tracer
-    {py27,py35,py36,py37,py38}-profile{,-gevent}
-    {py27,py35,py36,py37,py38}-profile-minreqs{,-gevent}
+    {py27,py35,py36,py37,py38,py39}-profile{,-gevent}
+    {py27,py35,py36,py37,py38,py39}-profile-minreqs{,-gevent}
     {py27,py35,py36,py37,py38}-internal
     {py27,py35,py36,py37,py38}-integration
     {py27,py35,py36,py37,py38}-ddtracerun
@@ -200,7 +200,8 @@ deps =
     profile-minreqs: tenacity==5.0.1
     profile-!minreqs-gevent: gevent
     py27-profile-minreqs-gevent: gevent==1.1.0
-    !py27-profile-minreqs-gevent: gevent==1.4.0
+    py{35,36,37,38}-profile-minreqs-gevent: gevent==1.4.0
+    py39-profile-minreqs-gevent: gevent==20.6.0
 # force the downgrade as a workaround
 # https://github.com/aio-libs/aiohttp/issues/2662
     yarl: yarl==0.18.0


### PR DESCRIPTION
## fix(profiling): disable exception sampling on Python 3.9

https://github.com/python/cpython/pull/16347 made the symbols hidden so we
can't use private functions anymore.

## ci: test profiler on Python 3.9
