### PR TITLE
tests: wait for uds server to start before using it

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,6 +59,9 @@ def _make_uds_server(path, request_handler):
     # Set daemon just in case something fails
     t.daemon = True
     t.start()
+
+    # Wait for the server to start
+    time.sleep(0.2)
     return server, t
 
 


### PR DESCRIPTION
There's a race between starting a UDS server and using it: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/1257/workflows/23c32c73-3dfb-48f9-832c-0f6db3e728b7/jobs/261005

This PR adds a delay to work around this. A better solution would be to synchronize the threads but would be a quite a bit more involved.

Fixes #1215 