### PR TITLE
Do not rate limit logs when in debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - feat(core): backport contextvars
 - fix(sanic): fix patching for sanic async http server (#1659)
 - fix(flask): make template patching idempotent
+- fix(core): Do not rate limit log lines when in debug
 
 ---
 

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -113,7 +113,8 @@ class DDLogger(logging.Logger):
         :type record: ``logging.LogRecord``
         """
         # If rate limiting has been disabled (`DD_LOGGING_RATE_LIMIT=0`) then apply no rate limit
-        if not self.rate_limit:
+        # If the logging is in debug, then do not apply any limits to any log
+        if not self.rate_limit or self.getEffectiveLevel() == logging.DEBUG:
             super(DDLogger, self).handle(record)
             return
 

--- a/tests/tracer/test_logger.py
+++ b/tests/tracer/test_logger.py
@@ -194,6 +194,31 @@ class DDLoggerTestCase(BaseTestCase):
         self.assertEqual(log.buckets, dict())
 
     @mock.patch('logging.Logger.handle')
+    def test_logger_handle_debug(self, base_handle):
+        """
+        Calling `DDLogger.handle`
+            When effective level is DEBUG
+                Always calls the base `Logger.handle`
+        """
+        # Configure an INFO logger with no rate limit
+        log = get_logger('test.logger')
+        log.setLevel(logging.DEBUG)
+        assert log.rate_limit > 0
+
+        # Log a bunch of times very quickly (this is fast)
+        for level in ALL_LEVEL_NAMES:
+            log_fn = getattr(log, level)
+            for _ in range(1000):
+                log_fn('test')
+
+        # Assert that we did not perform any rate limiting
+        total = 1000 * len(ALL_LEVEL_NAMES)
+        self.assertEqual(base_handle.call_count, total)
+
+        # Our buckets are empty
+        self.assertEqual(log.buckets, dict())
+
+    @mock.patch('logging.Logger.handle')
     def test_logger_handle_bucket(self, base_handle):
         """
         When calling `DDLogger.handle`


### PR DESCRIPTION
## Description
When debug logging is enabled in the tracer, do not rate limit _any_ log lines.

### Manually testing
Run the tracer with debug logging and expect that no log lines are limited (e.g. end with `, skipped X additional messages`)

`DD_TRACE_DEBUG=true python script.py`


## Checklist
- [x] Entry added to `CHANGELOG.md`.
- [x] Tests provided; and/or
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [x] ~Library documentation is updated.~
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
