### PR TITLE
fix(profiling): disable exception profiling on Windows

### DIFF
--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -172,7 +172,7 @@ class StackExceptionSampleEvent(StackBasedEvent):
 
 
 # The head lock (the interpreter mutex) is only exposed in a data structure in Python ≥ 3.7
-IF PY_MAJOR_VERSION >= 3 and PY_MINOR_VERSION >= 7:
+IF UNAME_SYSNAME != "Windows" and PY_MAJOR_VERSION >= 3 and PY_MINOR_VERSION >= 7:
     FEATURES['stack-exceptions'] = True
 
     from cpython cimport PyInterpreterState
@@ -250,7 +250,7 @@ cdef get_thread_name(thread_id):
 cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_time, thread_span_links):
     current_exceptions = []
 
-    IF PY_MAJOR_VERSION >= 3 and PY_MINOR_VERSION >= 7:
+    IF UNAME_SYSNAME != "Windows" and PY_MAJOR_VERSION >= 3 and PY_MINOR_VERSION >= 7:
         cdef PyInterpreterState* interp
         cdef PyThreadState* tstate
         cdef _PyErr_StackItem* exc_info

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 
 from setuptools import setup, find_packages
@@ -100,6 +101,12 @@ def get_exts_for(name):
         return []
 
 
+if platform.uname()[0] != "Windows":
+    extra_compile_args = ["-DPy_BUILD_CORE"]
+else:
+    extra_compile_args = []
+
+
 # Base `setup()` kwargs without any C-extension registering
 setup(
     **dict(
@@ -157,7 +164,7 @@ setup(
                     "ddtrace.profiling.collector.stack",
                     sources=["ddtrace/profiling/collector/stack.pyx"],
                     language="c",
-                    extra_compile_args=["-DPy_BUILD_CORE"],
+                    extra_compile_args=extra_compile_args,
                 ),
                 Cython.Distutils.Extension(
                     "ddtrace.profiling.collector._traceback",


### PR DESCRIPTION
This feature relies on POSIX features, it won't work on Windows.

Fixes #1487
