### PR TITLE
perf: force msgpack < 1 for python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,12 @@ setup(
         # enum34 is an enum backport for earlier versions of python
         # funcsigs backport required for vendored debtcollector
         # encoding using msgpack
-        install_requires=["enum34; python_version<'3.4'", "funcsigs>=1.0.0; python_version=='2.7'", "msgpack>=0.5.0"],
+        install_requires=[
+            "enum34; python_version<'3.4'",
+            "funcsigs>=1.0.0; python_version=='2.7'",
+            "msgpack>=0.5.0; python_version>'3.4'",
+            "msgpack<1; python_version=='2.7'",
+        ],
         extras_require={
             # users can include opentracing by having:
             # install_requires=['ddtrace[opentracing]', ...]


### PR DESCRIPTION
msgpack 1.0 [dropped C-extension support for Python 2.7](https://pypi.org/project/msgpack/1.0.0/). We specify `msgpack>=0.5.0` as the dependency and so Python 2 users of the library will have msgpack falling back to the pure python implementation which is substantially slower.

This PR introduces a requirement for msgpack < 1 for Python 2.7.

Python 2.7 traced flask app with msgpack >= 1.0 performance compared to no tracing
![image](https://user-images.githubusercontent.com/6321485/80851956-bc8e2480-8bf2-11ea-8ad4-0c1bb467d523.png)

Python 2.7 instrumented flask app with msgpack < 1.0 compared to no tracing
![image](https://user-images.githubusercontent.com/6321485/80851958-c152d880-8bf2-11ea-932e-091c4ae35390.png)
