### PR TITLE
feat(profiling): track gevent greenlets

### DIFF
--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -2,6 +2,7 @@ import platform
 import random
 import re
 import sys
+import threading
 import textwrap
 
 from ddtrace.vendor import six
@@ -99,6 +100,12 @@ if sys.version_info.major < 3:
     getrandbits = random.SystemRandom().getrandbits
 else:
     getrandbits = random.getrandbits
+
+
+if sys.version_info.major < 3:
+    main_thread = threading._MainThread()
+else:
+    main_thread = threading.main_thread()
 
 
 if PYTHON_VERSION_INFO[0:2] >= (3, 4):

--- a/ddtrace/profiling/_nogevent.py
+++ b/ddtrace/profiling/_nogevent.py
@@ -2,6 +2,7 @@
 """This files exposes non-gevent Python original functions."""
 import threading
 
+from ddtrace import compat
 from ddtrace.vendor import six
 from ddtrace.vendor import attr
 
@@ -73,7 +74,4 @@ if is_module_patched("threading"):
     # We don't have the choice has we can't access the original MainThread
     main_thread_id = thread_get_ident()
 else:
-    if six.PY2:
-        main_thread_id = threading._MainThread().ident
-    else:
-        main_thread_id = threading.main_thread().ident
+    main_thread_id = compat.main_thread.ident

--- a/ddtrace/profiling/collector/_threading.pyx
+++ b/ddtrace/profiling/collector/_threading.pyx
@@ -20,15 +20,16 @@ cpdef get_thread_name(thread_id):
     try:
         return _periodic.PERIODIC_THREADS[thread_id].name
     except KeyError:
-        # Since we own the GIL, we can safely run this and assume no change will happen,
-        # without bothering to lock anything
+        # We don't want to bother to lock anything, especially with eventlet involved, so we do a best effort to get the
+        # without bothering to lock anything data; if we fail, it'll just be an anonymous thread because it's either
+        # starting or dying.
         try:
             return threading._active[thread_id].name
         except KeyError:
             try:
                 return threading._limbo[thread_id].name
             except KeyError:
-                return "Anonymous Thread %d" % thread_id
+                return None
 
 
 cpdef get_thread_native_id(thread_id):

--- a/ddtrace/profiling/collector/_threading.pyx
+++ b/ddtrace/profiling/collector/_threading.pyx
@@ -20,9 +20,8 @@ cpdef get_thread_name(thread_id):
     try:
         return _periodic.PERIODIC_THREADS[thread_id].name
     except KeyError:
-        # We don't want to bother to lock anything, especially with eventlet involved, so we do a best effort to get the
-        # without bothering to lock anything data; if we fail, it'll just be an anonymous thread because it's either
-        # starting or dying.
+        # We don't want to bother to lock anything here, especially with eventlet involved 😓. We make a best effort to
+        # get the thread name; if we fail, it'll just be an anonymous thread because it's either starting or dying.
         try:
             return threading._active[thread_id].name
         except KeyError:

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -23,11 +23,26 @@ from ddtrace.vendor import six
 # module without having gevent crashing our dedicated thread.
 
 
-# Those are special features that might not be available depending on your Python version and platform
+# These are special features that might not be available depending on your Python version and platform
 FEATURES = {
     "cpu-time": False,
     "stack-exceptions": False,
+    "gevent-tasks": False,
 }
+
+
+_gevent_tracer = None
+try:
+    import gevent._tracer
+    import gevent.thread
+except ImportError:
+    _gevent_tracer = None
+else:
+    # NOTE: bold assumption: this module is always imported by the MainThread.
+    # A GreenletTracer is local to the thread instantiating it and we assume this is run by the MainThread.
+    _gevent_tracer = gevent._tracer.GreenletTracer()
+    FEATURES["gevent-tasks"] = True
+
 
 IF UNAME_SYSNAME == "Linux":
     FEATURES['cpu-time'] = True
@@ -214,6 +229,26 @@ ELSE:
         PyObject* _PyThread_CurrentFrames()
 
 
+cdef get_task(thread_id):
+    """Return the task id and name for a thread."""
+    # gevent greenlet support:
+    # we only support tracing tasks in the greenlets are run in the MainThread.
+    if thread_id == _nogevent.main_thread_id and _gevent_tracer is not None:
+        if _gevent_tracer.active_greenlet is None:
+            # That means gevent never switch to another greenlet, we're still in the main one
+            task_id = compat.main_thread.ident
+        else:
+            task_id = gevent.thread.get_ident(_gevent_tracer.active_greenlet)
+
+        # Greenlets might be started as Thread in gevent
+        task_name = _threading.get_thread_name(task_id)
+    else:
+        task_id = None
+        task_name = None
+
+    return task_id, task_name
+
+
 cdef collect_threads(ignore_profiler, thread_time, thread_span_links) with gil:
     cdef dict current_exceptions = {}
 
@@ -288,11 +323,16 @@ cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_tim
 
     for thread_id, thread_native_id, thread_name, frame, exception, spans, cpu_time in running_threads:
         frames, nframes = _traceback.pyframe_to_frames(frame, max_nframes)
+
+        task_id, task_name = get_task(thread_id)
+
         stack_events.append(
             StackSampleEvent(
                 thread_id=thread_id,
                 thread_native_id=thread_native_id,
                 thread_name=thread_name,
+                task_id=task_id,
+                task_name=task_name,
                 trace_ids=set(span.trace_id for span in spans),
                 span_ids=set(span.span_id for span in spans),
                 nframes=nframes, frames=frames,
@@ -310,6 +350,8 @@ cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_tim
                     thread_id=thread_id,
                     thread_name=thread_name,
                     thread_native_id=thread_native_id,
+                    task_id=task_id,
+                    task_name=task_name,
                     nframes=nframes,
                     frames=frames,
                     sampling_period=int(interval * 1e9),

--- a/ddtrace/profiling/event.py
+++ b/ddtrace/profiling/event.py
@@ -37,6 +37,8 @@ class StackBasedEvent(SampleEvent):
     thread_id = attr.ib(default=None)
     thread_name = attr.ib(default=None)
     thread_native_id = attr.ib(default=None)
+    task_id = attr.ib(default=None)
+    task_name = attr.ib(default=None)
     frames = attr.ib(default=None)
     nframes = attr.ib(default=None)
     trace_ids = attr.ib(default=None)

--- a/ddtrace/profiling/exporter/pprof.pyx
+++ b/ddtrace/profiling/exporter/pprof.pyx
@@ -290,12 +290,18 @@ class PprofExporter(exporter.Exporter):
             return str(list(sorted(event.span_ids))[0])
         return ""
 
+    @staticmethod
+    def _get_thread_name(thread_id, thread_name):
+        if thread_name is None:
+            return "Anonymous Thread %d" % thread_id
+        return thread_name
+
     def _stack_event_group_key(self, event):
         # If multiple traces were active, we pick only one :(
         return (
             event.thread_id,
             event.thread_native_id,
-            str(event.thread_name),
+            self._get_thread_name(event.thread_id, event.thread_name),
             self._get_trace_id(event),
             self._get_span_id(event),
             tuple(event.frames),
@@ -312,7 +318,7 @@ class PprofExporter(exporter.Exporter):
         return (
             event.lock_name,
             event.thread_id,
-            str(event.thread_name),
+            self._get_thread_name(event.thread_id, event.thread_name),
             self._get_trace_id(event),
             self._get_span_id(event),
             tuple(event.frames),
@@ -331,7 +337,7 @@ class PprofExporter(exporter.Exporter):
         return (
             event.thread_id,
             event.thread_native_id,
-            str(event.thread_name),
+            self._get_thread_name(event.thread_id, event.thread_name),
             self._get_trace_id(event),
             self._get_span_id(event),
             tuple(event.frames),
@@ -345,11 +351,16 @@ class PprofExporter(exporter.Exporter):
             key=self._stack_exception_group_key,
         )
 
-    @staticmethod
-    def _exception_group_key(event):
+    def _exception_group_key(self, event):
         exc_type = event.exc_type
         exc_type_name = exc_type.__module__ + "." + exc_type.__name__
-        return (event.thread_id, str(event.thread_name), tuple(event.frames), event.nframes, exc_type_name)
+        return (
+            event.thread_id,
+            self._get_thread_name(event.thread_id, event.thread_name),
+            tuple(event.frames),
+            event.nframes,
+            exc_type_name,
+        )
 
     def _group_exception_events(self, events):
         return itertools.groupby(

--- a/releasenotes/notes/profiler-stack-greenlet-tracer-6f960c1557fd39c4.yaml
+++ b/releasenotes/notes/profiler-stack-greenlet-tracer-6f960c1557fd39c4.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The profiler now tracks the running gevent Greenlet and store it as part
+    of the CPU and wall time profiling information.


### PR DESCRIPTION
## refactor(profiling/stack): don't compute thread name at collect time

This makes the export more flexible: by setting the thread_name to None in the
event, any exporter can implement its own logic for anonymous thread name.

## feat(profiling/stack): use greenlet tracer to track gevent greenlet

This leverages the gevent GreenletTracer to keep track of the greenlet running
in the main thread.

This allows us to add information in stack events about the currently running
gevent thread, and store its name if it has one.
