### PR TITLE
build: use release-branch-semver versioning in setuptool-scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "setuptools-scm", "cython"]
+requires = ["setuptools >= 40.6.0", "setuptools_scm[toml] >= 4", "cython"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+version_scheme = "release-branch-semver"
 
 [tool.black]
 line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ setup(
             "Programming Language :: Python :: 3.8",
         ],
         use_scm_version=True,
-        setup_requires=["setuptools_scm", "cython"],
+        setup_requires=["setuptools_scm[toml]>=4", "cython"],
         ext_modules=cythonize(
             [
                 Cython.Distutils.Extension(


### PR DESCRIPTION
That makes sure that when the last tag on `master` is 0.39, then the next
version for master is 0.40(.devN).
On the other hand, when on a branch named 0.39, the next version will be
0.39.1(.devN).
