### PR TITLE
fix(profiling): use gevent.monkey rather than private _threading module

### DIFF
--- a/ddtrace/profiling/_periodic.py
+++ b/ddtrace/profiling/_periodic.py
@@ -4,6 +4,7 @@ import threading
 
 from ddtrace.profiling import _service
 from ddtrace.vendor import attr
+from ddtrace.vendor import six
 
 
 PERIODIC_THREAD_IDS = set()
@@ -83,7 +84,9 @@ class _GeventPeriodicThread(PeriodicThread):
 
     def start(self):
         """Start the thread."""
-        from gevent._threading import start_new_thread
+        import gevent.monkey
+
+        start_new_thread = gevent.monkey.get_original(six.moves._thread.__name__, "start_new_thread")
 
         self.quit = False
         self.has_quit = False


### PR DESCRIPTION
This does not change the functionality but should be slightly cleaner.
