### PR TITLE
Make hooks settings generic

### DIFF
--- a/ddtrace/_hooks.py
+++ b/ddtrace/_hooks.py
@@ -86,7 +86,7 @@ class Hooks(object):
             if func in funcs:
                 funcs.remove(func)
 
-    def _emit(self, hook, span, *args, **kwargs):
+    def emit(self, hook, span, *args, **kwargs):
         """
         Function used to call registered hook functions.
 

--- a/ddtrace/_hooks.py
+++ b/ddtrace/_hooks.py
@@ -46,7 +46,7 @@ class Hooks(object):
                 pass
 
         :param hook: The name of the hook to register the function for
-        :type hook: str
+        :type hook: object
         :param func: The function to register, or ``None`` if a decorator should be returned
         :type func: function, None
         :returns: Either a function decorator if ``func is None``, otherwise ``None``
@@ -68,9 +68,9 @@ class Hooks(object):
     #        pass
     on = register
 
-    def deregister(self, func):
+    def deregister(self, hook, func):
         """
-        Function to deregister a function from all hooks it was registered under
+        Function to deregister a function from a hook it was registered under
 
         Example::
 
@@ -78,15 +78,18 @@ class Hooks(object):
             def on_request(span, request, response):
                 pass
 
-            config.falcon.hooks.deregister(on_request)
+            config.falcon.hooks.deregister('request', on_request)
 
-
+        :param hook: The name of the hook to register the function for
+        :type hook: object
         :param func: Function hook to register
         :type func: function
         """
-        for funcs in self._hooks.values():
-            if func in funcs:
-                funcs.remove(func)
+        if hook in self._hooks:
+            try:
+                self._hooks[hook].remove(func)
+            except KeyError:
+                pass
 
     def emit(self, hook, *args, **kwargs):
         """

--- a/ddtrace/_hooks.py
+++ b/ddtrace/_hooks.py
@@ -4,9 +4,12 @@ from copy import deepcopy
 from .internal.logger import get_logger
 from .span import Span
 
+from .vendor import attr
+
 log = get_logger(__name__)
 
 
+@attr.s(slots=True)
 class Hooks(object):
     """
     Hooks configuration object is used for registering and calling hook functions
@@ -17,10 +20,7 @@ class Hooks(object):
         def on_request(span, request, response):
             pass
     """
-    __slots__ = ['_hooks']
-
-    def __init__(self):
-        self._hooks = collections.defaultdict(set)
+    _hooks = attr.ib(init=False, factory=lambda: collections.defaultdict(set))
 
     def __deepcopy__(self, memodict=None):
         hooks = Hooks()
@@ -114,9 +114,3 @@ class Hooks(object):
             except Exception:
                 # DEV: Use log.debug instead of log.error until we have a throttled logger
                 log.debug('Failed to run hook %s function %s', hook, func, exc_info=True)
-
-    def __repr__(self):
-        """Return string representation of this class instance"""
-        cls = self.__class__
-        hooks = ','.join(self._hooks.keys())
-        return '{}.{}({})'.format(cls.__module__, cls.__name__, hooks)

--- a/ddtrace/_hooks.py
+++ b/ddtrace/_hooks.py
@@ -19,6 +19,7 @@ class Hooks(object):
         def on_request(span, request, response):
             pass
     """
+
     _hooks = attr.ib(init=False, factory=lambda: collections.defaultdict(set))
 
     def __deepcopy__(self, memodict=None):
@@ -53,9 +54,11 @@ class Hooks(object):
         """
         # If they didn't provide a function, then return a decorator
         if not func:
+
             def wrapper(func):
                 self.register(hook, func)
                 return func
+
             return wrapper
         self._hooks[hook].add(func)
 
@@ -102,4 +105,4 @@ class Hooks(object):
                 func(*args, **kwargs)
             except Exception:
                 # DEV: Use log.debug instead of log.error until we have a throttled logger
-                log.debug('Failed to run hook %s function %s', hook, func, exc_info=True)
+                log.debug("Failed to run hook %s function %s", hook, func, exc_info=True)

--- a/ddtrace/_hooks.py
+++ b/ddtrace/_hooks.py
@@ -2,7 +2,6 @@ import collections
 from copy import deepcopy
 
 from .internal.logger import get_logger
-from .span import Span
 
 from .vendor import attr
 
@@ -86,31 +85,21 @@ class Hooks(object):
             if func in funcs:
                 funcs.remove(func)
 
-    def emit(self, hook, span, *args, **kwargs):
+    def emit(self, hook, *args, **kwargs):
         """
         Function used to call registered hook functions.
 
         :param hook: The hook to call functions for
         :type hook: str
-        :param span: The span to call the hook with
-        :type span: :class:`ddtrace.span.Span`
         :param args: Positional arguments to pass to the hook functions
         :type args: list
         :param kwargs: Keyword arguments to pass to the hook functions
         :type kwargs: dict
         """
-        # Return early if no hooks are registered
-        if hook not in self._hooks:
-            return
-
-        # Return early if we don't have a Span
-        if not isinstance(span, Span):
-            return
-
         # Call registered hooks
-        for func in self._hooks[hook]:
+        for func in self._hooks.get(hook, ()):
             try:
-                func(span, *args, **kwargs)
+                func(*args, **kwargs)
             except Exception:
                 # DEV: Use log.debug instead of log.error until we have a throttled logger
                 log.debug('Failed to run hook %s function %s', hook, func, exc_info=True)

--- a/ddtrace/_hooks.py
+++ b/ddtrace/_hooks.py
@@ -1,8 +1,8 @@
 import collections
 from copy import deepcopy
 
-from ..internal.logger import get_logger
-from ..span import Span
+from .internal.logger import get_logger
+from .span import Span
 
 log = get_logger(__name__)
 

--- a/ddtrace/contrib/falcon/middleware.py
+++ b/ddtrace/contrib/falcon/middleware.py
@@ -92,7 +92,7 @@ class TraceMiddleware(object):
 
         # Emit span hook for this response
         # DEV: Emit before closing so they can overwrite `span.resource` if they want
-        config.falcon.hooks._emit('request', span, req, resp)
+        config.falcon.hooks.emit('request', span, req, resp)
 
         # Close the span
         span.finish()

--- a/ddtrace/settings/__init__.py
+++ b/ddtrace/settings/__init__.py
@@ -1,7 +1,7 @@
 from .config import Config
 from .exceptions import ConfigException
 from .http import HttpConfig
-from .hooks import Hooks
+from .._hooks import Hooks
 from .integration import IntegrationConfig
 
 # Default global config

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from ..utils.attrdict import AttrDict
 from ..utils.formats import asbool, get_env
 from .http import HttpConfig
-from .hooks import Hooks
+from .._hooks import Hooks
 
 
 class IntegrationConfig(AttrDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude = '''
   | build/
   | dist/
   | ddtrace/(
-    (?!(compat|span|__init__)\.py$)[^/]+\.py$
+    (?!(compat|span|__init__|_hooks)\.py$)[^/]+\.py$
     | commands/
     | contrib/
     (

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -98,7 +98,7 @@ class GlobalConfigTestCase(TestCase):
 
     def test_settings_hook(self):
         """
-        When calling `Hooks._emit()`
+        When calling `Hooks.emit()`
             When there is a hook registered
                 we call the hook as expected
         """
@@ -112,14 +112,14 @@ class GlobalConfigTestCase(TestCase):
         assert 'web.request' not in span.meta
 
         # Emit the span
-        self.config.web.hooks._emit('request', span)
+        self.config.web.hooks.emit('request', span)
 
         # Assert we updated the span as expected
         assert span.get_tag('web.request') == '/'
 
     def test_settings_hook_args(self):
         """
-        When calling `Hooks._emit()` with arguments
+        When calling `Hooks.emit()` with arguments
             When there is a hook registered
                 we call the hook as expected
         """
@@ -135,7 +135,7 @@ class GlobalConfigTestCase(TestCase):
 
         # Emit the span
         # DEV: The actual values don't matter, we just want to test args + kwargs usage
-        self.config.web.hooks._emit('request', span, 'request', response='response')
+        self.config.web.hooks.emit('request', span, 'request', response='response')
 
         # Assert we updated the span as expected
         assert span.get_tag('web.request') == 'request'
@@ -143,7 +143,7 @@ class GlobalConfigTestCase(TestCase):
 
     def test_settings_hook_args_failure(self):
         """
-        When calling `Hooks._emit()` with arguments
+        When calling `Hooks.emit()` with arguments
             When there is a hook registered that is missing parameters
                 we do not raise an exception
         """
@@ -159,14 +159,14 @@ class GlobalConfigTestCase(TestCase):
 
         # Emit the span
         # DEV: This also asserts that no exception was raised
-        self.config.web.hooks._emit('request', span, 'request', response='response')
+        self.config.web.hooks.emit('request', span, 'request', response='response')
 
         # Assert we did not update the span
         assert 'web.request' not in span.meta
 
     def test_settings_multiple_hooks(self):
         """
-        When calling `Hooks._emit()`
+        When calling `Hooks.emit()`
             When there are multiple hooks registered
                 we do not raise an exception
         """
@@ -190,7 +190,7 @@ class GlobalConfigTestCase(TestCase):
         assert 'web.method' not in span.meta
 
         # Emit the span
-        self.config.web.hooks._emit('request', span)
+        self.config.web.hooks.emit('request', span)
 
         # Assert we updated the span as expected
         assert span.get_tag('web.request') == '/'
@@ -199,7 +199,7 @@ class GlobalConfigTestCase(TestCase):
 
     def test_settings_hook_failure(self):
         """
-        When calling `Hooks._emit()`
+        When calling `Hooks.emit()`
             When the hook raises an exception
                 we do not raise an exception
         """
@@ -212,12 +212,12 @@ class GlobalConfigTestCase(TestCase):
 
         # Emit the span
         # DEV: This is the test, to ensure no exceptions are raised
-        self.config.web.hooks._emit('request', span)
+        self.config.web.hooks.emit('request', span)
         on_web_request.assert_called()
 
     def test_settings_no_hook(self):
         """
-        When calling `Hooks._emit()`
+        When calling `Hooks.emit()`
             When no hook is registered
                 we do not raise an exception
         """
@@ -226,11 +226,11 @@ class GlobalConfigTestCase(TestCase):
 
         # Emit the span
         # DEV: This is the test, to ensure no exceptions are raised
-        self.config.web.hooks._emit('request', span)
+        self.config.web.hooks.emit('request', span)
 
     def test_settings_no_span(self):
         """
-        When calling `Hooks._emit()`
+        When calling `Hooks.emit()`
             When no span is provided
                 we do not raise an exception
         """
@@ -241,7 +241,7 @@ class GlobalConfigTestCase(TestCase):
 
         # Emit the span
         # DEV: This is the test, to ensure no exceptions are raised
-        self.config.web.hooks._emit('request', None)
+        self.config.web.hooks.emit('request', None)
 
     def test_dd_version(self):
         c = Config()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,29 @@
+from ddtrace import _hooks
+
+
+def test_deregister():
+    hooks = _hooks.Hooks()
+
+    x = {}
+
+    @hooks.register("key")
+    def do_not_call():
+        x["x"] = True
+
+    hooks.emit("key")
+    assert x["x"]
+    del x["x"]
+
+    hooks.deregister("key", do_not_call)
+
+    hooks.emit("key")
+
+    assert len(x) == 0
+
+
+def test_deregister_unknown():
+    hooks = _hooks.Hooks()
+
+    hooks.deregister("key", test_deregister_unknown)
+
+    hooks.emit("key")


### PR DESCRIPTION
## refactor: move hooks module out of settings

This move the hooks class away of settings so it can be used by non-settings
code without import statement looking weird.

It also hides the module as being private.

## refactor(hooks): make `emit` a public method


## refactor(hooks): leverage attr to simplify code


## refactor(hooks): remove span argument

The only user of this API seems to always send a span and nothing breaks while
removing this check.

## chore: add _hooks to black


## feat(hooks): make deregister take a `hook` argument

That makes sure we are able to deregister a hook for a particular event.
