### PR TITLE
test(profiling): fix stress test

### DIFF
--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -342,7 +342,7 @@ def test_stress_trace_collection(tracer_and_collector):
             with tracer.trace("hello"):
                 time.sleep(0.001)
 
-    NB_THREADS = 50
+    NB_THREADS = 30
 
     threads = []
     for i in range(NB_THREADS):
@@ -351,9 +351,6 @@ def test_stress_trace_collection(tracer_and_collector):
 
     for t in threads:
         t.start()
-
-    for _ in range(10000):
-        collector.collect()
 
     for t in threads:
         t.join()


### PR DESCRIPTION
The stress test run the collect function while the collector thread is running;
however, the collector is not thread-safe itself and not designed to be run on
2 threads at the same time, triggering race conditions. For example:

  ddtrace/profiling/collector/stack.pyx:480: in ddtrace.profiling.collector.stack.StackCollector.collect
      all_events = stack_collect(
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

  >   cpu_time_ns=cpu_time[tid],
  E   KeyError: 140707993589504
