### PR TITLE
Updates configuration docs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -18,7 +18,7 @@ below:
    * - ``DD_ENV``
      - String
      -
-     - Set an application's environment e.g. ``prod``, ``pre-prod``, ``stage``.
+     - Set an application's environment e.g. ``prod``, ``pre-prod``, ``stage``. Added in ``v0.36.0``.
    * - ``DATADOG_ENV``
      - String
      -
@@ -29,7 +29,7 @@ below:
      - Set the service name to be used for this application. A default is
        provided for these integrations: :ref:`bottle`, :ref:`flask`, :ref:`grpc`,
        :ref:`pyramid`, :ref:`pylons`, :ref:`tornado`, :ref:`celery`, :ref:`django` and
-       :ref:`falcon`.
+       :ref:`falcon`. Added in ``v0.36.0``.
    * - ``DD_SERVICE_NAME`` or ``DATADOG_SERVICE_NAME``
      - String
      -
@@ -38,7 +38,7 @@ below:
      - String
      -
      - Set an application's version in traces and logs e.g. ``1.2.3``,
-       ``6c44da20``, ``2020.02.13``.
+       ``6c44da20``, ``2020.02.13``. Added in ``v0.36.0``.
    * - ``DD_SITE``
      - String
      - datadoghq.com


### PR DESCRIPTION
This updates the configuration docs, calling out that the DD_SERVICE, DD_ENV, and DD_VERSION env vars were added in v0.36.0

I spent more time than I'd care to say debugging why traces weren't falling into the correct environment in the UI, only later to realize I was using v0.33.0 and while I added the new env vars, that version wasn't using them.

My goal in calling out when these env vars were added to ddtrace is to remind those using the library to check their versions and not waste time like I did.