### PR TITLE
test(profiling): fix process waiting

### DIFF
--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -68,8 +68,8 @@ def test_fork(tmp_path, monkeypatch):
     subp = subprocess.Popen(
         ["python", os.path.join(os.path.dirname(__file__), "simple_program_fork.py")], stdout=subprocess.PIPE
     )
-    assert subp.wait() == 0
     stdout, stderr = subp.communicate()
+    assert subp.wait() == 0
     child_pid = stdout.decode().strip()
     check_pprof_file(filename + "." + str(subp.pid) + ".1")
     check_pprof_file(filename + "." + str(child_pid) + ".1")


### PR DESCRIPTION
If stdout is not read, the process is blocked and never exits, making the test
hang forever.