### PR TITLE
revert span/trace id generation

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -3,7 +3,7 @@ import sys
 import traceback
 
 from .vendor import six
-from .compat import StringIO, stringify, iteritems, numeric_types, time_ns, is_integer
+from .compat import StringIO, stringify, iteritems, numeric_types, time_ns, is_integer, getrandbits
 from .constants import (
     NUMERIC_TAGS,
     MANUAL_DROP_KEY,
@@ -15,7 +15,6 @@ from .constants import (
 )
 from .ext import SpanTypes, errors, priority, net, http
 from .internal.logger import get_logger
-from .internal import _rand
 
 log = get_logger(__name__)
 
@@ -93,8 +92,8 @@ class Span(object):
         self.duration_ns = None
 
         # tracing
-        self.trace_id = trace_id or _rand.rand64bits()
-        self.span_id = span_id or _rand.rand64bits()
+        self.trace_id = trace_id or getrandbits(64)
+        self.span_id = span_id or getrandbits(64)
         self.parent_id = parent_id
         self.tracer = tracer
 


### PR DESCRIPTION
The newly introduced span/trace id generation did not take into consideration forking processes. For which, the seed would be shared among the processes and would result in id collisions for spans and traces.