### PR TITLE
Add runtime id tag support for traces & profiles

### DIFF
--- a/ddtrace/internal/runtime/__init__.py
+++ b/ddtrace/internal/runtime/__init__.py
@@ -1,3 +1,6 @@
+import os
+import uuid
+
 from .runtime_metrics import (
     RuntimeTags,
     RuntimeMetrics,
@@ -9,4 +12,50 @@ __all__ = [
     "RuntimeTags",
     "RuntimeMetrics",
     "RuntimeWorker",
+    "get_runtime_id",
 ]
+
+
+def _generate_runtime_id():
+    return uuid.uuid4().hex
+
+
+_RUNTIME_ID = _generate_runtime_id()
+
+
+if hasattr(os, "register_at_fork"):
+
+    def _set_runtime_id():
+        global _RUNTIME_ID
+        _RUNTIME_ID = _generate_runtime_id()
+
+    os.register_at_fork(after_in_child=_set_runtime_id)
+
+    def get_runtime_id():
+        return _RUNTIME_ID
+
+
+else:
+    # Non-POSIX systems or Python < 3.7
+    import threading
+
+    _RUNTIME_PID = os.getpid()
+
+    def _set_runtime_id():
+        global _RUNTIME_ID, _RUNTIME_PID
+        _RUNTIME_ID = _generate_runtime_id()
+        _RUNTIME_PID = os.getpid()
+
+    _RUNTIME_LOCK = threading.Lock()
+
+    def get_runtime_id():
+        with _RUNTIME_LOCK:
+            pid = os.getpid()
+            if pid != _RUNTIME_PID:
+                _set_runtime_id()
+            return _RUNTIME_ID
+
+
+get_runtime_id.__doc__ = """Return a unique string identifier for this runtime.
+
+Do not store this identifier as it can change when, e.g., the process forks."""

--- a/ddtrace/profiling/exporter/http.py
+++ b/ddtrace/profiling/exporter/http.py
@@ -4,7 +4,6 @@ import datetime
 import gzip
 import os
 import platform
-import uuid
 
 import tenacity
 
@@ -16,6 +15,7 @@ from ddtrace.vendor.six.moves.urllib import error
 from ddtrace.vendor.six.moves.urllib import request
 
 import ddtrace
+from ddtrace.internal import runtime
 from ddtrace.profiling import _attr
 from ddtrace.profiling import _traceback
 from ddtrace.profiling import exporter
@@ -23,7 +23,6 @@ from ddtrace.vendor import attr
 from ddtrace.profiling.exporter import pprof
 
 
-RUNTIME_ID = str(uuid.uuid4()).encode()
 HOSTNAME = platform.node()
 PYTHON_IMPLEMENTATION = platform.python_implementation().encode()
 PYTHON_VERSION = platform.python_version().encode()
@@ -134,7 +133,7 @@ class PprofHTTPExporter(pprof.PprofExporter):
         tags = {
             "service": service.encode("utf-8"),
             "host": HOSTNAME.encode("utf-8"),
-            "runtime-id": RUNTIME_ID,
+            "runtime-id": runtime.get_runtime_id().encode("ascii"),
             "language": b"python",
             "runtime": PYTHON_IMPLEMENTATION,
             "runtime_version": PYTHON_VERSION,
@@ -173,7 +172,7 @@ class PprofHTTPExporter(pprof.PprofExporter):
         with gzip.GzipFile(fileobj=s, mode="wb") as gz:
             gz.write(profile.SerializeToString())
         fields = {
-            "runtime-id": RUNTIME_ID,
+            "runtime-id": runtime.get_runtime_id().encode("ascii"),
             "recording-start": (
                 datetime.datetime.utcfromtimestamp(start_time_ns / 1e9).replace(microsecond=0).isoformat() + "Z"
             ).encode(),

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -8,7 +8,7 @@ from .constants import FILTERS_KEY, SAMPLE_RATE_METRIC_KEY, VERSION_KEY, ENV_KEY
 from .ext import system
 from .ext.priority import AUTO_REJECT, AUTO_KEEP
 from .internal.logger import get_logger
-from .internal.runtime import RuntimeTags, RuntimeWorker
+from .internal.runtime import RuntimeTags, RuntimeWorker, get_runtime_id
 from .internal.writer import AgentWriter, LogWriter
 from .provider import DefaultContextProvider
 from .context import Context
@@ -443,6 +443,7 @@ class Tracer(object):
 
         if not span._parent:
             span.set_tag(system.PID, getpid())
+            span.set_tag("runtime-id", get_runtime_id())
 
         # add it to the current context
         context.add_span(span)

--- a/tests/contrib/flask/test_flask_helpers.py
+++ b/tests/contrib/flask/test_flask_helpers.py
@@ -49,7 +49,7 @@ class FlaskHelpersTestCase(BaseFlaskTestCase):
         self.assertIsNone(spans[0].service)
         self.assertEqual(spans[0].name, 'flask.jsonify')
         self.assertEqual(spans[0].resource, 'flask.jsonify')
-        assert spans[0].meta == dict()
+        assert set(spans[0].meta.keys()) == {"runtime-id"}
 
         self.assertEqual(spans[1].name, 'flask.do_teardown_request')
         self.assertEqual(spans[2].name, 'flask.do_teardown_appcontext')
@@ -96,7 +96,7 @@ class FlaskHelpersTestCase(BaseFlaskTestCase):
         self.assertEqual(spans[0].service, 'flask')
         self.assertEqual(spans[0].name, 'flask.send_file')
         self.assertEqual(spans[0].resource, 'flask.send_file')
-        assert spans[0].meta == dict()
+        assert set(spans[0].meta.keys()) == {"runtime-id"}
 
         self.assertEqual(spans[1].name, 'flask.do_teardown_request')
         self.assertEqual(spans[2].name, 'flask.do_teardown_appcontext')

--- a/tests/contrib/flask/test_signals.py
+++ b/tests/contrib/flask/test_signals.py
@@ -109,7 +109,7 @@ class FlaskSignalsTestCase(BaseFlaskTestCase):
             self.assertEqual(span.service, 'flask')
             self.assertEqual(span.name, 'tests.contrib.flask.{}'.format(signal_name))
             self.assertEqual(span.resource, 'tests.contrib.flask.{}'.format(signal_name))
-            self.assertEqual(set(span.meta.keys()), set(['flask.signal']))
+            self.assertEqual(set(span.meta.keys()), set(['flask.signal', "runtime-id"]))
             self.assertEqual(span.meta['flask.signal'], signal_name)
 
     def test_signals_multiple(self):
@@ -144,7 +144,7 @@ class FlaskSignalsTestCase(BaseFlaskTestCase):
         self.assertEqual(span_a.service, 'flask')
         self.assertEqual(span_a.name, 'tests.contrib.flask.request_started_a')
         self.assertEqual(span_a.resource, 'tests.contrib.flask.request_started_a')
-        self.assertEqual(set(span_a.meta.keys()), set(['flask.signal']))
+        self.assertEqual(set(span_a.meta.keys()), set(['flask.signal', "runtime-id"]))
         self.assertEqual(span_a.meta['flask.signal'], 'request_started')
 
         # Assert the span that was created
@@ -152,7 +152,7 @@ class FlaskSignalsTestCase(BaseFlaskTestCase):
         self.assertEqual(span_b.service, 'flask')
         self.assertEqual(span_b.name, 'tests.contrib.flask.request_started_b')
         self.assertEqual(span_b.resource, 'tests.contrib.flask.request_started_b')
-        self.assertEqual(set(span_b.meta.keys()), set(['flask.signal']))
+        self.assertEqual(set(span_b.meta.keys()), set(['flask.signal', "runtime-id"]))
         self.assertEqual(span_b.meta['flask.signal'], 'request_started')
 
     def test_signals_pin_disabled(self):

--- a/tests/contrib/flask/test_template.py
+++ b/tests/contrib/flask/test_template.py
@@ -50,7 +50,7 @@ class FlaskTemplateTestCase(BaseFlaskTestCase):
         self.assertIsNone(spans[0].service)
         self.assertEqual(spans[0].name, 'flask.render_template')
         self.assertEqual(spans[0].resource, 'test.html')
-        self.assertEqual(set(spans[0].meta.keys()), set(['flask.template_name']))
+        self.assertEqual(set(spans[0].meta.keys()), set(['flask.template_name', "runtime-id"]))
         self.assertEqual(spans[0].meta['flask.template_name'], 'test.html')
 
         self.assertEqual(spans[1].name, 'flask.do_teardown_request')
@@ -91,7 +91,7 @@ class FlaskTemplateTestCase(BaseFlaskTestCase):
         self.assertIsNone(spans[0].service)
         self.assertEqual(spans[0].name, 'flask.render_template_string')
         self.assertEqual(spans[0].resource, '<memory>')
-        self.assertEqual(set(spans[0].meta.keys()), set(['flask.template_name']))
+        self.assertEqual(set(spans[0].meta.keys()), set(['flask.template_name', "runtime-id"]))
         self.assertEqual(spans[0].meta['flask.template_name'], '<memory>')
 
         self.assertEqual(spans[1].name, 'flask.do_teardown_request')

--- a/tests/internal/runtime/test_runtime_id.py
+++ b/tests/internal/runtime/test_runtime_id.py
@@ -1,0 +1,34 @@
+import os
+
+from ddtrace.internal import runtime
+
+
+def test_get_runtime_id():
+    runtime_id = runtime.get_runtime_id()
+    assert isinstance(runtime_id, str)
+    assert runtime_id == runtime.get_runtime_id()
+    assert runtime_id == runtime.get_runtime_id()
+
+
+def test_get_runtime_id_fork():
+    runtime_id = runtime.get_runtime_id()
+    assert isinstance(runtime_id, str)
+    assert runtime_id == runtime.get_runtime_id()
+    assert runtime_id == runtime.get_runtime_id()
+
+    child = os.fork()
+
+    if child == 0:
+        runtime_id_child = runtime.get_runtime_id()
+        assert isinstance(runtime_id_child, str)
+        assert runtime_id != runtime_id_child
+        assert runtime_id != runtime.get_runtime_id()
+        assert runtime_id_child == runtime.get_runtime_id()
+        assert runtime_id_child == runtime.get_runtime_id()
+        os._exit(42)
+
+    pid, status = os.waitpid(child, 0)
+
+    exit_code = os.WEXITSTATUS(status)
+
+    assert exit_code == 42

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -289,8 +289,8 @@ class TestAPITransport(TestCase):
         # register a single trace with a span and send them to the trace agent
         self.tracer.trace("client.testing").finish()
         trace = self.tracer.writer.pop()
-        # 30k is a right number to have both json and msgpack send 2 payload :)
-        traces = [trace] * 30000
+        # 20k is a right number to have both json and msgpack send 2 payload :)
+        traces = [trace] * 20000
 
         self._send_traces_and_check(traces, 2)
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -952,3 +952,33 @@ def test_tracer_custom_max_traces(monkeypatch):
     monkeypatch.setenv("DD_TRACE_MAX_TPS", "2000")
     tracer = ddtrace.Tracer()
     assert tracer.writer._trace_queue.maxsize == 2000
+
+
+def test_tracer_set_runtime_tags():
+    t = ddtrace.Tracer()
+    span = t.start_span("foobar")
+
+    assert len(span.get_tag("runtime-id"))
+
+    t2 = ddtrace.Tracer()
+    span2 = t2.start_span("foobaz")
+
+    assert span.get_tag("runtime-id") == span2.get_tag("runtime-id")
+
+
+def test_tracer_runtime_tags_fork():
+    tracer = ddtrace.Tracer()
+
+    def task(tracer, q):
+        span = tracer.start_span("foobaz")
+        q.put(span.get_tag("runtime-id"))
+
+    span = tracer.start_span("foobar")
+
+    q = multiprocessing.Queue()
+    p = multiprocessing.Process(target=task, args=(tracer, q))
+    p.start()
+    p.join()
+
+    children_tag = q.get()
+    assert children_tag != span.get_tag("runtime-id")


### PR DESCRIPTION
## feat(runtime): implement runtime id

This adds support for a runtime id, a unique identifier that can identifies a
running process during his lifecycle.

## feat(profiling): use ddtrace.runtime to get runtime id

This actually fixes the collision that occurred when a process was forking and
its runtime id was the same.

## feat(tracer): tag spans with runtime id

This adds a tag named `runtime-id` to the root span that matches the generated
runtime id.
As profiles are also tagged with that same runtime-id, it makes it easy to link
traces and profiles.
