### PR TITLE
feat: add global service name configuration for dbapi integrations

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -97,7 +97,7 @@ def patch_conn(django, conn):
             "django.db.alias": alias,
         }
         pin = Pin(service, tags=tags, tracer=pin.tracer, app=prefix)
-        return dbapi.TracedCursor(func(*args, **kwargs), pin)
+        return dbapi.TracedCursor(func(*args, **kwargs), pin, config.django, None)
 
     if not isinstance(conn.cursor, wrapt.ObjectProxy):
         conn.cursor = wrapt.FunctionWrapper(conn.cursor, with_traced_module(cursor)(django))

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -97,7 +97,7 @@ def patch_conn(django, conn):
             "django.db.alias": alias,
         }
         pin = Pin(service, tags=tags, tracer=pin.tracer, app=prefix)
-        return dbapi.TracedCursor(func(*args, **kwargs), pin, config.django, None)
+        return dbapi.TracedCursor(func(*args, **kwargs), pin, config.django)
 
     if not isinstance(conn.cursor, wrapt.ObjectProxy):
         conn.cursor = wrapt.FunctionWrapper(conn.cursor, with_traced_module(cursor)(django))

--- a/ddtrace/contrib/mysql/__init__.py
+++ b/ddtrace/contrib/mysql/__init__.py
@@ -1,27 +1,55 @@
-"""Instrument mysql to report MySQL queries.
+"""
+The mysql integration instruments the mysql library to trace MySQL queries.
 
-``patch_all`` will automatically patch your mysql connection to make it work.
 
-::
+Enabling
+~~~~~~~~
 
+The mysql integration is enabled automatically when using
+:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+
+Or use :ref:`patch()<patch>` to manually enable the integration::
+
+    from ddtrace import patch
+    patch(mysql=True)
+
+
+Global Configuration
+~~~~~~~~~~~~~~~~~~~~
+
+.. py:data:: ddtrace.config.mysql["service"]
+
+   The service name reported by default for mysql spans.
+
+   This option can also be set with the ``DD_MYSQL_SERVICE`` environment
+   variable.
+
+   Default: ``"mysql"``
+
+
+Instance Configuration
+~~~~~~~~~~~~~~~~~~~~~~
+
+To configure the mysql integration on an per-connection basis use the
+``Pin`` API::
+
+    from ddtrace import Pin
     # Make sure to import mysql.connector and not the 'connect' function,
     # otherwise you won't have access to the patched version
-    from ddtrace import Pin, patch
     import mysql.connector
-
-    # If not patched yet, you can patch mysql specifically
-    patch(mysql=True)
 
     # This will report a span with the default settings
     conn = mysql.connector.connect(user="alice", password="b0b", host="localhost", port=3306, database="test")
+
+    # Use a pin to override the service name for this connection.
+    Pin.override(conn, service='mysql-users')
+
     cursor = conn.cursor()
     cursor.execute("SELECT 6*7 AS the_answer;")
 
-    # Use a pin to specify metadata related to this connection
-    Pin.override(conn, service='mysql-users')
 
 Only the default full-Python integration works. The binary C connector,
-provided by _mysql_connector, is not supported yet.
+provided by _mysql_connector, is not supported.
 
 Help on mysql.connector can be found on:
 https://dev.mysql.com/doc/connector-python/en/

--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -1,12 +1,15 @@
-# 3p
 from ddtrace.vendor import wrapt
 import mysql.connector
 
-# project
+from ddtrace import config
 from ddtrace import Pin
 from ddtrace.contrib.dbapi import TracedConnection
 from ...ext import net, db
 
+
+config._add("mysql", dict(
+    _default_service="mysql",
+))
 
 CONN_ATTR_BY_TAG = {
     net.TARGET_HOST: 'server_host',
@@ -38,9 +41,9 @@ def _connect(func, instance, args, kwargs):
 def patch_conn(conn):
 
     tags = {t: getattr(conn, a) for t, a in CONN_ATTR_BY_TAG.items() if getattr(conn, a, '') != ''}
-    pin = Pin(service='mysql', app='mysql', tags=tags)
+    pin = Pin(app='mysql', tags=tags)
 
     # grab the metadata from the conn
-    wrapped = TracedConnection(conn, pin=pin)
+    wrapped = TracedConnection(conn, pin=pin, cfg=config.mysql)
     pin.onto(wrapped)
     return wrapped

--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -1,8 +1,7 @@
 from ddtrace.vendor import wrapt
 import mysql.connector
 
-from ddtrace import config
-from ddtrace import Pin
+from ddtrace import config, Pin
 from ddtrace.contrib.dbapi import TracedConnection
 from ...ext import net, db
 

--- a/ddtrace/contrib/mysqldb/__init__.py
+++ b/ddtrace/contrib/mysqldb/__init__.py
@@ -1,28 +1,56 @@
-"""Instrument mysqlclient / MySQL-python to report MySQL queries.
+"""
+The mysqldb integration instruments the mysqlclient and MySQL-python  libraries to trace MySQL queries.
 
-``patch_all`` will automatically patch your mysql connection to make it work.
 
-::
+Enabling
+~~~~~~~~
+
+The integration is enabled automatically when using
+:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+
+Or use :ref:`patch()<patch>` to manually enable the integration::
+
+    from ddtrace import patch
+    patch(mysqldb=True)
+
+
+Global Configuration
+~~~~~~~~~~~~~~~~~~~~
+
+.. py:data:: ddtrace.config.mysqldb["service"]
+
+   The service name reported by default for spans.
+
+   This option can also be set with the ``DD_MYSQLDB_SERVICE`` environment
+   variable.
+
+   Default: ``"mysql"``
+
+
+Instance Configuration
+~~~~~~~~~~~~~~~~~~~~~~
+
+To configure the integration on an per-connection basis use the
+``Pin`` API::
 
     # Make sure to import MySQLdb and not the 'connect' function,
     # otherwise you won't have access to the patched version
-    from ddtrace import Pin, patch
+    from ddtrace import Pin
     import MySQLdb
-
-    # If not patched yet, you can patch mysqldb specifically
-    patch(mysqldb=True)
 
     # This will report a span with the default settings
     conn = MySQLdb.connect(user="alice", passwd="b0b", host="localhost", port=3306, db="test")
+
+    # Use a pin to override the service.
+    Pin.override(conn, service='mysql-users')
+
     cursor = conn.cursor()
     cursor.execute("SELECT 6*7 AS the_answer;")
 
-    # Use a pin to specify metadata related to this connection
-    Pin.override(conn, service='mysql-users')
 
 This package works for mysqlclient or MySQL-python. Only the default
 full-Python integration works. The binary C connector provided by
-_mysql is not yet supported.
+_mysql is not supported.
 
 Help on mysqlclient can be found on:
 https://mysqlclient.readthedocs.io/

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -4,11 +4,16 @@ import MySQLdb
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 # project
-from ddtrace import Pin
+from ddtrace import config, Pin
 from ddtrace.contrib.dbapi import TracedConnection
 
 from ...ext import net, db
 from ...utils.wrappers import unwrap as _u
+
+
+config._add("mysqldb", dict(
+    _default_service="mysql",
+))
 
 KWPOS_BY_TAG = {
     net.TARGET_HOST: ('host', 0),
@@ -55,9 +60,9 @@ def patch_conn(conn, *args, **kwargs):
             for t, (k, p) in KWPOS_BY_TAG.items()
             if k in kwargs or len(args) > p}
     tags[net.TARGET_PORT] = conn.port
-    pin = Pin(service='mysql', app='mysql', tags=tags)
+    pin = Pin(app='mysql', tags=tags)
 
     # grab the metadata from the conn
-    wrapped = TracedConnection(conn, pin=pin)
+    wrapped = TracedConnection(conn, pin=pin, cfg=config.mysqldb)
     pin.onto(wrapped)
     return wrapped

--- a/ddtrace/contrib/psycopg/__init__.py
+++ b/ddtrace/contrib/psycopg/__init__.py
@@ -1,21 +1,47 @@
-"""Instrument psycopg2 to report Postgres queries.
+"""
+The psycopg integration instruments the psycopg2 library to trace Postgres queries.
 
-``patch_all`` will automatically patch your psycopg2 connection to make it work.
-::
 
-    from ddtrace import Pin, patch
-    import psycopg2
+Enabling
+~~~~~~~~
 
-    # If not patched yet, you can patch psycopg2 specifically
+The mysql integration is enabled automatically when using
+:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+
+Or use :ref:`patch()<patch>` to manually enable the integration::
+
+    from ddtrace import patch
     patch(psycopg=True)
 
-    # This will report a span with the default settings
+
+Global Configuration
+~~~~~~~~~~~~~~~~~~~~
+
+.. py:data:: ddtrace.config.psycopg["service"]
+
+   The service name reported by default for psycopg spans.
+
+   This option can also be set with the ``DD_PSYCOPG_SERVICE`` environment
+   variable.
+
+   Default: ``"postgres"``
+
+
+Instance Configuration
+~~~~~~~~~~~~~~~~~~~~~~
+
+To configure the psycopg integration on an per-connection basis use the
+``Pin`` API::
+
+    from ddtrace import Pin
+    import psycopg2
+
     db = psycopg2.connect(connection_factory=factory)
+    # Use a pin to override the service name.
+    Pin.override(db, service="postgres-users")
+
     cursor = db.cursor()
     cursor.execute("select * from users where id = 1")
-
-    # Use a pin to specify metadata related to this connection
-    Pin.override(db, service='postgres-users')
 """
 from ...utils.importlib import require_modules
 

--- a/ddtrace/contrib/psycopg/connection.py
+++ b/ddtrace/contrib/psycopg/connection.py
@@ -43,7 +43,9 @@ class TracedCursor(cursor):
         if not self._datadog_tracer:
             return cursor.execute(self, query, vars)
 
-        with self._datadog_tracer.trace('postgres.query', service=self._datadog_service, span_type=SpanTypes.SQL) as s:
+        with self._datadog_tracer.trace(
+            'postgres.query', service=self._datadog_service, span_type=SpanTypes.SQL
+        ) as s:
             s.set_tag(SPAN_MEASURED_KEY)
             if not s.sampled:
                 return super(TracedCursor, self).execute(query, vars)

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -7,6 +7,9 @@ from ddtrace import Pin, config
 from ddtrace.contrib import dbapi
 from ddtrace.ext import sql, net, db
 
+
+config._add("psycopg", dict())
+
 # Original connect method
 _connect = psycopg2.connect
 
@@ -65,7 +68,7 @@ class Psycopg2TracedConnection(dbapi.TracedConnection):
             if config.dbapi2.trace_fetch_methods:
                 cursor_cls = Psycopg2FetchTracedCursor
 
-        super(Psycopg2TracedConnection, self).__init__(conn, pin, cursor_cls=cursor_cls)
+        super(Psycopg2TracedConnection, self).__init__(conn, pin, config.psycopg, "postgres", cursor_cls=cursor_cls)
 
 
 def patch_conn(conn, traced_conn_cls=Psycopg2TracedConnection):
@@ -86,10 +89,7 @@ def patch_conn(conn, traced_conn_cls=Psycopg2TracedConnection):
         'db.application': dsn.get('application_name'),
     }
 
-    Pin(
-        service='postgres',
-        app='postgres',
-        tags=tags).onto(c)
+    Pin(app='postgres', tags=tags).onto(c)
 
     return c
 

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -8,7 +8,9 @@ from ddtrace.contrib import dbapi
 from ddtrace.ext import sql, net, db
 
 
-config._add("psycopg", dict())
+config._add("psycopg", dict(
+    _default_service="postgres"
+))
 
 # Original connect method
 _connect = psycopg2.connect
@@ -68,7 +70,7 @@ class Psycopg2TracedConnection(dbapi.TracedConnection):
             if config.dbapi2.trace_fetch_methods:
                 cursor_cls = Psycopg2FetchTracedCursor
 
-        super(Psycopg2TracedConnection, self).__init__(conn, pin, config.psycopg, "postgres", cursor_cls=cursor_cls)
+        super(Psycopg2TracedConnection, self).__init__(conn, pin, config.psycopg, cursor_cls=cursor_cls)
 
 
 def patch_conn(conn, traced_conn_cls=Psycopg2TracedConnection):

--- a/ddtrace/contrib/pymysql/__init__.py
+++ b/ddtrace/contrib/pymysql/__init__.py
@@ -1,21 +1,50 @@
-"""Instrument pymysql to report MySQL queries.
+"""
+The pymysql integration instruments the pymysql library to trace MySQL queries.
 
-``patch_all`` will automatically patch your pymysql connection to make it work.
-::
 
-    from ddtrace import Pin, patch
-    from pymysql import connect
+Enabling
+~~~~~~~~
 
-    # If not patched yet, you can patch pymysql specifically
+The integration is enabled automatically when using
+:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+
+Or use :ref:`patch()<patch>` to manually enable the integration::
+
+    from ddtrace import patch
     patch(pymysql=True)
+
+
+Global Configuration
+~~~~~~~~~~~~~~~~~~~~
+
+.. py:data:: ddtrace.config.pymysql["service"]
+
+   The service name reported by default for pymysql spans.
+
+   This option can also be set with the ``DD_PYMYSQL_SERVICE`` environment
+   variable.
+
+   Default: ``"mysql"``
+
+
+Instance Configuration
+~~~~~~~~~~~~~~~~~~~~~~
+
+To configure the integration on an per-connection basis use the
+``Pin`` API::
+
+    from ddtrace import Pin
+    from pymysql import connect
 
     # This will report a span with the default settings
     conn = connect(user="alice", password="b0b", host="localhost", port=3306, database="test")
+
+    # Use a pin to override the service name for this connection.
+    Pin.override(conn, service="pymysql-users")
+
+
     cursor = conn.cursor()
     cursor.execute("SELECT 6*7 AS the_answer;")
-
-    # Use a pin to specify metadata related to this connection
-    Pin.override(conn, service='pymysql-users')
 """
 
 from ...utils.importlib import require_modules

--- a/ddtrace/contrib/pymysql/patch.py
+++ b/ddtrace/contrib/pymysql/patch.py
@@ -3,9 +3,15 @@ from ddtrace.vendor import wrapt
 import pymysql
 
 # project
-from ddtrace import Pin
+from ddtrace import config, Pin
 from ddtrace.contrib.dbapi import TracedConnection
 from ...ext import net, db
+
+
+config._add("pymysql", dict(
+    # TODO[v1.0] this should be "mysql"
+    _default_service="pymysql",
+))
 
 CONN_ATTR_BY_TAG = {
     net.TARGET_HOST: 'host',
@@ -31,9 +37,9 @@ def _connect(func, instance, args, kwargs):
 
 def patch_conn(conn):
     tags = {t: getattr(conn, a, '') for t, a in CONN_ATTR_BY_TAG.items()}
-    pin = Pin(service='pymysql', app='pymysql', tags=tags)
+    pin = Pin(app='pymysql', tags=tags)
 
     # grab the metadata from the conn
-    wrapped = TracedConnection(conn, pin=pin)
+    wrapped = TracedConnection(conn, pin=pin, cfg=config.pymysql)
     pin.onto(wrapped)
     return wrapped

--- a/ddtrace/contrib/sqlite3/__init__.py
+++ b/ddtrace/contrib/sqlite3/__init__.py
@@ -1,21 +1,49 @@
-"""Instrument sqlite3 to report SQLite queries.
+"""
+The sqlite integration instruments the built-in sqlite module to trace SQLite queries.
 
-``patch_all`` will automatically patch your sqlite3 connection to make it work.
-::
 
-    from ddtrace import Pin, patch
+Enabling
+~~~~~~~~
+
+The integration is enabled automatically when using
+:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+
+Or use :ref:`patch()<patch>` to manually enable the integration::
+
+    from ddtrace import patch
+    patch(sqlite=True)
+
+
+Global Configuration
+~~~~~~~~~~~~~~~~~~~~
+
+.. py:data:: ddtrace.config.sqlite["service"]
+
+   The service name reported by default for sqlite spans.
+
+   This option can also be set with the ``DD_SQLITE_SERVICE`` environment
+   variable.
+
+   Default: ``"sqlite"``
+
+
+Instance Configuration
+~~~~~~~~~~~~~~~~~~~~~~
+
+To configure the integration on an per-connection basis use the
+``Pin`` API::
+
+    from ddtrace import Pin
     import sqlite3
-
-    # If not patched yet, you can patch sqlite3 specifically
-    patch(sqlite3=True)
 
     # This will report a span with the default settings
     db = sqlite3.connect(":memory:")
+
+    # Use a pin to override the service name for the connection.
+    Pin.override(db, service='sqlite-users')
+
     cursor = db.cursor()
     cursor.execute("select * from users where id = 1")
-
-    # Use a pin to specify metadata related to this connection
-    Pin.override(db, service='sqlite-users')
 """
 from .connection import connection_factory
 from .patch import patch

--- a/ddtrace/contrib/sqlite3/patch.py
+++ b/ddtrace/contrib/sqlite3/patch.py
@@ -11,6 +11,10 @@ from ...settings import config
 # Original connect method
 _connect = sqlite3.connect
 
+config._add("sqlite", dict(
+    _default_service="sqlite",
+))
+
 
 def patch():
     wrapped = wrapt.FunctionWrapper(_connect, traced_connect)
@@ -31,7 +35,7 @@ def traced_connect(func, _, args, kwargs):
 
 def patch_conn(conn):
     wrapped = TracedSQLite(conn)
-    Pin(service='sqlite', app='sqlite').onto(wrapped)
+    Pin(app='sqlite').onto(wrapped)
     return wrapped
 
 
@@ -59,7 +63,7 @@ class TracedSQLite(TracedConnection):
             if config.dbapi2.trace_fetch_methods:
                 cursor_cls = TracedSQLiteFetchCursor
 
-            super(TracedSQLite, self).__init__(conn, pin=pin, cursor_cls=cursor_cls)
+            super(TracedSQLite, self).__init__(conn, pin=pin, cfg=config.sqlite, cursor_cls=cursor_cls)
 
     def execute(self, *args, **kwargs):
         # sqlite has a few extra sugar functions

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -185,6 +185,7 @@ class TestTracedCursor(TracerTestCase):
     def test_cfg_service(self):
         cursor = self.cursor
         tracer = self.tracer
+        cursor.rowcount = 123
         pin = Pin(None, app='my_app', tracer=tracer, tags={'pin1': 'value_pin1'})
         cfg = AttrDict(service="cfg-service")
         traced_cursor = TracedCursor(cursor, pin, cfg, None)
@@ -199,6 +200,7 @@ class TestTracedCursor(TracerTestCase):
     def test_default_service(self):
         cursor = self.cursor
         tracer = self.tracer
+        cursor.rowcount = 123
         pin = Pin(None, app='my_app', tracer=tracer, tags={'pin1': 'value_pin1'})
         cfg = AttrDict(service=None)
         traced_cursor = TracedCursor(cursor, pin, cfg, "default-svc")

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -226,6 +226,21 @@ class TestTracedCursor(TracerTestCase):
         span = tracer.writer.pop()[0]  # type: Span
         assert span.service == "default-svc"
 
+    def test_service_cfg_and_pin(self):
+        cursor = self.cursor
+        tracer = self.tracer
+        cursor.rowcount = 123
+        pin = Pin("pin-svc", app='my_app', tracer=tracer, tags={'pin1': 'value_pin1'})
+        cfg = AttrDict(_default_service="cfg-svc")
+        traced_cursor = TracedCursor(cursor, pin, cfg)
+
+        def method():
+            pass
+
+        traced_cursor._trace_method(method, 'my_name', 'my_resource', {'extra1': 'value_extra1'})
+        span = tracer.writer.pop()[0]  # type: Span
+        assert span.service == "pin-svc"
+
     def test_django_traced_cursor_backward_compatibility(self):
         cursor = self.cursor
         tracer = self.tracer

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -305,7 +305,7 @@ class TestFetchTracedCursor(TracerTestCase):
         cursor.execute.return_value = '__result__'
 
         pin = Pin('pin_name', tracer=self.tracer)
-        traced_cursor = FetchTracedCursor(cursor, pin, {}, None)
+        traced_cursor = FetchTracedCursor(cursor, pin, {})
         assert '__result__' == traced_cursor.execute('__query__', 'arg_1', kwarg1='kwarg1')
         cursor.execute.assert_called_once_with('__query__', 'arg_1', kwarg1='kwarg1')
 
@@ -315,7 +315,7 @@ class TestFetchTracedCursor(TracerTestCase):
         cursor.executemany.return_value = '__result__'
 
         pin = Pin('pin_name', tracer=self.tracer)
-        traced_cursor = FetchTracedCursor(cursor, pin, {}, None)
+        traced_cursor = FetchTracedCursor(cursor, pin, {})
         assert '__result__' == traced_cursor.executemany('__query__', 'arg_1', kwarg1='kwarg1')
         cursor.executemany.assert_called_once_with('__query__', 'arg_1', kwarg1='kwarg1')
 
@@ -324,7 +324,7 @@ class TestFetchTracedCursor(TracerTestCase):
         cursor.rowcount = 0
         cursor.fetchone.return_value = '__result__'
         pin = Pin('pin_name', tracer=self.tracer)
-        traced_cursor = FetchTracedCursor(cursor, pin, {}, None)
+        traced_cursor = FetchTracedCursor(cursor, pin, {})
         assert '__result__' == traced_cursor.fetchone('arg_1', kwarg1='kwarg1')
         cursor.fetchone.assert_called_once_with('arg_1', kwarg1='kwarg1')
 
@@ -333,7 +333,7 @@ class TestFetchTracedCursor(TracerTestCase):
         cursor.rowcount = 0
         cursor.fetchall.return_value = '__result__'
         pin = Pin('pin_name', tracer=self.tracer)
-        traced_cursor = FetchTracedCursor(cursor, pin, {}, None)
+        traced_cursor = FetchTracedCursor(cursor, pin, {})
         assert '__result__' == traced_cursor.fetchall('arg_1', kwarg1='kwarg1')
         cursor.fetchall.assert_called_once_with('arg_1', kwarg1='kwarg1')
 
@@ -342,7 +342,7 @@ class TestFetchTracedCursor(TracerTestCase):
         cursor.rowcount = 0
         cursor.fetchmany.return_value = '__result__'
         pin = Pin('pin_name', tracer=self.tracer)
-        traced_cursor = FetchTracedCursor(cursor, pin, {}, None)
+        traced_cursor = FetchTracedCursor(cursor, pin, {})
         assert '__result__' == traced_cursor.fetchmany('arg_1', kwarg1='kwarg1')
         cursor.fetchmany.assert_called_once_with('arg_1', kwarg1='kwarg1')
 
@@ -351,7 +351,7 @@ class TestFetchTracedCursor(TracerTestCase):
         tracer = self.tracer
         cursor.rowcount = 0
         pin = Pin('pin_name', tracer=tracer)
-        traced_cursor = FetchTracedCursor(cursor, pin, {}, None)
+        traced_cursor = FetchTracedCursor(cursor, pin, {})
 
         traced_cursor.execute('arg_1', kwarg1='kwarg1')
         self.assert_structure(dict(name='sql.query'))
@@ -382,7 +382,7 @@ class TestFetchTracedCursor(TracerTestCase):
         tracer = self.tracer
         cursor.rowcount = 0
         pin = Pin('pin_name', app='changed', tracer=tracer)
-        traced_cursor = FetchTracedCursor(cursor, pin, {}, None)
+        traced_cursor = FetchTracedCursor(cursor, pin, {})
 
         traced_cursor.execute('arg_1', kwarg1='kwarg1')
         self.assert_structure(dict(name='changed.query'))
@@ -417,7 +417,7 @@ class TestFetchTracedCursor(TracerTestCase):
 
         tracer.enabled = False
         pin = Pin('pin_name', tracer=tracer)
-        traced_cursor = FetchTracedCursor(cursor, pin, {}, None)
+        traced_cursor = FetchTracedCursor(cursor, pin, {})
 
         assert '__result__' == traced_cursor.execute('arg_1', kwarg1='kwarg1')
         assert len(tracer.writer.pop()) == 0
@@ -446,7 +446,7 @@ class TestFetchTracedCursor(TracerTestCase):
         tracer = self.tracer
         cursor.rowcount = 123
         pin = Pin('my_service', app='my_app', tracer=tracer, tags={'pin1': 'value_pin1'})
-        traced_cursor = FetchTracedCursor(cursor, pin, {}, None)
+        traced_cursor = FetchTracedCursor(cursor, pin, {})
 
         def method():
             pass
@@ -471,7 +471,7 @@ class TestFetchTracedCursor(TracerTestCase):
         # set by the legacy replaced implementation.
         cursor.rowcount = 123
         pin = Pin('my_service', app='my_app', tracer=tracer, tags={'pin1': 'value_pin1'})
-        traced_cursor = FetchTracedCursor(cursor, pin, {}, None)
+        traced_cursor = FetchTracedCursor(cursor, pin, {})
 
         def method():
             pass
@@ -492,7 +492,7 @@ class TestFetchTracedCursor(TracerTestCase):
             cursor.rowcount = 0
             cursor.fetchone.return_value = '__result__'
             pin = Pin('pin_name', tracer=self.tracer)
-            traced_cursor = FetchTracedCursor(cursor, pin, {}, None)
+            traced_cursor = FetchTracedCursor(cursor, pin, {})
             assert '__result__' == traced_cursor.fetchone('arg_1', kwarg1='kwarg1')
 
             span = self.tracer.writer.pop()[0]
@@ -502,7 +502,7 @@ class TestFetchTracedCursor(TracerTestCase):
             cursor.rowcount = 0
             cursor.fetchall.return_value = '__result__'
             pin = Pin('pin_name', tracer=self.tracer)
-            traced_cursor = FetchTracedCursor(cursor, pin, {}, None)
+            traced_cursor = FetchTracedCursor(cursor, pin, {})
             assert '__result__' == traced_cursor.fetchall('arg_1', kwarg1='kwarg1')
 
             span = self.tracer.writer.pop()[0]
@@ -512,7 +512,7 @@ class TestFetchTracedCursor(TracerTestCase):
             cursor.rowcount = 0
             cursor.fetchmany.return_value = '__result__'
             pin = Pin('pin_name', tracer=self.tracer)
-            traced_cursor = FetchTracedCursor(cursor, pin, {}, None)
+            traced_cursor = FetchTracedCursor(cursor, pin, {})
             assert '__result__' == traced_cursor.fetchmany('arg_1', kwarg1='kwarg1')
 
             span = self.tracer.writer.pop()[0]

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -327,7 +327,7 @@ class PsycopgCore(TracerTestCase):
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_service(self):
+    def test_user_specified_app_service(self):
         """
         When a user specifies a service for the app
             The psycopg integration should not use it.
@@ -342,6 +342,16 @@ class PsycopgCore(TracerTestCase):
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
         assert spans[0].service != "mysvc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_PSYCOPG_SERVICE="mysvc"))
+    def test_user_specified_service(self):
+        conn = self._get_conn()
+        conn.cursor().execute("""select 'blah'""")
+
+        spans = self.get_spans()
+        self.assertEqual(len(spans), 1)
+        print(spans[0].service)
+        assert spans[0].service == "mysvc"
 
 
 def test_backwards_compatibilty_v3():

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -350,7 +350,6 @@ class PsycopgCore(TracerTestCase):
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
-        print(spans[0].service)
         assert spans[0].service == "mysvc"
 
 


### PR DESCRIPTION
Add the global service name configuration for all dbapi based integrations. This will allow the configuration of the service name for:

- psycopg
- mysql
- mysqldb
- sqlite
- pymysql