### PR TITLE
refactor(profiling): enhance event type limit

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -113,10 +113,6 @@ below:
      - The percentage of events that should be captured (e.g. memory
        allocation). Greater values reduce the program execution speed. Must be
        greater than 0 lesser or equal to 100.
-   * - ``DD_PROFILING_MAX_EVENTS``
-     - Integer
-     - 49152
-     - The maximum number of total events captured that are stored in memory.
    * - ``DD_PROFILING_UPLOAD_INTERVAL``
      - Float
      - 60

--- a/tests/profiling/collector/test_memory.py
+++ b/tests/profiling/collector/test_memory.py
@@ -37,7 +37,8 @@ def test_repr():
     test_collector._test_repr(
         memory.MemoryCollector,
         "MemoryCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
-        "recorder=Recorder(max_size=49152), capture_pct=5.0, nframes=64, ignore_profiler=True)",
+        "recorder=Recorder(default_max_events=32768, max_events={}), "
+        "capture_pct=5.0, nframes=64, ignore_profiler=True)",
     )
 
 

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -112,7 +112,7 @@ def test_repr():
     test_collector._test_repr(
         stack.StackCollector,
         "StackCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
-        "recorder=Recorder(max_size=49152), max_time_usage_pct=2.0, "
+        "recorder=Recorder(default_max_events=32768, max_events={}), max_time_usage_pct=2.0, "
         "nframes=64, ignore_profiler=True, tracer=None)",
     )
 

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -15,7 +15,7 @@ def test_repr():
     test_collector._test_repr(
         collector_threading.LockCollector,
         "LockCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
-        "recorder=Recorder(max_size=49152), capture_pct=5.0, nframes=64)",
+        "recorder=Recorder(default_max_events=32768, max_events={}), capture_pct=5.0, nframes=64)",
     )
 
 

--- a/tests/profiling/test_recorder.py
+++ b/tests/profiling/test_recorder.py
@@ -1,6 +1,25 @@
 # -*- encoding: utf-8 -*-
 from ddtrace.profiling import event
 from ddtrace.profiling import recorder
+from ddtrace.profiling.collector import stack
+
+import pytest
+
+
+def test_defaultdictkey():
+    d = recorder._defaultdictkey(lambda k: [str(k) + "k"])
+    assert isinstance(d["abc"], list)
+    assert 2 not in d
+    d[1].append("hello")
+    assert d[1] == ["1k", "hello"]
+    d[1].append("bar")
+    assert d[1] == ["1k", "hello", "bar"]
+
+
+def test_defaultdictkey_no_factory():
+    d = recorder._defaultdictkey()
+    with pytest.raises(KeyError):
+        d[1]
 
 
 def test_reset():
@@ -19,3 +38,9 @@ def test_push_events_empty():
     r = recorder.Recorder()
     r.push_events([])
     assert len(r.events[event.Event]) == 0
+
+
+def test_limit():
+    r = recorder.Recorder(default_max_events=12, max_events={stack.StackSampleEvent: 24,})
+    assert r.events[stack.StackExceptionSampleEvent].maxlen == 12
+    assert r.events[stack.StackSampleEvent].maxlen == 24


### PR DESCRIPTION
This introduces a per-event-type maximum number of event limit.
So far, the event was global per event type. However, not all event type are
equal and some are bigger than others.

This reduces the default maximum number of events for an event type to 32768
and remove it as a publicly documented interface via the environment variable.

It sets default value for MemorySampleEvent which can be quite big, and
slightly increase the number of StackBasedEvent that can be stored by default
(from 49152 to 60000).

Related to #1481
