### PR TITLE
core: add DD_<INTEGRATION>_SERVICE to integration config

### DIFF
--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -4,6 +4,8 @@ from ddtrace.settings import config
 from ddtrace.utils.wrappers import unwrap as _u
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
+from .. import trace_utils
+
 DD_PATCH_ATTR = '_datadog_patch'
 
 SERVICE_NAME = 'algoliasearch'
@@ -16,7 +18,6 @@ try:
 
     # Default configuration
     config._add('algoliasearch', dict(
-        service_name=config.service or SERVICE_NAME,
         collect_query_text=False
     ))
 except ImportError:
@@ -32,9 +33,7 @@ def patch():
 
     setattr(algoliasearch, '_datadog_patch', True)
 
-    pin = Pin(
-        service=config.algoliasearch.service_name, app=APP_NAME
-    )
+    pin = Pin(app=APP_NAME)
 
     if algoliasearch_version < (2, 0) and algoliasearch_version >= (1, 0):
         _w(algoliasearch.index, 'Index.search', _patched_search)
@@ -101,7 +100,9 @@ def _patched_search(func, instance, wrapt_args, wrapt_kwargs):
     if not pin or not pin.enabled():
         return func(*wrapt_args, **wrapt_kwargs)
 
-    with pin.tracer.trace('algoliasearch.search', service=pin.service) as span:
+    with pin.tracer.trace(
+        'algoliasearch.search', service=trace_utils.ext_service(config.algoliasearch, pin, SERVICE_NAME)
+    ) as span:
         span.set_tag(SPAN_MEASURED_KEY)
 
         if not span.sampled:

--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -18,6 +18,7 @@ try:
 
     # Default configuration
     config._add('algoliasearch', dict(
+        _default_service=SERVICE_NAME,
         collect_query_text=False
     ))
 except ImportError:
@@ -101,7 +102,7 @@ def _patched_search(func, instance, wrapt_args, wrapt_kwargs):
         return func(*wrapt_args, **wrapt_kwargs)
 
     with pin.tracer.trace(
-        'algoliasearch.search', service=trace_utils.ext_service(config.algoliasearch, pin, SERVICE_NAME)
+        'algoliasearch.search', service=trace_utils.ext_service(pin, config.algoliasearch)
     ) as span:
         span.set_tag(SPAN_MEASURED_KEY)
 

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -33,6 +33,7 @@ log = get_logger(__name__)
 config._add(
     "django",
     dict(
+        _default_service="django",
         cache_service_name=get_env("django", "cache_service_name") or "django",
         database_service_name_prefix=get_env("django", "database_service_name_prefix", default=""),
         distributed_tracing_enabled=True,
@@ -395,7 +396,7 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
         with pin.tracer.trace(
             "django.request",
             resource=resource,
-            service=trace_utils.int_service(config.django, pin, "django"),
+            service=trace_utils.int_service(pin, config.django),
             span_type=SpanTypes.HTTP,
         ) as span:
             analytics_sr = config.django.get_analytics_sample_rate(use_global_config=True)

--- a/ddtrace/contrib/flask/helpers.py
+++ b/ddtrace/contrib/flask/helpers.py
@@ -1,5 +1,7 @@
-from ddtrace import Pin
+from ddtrace import Pin, config
 import flask
+
+from .. import trace_utils
 
 
 def get_current_app():
@@ -25,7 +27,7 @@ def simple_tracer(name, span_type=None):
     """Generate a simple tracer that wraps the function call with `with tracer.trace()`"""
     @with_instance_pin
     def wrapper(pin, wrapped, instance, args, kwargs):
-        with pin.tracer.trace(name, service=pin.service, span_type=span_type):
+        with pin.tracer.trace(name, service=trace_utils.int_service(config.flask, pin, "flask"), span_type=span_type):
             return wrapped(*args, **kwargs)
     return wrapper
 

--- a/ddtrace/contrib/flask/helpers.py
+++ b/ddtrace/contrib/flask/helpers.py
@@ -27,7 +27,7 @@ def simple_tracer(name, span_type=None):
     """Generate a simple tracer that wraps the function call with `with tracer.trace()`"""
     @with_instance_pin
     def wrapper(pin, wrapped, instance, args, kwargs):
-        with pin.tracer.trace(name, service=trace_utils.int_service(config.flask, pin, "flask"), span_type=span_type):
+        with pin.tracer.trace(name, service=trace_utils.int_service(pin, config.flask, pin), span_type=span_type):
             return wrapped(*args, **kwargs)
     return wrapper
 

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -10,6 +10,7 @@ from ...ext import SpanTypes, http
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
 from ...utils.wrappers import unwrap as _u
+from .. import trace_utils
 from .helpers import get_current_app, get_current_span, simple_tracer, with_instance_pin
 from .wrappers import wrap_function, wrap_signal
 
@@ -23,7 +24,6 @@ FLASK_VERSION = 'flask.version'
 # Configure default configuration
 config._add('flask', dict(
     # Flask service configuration
-    service_name=config._get_service(default="flask"),
     app='flask',
 
     collect_view_args=True,
@@ -62,11 +62,7 @@ def patch():
         return
     setattr(flask, '_datadog_patch', True)
 
-    # Attach service pin to `flask.app.Flask`
-    Pin(
-        service=config.flask['service_name'],
-        app=config.flask['app']
-    ).onto(flask.Flask)
+    Pin().onto(flask.Flask)
 
     # flask.app.Flask methods that have custom tracing (add metadata, wrap functions, etc)
     _w('flask', 'Flask.wsgi_app', traced_wsgi_app)
@@ -279,7 +275,12 @@ def traced_wsgi_app(pin, wrapped, instance, args, kwargs):
     #   POST /save
     # We will override this below in `traced_dispatch_request` when we have a `RequestContext` and possibly a url rule
     resource = u'{} {}'.format(request.method, request.path)
-    with pin.tracer.trace('flask.request', service=pin.service, resource=resource, span_type=SpanTypes.WEB) as s:
+    with pin.tracer.trace(
+        "flask.request",
+        service=trace_utils.int_service(config.flask, pin, "flask"),
+        resource=resource,
+        span_type=SpanTypes.WEB,
+    ) as s:
         s.set_tag(SPAN_MEASURED_KEY)
         # set analytics sample rate with global config enabled
         sample_rate = config.flask.get_analytics_sample_rate(use_global_config=True)
@@ -468,7 +469,7 @@ def request_tracer(name):
         except Exception:
             log.debug('failed to set tags for "flask.request" span', exc_info=True)
 
-        with pin.tracer.trace('flask.{}'.format(name), service=pin.service):
+        with pin.tracer.trace('flask.{}'.format(name), service=trace_utils.int_service(config.flask, pin, "flask")):
             return wrapped(*args, **kwargs)
     return _traced_request
 

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -24,6 +24,7 @@ FLASK_VERSION = 'flask.version'
 # Configure default configuration
 config._add('flask', dict(
     # Flask service configuration
+    _default_service="flask",
     app='flask',
 
     collect_view_args=True,
@@ -277,7 +278,7 @@ def traced_wsgi_app(pin, wrapped, instance, args, kwargs):
     resource = u'{} {}'.format(request.method, request.path)
     with pin.tracer.trace(
         "flask.request",
-        service=trace_utils.int_service(config.flask, pin, "flask"),
+        service=trace_utils.int_service(pin, config.flask),
         resource=resource,
         span_type=SpanTypes.WEB,
     ) as s:
@@ -469,7 +470,7 @@ def request_tracer(name):
         except Exception:
             log.debug('failed to set tags for "flask.request" span', exc_info=True)
 
-        with pin.tracer.trace('flask.{}'.format(name), service=trace_utils.int_service(config.flask, pin, "flask")):
+        with pin.tracer.trace('flask.{}'.format(name), service=trace_utils.int_service(pin, config.flask, pin)):
             return wrapped(*args, **kwargs)
     return _traced_request
 

--- a/ddtrace/contrib/flask/wrappers.py
+++ b/ddtrace/contrib/flask/wrappers.py
@@ -1,7 +1,9 @@
 from ddtrace.vendor.wrapt import function_wrapper
+from ddtrace import config
 
 from ...pin import Pin
 from ...utils.importlib import func_name
+from .. import trace_utils
 from .helpers import get_current_app
 
 
@@ -19,7 +21,7 @@ def wrap_function(instance, func, name=None, resource=None):
         pin = Pin._find(wrapped, _instance, instance, get_current_app())
         if not pin or not pin.enabled():
             return wrapped(*args, **kwargs)
-        with pin.tracer.trace(name, service=pin.service, resource=resource):
+        with pin.tracer.trace(name, service=trace_utils.int_service(config.flask, pin, "flask"), resource=resource):
             return wrapped(*args, **kwargs)
 
     return trace_func(func)
@@ -39,7 +41,7 @@ def wrap_signal(app, signal, func):
         if not pin or not pin.enabled():
             return wrapped(*args, **kwargs)
 
-        with pin.tracer.trace(name, service=pin.service) as span:
+        with pin.tracer.trace(name, service=trace_utils.int_service(config.flask, pin, "flask")) as span:
             span.set_tag('flask.signal', signal)
             return wrapped(*args, **kwargs)
 

--- a/ddtrace/contrib/flask/wrappers.py
+++ b/ddtrace/contrib/flask/wrappers.py
@@ -21,7 +21,7 @@ def wrap_function(instance, func, name=None, resource=None):
         pin = Pin._find(wrapped, _instance, instance, get_current_app())
         if not pin or not pin.enabled():
             return wrapped(*args, **kwargs)
-        with pin.tracer.trace(name, service=trace_utils.int_service(config.flask, pin, "flask"), resource=resource):
+        with pin.tracer.trace(name, service=trace_utils.int_service(pin, config.flask), resource=resource):
             return wrapped(*args, **kwargs)
 
     return trace_func(func)
@@ -41,7 +41,7 @@ def wrap_signal(app, signal, func):
         if not pin or not pin.enabled():
             return wrapped(*args, **kwargs)
 
-        with pin.tracer.trace(name, service=trace_utils.int_service(config.flask, pin, "flask")) as span:
+        with pin.tracer.trace(name, service=trace_utils.int_service(pin, config.flask)) as span:
             span.set_tag('flask.signal', signal)
             return wrapped(*args, **kwargs)
 

--- a/ddtrace/contrib/grpc/__init__.py
+++ b/ddtrace/contrib/grpc/__init__.py
@@ -19,7 +19,7 @@ Or use :ref:`patch()<patch>` to manually enable the integration::
 Global Configuration
 ~~~~~~~~~~~~~~~~~~~~
 
-.. py:data:: ddtrace.config.grpc["service_name"]
+.. py:data:: ddtrace.config.grpc["service"]
 
    The service name reported by default for gRPC client instances.
 
@@ -27,6 +27,15 @@ Global Configuration
    variable.
 
    Default: ``"grpc-client"``
+
+.. py:data:: ddtrace.config.grpc_server["service"]
+
+   The service name reported by default for gRPC server instances.
+
+   This option can also be set with the ``DD_SERVICE`` or
+   ``DD_GRPC_SERVER_SERVICE`` environment variables.
+
+   Default: ``"grpc-server"``
 
 
 Instance Configuration

--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -5,7 +5,8 @@ from ddtrace.vendor import wrapt
 from ddtrace import config
 from ddtrace.compat import to_unicode
 from ddtrace.ext import SpanTypes, errors
-from ... import utils
+
+from .. import trace_utils
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -155,7 +156,7 @@ class _ClientInterceptor(
         span = tracer.trace(
             "grpc",
             span_type=SpanTypes.GRPC,
-            service=utils.integration_service(config.grpc, self._pin),
+            service=trace_utils.ext_service(config.grpc, self._pin, constants.GRPC_SERVICE_CLIENT),
             resource=client_call_details.method,
         )
 

--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -156,7 +156,7 @@ class _ClientInterceptor(
         span = tracer.trace(
             "grpc",
             span_type=SpanTypes.GRPC,
-            service=trace_utils.ext_service(config.grpc, self._pin, constants.GRPC_SERVICE_CLIENT),
+            service=trace_utils.ext_service(self._pin, config.grpc),
             resource=client_call_details.method,
         )
 

--- a/ddtrace/contrib/grpc/patch.py
+++ b/ddtrace/contrib/grpc/patch.py
@@ -1,5 +1,3 @@
-import os
-
 import grpc
 
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
@@ -13,27 +11,13 @@ from .server_interceptor import create_server_interceptor
 
 
 config._add('grpc_server', dict(
-    service_name=config._get_service(default=constants.GRPC_SERVICE_SERVER),
     distributed_tracing_enabled=True,
 ))
-
-
-# Precedence for the service name:
-# 1) DD_GRPC_SERVICE if defined; or
-# 2) For compatibility, the globally set service + "-grpc-client"; or
-# 3) The fall-back "grpc-client"
-if "DD_GRPC_SERVICE" in os.environ:
-    service = os.getenv("DD_GRPC_SERVICE")
-elif config._get_service():
-    service = "{}-{}".format(config._get_service(), constants.GRPC_SERVICE_CLIENT)
-else:
-    service = constants.GRPC_SERVICE_CLIENT
 
 
 # TODO[tbutt]: keeping name for client config unchanged to maintain backwards
 # compatibility but should change in future
 config._add('grpc', dict(
-    service_name=service,
     distributed_tracing_enabled=True,
 ))
 

--- a/ddtrace/contrib/grpc/patch.py
+++ b/ddtrace/contrib/grpc/patch.py
@@ -11,6 +11,7 @@ from .server_interceptor import create_server_interceptor
 
 
 config._add('grpc_server', dict(
+    _default_service=constants.GRPC_SERVICE_SERVER,
     distributed_tracing_enabled=True,
 ))
 
@@ -18,6 +19,7 @@ config._add('grpc_server', dict(
 # TODO[tbutt]: keeping name for client config unchanged to maintain backwards
 # compatibility but should change in future
 config._add('grpc', dict(
+    _default_service=constants.GRPC_SERVICE_CLIENT,
     distributed_tracing_enabled=True,
 ))
 

--- a/ddtrace/contrib/grpc/server_interceptor.py
+++ b/ddtrace/contrib/grpc/server_interceptor.py
@@ -5,7 +5,7 @@ from ddtrace import config
 from ddtrace.ext import errors
 from ddtrace.compat import to_unicode
 
-from ... import utils
+from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY, SPAN_MEASURED_KEY
 from ...ext import SpanTypes
 from ...propagation.http import HTTPPropagator
@@ -75,7 +75,7 @@ class _TracedRpcMethodHandler(wrapt.ObjectProxy):
         span = tracer.trace(
             'grpc',
             span_type=SpanTypes.GRPC,
-            service=utils.integration_service(config.grpc_server, self._pin),
+            service=trace_utils.int_service(config.grpc_server, self._pin, default=constants.GRPC_SERVICE_SERVER),
             resource=self._handler_call_details.method,
         )
         span.set_tag(SPAN_MEASURED_KEY)

--- a/ddtrace/contrib/grpc/server_interceptor.py
+++ b/ddtrace/contrib/grpc/server_interceptor.py
@@ -75,7 +75,7 @@ class _TracedRpcMethodHandler(wrapt.ObjectProxy):
         span = tracer.trace(
             'grpc',
             span_type=SpanTypes.GRPC,
-            service=trace_utils.int_service(config.grpc_server, self._pin, default=constants.GRPC_SERVICE_SERVER),
+            service=trace_utils.int_service(self._pin, config.grpc_server),
             resource=self._handler_call_details.method,
         )
         span.set_tag(SPAN_MEASURED_KEY)

--- a/ddtrace/contrib/molten/__init__.py
+++ b/ddtrace/contrib/molten/__init__.py
@@ -41,7 +41,7 @@ Configuration
 """
 from ...utils.importlib import require_modules
 
-required_modules = ['molten']
+required_modules = ["molten"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
@@ -50,4 +50,4 @@ with require_modules(required_modules) as missing_modules:
         patch = _patch.patch
         unpatch = _patch.unpatch
 
-        __all__ = ['patch', 'unpatch']
+        __all__ = ["patch", "unpatch"]

--- a/ddtrace/contrib/molten/patch.py
+++ b/ddtrace/contrib/molten/patch.py
@@ -15,45 +15,49 @@ from .. import trace_utils
 from .wrappers import WrapperComponent, WrapperRenderer, WrapperMiddleware, WrapperRouter, MOLTEN_ROUTE
 
 
-MOLTEN_VERSION = tuple(map(int, molten.__version__.split()[0].split('.')))
+MOLTEN_VERSION = tuple(map(int, molten.__version__.split()[0].split(".")))
 
 # Configure default configuration
-config._add('molten', dict(
-    app='molten',
-    distributed_tracing=asbool(get_env('molten', 'distributed_tracing', default=True)),
-))
+config._add(
+    "molten",
+    dict(
+        _default_service="molten",
+        app="molten",
+        distributed_tracing=asbool(get_env("molten", "distributed_tracing", default=True)),
+    ),
+)
 
 
 def patch():
     """Patch the instrumented methods
     """
-    if getattr(molten, '_datadog_patch', False):
+    if getattr(molten, "_datadog_patch", False):
         return
-    setattr(molten, '_datadog_patch', True)
+    setattr(molten, "_datadog_patch", True)
 
-    pin = Pin(app=config.molten['app'])
+    pin = Pin(app=config.molten["app"])
 
     # add pin to module since many classes use __slots__
     pin.onto(molten)
 
-    _w(molten.BaseApp, '__init__', patch_app_init)
-    _w(molten.App, '__call__', patch_app_call)
+    _w(molten.BaseApp, "__init__", patch_app_init)
+    _w(molten.App, "__call__", patch_app_call)
 
 
 def unpatch():
     """Remove instrumentation
     """
-    if getattr(molten, '_datadog_patch', False):
-        setattr(molten, '_datadog_patch', False)
+    if getattr(molten, "_datadog_patch", False):
+        setattr(molten, "_datadog_patch", False)
 
         # remove pin
         pin = Pin.get_from(molten)
         if pin:
             pin.remove_from(molten)
 
-        _u(molten.BaseApp, '__init__')
-        _u(molten.App, '__call__')
-        _u(molten.Router, 'add_route')
+        _u(molten.BaseApp, "__init__")
+        _u(molten.App, "__call__")
+        _u(molten.Router, "add_route")
 
 
 def patch_app_call(wrapped, instance, args, kwargs):
@@ -72,7 +76,7 @@ def patch_app_call(wrapped, instance, args, kwargs):
     resource = func_name(wrapped)
 
     # Configure distributed tracing
-    if config.molten.get('distributed_tracing', True):
+    if config.molten.get("distributed_tracing", True):
         propagator = HTTPPropagator()
         # request.headers is type Iterable[Tuple[str, str]]
         context = propagator.extract(dict(request.headers))
@@ -81,17 +85,14 @@ def patch_app_call(wrapped, instance, args, kwargs):
             pin.tracer.context_provider.activate(context)
 
     with pin.tracer.trace(
-        'molten.request',
-        service=trace_utils.int_service(config.molten, pin, "molten"),
+        "molten.request",
+        service=trace_utils.int_service(pin, config.molten),
         resource=resource,
         span_type=SpanTypes.WEB,
     ) as span:
         span.set_tag(SPAN_MEASURED_KEY)
         # set analytics sample rate with global config enabled
-        span.set_tag(
-            ANALYTICS_SAMPLE_RATE_KEY,
-            config.molten.get_analytics_sample_rate(use_global_config=True)
-        )
+        span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, config.molten.get_analytics_sample_rate(use_global_config=True))
 
         @wrapt.function_wrapper
         def _w_start_response(wrapped, instance, args, kwargs):
@@ -102,7 +103,7 @@ def patch_app_call(wrapped, instance, args, kwargs):
                 return wrapped(*args, **kwargs)
 
             status, headers, exc_info = args
-            code, _, _ = status.partition(' ')
+            code, _, _ = status.partition(" ")
 
             try:
                 code = int(code)
@@ -111,7 +112,7 @@ def patch_app_call(wrapped, instance, args, kwargs):
 
             if not span.get_tag(MOLTEN_ROUTE):
                 # if route never resolve, update root resource
-                span.resource = u'{} {}'.format(request.method, code)
+                span.resource = u"{} {}".format(request.method, code)
 
             span.set_tag(http.STATUS_CODE, code)
 
@@ -125,12 +126,10 @@ def patch_app_call(wrapped, instance, args, kwargs):
         start_response = _w_start_response(start_response)
 
         span.set_tag(http.METHOD, request.method)
-        span.set_tag(http.URL, '%s://%s:%s%s' % (
-            request.scheme, request.host, request.port, request.path,
-        ))
+        span.set_tag(http.URL, "%s://%s:%s%s" % (request.scheme, request.host, request.port, request.path,))
         if config.molten.trace_query_string:
             span.set_tag(http.QUERY_STRING, urlencode(dict(request.params)))
-        span.set_tag('molten.version', molten.__version__)
+        span.set_tag("molten.version", molten.__version__)
         return wrapped(environ, start_response, **kwargs)
 
 
@@ -153,21 +152,12 @@ def patch_app_init(wrapped, instance, args, kwargs):
     instance.router = WrapperRouter(instance.router)
 
     # wrap middleware functions/callables
-    instance.middleware = [
-        WrapperMiddleware(mw)
-        for mw in instance.middleware
-    ]
+    instance.middleware = [WrapperMiddleware(mw) for mw in instance.middleware]
 
     # wrap components objects within injector
     # NOTE: the app instance also contains a list of components but it does not
     # appear to be used for anything passing along to the dependency injector
-    instance.injector.components = [
-        WrapperComponent(c)
-        for c in instance.injector.components
-    ]
+    instance.injector.components = [WrapperComponent(c) for c in instance.injector.components]
 
     # but renderers objects
-    instance.renderers = [
-        WrapperRenderer(r)
-        for r in instance.renderers
-    ]
+    instance.renderers = [WrapperRenderer(r) for r in instance.renderers]

--- a/ddtrace/contrib/molten/wrappers.py
+++ b/ddtrace/contrib/molten/wrappers.py
@@ -1,8 +1,11 @@
+from ddtrace import config
 from ddtrace.vendor import wrapt
 import molten
 
 from ... import Pin
 from ...utils.importlib import func_name
+
+from .. import trace_utils
 
 MOLTEN_ROUTE = 'molten.route'
 
@@ -12,7 +15,9 @@ def trace_wrapped(resource, wrapped, *args, **kwargs):
     if not pin or not pin.enabled():
         return wrapped(*args, **kwargs)
 
-    with pin.tracer.trace(func_name(wrapped), service=pin.service, resource=resource):
+    with pin.tracer.trace(
+        func_name(wrapped), service=trace_utils.int_service(config.molten, pin, "molten"), resource=resource
+    ):
         return wrapped(*args, **kwargs)
 
 
@@ -26,7 +31,9 @@ def trace_func(resource):
         if not pin or not pin.enabled():
             return wrapped(*args, **kwargs)
 
-        with pin.tracer.trace(func_name(wrapped), service=pin.service, resource=resource):
+        with pin.tracer.trace(
+            func_name(wrapped), service=trace_utils.int_service(config.molten, pin, "molten"), resource=resource
+        ):
             return wrapped(*args, **kwargs)
 
     return _trace_func

--- a/ddtrace/contrib/molten/wrappers.py
+++ b/ddtrace/contrib/molten/wrappers.py
@@ -7,7 +7,7 @@ from ...utils.importlib import func_name
 
 from .. import trace_utils
 
-MOLTEN_ROUTE = 'molten.route'
+MOLTEN_ROUTE = "molten.route"
 
 
 def trace_wrapped(resource, wrapped, *args, **kwargs):
@@ -15,15 +15,14 @@ def trace_wrapped(resource, wrapped, *args, **kwargs):
     if not pin or not pin.enabled():
         return wrapped(*args, **kwargs)
 
-    with pin.tracer.trace(
-        func_name(wrapped), service=trace_utils.int_service(config.molten, pin, "molten"), resource=resource
-    ):
+    with pin.tracer.trace(func_name(wrapped), service=trace_utils.int_service(pin, config.molten), resource=resource):
         return wrapped(*args, **kwargs)
 
 
 def trace_func(resource):
     """Trace calls to function using provided resource name
     """
+
     @wrapt.function_wrapper
     def _trace_func(wrapped, instance, args, kwargs):
         pin = Pin.get_from(molten)
@@ -32,7 +31,7 @@ def trace_func(resource):
             return wrapped(*args, **kwargs)
 
         with pin.tracer.trace(
-            func_name(wrapped), service=trace_utils.int_service(config.molten, pin, "molten"), resource=resource
+            func_name(wrapped), service=trace_utils.int_service(pin, config.molten, pin), resource=resource
         ):
             return wrapped(*args, **kwargs)
 
@@ -41,10 +40,11 @@ def trace_func(resource):
 
 class WrapperComponent(wrapt.ObjectProxy):
     """ Tracing of components """
+
     def can_handle_parameter(self, *args, **kwargs):
         func = self.__wrapped__.can_handle_parameter
         cname = func_name(self.__wrapped__)
-        resource = '{}.{}'.format(cname, func.__name__)
+        resource = "{}.{}".format(cname, func.__name__)
         return trace_wrapped(resource, func, *args, **kwargs)
 
     # TODO[tahir]: the signature of a wrapped resolve method causes DIError to
@@ -53,15 +53,17 @@ class WrapperComponent(wrapt.ObjectProxy):
 
 class WrapperRenderer(wrapt.ObjectProxy):
     """ Tracing of renderers """
+
     def render(self, *args, **kwargs):
         func = self.__wrapped__.render
         cname = func_name(self.__wrapped__)
-        resource = '{}.{}'.format(cname, func.__name__)
+        resource = "{}.{}".format(cname, func.__name__)
         return trace_wrapped(resource, func, *args, **kwargs)
 
 
 class WrapperMiddleware(wrapt.ObjectProxy):
     """ Tracing of callable functional-middleware """
+
     def __call__(self, *args, **kwargs):
         func = self.__wrapped__.__call__
         resource = func_name(self.__wrapped__)
@@ -70,6 +72,7 @@ class WrapperMiddleware(wrapt.ObjectProxy):
 
 class WrapperRouter(wrapt.ObjectProxy):
     """ Tracing of router on the way back from a matched route """
+
     def match(self, *args, **kwargs):
         # catch matched route and wrap tracer around its handler and set root span resource
         func = self.__wrapped__.match
@@ -85,10 +88,7 @@ class WrapperRouter(wrapt.ObjectProxy):
             route.handler = trace_func(func_name(route.handler))(route.handler)
 
             # update root span resource while we know the matched route
-            resource = '{} {}'.format(
-                route.method,
-                route.template,
-            )
+            resource = "{} {}".format(route.method, route.template,)
             root_span = pin.tracer.current_root_span()
             root_span.resource = resource
 

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -1,19 +1,17 @@
-# 3p
 import redis
 from ddtrace.vendor import wrapt
 
-# project
 from ddtrace import config
-from ddtrace.utils.formats import get_env
+
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY, SPAN_MEASURED_KEY
 from ...pin import Pin
 from ...ext import SpanTypes, redis as redisx
 from ...utils.wrappers import unwrap
-from ... import utils
+from .. import trace_utils
 from .util import format_command_args, _extract_conn_tags
 
 
-config._add("redis", dict(service=get_env("redis", "service") or redisx.DEFAULT_SERVICE,))
+config._add("redis", dict())
 
 
 def patch():
@@ -68,7 +66,7 @@ def traced_execute_command(func, instance, args, kwargs):
         return func(*args, **kwargs)
 
     with pin.tracer.trace(
-        redisx.CMD, service=utils.integration_service(config.redis, pin), span_type=SpanTypes.REDIS
+        redisx.CMD, service=trace_utils.ext_service(config.redis, pin, default="redis"), span_type=SpanTypes.REDIS
     ) as s:
         s.set_tag(SPAN_MEASURED_KEY)
         query = format_command_args(args)
@@ -102,7 +100,10 @@ def traced_execute_pipeline(func, instance, args, kwargs):
     resource = "\n".join(cmds)
     tracer = pin.tracer
     with tracer.trace(
-        redisx.CMD, resource=resource, service=utils.integration_service(config.redis, pin), span_type=SpanTypes.REDIS
+        redisx.CMD,
+        resource=resource,
+        service=trace_utils.ext_service(config.redis, pin, default="redis"),
+        span_type=SpanTypes.REDIS,
     ) as s:
         s.set_tag(SPAN_MEASURED_KEY)
         s.set_tag(redisx.RAWCMD, resource)

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -11,7 +11,7 @@ from .. import trace_utils
 from .util import format_command_args, _extract_conn_tags
 
 
-config._add("redis", dict())
+config._add("redis", dict(_default_service="redis"))
 
 
 def patch():
@@ -66,7 +66,7 @@ def traced_execute_command(func, instance, args, kwargs):
         return func(*args, **kwargs)
 
     with pin.tracer.trace(
-        redisx.CMD, service=trace_utils.ext_service(config.redis, pin, default="redis"), span_type=SpanTypes.REDIS
+        redisx.CMD, service=trace_utils.ext_service(pin, config.redis, pin), span_type=SpanTypes.REDIS
     ) as s:
         s.set_tag(SPAN_MEASURED_KEY)
         query = format_command_args(args)
@@ -100,10 +100,7 @@ def traced_execute_pipeline(func, instance, args, kwargs):
     resource = "\n".join(cmds)
     tracer = pin.tracer
     with tracer.trace(
-        redisx.CMD,
-        resource=resource,
-        service=trace_utils.ext_service(config.redis, pin, default="redis"),
-        span_type=SpanTypes.REDIS,
+        redisx.CMD, resource=resource, service=trace_utils.ext_service(pin, config.redis), span_type=SpanTypes.REDIS,
     ) as s:
         s.set_tag(SPAN_MEASURED_KEY)
         s.set_tag(redisx.RAWCMD, resource)

--- a/ddtrace/contrib/requests/connection.py
+++ b/ddtrace/contrib/requests/connection.py
@@ -30,8 +30,10 @@ def _extract_service_name(session, span, hostname=None):
         return hostname
 
     service_name = cfg["service_name"]
-    if service_name == DEFAULT_SERVICE and span._parent is not None and span._parent.service is not None:
+    if service_name is None and span._parent is not None and span._parent.service is not None:
         service_name = span._parent.service
+    elif service_name is None:
+        service_name = DEFAULT_SERVICE
     return service_name
 
 

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -8,12 +8,10 @@ from ...pin import Pin
 from ...utils.formats import asbool, get_env
 from ...utils.wrappers import unwrap as _u
 from .legacy import _distributed_tracing, _distributed_tracing_setter
-from .constants import DEFAULT_SERVICE
 from .connection import _wrap_send
 
 # requests default settings
 config._add('requests', {
-    'service_name': get_env('requests', 'service_name', default=DEFAULT_SERVICE),
     'distributed_tracing': asbool(get_env('requests', 'distributed_tracing', default=True)),
     'split_by_domain': asbool(get_env('requests', 'split_by_domain', default=False)),
 })
@@ -26,11 +24,7 @@ def patch():
     setattr(requests, '__datadog_patch', True)
 
     _w('requests', 'Session.send', _wrap_send)
-    Pin(
-        service=config.requests['service_name'],
-        app='requests',
-        _config=config.requests,
-    ).onto(requests.Session)
+    Pin(app='requests', _config=config.requests).onto(requests.Session)
 
     # [Backward compatibility]: `session.distributed_tracing` should point and
     # update the `Pin` configuration instead. This block adds a property so that

--- a/ddtrace/contrib/sanic/patch.py
+++ b/ddtrace/contrib/sanic/patch.py
@@ -10,11 +10,12 @@ from ddtrace.utils.wrappers import unwrap as _u
 from ddtrace.vendor import wrapt
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
+from .. import trace_utils
 from ...internal.logger import get_logger
 
 log = get_logger(__name__)
 
-config._add("sanic", dict(service=config._get_service(default="sanic"), distributed_tracing=True))
+config._add("sanic", dict(distributed_tracing=True))
 
 
 def _extract_tags_from_request(request):
@@ -100,7 +101,10 @@ def patch_handle_request(wrapped, instance, args, kwargs):
             ddtrace.tracer.context_provider.activate(context)
 
     span = ddtrace.tracer.trace(
-        "sanic.request", service=config.sanic.service, resource=resource, span_type=SpanTypes.WEB
+        "sanic.request",
+        service=trace_utils.int_service(config.sanic, None, "sanic"),
+        resource=resource,
+        span_type=SpanTypes.WEB,
     )
     sample_rate = config.sanic.get_analytics_sample_rate(use_global_config=True)
     if sample_rate is not None:

--- a/ddtrace/contrib/sanic/patch.py
+++ b/ddtrace/contrib/sanic/patch.py
@@ -15,7 +15,7 @@ from ...internal.logger import get_logger
 
 log = get_logger(__name__)
 
-config._add("sanic", dict(distributed_tracing=True))
+config._add("sanic", dict(_default_service="sanic", distributed_tracing=True))
 
 
 def _extract_tags_from_request(request):
@@ -102,7 +102,7 @@ def patch_handle_request(wrapped, instance, args, kwargs):
 
     span = ddtrace.tracer.trace(
         "sanic.request",
-        service=trace_utils.int_service(config.sanic, None, "sanic"),
+        service=trace_utils.int_service(None, config.sanic),
         resource=resource,
         span_type=SpanTypes.WEB,
     )

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -2,11 +2,15 @@
 This module contains utility functions for writing ddtrace integrations.
 """
 
+from ddtrace.internal.logger import get_logger
 
-def int_service(config, pin, default=None):
+log = get_logger(__name__)
+
+
+def int_service(pin, config, default=None):
     """Returns the service name for an integration which is internal
     to the application. Internal meaning that the work belongs to the
-    user's application. Eg. Web framework, sqlalchemy, servers.
+    user's application. Eg. Web framework, sqlalchemy, web servers.
 
     For internal integrations we prioritize overrides, then global defaults and
     lastly the default provided by the integration.
@@ -28,10 +32,14 @@ def int_service(config, pin, default=None):
     global_service = config.global_config._get_service()
     if global_service:
         return global_service
+
+    if "_default_service" in config and config._default_service is not None:
+        return config._default_service
+
     return default
 
 
-def ext_service(config, pin, default):
+def ext_service(pin, config, default=None):
     """Returns the service name for an integration which is external
     to the application. External meaning that the integration generates
     spans wrapping code that is outside the scope of the user's application. Eg. A database, RPC, cache, etc.
@@ -45,6 +53,9 @@ def ext_service(config, pin, default):
         return config.service
     if "service_name" in config and config.service_name is not None:
         return config.service_name
+
+    if "_default_service" in config and config._default_service is not None:
+        return config._default_service
 
     # A default is required since it's an external service.
     return default

--- a/ddtrace/contrib/vertica/patch.py
+++ b/ddtrace/contrib/vertica/patch.py
@@ -56,6 +56,7 @@ def cursor_span_end(instance, cursor, _, conf, *args, **kwargs):
 config._add(
     'vertica',
     {
+        "_default_service": "vertica",
         'app': 'vertica',
         'patch': {
             'vertica_python.vertica.connection.Connection': {
@@ -203,7 +204,7 @@ def _install_routine(patch_routine, patch_class, patch_mod, config):
             tracer = pin.tracer
             with tracer.trace(
                 operation_name,
-                service=trace_utils.ext_service(config, pin, "vertica"),
+                service=trace_utils.ext_service(pin, config),
                 span_type=conf.get("span_type"),
             ) as span:
                 if conf.get('measured', False):

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -50,8 +50,16 @@ class IntegrationConfig(AttrDict):
             analytics_enabled_env = asbool(analytics_enabled_env)
         self.setdefault("analytics_enabled", analytics_enabled_env)
         old_analytics_rate = get_env(name, "analytics_sample_rate", default=1.0)
+
         analytics_rate = os.environ.get("DD_TRACE_%s_ANALYTICS_SAMPLE_RATE" % name.upper(), old_analytics_rate)
         self.setdefault("analytics_sample_rate", float(analytics_rate))
+
+        service = get_env(name, "service", default=get_env(name, "service_name", default=None))
+        self.setdefault("service", service)
+        # TODO[v1.0]: this is required for backwards compatibility since some
+        # integrations use service_name instead of service. These should be
+        # unified.
+        self.setdefault("service_name", service)
 
     def __deepcopy__(self, memodict=None):
         new = IntegrationConfig(self.global_config, self.integration_name, deepcopy(dict(self), memodict))

--- a/ddtrace/utils/__init__.py
+++ b/ddtrace/utils/__init__.py
@@ -25,22 +25,3 @@ class removed_classproperty(property):
             "Usage of ddtrace.ext.AppTypes is not longer supported, please use ddtrace.ext.SpanTypes"
         )
         return classmethod(self.fget).__get__(None, owner)()
-
-
-def integration_service(config, pin, global_service_fallback=False):
-    """Compute the service name that should be used for an integration
-    based off the given config and pin instances.
-    """
-    if pin.service:
-        return pin.service
-
-    # Integrations unfortunately use both service and service_name in their
-    # configs :/
-    elif "service" in config:
-        return config.service
-    elif "service_name" in config:
-        return config.service_name
-    elif global_service_fallback:
-        return config.global_config._get_service()
-    else:
-        return None

--- a/tests/contrib/algoliasearch/test.py
+++ b/tests/contrib/algoliasearch/test.py
@@ -148,7 +148,7 @@ class AlgoliasearchTest(TracerTestCase):
     def test_user_specified_service(self):
         """
         When a service name is specified by the user
-            The algoliasearch integration should use it as the service name
+            The algoliasearch integration shouldn't use it as the service name
         """
         patch_all()
         Pin.override(self.index, tracer=self.tracer)
@@ -157,5 +157,5 @@ class AlgoliasearchTest(TracerTestCase):
         self.reset()
         assert spans, spans
         assert len(spans) == 1
-        assert spans[0].service == "mysvc"
+        assert spans[0].service == "algoliasearch"
         unpatch()

--- a/tests/contrib/flask/test_blueprint.py
+++ b/tests/contrib/flask/test_blueprint.py
@@ -46,7 +46,7 @@ class FlaskBlueprintTestCase(BaseFlaskTestCase):
         bp = flask.Blueprint('not-pinned', __name__)
         self.app.register_blueprint(bp)
         pin = Pin.get_from(bp)
-        self.assertEqual(pin.service, 'flask')
+        self.assertNotEqual(pin.service, 'flask-bp')
 
     def test_blueprint_add_url_rule(self):
         """

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -468,7 +468,7 @@ class GrpcTestCase(TracerTestCase):
         spans = self.get_spans_with_sync_and_assert(size=2)
 
         self._check_server_span(spans[0], "mysvc", "SayHello", "unary")
-        self._check_client_span(spans[1], "mysvc-grpc-client", "SayHello", "unary")
+        self._check_client_span(spans[1], "grpc-client", "SayHello", "unary")
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_service_name_config_override(self):

--- a/tests/contrib/sanic/test_sanic.py
+++ b/tests/contrib/sanic/test_sanic.py
@@ -13,7 +13,7 @@ import ddtrace
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.sanic import patch, unpatch
 from ddtrace.propagation import http as http_propagation
-from tests import BaseTestCase, override_config, override_http_config
+from tests import override_config, override_http_config
 from tests.tracer.test_tracer import get_dummy_tracer
 
 
@@ -228,12 +228,3 @@ async def test_multiple_requests(tracer, client):
     assert spans[1][1].name == "tests.contrib.sanic.test_sanic.random_sleep"
     assert spans[1][0].parent_id is None
     assert spans[1][1].parent_id == spans[1][0].span_id
-
-
-class SanicConfigTestCase(BaseTestCase):
-    @BaseTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_service_global_config(self):
-        from ddtrace import config
-        from ddtrace.contrib.sanic import patch  # noqa: F401
-
-        assert config.sanic.service == "mysvc"

--- a/tests/tracer/test_settings.py
+++ b/tests/tracer/test_settings.py
@@ -289,3 +289,27 @@ class TestIntegrationConfig(BaseTestCase):
             assert key in ic
 
         assert ic == copy
+
+    def test_service(self):
+        ic = IntegrationConfig(self.config, "foo")
+        assert ic.service is None
+
+    @BaseTestCase.run_in_subprocess(env_overrides=dict(DD_FOO_SERVICE="foo-svc"))
+    def test_service_env_var(self):
+        ic = IntegrationConfig(self.config, "foo")
+        assert ic.service == "foo-svc"
+
+    @BaseTestCase.run_in_subprocess(env_overrides=dict(DATADOG_FOO_SERVICE="foo-svc"))
+    def test_service_env_var_legacy(self):
+        ic = IntegrationConfig(self.config, "foo")
+        assert ic.service == "foo-svc"
+
+    @BaseTestCase.run_in_subprocess(env_overrides=dict(DD_FOO_SERVICE_NAME="foo-svc"))
+    def test_service_name_env_var(self):
+        ic = IntegrationConfig(self.config, "foo")
+        assert ic.service == "foo-svc"
+
+    @BaseTestCase.run_in_subprocess(env_overrides=dict(DATADOG_FOO_SERVICE_NAME="foo-svc"))
+    def test_service_name_env_var_legacy(self):
+        ic = IntegrationConfig(self.config, "foo")
+        assert ic.service == "foo-svc"

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -34,18 +34,18 @@ def test_int_service(config, pin, config_val, default, global_service, expected)
     if global_service:
         config.service = global_service
 
-    assert trace_utils.int_service(config.myint, pin, default) == expected
+    assert trace_utils.int_service(pin, config.myint, default) == expected
 
 
 def test_int_service_integration(config):
     pin = Pin()
     tracer = Tracer()
-    assert trace_utils.int_service(config.myint, pin) is None
+    assert trace_utils.int_service(pin, config.myint) is None
 
     with override_global_config(dict(service="global-svc")):
-        assert trace_utils.int_service(config.myint, pin) is None
+        assert trace_utils.int_service(pin, config.myint) is None
 
-        with tracer.trace("something", service=trace_utils.int_service(config.myint, pin)) as s:
+        with tracer.trace("something", service=trace_utils.int_service(pin, config.myint)) as s:
             assert s.service == "global-svc"
 
 
@@ -62,4 +62,4 @@ def test_ext_service(config, pin, config_val, default, expected):
     if config_val:
         config.myint.service = config_val
 
-    assert trace_utils.ext_service(config.myint, pin, default) == expected
+    assert trace_utils.ext_service(pin, config.myint, default) == expected


### PR DESCRIPTION
This patch adds service as a field to the IntegrationConfig class. This
will enable all integrations to have a service name that will be
automatically read from the environment. Follow-up patches will be
required to make use of this functionality.

Based off of (and is dependent on) #1611.