### PR TITLE
fix: raise RuntimeError("threads can only be started once")

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -145,7 +145,6 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         if self._started is False:
             with self._started_lock:
                 if self._started == False:
-                    time.sleep(1)
                     self.start()
                     self._started = True
         if spans:

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -144,7 +144,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         # https://github.com/DataDog/dd-trace-py/issues/1192
         if self._started is False:
             with self._started_lock:
-                if self._started == False:
+                if self._started is False:
                     self.start()
                     self._started = True
         if spans:


### PR DESCRIPTION
fix: raise RuntimeError("threads can only be started once").

This occurs due to a race condition on `AgentWriter._started` when multiple threads start simultaneously and a writer has not yet been created.