### PR TITLE
feat(opentracer): implement active_span

### DIFF
--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -270,6 +270,25 @@ class Tracer(opentracing.Tracer):
 
         return otspan
 
+    @property
+    def active_span(self):
+        """Retrieves the active span from the opentracing scope manager
+
+        Falls back to using the datadog active span if one is not found. This
+        allows opentracing users to use datadog instrumentation.
+        """
+        scope = self._scope_manager.active
+        if scope:
+            return scope.span
+        else:
+            dd_span = self._dd_tracer.current_span()
+            if dd_span:
+                ot_span = Span(self, None, dd_span.name)
+                ot_span._associate_dd_span(dd_span)
+            else:
+                ot_span = None
+            return ot_span
+
     def inject(self, span_context, format, carrier):  # noqa: A002
         """Injects a span context into a carrier.
 

--- a/tests/opentracer/test_tracer.py
+++ b/tests/opentracer/test_tracer.py
@@ -416,6 +416,11 @@ class TestTracer(object):
         assert spans[2].parent_id is spans[0].span_id
         assert spans[3].parent_id is spans[2].span_id
 
+    def test_active_span(self, ot_tracer, writer):
+        with ot_tracer._dd_tracer.trace("dd") as span:
+            assert ot_tracer.active_span is not None
+            assert ot_tracer.active_span._dd_span is span
+
 
 @pytest.fixture
 def nop_span_ctx():


### PR DESCRIPTION
This PR implements `active_span` on the opentracing tracer. This now will allow opentracing library users to obtain the active span when using datadog instrumentation.

Should fix #1153.