### PR TITLE
test: show 10 slowest tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -575,7 +575,7 @@ basepython=python
 # DEV: We use `conftest.py` as a local pytest plugin to configure hooks for collection
 [pytest]
 # Common directories to ignore
-addopts = --ignore "tests/utils" --ignore "tests/base" --benchmark-disable
+addopts = --ignore "tests/utils" --ignore "tests/base" --benchmark-disable --durations=10
 # DEV: The default is `test_*\.py` which will miss `test.py` files
 python_files = test*\.py
 


### PR DESCRIPTION
This should make it easier to understand why the CI is slow as we'll be able to
identify the slowest tests — and then improve some tests to make them faster.