### PR TITLE
docs: add readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+version: 2
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt
+    - method: setuptools
+      path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,13 +17,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 
-import os
-import sys
 from datetime import datetime
-
-
-# append the ddtrace path to syspath
-sys.path.insert(0, os.path.abspath(".."))
 
 
 # -- General configuration ------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+cython
+sphinx
+opentracing


### PR DESCRIPTION
As tested in https://github.com/Kyle-Verhoog/dd-trace-py-test/commit/ab9d0f056ae25d4160979b715847fd56d7421cc9 (results [here](https://dd-trace-py-test.readthedocs.io/en/latest/web_integrations.html)) this is what is required in order for us to deploy our docs to readthedocs.

This will give us a good way to finally do versioned docs!

