### PR TITLE
fix(rediscluster): support rediscluster==2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- fix(rediscluster): support rediscluster==2.1.0
 - fix(asyncio): enable patch by default
 - fix(asyncio): patch base event loop class
 - fix(vertica): use strings in `__all__`

--- a/ddtrace/contrib/rediscluster/patch.py
+++ b/ddtrace/contrib/rediscluster/patch.py
@@ -26,9 +26,9 @@ def patch():
 
     _w = wrapt.wrap_function_wrapper
     if REDISCLUSTER_VERSION >= (2, 0, 0):
-        _w('rediscluster', 'RedisCluster.execute_command', traced_execute_command)
-        _w('rediscluster', 'RedisCluster.pipeline', traced_pipeline)
-        _w('rediscluster', 'ClusterPipeline.execute', traced_execute_pipeline)
+        _w('rediscluster', 'client.RedisCluster.execute_command', traced_execute_command)
+        _w('rediscluster', 'client.RedisCluster.pipeline', traced_pipeline)
+        _w('rediscluster', 'pipeline.ClusterPipeline.execute', traced_execute_pipeline)
         Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP).onto(rediscluster.RedisCluster)
     else:
         _w('rediscluster', 'StrictRedisCluster.execute_command', traced_execute_command)
@@ -42,9 +42,9 @@ def unpatch():
         setattr(rediscluster, '_datadog_patch', False)
 
         if REDISCLUSTER_VERSION >= (2, 0, 0):
-            unwrap(rediscluster.RedisCluster, 'execute_command')
-            unwrap(rediscluster.RedisCluster, 'pipeline')
-            unwrap(rediscluster.ClusterPipeline, 'execute')
+            unwrap(rediscluster.client.RedisCluster, 'execute_command')
+            unwrap(rediscluster.client.RedisCluster, 'pipeline')
+            unwrap(rediscluster.pipeline.ClusterPipeline, 'execute')
         else:
             unwrap(rediscluster.StrictRedisCluster, 'execute_command')
             unwrap(rediscluster.StrictRedisCluster, 'pipeline')

--- a/tox.ini
+++ b/tox.ini
@@ -446,6 +446,7 @@ deps =
     rediscluster135: redis-py-cluster>=1.3.5,<1.3.6
     rediscluster136: redis-py-cluster>=1.3.6,<1.3.7
     rediscluster200: redis-py-cluster>=2.0.0,<2.1.0
+    rediscluster210: redis-py-cluster>=2.1.0,<2.2.0
     requests_contrib: requests-mock>=1.4
     requests200: requests>=2.0,<2.1
     requests208: requests>=2.8,<2.9


### PR DESCRIPTION
## Description

Starting with `rediscluster==2.0.0` these classes were renamed, however our integration patched them in the top-level namespace rather than the module namespace. This PR changes this for 2.0.0 so that it works with 2.1.0 where the top-level imports were removed.

## Checklist
- [x] Entry added to `CHANGELOG.md`.
- [x] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
