### PR TITLE
tests(profiling): optimize test execution for speed

### DIFF
--- a/tests/profiling/exporter/test_http.py
+++ b/tests/profiling/exporter/test_http.py
@@ -157,7 +157,7 @@ def endpoint_test_unknown_server():
 
 def test_wrong_api_key(endpoint_test_server):
     # This is mostly testing our test server, not the exporter
-    exp = http.PprofHTTPExporter(_ENDPOINT, "this is not the right API key", max_retry_delay=10)
+    exp = http.PprofHTTPExporter(_ENDPOINT, "this is not the right API key", max_retry_delay=2)
     with pytest.raises(http.UploadFailed) as t:
         exp.export(test_pprof.TEST_EVENTS, 0, 1)
     e = t.value.exception
@@ -173,7 +173,7 @@ def test_export(endpoint_test_server):
 
 
 def test_export_server_down():
-    exp = http.PprofHTTPExporter("http://localhost:2", _API_KEY, max_retry_delay=10)
+    exp = http.PprofHTTPExporter("http://localhost:2", _API_KEY, max_retry_delay=2)
     with pytest.raises(http.UploadFailed) as t:
         exp.export(test_pprof.TEST_EVENTS, 0, 1)
     e = t.value.exception
@@ -183,7 +183,7 @@ def test_export_server_down():
 
 
 def test_export_timeout(endpoint_test_timeout_server):
-    exp = http.PprofHTTPExporter(_TIMEOUT_ENDPOINT, _API_KEY, timeout=1, max_retry_delay=10)
+    exp = http.PprofHTTPExporter(_TIMEOUT_ENDPOINT, _API_KEY, timeout=1, max_retry_delay=2)
     with pytest.raises(http.UploadFailed) as t:
         exp.export(test_pprof.TEST_EVENTS, 0, 1)
     e = t.value.exception
@@ -191,7 +191,7 @@ def test_export_timeout(endpoint_test_timeout_server):
 
 
 def test_export_reset(endpoint_test_reset_server):
-    exp = http.PprofHTTPExporter(_RESET_ENDPOINT, _API_KEY, timeout=1)
+    exp = http.PprofHTTPExporter(_RESET_ENDPOINT, _API_KEY, timeout=1, max_retry_delay=2)
     with pytest.raises(http.UploadFailed) as t:
         exp.export(test_pprof.TEST_EVENTS, 0, 1)
     e = t.value.exception

--- a/tests/profiling/test_compat.py
+++ b/tests/profiling/test_compat.py
@@ -3,7 +3,9 @@ import subprocess
 import os
 
 
-def test_call_script():
+def test_call_script(monkeypatch):
+    # Set a very short timeout to exit fast
+    monkeypatch.setenv("DD_PROFILING_API_TIMEOUT", 0.1)
     subp = subprocess.Popen(
         ["python", os.path.join(os.path.dirname(__file__), "compat_program.py")], stdout=subprocess.PIPE
     )

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -13,7 +13,9 @@ from ddtrace.profiling.collector import stack
 from ddtrace.profiling.exporter import pprof_pb2
 
 
-def test_call_script():
+def test_call_script(monkeypatch):
+    # Set a very short timeout to exit fast
+    monkeypatch.setenv("DD_PROFILING_API_TIMEOUT", 0.1)
     subp = subprocess.Popen(
         ["pyddprofile", os.path.join(os.path.dirname(__file__), "simple_program.py")], stdout=subprocess.PIPE
     )

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -11,7 +11,7 @@ def test_status():
     assert repr(p.status) == "STOPPED"
     p.start()
     assert repr(p.status) == "RUNNING"
-    p.stop()
+    p.stop(flush=False)
     assert repr(p.status) == "STOPPED"
 
 
@@ -31,8 +31,8 @@ def test_multiple_stop():
     """
     p = profiler.Profiler()
     p.start()
-    p.stop()
-    p.stop()
+    p.stop(flush=False)
+    p.stop(flush=False)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This changes a few settings to make sure test run as fast a possible. This
reduces timeout, and disable flush on exit in certain cases to avoid retrying
for several seconds on shutdown if the agent is down.

This brings down the execution time of while test suite from 4 minutes to
1 minute.
