### PR TITLE
feat(profiling): enable agent upload by default (#1494)

### DIFF
--- a/ddtrace/profiling/exporter/http.py
+++ b/ddtrace/profiling/exporter/http.py
@@ -7,7 +7,6 @@ import platform
 
 import tenacity
 
-from ddtrace.utils import deprecation
 from ddtrace.utils.formats import parse_tags_str
 from ddtrace.vendor import six
 from ddtrace.vendor.six.moves import http_client
@@ -28,50 +27,22 @@ PYTHON_IMPLEMENTATION = platform.python_implementation().encode()
 PYTHON_VERSION = platform.python_version().encode()
 
 
-class InvalidEndpoint(ValueError):
-    pass
-
-
 class UploadFailed(exporter.ExportError):
     """Upload failure."""
 
-    def __init__(self, exception):
+    def __init__(self, exception, msg=None):
         """Create a failed upload error based on raised exceptions."""
         self.exception = exception
-        super(UploadFailed, self).__init__("Unable to upload profile: " + _traceback.format_exception(exception))
-
-
-def _get_api_key():
-    legacy = _attr.from_env("DD_PROFILING_API_KEY", "", str)()
-    if legacy:
-        deprecation.deprecation("DD_PROFILING_API_KEY", "Use DD_API_KEY")
-        return legacy
-    return _attr.from_env("DD_API_KEY", "", str)()
-
-
-ENDPOINT_TEMPLATE = "https://intake.profile.{}/v1/input"
-
-
-def _get_endpoint():
-    legacy = _attr.from_env("DD_PROFILING_API_URL", "", str)()
-    if legacy:
-        deprecation.deprecation("DD_PROFILING_API_URL", "Use DD_SITE")
-        return legacy
-    site = _attr.from_env("DD_SITE", "datadoghq.com", str)()
-    return ENDPOINT_TEMPLATE.format(site)
-
-
-def _validate_enpoint(instance, attribute, value):
-    if not value:
-        raise InvalidEndpoint("Endpoint is empty")
+        msg = _traceback.format_exception(exception) if msg is None else msg
+        super(UploadFailed, self).__init__("Unable to upload profile: " + msg)
 
 
 @attr.s
 class PprofHTTPExporter(pprof.PprofExporter):
     """PProf HTTP exporter."""
 
-    endpoint = attr.ib(factory=_get_endpoint, type=str, validator=_validate_enpoint)
-    api_key = attr.ib(factory=_get_api_key, type=str)
+    endpoint = attr.ib()
+    api_key = attr.ib(default=None)
     timeout = attr.ib(factory=_attr.from_env("DD_PROFILING_API_TIMEOUT", 10, float), type=float)
     service = attr.ib(default=None)
     env = attr.ib(default=None)
@@ -138,6 +109,12 @@ class PprofHTTPExporter(pprof.PprofExporter):
         tags.update({k: six.ensure_binary(v) for k, v in user_tags.items()})
         return tags
 
+    @staticmethod
+    def _retry_on_http_5xx(exception):
+        if isinstance(exception, error.HTTPError):
+            return 500 <= exception.code < 600
+        return True
+
     def export(self, events, start_time_ns, end_time_ns):
         """Export events to an HTTP endpoint.
 
@@ -145,9 +122,12 @@ class PprofHTTPExporter(pprof.PprofExporter):
         :param start_time_ns: The start time of recording.
         :param end_time_ns: The end time of recording.
         """
-        common_headers = {
-            "DD-API-KEY": self.api_key.encode(),
-        }
+        if self.api_key:
+            headers = {
+                "DD-API-KEY": self.api_key.encode(),
+            }
+        else:
+            headers = {}
 
         profile = super(PprofHTTPExporter, self).export(events, start_time_ns, end_time_ns)
         s = six.BytesIO()
@@ -170,7 +150,6 @@ class PprofHTTPExporter(pprof.PprofExporter):
         service = self.service or os.path.basename(profile.string_table[profile.mapping[0].filename])
 
         content_type, body = self._encode_multipart_formdata(fields, tags=self._get_tags(service),)
-        headers = common_headers.copy()
         headers["Content-Type"] = content_type
 
         # urllib uses `POST` if `data` is supplied (Python 2 version does not handle `method` kwarg)
@@ -180,12 +159,20 @@ class PprofHTTPExporter(pprof.PprofExporter):
             # Retry after 1s, 2s, 4s, 8s with some randomness
             wait=tenacity.wait_random_exponential(multiplier=0.5),
             stop=tenacity.stop_after_delay(self.max_retry_delay),
-            retry=tenacity.retry_if_exception_type(
-                (error.HTTPError, error.URLError, http_client.HTTPException, OSError, IOError)
-            ),
+            retry=tenacity.retry_if_exception_type((http_client.HTTPException, OSError, IOError))
+            & tenacity.retry_if_exception(self._retry_on_http_5xx),
         )
 
         try:
             retry(request.urlopen, req, timeout=self.timeout)
         except tenacity.RetryError as e:
             raise UploadFailed(e.last_attempt.exception())
+        except error.HTTPError as e:
+            if e.code == 404 and not self.api_key:
+                msg = (
+                    "Datadog Agent is not accepting profiles. "
+                    "Agent-based profiling deployments require Datadog Agent >= 7.20"
+                )
+            else:
+                msg = None
+            raise UploadFailed(e, msg)

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -4,6 +4,7 @@ import os
 
 from ddtrace.profiling import recorder
 from ddtrace.profiling import scheduler
+from ddtrace.utils import deprecation
 from ddtrace.vendor import attr
 from ddtrace.profiling.collector import exceptions
 from ddtrace.profiling.collector import memory
@@ -16,19 +17,45 @@ from ddtrace.profiling.exporter import http
 LOG = logging.getLogger(__name__)
 
 
-def _build_default_exporters(service, env, version):
-    exporters = []
-    if "DD_PROFILING_API_KEY" in os.environ or "DD_API_KEY" in os.environ:
-        exporters.append(http.PprofHTTPExporter(service=service, env=env, version=version))
+ENDPOINT_TEMPLATE = "https://intake.profile.{}/v1/input"
 
+
+def _get_endpoint():
+    legacy = os.environ.get("DD_PROFILING_API_URL")
+    if legacy:
+        deprecation.deprecation("DD_PROFILING_API_URL", "Use DD_SITE")
+        return legacy
+    site = os.environ.get("DD_SITE", "datadoghq.com")
+    return ENDPOINT_TEMPLATE.format(site)
+
+
+def _get_api_key():
+    legacy = os.environ.get("DD_PROFILING_API_KEY")
+    if legacy:
+        deprecation.deprecation("DD_PROFILING_API_KEY", "Use DD_API_KEY")
+        return legacy
+    return os.environ.get("DD_API_KEY")
+
+
+def _build_default_exporters(service, env, version):
     _OUTPUT_PPROF = os.environ.get("DD_PROFILING_OUTPUT_PPROF")
     if _OUTPUT_PPROF:
-        exporters.append(file.PprofFileExporter(_OUTPUT_PPROF))
+        return [
+            file.PprofFileExporter(_OUTPUT_PPROF),
+        ]
 
-    if not exporters:
-        LOG.warning("No exporters are configured, no profile will be output")
+    api_key = _get_api_key()
+    if api_key:
+        # Agentless mode
+        endpoint = _get_endpoint()
+    else:
+        hostname = os.environ.get("DD_AGENT_HOST", os.environ.get("DATADOG_TRACE_AGENT_HOSTNAME", "localhost"))
+        port = int(os.environ.get("DD_TRACE_AGENT_PORT", 8126))
+        endpoint = os.environ.get("DD_TRACE_AGENT_URL", "http://%s:%d" % (hostname, port)) + "/profiling/v1/input"
 
-    return exporters
+    return [
+        http.PprofHTTPExporter(service=service, env=env, version=version, api_key=api_key, endpoint=endpoint),
+    ]
 
 
 def _get_service_name():

--- a/tests/profiling/exporter/test_http.py
+++ b/tests/profiling/exporter/test_http.py
@@ -91,12 +91,19 @@ class _ResetAPIEndpointRequestHandlerTest(_APIEndpointRequestHandlerTest):
         return
 
 
+class _UnknownAPIEndpointRequestHandlerTest(_APIEndpointRequestHandlerTest):
+    def do_POST(self):
+        self.send_error(404, "Argh")
+
+
 _PORT = 8992
 _TIMEOUT_PORT = _PORT + 1
 _RESET_PORT = _PORT + 2
+_UNKNOWN_PORT = _PORT + 3
 _ENDPOINT = "http://localhost:%d" % _PORT
 _TIMEOUT_ENDPOINT = "http://localhost:%d" % _TIMEOUT_PORT
 _RESET_ENDPOINT = "http://localhost:%d" % _RESET_PORT
+_UNKNOWN_ENDPOINT = "http://localhost:%d" % _UNKNOWN_PORT
 
 
 def _make_server(port, request_handler):
@@ -138,6 +145,16 @@ def endpoint_test_reset_server():
         thread.join()
 
 
+@pytest.fixture(scope="module")
+def endpoint_test_unknown_server():
+    server, thread = _make_server(_UNKNOWN_PORT, _UnknownAPIEndpointRequestHandlerTest)
+    try:
+        yield thread
+    finally:
+        server.shutdown()
+        thread.join()
+
+
 def test_wrong_api_key(endpoint_test_server):
     # This is mostly testing our test server, not the exporter
     exp = http.PprofHTTPExporter(_ENDPOINT, "this is not the right API key", max_retry_delay=10)
@@ -152,11 +169,6 @@ def test_wrong_api_key(endpoint_test_server):
 def test_export(endpoint_test_server):
     exp = http.PprofHTTPExporter(_ENDPOINT, _API_KEY)
     exp.export(test_pprof.TEST_EVENTS, 0, compat.time_ns())
-
-
-def test_export_no_endpoint(endpoint_test_server):
-    with pytest.raises(http.InvalidEndpoint):
-        http.PprofHTTPExporter(endpoint="")
 
 
 def test_export_server_down():
@@ -188,31 +200,30 @@ def test_export_reset(endpoint_test_reset_server):
         assert isinstance(e, http_client.BadStatusLine)
 
 
-def test_default_from_env(monkeypatch):
-    monkeypatch.setenv("DD_PROFILING_API_KEY", "123")
-    exp = http.PprofHTTPExporter()
-    assert exp.api_key == "123"
-    assert exp.endpoint == "https://intake.profile.datadoghq.com/v1/input"
+def test_export_404_agent(endpoint_test_unknown_server):
+    exp = http.PprofHTTPExporter(_UNKNOWN_ENDPOINT)
+    with pytest.raises(http.UploadFailed) as t:
+        exp.export(test_pprof.TEST_EVENTS, 0, 1)
+    e = t.value.exception
+    assert isinstance(e, error.HTTPError)
+    assert e.code == 404
+    assert str(t.value) == (
+        "Unable to upload profile: Datadog Agent is not accepting profiles. "
+        "Agent-based profiling deployments require Datadog Agent >= 7.20"
+    )
 
-    monkeypatch.setenv("DD_PROFILING_API_URL", "foobar")
-    exp = http.PprofHTTPExporter()
-    assert exp.endpoint == "foobar"
 
-    monkeypatch.setenv("DD_SITE", "datadoghq.eu")
-    exp = http.PprofHTTPExporter()
-    assert exp.endpoint == "foobar"
-
-    monkeypatch.delenv("DD_PROFILING_API_URL")
-    exp = http.PprofHTTPExporter()
-    assert exp.endpoint == "https://intake.profile.datadoghq.eu/v1/input"
-
-    monkeypatch.setenv("DD_API_KEY", "456")
-    exp = http.PprofHTTPExporter()
-    assert exp.api_key == "123"
-
-    monkeypatch.delenv("DD_PROFILING_API_KEY")
-    exp = http.PprofHTTPExporter()
-    assert exp.api_key == "456"
+def test_export_404_agentless(endpoint_test_unknown_server):
+    exp = http.PprofHTTPExporter(_UNKNOWN_ENDPOINT, api_key="123", timeout=1)
+    with pytest.raises(http.UploadFailed) as t:
+        exp.export(test_pprof.TEST_EVENTS, 0, 1)
+    e = t.value.exception
+    assert isinstance(e, error.HTTPError)
+    assert e.code == 404
+    if six.PY2:
+        assert str(t.value) == "Unable to upload profile: HTTPError: HTTP Error 404: Argh\n"
+    else:
+        assert str(t.value) == "Unable to upload profile: urllib.error.HTTPError: HTTP Error 404: Argh\n"
 
 
 def _check_tags_types(tags):
@@ -222,7 +233,7 @@ def _check_tags_types(tags):
 
 
 def test_get_tags():
-    tags = http.PprofHTTPExporter(env="foobar")._get_tags("foobar")
+    tags = http.PprofHTTPExporter(env="foobar", endpoint="")._get_tags("foobar")
     _check_tags_types(tags)
     assert len(tags) == 8
     assert tags["service"] == b"foobar"
@@ -237,7 +248,7 @@ def test_get_tags():
 
 def test_get_malformed(monkeypatch):
     monkeypatch.setenv("DD_TAGS", "mytagfoobar")
-    tags = http.PprofHTTPExporter()._get_tags("foobar")
+    tags = http.PprofHTTPExporter(endpoint="")._get_tags("foobar")
     _check_tags_types(tags)
     assert len(tags) == 7
     assert tags["service"] == b"foobar"
@@ -248,7 +259,7 @@ def test_get_malformed(monkeypatch):
     assert tags["profiler_version"] == ddtrace.__version__.encode("utf-8")
 
     monkeypatch.setenv("DD_TAGS", "mytagfoobar,")
-    tags = http.PprofHTTPExporter()._get_tags("foobar")
+    tags = http.PprofHTTPExporter(endpoint="")._get_tags("foobar")
     _check_tags_types(tags)
     assert len(tags) == 7
     assert tags["service"] == b"foobar"
@@ -259,7 +270,7 @@ def test_get_malformed(monkeypatch):
     assert tags["profiler_version"] == ddtrace.__version__.encode("utf-8")
 
     monkeypatch.setenv("DD_TAGS", ",")
-    tags = http.PprofHTTPExporter()._get_tags("foobar")
+    tags = http.PprofHTTPExporter(endpoint="")._get_tags("foobar")
     _check_tags_types(tags)
     assert len(tags) == 7
     assert tags["service"] == b"foobar"
@@ -270,7 +281,7 @@ def test_get_malformed(monkeypatch):
     assert tags["profiler_version"] == ddtrace.__version__.encode("utf-8")
 
     monkeypatch.setenv("DD_TAGS", "foo:bar,")
-    tags = http.PprofHTTPExporter()._get_tags("foobar")
+    tags = http.PprofHTTPExporter(endpoint="")._get_tags("foobar")
     _check_tags_types(tags)
     assert len(tags) == 8
     assert tags["service"] == b"foobar"
@@ -284,7 +295,7 @@ def test_get_malformed(monkeypatch):
 
 def test_get_tags_override(monkeypatch):
     monkeypatch.setenv("DD_TAGS", "mytag:foobar")
-    tags = http.PprofHTTPExporter()._get_tags("foobar")
+    tags = http.PprofHTTPExporter(endpoint="")._get_tags("foobar")
     _check_tags_types(tags)
     assert len(tags) == 8
     assert tags["service"] == b"foobar"
@@ -297,7 +308,7 @@ def test_get_tags_override(monkeypatch):
     assert "version" not in tags
 
     monkeypatch.setenv("DD_TAGS", "mytag:foobar,author:jd")
-    tags = http.PprofHTTPExporter()._get_tags("foobar")
+    tags = http.PprofHTTPExporter(endpoint="")._get_tags("foobar")
     _check_tags_types(tags)
     assert len(tags) == 9
     assert tags["service"] == b"foobar"
@@ -311,7 +322,7 @@ def test_get_tags_override(monkeypatch):
     assert "version" not in tags
 
     monkeypatch.setenv("DD_TAGS", "")
-    tags = http.PprofHTTPExporter()._get_tags("foobar")
+    tags = http.PprofHTTPExporter(endpoint="")._get_tags("foobar")
     _check_tags_types(tags)
     assert len(tags) == 7
     assert tags["service"] == b"foobar"
@@ -323,7 +334,7 @@ def test_get_tags_override(monkeypatch):
     assert "version" not in tags
 
     monkeypatch.setenv("DD_TAGS", "foobar:baz,service:mycustomservice")
-    tags = http.PprofHTTPExporter()._get_tags("foobar")
+    tags = http.PprofHTTPExporter(endpoint="")._get_tags("foobar")
     _check_tags_types(tags)
     assert len(tags) == 8
     assert tags["service"] == b"mycustomservice"
@@ -336,7 +347,7 @@ def test_get_tags_override(monkeypatch):
     assert "version" not in tags
 
     monkeypatch.setenv("DD_TAGS", "foobar:baz,service:🤣")
-    tags = http.PprofHTTPExporter()._get_tags("foobar")
+    tags = http.PprofHTTPExporter(endpoint="")._get_tags("foobar")
     _check_tags_types(tags)
     assert len(tags) == 8
     assert tags["service"] == u"🤣".encode("utf-8")
@@ -348,7 +359,7 @@ def test_get_tags_override(monkeypatch):
     assert tags["profiler_version"] == ddtrace.__version__.encode("utf-8")
     assert "version" not in tags
 
-    tags = http.PprofHTTPExporter(version="123")._get_tags("foobar")
+    tags = http.PprofHTTPExporter(endpoint="", version="123")._get_tags("foobar")
     _check_tags_types(tags)
     assert len(tags) == 9
     assert tags["service"] == u"🤣".encode("utf-8")
@@ -361,7 +372,7 @@ def test_get_tags_override(monkeypatch):
     assert tags["version"] == b"123"
     assert "env" not in tags
 
-    tags = http.PprofHTTPExporter(version="123", env="prod")._get_tags("foobar")
+    tags = http.PprofHTTPExporter(endpoint="", version="123", env="prod")._get_tags("foobar")
     _check_tags_types(tags)
     assert len(tags) == 10
     assert tags["service"] == u"🤣".encode("utf-8")
@@ -377,14 +388,14 @@ def test_get_tags_override(monkeypatch):
 
 def test_get_tags_legacy(monkeypatch):
     monkeypatch.setenv("DD_PROFILING_TAGS", "mytag:baz")
-    tags = http.PprofHTTPExporter()._get_tags("foobar")
+    tags = http.PprofHTTPExporter(endpoint="")._get_tags("foobar")
     _check_tags_types(tags)
     assert tags["mytag"] == b"baz"
 
     # precedence
     monkeypatch.setenv("DD_TAGS", "mytag:val1,ddtag:hi")
     monkeypatch.setenv("DD_PROFILING_TAGS", "mytag:val2,ddptag:lo")
-    tags = http.PprofHTTPExporter()._get_tags("foobar")
+    tags = http.PprofHTTPExporter(endpoint="")._get_tags("foobar")
     _check_tags_types(tags)
     assert tags["mytag"] == b"val2"
     assert tags["ddtag"] == b"hi"

--- a/tests/profiling/test_accuracy.py
+++ b/tests/profiling/test_accuracy.py
@@ -72,7 +72,7 @@ def total_time(time_data, funcname):
 def test_accuracy(monkeypatch):
     # Set this to 100 so we don't sleep too often and mess with the precision.
     monkeypatch.setenv("DD_PROFILING_MAX_TIME_USAGE_PCT", "100")
-    p = profiler.Profiler()
+    p = profiler.Profiler(exporters=[])
     p.start()
     spend_16()
     p.stop()


### PR DESCRIPTION
The upcoming Datadog agent release will support uploading profiles. This
enables its usage by default when configuration the profiler with no DD_API_KEY
set in the env.