### PR TITLE
core: clean-up some debug logs

### DIFF
--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -99,6 +99,10 @@ def get_container_info(pid="self"):
                 info = CGroupInfo.from_line(line)
                 if info and info.container_id:
                     return info
+    except FileNotFoundError:
+        # If the cgroup file does not exist then this is likely not a container
+        # which is a valid use-case so pass.
+        pass
     except Exception:
         log.debug("Failed to parse cgroup file for pid %r", pid, exc_info=True)
 

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -88,6 +88,10 @@ class PatchException(Exception):
     pass
 
 
+class ModuleNotFoundException(PatchException):
+    pass
+
+
 def _on_import_factory(module, raise_errors=True):
     """Factory to create an import hook for the provided module name"""
 
@@ -168,6 +172,10 @@ def patch_module(module, raise_errors=True):
     """
     try:
         return _patch_module(module)
+    except ModuleNotFoundException:
+        if raise_errors:
+            raise
+        return False
     except Exception:
         if raise_errors:
             raise
@@ -202,7 +210,7 @@ def _patch_module(module):
         except AttributeError:
             # if patch() is not available in the module, it means
             # that the library is not installed in the environment
-            raise PatchException("module '%s' not installed" % module)
+            raise ModuleNotFoundException("module '%s' not installed" % module)
 
         _PATCHED_MODULES.add(module)
         return True

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -203,14 +203,15 @@ def _patch_module(module):
 
         try:
             imported_module = importlib.import_module(path)
-            imported_module.patch()
         except ImportError:
             # if the import fails, the integration is not available
             raise PatchException("integration '%s' not available" % path)
-        except AttributeError:
+        else:
             # if patch() is not available in the module, it means
             # that the library is not installed in the environment
-            raise ModuleNotFoundException("module '%s' not installed" % module)
+            if not hasattr(imported_module, "patch"):
+                raise ModuleNotFoundException("module '%s' not installed" % module)
 
-        _PATCHED_MODULES.add(module)
-        return True
+            imported_module.patch()
+            _PATCHED_MODULES.add(module)
+            return True


### PR DESCRIPTION
The debug logs of the tracer have some noisy, not very helpful logs which can be cleaned up.

```
DEBUG:ddtrace.sampler:initialized RateSampler, sample 100% of traces
DEBUG:ddtrace.tracer:Connecting to DogStatsd(udp://localhost:8125)
DEBUG:ddtrace.internal.runtime.container:Failed to parse cgroup file for pid 'self'
Traceback (most recent call last):
  File "/Users/kyle.verhoog/dev/dd-trace-py/ddtrace/internal/runtime/container.py", line 97, in get_container_info
    with open(cgroup_file, mode="r") as fp:
FileNotFoundError: [Errno 2] No such file or directory: '/proc/self/cgroup'
DEBUG:ddtrace.monkey:failed to patch boto
Traceback (most recent call last):
  File "/Users/kyle.verhoog/dev/dd-trace-py/ddtrace/monkey.py", line 198, in _patch_module
    imported_module.patch()
AttributeError: module 'ddtrace.contrib.boto' has no attribute 'patch'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/kyle.verhoog/dev/dd-trace-py/ddtrace/monkey.py", line 170, in patch_module
    return _patch_module(module)
  File "/Users/kyle.verhoog/dev/dd-trace-py/ddtrace/monkey.py", line 205, in _patch_module
    raise PatchException("module '%s' not installed" % module)
ddtrace.monkey.PatchException: module 'boto' not installed
INFO:ddtrace.monkey:patched 9/33 modules (aiohttp,botocore,celery,elasticsearch,flask,pylibmc,redis,requests,sqlite3)
DEBUG:ddtrace._worker:Stopping AgentWriter thread
```

- `AttributeError: module 'ddtrace.contrib.boto' has no attribute 'patch'` often causes users to believe there is something broken or misconfigured with boto, when in reality this is expected behaviour for when boto is not installed.

- `Failed to parse cgroup file for pid 'self'` also looks like an error when in reality it is expected behaviour when running outside of a container.

Fixes #1634 