### PR TITLE
core: set tags from DD_TAGS

### DIFF
--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -1,12 +1,12 @@
 from copy import deepcopy
+import os
 
 from ..internal.logger import get_logger
 from ..pin import Pin
 from ..utils.deprecation import get_service_legacy
-from ..utils.formats import asbool
+from ..utils.formats import asbool, get_env, parse_tags_str
 from .http import HttpConfig
 from .integration import IntegrationConfig
-from ..utils.formats import get_env
 
 log = get_logger(__name__)
 
@@ -50,12 +50,23 @@ class Config(object):
 
         self.analytics_enabled = asbool(get_env("trace", "analytics_enabled", default=legacy_config_value))
 
+        self.tags = parse_tags_str(os.getenv("DD_TAGS") or "")
+
+        self.env = os.getenv("DD_ENV") or self.tags.get("env")
         # DEV: we don't use `self._get_service()` here because {DD,DATADOG}_SERVICE and
         # {DD,DATADOG}_SERVICE_NAME (deprecated) are distinct functionalities.
-        self.service = get_env("service")
+        self.service = os.getenv("DD_SERVICE") or os.getenv("DATADOG_SERVICE") or self.tags.get("service")
+        self.version = os.getenv("DD_VERSION") or self.tags.get("version")
 
-        self.env = get_env("env")
-        self.version = get_env("version")
+        # The service tag corresponds to span.service and should not be
+        # included in the global tags.
+        if self.service and "service" in self.tags:
+            del self.tags["service"]
+
+        # The version tag should not be included on all spans.
+        if self.version and "version" in self.tags:
+            del self.tags["version"]
+
         self.logs_injection = asbool(get_env("logs", "injection", default=False))
 
         self.report_hostname = asbool(get_env("trace", "report_hostname", default=False))

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -16,7 +16,7 @@ from .context import Context
 from .sampler import DatadogSampler, RateSampler, RateByServiceSampler
 from .settings import config
 from .span import Span
-from .utils.formats import get_env, parse_tags_str
+from .utils.formats import get_env
 from .utils.deprecation import deprecated, RemovedInDDTrace10Warning
 from .vendor.dogstatsd import DogStatsd
 from . import compat
@@ -118,10 +118,7 @@ class Tracer(object):
                 raise ValueError('Unknown scheme `%s` for agent URL' % url_parsed.scheme)
 
         # globally set tags
-        self.tags = {}
-        env_tags = environ.get("DD_TAGS")
-        if env_tags:
-            self.set_tags(parse_tags_str(env_tags))
+        self.tags = config.tags.copy()
 
         # a buffer for service info so we don't perpetually send the same things
         self._services = set()
@@ -382,12 +379,11 @@ class Tracer(object):
         #     a. User provided or integration provided service name
         # 2. Parent's service name (if defined)
         # 3. Globally configured service name
-        #     a. `config.service`/`DD_SERVICE`
+        #     a. `config.service`/`DD_SERVICE`/`DD_TAGS`
         if service is None:
             if parent:
                 service = parent.service
             else:
-                # ``config`` is initialized with DD_SERVICE env var if it exists.
                 service = config.service
 
         if trace_id:
@@ -451,14 +447,14 @@ class Tracer(object):
             if self._runtime_worker and self._is_span_internal(span):
                 span.set_tag('language', 'python')
 
-        # Apply default global tags
+        # Apply default global tags.
         if self.tags:
             span.set_tags(self.tags)
 
-        # Add env, service, and version tags
-        # DEV: These override the default global tags, `DD_VERSION` takes precedence over `DD_TAGS=version:v`
         if config.env:
             span.set_tag(ENV_KEY, config.env)
+
+        # Only set the version tag on internal spans.
         if config.version:
             root_span = self.current_root_span()
             # if: 1. the span is the root span and the span's service matches the global config; or

--- a/tests/contrib/logging/test_logging.py
+++ b/tests/contrib/logging/test_logging.py
@@ -65,7 +65,7 @@ class LoggingTestCase(BaseTracerTestCase):
         log = logging.getLogger()
         self.assertFalse(isinstance(log.makeRecord, wrapt.BoundFunctionWrapper))
 
-    def _test_logging(self, create_span, version="", env=""):
+    def _test_logging(self, create_span, service="", version="", env=""):
         def func():
             span = create_span()
             logger.info("Hello!")
@@ -78,7 +78,6 @@ class LoggingTestCase(BaseTracerTestCase):
             output, span = capture_function_log(func)
             trace_id = 0
             span_id = 0
-            service = ddtrace.config.service or ""
             if span:
                 trace_id = span.trace_id
                 span_id = span.span_id
@@ -105,10 +104,6 @@ class LoggingTestCase(BaseTracerTestCase):
             self._test_logging(create_span=create_span, version="global.version", env="global.env")
 
     def test_log_trace_service(self):
-        """
-        Check logging patched and formatter including trace info
-        """
-
         def create_span():
             return self.tracer.trace("test.logging", service="logging")
 
@@ -117,11 +112,16 @@ class LoggingTestCase(BaseTracerTestCase):
         with self.override_global_config(dict(version="global.version", env="global.env")):
             self._test_logging(create_span=create_span, version="global.version", env="global.env")
 
-    def test_log_trace_version(self):
-        """
-        Check logging patched and formatter including trace info
-        """
+    @BaseTracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_TAGS="service:ddtagservice,env:ddenv,version:ddversion")
+    )
+    def test_log_DD_TAGS(self):
+        def create_span():
+            return self.tracer.trace("test.logging")
 
+        self._test_logging(create_span=create_span, service="ddtagservice", version="ddversion", env="ddenv")
+
+    def test_log_trace_version(self):
         def create_span():
             span = self.tracer.trace("test.logging")
             span.set_tag(VERSION_KEY, "manual.version")

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -947,6 +947,38 @@ class EnvTracerTestCase(BaseTracerTestCase):
         assert "key2" in self.tracer.tags
         assert "key3" not in self.tracer.tags
 
+    @run_in_subprocess(env_overrides=dict(DD_TAGS="service:mysvc,env:myenv,version:myvers"))
+    def test_tags_from_DD_TAGS(self):
+        t = ddtrace.Tracer()
+        with t.trace("test") as s:
+            assert s.service == "mysvc"
+            assert s.get_tag("env") == "myenv"
+            assert s.get_tag("version") == "myvers"
+
+    @run_in_subprocess(env_overrides=dict(
+        DD_TAGS="service:s,env:e,version:v",
+        DD_ENV="env",
+        DD_SERVICE="svc",
+        DD_VERSION="0.123",
+    ))
+    def test_tags_from_DD_TAGS_precedence(self):
+        t = ddtrace.Tracer()
+        with t.trace("test") as s:
+            assert s.service == "svc"
+            assert s.get_tag("env") == "env"
+            assert s.get_tag("version") == "0.123"
+
+    @run_in_subprocess(env_overrides=dict(DD_TAGS="service:mysvc,env:myenv,version:myvers"))
+    def test_tags_from_DD_TAGS_override(self):
+        t = ddtrace.Tracer()
+        ddtrace.config.env = "env"
+        ddtrace.config.service = "service"
+        ddtrace.config.version = "0.123"
+        with t.trace("test") as s:
+            assert s.service == "service"
+            assert s.get_tag("env") == "env"
+            assert s.get_tag("version") == "0.123"
+
 
 def test_tracer_custom_max_traces(monkeypatch):
     monkeypatch.setenv("DD_TRACE_MAX_TPS", "2000")


### PR DESCRIPTION
We want to allow `service`, `env` and `version` to be set-able via the `DD_TAGS` environment variable.