### PR TITLE
ci: fix psycopg on Python 3.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -113,7 +113,8 @@ envlist =
     mysql_contrib-py{27,35,36,37,38}-mysqlconnector{80,}
     mysqldb_contrib-py27-mysqldb{12,}
     mysqldb_contrib-py{27,35,36,37,38}-mysqlclient{13,14,}
-    psycopg_contrib-{py27,py35,py36,37}-psycopg2{24,25,26,27,28}
+    psycopg_contrib-py{27,35,36}-psycopg2{24,25,26,27,28}
+    psycopg_contrib-py37-psycopg2{27,28}
 # psycopg <2.7 doesn't support Python 3.8: https://github.com/psycopg/psycopg2/issues/854
     psycopg_contrib-py{38}-psycopg2{28}
     pylibmc_contrib-py{27,35,36,37,38}-pylibmc{140,150,}


### PR DESCRIPTION
There is a typo in the psycopg env name which makes it use the default Python
version rather than Python 3.7.
