### PR TITLE
Profiling CI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fix(sanic): fix patching for sanic async http server (#1659)
 - fix(flask): make template patching idempotent
 - fix(core): Do not rate limit log lines when in debug
+- fix(profiling): Fix a potential deadlock on profiler restart after fork()
 
 ---
 

--- a/ddtrace/profiling/_periodic.py
+++ b/ddtrace/profiling/_periodic.py
@@ -35,7 +35,12 @@ class PeriodicThread(threading.Thread):
 
     def stop(self):
         """Stop the thread."""
-        self.quit.set()
+        # NOTE: make sure the thread is alive before using self.quit:
+        # 1. self.quit is Lock-based
+        # 2. if we're a child trying to stop a Thread,
+        #    the Lock might have been locked in a parent process while forking so that'd block forever
+        if self.is_alive():
+            self.quit.set()
 
     def run(self):
         """Run the target function periodically."""

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -161,17 +161,17 @@ class Profiler(object):
 
         :param flush: Wait for the flush of the remaining events before stopping.
         """
+        if self._scheduler:
+            self._scheduler.stop()
+
         for col in reversed(self._collectors):
             col.stop()
 
         for col in reversed(self._collectors):
             col.join()
 
-        if self._scheduler:
-            self._scheduler.stop()
-
-            if flush:
-                self._scheduler.join()
+        if self._scheduler and flush:
+            self._scheduler.join()
 
         self.status = ProfilerStatus.STOPPED
 

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -169,7 +169,7 @@ def test_memory_collector_ignore_profiler(ignore_profiler):
     r = recorder.Recorder()
     mc = memalloc.MemoryCollector(r, ignore_profiler=ignore_profiler)
     with mc:
-        _allocate_1k()
+        object()
         # Make sure we collect at least once
         mc.periodic()
 
@@ -180,6 +180,7 @@ def test_memory_collector_ignore_profiler(ignore_profiler):
                 assert frame[0] != _periodic.__file__
             elif frame[0] == _periodic.__file__:
                 ok = True
+                break
 
     if not ignore_profiler:
         assert ok

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -63,7 +63,6 @@ def test_call_script_pprof_output_interval(tmp_path, monkeypatch):
         check_pprof_file(filename + "." + str(pid) + (".%d" % i))
 
 
-@pytest.mark.skipif(os.getenv("DD_PROFILE_TEST_GEVENT", False), reason="Test hangs forever on gevent")
 def test_fork(tmp_path, monkeypatch):
     filename = str(tmp_path / "pprof")
     monkeypatch.setenv("DD_PROFILING_API_TIMEOUT", "0.1")


### PR DESCRIPTION
#1693 + #1695

## test(profiling): make sure we have samples for profilers

The scenario ignore_profiler=False randomly fails because there is no memory
allocation samples from the profiler. Indeed, when allocating 1k objects,
there's a chance they take all the places in the buffer and exclude the ones
from the profiler itself.

Reduce the allocation to 1 object so we're sure there are at least one sample
from the profiler itself in the sample list.

## fix(profiling): fix potential deadlock after fork()

When a process fork, its threading.Lock (and anything based on it) must be
considered unusable since there's no way to know in which state they are.

The workflow after fork()ing is to stop the old-parent-profiler, and start a
new one in the child.

The problem is that stopping the old profiler in the child would use at least
two locks:

1. one from the Event in the Scheduler that is used to stop the thread. This is
   fixed by checking if the thread actually needs to be stopped — which isn't the
   case in the child.
2. if a child process would try to release a Lock before before the fork, it
   could hit a deadlock from the Recorder's lock:
   When theading.Lock is wrapped by the Lock profiler, there's a small chance
   that it'll write an Event in the old-parent-Recorder. If the process forked
   while this Recorder lock was held by another thread, then trying to release
   a lock locked before the fork would dead lock:

     Traceback (most recent call first):
     Waiting for the GIL
     File "/src/ddtrace/profiling/recorder.py", line 56, in push_events
       with self._events_lock:
     File "/src/ddtrace/profiling/recorder.py", line 44, in push_event
       return self.push_events([event])
     File "/src/ddtrace/profiling/collector/threading.py", line 126, in release
       sampling_pct=self._self_capture_sampler.capture_pct,
     File "tests/profiling/simple_program_fork.py", line 33, in <module>
       lock_acquired_in_the_parent.release()