### PR TITLE
feat(profiling): reduce the default amount of sampling for memory/lock to 2%

### DIFF
--- a/ddtrace/profiling/collector/__init__.py
+++ b/ddtrace/profiling/collector/__init__.py
@@ -56,5 +56,5 @@ def _create_capture_sampler(collector):
 
 @attr.s
 class CaptureSamplerCollector(Collector):
-    capture_pct = attr.ib(factory=_attr.from_env("DD_PROFILING_CAPTURE_PCT", 5, float))
+    capture_pct = attr.ib(factory=_attr.from_env("DD_PROFILING_CAPTURE_PCT", 2, float))
     _capture_sampler = attr.ib(default=attr.Factory(_create_capture_sampler, takes_self=True), init=False, repr=False)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -103,7 +103,7 @@ below:
      - The maximum number of frames to capture in stack execution tracing.
    * - ``DD_PROFILING_CAPTURE_PCT``
      - Float
-     - 10
+     - 2
      - The percentage of events that should be captured (e.g. memory
        allocation). Greater values reduce the program execution speed. Must be
        greater than 0 lesser or equal to 100.

--- a/tests/profiling/collector/test_memory.py
+++ b/tests/profiling/collector/test_memory.py
@@ -38,7 +38,7 @@ def test_repr():
         memory.MemoryCollector,
         "MemoryCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
         "recorder=Recorder(default_max_events=32768, max_events={}), "
-        "capture_pct=5.0, nframes=64, ignore_profiler=True)",
+        "capture_pct=2.0, nframes=64, ignore_profiler=True)",
     )
 
 

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -15,7 +15,7 @@ def test_repr():
     test_collector._test_repr(
         collector_threading.LockCollector,
         "LockCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
-        "recorder=Recorder(default_max_events=32768, max_events={}), capture_pct=5.0, nframes=64)",
+        "recorder=Recorder(default_max_events=32768, max_events={}), capture_pct=2.0, nframes=64)",
     )
 
 


### PR DESCRIPTION
This should lower the default amount of memory overhead for the memory
tracer.
