### PR TITLE
feat(django): Add config for defining top-level resource name format (from PR 1415)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 # VS Code
 .vscode/
+
+# Mac
+.DS_Store

--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -101,6 +101,20 @@ Configuration
 
    Default: ``True``
 
+.. py:data:: ddtrace.config.django['parent_resource_format']
+
+   The format to use when settings the resource name for the parent django request.
+
+   This accepts a format string that has access to three variables, `handler`, `urlpattern`, and `method`.
+
+   For example, `"{method} {handler} {urlpattern}"` would name the top resource something like `GET myapp.views.index ^$`.
+
+   *Note:* `urlpattern` is not available for Django versions before 2.2.0. An empty string will be returned for that value instead.
+
+   Defaults:
+   Django >= 2.2.0: `"{method} {urlpattern}"`
+   Django < 2.2.0: `"{method} {handler}"`
+
 
 Example::
 

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -1348,3 +1348,50 @@ def test_user_name_excluded(client, test_spans):
     root = test_spans.get_root_span()
     assert "django.user.name" not in root.meta
     assert root.meta.get("django.user.is_authenticated") == "True"
+
+
+"""
+Test parent resource name formatting
+"""
+
+
+def test_django_parent_resource_name_format(client, test_spans):
+    """
+    Test that the expected format is used when not specified in settings.
+    """
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.content == b"Hello, test app."
+
+    # Assert the structure of the root `django.request` span
+    root = test_spans.get_root_span()
+    if django.VERSION >= (2, 2, 0):
+        resource = "GET ^$"
+    else:
+        resource = "GET tests.contrib.django.views.index"
+
+    root.assert_matches(resource=resource, parent_id=None, span_type="http")
+
+
+def test_django_root_span_name_format(client, test_spans):
+    """
+    Test that the specified format is used over the default.
+    """
+    if django.VERSION >= (2, 2, 0):
+        resource_format = "{urlpattern} {method}"
+    else:
+        resource_format = "{handler} {method}"
+
+    with BaseTestCase.override_config("django", dict(parent_resource_format=resource_format)):
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert resp.content == b"Hello, test app."
+
+        # Assert the structure of the root `django.request` span
+        root = test_spans.get_root_span()
+        if django.VERSION >= (2, 2, 0):
+            resource = "^$ GET"
+        else:
+            resource = "tests.contrib.django.views.index GET"
+
+        root.assert_matches(resource=resource, parent_id=None, span_type="http")


### PR DESCRIPTION
This is for PR #1415  but with the commits rebased against master HEAD.