### PR TITLE
feat(profiling/http): emit log message when server returns 400

### DIFF
--- a/ddtrace/profiling/exporter/http.py
+++ b/ddtrace/profiling/exporter/http.py
@@ -173,7 +173,9 @@ class PprofHTTPExporter(pprof.PprofExporter):
         except tenacity.RetryError as e:
             raise UploadFailed(e.last_attempt.exception())
         except error.HTTPError as e:
-            if e.code == 404 and not self.api_key:
+            if e.code == 400:
+                msg = "Server returned 400, check your API key"
+            elif e.code == 404 and not self.api_key:
                 msg = (
                     "Datadog Agent is not accepting profiles. "
                     "Agent-based profiling deployments require Datadog Agent >= 7.20"

--- a/tests/profiling/exporter/test_http.py
+++ b/tests/profiling/exporter/test_http.py
@@ -164,6 +164,7 @@ def test_wrong_api_key(endpoint_test_server):
     assert isinstance(e, error.HTTPError)
     assert e.code == 400
     assert e.reason == "Wrong API Key"
+    assert str(t.value) == "Unable to upload profile: Server returned 400, check your API key"
 
 
 def test_export(endpoint_test_server):


### PR DESCRIPTION
This is an alternative to #1459

Fixes #1452
