### PR TITLE
feat(ddtrace-run): allow to enable profiling

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -72,6 +72,10 @@ try:
     hostname = os.environ.get("DD_AGENT_HOST", os.environ.get("DATADOG_TRACE_AGENT_HOSTNAME"))
     port = os.environ.get("DATADOG_TRACE_AGENT_PORT")
     priority_sampling = os.environ.get("DATADOG_PRIORITY_SAMPLING")
+    profiling = asbool(os.environ.get("DD_PROFILING_ENABLED", False))
+
+    if profiling:
+        import ddtrace.profiling.auto  # noqa: F401
 
     opts = {}
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -85,6 +85,10 @@ below:
      - Integer
      -
      - Deprecated: use ``DD_TRACE_AGENT_URL``
+   * - ``DD_PROFILING_ENABLED``
+     - Boolean
+     - False
+     - Enable Datadog profiling when using ``ddtrace-run``.
    * - ``DD_PROFILING_API_TIMEOUT``
      - Float
      - 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,6 @@ exclude = '''
   | tests/
   (
     base
-    | commands
     | contrib/
     (
       aiobotocore

--- a/tests/commands/ddtrace_minimal.py
+++ b/tests/commands/ddtrace_minimal.py
@@ -1,5 +1,5 @@
 import ddtrace.bootstrap.sitecustomize as module
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print(module.loaded)

--- a/tests/commands/ddtrace_run_app_name.py
+++ b/tests/commands/ddtrace_run_app_name.py
@@ -1,5 +1,5 @@
 from ddtrace.opentracer import Tracer
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     tracer = Tracer()
     print(tracer._service_name)

--- a/tests/commands/ddtrace_run_argv.py
+++ b/tests/commands/ddtrace_run_argv.py
@@ -1,5 +1,5 @@
 import sys
 
-if __name__ == '__main__':
-    assert sys.argv[1:] == ['foo', 'bar']
-    print('Test success')
+if __name__ == "__main__":
+    assert sys.argv[1:] == ["foo", "bar"]
+    print("Test success")

--- a/tests/commands/ddtrace_run_debug.py
+++ b/tests/commands/ddtrace_run_debug.py
@@ -2,6 +2,6 @@ import logging
 
 from ddtrace import tracer
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     assert tracer.log.isEnabledFor(logging.DEBUG)
-    print('Test success')
+    print("Test success")

--- a/tests/commands/ddtrace_run_disabled.py
+++ b/tests/commands/ddtrace_run_disabled.py
@@ -1,6 +1,6 @@
 from ddtrace import tracer, monkey
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     assert not tracer.enabled
     assert len(monkey.get_patched_modules()) == 0
-    print('Test success')
+    print("Test success")

--- a/tests/commands/ddtrace_run_dogstatsd.py
+++ b/tests/commands/ddtrace_run_dogstatsd.py
@@ -2,11 +2,11 @@ from __future__ import print_function
 
 from ddtrace import tracer
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # check both configurations with host:port or unix socket
     if tracer._dogstatsd_client.socket_path is None:
-        assert tracer._dogstatsd_client.host == '172.10.0.1'
+        assert tracer._dogstatsd_client.host == "172.10.0.1"
         assert tracer._dogstatsd_client.port == 8120
     else:
-        assert tracer._dogstatsd_client.socket_path.endswith('dogstatsd.sock')
-    print('Test success')
+        assert tracer._dogstatsd_client.socket_path.endswith("dogstatsd.sock")
+    print("Test success")

--- a/tests/commands/ddtrace_run_enabled.py
+++ b/tests/commands/ddtrace_run_enabled.py
@@ -1,5 +1,5 @@
 from ddtrace import tracer
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     assert tracer.enabled
-    print('Test success')
+    print("Test success")

--- a/tests/commands/ddtrace_run_env.py
+++ b/tests/commands/ddtrace_run_env.py
@@ -1,5 +1,5 @@
 from ddtrace import tracer
 
-if __name__ == '__main__':
-    assert tracer.tags['env'] == 'test'
-    print('Test success')
+if __name__ == "__main__":
+    assert tracer.tags["env"] == "test"
+    print("Test success")

--- a/tests/commands/ddtrace_run_global_tags.py
+++ b/tests/commands/ddtrace_run_global_tags.py
@@ -1,7 +1,7 @@
 from ddtrace import tracer
 
-if __name__ == '__main__':
-    assert tracer.tags['a'] == 'True'
-    assert tracer.tags['b'] == '0'
-    assert tracer.tags['c'] == 'C'
-    print('Test success')
+if __name__ == "__main__":
+    assert tracer.tags["a"] == "True"
+    assert tracer.tags["b"] == "0"
+    assert tracer.tags["c"] == "C"
+    print("Test success")

--- a/tests/commands/ddtrace_run_hostname.py
+++ b/tests/commands/ddtrace_run_hostname.py
@@ -1,6 +1,6 @@
 from ddtrace import tracer
 
-if __name__ == '__main__':
-    assert tracer.writer.api.hostname == '172.10.0.1'
+if __name__ == "__main__":
+    assert tracer.writer.api.hostname == "172.10.0.1"
     assert tracer.writer.api.port == 8120
-    print('Test success')
+    print("Test success")

--- a/tests/commands/ddtrace_run_integration.py
+++ b/tests/commands/ddtrace_run_integration.py
@@ -9,8 +9,8 @@ from ddtrace import Pin
 from tests.contrib.config import REDIS_CONFIG
 from tests.test_tracer import DummyWriter
 
-if __name__ == '__main__':
-    r = redis.Redis(port=REDIS_CONFIG['port'])
+if __name__ == "__main__":
+    r = redis.Redis(port=REDIS_CONFIG["port"])
     pin = Pin.get_from(r)
     assert pin
 
@@ -19,23 +19,23 @@ if __name__ == '__main__':
     spans = pin.tracer.writer.pop()
 
     assert len(spans) == 1
-    assert spans[0].service == 'redis'
-    assert spans[0].resource == 'FLUSHALL'
+    assert spans[0].service == "redis"
+    assert spans[0].resource == "FLUSHALL"
 
-    long_cmd = 'mget %s' % ' '.join(map(str, range(1000)))
+    long_cmd = "mget %s" % " ".join(map(str, range(1000)))
     us = r.execute_command(long_cmd)
 
     spans = pin.tracer.writer.pop()
     assert len(spans) == 1
     span = spans[0]
-    assert span.service == 'redis'
-    assert span.name == 'redis.command'
-    assert span.span_type == 'redis'
+    assert span.service == "redis"
+    assert span.name == "redis.command"
+    assert span.span_type == "redis"
     assert span.error == 0
-    assert span.get_metric('out.port') == REDIS_CONFIG['port']
-    assert span.get_metric('out.redis_db') == 0
-    assert span.get_tag('out.host') == 'localhost'
-    assert span.get_tag('redis.raw_command').startswith(u'mget 0 1 2 3')
-    assert span.get_tag('redis.raw_command').endswith(u'...')
+    assert span.get_metric("out.port") == REDIS_CONFIG["port"]
+    assert span.get_metric("out.redis_db") == 0
+    assert span.get_tag("out.host") == "localhost"
+    assert span.get_tag("redis.raw_command").startswith(u"mget 0 1 2 3")
+    assert span.get_tag("redis.raw_command").endswith(u"...")
 
-    print('Test success')
+    print("Test success")

--- a/tests/commands/ddtrace_run_logs_injection.py
+++ b/tests/commands/ddtrace_run_logs_injection.py
@@ -5,13 +5,11 @@ if __name__ == "__main__":
     if getattr(logging, "_datadog_patch"):
         assert (
             "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s"
-            " dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s]"
-            in logging.root.handlers[0].formatter._fmt
+            " dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s]" in logging.root.handlers[0].formatter._fmt
         )
     else:
         assert (
             "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s"
-            " dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s]"
-            not in logging.root.handlers[0].formatter._fmt
+            " dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s]" not in logging.root.handlers[0].formatter._fmt
         )
     print("Test success")

--- a/tests/commands/ddtrace_run_no_debug.py
+++ b/tests/commands/ddtrace_run_no_debug.py
@@ -2,6 +2,6 @@ import logging
 
 from ddtrace import tracer
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     assert not tracer.log.isEnabledFor(logging.DEBUG)
-    print('Test success')
+    print("Test success")

--- a/tests/commands/ddtrace_run_patched_modules.py
+++ b/tests/commands/ddtrace_run_patched_modules.py
@@ -1,5 +1,5 @@
 from ddtrace import monkey
 
-if __name__ == '__main__':
-    assert 'redis' in monkey.get_patched_modules()
-    print('Test success')
+if __name__ == "__main__":
+    assert "redis" in monkey.get_patched_modules()
+    print("Test success")

--- a/tests/commands/ddtrace_run_priority_sampling.py
+++ b/tests/commands/ddtrace_run_priority_sampling.py
@@ -1,5 +1,5 @@
 from ddtrace import tracer
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     assert tracer.priority_sampler is not None
-    print('Test success')
+    print("Test success")

--- a/tests/commands/ddtrace_run_profiling.py
+++ b/tests/commands/ddtrace_run_profiling.py
@@ -1,0 +1,7 @@
+from ddtrace.profiling import bootstrap
+
+if __name__ == "__main__":
+    if hasattr(bootstrap, "profiler"):
+        print(str(bootstrap.profiler.status))
+    else:
+        print("NO PROFILER")

--- a/tests/commands/ddtrace_run_sitecustomize.py
+++ b/tests/commands/ddtrace_run_sitecustomize.py
@@ -1,15 +1,16 @@
 import sys
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # detect if `-S` is used
-    suppress = len(sys.argv) == 2 and sys.argv[1] == '-S'
+    suppress = len(sys.argv) == 2 and sys.argv[1] == "-S"
     if suppress:
-        assert 'sitecustomize' not in sys.modules
+        assert "sitecustomize" not in sys.modules
     else:
-        assert 'sitecustomize' in sys.modules
+        assert "sitecustomize" in sys.modules
 
     # ensure the right `sitecustomize` will be imported
     import sitecustomize
+
     assert sitecustomize.CORRECT_IMPORT
-    print('Test success')
+    print("Test success")

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -307,3 +307,18 @@ class DdtraceRunTest(BaseTestCase):
                 ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_logs_injection.py']
             )
             assert out.startswith(b'Test success')
+
+
+def test_env_profiling_enabled(monkeypatch):
+    """DD_PROFILING_ENABLED allows enabling the global profiler."""
+    # Off by default
+    out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_profiling.py"])
+    assert out.strip() == b"NO PROFILER"
+
+    monkeypatch.setenv("DD_PROFILING_ENABLED", "true")
+    out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_profiling.py"])
+    assert out.strip() == b"RUNNING"
+
+    monkeypatch.setenv("DD_PROFILING_ENABLED", "false")
+    out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_profiling.py"])
+    assert out.strip() == b"NO PROFILER"

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -15,17 +15,18 @@ def inject_sitecustomize(path):
               the given `sitecustomize.py`
     """
     from ddtrace import __file__ as root_file
+
     root_folder = os.path.dirname(root_file)
     # Copy the current environment and replace the PYTHONPATH. This is
     # required otherwise `ddtrace` scripts are not found when `env` kwarg is
     # passed
     env = os.environ.copy()
-    sitecustomize = os.path.join(root_folder, '..', path)
+    sitecustomize = os.path.join(root_folder, "..", path)
 
     # Add `bootstrap` directory to the beginning of PYTHONTPATH so we know
     # if `import sitecustomize` is run that it'll be the one we specify
     python_path = [sitecustomize] + list(sys.path)
-    env['PYTHONPATH'] = ':'.join(python_path)
+    env["PYTHONPATH"] = ":".join(python_path)
     return env
 
 
@@ -34,279 +35,228 @@ class DdtraceRunTest(BaseTestCase):
         """
         $DATADOG_SERVICE_NAME gets passed through to the program
         """
-        with self.override_env(dict(DATADOG_SERVICE_NAME='my_test_service')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_service.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DATADOG_SERVICE_NAME="my_test_service")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_service.py"])
+            assert out.startswith(b"Test success")
 
     def test_service_name_passthrough(self):
         """
         $DD_SERVICE gets passed through to the program
         """
-        with self.override_env(dict(DD_SERVICE='my_test_service')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_service.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DD_SERVICE="my_test_service")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_service.py"])
+            assert out.startswith(b"Test success")
 
     def test_env_name_passthrough(self):
         """
         $DATADOG_ENV gets passed through to the global tracer as an 'env' tag
         """
-        with self.override_env(dict(DATADOG_ENV='test')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_env.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DATADOG_ENV="test")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_env.py"])
+            assert out.startswith(b"Test success")
 
     def test_env_enabling(self):
         """
         DATADOG_TRACE_ENABLED=false allows disabling of the global tracer
         """
-        with self.override_env(dict(DATADOG_TRACE_ENABLED='false')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_disabled.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DATADOG_TRACE_ENABLED="false")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_disabled.py"])
+            assert out.startswith(b"Test success")
 
-        with self.override_env(dict(DATADOG_TRACE_ENABLED='true')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_enabled.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DATADOG_TRACE_ENABLED="true")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_enabled.py"])
+            assert out.startswith(b"Test success")
 
     def test_patched_modules(self):
         """
         Using `ddtrace-run` registers some generic patched modules
         """
-        out = subprocess.check_output(
-            ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_patched_modules.py']
-        )
-        assert out.startswith(b'Test success')
+        out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_patched_modules.py"])
+        assert out.startswith(b"Test success")
 
     def test_integration(self):
-        out = subprocess.check_output(
-            ['ddtrace-run', 'python', '-m', 'tests.commands.ddtrace_run_integration']
-        )
-        assert out.startswith(b'Test success')
+        out = subprocess.check_output(["ddtrace-run", "python", "-m", "tests.commands.ddtrace_run_integration"])
+        assert out.startswith(b"Test success")
 
     def test_debug_enabling(self):
         """
         DATADOG_TRACE_DEBUG=true allows setting debug logging of the global tracer
         """
-        with self.override_env(dict(DATADOG_TRACE_DEBUG='false')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_no_debug.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DATADOG_TRACE_DEBUG="false")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_no_debug.py"])
+            assert out.startswith(b"Test success")
 
-        with self.override_env(dict(DATADOG_TRACE_DEBUG='true')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_debug.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DATADOG_TRACE_DEBUG="true")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_debug.py"])
+            assert out.startswith(b"Test success")
 
     def test_host_port_from_env(self):
         """
         DATADOG_TRACE_AGENT_HOSTNAME|PORT point to the tracer
         to the correct host/port for submission
         """
-        with self.override_env(dict(DATADOG_TRACE_AGENT_HOSTNAME='172.10.0.1',
-                                    DATADOG_TRACE_AGENT_PORT='8120')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_hostname.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DATADOG_TRACE_AGENT_HOSTNAME="172.10.0.1", DATADOG_TRACE_AGENT_PORT="8120")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_hostname.py"])
+            assert out.startswith(b"Test success")
 
     def test_host_port_from_env_dd(self):
         """
         DD_AGENT_HOST|DD_TRACE_AGENT_PORT point to the tracer
         to the correct host/port for submission
         """
-        with self.override_env(dict(DD_AGENT_HOST='172.10.0.1',
-                                    DD_TRACE_AGENT_PORT='8120')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_hostname.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DD_AGENT_HOST="172.10.0.1", DD_TRACE_AGENT_PORT="8120")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_hostname.py"])
+            assert out.startswith(b"Test success")
 
             # Do we get the same results without `ddtrace-run`?
-            out = subprocess.check_output(
-                ['python', 'tests/commands/ddtrace_run_hostname.py']
-            )
-            assert out.startswith(b'Test success')
+            out = subprocess.check_output(["python", "tests/commands/ddtrace_run_hostname.py"])
+            assert out.startswith(b"Test success")
 
     def test_dogstatsd_client_env_host_and_port(self):
         """
         DD_AGENT_HOST and DD_DOGSTATSD_PORT used to configure dogstatsd with udp in tracer
         """
-        with self.override_env(dict(DD_AGENT_HOST='172.10.0.1',
-                                    DD_DOGSTATSD_PORT='8120')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_dogstatsd.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DD_AGENT_HOST="172.10.0.1", DD_DOGSTATSD_PORT="8120")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_dogstatsd.py"])
+            assert out.startswith(b"Test success")
 
     def test_dogstatsd_client_env_url_host_and_port(self):
         """
         DD_DOGSTATSD_URL=<host>:<port> used to configure dogstatsd with udp in tracer
         """
-        with self.override_env(dict(DD_DOGSTATSD_URL='172.10.0.1:8120')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_dogstatsd.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DD_DOGSTATSD_URL="172.10.0.1:8120")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_dogstatsd.py"])
+            assert out.startswith(b"Test success")
 
     def test_dogstatsd_client_env_url_udp(self):
         """
         DD_DOGSTATSD_URL=udp://<host>:<port> used to configure dogstatsd with udp in tracer
         """
-        with self.override_env(dict(DD_DOGSTATSD_URL='udp://172.10.0.1:8120')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_dogstatsd.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DD_DOGSTATSD_URL="udp://172.10.0.1:8120")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_dogstatsd.py"])
+            assert out.startswith(b"Test success")
 
     def test_dogstatsd_client_env_url_unix(self):
         """
         DD_DOGSTATSD_URL=unix://<path> used to configure dogstatsd with socket path in tracer
         """
-        with self.override_env(dict(DD_DOGSTATSD_URL='unix:///dogstatsd.sock')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_dogstatsd.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DD_DOGSTATSD_URL="unix:///dogstatsd.sock")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_dogstatsd.py"])
+            assert out.startswith(b"Test success")
 
     def test_dogstatsd_client_env_url_path(self):
         """
         DD_DOGSTATSD_URL=<path> used to configure dogstatsd with socket path in tracer
         """
-        with self.override_env(dict(DD_DOGSTATSD_URL='/dogstatsd.sock')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_dogstatsd.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DD_DOGSTATSD_URL="/dogstatsd.sock")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_dogstatsd.py"])
+            assert out.startswith(b"Test success")
 
     def test_priority_sampling_from_env(self):
         """
         DATADOG_PRIORITY_SAMPLING enables Distributed Sampling
         """
-        with self.override_env(dict(DATADOG_PRIORITY_SAMPLING='True')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_priority_sampling.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DATADOG_PRIORITY_SAMPLING="True")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_priority_sampling.py"])
+            assert out.startswith(b"Test success")
 
     def test_patch_modules_from_env(self):
         """
         DATADOG_PATCH_MODULES overrides the defaults for patch_all()
         """
         from ddtrace.bootstrap.sitecustomize import EXTRA_PATCHED_MODULES, update_patched_modules
+
         orig = EXTRA_PATCHED_MODULES.copy()
 
         # empty / malformed strings are no-ops
-        with self.override_env(dict(DATADOG_PATCH_MODULES='')):
+        with self.override_env(dict(DATADOG_PATCH_MODULES="")):
             update_patched_modules()
             assert orig == EXTRA_PATCHED_MODULES
 
-        with self.override_env(dict(DATADOG_PATCH_MODULES=':')):
+        with self.override_env(dict(DATADOG_PATCH_MODULES=":")):
             update_patched_modules()
             assert orig == EXTRA_PATCHED_MODULES
 
-        with self.override_env(dict(DATADOG_PATCH_MODULES=',')):
+        with self.override_env(dict(DATADOG_PATCH_MODULES=",")):
             update_patched_modules()
             assert orig == EXTRA_PATCHED_MODULES
 
-        with self.override_env(dict(DATADOG_PATCH_MODULES=',:')):
+        with self.override_env(dict(DATADOG_PATCH_MODULES=",:")):
             update_patched_modules()
             assert orig == EXTRA_PATCHED_MODULES
 
         # overrides work in either direction
-        with self.override_env(dict(DATADOG_PATCH_MODULES='django:false')):
+        with self.override_env(dict(DATADOG_PATCH_MODULES="django:false")):
             update_patched_modules()
-            assert EXTRA_PATCHED_MODULES['django'] is False
+            assert EXTRA_PATCHED_MODULES["django"] is False
 
-        with self.override_env(dict(DATADOG_PATCH_MODULES='boto:true')):
+        with self.override_env(dict(DATADOG_PATCH_MODULES="boto:true")):
             update_patched_modules()
-            assert EXTRA_PATCHED_MODULES['boto'] is True
+            assert EXTRA_PATCHED_MODULES["boto"] is True
 
-        with self.override_env(dict(DATADOG_PATCH_MODULES='django:true,boto:false')):
+        with self.override_env(dict(DATADOG_PATCH_MODULES="django:true,boto:false")):
             update_patched_modules()
-            assert EXTRA_PATCHED_MODULES['boto'] is False
-            assert EXTRA_PATCHED_MODULES['django'] is True
+            assert EXTRA_PATCHED_MODULES["boto"] is False
+            assert EXTRA_PATCHED_MODULES["django"] is True
 
-        with self.override_env(dict(DATADOG_PATCH_MODULES='django:false,boto:true')):
+        with self.override_env(dict(DATADOG_PATCH_MODULES="django:false,boto:true")):
             update_patched_modules()
-            assert EXTRA_PATCHED_MODULES['boto'] is True
-            assert EXTRA_PATCHED_MODULES['django'] is False
+            assert EXTRA_PATCHED_MODULES["boto"] is True
+            assert EXTRA_PATCHED_MODULES["django"] is False
 
     def test_sitecustomize_without_ddtrace_run_command(self):
         # [Regression test]: ensure `sitecustomize` path is removed only if it's
         # present otherwise it will cause:
         #   ValueError: list.remove(x): x not in list
         # as mentioned here: https://github.com/DataDog/dd-trace-py/pull/516
-        env = inject_sitecustomize('')
-        out = subprocess.check_output(
-            ['python', 'tests/commands/ddtrace_minimal.py'],
-            env=env,
-        )
+        env = inject_sitecustomize("")
+        out = subprocess.check_output(["python", "tests/commands/ddtrace_minimal.py"], env=env,)
         # `out` contains the `loaded` status of the module
-        result = out[:-1] == b'True'
+        result = out[:-1] == b"True"
         self.assertTrue(result)
 
     def test_sitecustomize_run(self):
         # [Regression test]: ensure users `sitecustomize.py` is properly loaded,
         # so that our `bootstrap/sitecustomize.py` doesn't override the one
         # defined in users' PYTHONPATH.
-        env = inject_sitecustomize('tests/commands/bootstrap')
+        env = inject_sitecustomize("tests/commands/bootstrap")
         out = subprocess.check_output(
-            ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_sitecustomize.py'],
-            env=env,
+            ["ddtrace-run", "python", "tests/commands/ddtrace_run_sitecustomize.py"], env=env,
         )
-        assert out.startswith(b'Test success')
+        assert out.startswith(b"Test success")
 
     def test_sitecustomize_run_suppressed(self):
         # ensure `sitecustomize.py` is not loaded if `-S` is used
-        env = inject_sitecustomize('tests/commands/bootstrap')
+        env = inject_sitecustomize("tests/commands/bootstrap")
         out = subprocess.check_output(
-            ['ddtrace-run', 'python', '-S', 'tests/commands/ddtrace_run_sitecustomize.py', '-S'],
-            env=env,
+            ["ddtrace-run", "python", "-S", "tests/commands/ddtrace_run_sitecustomize.py", "-S"], env=env,
         )
-        assert out.startswith(b'Test success')
+        assert out.startswith(b"Test success")
 
     def test_argv_passed(self):
-        out = subprocess.check_output(
-            ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_argv.py', 'foo', 'bar']
-        )
-        assert out.startswith(b'Test success')
+        out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_argv.py", "foo", "bar"])
+        assert out.startswith(b"Test success")
 
     def test_got_app_name(self):
         """
         apps run with ddtrace-run have a proper app name
         """
-        out = subprocess.check_output(
-            ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_app_name.py']
-        )
-        assert out.startswith(b'ddtrace_run_app_name.py')
+        out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_app_name.py"])
+        assert out.startswith(b"ddtrace_run_app_name.py")
 
     def test_global_trace_tags(self):
         """ Ensure global tags are passed in from environment
         """
-        with self.override_env(dict(DD_TRACE_GLOBAL_TAGS='a:True,b:0,c:C')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_global_tags.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DD_TRACE_GLOBAL_TAGS="a:True,b:0,c:C")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_global_tags.py"])
+            assert out.startswith(b"Test success")
 
     def test_logs_injection(self):
         """ Ensure logs injection works
         """
-        with self.override_env(dict(DD_LOGS_INJECTION='true')):
-            out = subprocess.check_output(
-                ['ddtrace-run', 'python', 'tests/commands/ddtrace_run_logs_injection.py']
-            )
-            assert out.startswith(b'Test success')
+        with self.override_env(dict(DD_LOGS_INJECTION="true")):
+            out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_logs_injection.py"])
+            assert out.startswith(b"Test success")
 
 
 def test_env_profiling_enabled(monkeypatch):


### PR DESCRIPTION
## feat(ddtrace-run): allow to enable profiling

This adds an environment variable DD_PROFILING_ENABLED (default to false). If
set to `true`, this will make the profiler run in the wrapped program.

## chore: black tests/commands