### PR TITLE
fix(profiling): use monotonic clock to compute duration

### DIFF
--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -29,7 +29,7 @@ class Scheduler(_periodic.PeriodicService):
         """Start the scheduler."""
         LOG.debug("Starting scheduler")
         super(Scheduler, self).start()
-        self._last_export = compat.time_ns()
+        self._last_export = compat.monotonic_ns()
         LOG.debug("Scheduler started")
 
     def flush(self):
@@ -38,7 +38,7 @@ class Scheduler(_periodic.PeriodicService):
         if self.exporters:
             events = self.recorder.reset()
             start = self._last_export
-            self._last_export = compat.time_ns()
+            self._last_export = compat.monotonic_ns()
             for exp in self.exporters:
                 try:
                     exp.export(events, start, self._last_export)

--- a/tests/profiling/exporter/test_http.py
+++ b/tests/profiling/exporter/test_http.py
@@ -168,7 +168,7 @@ def test_wrong_api_key(endpoint_test_server):
 
 def test_export(endpoint_test_server):
     exp = http.PprofHTTPExporter(_ENDPOINT, _API_KEY)
-    exp.export(test_pprof.TEST_EVENTS, 0, compat.time_ns())
+    exp.export(test_pprof.TEST_EVENTS, 0, compat.monotonic_ns())
 
 
 def test_export_server_down():


### PR DESCRIPTION
Using time_ns() might induce wrong results if the clock jumps.
