### PR TITLE
core: enable partial flush by default

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -25,8 +25,8 @@ class Context(object):
 
     This data structure is thread-safe.
     """
-    _partial_flush_enabled = asbool(get_env('tracer', 'partial_flush_enabled', default=False))
-    _partial_flush_min_spans = int(get_env('tracer', 'partial_flush_min_spans', default=500))
+    _partial_flush_enabled = asbool(get_env('tracer', 'partial_flush_enabled', default=True))
+    _partial_flush_min_spans = int(get_env('tracer', 'partial_flush_min_spans', default=5000))
 
     def __init__(self, trace_id=None, span_id=None, sampling_priority=None, _dd_origin=None):
         """


### PR DESCRIPTION
Partial flush allows a trace with a large number of spans to be written to the agent in chunks. The functionality to support this was added in #668 but the option was not enabled by default. This PR enables it by default, increases the minimum number of spans required before partial flushing occurs, and adds documentation.

**TODO** Needs documentation

Fixes #1577, #1600