### PR TITLE
fix(flask/tests): correct comparison

### DIFF
--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -687,7 +687,7 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
 
         spans = self.get_spans()
 
-        if flask_version >= (0, 12, 0):
+        if flask_version >= (0, 12):
             self.assertEqual(len(spans), 11)
 
             # Assert the order of the spans created


### PR DESCRIPTION
## Description
The comparison was not correct see the example below:

```python
>>> (0, 12) >= (0, 12, 0)
False
```

The flask version used here would be `(0, 12)` so the above check wasn't working properly.

## Checklist
- [ ] Entry added to `CHANGELOG.md`.
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
