### PR TITLE
fix(hooks): use log.error to log hook exceptions

### DIFF
--- a/ddtrace/_hooks.py
+++ b/ddtrace/_hooks.py
@@ -107,5 +107,4 @@ class Hooks(object):
             try:
                 func(*args, **kwargs)
             except Exception:
-                # DEV: Use log.debug instead of log.error until we have a throttled logger
-                log.debug("Failed to run hook %s function %s", hook, func, exc_info=True)
+                log.error("Failed to run hook %s function %s", hook, func, exc_info=True)


### PR DESCRIPTION
Using debug makes it impossible for a user of this hook to get feedback on a
possible failure.