### PR TITLE
chore: move override functions to tests.utils

### DIFF
--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -8,7 +8,7 @@ import pytest
 from asgiref.testing import ApplicationCommunicator
 from ddtrace.contrib.asgi import TraceMiddleware
 from ddtrace.propagation import http as http_propagation
-from tests import BaseTestCase
+from tests import override_http_config
 from tests.tracer.test_tracer import get_dummy_tracer
 
 
@@ -153,7 +153,7 @@ async def test_double_callable_asgi(scope, tracer):
 
 @pytest.mark.asyncio
 async def test_query_string(scope, tracer):
-    with BaseTestCase.override_http_config("asgi", dict(trace_query_string=True)):
+    with override_http_config("asgi", dict(trace_query_string=True)):
         app = TraceMiddleware(basic_app, tracer=tracer)
         scope["query_string"] = "foo=bar"
         instance = ApplicationCommunicator(app, scope)
@@ -233,7 +233,7 @@ async def test_distributed_tracing(scope, tracer):
 
 @pytest.mark.asyncio
 async def test_multiple_requests(tracer):
-    with BaseTestCase.override_http_config("asgi", dict(trace_query_string=True)):
+    with override_http_config("asgi", dict(trace_query_string=True)):
         app = TraceMiddleware(basic_app, tracer=tracer)
         async with httpx.AsyncClient(app=app) as client:
             responses = await asyncio.gather(

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -10,7 +10,7 @@ from ddtrace.ext.priority import USER_KEEP
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID, HTTP_HEADER_PARENT_ID, HTTP_HEADER_SAMPLING_PRIORITY
 from ddtrace.propagation.utils import get_wsgi_header
 
-from ... import BaseTestCase
+from tests import override_config, override_global_config, override_http_config
 from tests.opentracer.utils import init_tracer
 from ...util import assert_dict_issuperset
 
@@ -146,7 +146,7 @@ def test_http_header_tracing_disabled(client, test_spans):
 
 
 def test_http_header_tracing_enabled(client, test_spans):
-    with BaseTestCase.override_config("django", {}):
+    with override_config("django", {}):
         config.django.http.trace_headers(["my-header", "my-response-header"])
 
         headers = {
@@ -1049,7 +1049,7 @@ Configuration tests
 
 
 def test_service_can_be_overridden(client, test_spans):
-    with BaseTestCase.override_config("django", dict(service_name="test-service")):
+    with override_config("django", dict(service_name="test-service")):
         response = client.get("/")
         assert response.status_code == 200
 
@@ -1062,7 +1062,7 @@ def test_service_can_be_overridden(client, test_spans):
 
 @pytest.mark.django_db
 def test_database_service_prefix_can_be_overridden(test_spans):
-    with BaseTestCase.override_config("django", dict(database_service_name_prefix="my-")):
+    with override_config("django", dict(database_service_name_prefix="my-")):
         from django.contrib.auth.models import User
 
         User.objects.count()
@@ -1077,7 +1077,7 @@ def test_database_service_prefix_can_be_overridden(test_spans):
 def test_cache_service_can_be_overridden(test_spans):
     cache = django.core.cache.caches["default"]
 
-    with BaseTestCase.override_config("django", dict(cache_service_name="test-cache-service")):
+    with override_config("django", dict(cache_service_name="test-cache-service")):
         cache.get("missing_key")
 
     spans = test_spans.get_spans()
@@ -1122,7 +1122,7 @@ def test_django_request_distributed_disabled(client, test_spans):
         get_wsgi_header(HTTP_HEADER_PARENT_ID): "78910",
         get_wsgi_header(HTTP_HEADER_SAMPLING_PRIORITY): USER_KEEP,
     }
-    with BaseTestCase.override_config("django", dict(distributed_tracing_enabled=False)):
+    with override_config("django", dict(distributed_tracing_enabled=False)):
         resp = client.get("/", **headers)
     assert resp.status_code == 200
     assert resp.content == b"Hello, test app."
@@ -1140,7 +1140,7 @@ def test_analytics_global_off_integration_default(client, test_spans):
         When an integration trace search is not set and sample rate is set and globally trace search is disabled
             We expect the root span to not include tag
     """
-    with BaseTestCase.override_global_config(dict(analytics_enabled=False)):
+    with override_global_config(dict(analytics_enabled=False)):
         assert client.get("/users/").status_code == 200
 
     req_span = test_spans.get_root_span()
@@ -1155,7 +1155,7 @@ def test_analytics_global_on_integration_default(client, test_spans):
         When an integration trace search is not event sample rate is not set and globally trace search is enabled
             We expect the root span to have the appropriate tag
     """
-    with BaseTestCase.override_global_config(dict(analytics_enabled=True)):
+    with override_global_config(dict(analytics_enabled=True)):
         assert client.get("/users/").status_code == 200
 
     req_span = test_spans.get_root_span()
@@ -1170,8 +1170,8 @@ def test_analytics_global_off_integration_on(client, test_spans):
         When an integration trace search is enabled and sample rate is set and globally trace search is disabled
             We expect the root span to have the appropriate tag
     """
-    with BaseTestCase.override_global_config(dict(analytics_enabled=False)):
-        with BaseTestCase.override_config("django", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
+    with override_global_config(dict(analytics_enabled=False)):
+        with override_config("django", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
             assert client.get("/users/").status_code == 200
 
     sp_request = test_spans.get_root_span()
@@ -1188,8 +1188,8 @@ def test_analytics_global_off_integration_on_and_none(client, test_spans):
         Globally trace search is disabled
             We expect the root span to have the appropriate tag
     """
-    with BaseTestCase.override_global_config(dict(analytics_enabled=False)):
-        with BaseTestCase.override_config("django", dict(analytics_enabled=False, analytics_sample_rate=1.0)):
+    with override_global_config(dict(analytics_enabled=False)):
+        with override_config("django", dict(analytics_enabled=False, analytics_sample_rate=1.0)):
             assert client.get("/users/").status_code == 200
 
     sp_request = test_spans.get_root_span()
@@ -1198,7 +1198,7 @@ def test_analytics_global_off_integration_on_and_none(client, test_spans):
 
 
 def test_trace_query_string_integration_enabled(client, test_spans):
-    with BaseTestCase.override_http_config("django", dict(trace_query_string=True)):
+    with override_http_config("django", dict(trace_query_string=True)):
         assert client.get("/?key1=value1&key2=value2").status_code == 200
 
     sp_request = test_spans.get_root_span()
@@ -1207,7 +1207,7 @@ def test_trace_query_string_integration_enabled(client, test_spans):
 
 
 def test_disabled_caches(client, test_spans):
-    with BaseTestCase.override_config("django", dict(instrument_caches=False)):
+    with override_config("django", dict(instrument_caches=False)):
         cache = django.core.cache.caches["default"]
         cache.get("missing_key")
 
@@ -1340,7 +1340,7 @@ def test_user_name_excluded(client, test_spans):
     When making a request to a Django app with user name excluded
         We correctly omit the `django.user.name` tag to the root span
     """
-    with BaseTestCase.override_config("django", dict(include_user_name=False)):
+    with override_config("django", dict(include_user_name=False)):
         resp = client.get("/authenticated/")
     assert resp.status_code == 200
 
@@ -1354,7 +1354,7 @@ def test_django_use_handler_resource_format(client, test_spans):
     """
     Test that the specified format is used over the default.
     """
-    with BaseTestCase.override_config("django", dict(use_handler_resource_format=True)):
+    with override_config("django", dict(use_handler_resource_format=True)):
         resp = client.get("/")
         assert resp.status_code == 200
         assert resp.content == b"Hello, test app."

--- a/tests/contrib/django/test_django_migration.py
+++ b/tests/contrib/django/test_django_migration.py
@@ -5,7 +5,8 @@ import pytest
 from ddtrace import config, Pin
 from ddtrace.contrib.django.conf import configure_from_settings
 
-from tests import BaseTestCase
+from tests import override_config
+
 
 pytestmark = pytest.mark.skipif(
     "TEST_DATADOG_DJANGO_MIGRATION" not in os.environ, reason="test only relevant for migration"
@@ -19,7 +20,7 @@ migration tests
 def test_configure_from_settings(tracer):
     pin = Pin.get_from(django)
 
-    with BaseTestCase.override_config("django", dict()):
+    with override_config("django", dict()):
         assert "ddtrace.contrib.django" in django.conf.settings.INSTALLED_APPS
         assert hasattr(django.conf.settings, "DATADOG_TRACE")
 

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -17,7 +17,7 @@ from ddtrace.context import Context
 from ddtrace.constants import VERSION_KEY, ENV_KEY
 
 from tests.subprocesstest import run_in_subprocess
-from tests import TracerTestCase, DummyWriter, DummyTracer
+from tests import TracerTestCase, DummyWriter, DummyTracer, override_global_config
 from ddtrace.internal.writer import LogWriter, AgentWriter
 
 
@@ -792,7 +792,7 @@ def test_tracer_with_version():
     t = ddtrace.Tracer()
 
     # With global `config.version` defined
-    with TracerTestCase.override_global_config(dict(version='1.2.3')):
+    with override_global_config(dict(version='1.2.3')):
         with t.trace('test.span') as span:
             assert span.get_tag(VERSION_KEY) == '1.2.3'
 
@@ -810,7 +810,7 @@ def test_tracer_with_version():
 
     # With global tags set
     t.set_tags({VERSION_KEY: 'tags.version'})
-    with TracerTestCase.override_global_config(dict(version='config.version')):
+    with override_global_config(dict(version='config.version')):
         with t.trace('test.span') as span:
             assert span.get_tag(VERSION_KEY) == 'config.version'
 
@@ -819,7 +819,7 @@ def test_tracer_with_env():
     t = ddtrace.Tracer()
 
     # With global `config.env` defined
-    with TracerTestCase.override_global_config(dict(env='prod')):
+    with override_global_config(dict(env='prod')):
         with t.trace('test.span') as span:
             assert span.get_tag(ENV_KEY) == 'prod'
 
@@ -837,7 +837,7 @@ def test_tracer_with_env():
 
     # With global tags set
     t.set_tags({ENV_KEY: 'tags.env'})
-    with TracerTestCase.override_global_config(dict(env='config.env')):
+    with override_global_config(dict(env='config.env')):
         with t.trace('test.span') as span:
             assert span.get_tag(ENV_KEY) == 'config.env'
 


### PR DESCRIPTION
Move helper functions for overriding the tracer configuration for a test out of the `BaseTestCase` class into a module.