### PR TITLE
Make environment variables consistent with other languages

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -26,7 +26,10 @@ if config.logs_injection:
 # See https://github.com/python/cpython/blob/112e4afd582515fcdcc0cde5012a4866e5cfda12/Lib/logging/__init__.py#L1550
 # Debug mode from the tracer will do a basicConfig so only need to do this otherwise
 if not debug_mode:
-    logging.basicConfig(format=DD_LOG_FORMAT)
+    if config.logs_injection:
+        logging.basicConfig(format=DD_LOG_FORMAT)
+    else:
+        logging.basicConfig()
 
 log = get_logger(__name__)
 

--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -39,7 +39,7 @@ Configuration
 
    Whether to analyze spans for Django in App Analytics.
 
-   Can also be enabled with the ``DD_DJANGO_ANALYTICS_ENABLED`` environment variable.
+   Can also be enabled with the ``DD_TRACE_DJANGO_ANALYTICS_ENABLED`` environment variable.
 
    Default: ``None``
 
@@ -165,7 +165,7 @@ The mapping from old configuration settings to new ones.
 +-----------------------------+-------------------------------------------------------------------------------------------------------------------------+
 | ``TRACE_QUERY_STRING``      | ``config.django['trace_query_string']``                                                                                 |
 +-----------------------------+-------------------------------------------------------------------------------------------------------------------------+
-| ``TAGS``                    | ``DD_TRACE_GLOBAL_TAGS`` environment variable or ``tracer.set_tags()``                                                  |
+| ``TAGS``                    | ``DD_TAGS`` environment variable or ``tracer.set_tags()``                                                               |
 +-----------------------------+-------------------------------------------------------------------------------------------------------------------------+
 | ``TRACER``                  | N/A - if a particular tracer is required for the Django integration use ``Pin.override(Pin.get_from(django), tracer=)`` |
 +-----------------------------+-------------------------------------------------------------------------------------------------------------------------+

--- a/ddtrace/contrib/flask/__init__.py
+++ b/ddtrace/contrib/flask/__init__.py
@@ -41,7 +41,7 @@ Configuration
 
    Whether to analyze spans for Flask in App Analytics.
 
-   Can also be enabled with the ``DD_FLASK_ANALYTICS_ENABLED`` environment variable.
+   Can also be enabled with the ``DD_TRACE_FLASK_ANALYTICS_ENABLED`` environment variable.
 
    Default: ``None``
 

--- a/ddtrace/contrib/molten/__init__.py
+++ b/ddtrace/contrib/molten/__init__.py
@@ -27,7 +27,7 @@ Configuration
 
    Whether to analyze spans for Molten in App Analytics.
 
-   Can also be enabled with the ``DD_MOLTEN_ANALYTICS_ENABLED`` environment variable.
+   Can also be enabled with the ``DD_TRACE_MOLTEN_ANALYTICS_ENABLED`` environment variable.
 
    Default: ``None``
 
@@ -35,7 +35,7 @@ Configuration
 
    The service name reported for your Molten app.
 
-   Can also be configured via the ``DD_MOLTEN_SERVICE_NAME`` environment variable.
+   Can also be configured via the ``DD_SERVICE`` or ``DD_MOLTEN_SERVICE_NAME`` environment variables.
 
    Default: ``'molten'``
 """

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -1,3 +1,5 @@
+import os
+
 from .trace import trace_pyramid, DD_TWEEN_NAME
 from .constants import (
     SETTINGS_SERVICE, SETTINGS_DISTRIBUTED_TRACING,
@@ -32,10 +34,13 @@ def traced_init(wrapped, instance, args, kwargs):
     distributed_tracing = asbool(get_env('pyramid', 'distributed_tracing', default=True))
     # DEV: integration-specific analytics flag can be not set but still enabled
     # globally for web frameworks
-    analytics_enabled = get_env('pyramid', 'analytics_enabled')
+    old_analytics_enabled = get_env('pyramid', 'analytics_enabled')
+    analytics_enabled = os.environ.get("DD_TRACE_PYRAMID_ANALYTICS_ENABLED", old_analytics_enabled)
     if analytics_enabled is not None:
         analytics_enabled = asbool(analytics_enabled)
-    analytics_sample_rate = get_env('pyramid', 'analytics_sample_rate', default=True)
+    # TODO: why is analytics sample rate a string or a bool here?
+    old_analytics_sample_rate = get_env('pyramid', 'analytics_sample_rate', default=True)
+    analytics_sample_rate = os.environ.get("DD_TRACE_PYRAMID_ANALYTICS_SAMPLE_RATE", old_analytics_sample_rate)
     trace_settings = {
         SETTINGS_SERVICE: service,
         SETTINGS_DISTRIBUTED_TRACING: distributed_tracing,

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -149,9 +149,11 @@ def patch_module(module, raise_errors=True):
 
     Returns if the module got properly patched.
     """
-    if not formats.asbool(os.environ.get("DD_TRACE_%s_ENABLED" % module, True)):
-        log.info("Not patching %s as it's disabled by environment variable.", module)
+    env_var = "DD_TRACE_%s_ENABLED" % module
+    if not formats.asbool(os.environ.get(env_var, True)):
+        log.info("Not patching %s as it's disabled by environment variable %s.", module, env_var)
         return
+
 
     try:
         return _patch_module(module)

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -7,6 +7,7 @@ A library instrumentation can be configured (for instance, to report as another 
 using Pin. For that, check its documentation.
 """
 import importlib
+import os
 import sys
 import threading
 
@@ -14,6 +15,7 @@ from ddtrace.vendor.wrapt.importer import when_imported
 
 from .internal.logger import get_logger
 from .settings import config
+from .utils import formats
 
 
 log = get_logger(__name__)
@@ -147,6 +149,10 @@ def patch_module(module, raise_errors=True):
 
     Returns if the module got properly patched.
     """
+    if not formats.asbool(os.environ.get("DD_TRACE_%s_ENABLED" % module, True)):
+        log.info("Not patching %s as it's disabled by environment variable.", module)
+        return
+
     try:
         return _patch_module(module)
     except Exception:

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -1,4 +1,4 @@
-"""Patch librairies to be automatically instrumented.
+"""Patch libraries to be automatically instrumented.
 
 It can monkey patch supported standard libraries and third party modules.
 A patched module will automatically report spans with its default configuration.

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -43,12 +43,14 @@ class IntegrationConfig(AttrDict):
         # DEV: Default to `None` which means do not set this key
         # Inject environment variables for integration
         old_analytics_enabled_env = get_env(name, "analytics_enabled")
-        analytics_enabled_env = os.environ.get("DD_TRACE_%s_ANALYTICS_ENABLED" % name, old_analytics_enabled_env)
+        analytics_enabled_env = os.environ.get(
+            "DD_TRACE_%s_ANALYTICS_ENABLED" % name.upper(), old_analytics_enabled_env
+        )
         if analytics_enabled_env is not None:
             analytics_enabled_env = asbool(analytics_enabled_env)
         self.setdefault("analytics_enabled", analytics_enabled_env)
         old_analytics_rate = get_env(name, "analytics_sample_rate", default=1.0)
-        analytics_rate = os.environ.get("DD_TRACE_%s_ANALYTICS_SAMPLE_RATE" % name, old_analytics_rate)
+        analytics_rate = os.environ.get("DD_TRACE_%s_ANALYTICS_SAMPLE_RATE" % name.upper(), old_analytics_rate)
         self.setdefault("analytics_sample_rate", float(analytics_rate))
 
     def __deepcopy__(self, memodict=None):

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import os
 
 from ..utils.attrdict import AttrDict
 from ..utils.formats import asbool, get_env
@@ -41,11 +42,14 @@ class IntegrationConfig(AttrDict):
         # Set default analytics configuration, default is disabled
         # DEV: Default to `None` which means do not set this key
         # Inject environment variables for integration
-        analytics_enabled_env = get_env(name, "analytics_enabled")
+        old_analytics_enabled_env = get_env(name, "analytics_enabled")
+        analytics_enabled_env = os.environ.get("DD_TRACE_%s_ANALYTICS_ENABLED" % name, old_analytics_enabled_env)
         if analytics_enabled_env is not None:
             analytics_enabled_env = asbool(analytics_enabled_env)
         self.setdefault("analytics_enabled", analytics_enabled_env)
-        self.setdefault("analytics_sample_rate", float(get_env(name, "analytics_sample_rate", default=1.0)))
+        old_analytics_rate = get_env(name, "analytics_sample_rate", default=1.0)
+        analytics_rate = os.environ.get("DD_TRACE_%s_ANALYTICS_SAMPLE_RATE" % name, old_analytics_rate)
+        self.setdefault("analytics_sample_rate", float(analytics_rate))
 
     def __deepcopy__(self, memodict=None):
         new = IntegrationConfig(self.global_config, self.integration_name, deepcopy(dict(self), memodict))

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -28,7 +28,7 @@ from . import _hooks
 
 log = get_logger(__name__)
 
-debug_mode = asbool(environ.get("DD_TRACE_DEBUG", environ.get("DATADOG_TRACE_DEBUG", False)))
+debug_mode = asbool(get_env("trace", "debug", default=False))
 
 DD_LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] {}- %(message)s".format(
     "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s"

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -344,7 +344,7 @@ class Tracer(object):
         if (collect_metrics is None and runtime_metrics_was_running) or collect_metrics:
             self._start_runtime_worker()
 
-        if asbool(environ.get("DD_TRACE_STARTUP_LOGS", True)):
+        if debug_mode or asbool(environ.get("DD_TRACE_STARTUP_LOGS", True)):
             try:
                 info = debug.collect(self)
             except Exception as e:

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -30,13 +30,13 @@ log = get_logger(__name__)
 
 debug_mode = asbool(environ.get("DD_TRACE_DEBUG", environ.get("DATADOG_TRACE_DEBUG", False)))
 
+DD_LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] {}- %(message)s".format(
+    "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s"
+    " dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] "
+)
 if debug_mode and not hasHandlers(log):
     if config.logs_injection:
-        fmt = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] {}- %(message)s".format(
-            "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s"
-            " dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] "
-        )
-        logging.basicConfig(level=logging.DEBUG, format=fmt)
+        logging.basicConfig(level=logging.DEBUG, format=DD_LOG_FORMAT)
     else:
         logging.basicConfig(level=logging.DEBUG)
 
@@ -142,7 +142,7 @@ class Tracer(object):
         # traces
         self._pid = getpid()
 
-        self.enabled = asbool(environ.get("DD_TRACE_ENABLED", True))
+        self.enabled = asbool(get_env("trace", "enabled", default=True))
 
         # Apply the default configuration
         self.configure(

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -203,77 +203,77 @@ Enabling analyzed spans for all web frameworks can be accomplished by setting th
 * :ref:`tornado`
 
 
-For most libraries, analyzed spans can be enabled with the environment variable ``DD_{INTEGRATION}_ANALYTICS_ENABLED=true``:
+For most libraries, analyzed spans can be enabled with the environment variable ``DD_TRACE_{INTEGRATION}_ANALYTICS_ENABLED=true``:
 
-+----------------------+----------------------------------------+
-|       Library        |          Environment Variable          |
-+======================+========================================+
-| :ref:`aiobotocore`   | ``DD_AIOBOTOCORE_ANALYTICS_ENABLED``   |
-+----------------------+----------------------------------------+
-| :ref:`aiopg`         | ``DD_AIOPG_ANALYTICS_ENABLED``         |
-+----------------------+----------------------------------------+
-| :ref:`boto`          | ``DD_BOTO_ANALYTICS_ENABLED``          |
-+----------------------+----------------------------------------+
-| :ref:`botocore`      | ``DD_BOTOCORE_ANALYTICS_ENABLED``      |
-+----------------------+----------------------------------------+
-| :ref:`bottle`        | ``DD_BOTTLE_ANALYTICS_ENABLED``        |
-+----------------------+----------------------------------------+
-| :ref:`cassandra`     | ``DD_CASSANDRA_ANALYTICS_ENABLED``     |
-+----------------------+----------------------------------------+
-| :ref:`celery`        | ``DD_CELERY_ANALYTICS_ENABLED``        |
-+----------------------+----------------------------------------+
-| :ref:`elasticsearch` | ``DD_ELASTICSEARCH_ANALYTICS_ENABLED`` |
-+----------------------+----------------------------------------+
-| :ref:`falcon`        | ``DD_FALCON_ANALYTICS_ENABLED``        |
-+----------------------+----------------------------------------+
-| :ref:`flask`         | ``DD_FLASK_ANALYTICS_ENABLED``         |
-+----------------------+----------------------------------------+
-| :ref:`flask_cache`   | ``DD_FLASK_CACHE_ANALYTICS_ENABLED``   |
-+----------------------+----------------------------------------+
-| :ref:`grpc`          | ``DD_GRPC_ANALYTICS_ENABLED``          |
-+----------------------+----------------------------------------+
-| :ref:`httplib`       | ``DD_HTTPLIB_ANALYTICS_ENABLED``       |
-+----------------------+----------------------------------------+
-| :ref:`kombu`         | ``DD_KOMBU_ANALYTICS_ENABLED``         |
-+----------------------+----------------------------------------+
-| :ref:`molten`        | ``DD_MOLTEN_ANALYTICS_ENABLED``        |
-+----------------------+----------------------------------------+
-| :ref:`pylibmc`       | ``DD_PYLIBMC_ANALYTICS_ENABLED``       |
-+----------------------+----------------------------------------+
-| :ref:`pylons`        | ``DD_PYLONS_ANALYTICS_ENABLED``        |
-+----------------------+----------------------------------------+
-| :ref:`pymemcache`    | ``DD_PYMEMCACHE_ANALYTICS_ENABLED``    |
-+----------------------+----------------------------------------+
-| :ref:`pymongo`       | ``DD_PYMONGO_ANALYTICS_ENABLED``       |
-+----------------------+----------------------------------------+
-| :ref:`redis`         | ``DD_REDIS_ANALYTICS_ENABLED``         |
-+----------------------+----------------------------------------+
-| :ref:`rediscluster`  | ``DD_REDISCLUSTER_ANALYTICS_ENABLED``  |
-+----------------------+----------------------------------------+
-| :ref:`sqlalchemy`    | ``DD_SQLALCHEMY_ANALYTICS_ENABLED``    |
-+----------------------+----------------------------------------+
-| :ref:`vertica`       | ``DD_VERTICA_ANALYTICS_ENABLED``       |
-+----------------------+----------------------------------------+
++----------------------+----------------------------------------------+
+|       Library        |              Environment Variable            |
++======================+==============================================+
+| :ref:`aiobotocore`   | ``DD_TRACE_AIOBOTOCORE_ANALYTICS_ENABLED``   |
++----------------------+----------------------------------------------+
+| :ref:`aiopg`         | ``DD_TRACE_AIOPG_ANALYTICS_ENABLED``         |
++----------------------+----------------------------------------------+
+| :ref:`boto`          | ``DD_TRACE_BOTO_ANALYTICS_ENABLED``          |
++----------------------+----------------------------------------------+
+| :ref:`botocore`      | ``DD_TRACE_BOTOCORE_ANALYTICS_ENABLED``      |
++----------------------+----------------------------------------------+
+| :ref:`bottle`        | ``DD_TRACE_BOTTLE_ANALYTICS_ENABLED``        |
++----------------------+----------------------------------------------+
+| :ref:`cassandra`     | ``DD_TRACE_CASSANDRA_ANALYTICS_ENABLED``     |
++----------------------+----------------------------------------------+
+| :ref:`celery`        | ``DD_TRACE_CELERY_ANALYTICS_ENABLED``        |
++----------------------+----------------------------------------------+
+| :ref:`elasticsearch` | ``DD_TRACE_ELASTICSEARCH_ANALYTICS_ENABLED`` |
++----------------------+----------------------------------------------+
+| :ref:`falcon`        | ``DD_TRACE_FALCON_ANALYTICS_ENABLED``        |
++----------------------+----------------------------------------------+
+| :ref:`flask`         | ``DD_TRACE_FLASK_ANALYTICS_ENABLED``         |
++----------------------+----------------------------------------------+
+| :ref:`flask_cache`   | ``DD_TRACE_FLASK_CACHE_ANALYTICS_ENABLED``   |
++----------------------+----------------------------------------------+
+| :ref:`grpc`          | ``DD_TRACE_GRPC_ANALYTICS_ENABLED``          |
++----------------------+----------------------------------------------+
+| :ref:`httplib`       | ``DD_TRACE_HTTPLIB_ANALYTICS_ENABLED``       |
++----------------------+----------------------------------------------+
+| :ref:`kombu`         | ``DD_TRACE_KOMBU_ANALYTICS_ENABLED``         |
++----------------------+----------------------------------------------+
+| :ref:`molten`        | ``DD_TRACE_MOLTEN_ANALYTICS_ENABLED``        |
++----------------------+----------------------------------------------+
+| :ref:`pylibmc`       | ``DD_TRACE_PYLIBMC_ANALYTICS_ENABLED``       |
++----------------------+----------------------------------------------+
+| :ref:`pylons`        | ``DD_TRACE_PYLONS_ANALYTICS_ENABLED``        |
++----------------------+----------------------------------------------+
+| :ref:`pymemcache`    | ``DD_TRACE_PYMEMCACHE_ANALYTICS_ENABLED``    |
++----------------------+----------------------------------------------+
+| :ref:`pymongo`       | ``DD_TRACE_PYMONGO_ANALYTICS_ENABLED``       |
++----------------------+----------------------------------------------+
+| :ref:`redis`         | ``DD_TRACE_REDIS_ANALYTICS_ENABLED``         |
++----------------------+----------------------------------------------+
+| :ref:`rediscluster`  | ``DD_TRACE_REDISCLUSTER_ANALYTICS_ENABLED``  |
++----------------------+----------------------------------------------+
+| :ref:`sqlalchemy`    | ``DD_TRACE_SQLALCHEMY_ANALYTICS_ENABLED``    |
++----------------------+----------------------------------------------+
+| :ref:`vertica`       | ``DD_TRACE_VERTICA_ANALYTICS_ENABLED``       |
++----------------------+----------------------------------------------+
 
 For datastore libraries that extend another, use the setting for the underlying library:
 
-+------------------------+----------------------------------+
-|        Library         |       Environment Variable       |
-+========================+==================================+
-| :ref:`mongoengine`     | ``DD_PYMONGO_ANALYTICS_ENABLED`` |
-+------------------------+----------------------------------+
-| :ref:`mysql-connector` | ``DD_DBAPI2_ANALYTICS_ENABLED``  |
-+------------------------+----------------------------------+
-| :ref:`mysqldb`         | ``DD_DBAPI2_ANALYTICS_ENABLED``  |
-+------------------------+----------------------------------+
-| :ref:`psycopg2`        | ``DD_DBAPI2_ANALYTICS_ENABLED``  |
-+------------------------+----------------------------------+
-| :ref:`pymysql`         | ``DD_DBAPI2_ANALYTICS_ENABLED``  |
-+------------------------+----------------------------------+
-| :ref:`sqllite`         | ``DD_DBAPI2_ANALYTICS_ENABLED``  |
-+------------------------+----------------------------------+
++------------------------+----------------------------------------+
+|        Library         |          Environment Variable          |
++========================+========================================+
+| :ref:`mongoengine`     | ``DD_TRACE_PYMONGO_ANALYTICS_ENABLED`` |
++------------------------+----------------------------------------+
+| :ref:`mysql-connector` | ``DD_TRACE_DBAPI2_ANALYTICS_ENABLED``  |
++------------------------+----------------------------------------+
+| :ref:`mysqldb`         | ``DD_TRACE_DBAPI2_ANALYTICS_ENABLED``  |
++------------------------+----------------------------------------+
+| :ref:`psycopg2`        | ``DD_TRACE_DBAPI2_ANALYTICS_ENABLED``  |
++------------------------+----------------------------------------+
+| :ref:`pymysql`         | ``DD_TRACE_DBAPI2_ANALYTICS_ENABLED``  |
++------------------------+----------------------------------------+
+| :ref:`sqllite`         | ``DD_TRACE_DBAPI2_ANALYTICS_ENABLED``  |
++------------------------+----------------------------------------+
 
-Where environment variables are not used for configuring the tracer, the instructions for configuring app analytics is provided in the library documentation:
+Where environment variables are not used for configuring the tracer, the instructions for configuring app analytics are provided in the library documentation:
 
 * :ref:`aiohttp`
 * :ref:`django`

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -18,11 +18,7 @@ below:
    * - ``DD_ENV``
      - String
      -
-     - Set an application's environment e.g. ``prod``, ``pre-prod``, ``stage``. Added in ``v0.36.0``.
-   * - ``DATADOG_ENV``
-     - String
-     -
-     - Deprecated: use ``DD_ENV``
+     - Set an application's environment e.g. ``prod``, ``pre-prod``, ``staging``. Added in ``v0.36.0``.
    * - ``DD_SERVICE``
      - String
      - (autodetected)
@@ -30,10 +26,6 @@ below:
        provided for these integrations: :ref:`bottle`, :ref:`flask`, :ref:`grpc`,
        :ref:`pyramid`, :ref:`pylons`, :ref:`tornado`, :ref:`celery`, :ref:`django` and
        :ref:`falcon`. Added in ``v0.36.0``.
-   * - ``DD_SERVICE_NAME`` or ``DATADOG_SERVICE_NAME``
-     - String
-     -
-     - Deprecated: use ``DD_SERVICE``.
    * - ``DD_TAGS``
      - String
      -
@@ -48,15 +40,21 @@ below:
      - datadoghq.com
      - Specify which site to use for uploading profiles. Set to
        ``datadoghq.eu`` to use EU site.
-   * - ``DATADOG_TRACE_ENABLED``
+   * - ``DD_TRACE_ENABLED``
      - Boolean
      - True
-     - Enable web framework and library instrumentation. When false, your
-       application code will not generate any traces.
-   * - ``DATADOG_TRACE_DEBUG``
+     - Enable sending of spans to the Agent. Note that instrumentation will still be installed and spans will be
+       generated. Added in ``v0.41.0`` (formerly named ``DATADOG_TRACE_ENABLED``).
+   * - ``DD_TRACE_DEBUG``
      - Boolean
      - False
-     - Enable debug logging in the tracer
+     - Enables debug logging in the tracer. Setting this flag will cause the library to create a root logging handler if
+       one does not already exist. Added in ``v0.41.0`` (formerly named ``DATADOG_TRACE_DEBUG``).
+   * - ``DD_TRACE_<INTEGRATION>_ENABLED``
+     - Boolean
+     - True
+     - Enables <INTEGRATION> to be patched. For example, ``DD_TRACE_DJANGO_ENABLED=false`` will disable the Django
+       integration from being installed. Added in ``v0.41.0``.
    * - ``DATADOG_PATCH_MODULES``
      - String
      -
@@ -77,14 +75,6 @@ below:
      - The URL to use to connect the Datadog agent. The url can starts with
        ``http://`` to connect using HTTP or with ``unix://`` to use a Unix
        Domain Socket.
-   * - ``DATADOG_TRACE_AGENT_HOSTNAME``
-     - String
-     -
-     - Deprecated: use ``DD_TRACE_AGENT_URL``
-   * - ``DATADOG_TRACE_AGENT_PORT``
-     - Integer
-     -
-     - Deprecated: use ``DD_TRACE_AGENT_URL``
    * - ``DD_PROFILING_ENABLED``
      - Boolean
      - False
@@ -106,7 +96,7 @@ below:
      - Float
      - 2
      - The percentage of maximum time the stack profiler can use when computing
-       statistics. Must be greather than 0 and lesser or equal to 100.
+       statistics. Must be greater than 0 and lesser or equal to 100.
    * - ``DD_PROFILING_MAX_FRAMES``
      - Integer
      - 64

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -80,9 +80,7 @@ class DdtraceRunTest(BaseTestCase):
 
     def test_debug_enabling(self):
         """
-        DATADOG_TRACE_DEBUG=true allows setting debug logging of the global tracer
-
-        Debug logs are only output when log level is set to debug.
+        {DD,DATADOG}_TRACE_DEBUG=true allows setting debug logging of the global tracer
         """
         with self.override_env(dict(DATADOG_TRACE_DEBUG="false")):
             out = subprocess.check_output(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2,6 +2,8 @@ import os
 import logging
 import math
 import mock
+import subprocess
+import sys
 import ddtrace
 
 from unittest import TestCase, skip, skipUnless
@@ -491,3 +493,23 @@ class TestConfigure(TestCase):
         tracer.configure(priority_sampling=True)
         assert "127.0.0.1" == tracer.writer.api.hostname
         assert 8127 == tracer.writer.api.port
+
+
+def test_debug_mode():
+    p = subprocess.Popen(
+        [sys.executable, "-c", "import ddtrace"], env=dict(), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    p.wait()
+    assert p.stdout.read() == b""
+    assert b"DEBUG:ddtrace" not in p.stderr.read()
+
+    p = subprocess.Popen(
+        [sys.executable, "-c", "import ddtrace"],
+        env=dict(DD_TRACE_DEBUG="true"),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    p.wait()
+    assert p.stdout.read() == b""
+    # Stderr should have some debug lines
+    assert b"DEBUG:ddtrace" in p.stderr.read()

--- a/tests/test_monkey.py
+++ b/tests/test_monkey.py
@@ -19,12 +19,12 @@ class TestPatching(SubprocessTestCase):
         monkey.patch_all()
         assert "sqlite3" in monkey._PATCHED_MODULES
 
-    @run_in_subprocess(env_overrides=dict(DD_TRACE_REDIS_ENABLED="false"))
+    @run_in_subprocess(env_overrides=dict(DD_TRACE_SQLITE3_ENABLED="false"))
     def test_patch_all_env_override_sqlite_disabled(self):
         monkey.patch_all()
         assert "sqlite3" not in monkey._PATCHED_MODULES
 
-    @run_in_subprocess(env_overrides=dict(DD_TRACE_REDIS_ENABLED="false"))
+    @run_in_subprocess(env_overrides=dict(DD_TRACE_SQLITE3_ENABLED="false"))
     def test_patch_all_env_override_manual_patch(self):
         # Manual patching should not be affected by the environment variable override.
         monkey.patch(sqlite3=True)

--- a/tests/test_monkey.py
+++ b/tests/test_monkey.py
@@ -1,0 +1,42 @@
+from ddtrace import monkey
+from .subprocesstest import SubprocessTestCase, run_in_subprocess
+
+
+class TestPatching(SubprocessTestCase):
+    """
+    In these test cases it is assumed that:
+
+     1) redis is an integration that's available and is enabled by default
+     2) httplib is an integration that's available and is disabled by default
+
+     redis is used as a representative of enabled by default integrations.
+     httplib is used as a representative of disabled by default integrations.
+    """
+
+    @run_in_subprocess(env_overrides=dict())
+    def test_patch_all_env_override_redis_none(self):
+        # Make sure redis is enabled by default.
+        monkey.patch_all()
+        assert "redis" in monkey._PATCHED_MODULES
+
+    @run_in_subprocess(env_overrides=dict(DD_TRACE_REDIS_ENABLED="false"))
+    def test_patch_all_env_override_redis_disabled(self):
+        monkey.patch_all()
+        assert "redis" not in monkey._PATCHED_MODULES
+
+    @run_in_subprocess(env_overrides=dict(DD_TRACE_REDIS_ENABLED="false"))
+    def test_patch_all_env_override_manual_patch(self):
+        # Manual patching should not be affected by the environment variable override.
+        monkey.patch(redis=True)
+        assert "redis" in monkey._PATCHED_MODULES
+
+    @run_in_subprocess(env_overrides=dict())
+    def test_patch_all_env_override_httplib_none(self):
+        # Make sure httplib is disabled by default.
+        monkey.patch_all()
+        assert "httplib" not in monkey._PATCHED_MODULES
+
+    @run_in_subprocess(env_overrides=dict(DD_TRACE_HTTPLIB_ENABLED="true"))
+    def test_patch_all_env_override_httplib_enabled(self):
+        monkey.patch_all()
+        assert "httplib" in monkey._PATCHED_MODULES

--- a/tests/test_monkey.py
+++ b/tests/test_monkey.py
@@ -6,29 +6,29 @@ class TestPatching(SubprocessTestCase):
     """
     In these test cases it is assumed that:
 
-     1) redis is an integration that's available and is enabled by default
+     1) sqlite3 is an integration that's available and is enabled by default
      2) httplib is an integration that's available and is disabled by default
 
-     redis is used as a representative of enabled by default integrations.
+     sqlite3 is used as a representative of enabled by default integrations.
      httplib is used as a representative of disabled by default integrations.
     """
 
     @run_in_subprocess(env_overrides=dict())
-    def test_patch_all_env_override_redis_none(self):
-        # Make sure redis is enabled by default.
+    def test_patch_all_env_override_sqlite_none(self):
+        # Make sure sqlite is enabled by default.
         monkey.patch_all()
-        assert "redis" in monkey._PATCHED_MODULES
+        assert "sqlite3" in monkey._PATCHED_MODULES
 
     @run_in_subprocess(env_overrides=dict(DD_TRACE_REDIS_ENABLED="false"))
-    def test_patch_all_env_override_redis_disabled(self):
+    def test_patch_all_env_override_sqlite_disabled(self):
         monkey.patch_all()
-        assert "redis" not in monkey._PATCHED_MODULES
+        assert "sqlite3" not in monkey._PATCHED_MODULES
 
     @run_in_subprocess(env_overrides=dict(DD_TRACE_REDIS_ENABLED="false"))
     def test_patch_all_env_override_manual_patch(self):
         # Manual patching should not be affected by the environment variable override.
-        monkey.patch(redis=True)
-        assert "redis" in monkey._PATCHED_MODULES
+        monkey.patch(sqlite3=True)
+        assert "sqlite3" in monkey._PATCHED_MODULES
 
     @run_in_subprocess(env_overrides=dict())
     def test_patch_all_env_override_httplib_none(self):

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1048,3 +1048,12 @@ def test_deregister_start_span_hooks():
     t.start_span("hello")
 
     assert result == {}
+
+
+def test_enable(monkeypatch):
+    t1 = ddtrace.Tracer()
+    assert t1.enabled
+
+    monkeypatch.setenv("DD_TRACE_ENABLED", "false")
+    t2 = ddtrace.Tracer()
+    assert not t2.enabled

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -170,7 +170,17 @@ class TestIntegrationConfig(BaseTestCase):
             self.assertTrue(config.analytics_enabled)
             self.assertIsNone(config.foo.analytics_enabled)
 
+        with self.override_env(dict(DD_TRACE_ANALYTICS_ENABLED='True')):
+            config = Config()
+            self.assertTrue(config.analytics_enabled)
+            self.assertIsNone(config.foo.analytics_enabled)
+
         with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED='True')):
+            config = Config()
+            self.assertTrue(config.foo.analytics_enabled)
+            self.assertEqual(config.foo.analytics_sample_rate, 1.0)
+
+        with self.override_env(dict(DD_TRACE_FOO_ANALYTICS_ENABLED='True')):
             config = Config()
             self.assertTrue(config.foo.analytics_enabled)
             self.assertEqual(config.foo.analytics_sample_rate, 1.0)
@@ -179,7 +189,16 @@ class TestIntegrationConfig(BaseTestCase):
             config = Config()
             self.assertFalse(config.foo.analytics_enabled)
 
+        with self.override_env(dict(DD_TRACE_FOO_ANALYTICS_ENABLED='False')):
+            config = Config()
+            self.assertFalse(config.foo.analytics_enabled)
+
         with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED='True', DD_FOO_ANALYTICS_SAMPLE_RATE='0.5')):
+            config = Config()
+            self.assertTrue(config.foo.analytics_enabled)
+            self.assertEqual(config.foo.analytics_sample_rate, 0.5)
+
+        with self.override_env(dict(DD_TRACE_FOO_ANALYTICS_ENABLED='True', DD_TRACE_FOO_ANALYTICS_SAMPLE_RATE='0.5')):
             config = Config()
             self.assertTrue(config.foo.analytics_enabled)
             self.assertEqual(config.foo.analytics_sample_rate, 0.5)
@@ -193,6 +212,10 @@ class TestIntegrationConfig(BaseTestCase):
         self.assertFalse(ic.analytics_enabled)
 
         with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED='True')):
+            ic = IntegrationConfig(self.config, 'foo', analytics_enabled=False)
+            self.assertFalse(ic.analytics_enabled)
+
+        with self.override_env(dict(DD_TRACE_FOO_ANALYTICS_ENABLED='True')):
             ic = IntegrationConfig(self.config, 'foo', analytics_enabled=False)
             self.assertFalse(ic.analytics_enabled)
 
@@ -212,7 +235,17 @@ class TestIntegrationConfig(BaseTestCase):
             ic = IntegrationConfig(config, 'foo')
             self.assertEqual(ic.get_analytics_sample_rate(use_global_config=True), 1.0)
 
+        with self.override_env(dict(DD_TRACE_ANALYTICS_ENABLED='True')):
+            config = Config()
+            ic = IntegrationConfig(config, 'foo')
+            self.assertEqual(ic.get_analytics_sample_rate(use_global_config=True), 1.0)
+
         with self.override_env(dict(DD_ANALYTICS_ENABLED='False')):
+            config = Config()
+            ic = IntegrationConfig(config, 'foo')
+            self.assertIsNone(ic.get_analytics_sample_rate(use_global_config=True))
+
+        with self.override_env(dict(DD_TRACE_ANALYTICS_ENABLED='False')):
             config = Config()
             ic = IntegrationConfig(config, 'foo')
             self.assertIsNone(ic.get_analytics_sample_rate(use_global_config=True))


### PR DESCRIPTION
Add support for the following variables

- `DD_TRACE_ENABLED`: used to disable the sending of spans to the agent, spans are still produced. The variable was previously used only in `ddtrace-run` where it also disabled patching. This functionality is maintained for backwards compatibility while the new functionality is added to the core library.
- `DD_TRACE_DEBUG`: used to enable debug logging at the DEBUG level. This previously existed only in `ddtrace-run`. The functionality is now included in the core library.
- `DD_TRACE_<INTEGRATION>_ENABLED`: enables and disables integrations from being installed. This overlaps with the existing `DATADOG_PATCH_MODULES`, which will have lower precedence.
- `DD_TRACE_<INTEGRATION>_ANALYTICS_*`: These were previously `DD_<INTEGRATION>_ANALYTICS_*` and just had to be renamed.


TODO:

testing:
- [x] `DD_TRACE_ENABLED`
- [x] `DD_TRACE_<INTEGRATION>_ENABLED`
- [x] `DD_TRACE_<INTEGRATION>_ANALYTICS_*`
- [x] `DD_TRACE_DEBUG`