### PR TITLE
test: improve fork test speed

### DIFF
--- a/tests/profiling/simple_program_fork.py
+++ b/tests/profiling/simple_program_fork.py
@@ -5,23 +5,15 @@ import threading
 import ddtrace.profiling.auto
 import ddtrace.profiling.bootstrap
 import ddtrace.profiling.profiler
-from ddtrace.profiling.collector import memory
 from ddtrace.profiling.collector import stack
 from ddtrace.profiling.collector import threading as cthreading
 
 
-def _allocate_mem():
-    # Do some serious memory allocations!
-    for x in range(5000000):
-        object()
-
-
 lock = threading.Lock()
 lock.acquire()
-test_lock_name = "simple_program_fork.py:19"
+test_lock_name = "simple_program_fork.py:12"
 
 
-_ = _allocate_mem()
 assert ddtrace.profiling.bootstrap.profiler.status == ddtrace.profiling.profiler.ProfilerStatus.RUNNING
 
 parent_recorder = list(ddtrace.profiling.bootstrap.profiler.recorders)[0]
@@ -45,7 +37,7 @@ if child_pid == 0:
 
     # We track this one though
     lock = threading.Lock()
-    test_lock_name = "simple_program_fork.py:47"
+    test_lock_name = "simple_program_fork.py:39"
     assert test_lock_name not in set(e.lock_name for e in recorder.events[cthreading.LockAcquireEvent])
     lock.acquire()
     assert test_lock_name in set(e.lock_name for e in recorder.events[cthreading.LockAcquireEvent])
@@ -57,10 +49,9 @@ if child_pid == 0:
     assert test_lock_name not in set(e.lock_name for e in parent_recorder.events[cthreading.LockAcquireEvent])
     assert test_lock_name not in set(e.lock_name for e in parent_recorder.events[cthreading.LockReleaseEvent])
 
-    _ = _allocate_mem()
-    if sys.version_info[0] >= 3:
-        assert recorder.events[memory.MemorySampleEvent]
-    assert recorder.events[stack.StackSampleEvent]
+    # This can run forever if anything is broken!
+    while not recorder.events[stack.StackSampleEvent]:
+        pass
     assert recorder.events[cthreading.LockAcquireEvent]
 else:
     recorder = list(ddtrace.profiling.bootstrap.profiler.recorders)[0]

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -62,6 +62,7 @@ def test_call_script_pprof_output_interval(tmp_path, monkeypatch):
 
 def test_fork(tmp_path, monkeypatch):
     filename = str(tmp_path / "pprof")
+    monkeypatch.setenv("DD_PROFILING_API_TIMEOUT", "0.1")
     monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
     monkeypatch.setenv("DD_PROFILING_CAPTURE_PCT", "100")
     subp = subprocess.Popen(


### PR DESCRIPTION
This removes the memory testing with is not fork-dependent and make sure the
program exits as fast as possible.