### PR TITLE
writer: allow configuration of queue maxsize via env var

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -99,7 +99,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
             interval=self.QUEUE_PROCESSING_INTERVAL, exit_timeout=shutdown_timeout, name=self.__class__.__name__
         )
         # DEV: provide a _temporary_ solution to allow users to specify a custom max
-        maxsize = int(os.getenv("DD_TRACE_MAX_TRACES", self.QUEUE_MAX_TRACES_DEFAULT))
+        maxsize = int(os.getenv("DD_TRACE_MAX_TPS", self.QUEUE_MAX_TRACES_DEFAULT))
         self._trace_queue = Q(maxsize=maxsize)
         self._filters = filters
         self._sampler = sampler

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -938,6 +938,6 @@ class EnvTracerTestCase(BaseTracerTestCase):
 
 
 def test_tracer_custom_max_traces(monkeypatch):
-    monkeypatch.setenv("DD_TRACE_MAX_TRACES", "2000")
+    monkeypatch.setenv("DD_TRACE_MAX_TPS", "2000")
     tracer = ddtrace.Tracer()
     assert tracer.writer._trace_queue.maxsize == 2000

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -935,3 +935,9 @@ class EnvTracerTestCase(BaseTracerTestCase):
     @run_in_subprocess(env_overrides=dict(AWS_LAMBDA_FUNCTION_NAME="my-func", DD_AGENT_HOST="localhost"))
     def test_detect_agent_config(self):
         assert isinstance(self.tracer.original_writer, AgentWriter)
+
+
+def test_tracer_custom_max_traces(monkeypatch):
+    monkeypatch.setenv("DD_TRACE_MAX_TRACES", "2000")
+    tracer = ddtrace.Tracer()
+    assert tracer.writer._trace_queue.maxsize == 2000


### PR DESCRIPTION
This PR adds the ability to configure the maximum number of traces the writer can hold via an  environment variable `DD_TRACE_MAX_TRACES`.

Instead of trying to design and support a new public API around setting the queue max size as discussed in #1363 we'd rather provide a quick and dirty solution to allow users to set their own max traces limit.

This will be succeeded by either a public API if our current system is deemed adequate; or by changes we make to the underlying queuing and writing system we have.