### PR TITLE
core: rewrite queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ ddtrace/profiling/collector/_traceback.c
 ddtrace/profiling/collector/stack.c
 ddtrace/profiling/_build.c
 ddtrace/internal/_rand.c
+ddtrace/internal/_queue.c
 *.so
 
 # Distribution / packaging

--- a/ddtrace/internal/_queue.pyx
+++ b/ddtrace/internal/_queue.pyx
@@ -1,0 +1,52 @@
+import threading
+
+from ddtrace.vendor import attr
+from ..internal.logger import get_logger
+from . import _rand
+
+
+log = get_logger(__name__)
+
+
+@attr.s
+class TraceQueue(object):
+
+    maxsize = attr.ib(type=int, default=0)
+    _lock = attr.ib(init=False, factory=threading.Lock, repr=False)
+    _queue = attr.ib(init=False, factory=list, repr=False)
+    _accepted = attr.ib(init=False, type=int, default=0)
+    _accepted_lengths = attr.ib(init=False, type=int, default=0)
+    _dropped = attr.ib(init=False, type=int, default=0)
+
+    def __len__(self):
+        return len(self._queue)
+
+    def put(self, item):
+        with self._lock:
+            if self.maxsize <= 0 or len(self._queue) < self.maxsize:
+                self._queue.append(item)
+            else:
+                idx = _rand.rand64bits() % len(self._queue)
+                self._queue[idx] = item
+
+                self._dropped += 1
+                log.warning("Trace queue %r is full, dropping a random trace", self)
+
+            self._accepted += 1
+            self._accepted_lengths += len(item) if hasattr(item, "__len__") else 1
+
+    def get(self):
+        with self._lock:
+            try:
+                return self._queue
+            finally:
+                self._queue = []
+
+    def pop_stats(self):
+        with self._lock:
+            try:
+                return self._dropped, self._accepted, self._accepted_lengths
+            finally:
+                self._accepted = 0
+                self._accepted_lengths = 0
+                self._dropped = 0

--- a/setup.py
+++ b/setup.py
@@ -161,6 +161,9 @@ setup(
                     "ddtrace.internal._rand", sources=["ddtrace/internal/_rand.pyx"], language="c",
                 ),
                 Cython.Distutils.Extension(
+                    "ddtrace.internal._queue", sources=["ddtrace/internal/_queue.pyx"], language="c",
+                ),
+                Cython.Distutils.Extension(
                     "ddtrace.profiling.collector.stack",
                     sources=["ddtrace/profiling/collector/stack.pyx"],
                     language="c",

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,6 +1,6 @@
-from ddtrace import Tracer
 import pytest
 
+from ddtrace import Tracer
 from .test_tracer import DummyWriter
 
 
@@ -111,3 +111,24 @@ def test_randbits_stdlib(benchmark):
     from ddtrace.compat import getrandbits
 
     benchmark(getrandbits, 64)
+
+
+@pytest.mark.benchmark(group="queue", min_time=0.005)
+def test_trace_queue_put(benchmark):
+    from ddtrace.internal._queue import TraceQueue
+
+    @benchmark
+    def f():
+        q = TraceQueue()
+        q.put([])
+
+
+@pytest.mark.benchmark(group="queue", min_time=0.005)
+def test_trace_queue_get(benchmark):
+    from ddtrace.internal._queue import TraceQueue
+
+    @benchmark
+    def f():
+        q = TraceQueue()
+        q.put([])
+        q.get()

--- a/tests/internal/test_writer.py
+++ b/tests/internal/test_writer.py
@@ -1,12 +1,10 @@
 import time
 
-import pytest
-
 import mock
 
 from ddtrace.span import Span
 from ddtrace.api import API
-from ddtrace.internal.writer import AgentWriter, LogWriter, Q, Empty
+from ddtrace.internal.writer import AgentWriter, LogWriter
 from ..base import BaseTestCase
 
 
@@ -228,28 +226,3 @@ class LogWriterTests(BaseTestCase):
         self.create_writer([filtr])
         self.assertEqual(len(self.output.entries), 0)
         self.assertEqual(filtr.filtered_traces, self.N_TRACES)
-
-
-def test_queue_full():
-    q = Q(maxsize=3)
-    q.put([1])
-    q.put(2)
-    q.put([3])
-    q.put([4, 4])
-    assert list(q.queue) == [[1], 2, [4, 4]] or list(q.queue) == [[1], [4, 4], [3]] or list(q.queue) == [[4, 4], 2, [3]]
-    assert q.dropped == 1
-    assert q.accepted == 4
-    assert q.accepted_lengths == 5
-    dropped, accepted, accepted_lengths = q.reset_stats()
-    assert dropped == 1
-    assert accepted == 4
-    assert accepted_lengths == 5
-
-
-def test_queue_get():
-    q = Q(maxsize=3)
-    q.put(1)
-    q.put(2)
-    assert list(q.get()) == [1, 2]
-    with pytest.raises(Empty):
-        q.get(block=False)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,77 @@
+from ddtrace.internal._queue import TraceQueue
+
+
+def test_queue_no_limit():
+    q = TraceQueue()
+    for i in range(0, 10000):
+        q.put([i])
+
+    items = q.get()
+    assert len(items) == 10000
+    for i in range(0, 10000):
+        assert items[i] == [i]
+
+    dropped, accepted, lengths = q.pop_stats()
+    assert dropped == 0
+    assert accepted == 10000
+    assert lengths == 10000
+
+
+def test_queue_full():
+    q = TraceQueue(maxsize=3)
+    q.put([1])
+    q.put(2)
+    q.put([3])
+    q.put([4, 4])
+    assert len(q) == 3
+
+    state = list(q._queue)
+    assert state == [[1], 2, [4, 4]] or state == [[1], [4, 4], [3]] or state == [[4, 4], 2, [3]]
+    assert q._dropped == 1
+    assert q._accepted == 4
+    assert q._accepted_lengths == 5
+
+    dropped, accepted, accepted_lengths = q.pop_stats()
+    assert dropped == 1
+    assert accepted == 4
+    assert accepted_lengths == 5
+
+
+def test_queue_get():
+    q = TraceQueue(maxsize=3)
+    q.put(1)
+    q.put(2)
+    assert q.get() == [1, 2]
+    assert q.get() == []
+
+
+def test_multiple_queues():
+    q1 = TraceQueue()
+    q2 = TraceQueue()
+
+    q1.put(1)
+    q2.put(1)
+
+    assert len(q1) == 1
+    assert len(q2) == 1
+
+    q1.get()
+    assert len(q1) == 0
+    assert len(q2) == 1
+
+    q2.get()
+    assert len(q1) == 0
+    assert len(q2) == 0
+
+
+def test_queue_overflow():
+    q = TraceQueue(maxsize=1000)
+
+    for i in range(10000):
+        q.put([])
+        assert len(q) <= 1000
+
+    dropped, accepted, accepted_lengths = q.pop_stats()
+    assert dropped == 9000
+    assert accepted == 10000
+    assert accepted_lengths == 0

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -681,8 +681,8 @@ def test_tracer_fork():
                 assert t.writer._trace_queue != original_writer._trace_queue
 
         # Assert the trace got written into the correct queue
-        assert original_writer._trace_queue.empty()
-        assert t.writer._trace_queue.qsize() == 1
+        assert len(original_writer._trace_queue) == 0
+        assert len(t.writer._trace_queue) == 1
         assert [[span]] == list(t.writer._trace_queue.get())
 
     # Assert tracer in a new process correctly recreates the writer
@@ -702,8 +702,8 @@ def test_tracer_fork():
         assert t.writer._trace_queue == original_writer._trace_queue
 
     # Assert the trace got written into the correct queue
-    assert original_writer._trace_queue.qsize() == 1
-    assert t.writer._trace_queue.qsize() == 1
+    assert len(original_writer._trace_queue) == 1
+    assert len(t.writer._trace_queue) == 1
     assert [[span]] == list(t.writer._trace_queue.get())
 
 


### PR DESCRIPTION
The queue implementation subclassed the stdlib Queue while using none of its
features besides the built-in lock. The notifying capabilities are not used.

It was also noticed that the queue put operation was strangely more expensive
than simply adding an item to a mutex protected list, possibly due to the
additional notifying capabilities which there is no need of.

[In microbenchmarks](https://gist.github.com/Kyle-Verhoog/376d399f5217664ebb0fb561040676a9):

- **1.1-1.3x** speed-up in **trace creation** (creating, finishing and adding spans to the queue)
- **4-6x** speed-up in primitive operation usage over the previous queue
