### PR TITLE
fix(profiling): allow to build on Alpine Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ s3_bucket: &s3_bucket pypi.datadoghq.com
 resource_class: &resource_class medium
 busybox_image: &busybox_image busybox:latest
 cimg_base_image: &cimg_base_image cimg/base:2020.01
+python38-alpine_image: &python38-alpine_image python:3.8-alpine
 python38_image: &python38_image circleci/python:3.8
 python37_image: &python37_image circleci/python:3.7
 python36_image: &python36_image circleci/python:3.6
@@ -168,6 +169,10 @@ executors:
     docker:
       - image: *cimg_base_image
     resource_class: *resource_class
+  python38-alpine:
+    docker:
+      - image: *python38-alpine_image
+    resource_class: *resource_class
   python38:
     docker:
       - image: *python38_image
@@ -258,6 +263,11 @@ jobs:
       - run: |
           docker build .
 
+  test_build_alpine:
+    executor: python38-alpine
+    steps:
+      - run: apk add git gcc musl-dev libffi-dev openssl-dev
+      - test_build
   test_build_py38:
     executor: python38
     steps:
@@ -820,6 +830,7 @@ workflows:
       - flake8
 
       # Test building the package
+      - test_build_alpine: *requires_pre_test
       - test_build_py38: *requires_pre_test
       - test_build_py37: *requires_pre_test
       - test_build_py36: *requires_pre_test
@@ -938,6 +949,7 @@ workflows:
             - requestsgevent
             - sqlalchemy
             - sqlite3
+            - test_build_alpine
             - test_build_py38
             - test_build_py37
             - test_build_py36

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -32,8 +32,12 @@ IF UNAME_SYSNAME == "Linux":
 
     cdef extern from "<pthread.h>":
         # POSIX says this might be a struct, but CPython relies on it being an unsigned long.
-        ctypedef unsigned long pthread_t
-        int pthread_getcpuclockid(pthread_t thread, clockid_t *clock_id)
+        # We should be defining pthread_t here like this:
+        # ctypedef unsigned long pthread_t
+        # but e.g. musl libc defines pthread_t as a struct __pthread * which breaks the arithmetic Cython
+        # wants to do.
+        # We pay this with a warning at compilation time, but it works anyhow.
+        int pthread_getcpuclockid(unsigned long thread, clockid_t *clock_id)
 
     cdef p_pthread_getcpuclockid(tid):
         cdef clockid_t clock_id

--- a/docs/installation_quickstart.rst
+++ b/docs/installation_quickstart.rst
@@ -23,11 +23,6 @@ If you want to use the profiler, you'll need to specify the ``profiling`` flavor
 
   $ pip install ddtrace[profiling]
 
-
-.. note::
-
-   The profiler does not work on Alpine Linux.
-
 Quickstart
 ----------
 


### PR DESCRIPTION
This hides the pthread_t type usage and force the cast to unsigned long thread
no matter what.
This is fine with glibc and musl libc at least.

Fixes #1388
