### PR TITLE
ci: fix available Python versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,8 @@ RUN \
   && pyenv install 3.7.7 \
   && pyenv install 3.8.3 \
   && pyenv install 3.9-dev \
-  && pyenv global 2.7.17 3.5.9 3.6.9 3.7.7 3.8.3 3.9-dev \
+  # Order matters: first version is the global one
+  && pyenv global 3.8.3 2.7.17 3.5.9 3.6.9 3.7.7 3.9-dev \
   && pip install --upgrade pip
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN \
   && pyenv install 3.7.7 \
   && pyenv install 3.8.3 \
   && pyenv install 3.9-dev \
-  && pyenv global 3.8.3 \
+  && pyenv global 2.7.17 3.5.9 3.6.9 3.7.7 3.8.3 3.9-dev \
   && pip install --upgrade pip
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
## revert(ci): use Python 3.8 by default (#1510)

This reverts commit 94e6a849ff14a03b1227b2d9e9f629c429afee57.

## ci: set Python 3.8 by default