### PR TITLE
ci: fix install -U for tox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,11 +78,7 @@ commands:
   setup_tox:
     description: "Install tox"
     steps:
-      # We should be doing `pip install tox`
-      # But since ddtrace_py image has already tox, we need to force the
-      # upgrade here
-      # FIXME: remove -U as soon as the CI Docker image is rebuilt
-      - run: pip install -U tox virtualenv
+      - run: pip install tox
 
   restore_tox_cache:
     description: "Restore .tox directory from previous runs for faster installs"


### PR DESCRIPTION
Do not install virtualenv, we don't use it (directly).