### PR TITLE
Remove basicConfig call from ddtrace-run bootstrap if logs_injection i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - feat(core): backport contextvars
 - fix(sanic): fix patching for sanic async http server (#1659)
 - fix(flask): make template patching idempotent
+- fix(ddtrace-run): Do not call logging.basicConfig (and thereby create a StreamHandler on the Root logger) if we are not using DataDog's logs_injection functionality
 
 ---
 

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -28,8 +28,6 @@ if config.logs_injection:
 if not debug_mode:
     if config.logs_injection:
         logging.basicConfig(format=DD_LOG_FORMAT)
-    else:
-        logging.basicConfig()
 
 log = get_logger(__name__)
 

--- a/tests/commands/ddtrace_run_logs_injection.py
+++ b/tests/commands/ddtrace_run_logs_injection.py
@@ -12,4 +12,6 @@ if __name__ == "__main__":
             "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s"
             " dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s]" not in logging.root.handlers[0].formatter._fmt
         )
+
+        assert len(logging.root.handlers) == 0
     print("Test success")


### PR DESCRIPTION
…s not enabled

## Description
Currently the ddtrace-run bootstrap always calls logging.BasicConfig(), even if an app is not utilizing dd-trace-py's automatic logs_injection functionality.

This has the side effect of [creating a StreamHandler that by default outputs to `sys.stderr` and adding it to the root logger](https://docs.python.org/3/library/logging.html?highlight=basicconfig#logging.basicConfig), which introduces two issues:
* For apps using Python < 3.8, it logging.basicConfig can only be called once and cannot be configured and called by the downstream app after dd-trace-py calls it. This looks to be what users are running into in https://github.com/DataDog/dd-trace-py/issues/796
* Python application logs are now automatically sent to standard error. This is problematic for applications that are processing their logs outside of stdout/error.  Ex. we use a custom `logging.Handler` implementation to ship logs to fluentd and hydrate the dd correlation tags within our custom handler. Since we also ship our stdout/error logs for apps to DataDog to catch unexpected exceptions etc., we are now ingesting application logs twice and doubling our processing costs. This is also likely what @yesthesoup was seeing in the [above issue](https://github.com/DataDog/dd-trace-py/issues/796#issuecomment-602608093).

I believe this should not be a breaking change even if an application is unintentionally relying on dd-trace-py's logging.basicConfig() call to setup [since the logging functions debug(), info(), warning(), error() and critical() will call basicConfig() automatically if no handlers are defined for the root logger](https://docs.python.org/3/library/logging.html?highlight=basicconfig#logging.basicConfig).

~~I am curious if I'm missing some other reasoning for always having the bootstrap call logging.basicConfig, but think it was just [unintentionally introduced as part of some pyramid tracing improvements](https://github.com/DataDog/dd-trace-py/commit/bd1a44c393df342852408da02436c8d75b6bcb5c).~~ (see PR comment thread for reason this was introduced)

I didn't update any Library or Corp Site documentation as I think this is not expected behavior, let me know if I missed something.

**Manual Testing**
Ran a flask application with `export DD_LOGS_INJECTION=True` and verified application logs with dd trace correlations injected were sent to stderr.

Ran a flask application with `export DD_LOGS_INJECTION=True` and verified no application logs were sent to stderr.

## Checklist
- [X] Entry added to `CHANGELOG.md`.
- [X] Tests provided; and/or
- [X] Description of manual testing performed and explanation is included in the code and/or PR.
- [X] ~~Library documentation is updated.~~
- [X] ~~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~~
