### PR TITLE
ci: fix djangorestframework scenario

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,8 @@ envlist =
     django_drf_contrib-py{27,35,36}-django{111}-djangorestframework{34,37}
     django_drf_contrib-py35-django{22}-djangorestframework{38,310,}
     django_drf_contrib-py{36,37}-django{22}-djangorestframework{38,310,}
-    django_drf_contrib-py{36,37,38}-django{30,}-djangorestframework{310,}
+    django_drf_contrib-py{36,37,38}-django30-djangorestframework310
+    django_drf_contrib-py{36,37,38}-django-djangorestframework311
     dogpile_contrib-py{27,35}-dogpilecache{06,07,08,09}
     dogpile_contrib-py{36,37,38}-dogpilecache{06,07,08,09,10,}
     elasticsearch_contrib-{py27,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63,64}


### PR DESCRIPTION
Django 3.1 (latest as of now) breaks djangorestframework 3.10.
