### PR TITLE
ci: disable wheels for gevent

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -164,6 +164,8 @@ isolated_build = true
 #      https://stackoverflow.com/questions/57459123/why-do-i-need-to-run-tox-twice-to-test-a-python-package-with-c-extension
 whitelist_externals=rm
 commands_pre={envpython} {toxinidir}/setup.py develop
+# Wheels for gevent segfault pretty easily
+install_command=python -m pip install --no-binary gevent {opts} {packages}
 usedevelop =
   # do not use develop mode with celery as running multiple python versions within
   # same job will cause problem for tests that use ddtrace-run


### PR DESCRIPTION
Old gevent version wheels segfaults with some version of Python.
It's likely an ABI changed somewhere and breaks everything.