### PR TITLE
fix(flask): make template rendering idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- fix(flask): make template patching idempotent
+
+---
+
 ## 0.41.2 (25/08/2020)
 
 - Fix for an issue introduced by patching classes in the MRO of a Django View class (#1625).

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -188,15 +188,15 @@ def _patch_render(tracer):
     # fall back to patching  global method
     _render = flask.templating._render
 
-    if hasattr(_render, "__dd_patched"):
-        return
+    if hasattr(_render, "__dd_orig"):
+        _render = getattr(_render, "__dd_orig")
 
     def _traced_render(template, context, app):
         with tracer.trace('flask.template', span_type=SpanTypes.TEMPLATE) as span:
             span.set_tag('flask.template', template.name or 'string')
             return _render(template, context, app)
 
-    setattr(_traced_render, "__dd_patched", True)
+    setattr(_traced_render, "__dd_orig", _render)
     flask.templating._render = _traced_render
 
 

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -188,11 +188,15 @@ def _patch_render(tracer):
     # fall back to patching  global method
     _render = flask.templating._render
 
+    if hasattr(_render, "__dd_patched"):
+        return
+
     def _traced_render(template, context, app):
         with tracer.trace('flask.template', span_type=SpanTypes.TEMPLATE) as span:
             span.set_tag('flask.template', template.name or 'string')
             return _render(template, context, app)
 
+    setattr(_traced_render, "__dd_patched", True)
     flask.templating._render = _traced_render
 
 

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -188,6 +188,8 @@ def _patch_render(tracer):
     # fall back to patching  global method
     _render = flask.templating._render
 
+    # If the method has already been patched and we're patching again then
+    # we have to patch again with the new tracer reference.
     if hasattr(_render, "__dd_orig"):
         _render = getattr(_render, "__dd_orig")
 


### PR DESCRIPTION
#1651 exposed a bug in the flask instrumentation where patching template rendering was not idempotent. This wasn't caught in the tests because each time it was patched, it was patched with a different tracer instance. So when the spans were collected only the spans from the tracer instance specific to the test case were collected. [CI run](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/2519/workflows/04cb8a6d-9944-4f9c-a0ea-9ceaafc882b8/jobs/328555).

## Checklist
- [x] Entry added to `CHANGELOG.md`.
- [ ] Tests provided; and/or
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [x] Library documentation is updated.
- [x] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
