### PR TITLE
feat(profiling): allow to pass env to Profiler

### DIFF
--- a/ddtrace/profiling/exporter/http.py
+++ b/ddtrace/profiling/exporter/http.py
@@ -86,6 +86,7 @@ class PprofHTTPExporter(pprof.PprofExporter):
     api_key = attr.ib(factory=_get_api_key, type=str)
     timeout = attr.ib(factory=_attr.from_env("DD_PROFILING_API_TIMEOUT", 10, float), type=float)
     service = attr.ib(default=None)
+    env = attr.ib(default=None)
     max_retry_delay = attr.ib(default=None)
 
     def __attrs_post_init__(self):
@@ -126,8 +127,7 @@ class PprofHTTPExporter(pprof.PprofExporter):
 
         return content_type, body
 
-    @staticmethod
-    def _get_tags(service):
+    def _get_tags(self, service):
         tags = {
             "service": service.encode("utf-8"),
             "host": HOSTNAME.encode("utf-8"),
@@ -142,9 +142,8 @@ class PprofHTTPExporter(pprof.PprofExporter):
         if version:
             tags["version"] = version.encode("utf-8")
 
-        env = os.environ.get("DD_ENV")
-        if env:
-            tags["env"] = env.encode("utf-8")
+        if self.env:
+            tags["env"] = self.env.encode("utf-8")
 
         user_tags = parse_tags_str(os.environ.get("DD_TAGS", {}))
         user_tags.update(parse_tags_str(os.environ.get("DD_PROFILING_TAGS", {})))

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -17,10 +17,10 @@ from ddtrace.profiling.exporter import http
 LOG = logging.getLogger(__name__)
 
 
-def _build_default_exporters(service):
+def _build_default_exporters(service, env):
     exporters = []
     if "DD_PROFILING_API_KEY" in os.environ or "DD_API_KEY" in os.environ:
-        exporters.append(http.PprofHTTPExporter(service=service))
+        exporters.append(http.PprofHTTPExporter(service=service, env=env))
 
     _OUTPUT_PPROF = os.environ.get("DD_PROFILING_OUTPUT_PPROF")
     if _OUTPUT_PPROF:
@@ -77,6 +77,7 @@ class Profiler(object):
     """
 
     service = attr.ib(factory=_get_service_name)
+    env = attr.ib(factory=lambda: os.environ.get("DD_ENV"))
     collectors = attr.ib(factory=_build_default_collectors)
     exporters = attr.ib(default=None)
     schedulers = attr.ib(init=False, factory=list)
@@ -84,7 +85,7 @@ class Profiler(object):
 
     def __attrs_post_init__(self):
         if self.exporters is None:
-            self.exporters = _build_default_exporters(self.service)
+            self.exporters = _build_default_exporters(self.service, self.env)
 
         if self.exporters:
             for rec in self.recorders:

--- a/tests/profiling/exporter/test_http.py
+++ b/tests/profiling/exporter/test_http.py
@@ -220,13 +220,14 @@ def _check_tags_types(tags):
 
 
 def test_get_tags():
-    tags = http.PprofHTTPExporter()._get_tags("foobar")
+    tags = http.PprofHTTPExporter(env="foobar")._get_tags("foobar")
     _check_tags_types(tags)
-    assert len(tags) == 7
+    assert len(tags) == 8
     assert tags["service"] == b"foobar"
     assert len(tags["host"])
     assert len(tags["runtime-id"])
     assert tags["language"] == b"python"
+    assert tags["env"] == b"foobar"
     assert tags["runtime"] == b"CPython"
     assert tags["profiler_version"] == ddtrace.__version__.encode("utf-8")
     assert "version" not in tags
@@ -359,8 +360,7 @@ def test_get_tags_override(monkeypatch):
     assert tags["version"] == b"123"
     assert "env" not in tags
 
-    monkeypatch.setenv("DD_ENV", "prod")
-    tags = http.PprofHTTPExporter()._get_tags("foobar")
+    tags = http.PprofHTTPExporter(env="prod")._get_tags("foobar")
     _check_tags_types(tags)
     assert len(tags) == 10
     assert tags["service"] == u"🤣".encode("utf-8")

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -46,3 +46,28 @@ def test_service_api(monkeypatch):
             break
     else:
         pytest.fail("Unable to find HTTP exporter")
+
+
+def test_env_default(monkeypatch):
+    monkeypatch.setenv("DD_API_KEY", "foobar")
+    monkeypatch.setenv("DD_ENV", "staging")
+    prof = profiler.Profiler()
+    assert prof.env == "staging"
+    for exporter in prof.exporters:
+        if isinstance(exporter, http.PprofHTTPExporter):
+            assert exporter.env == "staging"
+            break
+    else:
+        pytest.fail("Unable to find HTTP exporter")
+
+
+def test_env_api(monkeypatch):
+    monkeypatch.setenv("DD_API_KEY", "foobar")
+    prof = profiler.Profiler(env="staging")
+    assert prof.env == "staging"
+    for exporter in prof.exporters:
+        if isinstance(exporter, http.PprofHTTPExporter):
+            assert exporter.env == "staging"
+            break
+    else:
+        pytest.fail("Unable to find HTTP exporter")


### PR DESCRIPTION
This allows to pass the env to the Profiler object when uploading profiles.