### PR TITLE
feat(redis): add global service configuration

### DIFF
--- a/ddtrace/contrib/redis/__init__.py
+++ b/ddtrace/contrib/redis/__init__.py
@@ -1,20 +1,35 @@
-"""Instrument redis to report Redis queries.
+"""
+Traces redis client queries.
 
-``patch_all`` will automatically patch your Redis client to make it work.
-::
+If you are not autoinstrumenting with ``ddtrace-run`` then install the redis
+instrumentation with::
 
-    from ddtrace import Pin, patch
+    from ddtrace import patch
+    patch(redis=True)
+
+
+Global Configuration
+~~~~~~~~~~~~~~~~~~~~
+
+.. py:data:: ddtrace.config.redis["service"]
+
+   The service name reported by default for your redis instances.
+
+   Default: ``"redis"``
+
+
+Instance Configuration
+~~~~~~~~~~~~~~~~~~~~~~
+
+    from ddtrace import Pin
     import redis
 
-    # If not patched yet, you can patch redis specifically
-    patch(redis=True)
+    # Override service name for this instance
+    Pin.override(client, service="redis-queue")
 
     # This will report a span with the default settings
     client = redis.StrictRedis(host="localhost", port=6379)
     client.get("my-key")
-
-    # Use a pin to specify metadata related to this client
-    Pin.override(client, service='redis-queue')
 """
 
 from ...utils.importlib import require_modules

--- a/ddtrace/contrib/redis/__init__.py
+++ b/ddtrace/contrib/redis/__init__.py
@@ -19,11 +19,11 @@
 
 from ...utils.importlib import require_modules
 
-required_modules = ['redis', 'redis.client']
+required_modules = ["redis", "redis.client"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
         from .patch import patch
         from .tracers import get_traced_redis, get_traced_redis_from
 
-        __all__ = ['get_traced_redis', 'get_traced_redis_from', 'patch']
+        __all__ = ["get_traced_redis", "get_traced_redis_from", "patch"]

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -13,12 +13,7 @@ from ... import utils
 from .util import format_command_args, _extract_conn_tags
 
 
-config._add(
-    "redis",
-    dict(
-        service=get_env("redis", "service") or redisx.DEFAULT_SERVICE,
-    )
-)
+config._add("redis", dict(service=get_env("redis", "service") or redisx.DEFAULT_SERVICE,))
 
 
 def patch():
@@ -27,41 +22,41 @@ def patch():
     This duplicated doesn't look nice. The nicer alternative is to use an ObjectProxy on top
     of Redis and StrictRedis. However, it means that any "import redis.Redis" won't be instrumented.
     """
-    if getattr(redis, '_datadog_patch', False):
+    if getattr(redis, "_datadog_patch", False):
         return
-    setattr(redis, '_datadog_patch', True)
+    setattr(redis, "_datadog_patch", True)
 
     _w = wrapt.wrap_function_wrapper
 
     if redis.VERSION < (3, 0, 0):
-        _w('redis', 'StrictRedis.execute_command', traced_execute_command)
-        _w('redis', 'StrictRedis.pipeline', traced_pipeline)
-        _w('redis', 'Redis.pipeline', traced_pipeline)
-        _w('redis.client', 'BasePipeline.execute', traced_execute_pipeline)
-        _w('redis.client', 'BasePipeline.immediate_execute_command', traced_execute_command)
+        _w("redis", "StrictRedis.execute_command", traced_execute_command)
+        _w("redis", "StrictRedis.pipeline", traced_pipeline)
+        _w("redis", "Redis.pipeline", traced_pipeline)
+        _w("redis.client", "BasePipeline.execute", traced_execute_pipeline)
+        _w("redis.client", "BasePipeline.immediate_execute_command", traced_execute_command)
     else:
-        _w('redis', 'Redis.execute_command', traced_execute_command)
-        _w('redis', 'Redis.pipeline', traced_pipeline)
-        _w('redis.client', 'Pipeline.execute', traced_execute_pipeline)
-        _w('redis.client', 'Pipeline.immediate_execute_command', traced_execute_command)
+        _w("redis", "Redis.execute_command", traced_execute_command)
+        _w("redis", "Redis.pipeline", traced_pipeline)
+        _w("redis.client", "Pipeline.execute", traced_execute_pipeline)
+        _w("redis.client", "Pipeline.immediate_execute_command", traced_execute_command)
     Pin(service=None, app=redisx.APP).onto(redis.StrictRedis)
 
 
 def unpatch():
-    if getattr(redis, '_datadog_patch', False):
-        setattr(redis, '_datadog_patch', False)
+    if getattr(redis, "_datadog_patch", False):
+        setattr(redis, "_datadog_patch", False)
 
         if redis.VERSION < (3, 0, 0):
-            unwrap(redis.StrictRedis, 'execute_command')
-            unwrap(redis.StrictRedis, 'pipeline')
-            unwrap(redis.Redis, 'pipeline')
-            unwrap(redis.client.BasePipeline, 'execute')
-            unwrap(redis.client.BasePipeline, 'immediate_execute_command')
+            unwrap(redis.StrictRedis, "execute_command")
+            unwrap(redis.StrictRedis, "pipeline")
+            unwrap(redis.Redis, "pipeline")
+            unwrap(redis.client.BasePipeline, "execute")
+            unwrap(redis.client.BasePipeline, "immediate_execute_command")
         else:
-            unwrap(redis.Redis, 'execute_command')
-            unwrap(redis.Redis, 'pipeline')
-            unwrap(redis.client.Pipeline, 'execute')
-            unwrap(redis.client.Pipeline, 'immediate_execute_command')
+            unwrap(redis.Redis, "execute_command")
+            unwrap(redis.Redis, "pipeline")
+            unwrap(redis.client.Pipeline, "execute")
+            unwrap(redis.client.Pipeline, "immediate_execute_command")
 
 
 #
@@ -72,7 +67,9 @@ def traced_execute_command(func, instance, args, kwargs):
     if not pin or not pin.enabled():
         return func(*args, **kwargs)
 
-    with pin.tracer.trace(redisx.CMD, service=utils.external_service(config.redis, pin), span_type=SpanTypes.REDIS) as s:
+    with pin.tracer.trace(
+        redisx.CMD, service=utils.external_service(config.redis, pin), span_type=SpanTypes.REDIS
+    ) as s:
         s.set_tag(SPAN_MEASURED_KEY)
         query = format_command_args(args)
         s.resource = query
@@ -82,10 +79,7 @@ def traced_execute_command(func, instance, args, kwargs):
         s.set_tags(_get_tags(instance))
         s.set_metric(redisx.ARGS_LEN, len(args))
         # set analytics sample rate if enabled
-        s.set_tag(
-            ANALYTICS_SAMPLE_RATE_KEY,
-            config.redis.get_analytics_sample_rate()
-        )
+        s.set_tag(ANALYTICS_SAMPLE_RATE_KEY, config.redis.get_analytics_sample_rate())
         # run the command
         return func(*args, **kwargs)
 
@@ -105,19 +99,18 @@ def traced_execute_pipeline(func, instance, args, kwargs):
 
     # FIXME[matt] done in the agent. worth it?
     cmds = [format_command_args(c) for c, _ in instance.command_stack]
-    resource = '\n'.join(cmds)
+    resource = "\n".join(cmds)
     tracer = pin.tracer
-    with tracer.trace(redisx.CMD, resource=resource, service=utils.external_service(config.redis, pin), span_type=SpanTypes.REDIS) as s:
+    with tracer.trace(
+        redisx.CMD, resource=resource, service=utils.external_service(config.redis, pin), span_type=SpanTypes.REDIS
+    ) as s:
         s.set_tag(SPAN_MEASURED_KEY)
         s.set_tag(redisx.RAWCMD, resource)
         s.set_tags(_get_tags(instance))
         s.set_metric(redisx.PIPELINE_LEN, len(instance.command_stack))
 
         # set analytics sample rate if enabled
-        s.set_tag(
-            ANALYTICS_SAMPLE_RATE_KEY,
-            config.redis.get_analytics_sample_rate()
-        )
+        s.set_tag(ANALYTICS_SAMPLE_RATE_KEY, config.redis.get_analytics_sample_rate())
 
         return func(*args, **kwargs)
 

--- a/ddtrace/contrib/redis/tracers.py
+++ b/ddtrace/contrib/redis/tracers.py
@@ -3,15 +3,15 @@ from redis import StrictRedis
 from ...utils.deprecation import deprecated
 
 
-DEFAULT_SERVICE = 'redis'
+DEFAULT_SERVICE = "redis"
 
 
-@deprecated(message='Use patching instead (see the docs).', version='1.0.0')
+@deprecated(message="Use patching instead (see the docs).", version="1.0.0")
 def get_traced_redis(ddtracer, service=DEFAULT_SERVICE, meta=None):
     return _get_traced_redis(ddtracer, StrictRedis, service, meta)
 
 
-@deprecated(message='Use patching instead (see the docs).', version='1.0.0')
+@deprecated(message="Use patching instead (see the docs).", version="1.0.0")
 def get_traced_redis_from(ddtracer, baseclass, service=DEFAULT_SERVICE, meta=None):
     return _get_traced_redis(ddtracer, baseclass, service, meta)
 

--- a/ddtrace/contrib/redis/util.py
+++ b/ddtrace/contrib/redis/util.py
@@ -4,9 +4,9 @@ Some utils used by the dogtrace redis integration
 from ...compat import stringify
 from ...ext import redis as redisx, net
 
-VALUE_PLACEHOLDER = '?'
+VALUE_PLACEHOLDER = "?"
 VALUE_MAX_LEN = 100
-VALUE_TOO_LONG_MARK = '...'
+VALUE_TOO_LONG_MARK = "..."
 CMD_MAX_LEN = 1000
 
 
@@ -14,9 +14,9 @@ def _extract_conn_tags(conn_kwargs):
     """ Transform redis conn info into dogtrace metas """
     try:
         return {
-            net.TARGET_HOST: conn_kwargs['host'],
-            net.TARGET_PORT: conn_kwargs['port'],
-            redisx.DB: conn_kwargs['db'] or 0,
+            net.TARGET_HOST: conn_kwargs["host"],
+            net.TARGET_PORT: conn_kwargs["port"],
+            redisx.DB: conn_kwargs["db"] or 0,
         }
     except Exception:
         return {}
@@ -39,8 +39,8 @@ def format_command_args(args):
                 cmd = cmd[:VALUE_MAX_LEN] + VALUE_TOO_LONG_MARK
 
             if length + len(cmd) > CMD_MAX_LEN:
-                prefix = cmd[:CMD_MAX_LEN - length]
-                out.append('%s%s' % (prefix, VALUE_TOO_LONG_MARK))
+                prefix = cmd[: CMD_MAX_LEN - length]
+                out.append("%s%s" % (prefix, VALUE_TOO_LONG_MARK))
                 break
 
             out.append(cmd)
@@ -49,4 +49,4 @@ def format_command_args(args):
             out.append(VALUE_PLACEHOLDER)
             break
 
-    return ' '.join(out)
+    return " ".join(out)

--- a/ddtrace/ext/redis.py
+++ b/ddtrace/ext/redis.py
@@ -1,19 +1,19 @@
 from . import SpanTypes
 
 # defaults
-APP = 'redis'
-DEFAULT_SERVICE = 'redis'
+APP = "redis"
+DEFAULT_SERVICE = "redis"
 
 # [TODO] Deprecated, remove when we remove AppTypes
 # type of the spans
 TYPE = SpanTypes.REDIS
 
 # net extension
-DB = 'out.redis_db'
+DB = "out.redis_db"
 
 # standard tags
-RAWCMD = 'redis.raw_command'
-CMD = 'redis.command'
-ARGS_LEN = 'redis.args_length'
-PIPELINE_LEN = 'redis.pipeline_length'
-PIPELINE_AGE = 'redis.pipeline_age'
+RAWCMD = "redis.raw_command"
+CMD = "redis.command"
+ARGS_LEN = "redis.args_length"
+PIPELINE_LEN = "redis.pipeline_length"
+PIPELINE_AGE = "redis.pipeline_age"

--- a/ddtrace/utils/__init__.py
+++ b/ddtrace/utils/__init__.py
@@ -25,3 +25,13 @@ class removed_classproperty(property):
             "Usage of ddtrace.ext.AppTypes is not longer supported, please use ddtrace.ext.SpanTypes"
         )
         return classmethod(self.fget).__get__(None, owner)()
+
+
+def external_service(config, pin):
+    if pin.service:
+        return pin.service
+    elif config.service:
+        return config.service
+    elif config.service_name:
+        return config.service_name
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ exclude = '''
       | pymongo
       | pymysql
       | pyramid
-      | redis
       | rediscluster
       | requests/
       (
@@ -93,7 +92,6 @@ exclude = '''
        | mongo.py
        | net.py
        | priority.py
-       | redis.py
        | sql.py
        | system.py
     )
@@ -150,7 +148,6 @@ exclude = '''
         | test_pyramid.py
         | test_pyramid_autopatch.py
       )
-      | redis
       | rediscluster
       | requests
       | requests_gevent

--- a/tests/commands/ddtrace_run_integration.py
+++ b/tests/commands/ddtrace_run_integration.py
@@ -13,8 +13,6 @@ if __name__ == '__main__':
     r = redis.Redis(port=REDIS_CONFIG['port'])
     pin = Pin.get_from(r)
     assert pin
-    assert pin.app == 'redis'
-    assert pin.service == 'redis'
 
     pin.tracer.writer = DummyWriter()
     r.flushall()


### PR DESCRIPTION
This patch adds global configuration functionality for setting the service in the redis integration.


A helper `utils.external_service` is added to be used in all external integrations to aid in setting the service name