### PR TITLE
fix(profiling,gevent): fix race condition with periodic thread

### DIFF
--- a/tests/profiling/test_periodic.py
+++ b/tests/profiling/test_periodic.py
@@ -53,13 +53,13 @@ def test_periodic():
     t = _periodic.PeriodicRealThread(0.001, _run_periodic, on_shutdown=_on_shutdown)
     t.start()
     thread_started.wait()
-    assert t.ident in _periodic.PERIODIC_THREAD_IDS
+    assert t.ident in _periodic.PERIODIC_THREADS
     thread_continue.set()
     t.stop()
     t.join()
     assert x["OK"]
     assert x["DOWN"]
-    assert t.ident not in _periodic.PERIODIC_THREAD_IDS
+    assert t.ident not in _periodic.PERIODIC_THREADS
     if hasattr(threading, "get_native_id"):
         assert t.native_id is not None
 
@@ -81,12 +81,12 @@ def test_periodic_error():
     t = _periodic.PeriodicRealThread(0.001, _run_periodic, on_shutdown=_on_shutdown)
     t.start()
     thread_started.wait()
-    assert t.ident in _periodic.PERIODIC_THREAD_IDS
+    assert t.ident in _periodic.PERIODIC_THREADS
     thread_continue.set()
     t.stop()
     t.join()
     assert "DOWN" not in x
-    assert t.ident not in _periodic.PERIODIC_THREAD_IDS
+    assert t.ident not in _periodic.PERIODIC_THREADS
 
 
 def test_gevent_class():
@@ -94,17 +94,6 @@ def test_gevent_class():
         assert isinstance(_periodic.PeriodicRealThread(1, sum), _periodic._GeventPeriodicThread)
     else:
         assert isinstance(_periodic.PeriodicRealThread(1, sum), _periodic.PeriodicThread)
-
-
-def test_periodic_real_thread_name():
-    def do_nothing():
-        pass
-
-    t = _periodic.PeriodicRealThread(interval=1, target=do_nothing)
-    t.start()
-    assert t in threading.enumerate()
-    t.stop()
-    t.join()
 
 
 def test_periodic_service_start_stop():


### PR DESCRIPTION
The lock used in the threading is a gevent coroutine-lock which break if locked
from different threads:

  Traceback (most recent call last):
    File "/root/project/ddtrace/profiling/_periodic.py", line 104, in run
      with threading._active_limbo_lock:
    File "src/gevent/_semaphore.py", line 191, in gevent._gevent_c_semaphore.Semaphore.__enter__
    File "src/gevent/_semaphore.py", line 192, in gevent._gevent_c_semaphore.Semaphore.__enter__
    File "src/gevent/_semaphore.py", line 143, in gevent._gevent_c_semaphore.Semaphore.acquire
    File "/root/project/.tox/py27-profile-gevent/lib/python2.7/site-packages/gevent/thread.py", line 118, in acquire
      acquired = BoundedSemaphore.acquire(self, blocking, timeout)
    File "src/gevent/_semaphore.py", line 143, in gevent._gevent_c_semaphore.Semaphore.acquire
    File "src/gevent/_semaphore.py", line 186, in gevent._gevent_c_semaphore.Semaphore.acquire
  AssertionError

This patches removes its usage by not registering our special thread in the
active list of threads from the `threading` module. That should not matter
since it is a real thread and not a gevent coroutine.

We still allow the stack profiler to find the thread (and get its name) by
making it look in the list of PERIODIC_THREADS.
