### PR TITLE
ci: Add tests for Windows builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ httpbin_image: &httpbin_image kennethreitz/httpbin@sha256:2c7abc4803080c22928265
 vertica_image: &vertica_image sumitchawla/vertica:latest
 rabbitmq_image: &rabbitmq_image rabbitmq:3.7-alpine
 
+orbs:
+  win: circleci/windows@2.2.0
+
 machine_executor: &machine_executor
   machine:
     image: ubuntu-1604:201903-01
@@ -276,6 +279,41 @@ jobs:
     executor: python27
     steps:
       - test_build
+  test_build_win_py38:
+    executor:
+      name: win/default
+      size: *resource_class
+    environment:
+      PYTHON_VERSION: 3.8.3
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: install python version
+          command: |
+            nuget install python -Version $env:PYTHON_VERSION -ExcludeVersion -OutputDirectory .
+            .\python\tools\python.exe --version
+            .\python\tools\python.exe -m pip install virtualenv
+            .\python\tools\python.exe -m virtualenv env
+      - run:
+          name: install dependencies
+          command: |
+            env\Scripts\activate.ps1
+            python --version
+            pip install twine readme_renderer[md] pyopenssl wheel cython
+      - run:
+          name: clean
+          shell: bash.exe
+          command: rm -rf build/ dist/
+      - run:
+          name: build extensions
+          command: |
+            env\Scripts\activate.ps1
+            python setup.py build_ext --inplace
+            python setup.py sdist
+            env\Scripts\activate.ps1
+            python setup.py bdist_wheel
+            twine check dist/*
 
   tracer:
     executor: ddtrace_dev
@@ -820,6 +858,7 @@ workflows:
       - test_build_py36: *requires_pre_test
       - test_build_py35: *requires_pre_test
       - test_build_py27: *requires_pre_test
+      - test_build_win_py38: *requires_pre_test
       - build_wheels: *requires_pre_test
 
       # Integration test suites

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,10 @@ httpbin_image: &httpbin_image kennethreitz/httpbin@sha256:2c7abc4803080c22928265
 vertica_image: &vertica_image sumitchawla/vertica:latest
 rabbitmq_image: &rabbitmq_image rabbitmq:3.7-alpine
 
+scripts_test_build: &scripts_test_build
+  name: Run build 
+  command: .circleci/scripts/test_build.sh
+
 orbs:
   win: circleci/windows@2.2.0
 
@@ -140,24 +144,8 @@ commands:
     description: "Build the package extensions and wheel to validate builds work"
     steps:
       - checkout
-
-      # Install required dependencies
-      # DEV: `pyopenssl` needed until the following PR is released
-      #      https://github.com/pypa/twine/pull/447
-      # DEV: `wheel` is needed to run `bdist_wheel`
-      - run: pip install twine readme_renderer[md] pyopenssl wheel cython
-      # Ensure we didn't cache from previous runs
-      - run: rm -rf build/ dist/
-      # Manually build any extensions to ensure they succeed
-      - run: python setup.py build_ext --force
-      # Ensure source package will build
-      - run: python setup.py sdist
-      # Ensure wheel will build
-      - run: python setup.py bdist_wheel
-      # Ensure package long description is valid and will render
-      # https://github.com/pypa/twine/tree/6c4d5ecf2596c72b89b969ccc37b82c160645df8#twine-check
-      - run: twine check dist/*
-
+      - run:
+          <<: *scripts_test_build
 
 executors:
   cimg_base:
@@ -257,7 +245,7 @@ jobs:
   test_build_alpine:
     executor: python38-alpine
     steps:
-      - run: apk add git gcc musl-dev libffi-dev openssl-dev
+      - run: apk add git gcc musl-dev libffi-dev openssl-dev bash
       - test_build
   test_build_py38:
     executor: python38
@@ -289,30 +277,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run:
-          name: install python version
-          command: |
-            nuget install python -Version $PYTHON_VERSION -ExcludeVersion -OutputDirectory .
-            ./python/tools/python.exe --version
-            ./python/tools/python.exe -m pip install virtualenv
-            ./python/tools/python.exe -m virtualenv env
-      - run:
-          name: install dependencies
-          command: |
-            source env/Scripts/activate
-            python --version
-            pip install twine readme_renderer[md] pyopenssl wheel cython
-      - run:
-          name: clean
-          command: rm -rf build/ dist/
-      - run:
-          name: build and check
-          command: |
-            source env/Scripts/activate
-            python setup.py build_ext --force
-            python setup.py sdist
-            python setup.py bdist_wheel
-            twine check dist/*
+      - test_build
   test_build_win_py37:
     <<: *test_build_win
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,6 @@ httpbin_image: &httpbin_image kennethreitz/httpbin@sha256:2c7abc4803080c22928265
 vertica_image: &vertica_image sumitchawla/vertica:latest
 rabbitmq_image: &rabbitmq_image rabbitmq:3.7-alpine
 
-scripts_test_build: &scripts_test_build
-  name: Run build 
-  command: .circleci/scripts/test_build.sh
-
 orbs:
   win: circleci/windows@2.2.0
 
@@ -145,7 +141,8 @@ commands:
     steps:
       - checkout
       - run:
-          <<: *scripts_test_build
+          name: Run test build
+          command: .circleci/scripts/test_build.sh
 
 executors:
   cimg_base:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,7 @@ jobs:
     executor:
       name: win/default
       size: *resource_class
+      shell: bash.exe
     environment:
       PYTHON_VERSION: 3.8.3
     working_directory: ~/repo
@@ -291,27 +292,25 @@ jobs:
       - run:
           name: install python version
           command: |
-            nuget install python -Version $env:PYTHON_VERSION -ExcludeVersion -OutputDirectory .
-            .\python\tools\python.exe --version
-            .\python\tools\python.exe -m pip install virtualenv
-            .\python\tools\python.exe -m virtualenv env
+            nuget install python -Version $PYTHON_VERSION -ExcludeVersion -OutputDirectory .
+            ./python/tools/python.exe --version
+            ./python/tools/python.exe -m pip install virtualenv
+            ./python/tools/python.exe -m virtualenv env
       - run:
           name: install dependencies
           command: |
-            env\Scripts\activate.ps1
+            source env/Scripts/activate
             python --version
             pip install twine readme_renderer[md] pyopenssl wheel cython
       - run:
           name: clean
-          shell: bash.exe
           command: rm -rf build/ dist/
       - run:
           name: build and check
           command: |
-            env\Scripts\activate.ps1
+            source env/Scripts/activate
             python setup.py build_ext --force
             python setup.py sdist
-            env\Scripts\activate.ps1
             python setup.py bdist_wheel
             twine check dist/*
   test_build_win_py37:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,7 +279,7 @@ jobs:
     executor: python27
     steps:
       - test_build
-  test_build_win_py38:
+  test_build_win_py38: &test_build_win
     executor:
       name: win/default
       size: *resource_class
@@ -306,14 +306,26 @@ jobs:
           shell: bash.exe
           command: rm -rf build/ dist/
       - run:
-          name: build extensions
+          name: build and check
           command: |
             env\Scripts\activate.ps1
-            python setup.py build_ext --inplace
+            python setup.py build_ext --force
             python setup.py sdist
             env\Scripts\activate.ps1
             python setup.py bdist_wheel
             twine check dist/*
+  test_build_win_py37:
+    <<: *test_build_win
+    environment:
+      PYTHON_VERSION: 3.7.7
+  test_build_win_py36:
+    <<: *test_build_win
+    environment:
+      PYTHON_VERSION: 3.6.8
+  test_build_win_py35:
+    <<: *test_build_win
+    environment:
+      PYTHON_VERSION: 3.5.4
 
   tracer:
     executor: ddtrace_dev
@@ -859,6 +871,9 @@ workflows:
       - test_build_py35: *requires_pre_test
       - test_build_py27: *requires_pre_test
       - test_build_win_py38: *requires_pre_test
+      - test_build_win_py37: *requires_pre_test
+      - test_build_win_py36: *requires_pre_test
+      - test_build_win_py35: *requires_pre_test
       - build_wheels: *requires_pre_test
 
       # Integration test suites

--- a/.circleci/scripts/test_build.sh
+++ b/.circleci/scripts/test_build.sh
@@ -7,7 +7,7 @@ if [[ "$OSTYPE" == "msys" ]]; then
     ./python/tools/python.exe --version
     ./python/tools/python.exe -m pip install virtualenv
     ./python/tools/python.exe -m virtualenv env
-    # When running script under Windows executor we need to activat the venv
+    # When running script under Windows executor we need to activate the venv
     # created for the specific Python version
     source env/Scripts/activate
 fi

--- a/.circleci/scripts/test_build.sh
+++ b/.circleci/scripts/test_build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eux -o pipefail
+
+if [[ "$OSTYPE" == "msys" ]]; then
+    # Install python version and create a virtuallenv
+    nuget install python -Version $PYTHON_VERSION -ExcludeVersion -OutputDirectory .
+    ./python/tools/python.exe --version
+    ./python/tools/python.exe -m pip install virtualenv
+    ./python/tools/python.exe -m virtualenv env
+    # When running script under Windows executor we need to activat the venv
+    # created for the specific Python version
+    source env/Scripts/activate
+fi
+
+# Install required dependencies
+# DEV: `pyopenssl` needed until the following PR is released
+#      https://github.com/pypa/twine/pull/447
+# DEV: `wheel` is needed to run `bdist_wheel`
+pip install twine readme_renderer[md] pyopenssl wheel cython
+# Ensure we didn't cache from previous runs
+rm -rf build/ dist/
+# Manually build any extensions to ensure they succeed
+python setup.py build_ext --force
+# Ensure source package will build
+python setup.py sdist
+# Ensure wheel will build
+python setup.py bdist_wheel
+# Ensure package long description is valid and will render
+# https://github.com/pypa/twine/tree/6c4d5ecf2596c72b89b969ccc37b82c160645df8#twine-check
+twine check dist/*


### PR DESCRIPTION
Adds CircleCI jobs to tests Windows builds for Python 3.5, 3.6, 3.7, and 3.8. Python 2.7 has not been added since it's not published on nuget, which we are using for installing versions under Windows. The test build commands that had been defined in the CircleCi config are now pulled out into a separate script and used across Linux and Windows jobs.