### PR TITLE
tracer: stop previous writer if a new one is created

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -272,6 +272,9 @@ class Tracer(object):
                 default_hostname = self.DEFAULT_HOSTNAME
                 default_port = self.DEFAULT_PORT
 
+            if hasattr(self, "writer") and self.writer.is_alive():
+                self.writer.stop()
+
             self.writer = AgentWriter(
                 hostname or default_hostname,
                 port or default_port,

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -599,6 +599,29 @@ def test_tracer_shutdown_no_timeout():
     t.writer.join.assert_called_once_with(timeout=None)
 
 
+def test_tracer_configure_writer_stop_unstarted():
+    t = ddtrace.Tracer()
+    t.writer = mock.Mock(wraps=t.writer)
+    orig_writer = t.writer
+
+    # Make sure we aren't calling stop for an unstarted writer
+    t.configure(hostname="localhost", port=8126)
+    assert not orig_writer.stop.called
+
+
+def test_tracer_configure_writer_stop_started():
+    t = ddtrace.Tracer()
+    t.writer = mock.Mock(wraps=t.writer)
+    orig_writer = t.writer
+
+    # Do a write to start the writer
+    with t.trace("something"):
+        pass
+
+    t.configure(hostname="localhost", port=8126)
+    orig_writer.stop.assert_called_once_with()
+
+
 def test_tracer_shutdown_timeout():
     t = ddtrace.Tracer()
     t.writer = mock.Mock(wraps=t.writer)


### PR DESCRIPTION
~Creating this as a draft for now as I'm not yet 100% of the implications this might have.~ It seems like (thankfully) we don't reuse or copy writers anywhere so I think this change isn't breaking.

I think this might be part (and only part) of the reason for cases like #1155. For this to be a solution for #1155 would mean that somehow the abandoned writer thread was somehow still having traces sent to it.
