### PR TITLE
feat(profiling): install the profiling extra by default

### DIFF
--- a/ddtrace/profiling/__init__.py
+++ b/ddtrace/profiling/__init__.py
@@ -9,7 +9,7 @@ def _not_compatible_abi():
     raise ImportError(
         "Python ABI is not compatible, you need to recompile this module.\n"
         "Reinstall it with the following command:\n"
-        "  pip install --no-binary ddtrace ddtrace[profiling]"
+        "  pip install --no-binary ddtrace ddtrace"
     )
 
 

--- a/docs/installation_quickstart.rst
+++ b/docs/installation_quickstart.rst
@@ -19,10 +19,6 @@ $ pip install ddtrace
 
 We strongly suggest pinning the version of the library you deploy.
 
-If you want to use the profiler, you'll need to specify the ``profiling`` flavor::
-
-  $ pip install ddtrace[profiling]
-
 Quickstart
 ----------
 

--- a/setup.py
+++ b/setup.py
@@ -100,9 +100,6 @@ def get_exts_for(name):
         return []
 
 
-_profiling_deps = ["protobuf>=3", "intervaltree", "tenacity>=5"]
-
-
 # Base `setup()` kwargs without any C-extension registering
 setup(
     **dict(
@@ -119,14 +116,18 @@ setup(
         # enum34 is an enum backport for earlier versions of python
         # funcsigs backport required for vendored debtcollector
         # encoding using msgpack
-        install_requires=["enum34; python_version<'3.4'", "funcsigs>=1.0.0; python_version=='2.7'", "msgpack>=0.5.0"],
+        install_requires=[
+            "enum34; python_version<'3.4'",
+            "funcsigs>=1.0.0; python_version=='2.7'",
+            "msgpack>=0.5.0",
+            "protobuf>=3",
+            "intervaltree",
+            "tenacity>=5",
+        ],
         extras_require={
             # users can include opentracing by having:
             # install_requires=['ddtrace[opentracing]', ...]
             "opentracing": ["opentracing>=2.0.0"],
-            # TODO: remove me when everything is updated to `profiling`
-            "profile": _profiling_deps,
-            "profiling": _profiling_deps,
         },
         # plugin tox
         tests_require=["tox", "flake8"],


### PR DESCRIPTION
We want users to be able to deploy and start profiling their applications right
away with this Python package, without having to pick a flavor.