### PR TITLE
cythonize: specify language_level

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,7 @@ setup(
                 "PY_MICRO_VERSION": sys.version_info.micro,
             },
             force=True,
+            compiler_directives=dict(language_level=sys.version_info[0]),
         )
         + get_exts_for("wrapt")
         + get_exts_for("psutil"),


### PR DESCRIPTION
Building the Cython extensions results in the following warning:

> Cython directive 'language_level' not set, using 2 for now (Py2). This
  will change in a later release!

So let's actually set the language_level to be that of the Python being
used.


I'm not 100% about this approach yet. Not sure if it's safe to depend on the Python used to invoke setup.py.