### PR TITLE
fix(profiling): fix negative CPU time

### DIFF
--- a/ddtrace/profiling/_periodic.py
+++ b/ddtrace/profiling/_periodic.py
@@ -75,6 +75,11 @@ class _GeventPeriodicThread(PeriodicThread):
         import gevent.monkey
 
         self._sleep = gevent.monkey.get_original("time", "sleep")
+        try:
+            # Python ≥ 3.8
+            self._get_native_id = gevent.monkey.get_original("threading", "get_native_id")
+        except AttributeError:
+            self._get_native_id = None
         self._tident = None
 
     @property
@@ -92,6 +97,8 @@ class _GeventPeriodicThread(PeriodicThread):
             self._tident = start_new_thread(self.run, tuple())
         except Exception:
             del threading._limbo[self]
+        if self._get_native_id:
+            self._native_id = self._get_native_id()
         PERIODIC_THREAD_IDS.add(self._tident)
 
     def join(self, timeout=None):

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -72,13 +72,16 @@ IF UNAME_SYSNAME == "Linux":
             return int(tp.tv_nsec + tp.tv_sec * 10e8)
         PyErr_SetFromErrno(OSError)
 
-    class ThreadTime(object):
+    class _ThreadTime(object):
         def __init__(self):
+            # This uses a tuple of (thread unique id, pthread_id) as the key to identify the thread: you'd think using
+            # the pthread_t id would be enough, but the glibc reuses the id.
             self._last_thread_time = {}
 
         def __call__(self, thread_ids):
             threads_cpu_time = {}
-            for tid in thread_ids:
+            for pthread_id, thread_native_id in thread_ids.items():
+                key = (pthread_id, thread_native_id)
                 # TODO: Use QueryThreadCycleTime on Windows?
                 # ⚠ WARNING ⚠
                 # `pthread_getcpuclockid` can make Python segfault if the thread is does not exist anymore.
@@ -86,25 +89,29 @@ IF UNAME_SYSNAME == "Linux":
                 # This is why this whole file is compiled down to C: we make sure we never release the GIL between
                 # calling sys._current_frames() and pthread_getcpuclockid, making sure no thread disappeared.
                 try:
-                    clock_id = p_pthread_getcpuclockid(tid)
+                    clock_id = p_pthread_getcpuclockid(pthread_id)
                 except OSError:
-                    cpu_time = self._last_thread_time.get(tid, 0)
+                    cpu_time = self._last_thread_time.get(key, 0)
                 else:
                     try:
                         cpu_time = p_clock_gettime_ns(clock_id)
                     except OSError:
-                        cpu_time = self._last_thread_time.get(tid, 0)
-                threads_cpu_time[tid] = cpu_time - self._last_thread_time.get(tid, cpu_time)
-                self._last_thread_time[tid] = cpu_time
+                        cpu_time = self._last_thread_time.get(key, 0)
+                # Do a max(0, …) here just in case the result is < 0:
+                # This should never happen, but it can happen if the one chance in a billion happens:
+                # A new thread has been created and has the same native id and the same pthread_id.
+                threads_cpu_time[pthread_id] = max(0, cpu_time - self._last_thread_time.get(key, cpu_time))
+                self._last_thread_time[key] = cpu_time
 
             # Clear cache
-            for thread_id in list(self._last_thread_time.keys()):
-                if thread_id not in thread_ids:
-                    del self._last_thread_time[thread_id]
+            keys = list(thread_ids.items())
+            for key in list(self._last_thread_time.keys()):
+                if key not in keys:
+                    del self._last_thread_time[key]
 
             return threads_cpu_time
 ELSE:
-    class ThreadTime(object):
+    class _ThreadTime(object):
         def __init__(self):
             self._last_process_time = compat.process_time_ns()
 
@@ -130,6 +137,7 @@ ELSE:
 class StackBasedEvent(event.SampleEvent):
     thread_id = attr.ib(default=None)
     thread_name = attr.ib(default=None)
+    thread_native_id = attr.ib(default=None)
     frames = attr.ib(default=None)
     nframes = attr.ib(default=None)
     trace_ids = attr.ib(default=None)
@@ -267,7 +275,31 @@ cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_tim
     if ignore_profiler:
         running_thread_ids -= _periodic.PERIODIC_THREAD_IDS
 
-    cpu_time = thread_time(running_thread_ids)
+    # Build a dict of pthread_t id -> native thread id
+    # We need to use both as pthread_id can be reused for new thread, messing with the CPU time clock
+    thread_native_ids = {}
+
+    for thread_id in running_thread_ids:
+        try:
+            thread_obj = threading._active[thread_id]
+        except KeyError:
+            # This should not happen, unless somebody started a thread without
+            # using the `threading` module; in that case, ignore the thread altogether.
+            # In that case, well… just use the thread_id as native_id 🤞
+            native_id = thread_id
+        else:
+            # We prioritize using native ids since we expect them to be surely unique for a program. This is less true
+            # for hashes since they are relative to the memory address which can easily be the same across different
+            # objects.
+            try:
+                native_id = thread_obj.native_id
+            except AttributeError:
+                # Python < 3.8
+                native_id = hash(thread_obj)
+
+        thread_native_ids[thread_id] = native_id
+
+    cpu_time = thread_time(thread_native_ids)
 
     stack_events = []
     for tid, frame in running_threads:
@@ -278,6 +310,7 @@ cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_tim
         stack_events.append(
             StackSampleEvent(
                 thread_id=tid,
+                thread_native_id=thread_native_ids.get(tid),
                 thread_name=get_thread_name(tid),
                 trace_ids=set(span.trace_id for span in spans),
                 nframes=nframes, frames=frames,
@@ -296,6 +329,7 @@ cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_tim
             StackExceptionSampleEvent(
                 thread_id=tid,
                 thread_name=get_thread_name(tid),
+                thread_native_id=thread_native_ids.get(tid),
                 nframes=nframes,
                 frames=frames,
                 sampling_period=int(interval * 1e9),
@@ -384,7 +418,7 @@ class StackCollector(collector.PeriodicCollector):
             raise ValueError("Max time usage percent must be greater than 0 and smaller or equal to 100")
 
     def start(self):
-        self._thread_time = ThreadTime()
+        self._thread_time = _ThreadTime()
         self._last_wall_time = compat.monotonic_ns()
         if self.tracer is not None:
             self.tracer.on_start_span(self._thread_span_links.link_span)

--- a/tests/profiling/exporter/test-pprof-exporter.txt
+++ b/tests/profiling/exporter/test-pprof-exporter.txt
@@ -34,27 +34,6 @@ sample {
   location_id: 1
   location_id: 2
   location_id: 3
-  value: 2
-  value: 842340
-  value: 19568
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  label {
-    key: 18
-    str: 19
-  }
-  label {
-    key: 20
-    str: 21
-  }
-}
-sample {
-  location_id: 1
-  location_id: 2
-  location_id: 3
   value: 0
   value: 0
   value: 0
@@ -130,10 +109,9 @@ sample {
   location_id: 1
   location_id: 2
   location_id: 3
-  location_id: 4
-  value: 1
-  value: 29121
-  value: 1324
+  value: 2
+  value: 842340
+  value: 19568
   value: 0
   value: 0
   value: 0
@@ -142,6 +120,10 @@ sample {
   label {
     key: 18
     str: 19
+  }
+  label {
+    key: 27
+    str: 28
   }
   label {
     key: 20
@@ -203,10 +185,11 @@ sample {
 sample {
   location_id: 1
   location_id: 2
-  location_id: 5
+  location_id: 3
+  location_id: 4
   value: 1
-  value: 1312
-  value: 13244
+  value: 29121
+  value: 1324
   value: 0
   value: 0
   value: 0
@@ -215,6 +198,10 @@ sample {
   label {
     key: 18
     str: 19
+  }
+  label {
+    key: 27
+    str: 28
   }
   label {
     key: 20
@@ -274,10 +261,10 @@ sample {
 sample {
   location_id: 1
   location_id: 2
-  location_id: 6
+  location_id: 5
   value: 1
-  value: 9042
-  value: 132444
+  value: 1312
+  value: 13244
   value: 0
   value: 0
   value: 0
@@ -286,6 +273,10 @@ sample {
   label {
     key: 18
     str: 19
+  }
+  label {
+    key: 27
+    str: 28
   }
   label {
     key: 20
@@ -346,10 +337,9 @@ sample {
   location_id: 1
   location_id: 2
   location_id: 6
-  location_id: 7
   value: 1
-  value: 94021
-  value: 213244
+  value: 9042
+  value: 132444
   value: 0
   value: 0
   value: 0
@@ -358,6 +348,10 @@ sample {
   label {
     key: 18
     str: 19
+  }
+  label {
+    key: 27
+    str: 28
   }
   label {
     key: 20
@@ -418,11 +412,12 @@ sample {
 }
 sample {
   location_id: 1
-  location_id: 8
-  location_id: 3
+  location_id: 2
+  location_id: 6
+  location_id: 7
   value: 1
-  value: 501809
-  value: 13244
+  value: 94021
+  value: 213244
   value: 0
   value: 0
   value: 0
@@ -431,6 +426,10 @@ sample {
   label {
     key: 18
     str: 19
+  }
+  label {
+    key: 27
+    str: 28
   }
   label {
     key: 20
@@ -487,9 +486,34 @@ sample {
     str: 26
   }
 }
+sample {
+  location_id: 1
+  location_id: 8
+  location_id: 3
+  value: 1
+  value: 501809
+  value: 13244
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  label {
+    key: 18
+    str: 19
+  }
+  label {
+    key: 27
+    str: 28
+  }
+  label {
+    key: 20
+    str: 21
+  }
+}
 mapping {
   id: 1
-  filename: 28
+  filename: 30
 }
 location {
   id: 1
@@ -600,12 +624,14 @@ string_table: "exceptions.IOError"
 string_table: "exceptions.ValueError"
 string_table: "lock name"
 string_table: "foobar.py:12"
+string_table: "thread native id"
+string_table: "123987"
 string_table: "time"
 string_table: "bonjour"
 time_nanos: 1
 duration_nanos: 6
 period_type {
-  type: 27
+  type: 29
   unit: 11
 }
 period: 1000000

--- a/tests/profiling/exporter/test-pprof-exporter_tracemalloc+stack-exceptions.txt
+++ b/tests/profiling/exporter/test-pprof-exporter_tracemalloc+stack-exceptions.txt
@@ -46,30 +46,6 @@ sample {
   location_id: 1
   location_id: 2
   location_id: 3
-  value: 2
-  value: 842340
-  value: 19568
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  label {
-    key: 22
-    str: 23
-  }
-  label {
-    key: 24
-    str: 25
-  }
-}
-sample {
-  location_id: 1
-  location_id: 2
-  location_id: 3
   value: 0
   value: 0
   value: 0
@@ -78,7 +54,7 @@ sample {
   value: 0
   value: 0
   value: 0
-  value: 1
+  value: 0
   value: 0
   value: 0
   label {
@@ -101,12 +77,12 @@ sample {
   value: 0
   value: 0
   value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
   value: 1
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
   value: 0
   value: 0
   label {
@@ -120,34 +96,6 @@ sample {
   label {
     key: 26
     str: 28
-  }
-}
-sample {
-  location_id: 1
-  location_id: 2
-  location_id: 3
-  value: 0
-  value: 0
-  value: 0
-  value: 1
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  label {
-    key: 22
-    str: 23
-  }
-  label {
-    key: 24
-    str: 25
-  }
-  label {
-    key: 26
-    str: 29
   }
 }
 sample {
@@ -174,18 +122,17 @@ sample {
     str: 25
   }
   label {
-    key: 30
-    str: 31
+    key: 29
+    str: 30
   }
 }
 sample {
   location_id: 1
   location_id: 2
   location_id: 3
-  location_id: 4
-  value: 1
-  value: 29121
-  value: 1324
+  value: 2
+  value: 842340
+  value: 19568
   value: 0
   value: 0
   value: 0
@@ -199,8 +146,76 @@ sample {
     str: 23
   }
   label {
+    key: 31
+    str: 32
+  }
+  label {
     key: 24
     str: 25
+  }
+}
+sample {
+  location_id: 1
+  location_id: 2
+  location_id: 3
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 1
+  value: 0
+  value: 0
+  label {
+    key: 22
+    str: 23
+  }
+  label {
+    key: 31
+    str: 32
+  }
+  label {
+    key: 24
+    str: 25
+  }
+  label {
+    key: 26
+    str: 27
+  }
+}
+sample {
+  location_id: 1
+  location_id: 2
+  location_id: 3
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 1
+  value: 0
+  value: 0
+  label {
+    key: 22
+    str: 23
+  }
+  label {
+    key: 31
+    str: 32
+  }
+  label {
+    key: 24
+    str: 25
+  }
+  label {
+    key: 26
+    str: 33
   }
 }
 sample {
@@ -230,35 +245,6 @@ sample {
   label {
     key: 26
     str: 27
-  }
-}
-sample {
-  location_id: 1
-  location_id: 2
-  location_id: 3
-  location_id: 4
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 1
-  value: 0
-  value: 0
-  label {
-    key: 22
-    str: 23
-  }
-  label {
-    key: 24
-    str: 25
-  }
-  label {
-    key: 26
-    str: 28
   }
 }
 sample {
@@ -286,17 +272,18 @@ sample {
     str: 25
   }
   label {
-    key: 30
-    str: 31
+    key: 29
+    str: 30
   }
 }
 sample {
   location_id: 1
   location_id: 2
-  location_id: 5
+  location_id: 3
+  location_id: 4
   value: 1
-  value: 1312
-  value: 13244
+  value: 29121
+  value: 1324
   value: 0
   value: 0
   value: 0
@@ -310,6 +297,10 @@ sample {
     str: 23
   }
   label {
+    key: 31
+    str: 32
+  }
+  label {
     key: 24
     str: 25
   }
@@ -317,7 +308,8 @@ sample {
 sample {
   location_id: 1
   location_id: 2
-  location_id: 5
+  location_id: 3
+  location_id: 4
   value: 0
   value: 0
   value: 0
@@ -327,6 +319,38 @@ sample {
   value: 0
   value: 0
   value: 1
+  value: 0
+  value: 0
+  label {
+    key: 22
+    str: 23
+  }
+  label {
+    key: 31
+    str: 32
+  }
+  label {
+    key: 24
+    str: 25
+  }
+  label {
+    key: 26
+    str: 33
+  }
+}
+sample {
+  location_id: 1
+  location_id: 2
+  location_id: 5
+  value: 0
+  value: 0
+  value: 0
+  value: 1
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
   value: 0
   value: 0
   label {
@@ -340,34 +364,6 @@ sample {
   label {
     key: 26
     str: 28
-  }
-}
-sample {
-  location_id: 1
-  location_id: 2
-  location_id: 5
-  value: 0
-  value: 0
-  value: 0
-  value: 1
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  label {
-    key: 22
-    str: 23
-  }
-  label {
-    key: 24
-    str: 25
-  }
-  label {
-    key: 26
-    str: 29
   }
 }
 sample {
@@ -394,17 +390,17 @@ sample {
     str: 25
   }
   label {
-    key: 30
-    str: 31
+    key: 29
+    str: 30
   }
 }
 sample {
   location_id: 1
   location_id: 2
-  location_id: 6
+  location_id: 5
   value: 1
-  value: 9042
-  value: 132444
+  value: 1312
+  value: 13244
   value: 0
   value: 0
   value: 0
@@ -418,8 +414,44 @@ sample {
     str: 23
   }
   label {
+    key: 31
+    str: 32
+  }
+  label {
     key: 24
     str: 25
+  }
+}
+sample {
+  location_id: 1
+  location_id: 2
+  location_id: 5
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 1
+  value: 0
+  value: 0
+  label {
+    key: 22
+    str: 23
+  }
+  label {
+    key: 31
+    str: 32
+  }
+  label {
+    key: 24
+    str: 25
+  }
+  label {
+    key: 26
+    str: 33
   }
 }
 sample {
@@ -448,34 +480,6 @@ sample {
   label {
     key: 26
     str: 27
-  }
-}
-sample {
-  location_id: 1
-  location_id: 2
-  location_id: 6
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 1
-  value: 0
-  value: 0
-  label {
-    key: 22
-    str: 23
-  }
-  label {
-    key: 24
-    str: 25
-  }
-  label {
-    key: 26
-    str: 29
   }
 }
 sample {
@@ -502,18 +506,17 @@ sample {
     str: 25
   }
   label {
-    key: 30
-    str: 31
+    key: 29
+    str: 30
   }
 }
 sample {
   location_id: 1
   location_id: 2
   location_id: 6
-  location_id: 7
   value: 1
-  value: 94021
-  value: 213244
+  value: 9042
+  value: 132444
   value: 0
   value: 0
   value: 0
@@ -527,8 +530,44 @@ sample {
     str: 23
   }
   label {
+    key: 31
+    str: 32
+  }
+  label {
     key: 24
     str: 25
+  }
+}
+sample {
+  location_id: 1
+  location_id: 2
+  location_id: 6
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 1
+  value: 0
+  value: 0
+  label {
+    key: 22
+    str: 23
+  }
+  label {
+    key: 31
+    str: 32
+  }
+  label {
+    key: 24
+    str: 25
+  }
+  label {
+    key: 26
+    str: 28
   }
 }
 sample {
@@ -558,35 +597,6 @@ sample {
   label {
     key: 26
     str: 27
-  }
-}
-sample {
-  location_id: 1
-  location_id: 2
-  location_id: 6
-  location_id: 7
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 1
-  value: 0
-  value: 0
-  label {
-    key: 22
-    str: 23
-  }
-  label {
-    key: 24
-    str: 25
-  }
-  label {
-    key: 26
-    str: 28
   }
 }
 sample {
@@ -614,17 +624,18 @@ sample {
     str: 25
   }
   label {
-    key: 30
-    str: 31
+    key: 29
+    str: 30
   }
 }
 sample {
   location_id: 1
-  location_id: 8
-  location_id: 3
+  location_id: 2
+  location_id: 6
+  location_id: 7
   value: 1
-  value: 501809
-  value: 13244
+  value: 94021
+  value: 213244
   value: 0
   value: 0
   value: 0
@@ -638,8 +649,45 @@ sample {
     str: 23
   }
   label {
+    key: 31
+    str: 32
+  }
+  label {
     key: 24
     str: 25
+  }
+}
+sample {
+  location_id: 1
+  location_id: 2
+  location_id: 6
+  location_id: 7
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 1
+  value: 0
+  value: 0
+  label {
+    key: 22
+    str: 23
+  }
+  label {
+    key: 31
+    str: 32
+  }
+  label {
+    key: 24
+    str: 25
+  }
+  label {
+    key: 26
+    str: 33
   }
 }
 sample {
@@ -654,7 +702,7 @@ sample {
   value: 0
   value: 0
   value: 0
-  value: 1
+  value: 0
   value: 0
   value: 0
   label {
@@ -694,13 +742,73 @@ sample {
     str: 25
   }
   label {
-    key: 30
-    str: 31
+    key: 29
+    str: 30
+  }
+}
+sample {
+  location_id: 1
+  location_id: 8
+  location_id: 3
+  value: 1
+  value: 501809
+  value: 13244
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  label {
+    key: 22
+    str: 23
+  }
+  label {
+    key: 31
+    str: 32
+  }
+  label {
+    key: 24
+    str: 25
+  }
+}
+sample {
+  location_id: 1
+  location_id: 8
+  location_id: 3
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 1
+  value: 0
+  value: 0
+  label {
+    key: 22
+    str: 23
+  }
+  label {
+    key: 31
+    str: 32
+  }
+  label {
+    key: 24
+    str: 25
+  }
+  label {
+    key: 26
+    str: 27
   }
 }
 mapping {
   id: 1
-  filename: 33
+  filename: 35
 }
 location {
   id: 1
@@ -812,16 +920,18 @@ string_table: "thread name"
 string_table: "MainThread"
 string_table: "exception type"
 string_table: "builtins.OSError"
-string_table: "builtins.TypeError"
 string_table: "builtins.ValueError"
 string_table: "lock name"
 string_table: "foobar.py:12"
+string_table: "thread native id"
+string_table: "123987"
+string_table: "builtins.TypeError"
 string_table: "time"
 string_table: "bonjour"
 time_nanos: 1
 duration_nanos: 6
 period_type {
-  type: 32
+  type: 34
   unit: 11
 }
 period: 1000000

--- a/tests/profiling/exporter/test-pprof-exporter_tracemalloc.txt
+++ b/tests/profiling/exporter/test-pprof-exporter_tracemalloc.txt
@@ -42,29 +42,6 @@ sample {
   location_id: 1
   location_id: 2
   location_id: 3
-  value: 2
-  value: 842340
-  value: 19568
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  value: 0
-  label {
-    key: 21
-    str: 22
-  }
-  label {
-    key: 23
-    str: 24
-  }
-}
-sample {
-  location_id: 1
-  location_id: 2
-  location_id: 3
   value: 0
   value: 0
   value: 0
@@ -146,10 +123,9 @@ sample {
   location_id: 1
   location_id: 2
   location_id: 3
-  location_id: 4
-  value: 1
-  value: 29121
-  value: 1324
+  value: 2
+  value: 842340
+  value: 19568
   value: 0
   value: 0
   value: 0
@@ -160,6 +136,10 @@ sample {
   label {
     key: 21
     str: 22
+  }
+  label {
+    key: 30
+    str: 31
   }
   label {
     key: 23
@@ -225,10 +205,11 @@ sample {
 sample {
   location_id: 1
   location_id: 2
-  location_id: 5
+  location_id: 3
+  location_id: 4
   value: 1
-  value: 1312
-  value: 13244
+  value: 29121
+  value: 1324
   value: 0
   value: 0
   value: 0
@@ -239,6 +220,10 @@ sample {
   label {
     key: 21
     str: 22
+  }
+  label {
+    key: 30
+    str: 31
   }
   label {
     key: 23
@@ -302,10 +287,10 @@ sample {
 sample {
   location_id: 1
   location_id: 2
-  location_id: 6
+  location_id: 5
   value: 1
-  value: 9042
-  value: 132444
+  value: 1312
+  value: 13244
   value: 0
   value: 0
   value: 0
@@ -316,6 +301,10 @@ sample {
   label {
     key: 21
     str: 22
+  }
+  label {
+    key: 30
+    str: 31
   }
   label {
     key: 23
@@ -380,10 +369,9 @@ sample {
   location_id: 1
   location_id: 2
   location_id: 6
-  location_id: 7
   value: 1
-  value: 94021
-  value: 213244
+  value: 9042
+  value: 132444
   value: 0
   value: 0
   value: 0
@@ -394,6 +382,10 @@ sample {
   label {
     key: 21
     str: 22
+  }
+  label {
+    key: 30
+    str: 31
   }
   label {
     key: 23
@@ -458,11 +450,12 @@ sample {
 }
 sample {
   location_id: 1
-  location_id: 8
-  location_id: 3
+  location_id: 2
+  location_id: 6
+  location_id: 7
   value: 1
-  value: 501809
-  value: 13244
+  value: 94021
+  value: 213244
   value: 0
   value: 0
   value: 0
@@ -473,6 +466,10 @@ sample {
   label {
     key: 21
     str: 22
+  }
+  label {
+    key: 30
+    str: 31
   }
   label {
     key: 23
@@ -533,9 +530,36 @@ sample {
     str: 29
   }
 }
+sample {
+  location_id: 1
+  location_id: 8
+  location_id: 3
+  value: 1
+  value: 501809
+  value: 13244
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  value: 0
+  label {
+    key: 21
+    str: 22
+  }
+  label {
+    key: 30
+    str: 31
+  }
+  label {
+    key: 23
+    str: 24
+  }
+}
 mapping {
   id: 1
-  filename: 31
+  filename: 33
 }
 location {
   id: 1
@@ -649,12 +673,14 @@ string_table: "builtins.OSError"
 string_table: "builtins.ValueError"
 string_table: "lock name"
 string_table: "foobar.py:12"
+string_table: "thread native id"
+string_table: "123987"
 string_table: "time"
 string_table: "bonjour"
 time_nanos: 1
 duration_nanos: 6
 period_type {
-  type: 30
+  type: 32
   unit: 11
 }
 period: 1000000

--- a/tests/profiling/exporter/test_pprof.py
+++ b/tests/profiling/exporter/test_pprof.py
@@ -22,6 +22,7 @@ TEST_EVENTS = {
         stack.StackExceptionSampleEvent(
             timestamp=1,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 44, "func2"), ("foobar.py", 19, "func5"),],
             exc_type=TypeError,
@@ -31,6 +32,7 @@ TEST_EVENTS = {
         stack.StackExceptionSampleEvent(
             timestamp=2,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 44, "func2"), ("foobar.py", 20, "func5"),],
             sampling_period=1000000,
@@ -40,6 +42,7 @@ TEST_EVENTS = {
         stack.StackExceptionSampleEvent(
             timestamp=3,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 44, "func2"), ("foobar.py", 19, "func5"),],
             sampling_period=1000000,
@@ -49,6 +52,7 @@ TEST_EVENTS = {
         stack.StackExceptionSampleEvent(
             timestamp=4,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 44, "func2"), ("foobar2.py", 19, "func5"),],
             sampling_period=1000000,
@@ -58,6 +62,7 @@ TEST_EVENTS = {
         stack.StackExceptionSampleEvent(
             timestamp=5,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 44, "func2"), ("foobar2.py", 19, "func5"),],
             sampling_period=1000000,
@@ -67,6 +72,7 @@ TEST_EVENTS = {
         stack.StackExceptionSampleEvent(
             timestamp=6,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 44, "func2"), ("foobar.py", 19, "func5"),],
             sampling_period=1000000,
@@ -76,6 +82,7 @@ TEST_EVENTS = {
         stack.StackExceptionSampleEvent(
             timestamp=7,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 49, "func2"), ("foobar.py", 19, "func5"),],
             sampling_period=1000000,
@@ -145,6 +152,7 @@ TEST_EVENTS = {
         stack.StackSampleEvent(
             timestamp=1,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 44, "func2"), ("foobar.py", 19, "func5"),],
             wall_time_ns=1324,
@@ -155,6 +163,7 @@ TEST_EVENTS = {
         stack.StackSampleEvent(
             timestamp=2,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 44, "func2"), ("foobar.py", 20, "func5"),],
             wall_time_ns=13244,
@@ -165,6 +174,7 @@ TEST_EVENTS = {
         stack.StackSampleEvent(
             timestamp=3,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 44, "func2"), ("foobar.py", 19, "func5"),],
             wall_time_ns=1324,
@@ -175,6 +185,7 @@ TEST_EVENTS = {
         stack.StackSampleEvent(
             timestamp=4,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 44, "func2"), ("foobar2.py", 19, "func5"),],
             wall_time_ns=213244,
@@ -185,6 +196,7 @@ TEST_EVENTS = {
         stack.StackSampleEvent(
             timestamp=5,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 44, "func2"), ("foobar2.py", 19, "func5"),],
             wall_time_ns=132444,
@@ -195,6 +207,7 @@ TEST_EVENTS = {
         stack.StackSampleEvent(
             timestamp=6,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 44, "func2"), ("foobar.py", 19, "func5"),],
             wall_time_ns=18244,
@@ -205,6 +218,7 @@ TEST_EVENTS = {
         stack.StackSampleEvent(
             timestamp=7,
             thread_id=67892304,
+            thread_native_id=123987,
             thread_name="MainThread",
             frames=[("foobar.py", 23, "func1"), ("foobar.py", 49, "func2"), ("foobar.py", 19, "func5"),],
             wall_time_ns=13244,

--- a/tests/profiling/test_periodic.py
+++ b/tests/profiling/test_periodic.py
@@ -25,6 +25,8 @@ def test_periodic():
     assert x["OK"]
     assert x["DOWN"]
     assert t.ident not in _periodic.PERIODIC_THREAD_IDS
+    if hasattr(threading, "get_native_id"):
+        assert t.native_id is not None
 
 
 def test_periodic_error():


### PR DESCRIPTION
## feat(periodic): add support for thread native id in gevent threads

Python ≥ 3.8 supports native OS thread id. Assign it to gevent custom thread
too.

## fix(profiling/stack): use native thread id as CPU time identifier

The current code uses the pthread_t id to cache CPU time between two polling.
This is very optimistic as the pthread_t id can be reused, and it seems Linux
does that quite often. When a program is heavily loaded, it will reuse the
pthread_t faster than the stack profiler can notice, meaning that the CPU time
might end up being negative:

1. cached previous thread with same pthread_t id cpu time = 1000
2. new thread with same pthread_t id cpu time = 500
3. cpu time = 500 - 1000 = -500 🤦

To fix that, we now also uses the native thread id to identify thread. This
should be unique and the couple (pthread_t, native id) has a really small
chance of collision only using hash instead of native id (for old Python
versions).

We also make sure we never put a negative CPU time, if a collision ever
happens. The CPU time will just be 0 for the first (and maybe only) polling,
which is safer.

## feat(pprof): use thread_native_id to sort/group stack events

This make sure the thread native id is also used to identify threads in case
their (pthread_t id, name) are reused. This also embeds the thread native id as
a label which can be useful for debugging.