### PR TITLE
fix(core): always store span_type as str on span

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -33,7 +33,7 @@ class Span(object):
         "meta",
         "error",
         "metrics",
-        "span_type",
+        "_span_type",
         "start_ns",
         "duration_ns",
         "tracer",
@@ -81,7 +81,8 @@ class Span(object):
         self.name = name
         self.service = service
         self.resource = resource or name
-        self.span_type = span_type.value if isinstance(span_type, SpanTypes) else span_type
+        self._span_type = None
+        self.span_type = span_type
 
         # tags / metadata
         self.meta = {}
@@ -112,6 +113,14 @@ class Span(object):
     @start.setter
     def start(self, value):
         self.start_ns = int(value * 1e9)
+
+    @property
+    def span_type(self):
+        return self._span_type
+
+    @span_type.setter
+    def span_type(self, value):
+        self._span_type = value.value if isinstance(value, SpanTypes) else value
 
     @property
     def finished(self):


### PR DESCRIPTION
Formerly if the span_type field was assigned to a Span object as a `SpanType` then it would fail to encode since the encoding does not handle the enum. This patch fixes this by making `span_type` a property and storing the enum value on the span.

```python
with tracer.trace("op", span_type=SpanTypes.WEB):
    pass

# Works fine because the initializer handles the conversion of enum to str
```

```python
with tracer.trace("op") as span:
    span.span_type = SpanTypes.WEB

# Fails to encode prior to this fix
```

thanks to @thehesiod for discovering this one!