### PR TITLE
fix(ci): pin black version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -560,9 +560,8 @@ ignore_outcome=true
 [testenv:black]
 commands_pre=
 skip_install=true
-deps=black
+deps=black==19.10b0
 commands=black --check .
-
 
 [testenv:flake8]
 commands_pre=

--- a/tox.ini
+++ b/tox.ini
@@ -563,6 +563,7 @@ skip_install=true
 deps=black
 commands=black --check .
 
+
 [testenv:flake8]
 commands_pre=
 skip_install=true


### PR DESCRIPTION
The latest black version seems to ignore our ignore list: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/2382/workflows/a434fb5a-ecf1-4ef7-a19e-fb807ce6230e/jobs/320709

Let's pin it for now.