### PR TITLE
fix(profiling/periodic): PERIODIC_THREAD_IDS race condition

### DIFF
--- a/ddtrace/profiling/_periodic.py
+++ b/ddtrace/profiling/_periodic.py
@@ -36,7 +36,6 @@ class PeriodicThread(threading.Thread):
     def start(self):
         """Start the thread."""
         super(PeriodicThread, self).start()
-        PERIODIC_THREAD_IDS.add(self.ident)
 
     def stop(self):
         """Stop the thread."""
@@ -44,6 +43,8 @@ class PeriodicThread(threading.Thread):
 
     def run(self):
         """Run the target function periodically."""
+        PERIODIC_THREAD_IDS.add(self.ident)
+
         try:
             while not self.quit.wait(self.interval):
                 self._target()
@@ -102,7 +103,6 @@ class _GeventPeriodicThread(PeriodicThread):
             del threading._limbo[self]
         if self._get_native_id:
             self._native_id = self._get_native_id()
-        PERIODIC_THREAD_IDS.add(self._tident)
 
     def join(self, timeout=None):
         # FIXME: handle the timeout argument
@@ -115,6 +115,8 @@ class _GeventPeriodicThread(PeriodicThread):
 
     def run(self):
         """Run the target function periodically."""
+        PERIODIC_THREAD_IDS.add(self._tident)
+
         with threading._active_limbo_lock:
             threading._active[self._tident] = self
             del threading._limbo[self]
@@ -137,7 +139,7 @@ class _GeventPeriodicThread(PeriodicThread):
             try:
                 self.has_quit = True
                 del threading._active[self._tident]
-                PERIODIC_THREAD_IDS.remove(self.ident)
+                PERIODIC_THREAD_IDS.remove(self._tident)
             except Exception:
                 # Exceptions might happen during interpreter shutdown.
                 # We're mimicking what `threading.Thread` does in daemon mode, we ignore them.

--- a/ddtrace/profiling/_periodic.py
+++ b/ddtrace/profiling/_periodic.py
@@ -33,10 +33,6 @@ class PeriodicThread(threading.Thread):
         self.quit = threading.Event()
         self.daemon = True
 
-    def start(self):
-        """Start the thread."""
-        super(PeriodicThread, self).start()
-
     def stop(self):
         """Stop the thread."""
         self.quit.set()

--- a/tests/profiling/test_periodic.py
+++ b/tests/profiling/test_periodic.py
@@ -7,23 +7,36 @@ from ddtrace.profiling import _periodic
 from ddtrace.profiling import _service
 
 
+if os.getenv("DD_PROFILE_TEST_GEVENT", False):
+    import gevent
+
+    # Event = gevent.monkey.get_original("threading", "Event")
+    Event = gevent.event.Event
+else:
+    # import gevent
+    Event = threading.Event
+
+
 def test_periodic():
     x = {"OK": False}
 
-    thread_started = threading.Event()
-    thread_continue = threading.Event()
+    # For some reason gevent requires an explicit timeout to be provided for Event.wait()
+    # events. Otherwise we get "gevent.exceptions.LoopExit: This operation would block forever"
+
+    thread_started = Event()
+    thread_continue = Event()
 
     def _run_periodic():
         thread_started.set()
         x["OK"] = True
-        thread_continue.wait()
+        thread_continue.wait(timeout=1)
 
     def _on_shutdown():
         x["DOWN"] = True
 
     t = _periodic.PeriodicRealThread(0.001, _run_periodic, on_shutdown=_on_shutdown)
     t.start()
-    thread_started.wait()
+    thread_started.wait(timeout=1)
     assert t.ident in _periodic.PERIODIC_THREAD_IDS
     thread_continue.set()
     t.stop()
@@ -43,7 +56,7 @@ def test_periodic_error():
 
     def _run_periodic():
         thread_started.set()
-        thread_continue.wait()
+        thread_continue.wait(timeout=1)
         raise ValueError
 
     def _on_shutdown():
@@ -51,7 +64,7 @@ def test_periodic_error():
 
     t = _periodic.PeriodicRealThread(0.001, _run_periodic, on_shutdown=_on_shutdown)
     t.start()
-    thread_started.wait()
+    thread_started.wait(timeout=1)
     assert t.ident in _periodic.PERIODIC_THREAD_IDS
     thread_continue.set()
     t.stop()


### PR DESCRIPTION
A seemingly [flaky test](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/1092/workflows/116cd465-3bd5-42fa-b277-632322e333c8/jobs/251605/steps) brought to my attention a race condition in `PeriodicThread` (described below).


~It also seems that `PERIODIC_THREAD_IDS` should be protected by a mutex since there could be multiple periodic threads (at least 1 in the profiler and 1 in the tracer). So I added a lock around the set. Although it'd be extremely rare for a collision to occur given our usage of `PeriodicThread`.~