### PR TITLE
feat: patch create_task with uvloop

### DIFF
--- a/ddtrace/contrib/uvloop/__init__.py
+++ b/ddtrace/contrib/uvloop/__init__.py
@@ -1,0 +1,24 @@
+"""
+This integration patches uvloop__ for tracing asynchronous code.
+
+Enable uvloop tracing automatically via ``ddtrace-run``::
+
+    ddtrace-run python app.py
+
+uvloop tracing can also be enabled manually::
+
+    from ddtrace import patch_all
+    patch_all(uvloop=True)
+
+.. __: http://uvloop.readthedocs.io/
+"""
+
+from ...utils.importlib import require_modules
+
+required_modules = ["uvloop"]
+
+with require_modules(required_modules) as missing_modules:
+    if not missing_modules:
+        from .patch import patch, unpatch
+
+        __all__ = ["patch", "unpatch"]

--- a/ddtrace/contrib/uvloop/patch.py
+++ b/ddtrace/contrib/uvloop/patch.py
@@ -1,0 +1,30 @@
+import uvloop
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
+
+from ...compat import CONTEXTVARS_IS_AVAILABLE
+from ...utils.wrappers import unwrap as _u
+from ..asyncio.wrappers import wrapped_create_task, wrapped_create_task_contextvars
+
+
+def patch():
+    """Patches current loop `create_task()` method to enable spawned tasks to
+    parent to the base task context.
+    """
+    if getattr(uvloop, "_datadog_patch", False):
+        return
+    setattr(uvloop, "_datadog_patch", True)
+
+    _w(
+        uvloop,
+        "Loop.create_task",
+        wrapped_create_task_contextvars if CONTEXTVARS_IS_AVAILABLE else wrapped_create_task,
+    )
+
+
+def unpatch():
+    """Remove tracing from patched modules."""
+
+    if getattr(uvloop, "_datadog_patch", False):
+        setattr(uvloop, "_datadog_patch", False)
+
+    _u(uvloop.Loop, "create_task")

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -59,6 +59,7 @@ PATCH_MODULES = {
     "flask": True,
     "kombu": False,
     "starlette": True,
+    "uvloop": True,
     # Ignore some web framework integrations that might be configured explicitly in code
     "falcon": False,
     "pylons": False,


### PR DESCRIPTION
## Description
While the asyncio integration patches the standard library event loop, additional patching is necessary if uvloop is used instead by an application. Without patching the `create_task` on the uvloop loop, we would run into the same problems that come with propagating the context object from one task to another.

## Checklist
- [ ] Entry added to `CHANGELOG.md`.
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
