### PR TITLE
gevent: patch ssl modules on import

### DIFF
--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -75,6 +75,8 @@ _PATCHED_MODULES = set()
 # DEV: This ensures we do not patch a module until it is needed
 # DEV: <contrib name> => <list of module names that trigger a patch>
 _PATCH_ON_IMPORT = {
+    "aiohttp": ("aiohttp",),
+    "aiobotocore": ("aiobotocore",),
     "celery": ("celery",),
     "flask": ("flask, "),
     "gevent": ("gevent",),

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -79,6 +79,8 @@ _PATCH_ON_IMPORT = {
     "flask": ("flask, "),
     "gevent": ("gevent",),
     "requests": ("requests",),
+    "botocore": ("botocore",),
+    "elasticsearch": ("elasticsearch",),
 }
 
 

--- a/tests/contrib/gevent/monkeypatch.py
+++ b/tests/contrib/gevent/monkeypatch.py
@@ -1,0 +1,3 @@
+import gevent.monkey
+gevent.monkey.patch_all()
+print("Test success")

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -3,6 +3,7 @@ import subprocess
 import gevent
 import gevent.pool
 import ddtrace
+from ddtrace.compat import PY3
 
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.context import Context
@@ -450,8 +451,9 @@ class TestGeventTracer(TracerTestCase):
         """
 
         # Ensure modules are installed
-        import aiohttp  # noqa
-        import aiobotocore  # noqa
+        if PY3:
+            import aiohttp  # noqa
+            import aiobotocore  # noqa
         import botocore  # noqa
         import requests  # noqa
         import elasticsearch  # noqa

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -450,6 +450,8 @@ class TestGeventTracer(TracerTestCase):
         """
 
         # Ensure modules are installed
+        import aiohttp  # noqa
+        import aiobotocore  # noqa
         import botocore  # noqa
         import requests  # noqa
         import elasticsearch  # noqa

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -1,3 +1,5 @@
+import subprocess
+
 import gevent
 import gevent.pool
 import ddtrace
@@ -7,15 +9,15 @@ from ddtrace.context import Context
 from ddtrace.contrib.gevent import patch, unpatch
 from ddtrace.ext.priority import USER_KEEP
 
-from unittest import TestCase
 from opentracing.scope_managers.gevent import GeventScopeManager
 from tests.opentracer.utils import init_tracer
 from tests.tracer.test_tracer import get_dummy_tracer
+from tests import TracerTestCase
 
 from .utils import silence_errors
 
 
-class TestGeventTracer(TestCase):
+class TestGeventTracer(TracerTestCase):
     """
     Ensures that greenlets are properly traced when using
     the default Tracer.
@@ -436,3 +438,30 @@ class TestGeventTracer(TestCase):
 
         spans = self.tracer.writer.pop()
         self._assert_spawn_multiple_greenlets(spans)
+
+    def test_ddtracerun(self):
+        """
+        Regression test case for the following issue.
+
+        ddtrace-run imports all available modules in order to patch them.
+        However, gevent depends on the ssl module not being imported when it
+        goes to monkeypatch. Modules that import ssl include botocore, requests
+        and elasticsearch.
+        """
+
+        # Ensure modules are installed
+        import botocore  # noqa
+        import requests  # noqa
+        import elasticsearch  # noqa
+
+        p = subprocess.Popen(
+            ["ddtrace-run", "python", "tests/contrib/gevent/monkeypatch.py"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        p.wait()
+        stdout, stderr = p.stdout.read(), p.stderr.read()
+        assert p.returncode == 0, stderr
+        assert b"Test success" in stdout
+        assert b"RecursionError" not in stderr

--- a/tox.ini
+++ b/tox.ini
@@ -92,10 +92,10 @@ envlist =
     flask_cache_contrib{,_autopatch}-{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker
     futures_contrib-py27-futures{30,31,32,}
     futures_contrib-py{35,36,37,38}
-    gevent_contrib-{py27,py35,py36}-gevent{11,12,13}
-    gevent_contrib-py{37,38}-gevent{13,14}
+    gevent_contrib-{py27,py35,py36}-gevent{11,12,13}-sslmodules
+    gevent_contrib-py{37,38}-gevent{13,14}-sslmodules
 # gevent 1.0 is not python 3 compatible
-    gevent_contrib-{py27}-gevent{10}
+    gevent_contrib-{py27}-gevent{10}-sslmodules
 # use grpcio versions with bdist_wheel packages for python versions
 # py27,py35,py36: grpcio>=1.13.0
 # py37: grpcio>=1.13.0
@@ -457,6 +457,9 @@ deps =
     sqlalchemy11: sqlalchemy>=1.1,<1.2
     sqlalchemy12: sqlalchemy>=1.2,<1.3
     sqlalchemy13: sqlalchemy>=1.3,<1.4
+    sslmodules: botocore
+    sslmodules: requests
+    sslmodules: elasticsearch
     tornado: tornado
     tornado44: tornado>=4.4,<4.5
     tornado45: tornado>=4.5,<4.6
@@ -560,7 +563,7 @@ ignore_outcome=true
 [testenv:black]
 commands_pre=
 skip_install=true
-deps=black
+deps=black==19.10b0
 commands=black --check .
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -457,6 +457,8 @@ deps =
     sqlalchemy11: sqlalchemy>=1.1,<1.2
     sqlalchemy12: sqlalchemy>=1.2,<1.3
     sqlalchemy13: sqlalchemy>=1.3,<1.4
+    sslmodules: aiohttp
+    sslmodules: aiobotocore
     sslmodules: botocore
     sslmodules: requests
     sslmodules: elasticsearch

--- a/tox.ini
+++ b/tox.ini
@@ -92,10 +92,11 @@ envlist =
     flask_cache_contrib{,_autopatch}-{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker
     futures_contrib-py27-futures{30,31,32,}
     futures_contrib-py{35,36,37,38}
-    gevent_contrib-{py27,py35,py36}-gevent{11,12,13}-sslmodules
-    gevent_contrib-py{37,38}-gevent{13,14}-sslmodules
+    gevent_contrib-py27-gevent{11,12,13}-sslmodules
+    gevent_contrib-py{35,36}-gevent{11,12,13}-sslmodules3-sslmodules
+    gevent_contrib-py{37,38}-gevent{13,14}-sslmodules3-sslmodules
 # gevent 1.0 is not python 3 compatible
-    gevent_contrib-{py27}-gevent{10}-sslmodules
+    gevent_contrib-py27-gevent10-sslmodules
 # use grpcio versions with bdist_wheel packages for python versions
 # py27,py35,py36: grpcio>=1.13.0
 # py37: grpcio>=1.13.0
@@ -457,8 +458,8 @@ deps =
     sqlalchemy11: sqlalchemy>=1.1,<1.2
     sqlalchemy12: sqlalchemy>=1.2,<1.3
     sqlalchemy13: sqlalchemy>=1.3,<1.4
-    sslmodules: aiohttp
-    sslmodules: aiobotocore
+    sslmodules3: aiohttp
+    sslmodules3: aiobotocore
     sslmodules: botocore
     sslmodules: requests
     sslmodules: elasticsearch


### PR DESCRIPTION
As described in #662, modules that result in the ssl module being imported cause gevent monkey patching to potentially crash. When ddtrace-run is used this could not be avoided since it attempts to import and patch most modules.

This PR makes these modules be patched on import instead which should address the issue.

Fixes #662, #1624, #506, #1090