### PR TITLE
fix(core): expose http setting on global config

### DIFF
--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -108,7 +108,7 @@ def on_prepare(request, response):
     # DEV: aiohttp is special case maintains separate configuration from config api
     trace_query_string = request[REQUEST_CONFIG_KEY].get('trace_query_string')
     if trace_query_string is None:
-        trace_query_string = config._http.trace_query_string
+        trace_query_string = config.http.trace_query_string
     if trace_query_string:
         request_span.set_tag(http.QUERY_STRING, request.query_string)
     request_span.finish()

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -42,7 +42,7 @@ class Config(object):
     def __init__(self):
         # use a dict as underlying storing mechanism
         self._config = {}
-        self._http = HttpConfig()
+        self.http = HttpConfig()
         # Master switch for turning on and off trace search by default
         # this weird invocation of get_env is meant to read the DD_ANALYTICS_ENABLED
         # legacy environment variable. It should be removed in the future
@@ -129,7 +129,7 @@ class Config(object):
         :return: self
         :rtype: HttpConfig
         """
-        self._http.trace_headers(whitelist)
+        self.http.trace_headers(whitelist)
         return self
 
     def header_is_traced(self, header_name):
@@ -139,7 +139,7 @@ class Config(object):
         :type header_name: str
         :rtype: bool
         """
-        return self._http.header_is_traced(header_name)
+        return self.http.header_is_traced(header_name)
 
     def _get_service(self, default=None):
         """

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -69,7 +69,7 @@ class IntegrationConfig(AttrDict):
     def trace_query_string(self):
         if self.http.trace_query_string is not None:
             return self.http.trace_query_string
-        return self.global_config._http.trace_query_string
+        return self.global_config.http.trace_query_string
 
     def header_is_traced(self, header_name):
         """

--- a/tests/tracer/test_settings.py
+++ b/tests/tracer/test_settings.py
@@ -59,6 +59,22 @@ class TestConfig(BaseTestCase):
             config = Config()
             self.assertEqual(config.service, "my-service")
 
+    def test_http_config(self):
+        config = Config()
+        config._add("django", dict())
+        assert config.django.trace_query_string is None
+        config.http.trace_query_string = True
+        assert config.http.trace_query_string is True
+        assert config.django.trace_query_string is True
+
+        # Integration usage
+        config = Config()
+        config._add("django", dict())
+        config.django.http.trace_query_string = True
+        assert config.http.trace_query_string is None
+        assert config.django.trace_query_string is True
+        assert config.django.http.trace_query_string is True
+
 
 class TestHttpConfig(BaseTestCase):
 


### PR DESCRIPTION
This setting is referenced in documentation as being public on the global
config but it never actually was.

Fixes #1573.