### PR TITLE
docs: manual tracing of starlette and fastapi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,6 +357,18 @@ jobs:
       - run_tox_scenario:
           pattern: '^asgi_contrib-'
 
+  starlette:
+    executor: ddtrace_dev
+    steps:
+      - run_tox_scenario:
+          pattern: '^starlette_contrib-'
+
+  fastapi:
+    executor: ddtrace_dev
+    steps:
+      - run_tox_scenario:
+          pattern: '^fastapi_contrib-'
+
   tornado:
     executor: ddtrace_dev
     steps:
@@ -786,6 +798,7 @@ requires_tests: &requires_tests
   - djangorestframework
   - elasticsearch
   - falcon
+  - fastapi
   - flask
   - futures
   - gevent
@@ -815,6 +828,7 @@ requires_tests: &requires_tests
   - requestsgevent
   - sqlalchemy
   - sqlite3
+  - starlette
   - test_build_alpine
   - test_build_py38
   - test_build_py37
@@ -883,6 +897,7 @@ workflows:
       - dogpile_cache: *requires_pre_test
       - elasticsearch: *requires_pre_test
       - falcon: *requires_pre_test
+      - fastapi: *requires_pre_test
       - flask: *requires_pre_test
       - futures: *requires_pre_test
       - gevent: *requires_pre_test
@@ -913,6 +928,7 @@ workflows:
       - sanic: *requires_pre_test
       - sqlalchemy: *requires_pre_test
       - sqlite3: *requires_pre_test
+      - starlette: *requires_pre_test
       - test_logging: *requires_pre_test
       - tornado: *requires_pre_test
       # tracer

--- a/ddtrace/contrib/fastapi/__init__.py
+++ b/ddtrace/contrib/fastapi/__init__.py
@@ -11,9 +11,15 @@ To configure tracing manually::
 If using Python 3.6, the legacy ``AsyncioContextProvider`` will have to be
 enabled before using the middleware::
 
+    from ddtrace.contrib.asgi import TraceMiddleware
     from ddtrace.contrib.asyncio.provider import AsyncioContextProvider
     from ddtrace import tracer  # Or whichever tracer instance you plan to use
+
+
     tracer.configure(context_provider=AsyncioContextProvider())
+
+    app = FastAPI()
+    app.add_middleware(TraceMiddleware, tracer=tracer)
 
 
 Configuration

--- a/ddtrace/contrib/fastapi/__init__.py
+++ b/ddtrace/contrib/fastapi/__init__.py
@@ -1,0 +1,45 @@
+"""
+The FastAPI__ integration is provided by a ASGI middleware.
+
+To configure tracing manually::
+
+    from ddtrace.contrib.asgi import TraceMiddleware
+
+    app = FastAPI()
+    app.add_middleware(TraceMiddleware)
+
+If using Python 3.6, the legacy ``AsyncioContextProvider`` will have to be
+enabled before using the middleware::
+
+    from ddtrace.contrib.asyncio.provider import AsyncioContextProvider
+    from ddtrace import tracer  # Or whichever tracer instance you plan to use
+    tracer.configure(context_provider=AsyncioContextProvider())
+
+
+Configuration
+~~~~~~~~~~~~~
+
+.. py:data:: ddtrace.config.asgi['distributed_tracing_enabled']
+
+   Whether to use distributed tracing headers from requests received by your ASGI app.
+
+   Default: ``True``
+
+.. py:data:: ddtrace.config.asgi['analytics_enabled']
+
+   Whether to analyze spans for your ASGI app in App Analytics.
+
+   Can also be enabled with the ``DD_TRACE_ASGI_ANALYTICS_ENABLED`` environment variable.
+
+   Default: ``None``
+
+.. py:data:: ddtrace.config.asgi['service_name']
+
+   The service name reported for your ASGI app.
+
+   Can also be configured via the ``DD_SERVICE`` environment variable.
+
+   Default: ``'asgi'``
+
+.. __: https://fastapi.tiangolo.com/
+"""

--- a/ddtrace/contrib/starlette/__init__.py
+++ b/ddtrace/contrib/starlette/__init__.py
@@ -1,0 +1,45 @@
+"""
+The Starlette__ integration is provided by a ASGI middleware.
+
+To configure tracing manually::
+
+    from ddtrace.contrib.asgi import TraceMiddleware
+
+    app = Starlette()
+    app.add_middleware(TraceMiddleware)
+
+If using Python 3.6, the legacy ``AsyncioContextProvider`` will have to be
+enabled before using the middleware::
+
+    from ddtrace.contrib.asyncio.provider import AsyncioContextProvider
+    from ddtrace import tracer  # Or whichever tracer instance you plan to use
+    tracer.configure(context_provider=AsyncioContextProvider())
+
+
+Configuration
+~~~~~~~~~~~~~
+
+.. py:data:: ddtrace.config.asgi['distributed_tracing_enabled']
+
+   Whether to use distributed tracing headers from requests received by your ASGI app.
+
+   Default: ``True``
+
+.. py:data:: ddtrace.config.asgi['analytics_enabled']
+
+   Whether to analyze spans for your ASGI app in App Analytics.
+
+   Can also be enabled with the ``DD_TRACE_ASGI_ANALYTICS_ENABLED`` environment variable.
+
+   Default: ``None``
+
+.. py:data:: ddtrace.config.asgi['service_name']
+
+   The service name reported for your ASGI app.
+
+   Can also be configured via the ``DD_SERVICE`` environment variable.
+
+   Default: ``'asgi'``
+
+.. __: https://www.starlette.io/
+"""

--- a/ddtrace/contrib/starlette/__init__.py
+++ b/ddtrace/contrib/starlette/__init__.py
@@ -11,9 +11,15 @@ To configure tracing manually::
 If using Python 3.6, the legacy ``AsyncioContextProvider`` will have to be
 enabled before using the middleware::
 
+    from ddtrace.contrib.asgi import TraceMiddleware
     from ddtrace.contrib.asyncio.provider import AsyncioContextProvider
     from ddtrace import tracer  # Or whichever tracer instance you plan to use
+
+
     tracer.configure(context_provider=AsyncioContextProvider())
+
+    app = Starlette()
+    app.add_middleware(TraceMiddleware, tracer=tracer)
 
 
 Configuration

--- a/docs/web_integrations.rst
+++ b/docs/web_integrations.rst
@@ -52,6 +52,12 @@ Falcon
 .. automodule:: ddtrace.contrib.falcon
 
 
+FastAPI
+^^^^^^^
+
+.. automodule:: ddtrace.contrib.fastapi
+
+
 .. _flask:
 
 Flask
@@ -89,6 +95,12 @@ Sanic
 ^^^^^
 
 .. automodule:: ddtrace.contrib.sanic
+
+
+Starlette
+^^^^^^^^^
+
+.. automodule:: ddtrace.contrib.starlette
 
 
 .. _tornado:

--- a/tests/contrib/fastapi/test_fastapi.py
+++ b/tests/contrib/fastapi/test_fastapi.py
@@ -1,0 +1,199 @@
+import asyncio
+import random
+import sys
+from typing import NoReturn
+
+import httpx
+import pytest
+from ddtrace.contrib.asgi import TraceMiddleware
+from ddtrace.propagation import http as http_propagation
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import PlainTextResponse
+from tests import override_http_config
+from tests.tracer.test_tracer import get_dummy_tracer
+
+
+@pytest.fixture
+def tracer():
+    tracer = get_dummy_tracer()
+    if sys.version_info < (3, 7):
+        # enable legacy asyncio support
+        from ddtrace.contrib.asyncio.provider import AsyncioContextProvider
+
+        tracer.configure(context_provider=AsyncioContextProvider())
+    yield tracer
+
+
+async def hello(request: Request) -> Response:
+    if "sleep" in request.query_params:
+        await asyncio.sleep(random.random())
+        return PlainTextResponse("sleep")
+
+    return PlainTextResponse("hello")
+
+
+async def error(request: Request) -> Response:
+    raise RuntimeError("Test")
+
+
+@pytest.fixture
+async def app(tracer):
+    app = FastAPI()
+
+    @app.get("/", response_class=PlainTextResponse)
+    async def hello(request: Request) -> Response:
+        if "sleep" in request.query_params:
+            await asyncio.sleep(random.random())
+            return PlainTextResponse("sleep")
+
+        return PlainTextResponse("hello")
+
+    @app.get("/error/")
+    async def error(request: Request) -> NoReturn:
+        raise RuntimeError("Test")
+
+    yield app
+
+
+@pytest.mark.asyncio
+async def test_200(app, tracer):
+    app.add_middleware(TraceMiddleware, tracer=tracer)
+    async with httpx.AsyncClient(app=app) as client:
+        r = await client.get("http://testserver/")
+
+    assert r.status_code == 200
+    assert r.text == "hello"
+
+    spans = tracer.writer.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 1
+    request_span = spans[0][0]
+    assert request_span.name == "asgi.request"
+    assert request_span.error == 0
+    assert request_span.get_tag("http.method") == "GET"
+    assert request_span.get_tag("http.url") == "http://testserver/"
+    assert request_span.get_tag("http.status_code") == "200"
+    assert request_span.get_tag("http.status_code") == "200"
+    assert request_span.get_tag("http.query.string") is None
+
+
+@pytest.mark.asyncio
+async def test_200_query_string(app, tracer):
+    with override_http_config("asgi", dict(trace_query_string=True)):
+        app.add_middleware(TraceMiddleware, tracer=tracer)
+        async with httpx.AsyncClient(app=app) as client:
+            r = await client.get("http://testserver/?foo=bar")
+
+    assert r.status_code == 200
+    assert r.text == "hello"
+
+    spans = tracer.writer.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 1
+    request_span = spans[0][0]
+    assert request_span.name == "asgi.request"
+    assert request_span.error == 0
+    assert request_span.get_tag("http.method") == "GET"
+    assert request_span.get_tag("http.url") == "http://testserver/"
+    assert request_span.get_tag("http.status_code") == "200"
+    assert request_span.get_tag("http.query.string") == "foo=bar"
+
+
+@pytest.mark.asyncio
+async def test_404(app, tracer):
+    app.add_middleware(TraceMiddleware, tracer=tracer)
+    async with httpx.AsyncClient(app=app) as client:
+        r = await client.get("http://testserver/notfound")
+
+    assert r.status_code == 404
+    assert r.text == "{\"detail\":\"Not Found\"}"
+
+    spans = tracer.writer.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 1
+    request_span = spans[0][0]
+    assert request_span.name == "asgi.request"
+    assert request_span.error == 0
+    assert request_span.get_tag("http.method") == "GET"
+    assert request_span.get_tag("http.url") == "http://testserver/notfound"
+    assert request_span.get_tag("http.status_code") == "404"
+
+
+@pytest.mark.asyncio
+async def test_error(app, tracer):
+    app.add_middleware(TraceMiddleware, tracer=tracer)
+    async with httpx.AsyncClient(app=app) as client:
+        with pytest.raises(RuntimeError):
+            await client.get("http://testserver/error/")
+
+    spans = tracer.writer.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 1
+    request_span = spans[0][0]
+    assert request_span.name == "asgi.request"
+    assert request_span.error == 1
+    assert request_span.get_tag("http.method") == "GET"
+    assert request_span.get_tag("http.url") == "http://testserver/error/"
+    # FIXME: asgi middleware should set status code when exception raised
+    assert request_span.get_tag("http.status_code") is None
+    assert request_span.get_tag("error.msg") == "Test"
+    assert request_span.get_tag("error.type") == "builtins.RuntimeError"
+    assert 'raise RuntimeError("Test")' in request_span.get_tag("error.stack")
+
+
+@pytest.mark.asyncio
+async def test_distributed_tracing(app, tracer):
+    app.add_middleware(TraceMiddleware, tracer=tracer)
+    headers = [
+        (http_propagation.HTTP_HEADER_PARENT_ID.encode(), "1234".encode()),
+        (http_propagation.HTTP_HEADER_TRACE_ID.encode(), "5678".encode()),
+    ]
+    async with httpx.AsyncClient(app=app) as client:
+        r = await client.get("http://testserver/", headers=headers)
+
+    assert r.status_code == 200
+    assert r.text == "hello"
+
+    spans = tracer.writer.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 1
+    request_span = spans[0][0]
+    assert request_span.name == "asgi.request"
+    assert request_span.error == 0
+    assert request_span.get_tag("http.method") == "GET"
+    assert request_span.get_tag("http.url") == "http://testserver/"
+    assert request_span.get_tag("http.status_code") == "200"
+    assert request_span.parent_id == 1234
+    assert request_span.trace_id == 5678
+
+
+@pytest.mark.asyncio
+async def test_multiple_requests(app, tracer):
+    with override_http_config("asgi", dict(trace_query_string=True)):
+        app.add_middleware(TraceMiddleware, tracer=tracer)
+        async with httpx.AsyncClient(app=app) as client:
+            responses = await asyncio.gather(
+                client.get("http://testserver/", params={"sleep": True}),
+                client.get("http://testserver/", params={"sleep": True}),
+            )
+
+    assert len(responses) == 2
+    assert [r.status_code for r in responses] == [200] * 2
+    assert [r.text for r in responses] == ["sleep"] * 2
+
+    spans = tracer.writer.pop_traces()
+    assert len(spans) == 2
+    assert len(spans[0]) == 1
+    assert len(spans[1]) == 1
+
+    r1_span = spans[0][0]
+    assert r1_span.name == "asgi.request"
+    assert r1_span.get_tag("http.method") == "GET"
+    assert r1_span.get_tag("http.url") == "http://testserver/"
+    assert r1_span.get_tag("http.query.string") == "sleep=true"
+
+    r2_span = spans[0][0]
+    assert r2_span.name == "asgi.request"
+    assert r2_span.get_tag("http.method") == "GET"
+    assert r2_span.get_tag("http.url") == "http://testserver/"
+    assert r2_span.get_tag("http.query.string") == "sleep=true"

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -1,0 +1,187 @@
+import asyncio
+import random
+import sys
+
+import httpx
+import pytest
+from ddtrace.contrib.asgi import TraceMiddleware
+from ddtrace.propagation import http as http_propagation
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
+from starlette.routing import Route
+from tests import override_http_config
+from tests.tracer.test_tracer import get_dummy_tracer
+
+
+@pytest.fixture
+def tracer():
+    tracer = get_dummy_tracer()
+    if sys.version_info < (3, 7):
+        # enable legacy asyncio support
+        from ddtrace.contrib.asyncio.provider import AsyncioContextProvider
+
+        tracer.configure(context_provider=AsyncioContextProvider())
+    yield tracer
+
+
+async def hello(request: Request) -> Response:
+    if "sleep" in request.query_params:
+        await asyncio.sleep(random.random())
+        return PlainTextResponse("sleep")
+
+    return PlainTextResponse("hello")
+
+
+async def error(request: Request) -> Response:
+    raise RuntimeError("Test")
+
+
+@pytest.fixture
+async def app(tracer):
+    app = Starlette(routes=[Route("/", hello), Route("/error/", error)])
+    yield app
+
+
+@pytest.mark.asyncio
+async def test_200(app, tracer):
+    app.add_middleware(TraceMiddleware, tracer=tracer)
+    async with httpx.AsyncClient(app=app) as client:
+        r = await client.get("http://testserver/")
+
+    assert r.status_code == 200
+    assert r.text == "hello"
+
+    spans = tracer.writer.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 1
+    request_span = spans[0][0]
+    assert request_span.name == "asgi.request"
+    assert request_span.error == 0
+    assert request_span.get_tag("http.method") == "GET"
+    assert request_span.get_tag("http.url") == "http://testserver/"
+    assert request_span.get_tag("http.status_code") == "200"
+    assert request_span.get_tag("http.status_code") == "200"
+    assert request_span.get_tag("http.query.string") is None
+
+
+@pytest.mark.asyncio
+async def test_200_query_string(app, tracer):
+    with override_http_config("asgi", dict(trace_query_string=True)):
+        app.add_middleware(TraceMiddleware, tracer=tracer)
+        async with httpx.AsyncClient(app=app) as client:
+            r = await client.get("http://testserver/?foo=bar")
+
+    assert r.status_code == 200
+    assert r.text == "hello"
+
+    spans = tracer.writer.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 1
+    request_span = spans[0][0]
+    assert request_span.name == "asgi.request"
+    assert request_span.error == 0
+    assert request_span.get_tag("http.method") == "GET"
+    assert request_span.get_tag("http.url") == "http://testserver/"
+    assert request_span.get_tag("http.status_code") == "200"
+    assert request_span.get_tag("http.query.string") == "foo=bar"
+
+
+@pytest.mark.asyncio
+async def test_404(app, tracer):
+    app.add_middleware(TraceMiddleware, tracer=tracer)
+    async with httpx.AsyncClient(app=app) as client:
+        r = await client.get("http://testserver/notfound")
+
+    assert r.status_code == 404
+    assert r.text == "Not Found"
+
+    spans = tracer.writer.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 1
+    request_span = spans[0][0]
+    assert request_span.name == "asgi.request"
+    assert request_span.error == 0
+    assert request_span.get_tag("http.method") == "GET"
+    assert request_span.get_tag("http.url") == "http://testserver/notfound"
+    assert request_span.get_tag("http.status_code") == "404"
+
+
+@pytest.mark.asyncio
+async def test_error(app, tracer):
+    app.add_middleware(TraceMiddleware, tracer=tracer)
+    async with httpx.AsyncClient(app=app) as client:
+        with pytest.raises(RuntimeError):
+            await client.get("http://testserver/error/")
+
+    spans = tracer.writer.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 1
+    request_span = spans[0][0]
+    assert request_span.name == "asgi.request"
+    assert request_span.error == 1
+    assert request_span.get_tag("http.method") == "GET"
+    assert request_span.get_tag("http.url") == "http://testserver/error/"
+    # FIXME: asgi middleware should set status code when exception raised
+    assert request_span.get_tag("http.status_code") is None
+    assert request_span.get_tag("error.msg") == "Test"
+    assert request_span.get_tag("error.type") == "builtins.RuntimeError"
+    assert 'raise RuntimeError("Test")' in request_span.get_tag("error.stack")
+
+
+@pytest.mark.asyncio
+async def test_distributed_tracing(app, tracer):
+    app.add_middleware(TraceMiddleware, tracer=tracer)
+    headers = [
+        (http_propagation.HTTP_HEADER_PARENT_ID.encode(), "1234".encode()),
+        (http_propagation.HTTP_HEADER_TRACE_ID.encode(), "5678".encode()),
+    ]
+    async with httpx.AsyncClient(app=app) as client:
+        r = await client.get("http://testserver/", headers=headers)
+
+    assert r.status_code == 200
+    assert r.text == "hello"
+
+    spans = tracer.writer.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 1
+    request_span = spans[0][0]
+    assert request_span.name == "asgi.request"
+    assert request_span.error == 0
+    assert request_span.get_tag("http.method") == "GET"
+    assert request_span.get_tag("http.url") == "http://testserver/"
+    assert request_span.get_tag("http.status_code") == "200"
+    assert request_span.parent_id == 1234
+    assert request_span.trace_id == 5678
+
+
+@pytest.mark.asyncio
+async def test_multiple_requests(app, tracer):
+    with override_http_config("asgi", dict(trace_query_string=True)):
+        app.add_middleware(TraceMiddleware, tracer=tracer)
+        async with httpx.AsyncClient(app=app) as client:
+            responses = await asyncio.gather(
+                client.get("http://testserver/", params={"sleep": True}),
+                client.get("http://testserver/", params={"sleep": True}),
+            )
+
+    assert len(responses) == 2
+    assert [r.status_code for r in responses] == [200] * 2
+    assert [r.text for r in responses] == ["sleep"] * 2
+
+    spans = tracer.writer.pop_traces()
+    assert len(spans) == 2
+    assert len(spans[0]) == 1
+    assert len(spans[1]) == 1
+
+    r1_span = spans[0][0]
+    assert r1_span.name == "asgi.request"
+    assert r1_span.get_tag("http.method") == "GET"
+    assert r1_span.get_tag("http.url") == "http://testserver/"
+    assert r1_span.get_tag("http.query.string") == "sleep=true"
+
+    r2_span = spans[0][0]
+    assert r2_span.name == "asgi.request"
+    assert r2_span.get_tag("http.method") == "GET"
+    assert r2_span.get_tag("http.url") == "http://testserver/"
+    assert r2_span.get_tag("http.query.string") == "sleep=true"

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,7 @@ envlist =
     elasticsearch_contrib-{py27,py35,py36}-elasticsearch5{50}
     elasticsearch_contrib-{py27,py35,py36}-elasticsearch6{40}
     falcon_contrib{,_autopatch}-{py27,py35,py36}-falcon{10,11,12,13,14}
+    fastapi_contrib-{py36,py37,py38}-fastapi
     flask_contrib{,_autopatch}-{py27,py35,py36}-flask{010,011,012,10}-blinker
 # Flask <=0.9 does not support Python 3
     flask_contrib{,_autopatch}-{py27}-flask{09}-blinker
@@ -138,6 +139,7 @@ envlist =
     requests_gevent_contrib-py{37,38}-requests{208,209,210,211,212,213,219}-gevent13
     sanic_contrib-py{36,37,38}-sanic
     sqlalchemy_contrib-py{27,35,36,37,38}-sqlalchemy{10,11,12,13,}-psycopg228-mysqlconnector
+    starlette_contrib-{py36,py37,py38}-starlette
     sqlite3_contrib-{py27,py35,py36,py37,py38}-sqlite3
     tornado_contrib-py{27,35,36,37,38}-tornado{44,45}
     tornado_contrib-py{37,38}-tornado{50,51,60,}
@@ -317,6 +319,9 @@ deps =
     falcon12: falcon>=1.2,<1.3
     falcon13: falcon>=1.3,<1.4
     falcon14: falcon>=1.4,<1.5
+    fastapi: fastapi
+    fastapi_contrib: pytest-asyncio
+    fastapi_contrib: httpx
     flask09: flask>=0.9,<0.10
     flask09: Werkzeug<1
     flask010: flask>=0.10,<0.11
@@ -463,6 +468,9 @@ deps =
     sslmodules: botocore
     sslmodules: requests
     sslmodules: elasticsearch
+    starlette: starlette
+    starlette_contrib: pytest-asyncio
+    starlette_contrib: httpx
     tornado: tornado
     tornado44: tornado>=4.4,<4.5
     tornado45: tornado>=4.5,<4.6
@@ -509,6 +517,7 @@ commands =
     elasticsearch_contrib: pytest {posargs} tests/contrib/elasticsearch
     falcon_contrib: pytest {posargs} tests/contrib/falcon/test_middleware.py tests/contrib/falcon/test_distributed_tracing.py
     falcon_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/falcon/test_autopatch.py
+    fastapi_contrib: pytest {posargs} tests/contrib/fastapi
     flask_contrib: pytest {posargs} tests/contrib/flask
     flask_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/flask_autopatch
     flask_cache_contrib: pytest {posargs} tests/contrib/flask_cache
@@ -539,6 +548,7 @@ commands =
     sanic_contrib: pytest {posargs} tests/contrib/sanic
     sqlalchemy_contrib: pytest {posargs} tests/contrib/sqlalchemy
     sqlite3_contrib: pytest {posargs} tests/contrib/sqlite3
+    starlette_contrib: pytest {posargs} tests/contrib/starlette
     tornado_contrib: pytest {posargs} tests/contrib/tornado
     vertica_contrib: pytest {posargs} tests/contrib/vertica/
 # run subsets of the tests for particular library versions


### PR DESCRIPTION
Add documentation on how to enable tracing for starlette and fastapi using the ASGI middleware. Configuration for these services will continue being through `ddtrace.config.asgi` for now. One result of this for now is that the default service name for a Starlette/FastAPI app would be `"asgi"` but this can be changed by setting `ddtrace.config.asgi.service_name`. 

In the future we will provide automatic instrumentation for these ASGI web frameworks with their own configuration options.

I've included tests for verifying that the asgi middleware works as expected with both instrumentations when manually added.