### PR TITLE
feat: add items api to context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- feat(core): add context items
 - fix(rediscluster): support rediscluster==2.1.0
 - fix(asyncio): enable patch by default
 - fix(asyncio): patch base event loop class

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -72,15 +72,22 @@ class Context(object):
             self._sampling_priority = value
 
     def set_ctx_item(self, key, val):
+        """Set a context item.
+        """
         with self._lock:
             self._ctx[key] = val
 
     def get_ctx_item(self, key, default=None):
+        """Get a context item for `key` falling back to `default` if no value
+        exists.
+        """
         with self._lock:
             return self._ctx.get(key, default)
 
     @contextlib.contextmanager
     def override_ctx_item(self, key, val):
+        """Temporarily override a context item.
+        """
         prev = self.get_ctx_item(key)
         try:
             self.set_ctx_item(key, val)

--- a/tests/tracer/test_context.py
+++ b/tests/tracer/test_context.py
@@ -447,3 +447,16 @@ class TestTracingContext(BaseTestCase):
         assert cloned_ctx._dd_origin == ctx._dd_origin
         assert cloned_ctx._current_span == ctx._current_span
         assert cloned_ctx._trace == []
+
+    def test_items(self):
+        ctx = Context()
+        assert ctx.get_ctx_item("trace_deferreds") is None
+        ctx.set_ctx_item("trace_deferreds", True)
+        assert ctx.get_ctx_item("trace_deferreds") is True
+
+        ctx.set_ctx_item("trace_deferreds", False)
+        assert ctx.get_ctx_item("trace_deferreds") is False
+
+        with ctx.override_ctx_item("trace_deferreds", True):
+            assert ctx.get_ctx_item("trace_deferreds") is True
+        assert ctx.get_ctx_item("trace_deferreds") is False


### PR DESCRIPTION
## Description
<!-- Please briefly describe the change and why it was required. -->

While developing the [twisted integration](https://github.com/Datadog/dd-trace-py/pull/1669)
the need arose for the integration to add and retrieve items from the context
in order to trace `Deferred` objects. This API provides a simple way to do
this.


## Checklist
- [x] Entry added to `CHANGELOG.md`.
- [x] Tests provided; and/or
- [x] ~~Description of manual testing performed and explanation is included in the code and/or PR.~~
- [x] ~~Library documentation is updated.~~ (done automatically)
- [x] ~~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~~ N/A
