### PR TITLE
fix: celery and botocore tests

### DIFF
--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -104,7 +104,7 @@ class BotocoreTest(TracerTestCase):
         params = dict(Key='foo', Bucket='mybucket', Body=b'bar')
         s3 = self.session.create_client('s3', region_name='us-west-2')
         Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(s3)
-        s3.create_bucket(Bucket='mybucket')
+        s3.create_bucket(Bucket='mybucket', region="us-east-1")
         s3.put_object(**params)
 
         spans = self.get_spans()

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -101,10 +101,16 @@ class BotocoreTest(TracerTestCase):
 
     @mock_s3
     def test_s3_put(self):
-        params = dict(Key='foo', Bucket='mybucket', Body=b'bar')
         s3 = self.session.create_client('s3', region_name='us-west-2')
         Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(s3)
-        s3.create_bucket(Bucket='mybucket', region="us-east-1")
+        params = {
+            "Bucket": "mybucket",
+            "CreateBucketConfiguration": {
+                "LocationConstraint": "us-west-2",
+            }
+        }
+        s3.create_bucket(**params)
+        params = dict(Key='foo', Bucket='mybucket', Body=b'bar')
         s3.put_object(**params)
 
         spans = self.get_spans()

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ envlist =
     celery_contrib-py{27,35,36}-celery42-redis210-kombu43
 # Celery 4.3 wants Kombu >= 4.4 and Redis >= 3.2
 # Python 3.7 needs Celery 4.3
-    celery_contrib-py{27,35,36,37,38}-celery43-redis32
+    celery_contrib-py{27,35,36,37,38}-celery43-redis32-kombu44
     consul_contrib-py{27,35,36,37,38}-consul{07,10,11,}
     dbapi_contrib-py{27,35,36,37,38}
 # Django  Python version support
@@ -265,6 +265,7 @@ deps =
     celery41: celery>=4.1,<4.2
     celery42: celery>=4.2,<4.3
     celery43: celery>=4.3,<4.4
+    celery43: vine==1.3
     consul: python-consul
     consul07: python-consul>=0.7,<1.0
     consul10: python-consul>=1.0,<1.1

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ envlist =
     celery_contrib-py{27,35,36}-celery42-redis210-kombu43
 # Celery 4.3 wants Kombu >= 4.4 and Redis >= 3.2
 # Python 3.7 needs Celery 4.3
-    celery_contrib-py{27,35,36,37,38}-celery43-redis32-kombu44
+    celery_contrib-py{27,35,36,37,38}-celery43-redis32
     consul_contrib-py{27,35,36,37,38}-consul{07,10,11,}
     dbapi_contrib-py{27,35,36,37,38}
 # Django  Python version support


### PR DESCRIPTION
## Celery

We were specifying celery==4.3 and `kombu==4.4` to run our test cases against.

celery==4.3 has the [dependencies](https://github.com/celery/celery/blob/v4.3.0/requirements/default.txt):
- pytz>dev
- billiard>=3.6.0,<4.0
- kombu>=4.4.0,<5.0
- vine>=1.3.0

Celery is installed first which installs `vine==5.0.0`, the latest version.

`kombu==4.4` has the [dependencies](https://github.com/celery/kombu/blob/v4.4.0/requirements/default.txt)
- amqp>=2.4.0,<3.0

Which installs `amqp==2.6.1` which has the [dependency](https://github.com/celery/py-amqp/blob/v2.6.1/requirements/default.txt)

- vine>=1.1.3, <5.0.0a1

which conflicts with the `vine==5.0.0` installed above 😕 🤦 

This is solved by explicitly stating vine==1.3 as a dependency of celery

## Botocore
The botocore tests had an issue where for some reason the region now has to be explicitly included to `create_bucket` 🤷 