### PR TITLE
fix(django): handle all template name types

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -419,7 +419,7 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
                         template_names = [template]
                     if isinstance(template, (list, tuple,)):
                         template_names = template
-                    elif hasattr(template, 'template'):
+                    elif hasattr(template, "template"):
                         template_names = [template.template.name]
                     else:
                         template_names = None

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -422,6 +422,9 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
                     elif isinstance(template, (list, tuple,)):
                         template_names = template
                     elif hasattr(template, "template"):
+                        # ^ checking by atttribute here because
+                        # django backend implementations don't have a common base
+                        # `.template` is also the most consistent across django versions
                         template_names = [template.template.name]
                     else:
                         template_names = None

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -411,7 +411,21 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
                     span.error = 1
                 span.set_tag("django.response.class", func_name(response))
                 if hasattr(response, "template_name"):
-                    utils.set_tag_array(span, "django.response.template", response.template_name)
+                    # template_name is a bit of a misnomer, as it could be any of:
+                    # a list of strings, a tuple of strings, a single string, or an instance of Template
+                    template = response.template_name
+
+                    if isinstance(template, str):
+                        template_names = [template]
+                    if isinstance(template, (list, tuple,)):
+                        template_names = template
+                    elif hasattr(template, 'template'):
+                        template_names = [template.template.name]
+                    else:
+                        template_names = None
+
+                    utils.set_tag_array(span, "django.response.template", template_names)
+
             return response
 
 

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -11,7 +11,7 @@ import sys
 from inspect import isclass, isfunction
 
 from ddtrace import config, Pin
-from ddtrace.vendor import debtcollector, wrapt
+from ddtrace.vendor import debtcollector, six, wrapt
 from ddtrace.compat import getattr_static
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib import func_name, dbapi
@@ -413,11 +413,13 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
                 if hasattr(response, "template_name"):
                     # template_name is a bit of a misnomer, as it could be any of:
                     # a list of strings, a tuple of strings, a single string, or an instance of Template
+                    # for more detail, see:
+                    # https://docs.djangoproject.com/en/3.0/ref/template-response/#django.template.response.SimpleTemplateResponse.template_name
                     template = response.template_name
 
-                    if isinstance(template, str):
+                    if isinstance(template, six.string_types):
                         template_names = [template]
-                    if isinstance(template, (list, tuple,)):
+                    elif isinstance(template, (list, tuple,)):
                         template_names = template
                     elif hasattr(template, "template"):
                         template_names = [template.template.name]

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -422,7 +422,7 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
                     elif isinstance(template, (list, tuple,)):
                         template_names = template
                     elif hasattr(template, "template"):
-                        # ^ checking by atttribute here because
+                        # ^ checking by attribute here because
                         # django backend implementations don't have a common base
                         # `.template` is also the most consistent across django versions
                         template_names = [template.template.name]

--- a/tests/contrib/django/django1_app/urls.py
+++ b/tests/contrib/django/django1_app/urls.py
@@ -17,5 +17,5 @@ urlpatterns = [
     url(r"^partial-view/$", views.partial_view, name="partial-view"),
     url(r"^lambda-view/$", views.lambda_view, name="lambda-view"),
     url(r"^error-500/$", views.error_500, name="error-500"),
-    url(r"^template-view/$", views.template_view, name='template-view'),
+    url(r"^template-view/$", views.template_view, name="template-view"),
 ]

--- a/tests/contrib/django/django1_app/urls.py
+++ b/tests/contrib/django/django1_app/urls.py
@@ -18,4 +18,6 @@ urlpatterns = [
     url(r"^lambda-view/$", views.lambda_view, name="lambda-view"),
     url(r"^error-500/$", views.error_500, name="error-500"),
     url(r"^template-view/$", views.template_view, name="template-view"),
+    url(r"^template-simple-view/$", views.template_simple_view, name="template-simple-view"),
+    url(r"^template-list-view/$", views.template_list_view, name="template-list-view"),
 ]

--- a/tests/contrib/django/django1_app/urls.py
+++ b/tests/contrib/django/django1_app/urls.py
@@ -17,4 +17,5 @@ urlpatterns = [
     url(r"^partial-view/$", views.partial_view, name="partial-view"),
     url(r"^lambda-view/$", views.lambda_view, name="lambda-view"),
     url(r"^error-500/$", views.error_500, name="error-500"),
+    url(r"^template-view/$", views.template_view, name='template-view'),
 ]

--- a/tests/contrib/django/django_app/urls.py
+++ b/tests/contrib/django/django_app/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     url(r"^partial-view/$", views.partial_view, name="partial-view"),
     url(r"^lambda-view/$", views.lambda_view, name="lambda-view"),
     url(r"^error-500/$", views.error_500, name="error-500"),
+    url(r"^template-view/$", views.template_view, name='template-view'),
     re_path(r"re-path.*/", repath_view),
     path("path/", path_view),
     path("include/", include("tests.contrib.django.django_app.extra_urls")),

--- a/tests/contrib/django/django_app/urls.py
+++ b/tests/contrib/django/django_app/urls.py
@@ -44,6 +44,8 @@ urlpatterns = [
     url(r"^lambda-view/$", views.lambda_view, name="lambda-view"),
     url(r"^error-500/$", views.error_500, name="error-500"),
     url(r"^template-view/$", views.template_view, name="template-view"),
+    url(r"^template-simple-view/$", views.template_simple_view, name="template-simple-view"),
+    url(r"^template-list-view/$", views.template_list_view, name="template-list-view"),
     re_path(r"re-path.*/", repath_view),
     path("path/", path_view),
     path("include/", include("tests.contrib.django.django_app.extra_urls")),

--- a/tests/contrib/django/django_app/urls.py
+++ b/tests/contrib/django/django_app/urls.py
@@ -43,7 +43,7 @@ urlpatterns = [
     url(r"^partial-view/$", views.partial_view, name="partial-view"),
     url(r"^lambda-view/$", views.lambda_view, name="lambda-view"),
     url(r"^error-500/$", views.error_500, name="error-500"),
-    url(r"^template-view/$", views.template_view, name='template-view'),
+    url(r"^template-view/$", views.template_view, name="template-view"),
     re_path(r"re-path.*/", repath_view),
     path("path/", path_view),
     path("include/", include("tests.contrib.django.django_app.extra_urls")),

--- a/tests/contrib/django/templates/basic.html
+++ b/tests/contrib/django/templates/basic.html
@@ -1,0 +1,1 @@
+some content

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -377,6 +377,24 @@ def test_lambda_based_view(client, test_spans):
         assert span.resource == "GET tests.contrib.django.views.<lambda>"
 
 
+def test_template_view(client, test_spans):
+    resp = client.get("/template-view/")
+    assert resp.status_code == 200
+    assert resp.content == b"some content\n"
+
+    view_spans = list(test_spans.filter_spans(name="django.view"))
+    assert len(view_spans) == 1
+
+    # Assert span properties
+    view_span = view_spans[0]
+    view_span.assert_matches(
+        name="django.view", service="django", resource="tests.contrib.django.views.template_view", error=0,
+    )
+
+    root_span = test_spans.get_root_span()
+    assert root_span.get_tag("django.response.template") == "basic.html"
+
+
 def test_middleware_trace_function_based_view(client, test_spans):
     # ensures that the internals are properly traced when using a function views
     assert client.get("/fn-view/").status_code == 200

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -395,6 +395,43 @@ def test_template_view(client, test_spans):
     assert root_span.get_tag("django.response.template") == "basic.html"
 
 
+def test_template_simple_view(client, test_spans):
+    resp = client.get("/template-simple-view/")
+    assert resp.status_code == 200
+    assert resp.content == b"some content\n"
+
+    view_spans = list(test_spans.filter_spans(name="django.view"))
+    assert len(view_spans) == 1
+
+    # Assert span properties
+    view_span = view_spans[0]
+    view_span.assert_matches(
+        name="django.view", service="django", resource="tests.contrib.django.views.template_simple_view", error=0,
+    )
+
+    root_span = test_spans.get_root_span()
+    assert root_span.get_tag("django.response.template") == "basic.html"
+
+
+def test_template_list_view(client, test_spans):
+    resp = client.get("/template-list-view/")
+    assert resp.status_code == 200
+    assert resp.content == b"some content\n"
+
+    view_spans = list(test_spans.filter_spans(name="django.view"))
+    assert len(view_spans) == 1
+
+    # Assert span properties
+    view_span = view_spans[0]
+    view_span.assert_matches(
+        name="django.view", service="django", resource="tests.contrib.django.views.template_list_view", error=0,
+    )
+
+    root_span = test_spans.get_root_span()
+    assert root_span.get_tag("django.response.template.0") == "doesntexist.html"
+    assert root_span.get_tag("django.response.template.1") == "basic.html"
+
+
 def test_middleware_trace_function_based_view(client, test_spans):
     # ensures that the internals are properly traced when using a function views
     assert client.get("/fn-view/").status_code == 200

--- a/tests/contrib/django/views.py
+++ b/tests/contrib/django/views.py
@@ -4,12 +4,12 @@ Class based views used for Django tests.
 
 from functools import partial
 
-from django.http import HttpResponse
-
-from django.views.generic import ListView, TemplateView, View
-
 from django.contrib.auth.models import User
 from django.contrib.syndication.views import Feed
+from django.http import HttpResponse
+from django.template import loader
+from django.template.response import TemplateResponse
+from django.views.generic import ListView, TemplateView, View
 
 
 class UserList(ListView):
@@ -82,3 +82,11 @@ lambda_view = lambda request: function_view(request)  # NOQA
 
 def index(request):
     return HttpResponse("Hello, test app.")
+
+
+def template_view(request):
+    """
+    View that uses a template instance
+    """
+    template = loader.select_template(['basic.html'])
+    return TemplateResponse(request, template)

--- a/tests/contrib/django/views.py
+++ b/tests/contrib/django/views.py
@@ -88,5 +88,5 @@ def template_view(request):
     """
     View that uses a template instance
     """
-    template = loader.select_template(['basic.html'])
+    template = loader.select_template(["basic.html"])
     return TemplateResponse(request, template)

--- a/tests/contrib/django/views.py
+++ b/tests/contrib/django/views.py
@@ -90,3 +90,17 @@ def template_view(request):
     """
     template = loader.select_template(["basic.html"])
     return TemplateResponse(request, template)
+
+
+def template_simple_view(request):
+    """
+    Basic django templated view
+    """
+    return TemplateResponse(request, "basic.html")
+
+
+def template_list_view(request):
+    """
+    For testing resolving a list of templates
+    """
+    return TemplateResponse(request, ["doesntexist.html", "basic.html"])


### PR DESCRIPTION
This is just #1441 brought up to date with master since it had some conflicts and we didn't have permissions to update the remote branch. Thanks @sibsibsib for the contribution!



closes #1441.