### PR TITLE
docs: add generic, default PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Description
+<!-- Please briefly describe the change and why it was required. -->
+
+
+## Checklist
+- [ ] Entry added to `CHANGELOG.md`.
+- [ ] Tests provided; and/or
+- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
+- [ ] Library documentation is updated.
+- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).


### PR DESCRIPTION
PR templates were introduced in #1590 but they aren't used by default. `.github/PULL_REQUEST_TEMPLATE.md` is the template that is used by default.