### PR TITLE
core: disable import hooks

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -1,10 +1,5 @@
 import pkg_resources
 
-# Always import and patch import hooks before loading anything else
-from .internal.import_hooks import patch as patch_import_hooks
-
-patch_import_hooks()  # noqa: E402
-
 from .monkey import patch, patch_all  # noqa: E402
 from .pin import Pin  # noqa: E402
 from .span import Span  # noqa: E402

--- a/tests/internal/import_hooks/test_integration.py
+++ b/tests/internal/import_hooks/test_integration.py
@@ -9,6 +9,9 @@ from ddtrace.internal import import_hooks
 from tests.subprocesstest import run_in_subprocess, SubprocessTestCase
 
 
+import_hooks.patch()
+
+
 @pytest.fixture
 def hooks():
     import_hooks.hooks.reset()


### PR DESCRIPTION
The import hooks have been causing a few issues. #1553 is one example of which (I'm going to try to dig up other instances but memory serves that it's come up before). We don't use the import hooking mechanism anywhere within the project, we just install the patches which is causing issues.

So the patching can be safely disabled until a find a root cause for #1553 is found and more time is allocated for testing the hooks more thoroughly.

Fixes #1553.