### PR TITLE
tests: skip grpc 1.16

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -100,8 +100,8 @@ envlist =
 # py27,py35,py36: grpcio>=1.13.0
 # py37: grpcio>=1.13.0
 # py38: grpcio>=1.24.3
-    grpc_contrib-py{27,35,36}-grpc{112,114,116,118,120,121,122}-googleapis-common-protos
-    grpc_contrib-py{37}-grpc{114,116,118,120,121,122,124,126,128,}-googleapis-common-protos
+    grpc_contrib-py{27,35,36}-grpc{112,114,118,120,121,122}-googleapis-common-protos
+    grpc_contrib-py{37}-grpc{114,118,120,121,122,124,126,128,}-googleapis-common-protos
     grpc_contrib-py{38}-grpc{124,126,128,}-googleapis-common-protos
     httplib_contrib-py{27,35,36,37,38}
     jinja2_contrib-py{27,35,36,37,38}-jinja{27,28,29,210,211,}
@@ -336,7 +336,6 @@ deps =
     googleapis-common-protos: googleapis-common-protos
     grpc112: grpcio>=1.12,<1.13
     grpc114: grpcio>=1.14,<1.15
-    grpc116: grpcio>=1.16,<1.17
     grpc118: grpcio>=1.18,<1.19
     grpc120: grpcio>=1.20,<1.21
     grpc121: grpcio>=1.21,<1.22


### PR DESCRIPTION
This appears to be the cause for the recent flakiness in CI (no idea why):

- https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/1986/workflows/b397a441-bf0f-42b1-9f28-0b863fdc15ef/jobs/298112
- https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/1989/workflows/df14ba71-ed2a-452b-9fe6-99d84c011450/jobs/298278
- https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/1958/workflows/d5b505e0-ea16-41cd-93cb-a3d1f892f117/jobs/297207
- https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/1985/workflows/195359db-46e9-4f07-9f70-09d16d3aee44/jobs/298030