### PR TITLE
refactor(profiling): hide collector and scheduler

### DIFF
--- a/tests/profiling/compat_program.py
+++ b/tests/profiling/compat_program.py
@@ -7,7 +7,7 @@ from ddtrace.profile import bootstrap
 from ddtrace.profile import collector  # noqa
 from ddtrace.profile.collector import stack
 
-for running_collector in bootstrap.profiler.collectors:
+for running_collector in bootstrap.profiler._collectors:
     if isinstance(running_collector, stack.StackCollector):
         break
 else:

--- a/tests/profiling/simple_program.py
+++ b/tests/profiling/simple_program.py
@@ -5,7 +5,7 @@ from ddtrace.profiling import _service
 from ddtrace.profiling import bootstrap
 from ddtrace.profiling.collector import stack
 
-for running_collector in bootstrap.profiler.collectors:
+for running_collector in bootstrap.profiler._collectors:
     if isinstance(running_collector, stack.StackCollector):
         break
 else:

--- a/tests/profiling/test_accuracy.py
+++ b/tests/profiling/test_accuracy.py
@@ -72,7 +72,9 @@ def total_time(time_data, funcname):
 def test_accuracy(monkeypatch):
     # Set this to 100 so we don't sleep too often and mess with the precision.
     monkeypatch.setenv("DD_PROFILING_MAX_TIME_USAGE_PCT", "100")
-    p = profiler.Profiler(exporters=[])
+    p = profiler.Profiler()
+    # don't export data
+    p._scheduler = None
     p.start()
     spend_16()
     p.stop()

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -42,7 +42,7 @@ def test_default_from_env(service_name_var, monkeypatch):
     monkeypatch.setenv("DD_API_KEY", "foobar")
     monkeypatch.setenv(service_name_var, "foobar")
     prof = profiler.Profiler()
-    for exporter in prof.exporters:
+    for exporter in prof._scheduler.exporters:
         if isinstance(exporter, http.PprofHTTPExporter):
             assert exporter.service == "foobar"
             break
@@ -54,7 +54,7 @@ def test_service_api(monkeypatch):
     monkeypatch.setenv("DD_API_KEY", "foobar")
     prof = profiler.Profiler(service="foobar")
     assert prof.service == "foobar"
-    for exporter in prof.exporters:
+    for exporter in prof._scheduler.exporters:
         if isinstance(exporter, http.PprofHTTPExporter):
             assert exporter.service == "foobar"
             break
@@ -66,7 +66,7 @@ def test_tracer_api(monkeypatch):
     monkeypatch.setenv("DD_API_KEY", "foobar")
     prof = profiler.Profiler(tracer=ddtrace.tracer)
     assert prof.tracer == ddtrace.tracer
-    for collector in prof.collectors:
+    for collector in prof._collectors:
         if isinstance(collector, stack.StackCollector):
             assert collector.tracer == ddtrace.tracer
             break
@@ -81,7 +81,7 @@ def test_env_default(monkeypatch):
     prof = profiler.Profiler()
     assert prof.env == "staging"
     assert prof.version == "123"
-    for exporter in prof.exporters:
+    for exporter in prof._scheduler.exporters:
         if isinstance(exporter, http.PprofHTTPExporter):
             assert exporter.env == "staging"
             assert exporter.version == "123"
@@ -94,7 +94,7 @@ def test_env_api():
     prof = profiler.Profiler(env="staging", version="123")
     assert prof.env == "staging"
     assert prof.version == "123"
-    for exporter in prof.exporters:
+    for exporter in prof._scheduler.exporters:
         if isinstance(exporter, http.PprofHTTPExporter):
             assert exporter.env == "staging"
             assert exporter.version == "123"
@@ -109,7 +109,7 @@ def test_env_api():
 def test_env_api_key(name_var, monkeypatch):
     monkeypatch.setenv(name_var, "foobar")
     prof = profiler.Profiler()
-    for exporter in prof.exporters:
+    for exporter in prof._scheduler.exporters:
         if isinstance(exporter, http.PprofHTTPExporter):
             assert exporter.api_key == "foobar"
             assert exporter.endpoint == "https://intake.profile.datadoghq.com/v1/input"
@@ -120,7 +120,7 @@ def test_env_api_key(name_var, monkeypatch):
 
 def test_env_no_api_key():
     prof = profiler.Profiler()
-    for exporter in prof.exporters:
+    for exporter in prof._scheduler.exporters:
         if isinstance(exporter, http.PprofHTTPExporter):
             assert exporter.api_key is None
             assert exporter.endpoint == "http://localhost:8126/profiling/v1/input"
@@ -133,7 +133,7 @@ def test_env_endpoint_url(monkeypatch):
     monkeypatch.setenv("DD_AGENT_HOST", "foobar")
     monkeypatch.setenv("DD_TRACE_AGENT_PORT", "123")
     prof = profiler.Profiler()
-    for exporter in prof.exporters:
+    for exporter in prof._scheduler.exporters:
         if isinstance(exporter, http.PprofHTTPExporter):
             assert exporter.api_key is None
             assert exporter.endpoint == "http://foobar:123/profiling/v1/input"
@@ -146,7 +146,7 @@ def test_env_endpoint_url_no_agent(monkeypatch):
     monkeypatch.setenv("DD_SITE", "datadoghq.eu")
     monkeypatch.setenv("DD_API_KEY", "123")
     prof = profiler.Profiler()
-    for exporter in prof.exporters:
+    for exporter in prof._scheduler.exporters:
         if isinstance(exporter, http.PprofHTTPExporter):
             assert exporter.api_key == "123"
             assert exporter.endpoint == "https://intake.profile.datadoghq.eu/v1/input"


### PR DESCRIPTION
This simplifies the Profiler object to only have one scheduler and hide everything from the user.