### PR TITLE
refactor: move flatten_dict to ext.aws

### DIFF
--- a/ddtrace/ext/aws.py
+++ b/ddtrace/ext/aws.py
@@ -1,10 +1,20 @@
-from ..utils.formats import flatten_dict
-
-
-BLACKLIST_ENDPOINT = ['kms', 'sts']
+BLACKLIST_ENDPOINT = ["kms", "sts"]
 BLACKLIST_ENDPOINT_TAGS = {
-    's3': ['params.Body'],
+    "s3": ["params.Body"],
 }
+
+
+def _flatten_dict(d, sep=".", prefix=""):
+    """
+    Returns a normalized dict of depth 1 with keys in order of embedding
+
+    """
+    # adapted from https://stackoverflow.com/a/19647596
+    return (
+        {prefix + sep + k if prefix else k: v for kk, vv in d.items() for k, v in _flatten_dict(vv, sep, kk).items()}
+        if isinstance(d, dict)
+        else {prefix: d}
+    )
 
 
 def truncate_arg_value(value, max_len=1024):
@@ -12,7 +22,7 @@ def truncate_arg_value(value, max_len=1024):
     Useful for parameters like 'Body' in `put_object` operations.
     """
     if isinstance(value, bytes) and len(value) > max_len:
-        return b'...'
+        return b"..."
 
     return value
 
@@ -20,20 +30,12 @@ def truncate_arg_value(value, max_len=1024):
 def add_span_arg_tags(span, endpoint_name, args, args_names, args_traced):
     if endpoint_name not in BLACKLIST_ENDPOINT:
         blacklisted = BLACKLIST_ENDPOINT_TAGS.get(endpoint_name, [])
-        tags = dict(
-            (name, value)
-            for (name, value) in zip(args_names, args)
-            if name in args_traced
-        )
-        tags = flatten_dict(tags)
-        tags = {
-            k: truncate_arg_value(v)
-            for k, v in tags.items()
-            if k not in blacklisted
-        }
+        tags = dict((name, value) for (name, value) in zip(args_names, args) if name in args_traced)
+        tags = _flatten_dict(tags)
+        tags = {k: truncate_arg_value(v) for k, v in tags.items() if k not in blacklisted}
         span.set_tags(tags)
 
 
-REGION = 'aws.region'
-AGENT = 'aws.agent'
-OPERATION = 'aws.operation'
+REGION = "aws.region"
+AGENT = "aws.agent"
+OPERATION = "aws.operation"

--- a/ddtrace/utils/formats.py
+++ b/ddtrace/utils/formats.py
@@ -82,19 +82,6 @@ def asbool(value):
     return value.lower() in ("true", "1")
 
 
-def flatten_dict(d, sep=".", prefix=""):
-    """
-    Returns a normalized dict of depth 1 with keys in order of embedding
-
-    """
-    # adapted from https://stackoverflow.com/a/19647596
-    return (
-        {prefix + sep + k if prefix else k: v for kk, vv in d.items() for k, v in flatten_dict(vv, sep, kk).items()}
-        if isinstance(d, dict)
-        else {prefix: d}
-    )
-
-
 def parse_tags_str(tags_str):
     """Parse a string of tags typically provided via environment variables.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,22 @@ exclude = '''
       | vertica
     )
     | ext/
+    (
+       cassandra.py
+       | consul.py
+       | db.py
+       | elasticsearch.py
+       | errors.py
+       | http.py
+       | kombu.py
+       | memcached.py
+       | mongo.py
+       | net.py
+       | priority.py
+       | redis.py
+       | sql.py
+       | system.py
+    )
     | http/
     | opentracer/
     | profiling/exporter/pprof_pb2.py$
@@ -184,9 +200,14 @@ exclude = '''
     | test_sampler.py
     | test_span.py
     | test_tracer.py
-    | test_utils.py
     | test_worker.py
-    | unit
+    | unit/
+    (
+      test_settings.py
+      | test_ext.py
+      | utils/
+      | http/
+    )
     | util.py
     | utils
     | vendor

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,104 +4,90 @@ import unittest
 import warnings
 
 from ddtrace.utils.deprecation import deprecation, deprecated, format_message
-from ddtrace.utils.formats import asbool, get_env, flatten_dict, parse_tags_str
+from ddtrace.utils.formats import asbool, get_env, parse_tags_str
 
 
 class TestUtils(unittest.TestCase):
     def test_asbool(self):
         # ensure the value is properly cast
-        self.assertTrue(asbool('True'))
-        self.assertTrue(asbool('true'))
-        self.assertTrue(asbool('1'))
-        self.assertFalse(asbool('False'))
-        self.assertFalse(asbool('false'))
+        self.assertTrue(asbool("True"))
+        self.assertTrue(asbool("true"))
+        self.assertTrue(asbool("1"))
+        self.assertFalse(asbool("False"))
+        self.assertFalse(asbool("false"))
         self.assertFalse(asbool(None))
-        self.assertFalse(asbool(''))
+        self.assertFalse(asbool(""))
         self.assertTrue(asbool(True))
         self.assertFalse(asbool(False))
 
     def test_get_env(self):
         # ensure `get_env` returns a default value if environment variables
         # are not set
-        value = get_env('django', 'distributed_tracing')
+        value = get_env("django", "distributed_tracing")
         self.assertIsNone(value)
-        value = get_env('django', 'distributed_tracing', default=False)
+        value = get_env("django", "distributed_tracing", default=False)
         self.assertFalse(value)
 
     def test_get_env_long(self):
-        os.environ['DD_SOME_VERY_LONG_TEST_KEY'] = '1'
-        value = get_env('some', 'very', 'long', 'test', 'key', default='2')
-        assert value == '1'
+        os.environ["DD_SOME_VERY_LONG_TEST_KEY"] = "1"
+        value = get_env("some", "very", "long", "test", "key", default="2")
+        assert value == "1"
 
     def test_get_env_found(self):
         # ensure `get_env` returns a value if the environment variable is set
-        os.environ['DD_REQUESTS_DISTRIBUTED_TRACING'] = '1'
-        value = get_env('requests', 'distributed_tracing')
-        self.assertEqual(value, '1')
+        os.environ["DD_REQUESTS_DISTRIBUTED_TRACING"] = "1"
+        value = get_env("requests", "distributed_tracing")
+        self.assertEqual(value, "1")
 
     def test_get_env_found_legacy(self):
         # ensure `get_env` returns a value if legacy environment variables
         # are used, raising a Deprecation warning
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            os.environ['DATADOG_REQUESTS_DISTRIBUTED_TRACING'] = '1'
-            value = get_env('requests', 'distributed_tracing')
-            self.assertEqual(value, '1')
+            warnings.simplefilter("always")
+            os.environ["DATADOG_REQUESTS_DISTRIBUTED_TRACING"] = "1"
+            value = get_env("requests", "distributed_tracing")
+            self.assertEqual(value, "1")
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertTrue('Use `DD_` prefix instead' in str(w[-1].message))
+            self.assertTrue("Use `DD_` prefix instead" in str(w[-1].message))
 
     def test_get_env_key_priority(self):
         # ensure `get_env` use `DD_` with highest priority
-        os.environ['DD_REQUESTS_DISTRIBUTED_TRACING'] = 'highest'
-        os.environ['DATADOG_REQUESTS_DISTRIBUTED_TRACING'] = 'lowest'
-        value = get_env('requests', 'distributed_tracing')
-        self.assertEqual(value, 'highest')
+        os.environ["DD_REQUESTS_DISTRIBUTED_TRACING"] = "highest"
+        os.environ["DATADOG_REQUESTS_DISTRIBUTED_TRACING"] = "lowest"
+        value = get_env("requests", "distributed_tracing")
+        self.assertEqual(value, "highest")
 
     def test_deprecation_formatter(self):
         # ensure the formatter returns the proper message
-        msg = format_message(
-            'deprecated_function',
-            'use something else instead',
-            '1.0.0',
-        )
+        msg = format_message("deprecated_function", "use something else instead", "1.0.0",)
         expected = (
-            '\'deprecated_function\' is deprecated and will be remove in future versions (1.0.0). '
-            'use something else instead'
+            "'deprecated_function' is deprecated and will be remove in future versions (1.0.0). "
+            "use something else instead"
         )
         self.assertEqual(msg, expected)
 
     def test_deprecation(self):
         # ensure `deprecation` properly raise a DeprecationWarning
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            deprecation(
-                name='fn',
-                message='message',
-                version='1.0.0'
-            )
+            warnings.simplefilter("always")
+            deprecation(name="fn", message="message", version="1.0.0")
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn('message', str(w[-1].message))
+            self.assertIn("message", str(w[-1].message))
 
     def test_deprecated_decorator(self):
         # ensure `deprecated` decorator properly raise a DeprecationWarning
-        @deprecated('decorator', version='1.0.0')
+        @deprecated("decorator", version="1.0.0")
         def fxn():
             pass
 
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+            warnings.simplefilter("always")
             fxn()
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn('decorator', str(w[-1].message))
-
-    def test_flatten_dict(self):
-        """ ensure that flattening of a nested dict results in a normalized, 1-level dict """
-        d = dict(A=1, B=2, C=dict(A=3, B=4, C=dict(A=5, B=6)))
-        e = dict(A=1, B=2, C_A=3, C_B=4, C_C_A=5, C_C_B=6)
-        self.assertEquals(flatten_dict(d, sep='_'), e)
+            self.assertIn("decorator", str(w[-1].message))
 
     def test_parse_env_tags(self):
         tags = parse_tags_str("key:val")
@@ -150,8 +136,10 @@ class TestUtils(unittest.TestCase):
         with mock.patch("ddtrace.utils.formats.log") as log:
             tags = parse_tags_str("key,key2,key3")
         assert tags == dict()
-        log.error.assert_has_calls([
-            mock.call("Malformed tag in tag pair '%s' from tag string '%s'.", "key", "key,key2,key3"),
-            mock.call("Malformed tag in tag pair '%s' from tag string '%s'.", "key2", "key,key2,key3"),
-            mock.call("Malformed tag in tag pair '%s' from tag string '%s'.", "key3", "key,key2,key3"),
-        ])
+        log.error.assert_has_calls(
+            [
+                mock.call("Malformed tag in tag pair '%s' from tag string '%s'.", "key", "key,key2,key3"),
+                mock.call("Malformed tag in tag pair '%s' from tag string '%s'.", "key2", "key,key2,key3"),
+                mock.call("Malformed tag in tag pair '%s' from tag string '%s'.", "key3", "key,key2,key3"),
+            ]
+        )

--- a/tests/unit/test_ext.py
+++ b/tests/unit/test_ext.py
@@ -1,0 +1,8 @@
+from ddtrace.ext import aws
+
+
+def test_flatten_dict():
+    """Ensure that flattening of a nested dict results in a normalized, 1-level dict"""
+    d = dict(A=1, B=2, C=dict(A=3, B=4, C=dict(A=5, B=6)))
+    e = dict(A=1, B=2, C_A=3, C_B=4, C_C_A=5, C_C_B=6)
+    assert aws._flatten_dict(d, sep="_") == e


### PR DESCRIPTION
This function is only used there so there's no need to carry it around.
Also make it private since it shouldn't be part of the exposed API.
Finally, this black some more files that are touched by this patch.