### PR TITLE
test(profiling): enable verbose + no capture

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -456,7 +456,7 @@ passenv=TEST_*
 commands =
 # run only essential tests related to the tracing client
     tracer: pytest {posargs} --ignore="tests/contrib" --ignore="tests/test_integration.py" --ignore="tests/commands" --ignore="tests/opentracer" --ignore="tests/unit" --ignore="tests/internal" --ignore="tests/profiling" tests
-    profile: python -m tests.profiling.run pytest {posargs} tests/profiling
+    profile: python -m tests.profiling.run pytest --capture=no --verbose {posargs} tests/profiling
 # run only the `ddtrace.internal` tests
     internal: pytest {posargs} tests/internal
 # run only the opentrace tests


### PR DESCRIPTION
Once in a while, a test hangs in the CI and it's impossible to see which one
and why. This should gives more insight about what's happening.