### PR TITLE
feat(django): add database_service_name config option

### DIFF
--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -59,6 +59,14 @@ Configuration
 
    Default: ``'django'``
 
+.. py:data:: ddtrace.config.django['database_service_name']
+
+   A string reported as the service name of the Django app database layer.
+
+   Can also be configured via the ``DD_DJANGO_DATABASE_SERVICE_NAME`` environment variable.
+
+   Default: ``''``
+
 .. py:data:: ddtrace.config.django['database_service_name_prefix']
 
    A string to be prepended to the service name reported for your Django app database layer.

--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -65,6 +65,8 @@ Configuration
 
    Can also be configured via the ``DD_DJANGO_DATABASE_SERVICE_NAME`` environment variable.
 
+   Takes precedence over database_service_name_prefix.
+
    Default: ``''``
 
 .. py:data:: ddtrace.config.django['database_service_name_prefix']
@@ -73,7 +75,7 @@ Configuration
 
    Can also be configured via the ``DD_DJANGO_DATABASE_SERVICE_NAME_PREFIX`` environment variable.
 
-   The database service name is the name of the database appended with 'db'.
+   The database service name is the name of the database appended with 'db'. Has a lower precedence than database_service_name.
 
    Default: ``''``
 

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -1075,6 +1075,34 @@ def test_database_service_prefix_can_be_overridden(test_spans):
     assert span.service == "my-defaultdb"
 
 
+@pytest.mark.django_db
+def test_database_service_can_be_overridden(test_spans):
+    with override_config("django", dict(database_service_name="django-db")):
+        from django.contrib.auth.models import User
+
+        User.objects.count()
+
+    spans = test_spans.get_spans()
+    assert len(spans) > 0
+
+    span = spans[0]
+    assert span.service == "django-db"
+
+
+@pytest.mark.django_db
+def test_database_service_prefix_precedence(test_spans):
+    with override_config("django", dict(database_service_name="django-db", database_service_name_prefix="my-")):
+        from django.contrib.auth.models import User
+
+        User.objects.count()
+
+    spans = test_spans.get_spans()
+    assert len(spans) > 0
+
+    span = spans[0]
+    assert span.service == "django-db"
+
+
 def test_cache_service_can_be_overridden(test_spans):
     cache = django.core.cache.caches["default"]
 


### PR DESCRIPTION
This allows the configuration of the service name directly in addition to providing a prefix.