### PR TITLE
fix(integration config): copy and deepcopy implementations

### DIFF
--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -47,9 +47,15 @@ class IntegrationConfig(AttrDict):
         self.setdefault('analytics_sample_rate', float(get_env(name, 'analytics_sample_rate', default=1.0)))
 
     def __deepcopy__(self, memodict=None):
-        new = IntegrationConfig(self.global_config, deepcopy(dict(self)))
+        new = IntegrationConfig(self.global_config, self.integration_name, deepcopy(dict(self)))
         new.hooks = deepcopy(self.hooks)
         new.http = deepcopy(self.http)
+        return new
+
+    def copy(self):
+        new = IntegrationConfig(self.global_config, self.integration_name, dict(self))
+        new.hooks = self.hooks
+        new.http = self.http
         return new
 
     @property

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from ddtrace.settings import Config, HttpConfig, IntegrationConfig
 
 from ..base import BaseTestCase
@@ -214,3 +216,27 @@ class TestIntegrationConfig(BaseTestCase):
             config = Config()
             ic = IntegrationConfig(config, 'foo')
             self.assertIsNone(ic.get_analytics_sample_rate(use_global_config=True))
+
+    def test_deepcopy(self):
+        ic = IntegrationConfig(
+            self.config, 'foo', analytics_enabled=True, analytics_sample_rate=0.5, deep={"field": "sodeep"}
+        )
+        cpy = deepcopy(ic)
+        assert isinstance(cpy, IntegrationConfig)
+        assert cpy == ic
+        assert cpy.deep["field"] == ic.deep["field"]
+        ic.deep["field"] = ""
+        assert cpy.deep["field"] != ic.deep["field"]
+
+    def test_copy(self):
+        ic = IntegrationConfig(self.config, 'foo', analytics_enabled=True, analytics_sample_rate=0.5)
+        copy = ic.copy()
+        assert isinstance(copy, IntegrationConfig)
+
+        for key in ic:
+            assert key in copy
+
+        for key in copy:
+            assert key in ic
+
+        assert ic == copy


### PR DESCRIPTION
`IntegrationConfig` has a broken implementation of `deepcopy` and a non-existent/broken implementation for `copy` since it falls back to using `dict.copy`.

This PR fixes the bug in the `deepcopy` implementation and adds an implementation for `copy` as well as some basic tests.