### PR TITLE
fix(profiling): use timeout attribute

### DIFF
--- a/ddtrace/profiling/exporter/http.py
+++ b/ddtrace/profiling/exporter/http.py
@@ -5,6 +5,7 @@ import gzip
 import logging
 import os
 import platform
+import socket
 import uuid
 
 from ddtrace.utils import deprecation
@@ -200,6 +201,6 @@ class PprofHTTPExporter(pprof.PprofExporter):
         req = request.Request(self.endpoint, data=body, headers=headers)
 
         try:
-            request.urlopen(req)
-        except (error.HTTPError, error.URLError, http_client.HTTPException) as e:
+            request.urlopen(req, timeout=self.timeout)
+        except (error.HTTPError, error.URLError, http_client.HTTPException, socket.timeout) as e:
             raise UploadFailed(e)

--- a/tests/profiling/exporter/test_http.py
+++ b/tests/profiling/exporter/test_http.py
@@ -2,6 +2,7 @@
 import collections
 import email.parser
 import platform
+import socket
 import threading
 import time
 
@@ -11,7 +12,6 @@ from ddtrace import compat
 from ddtrace.vendor import six
 from ddtrace.vendor.six.moves import BaseHTTPServer
 from ddtrace.vendor.six.moves import http_client
-from ddtrace.vendor.six.moves.urllib import error
 
 import ddtrace
 from ddtrace.profiling.exporter import http
@@ -172,7 +172,7 @@ def test_export_timeout(endpoint_test_timeout_server):
     with pytest.raises(http.UploadFailed) as t:
         exp.export(test_pprof.TEST_EVENTS, 0, 1)
     e = t.value.exception
-    assert isinstance(e, error.HTTPError)
+    assert isinstance(e, socket.timeout)
 
 
 def test_export_reset(endpoint_test_reset_server):


### PR DESCRIPTION
The timeout defined in the HTTP exporter was never used and system default was
used instead.
