### PR TITLE
tests: fix test for dogpile.cache 1.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,8 @@ envlist =
     django_drf_contrib-py35-django{22}-djangorestframework{38,310,}
     django_drf_contrib-py{36,37}-django{22}-djangorestframework{38,310,}
     django_drf_contrib-py{36,37,38}-django{30,}-djangorestframework{310,}
-    dogpile_contrib-py{27,35,36,37,38}-dogpilecache{06,07,08,}
+    dogpile_contrib-py{27,35}-dogpilecache{06,07,08,09}
+    dogpile_contrib-py{36,37,38}-dogpilecache{06,07,08,09,10,}
     elasticsearch_contrib-{py27,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63,64}
     elasticsearch_contrib-{py27,py35,py36}-elasticsearch1{100}
     elasticsearch_contrib-{py27,py35,py36}-elasticsearch2{50}
@@ -283,6 +284,8 @@ deps =
     dogpilecache06: dogpile.cache==0.6.*
     dogpilecache07: dogpile.cache==0.7.*
     dogpilecache08: dogpile.cache==0.8.*
+    dogpilecache09: dogpile.cache==0.9.*
+    dogpilecache10: dogpile.cache==1.0.*
     elasticsearch16: elasticsearch>=1.6,<1.7
     elasticsearch17: elasticsearch>=1.7,<1.8
     elasticsearch18: elasticsearch>=1.8,<1.9


### PR DESCRIPTION
Dogpile 1.0 was [released](https://github.com/sqlalchemy/dogpile.cache/releases/tag/rel_1_0_1) which drops support for Python < 3.6. This broke our tests as we were testing with the latest version across all python versions.