### PR TITLE
ci: do not install tox in the base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ commands:
       # We should be doing `pip install tox`
       # But since ddtrace_py image has already tox, we need to force the
       # upgrade here
-      # FIXME: remove tox from the base image
+      # FIXME: remove -U as soon as the CI Docker image is rebuilt
       - run: pip install -U tox virtualenv
 
   restore_tox_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,4 @@ RUN \
   && pyenv global 2.7.17 3.5.9 3.6.9 3.7.7 3.8.3 3.9-dev \
   && pip install --upgrade pip
 
-# Install Python dependencies
-# DEV: `tox==3.7` introduced parallel execution mode
-#      https://tox.readthedocs.io/en/3.7.0/example/basic.html#parallel-mode
-RUN pip install "tox>=3.7,<4.0"
-
 CMD ["/bin/bash"]


### PR DESCRIPTION
It is automatically pulled by CircleCI job.
