### PR TITLE
fix(asgi): handle when server port is not set

### DIFF
--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -40,7 +40,7 @@ def _extract_tags_from_scope(scope):
     server = scope.get("server")
     if server and len(server) == 2:
         port = server[1]
-        server_host = server[0] + (":" + str(port) if port != 80 else "")
+        server_host = server[0] + (":" + str(port) if port is not None and port != 80 else "")
         full_path = scope.get("root_path", "") + scope.get("path", "")
         http_url = scope.get("scheme", "http") + "://" + server_host + full_path
         tags[http.URL] = http_url

--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -17,6 +17,7 @@ from tests.tracer.test_tracer import get_dummy_tracer
         {},
         {"server": None},
         {"server": ("dev", 8000)},
+        {"server": ("dev", None)},
         {"http_version": "1.0", "asgi": {}},
         {"http_version": "1.0", "asgi": {"version": "3.2"}},
         {"http_version": "1.0", "asgi": {"spec_version": "2.1",}},


### PR DESCRIPTION
This surfaced with a recent update to `httpx` (which the asgi tests use for multiple async requests) which treats url ports optional: https://github.com/encode/httpx/pull/1080