### PR TITLE
ci: make sure we test a low enough gevent version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -194,7 +194,8 @@ deps =
     profile-minreqs: protobuf==3.0.0
     profile-minreqs: tenacity==5.0.1
     profile-!minreqs-gevent: gevent
-    profile-minreqs-gevent: gevent==1.4.0
+    py27-profile-minreqs-gevent: gevent==1.1.0
+    !py27-profile-minreqs-gevent: gevent==1.4.0
 # force the downgrade as a workaround
 # https://github.com/aio-libs/aiohttp/issues/2662
     yarl: yarl==0.18.0


### PR DESCRIPTION
We can at least run with 1.1.0 on Python 2.7.