### PR TITLE
docs: limit depth of headings in sidebar

### DIFF
--- a/docs/_templates/navigation.html
+++ b/docs/_templates/navigation.html
@@ -1,4 +1,4 @@
-{{ toctree(includehidden=theme_sidebar_includehidden, collapse=theme_sidebar_collapse) }}
+{{ toctree(maxdepth=2, includehidden=theme_sidebar_includehidden, collapse=theme_sidebar_collapse) }}
 {% if theme_extra_nav_links %}
 <hr />
 <ul>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,11 @@
 
 from datetime import datetime
 
+# append the ddtrace path to syspath
+# this is required when building the docs manually
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath(".."))
 
 # -- General configuration ------------------------------------------------
 
@@ -184,7 +189,7 @@ html_theme_options = {
 
 # Custom sidebar templates, maps document names to template names.
 #
-html_sidebars = {"**": ["about.html", "nav.html", "relations.html", "searchbox.html"]}
+html_sidebars = {"**": ["about.html", "navigation.html", "relations.html", "searchbox.html"]}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
## Description
Limits the depth in the sidebar to 2 so that the listing doesn't get too big.

## Checklist
- [ ] Entry added to `CHANGELOG.md`.
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
