### PR TITLE
pin: remove get/set api

### DIFF
--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -62,12 +62,6 @@ class TracedMongoClient(ObjectProxy):
         # Default Pin
         ddtrace.Pin(service=mongox.SERVICE, app=mongox.SERVICE).onto(self)
 
-    def __setddpin__(self, pin):
-        pin.onto(self._topology)
-
-    def __getddpin__(self):
-        return ddtrace.Pin.get_from(self._topology)
-
 
 class TracedTopology(ObjectProxy):
 

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -91,9 +91,6 @@ class Pin(object):
         :rtype: :class:`ddtrace.pin.Pin`, None
         :returns: :class:`ddtrace.pin.Pin` associated with the object, or None if none was found
         """
-        if hasattr(obj, '__getddpin__'):
-            return obj.__getddpin__()
-
         pin_name = _DD_PIN_PROXY_NAME if isinstance(obj, wrapt.ObjectProxy) else _DD_PIN_NAME
         pin = getattr(obj, pin_name, None)
         # detect if the PIN has been inherited from a class
@@ -138,9 +135,6 @@ class Pin(object):
         """
         # Actually patch it on the object.
         try:
-            if hasattr(obj, '__setddpin__'):
-                return obj.__setddpin__(self)
-
             pin_name = _DD_PIN_PROXY_NAME if isinstance(obj, wrapt.ObjectProxy) else _DD_PIN_NAME
 
             # set the target reference; any get_from, clones and retarget the new PIN


### PR DESCRIPTION
This API is only used in one place and AFAICT isn't actually even required in the one place it's being used.

This API is undocumented and only used internally in one ancient integration. I think it's safe to remove without deprecation.