### PR TITLE
Expose register_at_fork for all Python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ ddtrace/profiling/collector/_traceback.c
 ddtrace/profiling/collector/stack.c
 ddtrace/profiling/_build.c
 ddtrace/internal/_rand.c
+ddtrace/compat/_os.c
 *.so
 
 # Distribution / packaging

--- a/ddtrace/compat/__init__.py
+++ b/ddtrace/compat/__init__.py
@@ -1,6 +1,7 @@
 import platform
 import random
 import re
+import os
 import sys
 import textwrap
 
@@ -17,6 +18,16 @@ __all__ = [
     "parse",
     "reraise",
 ]
+
+
+if hasattr(os, "register_at_fork"):
+    register_at_fork = os.register_at_fork
+else:
+    from . import _os
+
+    if hasattr(_os, "register_at_fork"):
+        register_at_fork = _os.register_at_fork
+
 
 PYTHON_VERSION_INFO = sys.version_info
 PY2 = sys.version_info[0] == 2
@@ -74,7 +85,7 @@ except ImportError:
 try:
     from time import monotonic
 except ImportError:
-    from .vendor.monotonic import monotonic
+    from ..vendor.monotonic import monotonic
 
 
 try:

--- a/ddtrace/compat/_os.pyx
+++ b/ddtrace/compat/_os.pyx
@@ -1,0 +1,50 @@
+"""Implementation of os.register_at_fork using pthread_atfork on POSIX systems.
+
+Be aware that this is not a strict equivalent of os.register_at_fork from Python.
+
+The latter is handled by the interpreter and is safer. For example, it is run after the `threading.Lock` have been
+released in the child process, which is *not* the case by this implementation.
+
+This is only meant to be used to straightforward tasks with almost no side-effects.
+
+"""
+
+from __future__ import print_function
+
+
+IF UNAME_SYSNAME in ("Linux", "Darwin", "FreeBSD", "OpenBSD", "NetBSD"):
+    import sys
+
+    cdef extern from "<pthread.h>":
+        int pthread_atfork(object (*prepare)(), object (*parent)(), object (*child)());
+
+    _before = []
+    _after_in_child = []
+    _after_in_parent = []
+
+    def register_at_fork(before=None, after_in_child=None, after_in_parent=None):
+        if before is not None:
+            _before.insert(0, before)
+        if after_in_child is not None:
+            _after_in_child.append(after_in_child)
+        if after_in_parent is not None:
+            _after_in_parent.append(after_in_parent)
+
+    cdef _run_handlers(handlers):
+        for func in handlers:
+            try:
+                func()
+            except Exception as e:
+                # Mimic PyErr_WriteUnraisable
+                print("Error running handler %s: %s" % (func, e), file=sys.stderr)
+
+    cdef _pthread_atfork_prepare():
+        _run_handlers(_before)
+
+    cdef _pthread_atfork_after_in_parent():
+        _run_handlers(_after_in_parent)
+
+    cdef _pthread_atfork_after_in_child():
+        _run_handlers(_after_in_child)
+
+    pthread_atfork(&_pthread_atfork_prepare, &_pthread_atfork_after_in_parent, &_pthread_atfork_after_in_child)

--- a/ddtrace/internal/_rand.pyx
+++ b/ddtrace/internal/_rand.pyx
@@ -87,9 +87,9 @@ cpdef rand64bits(check_pid=True):
     return <uint64_t>(state * <uint64_t>2685821657736338717)
 
 
-# Should be available in Python 3.7+
-if hasattr(os, "register_at_fork"):
-    os.register_at_fork(after_in_child=seed)
+# Should be available on POSIX platforms
+if hasattr(compat, "register_at_fork"):
+    compat.register_at_fork(after_in_child=seed)
 
 
 seed()

--- a/ddtrace/internal/runtime/__init__.py
+++ b/ddtrace/internal/runtime/__init__.py
@@ -1,6 +1,8 @@
 import os
 import uuid
 
+from ddtrace import compat
+
 from .runtime_metrics import (
     RuntimeTags,
     RuntimeMetrics,
@@ -23,13 +25,13 @@ def _generate_runtime_id():
 _RUNTIME_ID = _generate_runtime_id()
 
 
-if hasattr(os, "register_at_fork"):
+if hasattr(compat, "register_at_fork"):
 
     def _set_runtime_id():
         global _RUNTIME_ID
         _RUNTIME_ID = _generate_runtime_id()
 
-    os.register_at_fork(after_in_child=_set_runtime_id)
+    compat.register_at_fork(after_in_child=_set_runtime_id)
 
     def get_runtime_id():
         return _RUNTIME_ID

--- a/ddtrace/profiling/bootstrap/sitecustomize.py
+++ b/ddtrace/profiling/bootstrap/sitecustomize.py
@@ -14,7 +14,10 @@ def start_profiler():
         # Python 2 does not have unregister so we can't use it all the time
         if six.PY3:
             atexit.unregister(bootstrap.profiler.stop)
-        bootstrap.profiler.stop()
+        # Do not flush the profiler since we don't care about the events from our parents
+        # This also prevents deadlocking on Python < 3.7 since our version of register_at_fork do not unlock the
+        # `threading.Lock` of our parent and prevents us of join()ing the profiler threads.
+        bootstrap.profiler.stop(flush=False)
     # Export the profiler so we can introspect it if needed
     bootstrap.profiler = profiler.Profiler()
     bootstrap.profiler.start()

--- a/ddtrace/profiling/bootstrap/sitecustomize.py
+++ b/ddtrace/profiling/bootstrap/sitecustomize.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 """Bootstrapping code that is run when using the `pyddprofile`."""
 import atexit
-import os
 
+from ddtrace import compat
 from ddtrace.profiling import bootstrap
 from ddtrace.profiling import profiler
 from ddtrace.vendor import six
@@ -24,5 +24,5 @@ def start_profiler():
 start_profiler()
 # When forking, all threads are stop in the child.
 # Restart a new profiler.
-if hasattr(os, "register_at_fork"):
-    os.register_at_fork(after_in_child=start_profiler)
+if hasattr(compat, "register_at_fork"):
+    compat.register_at_fork(after_in_child=start_profiler)

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -133,8 +133,9 @@ class Profiler(object):
         for col in reversed(self.collectors):
             col.stop()
 
-        for col in reversed(self.collectors):
-            col.join()
+        if flush:
+            for col in reversed(self.collectors):
+                col.join()
 
         for s in reversed(self.schedulers):
             s.stop()

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -167,12 +167,11 @@ Handling `os.fork`
 When your process forks using `os.fork`, the profiler is stopped in the child
 process.
 
-For Python 3.7 and later on POSIX platforms, a new profiler will be started if
-you enabled the profiler via `pyddprofile` or `ddtrace.profiling.auto`.
+For POSIX platforms, a new profiler will be started if you enabled the profiler
+via `pyddprofile` or `ddtrace.profiling.auto`.
 
-If you manually instrument the profiler, or if you rely on Python 3.6 or a
-non-POSIX platform and earlier version, you'll have to manually restart the
-profiler in your child.
+If you manually instrument the profiler, or if you rely on a non-POSIX
+platform, you'll have to manually restart the profiler in your child.
 
 The global profiler instrumented by `pyddprofile` and `ddtrace.profiling.auto`
 can be started by calling `ddtrace.profiling.auto.start_profiler`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude = '''
   | build/
   | dist/
   | ddtrace/(
-    (?!(compat|monkey|span|__init__|_hooks)\.py$)[^/]+\.py$
+    (?!(monkey|span|__init__|_hooks)\.py$)[^/]+\.py$
     | commands/
     | contrib/
     (

--- a/setup.py
+++ b/setup.py
@@ -153,9 +153,7 @@ setup(
                 Cython.Distutils.Extension(
                     "ddtrace.internal._rand", sources=["ddtrace/internal/_rand.pyx"], language="c",
                 ),
-                Cython.Distutils.Extension(
-                    "ddtrace.compat._os", sources=["ddtrace/compat/_os.pyx"], language="c",
-                ),
+                Cython.Distutils.Extension("ddtrace.compat._os", sources=["ddtrace/compat/_os.pyx"], language="c",),
                 Cython.Distutils.Extension(
                     "ddtrace.profiling.collector.stack",
                     sources=["ddtrace/profiling/collector/stack.pyx"],

--- a/setup.py
+++ b/setup.py
@@ -154,6 +154,9 @@ setup(
                     "ddtrace.internal._rand", sources=["ddtrace/internal/_rand.pyx"], language="c",
                 ),
                 Cython.Distutils.Extension(
+                    "ddtrace.compat._os", sources=["ddtrace/compat/_os.pyx"], language="c",
+                ),
+                Cython.Distutils.Extension(
                     "ddtrace.profiling.collector.stack",
                     sources=["ddtrace/profiling/collector/stack.pyx"],
                     language="c",

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -10,7 +10,7 @@ import os
 import threading
 
 from ddtrace import tracer, Span
-from ddtrace.compat import PYTHON_VERSION_INFO, Queue
+from ddtrace.compat import Queue
 from ddtrace.internal import _rand
 
 
@@ -35,15 +35,7 @@ def test_fork_no_pid_check():
         rns = {_rand.rand64bits(check_pid=False) for _ in range(100)}
         child_rns = q.get()
 
-        if PYTHON_VERSION_INFO >= (3, 7):
-            # Python 3.7+ have fork hooks which should be used
-            # Hence we should not get any collisions
-            assert rns & child_rns == set()
-        else:
-            # Python < 3.7 we don't have any mechanism (other than the pid
-            # check) to reseed on so we expect there to be collisions.
-            assert rns == child_rns
-
+        assert rns & child_rns == set()
     else:
         # child
         try:
@@ -68,15 +60,7 @@ def test_fork_pid_check():
         rns = {_rand.rand64bits(check_pid=True) for _ in range(100)}
         child_rns = q.get()
 
-        if PYTHON_VERSION_INFO >= (3, 7):
-            # Python 3.7+ have fork hooks which should be used
-            # Hence we should not get any collisions
-            assert rns & child_rns == set()
-        else:
-            # Python < 3.7 we have the pid check so there also
-            # should not be any collisions.
-            assert rns & child_rns == set()
-
+        assert rns & child_rns == set()
     else:
         # child
         try:


### PR DESCRIPTION
## refactor: allow to use register_at_fork on Python < 3.7

For platforms that provides pthread_atfork, we make it possible to have
os.register_at_fork even if it does not exist in old Python versions.

## feat: switch to compat.register_at_fork

This improves compatibility for register_at_fork to all Python versions.

## fix(profiling): do not join collector threads when not flushing

This makes stopping the profiler faster if no flushing is intended.
This also fixes an issue when stopping the profiler after forking.
