### PR TITLE
Add analyzed span configuration option for Celery

### DIFF
--- a/ddtrace/contrib/celery/signals.py
+++ b/ddtrace/contrib/celery/signals.py
@@ -2,7 +2,7 @@ from ddtrace import Pin, config
 
 from celery import registry
 
-from ...constants import SPAN_MEASURED_KEY
+from ...constants import ANALYTICS_SAMPLE_RATE_KEY, SPAN_MEASURED_KEY
 from ...ext import SpanTypes
 from ...internal.logger import get_logger
 from . import constants as c
@@ -30,6 +30,11 @@ def trace_prerun(*args, **kwargs):
     # propagate the `Span` in the current task Context
     service = config.celery['worker_service_name']
     span = pin.tracer.trace(c.WORKER_ROOT_SPAN, service=service, resource=task.name, span_type=SpanTypes.WORKER)
+    # set analytics sample rate
+    s.set_tag(
+        ANALYTICS_SAMPLE_RATE_KEY,
+        config.celery.get_analytics_sample_rate()
+    )
     span.set_tag(SPAN_MEASURED_KEY)
     attach_span(task, task_id, span)
 
@@ -81,6 +86,11 @@ def trace_before_publish(*args, **kwargs):
     # in the task_after_publish signal
     service = config.celery['producer_service_name']
     span = pin.tracer.trace(c.PRODUCER_ROOT_SPAN, service=service, resource=task_name)
+    # set analytics sample rate
+    s.set_tag(
+        ANALYTICS_SAMPLE_RATE_KEY,
+        config.celery.get_analytics_sample_rate()
+    )
     span.set_tag(SPAN_MEASURED_KEY)
     span.set_tag(c.TASK_TAG_KEY, c.TASK_APPLY_ASYNC)
     span.set_tag('celery.id', task_id)

--- a/ddtrace/contrib/celery/signals.py
+++ b/ddtrace/contrib/celery/signals.py
@@ -31,10 +31,10 @@ def trace_prerun(*args, **kwargs):
     service = config.celery['worker_service_name']
     span = pin.tracer.trace(c.WORKER_ROOT_SPAN, service=service, resource=task.name, span_type=SpanTypes.WORKER)
     # set analytics sample rate
-    span.set_tag(
-        ANALYTICS_SAMPLE_RATE_KEY,
-        config.celery.get_analytics_sample_rate()
-    )
+    rate = config.celery.get_analytics_sample_rate()
+    if rate is not None:
+        span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, rate)
+
     span.set_tag(SPAN_MEASURED_KEY)
     attach_span(task, task_id, span)
 
@@ -87,10 +87,10 @@ def trace_before_publish(*args, **kwargs):
     service = config.celery['producer_service_name']
     span = pin.tracer.trace(c.PRODUCER_ROOT_SPAN, service=service, resource=task_name)
     # set analytics sample rate
-    span.set_tag(
-        ANALYTICS_SAMPLE_RATE_KEY,
-        config.celery.get_analytics_sample_rate()
-    )
+    rate = config.celery.get_analytics_sample_rate()
+    if rate is not None:
+        span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, rate)
+
     span.set_tag(SPAN_MEASURED_KEY)
     span.set_tag(c.TASK_TAG_KEY, c.TASK_APPLY_ASYNC)
     span.set_tag('celery.id', task_id)

--- a/ddtrace/contrib/celery/signals.py
+++ b/ddtrace/contrib/celery/signals.py
@@ -31,7 +31,7 @@ def trace_prerun(*args, **kwargs):
     service = config.celery['worker_service_name']
     span = pin.tracer.trace(c.WORKER_ROOT_SPAN, service=service, resource=task.name, span_type=SpanTypes.WORKER)
     # set analytics sample rate
-    s.set_tag(
+    span.set_tag(
         ANALYTICS_SAMPLE_RATE_KEY,
         config.celery.get_analytics_sample_rate()
     )
@@ -87,7 +87,7 @@ def trace_before_publish(*args, **kwargs):
     service = config.celery['producer_service_name']
     span = pin.tracer.trace(c.PRODUCER_ROOT_SPAN, service=service, resource=task_name)
     # set analytics sample rate
-    s.set_tag(
+    span.set_tag(
         ANALYTICS_SAMPLE_RATE_KEY,
         config.celery.get_analytics_sample_rate()
     )

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -220,6 +220,8 @@ For most libraries, APM events can be enabled with the environment variable ``DD
 +----------------------+----------------------------------------+
 | :ref:`cassandra`     | ``DD_CASSANDRA_ANALYTICS_ENABLED``     |
 +----------------------+----------------------------------------+
+| :ref:`celery`        | ``DD_CELERY_ANALYTICS_ENABLED``        |
++----------------------+----------------------------------------+
 | :ref:`elasticsearch` | ``DD_ELASTICSEARCH_ANALYTICS_ENABLED`` |
 +----------------------+----------------------------------------+
 | :ref:`falcon`        | ``DD_FALCON_ANALYTICS_ENABLED``        |

--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -474,7 +474,7 @@ class CeleryIntegrationTask(CeleryBaseTestCase):
         def fn_task():
             return 42
 
-        # Ensure producer analytics sample rate is disabled by default 
+        # Ensure producer analytics sample rate is disabled by default
         t = fn_task.delay()
         self.assertEqual("PENDING", t.status)
 


### PR DESCRIPTION
### Summary

This PR addresses [Open Issue 1217](https://github.com/DataDog/dd-trace-py/issues/1217), by adding app analytics support for celery worker and producer spans. Previously it was not possible to enable spans created by Celery instrumentation as analyzed spans for use in app analytics. The only workaround was relying on the [datadog-agent configuration setting](https://docs.datadoghq.com/tracing/guide/app_analytics_agent_configuration/?tab=agent630#pagetitle) which is brittle and decoupled from application settings, making it difficult to maintain. This PR exposes an environment variable `DD_CELERY_ANALYTICS_ENABLED` at the application level to enable analyzed spans for celery.

### Example Usage
```
DD_CELERY_ANALYTICS_ENABLED=true ddtrace-run python app.py
```

### Notes

- long time listener first time caller. Tried to follow the documentation and test style of similar integrations where app analytics is disabled by default but can be enabled optionally via env var. Please let me know if there's anything I missed or any way y'all would prefer this documented. Happy to make any changes

- Additionally, it's worth noting that this option enables both worker and producer spans for app analytics.  Seemed like a reasonable enough behaviour, but if you feel like there ought to be optionality to choose _only_ worker spans or _only_ producer spans to be enabled for app analytics, I'm happy to refactor this. I noticed that celery's configuration offers the ability to name the `worker_service_name` and `producer_service_name` separately.

- Lastly, it appears that `algoliasearch`, `dogpile_cache`, `jinja2`, and `mako` also cannot enable app analytics at the moment. If this approach looks good I would be happy to try to tackle those as well either in this pr or in a separate one.  Just figured I would grab celery first since there's an open issue on it.