### PR TITLE
Cast span_id and trace_id as string when adding to the record.

### DIFF
--- a/ddtrace/contrib/logging/patch.py
+++ b/ddtrace/contrib/logging/patch.py
@@ -44,8 +44,8 @@ def _w_makeRecord(func, instance, args, kwargs):
         span = _get_current_span(tracer=ddtrace.config.logging.tracer)
 
     if span:
-        setattr(record, RECORD_ATTR_TRACE_ID, "{}".format(span.trace_id))
-        setattr(record, RECORD_ATTR_SPAN_ID, "{}".format(span.span_id))
+        setattr(record, RECORD_ATTR_TRACE_ID, str(span.trace_id))
+        setattr(record, RECORD_ATTR_SPAN_ID, str(span.span_id))
     else:
         setattr(record, RECORD_ATTR_TRACE_ID, RECORD_ATTR_VALUE_ZERO)
         setattr(record, RECORD_ATTR_SPAN_ID, RECORD_ATTR_VALUE_ZERO)

--- a/ddtrace/contrib/logging/patch.py
+++ b/ddtrace/contrib/logging/patch.py
@@ -10,7 +10,7 @@ RECORD_ATTR_SPAN_ID = "dd.span_id"
 RECORD_ATTR_ENV = "dd.env"
 RECORD_ATTR_VERSION = "dd.version"
 RECORD_ATTR_SERVICE = "dd.service"
-RECORD_ATTR_VALUE_ZERO = 0
+RECORD_ATTR_VALUE_ZERO = "0"
 RECORD_ATTR_VALUE_EMPTY = ""
 
 ddtrace.config._add("logging", dict(tracer=None,))  # by default, override here for custom tracer
@@ -44,8 +44,8 @@ def _w_makeRecord(func, instance, args, kwargs):
         span = _get_current_span(tracer=ddtrace.config.logging.tracer)
 
     if span:
-        setattr(record, RECORD_ATTR_TRACE_ID, span.trace_id)
-        setattr(record, RECORD_ATTR_SPAN_ID, span.span_id)
+        setattr(record, RECORD_ATTR_TRACE_ID, "{}".format(span.trace_id))
+        setattr(record, RECORD_ATTR_SPAN_ID, "{}".format(span.span_id))
     else:
         setattr(record, RECORD_ATTR_TRACE_ID, RECORD_ATTR_VALUE_ZERO)
         setattr(record, RECORD_ATTR_SPAN_ID, RECORD_ATTR_VALUE_ZERO)


### PR DESCRIPTION
If you are using a json logger the record value will be interpreted as a number which will result in values being rounded in the log pipeline.