### PR TITLE
test(profiling): speed up gevent script test

### DIFF
--- a/tests/profiling/simple_program_gevent.py
+++ b/tests/profiling/simple_program_gevent.py
@@ -19,17 +19,16 @@ def fibonacci(n):
         return fibonacci(n - 1) + fibonacci(n - 2)
 
 
-threads = []
-for x in range(10):
-    t = threading.Thread(target=fibonacci, args=(32,))
-    t.start()
-    threads.append(t)
+recorder = list(bootstrap.profiler.recorders)[0]
 
-
-for t in threads:
-    t.join()
-
-
-recorder = bootstrap.profiler.recorders.pop()
 # When not using our special PeriodicThread based on real threads, there's 0 event captured.
-assert len(recorder.events[stack.StackSampleEvent]) > 10
+i = 1
+while len(recorder.events[stack.StackSampleEvent]) < 10:
+    threads = []
+    for _ in range(10):
+        t = threading.Thread(target=fibonacci, args=(i,))
+        t.start()
+        threads.append(t)
+    i += 1
+    for t in threads:
+        t.join()

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -28,7 +28,8 @@ def test_call_script(monkeypatch):
 
 
 @pytest.mark.skipif(not os.getenv("DD_PROFILE_TEST_GEVENT", False), reason="Not testing gevent")
-def test_call_script_gevent():
+def test_call_script_gevent(monkeypatch):
+    monkeypatch.setenv("DD_PROFILING_API_TIMEOUT", 0.1)
     subp = subprocess.Popen(
         ["python", os.path.join(os.path.dirname(__file__), "simple_program_gevent.py")], stdout=subprocess.PIPE
     )


### PR DESCRIPTION
This rewrite the test to exit faster and cut down the timeout for flushing
profiles.

This brings the speed from 45 to 1.3 second.