### PR TITLE
fix: log warnings for full payload

### DIFF
--- a/ddtrace/api.py
+++ b/ddtrace/api.py
@@ -217,6 +217,7 @@ class API(object):
                     # Is payload full or is the trace too big?
                     # If payload is not empty, then using a new Payload might allow us to fit the trace.
                     # Let's flush the Payload and try to put the trace in a new empty Payload.
+                    # If payload is empty, then the trace was larger than the max payload size
                     if not payload.empty:
                         responses.append(self._flush(payload))
                         # Create a new payload
@@ -227,6 +228,8 @@ class API(object):
                         except PayloadFull:
                             # If the trace does not fit in a payload on its own, that's bad. Drop it.
                             log.warning('Trace is too big to fit in a payload, dropping it')
+                    else:
+                        log.warning('Trace is larger than the max payload size, dropping it')
 
             # Check that the Payload is not empty:
             # it could be empty if the last trace was too big to fit.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import math
 import mock
 import ddtrace
 
@@ -13,6 +14,8 @@ from ddtrace.tracer import Tracer
 from ddtrace.encoding import JSONEncoder, MsgpackEncoder
 from ddtrace.compat import httplib, PYTHON_INTERPRETER, PYTHON_VERSION
 from ddtrace.internal.runtime.container import CGroupInfo
+from ddtrace.payload import Payload
+from ddtrace.span import Span
 from ddtrace.compat import monotonic
 from tests.test_tracer import get_dummy_tracer
 
@@ -293,6 +296,60 @@ class TestAPITransport(TestCase):
         traces = [trace] * 20000
 
         self._send_traces_and_check(traces, 2)
+
+    def test_send_single_trace_max_payload(self):
+        payload = Payload()
+
+        # compute number of spans to create to surpass max payload
+        trace = [Span(self.tracer, "child.span")]
+        trace_size = len(payload.encoder.encode_trace(trace))
+        num_spans = int(math.floor(payload.max_payload_size / trace_size))
+
+        # setup logging capture
+        log = logging.getLogger("ddtrace.api")
+        log_handler = MockedLogHandler(level="WARNING")
+        log.addHandler(log_handler)
+
+        with self.tracer.trace("client.testing"):
+            for n in range(num_spans):
+                self.tracer.trace("child.span").finish()
+
+        trace = self.tracer.writer.pop()
+
+        self._send_traces_and_check([trace], 0)
+
+        logged_warnings = log_handler.messages["warning"]
+        assert len(logged_warnings) == 1
+        assert "Trace is larger than the max payload size, dropping it" in logged_warnings[0]
+
+    def test_send_multiple_trace_max_payload(self):
+        payload = Payload()
+
+        # compute number of spans to create to surpass max payload
+        trace = [Span(self.tracer, "child.span")]
+        trace_size = len(payload.encoder.encode_trace(trace))
+        num_spans = int(math.floor((payload.max_payload_size - trace_size) / trace_size))
+
+        # setup logging capture
+        log = logging.getLogger("ddtrace.api")
+        log_handler = MockedLogHandler(level="WARNING")
+        log.addHandler(log_handler)
+
+        self.tracer.trace("client.testing").finish()
+        traces = [self.tracer.writer.pop()]
+
+        # create a trace larger than max payload size
+        with self.tracer.trace("client.testing"):
+            for n in range(num_spans):
+                self.tracer.trace("child.span").finish()
+
+        traces.append(self.tracer.writer.pop())
+
+        self._send_traces_and_check(traces, 1)
+
+        logged_warnings = log_handler.messages["warning"]
+        assert len(logged_warnings) == 1
+        assert "Trace is too big to fit in a payload, dropping it" in logged_warnings[0]
 
     def test_send_single_with_wrong_errors(self):
         # if the error field is set to True, it must be cast as int so


### PR DESCRIPTION
This fixes the lack of a log warning for sending a single trace to the agent that is larger than the max payload size. At the moment there is a log warning when a trace is larger than the max payload size is sent but only when alongside other traces.