### PR TITLE
pin: make service optional

### DIFF
--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -68,7 +68,7 @@ def traced_execute_command(func, instance, args, kwargs):
         return func(*args, **kwargs)
 
     with pin.tracer.trace(
-        redisx.CMD, service=utils.external_service(config.redis, pin), span_type=SpanTypes.REDIS
+        redisx.CMD, service=utils.integration_service(config.redis, pin), span_type=SpanTypes.REDIS
     ) as s:
         s.set_tag(SPAN_MEASURED_KEY)
         query = format_command_args(args)
@@ -102,7 +102,7 @@ def traced_execute_pipeline(func, instance, args, kwargs):
     resource = "\n".join(cmds)
     tracer = pin.tracer
     with tracer.trace(
-        redisx.CMD, resource=resource, service=utils.external_service(config.redis, pin), span_type=SpanTypes.REDIS
+        redisx.CMD, resource=resource, service=utils.integration_service(config.redis, pin), span_type=SpanTypes.REDIS
     ) as s:
         s.set_tag(SPAN_MEASURED_KEY)
         s.set_tag(redisx.RAWCMD, resource)

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -29,7 +29,7 @@ class Pin(object):
     __slots__ = ['app', 'tags', 'tracer', '_target', '_config', '_initialized']
 
     @debtcollector.removals.removed_kwarg("app_type")
-    def __init__(self, service, app=None, app_type=None, tags=None, tracer=None, _config=None):
+    def __init__(self, service=None, app=None, app_type=None, tags=None, tracer=None, _config=None):
         tracer = tracer or ddtrace.tracer
         self.app = app
         self.tags = tags

--- a/ddtrace/utils/__init__.py
+++ b/ddtrace/utils/__init__.py
@@ -27,7 +27,7 @@ class removed_classproperty(property):
         return classmethod(self.fget).__get__(None, owner)()
 
 
-def external_service(config, pin):
+def integration_service(config, pin):
     if pin.service:
         return pin.service
     elif config.service:


### PR DESCRIPTION
The Pin is no longer the primary source of configuring the service name. As
such, it doesn't make sense to enforce that the service name be required since
it may be provided by a global configuration option instead.