### PR TITLE
feat(profiling): disable trace tracking in tracer by default

### DIFF
--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -1,6 +1,8 @@
 import pytest
 
+import ddtrace
 from ddtrace.profiling import profiler
+from ddtrace.profiling.collector import stack
 from ddtrace.profiling.exporter import http
 
 
@@ -46,6 +48,18 @@ def test_service_api(monkeypatch):
             break
     else:
         pytest.fail("Unable to find HTTP exporter")
+
+
+def test_tracer_api(monkeypatch):
+    monkeypatch.setenv("DD_API_KEY", "foobar")
+    prof = profiler.Profiler(tracer=ddtrace.tracer)
+    assert prof.tracer == ddtrace.tracer
+    for collector in prof.collectors:
+        if isinstance(collector, stack.StackCollector):
+            assert collector.tracer == ddtrace.tracer
+            break
+    else:
+        pytest.fail("Unable to find stack collector")
 
 
 def test_env_default(monkeypatch):


### PR DESCRIPTION
This disables the tracer usage by default in the profiler.
