### PR TITLE
internal: Change trace too large message to debug

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -226,7 +226,7 @@ class API(object):
                             payload.add_trace(trace)
                         except PayloadFull:
                             # If the trace does not fit in a payload on its own, that's bad. Drop it.
-                            log.warning('Trace %r is too big to fit in a payload, dropping it', trace)
+                            log.debug('Trace %r is too big to fit in a payload, dropping it', trace)
 
             # Check that the Payload is not empty:
             # it could be empty if the last trace was too big to fit.

--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -226,7 +226,7 @@ class API(object):
                             payload.add_trace(trace)
                         except PayloadFull:
                             # If the trace does not fit in a payload on its own, that's bad. Drop it.
-                            log.warning('Trace is too big to fit in a payload, dropping it', trace)
+                            log.warning('Trace is too big to fit in a payload, dropping it')
 
             # Check that the Payload is not empty:
             # it could be empty if the last trace was too big to fit.

--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -226,7 +226,7 @@ class API(object):
                             payload.add_trace(trace)
                         except PayloadFull:
                             # If the trace does not fit in a payload on its own, that's bad. Drop it.
-                            log.debug('Trace %r is too big to fit in a payload, dropping it', trace)
+                            log.warning('Trace is too big to fit in a payload, dropping it', trace)
 
             # Check that the Payload is not empty:
             # it could be empty if the last trace was too big to fit.


### PR DESCRIPTION
Essentially the issue is that we don't accept logs bigger than 256kb: "Any log exceeding 256KB is accepted and truncated by server" and when we log that a trace payload is too large, we print the whole trace, causing a log larger than the acceptable size: https://github.com/DataDog/dd-trace-py/blob/master/ddtrace/api.py#L229

This causes many error level logs to be generated

Which is causing the customer's monitor for error level logs on this application to alert.