### PR TITLE
bottle: update tests to latest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ envlist =
 # boto needs moto<1 and moto<1 does not support Python >= 3.7
     boto_contrib-{py27,py35,py36}-boto
     botocore_contrib-{py27,py35,py36,py37,py38}-botocore
-    bottle_contrib{,_autopatch}-{py27,py35,py36,py37,py38}-bottle{11,12}-webtest
+    bottle_contrib{,_autopatch}-py{27,35,36,37,38}-bottle{11,12,}-webtest
     cassandra_contrib-{py27,py35,py36,py37,py38}-cassandra{35,36,37,38,315}
 # Non-4.x celery should be able to use the older redis lib, since it locks to an older kombu
     celery_contrib-{py27,py35,py36}-celery{31}-redis{210}
@@ -242,6 +242,7 @@ deps =
     boto: moto<1.0
     botocore: botocore
     botocore: moto>=1.0,<2
+    bottle: bottle
     bottle11: bottle>=0.11,<0.12
     bottle12: bottle>=0.12,<0.13
     cassandra35: cassandra-driver>=3.5,<3.6


### PR DESCRIPTION
should be the last one until we fix the libraries for which we don't support the latest versions 😄 