### PR TITLE
Cap setuptools_scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "setuptools-scm", "cython"]
+requires = ["setuptools >= 40.6.0", "setuptools-scm < 4.0", "cython"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,7 @@ setup(
             "Programming Language :: Python :: 3.8",
         ],
         use_scm_version=True,
+        # setuptools_scm capped at 4.0 due to: https://github.com/pypa/setuptools_scm/issues/442
         setup_requires=["setuptools_scm<4.0", "cython"],
         ext_modules=cythonize(
             [

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup(
             "Programming Language :: Python :: 3.8",
         ],
         use_scm_version=True,
-        setup_requires=["setuptools_scm", "cython"],
+        setup_requires=["setuptools_scm<4.0", "cython"],
         ext_modules=cythonize(
             [
                 Cython.Distutils.Extension(


### PR DESCRIPTION

 `setuptools_scm` 4.0 breaks on Windows + 2.7:

https://github.com/pypa/setuptools_scm/issues/442