### PR TITLE
fix(grpc): compute service name dynamically

### DIFF
--- a/ddtrace/contrib/grpc/__init__.py
+++ b/ddtrace/contrib/grpc/__init__.py
@@ -1,16 +1,36 @@
 """
-The gRPC integration traces the client and server using interceptor pattern.
+The gRPC integration traces the client and server using the interceptor pattern.
 
-gRPC will be automatically instrumented with ``patch_all``, or when using
-the ``ddtrace-run`` command.
-gRPC is instrumented on import. To instrument gRPC manually use the
-``patch`` function.::
 
-    import grpc
+Enabling
+~~~~~~~~
+
+The gRPC integration is enabled automatically when using
+:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+
+Or use :ref:`patch()<patch>` to manually enable the integration::
+
     from ddtrace import patch
     patch(grpc=True)
 
     # use grpc like usual
+
+
+Global Configuration
+~~~~~~~~~~~~~~~~~~~~
+
+.. py:data:: ddtrace.config.grpc["service_name"]
+
+   The service name reported by default for gRPC client instances.
+
+   This option can also be set with the ``DD_GRPC_SERVICE`` environment
+   variable.
+
+   Default: ``"grpc-client"``
+
+
+Instance Configuration
+~~~~~~~~~~~~~~~~~~~~~~
 
 To configure the gRPC integration on an per-channel basis use the
 ``Pin`` API::

--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -5,6 +5,7 @@ from ddtrace.vendor import wrapt
 from ddtrace import config
 from ddtrace.compat import to_unicode
 from ddtrace.ext import SpanTypes, errors
+from ... import utils
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -152,7 +153,10 @@ class _ClientInterceptor(
         tracer = self._pin.tracer
 
         span = tracer.trace(
-            "grpc", span_type=SpanTypes.GRPC, service=self._pin.service, resource=client_call_details.method,
+            "grpc",
+            span_type=SpanTypes.GRPC,
+            service=utils.integration_service(config.grpc, self._pin),
+            resource=client_call_details.method,
         )
 
         # tags for method details

--- a/ddtrace/contrib/grpc/server_interceptor.py
+++ b/ddtrace/contrib/grpc/server_interceptor.py
@@ -5,6 +5,7 @@ from ddtrace import config
 from ddtrace.ext import errors
 from ddtrace.compat import to_unicode
 
+from ... import utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY, SPAN_MEASURED_KEY
 from ...ext import SpanTypes
 from ...propagation.http import HTTPPropagator
@@ -74,7 +75,7 @@ class _TracedRpcMethodHandler(wrapt.ObjectProxy):
         span = tracer.trace(
             'grpc',
             span_type=SpanTypes.GRPC,
-            service=self._pin.service,
+            service=utils.integration_service(config.grpc_server, self._pin),
             resource=self._handler_call_details.method,
         )
         span.set_tag(SPAN_MEASURED_KEY)

--- a/ddtrace/utils/__init__.py
+++ b/ddtrace/utils/__init__.py
@@ -27,11 +27,23 @@ class removed_classproperty(property):
         return classmethod(self.fget).__get__(None, owner)()
 
 
-def integration_service(config, pin):
+def integration_service(config, pin, global_service_fallback=False):
+    """Compute the service name that should be used for an integration
+    based off the given config and pin instances.
+    """
     if pin.service:
         return pin.service
-    elif config.service:
+
+    # Integrations unfortuantely use both service and service_name in their
+    # configs :/
+    elif "service" in config:
         return config.service
-    elif config.service_name:
+    elif "service_name" in config:
         return config.service_name
-    return None
+    elif global_service_fallback:
+        return config.global_config._get_service()
+    else:
+        return None
+
+
+

--- a/ddtrace/utils/__init__.py
+++ b/ddtrace/utils/__init__.py
@@ -34,7 +34,7 @@ def integration_service(config, pin, global_service_fallback=False):
     if pin.service:
         return pin.service
 
-    # Integrations unfortuantely use both service and service_name in their
+    # Integrations unfortunately use both service and service_name in their
     # configs :/
     elif "service" in config:
         return config.service
@@ -44,6 +44,3 @@ def integration_service(config, pin, global_service_fallback=False):
         return config.global_config._get_service()
     else:
         return None
-
-
-

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -650,6 +650,8 @@ API
 
 .. autofunction:: ddtrace.monkey.patch_all
 
+.. _patch:
+
 ``patch``
 ^^^^^^^^^
 .. autofunction:: ddtrace.monkey.patch

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -449,7 +449,7 @@ class GrpcTestCase(BaseTracerTestCase):
             assert grpc.StatusCode.UNIMPLEMENTED == rpc_error.code()
 
     @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_server_app_service_name(self):
+    def test_app_service_name(self):
         """
         When a service name is specified by the user
             It should be used for grpc server spans
@@ -471,7 +471,7 @@ class GrpcTestCase(BaseTracerTestCase):
         self._check_client_span(spans[1], "mysvc-grpc-client", "SayHello", "unary")
 
     @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_server_service_name_config_override(self):
+    def test_service_name_config_override(self):
         """
         When a service name is specified by the user in config.grpc{_server}
             It should be used in grpc client spans
@@ -490,11 +490,10 @@ class GrpcTestCase(BaseTracerTestCase):
         self._check_client_span(spans[1], "myclientsvc", "SayHello", "unary")
 
     @BaseTracerTestCase.run_in_subprocess(env_overrides=dict(DD_GRPC_SERVICE="myclientsvc"))
-    def test_server_service_name_config_env_override(self):
+    def test_client_service_name_config_env_override(self):
         """
         When a service name is specified by the user in the DD_GRPC_SERVICE env var
             It should be used in grpc client spans
-            It should be used in grpc server spans
         """
         channel1 = grpc.insecure_channel("localhost:%d" % (_GRPC_PORT))
         stub1 = HelloStub(channel1)
@@ -502,10 +501,7 @@ class GrpcTestCase(BaseTracerTestCase):
         channel1.close()
 
         spans = self.get_spans_with_sync_and_assert(size=2)
-
-        self._check_server_span(spans[0], "myserversvc", "SayHello", "unary")
         self._check_client_span(spans[1], "myclientsvc", "SayHello", "unary")
-
 
 
 class _HelloServicer(HelloServicer):


### PR DESCRIPTION
The service name can be changed post-patch-time. This patch adds the
functionality to look-up the service name dynamically to achieve the correct
service name behaviour.