### PR TITLE
fix(settings): pass the `memodict` argument to subcall to deepcopy

### DIFF
--- a/ddtrace/settings/hooks.py
+++ b/ddtrace/settings/hooks.py
@@ -24,7 +24,7 @@ class Hooks(object):
 
     def __deepcopy__(self, memodict=None):
         hooks = Hooks()
-        hooks._hooks = deepcopy(self._hooks)
+        hooks._hooks = deepcopy(self._hooks, memodict)
         return hooks
 
     def register(self, hook, func=None):

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -47,9 +47,9 @@ class IntegrationConfig(AttrDict):
         self.setdefault('analytics_sample_rate', float(get_env(name, 'analytics_sample_rate', default=1.0)))
 
     def __deepcopy__(self, memodict=None):
-        new = IntegrationConfig(self.global_config, self.integration_name, deepcopy(dict(self)))
-        new.hooks = deepcopy(self.hooks)
-        new.http = deepcopy(self.http)
+        new = IntegrationConfig(self.global_config, self.integration_name, deepcopy(dict(self), memodict))
+        new.hooks = deepcopy(self.hooks, memodict)
+        new.http = deepcopy(self.http, memodict)
         return new
 
     def copy(self):


### PR DESCRIPTION
There's a potential bug here as the `memodict` is not passed to call from the
__deepcopy__ special method. That means the module might copy too much data,
especially data that can be shared.