### PR TITLE
fix(profiling): lock Recorder on reset

### DIFF
--- a/ddtrace/profiling/_nogevent.py
+++ b/ddtrace/profiling/_nogevent.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+"""This files exposes non-gevent Python original functions."""
+from ddtrace.vendor import six
+
+try:
+    import gevent.monkey
+except ImportError:
+
+    def get_original(module, func):
+        return getattr(__import__(module), func)
+
+    def is_module_patched(module):
+        return False
+
+
+else:
+    get_original = gevent.monkey.get_original
+    is_module_patched = gevent.monkey.is_module_patched
+
+
+sleep = get_original("time", "sleep")
+
+try:
+    # Python ≥ 3.8
+    threading_get_native_id = get_original("threading", "get_native_id")
+except AttributeError:
+    threading_get_native_id = None
+
+start_new_thread = get_original(six.moves._thread.__name__, "start_new_thread")
+thread_get_ident = get_original(six.moves._thread.__name__, "get_ident")
+Thread = get_original("threading", "Thread")
+Lock = get_original("threading", "Lock")

--- a/ddtrace/profiling/_nogevent.py
+++ b/ddtrace/profiling/_nogevent.py
@@ -1,6 +1,10 @@
 # -*- encoding: utf-8 -*-
 """This files exposes non-gevent Python original functions."""
+import threading
+
 from ddtrace.vendor import six
+from ddtrace.vendor import attr
+
 
 try:
     import gevent.monkey
@@ -30,3 +34,34 @@ start_new_thread = get_original(six.moves._thread.__name__, "start_new_thread")
 thread_get_ident = get_original(six.moves._thread.__name__, "get_ident")
 Thread = get_original("threading", "Thread")
 Lock = get_original("threading", "Lock")
+
+
+if is_module_patched("threading"):
+
+    @attr.s
+    class DoubleLock(object):
+        """A lock that prevent concurrency from a gevent coroutine and from a threading.Thread at the same time."""
+
+        _lock = attr.ib(factory=threading.Lock, init=False, repr=False)
+        _thread_lock = attr.ib(factory=Lock, init=False, repr=False)
+
+        def acquire(self):
+            # You cannot acquire a gevent-lock from another thread if it has been acquired already:
+            # make sure we exclude the gevent-lock from being acquire by another thread by using a thread-lock first.
+            self._thread_lock.acquire()
+            self._lock.acquire()
+
+        def release(self):
+            self._lock.release()
+            self._thread_lock.release()
+
+        def __enter__(self):
+            self.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            self.release()
+
+
+else:
+    DoubleLock = threading.Lock

--- a/ddtrace/profiling/_service.py
+++ b/ddtrace/profiling/_service.py
@@ -27,7 +27,8 @@ class Service(object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        return self.stop()
+        self.stop()
+        self.join()
 
     def start(self):
         """Start the service."""

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -182,6 +182,25 @@ def test_stress_threads():
         t.join()
 
 
+def test_stress_threads_run_as_thread():
+    NB_THREADS = 40
+
+    threads = []
+    for i in range(NB_THREADS):
+        t = threading.Thread(target=_f0)  # noqa: E149,F821
+        t.start()
+        threads.append(t)
+
+    r = recorder.Recorder()
+    s = stack.StackCollector(recorder=r)
+    # This mainly check nothing bad happens when we collect a lot of threads and store the result in the Recorder
+    with s:
+        time.sleep(3)
+    assert r.events[stack.StackSampleEvent]
+    for t in threads:
+        t.join()
+
+
 @pytest.mark.skipif(not stack.FEATURES["stack-exceptions"], reason="Stack exceptions not supported")
 @pytest.mark.skipif(TESTING_GEVENT, reason="Test not compatible with gevent")
 def test_exception_collection_threads():
@@ -224,7 +243,7 @@ def test_exception_collection():
     assert e.sampling_period > 0
     assert e.thread_id == _nogevent.thread_get_ident()
     assert e.thread_name == "MainThread"
-    assert e.frames == [(__file__, 218, "test_exception_collection")]
+    assert e.frames == [(__file__, 237, "test_exception_collection")]
     assert e.nframes == 1
     assert e.exc_type == ValueError
 

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -211,12 +211,11 @@ def test_exception_collection_threads():
 def test_exception_collection():
     r = recorder.Recorder()
     c = stack.StackCollector(r)
-    c.start()
-    try:
-        raise ValueError("hello")
-    except Exception:
-        _nogevent.sleep(1)
-    c.stop()
+    with c:
+        try:
+            raise ValueError("hello")
+        except Exception:
+            _nogevent.sleep(1)
 
     exception_events = r.events[stack.StackExceptionSampleEvent]
     assert len(exception_events) >= 1

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -9,23 +9,13 @@ import pytest
 import ddtrace
 from ddtrace.vendor import six
 
+from ddtrace.profiling import _nogevent
 from ddtrace.profiling import recorder
 from ddtrace.profiling.collector import stack
 
 from . import test_collector
 
 TESTING_GEVENT = os.getenv("DD_PROFILE_TEST_GEVENT", False)
-
-try:
-    from gevent import monkey
-except ImportError:
-    real_sleep = time.sleep
-    real_Thread = threading.Thread
-    real_Lock = threading.Lock
-else:
-    real_sleep = monkey.get_original("time", "sleep")
-    real_Thread = monkey.get_original("threading", "Thread")
-    real_Lock = monkey.get_original("threading", "Lock")
 
 
 def func1():
@@ -45,7 +35,7 @@ def func4():
 
 
 def func5():
-    return real_sleep(1)
+    return _nogevent.sleep(1)
 
 
 def test_collect_truncate():
@@ -225,7 +215,7 @@ def test_exception_collection():
     try:
         raise ValueError("hello")
     except Exception:
-        real_sleep(1)
+        _nogevent.sleep(1)
     c.stop()
 
     exception_events = r.events[stack.StackExceptionSampleEvent]
@@ -233,9 +223,9 @@ def test_exception_collection():
     e = exception_events[0]
     assert e.timestamp > 0
     assert e.sampling_period > 0
-    assert e.thread_id == stack._thread_get_ident()
+    assert e.thread_id == _nogevent.thread_get_ident()
     assert e.thread_name == "MainThread"
-    assert e.frames == [(__file__, 228, "test_exception_collection")]
+    assert e.frames == [(__file__, 218, "test_exception_collection")]
     assert e.nframes == 1
     assert e.exc_type == ValueError
 
@@ -255,7 +245,7 @@ def tracer_and_collector():
 def test_thread_to_span_thread_isolation(tracer_and_collector):
     t, c = tracer_and_collector
     root = t.start_span("root")
-    thread_id = stack._thread_get_ident()
+    thread_id = _nogevent.thread_get_ident()
     assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {root}
 
     store = {}
@@ -278,7 +268,7 @@ def test_thread_to_span_thread_isolation(tracer_and_collector):
 def test_thread_to_span_multiple(tracer_and_collector):
     t, c = tracer_and_collector
     root = t.start_span("root")
-    thread_id = stack._thread_get_ident()
+    thread_id = _nogevent.thread_get_ident()
     assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {root}
     subspan = t.start_span("subtrace", child_of=root)
     assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {subspan}
@@ -297,7 +287,7 @@ def test_thread_to_child_span_multiple_unknown_thread(tracer_and_collector):
 def test_thread_to_child_span_clear(tracer_and_collector):
     t, c = tracer_and_collector
     root = t.start_span("root")
-    thread_id = stack._thread_get_ident()
+    thread_id = _nogevent.thread_get_ident()
     assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {root}
     c._thread_span_links.clear_threads(set())
     assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == set()
@@ -306,7 +296,7 @@ def test_thread_to_child_span_clear(tracer_and_collector):
 def test_thread_to_child_span_multiple_more_children(tracer_and_collector):
     t, c = tracer_and_collector
     root = t.start_span("root")
-    thread_id = stack._thread_get_ident()
+    thread_id = _nogevent.thread_get_ident()
     assert c._thread_span_links.get_active_leaf_spans_from_thread_id(thread_id) == {root}
     subspan = t.start_span("subtrace", child_of=root)
     subsubspan = t.start_span("subsubtrace", child_of=subspan)
@@ -374,10 +364,10 @@ def test_stress_trace_collection(tracer_and_collector):
 def test_thread_time_cache():
     tt = stack._ThreadTime()
 
-    lock = real_Lock()
+    lock = _nogevent.Lock()
     lock.acquire()
 
-    t = real_Thread(target=lock.acquire)
+    t = _nogevent.Thread(target=lock.acquire)
     t.start()
 
     main_thread_id = threading.current_thread().ident


### PR DESCRIPTION
## refactor(profiling): move gevent/no-gevent code in a _nogevent module

This should make it easier to access non-gevent function under gevent.

## refactor(profiling): wait for service to join when using context manager


## fix(profiling): lock Recorder on reset

The lock-free approach does not work as the following scenario might happen:
- Recorder.push_events() is called from a Collector
- The collector gets a reference to the event queue and is interrupted
- The Scheduler calls Recorder.reset() and passes the old events queue to the
  Exporter
- The Exporter starts to export and iterate over the list of events
- The Exporter gets interrupted and the Collector resumes
- The Collectors finally pushes its events and go back to sleep
- The Exporter resumes and the iteration breaks because the event queue changed

This can be seen in the wild with the following backtrace:

  Traceback (most recent call last):
    File "/lib/python2.7/site-packages/ddtrace/profiling/scheduler.py", line 44, in flush
      exp.export(events, start, self._last_export)
    File "/lib/python2.7/site-packages/ddtrace/profiling/exporter/http.py", line 132, in export
      profile = super(PprofHTTPExporter, self).export(events, start_time_ns, end_time_ns)
    File "/lib/python2.7/site-packages/ddtrace/profiling/exporter/pprof.py", line 327, in export
      for event in events.get(stack.StackSampleEvent, []):
  RuntimeError: deque mutated during iteration

In order to fix that, a Lock must be used.

For the gevent case, we actually need two locks:
- one for locking out the coroutines
- one for locking out the OS thread that might be used (e.g. stack collector)

We introduce a DoubleLock class that does exactly that.
