### PR TITLE
Add config to omit `django.user.name` tag from request root span

### DIFF
--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -87,7 +87,7 @@ Configuration
 
    Default: ``False``
 
-.. py:data:: ddtrace.config.django['user_name_enabled']
+.. py:data:: ddtrace.config.django['include_user_name']
 
    Whether or not to include the authenticated user's username as a tag on the root request span.
 

--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -87,6 +87,12 @@ Configuration
 
    Default: ``False``
 
+.. py:data:: ddtrace.config.django['user_name_enabled']
+
+   Whether or not to include the authenticated user's username as a tag.
+
+   Default: ``True``
+
 
 Example::
 

--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -89,7 +89,7 @@ Configuration
 
 .. py:data:: ddtrace.config.django['user_name_enabled']
 
-   Whether or not to include the authenticated user's username as a tag.
+   Whether or not to include the authenticated user's username as a tag on the root request span.
 
    Default: ``True``
 

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -40,7 +40,7 @@ config._add(
         analytics_enabled=None,  # None allows the value to be overridden by the global config
         analytics_sample_rate=None,
         trace_query_string=None,  # Default to global config
-        user_name_enabled=True,
+        include_user_name=True,
     ),
 )
 
@@ -129,7 +129,7 @@ def _set_request_tags(span, request):
         if uid:
             span.set_tag("django.user.id", uid)
 
-        if config.django.user_name_enabled:
+        if config.django.include_user_name:
             username = getattr(user, "username", None)
             if username:
                 span.set_tag("django.user.name", username)

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -40,6 +40,7 @@ config._add(
         analytics_enabled=None,  # None allows the value to be overridden by the global config
         analytics_sample_rate=None,
         trace_query_string=None,  # Default to global config
+        user_name_enabled=True,
     ),
 )
 
@@ -128,9 +129,10 @@ def _set_request_tags(span, request):
         if uid:
             span.set_tag("django.user.id", uid)
 
-        username = getattr(user, "username", None)
-        if username:
-            span.set_tag("django.user.name", username)
+        if config.django.user_name_enabled:
+            username = getattr(user, "username", None)
+            if username:
+                span.set_tag("django.user.name", username)
 
 
 @with_traced_module

--- a/tests/contrib/django/django_app/urls.py
+++ b/tests/contrib/django/django_app/urls.py
@@ -1,4 +1,6 @@
 from django.conf.urls import url
+from django.contrib.auth import login
+from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.views.decorators.cache import cache_page
 from django.urls import include, path, re_path
@@ -14,6 +16,19 @@ def path_view(request):
     return HttpResponse(status=200)
 
 
+def authenticated_view(request):
+    """
+    This view can be used to test requests with an authenticated user. Create a
+    user with a default username, save it and then use this user to log in.
+    Always returns a 200.
+    """
+
+    user = User(username="Jane Doe")
+    user.save()
+    login(request, user)
+    return HttpResponse(status=200)
+
+
 urlpatterns = [
     url(r"^$", views.index),
     url(r"^simple/$", views.BasicView.as_view()),
@@ -21,6 +36,7 @@ urlpatterns = [
     url(r"^cached-template/$", views.TemplateCachedUserList.as_view(), name="cached-template-list"),
     url(r"^cached-users/$", cache_page(60)(views.UserList.as_view()), name="cached-users-list"),
     url(r"^fail-view/$", views.ForbiddenView.as_view(), name="forbidden-view"),
+    url(r"^authenticated/$", authenticated_view, name="authenticated-view"),
     url(r"^static-method-view/$", views.StaticMethodView.as_view(), name="static-method-view"),
     url(r"^fn-view/$", views.function_view, name="fn-view"),
     url(r"^feed-view/$", views.FeedView(), name="feed-view"),

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -1257,5 +1257,5 @@ def test_user_name_disabled(client, test_spans):
 
     # user name should not be present in root span tag
     root = test_spans.get_root_span()
-    assert root.meta.get("django.user.name") is None
+    assert "django.user.name" not in root.meta
     assert root.meta.get("django.user.is_authenticated") == "True"

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -1230,15 +1230,15 @@ def test_urlpatterns_repath(client, test_spans):
 
 @pytest.mark.skipif(django.VERSION < (2, 0, 0), reason="")
 @pytest.mark.django_db
-def test_user_name_enabled(client, test_spans):
+def test_user_name_included(client, test_spans):
     """
-    When making a request to a Django app with user name enabled
+    When making a request to a Django app with user name included
         We correctly add the `django.user.name` tag to the root span
     """
     resp = client.get("/authenticated/")
     assert resp.status_code == 200
 
-    # user name should be present in root span tag
+    # user name should be present in root span tags
     root = test_spans.get_root_span()
     assert root.meta.get("django.user.name") == "Jane Doe"
     assert root.meta.get("django.user.is_authenticated") == "True"
@@ -1246,16 +1246,16 @@ def test_user_name_enabled(client, test_spans):
 
 @pytest.mark.skipif(django.VERSION < (2, 0, 0), reason="")
 @pytest.mark.django_db
-def test_user_name_disabled(client, test_spans):
+def test_user_name_excluded(client, test_spans):
     """
-    When making a request to a Django app with user name disabled
+    When making a request to a Django app with user name excluded
         We correctly omit the `django.user.name` tag to the root span
     """
-    with BaseTestCase.override_config("django", dict(user_name_enabled=False)):
+    with BaseTestCase.override_config("django", dict(include_user_name=False)):
         resp = client.get("/authenticated/")
     assert resp.status_code == 200
 
-    # user name should not be present in root span tag
+    # user name should not be present in root span tags
     root = test_spans.get_root_span()
     assert "django.user.name" not in root.meta
     assert root.meta.get("django.user.is_authenticated") == "True"

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -1239,17 +1239,9 @@ def test_user_name_enabled(client, test_spans):
     assert resp.status_code == 200
 
     # user name should be present in root span tag
-    assert test_spans.get_root_span().meta == {
-        "django.request.class": "django.core.handlers.wsgi.WSGIRequest",
-        "django.response.class": "django.http.response.HttpResponse",
-        "django.user.is_authenticated": "True",
-        "django.user.name": "Jane Doe",
-        "django.view": "authenticated-view",
-        "http.method": "GET",
-        "http.status_code": "200",
-        "http.route": "^authenticated/$",
-        "http.url": "http://testserver/authenticated/",
-    }
+    root = test_spans.get_root_span()
+    assert root.meta.get("django.user.name") == "Jane Doe"
+    assert root.meta.get("django.user.is_authenticated") == "True"
 
 
 @pytest.mark.skipif(django.VERSION < (2, 0, 0), reason="")
@@ -1264,13 +1256,6 @@ def test_user_name_disabled(client, test_spans):
     assert resp.status_code == 200
 
     # user name should not be present in root span tag
-    assert test_spans.get_root_span().meta == {
-        "django.request.class": "django.core.handlers.wsgi.WSGIRequest",
-        "django.response.class": "django.http.response.HttpResponse",
-        "django.user.is_authenticated": "True",
-        "django.view": "authenticated-view",
-        "http.method": "GET",
-        "http.status_code": "200",
-        "http.route": "^authenticated/$",
-        "http.url": "http://testserver/authenticated/",
-    }
+    root = test_spans.get_root_span()
+    assert root.meta.get("django.user.name") is None
+    assert root.meta.get("django.user.is_authenticated") == "True"


### PR DESCRIPTION
The default behaviour of the Django contrib package is to add a `django.user.name` tag with the username to the root span of the Django request.

![image](https://user-images.githubusercontent.com/4504270/79243960-36da4d00-7e6e-11ea-84db-cb6a7b30cca0.png)

This is a concern as the user's name is personally identifiable data and should not be leaving the system.

This PR adds a `user_name_enabled` config to the Django contrib package which defaults to `True`, but when set to `False` would mean that the Django user's username is omitted from the root request span tags.