### PR TITLE
ci: more C checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,11 +212,14 @@ jobs:
       - setup_tox
       - run: tox -e black
 
-  cformat:
-    executor: ddtrace_dev
+  ccheck:
+    executor: cimg_base
     steps:
       - checkout
+      - run: sudo apt-get update
+      - run: sudo apt-get install --yes clang-format gcc-10 python3 python3-setuptools cython3
       - run: scripts/cformat.sh
+      - run: DD_COMPILE_DEBUG=1 CC=gcc-10 python3 setup.py build_ext
 
   flake8:
     executor: python38
@@ -788,7 +791,7 @@ requires_pre_test: &requires_pre_test
   requires:
     - black
     - flake8
-    - cformat
+    - ccheck
 
 requires_tests: &requires_tests
   - build_docs
@@ -877,7 +880,7 @@ workflows:
       - build_docs
       - black
       - flake8
-      - cformat
+      - ccheck
 
       # Test building the package
       - test_build_alpine: *requires_pre_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,9 +216,6 @@ jobs:
     executor: ddtrace_dev
     steps:
       - checkout
-      # TODO: remove me once this the docker image is rebuilt
-      - run: apt-get update
-      - run: apt-get install --yes clang-format
       - run: scripts/cformat.sh
 
   flake8:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ s3_dir_prod: &s3_dir_prod trace
 s3_bucket: &s3_bucket pypi.datadoghq.com
 
 resource_class: &resource_class medium
-cimg_base_image: &cimg_base_image cimg/base:2020.01
+cimg_base_image: &cimg_base_image cimg/base:stable
 python38-alpine_image: &python38-alpine_image python:3.8-alpine
 python38_image: &python38_image circleci/python:3.8
 python37_image: &python37_image circleci/python:3.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN \
       python-openssl\
       wget \
       zlib1g-dev \
-      clang-format \
   # Cleaning up apt cache space
   && rm -rf /var/lib/apt/lists/*
 

--- a/setup.py
+++ b/setup.py
@@ -107,18 +107,25 @@ else:
     encoding_macros = [("__LITTLE_ENDIAN__", "1")]
 
 
-if platform.uname()[0] != "Windows":
-    encoding_libraries = []
-    extra_compile_args = ["-DPy_BUILD_CORE"]
-else:
+if platform.system() == "Windows":
     encoding_libraries = ["ws2_32"]
     extra_compile_args = []
+    debug_compile_args = []
+else:
+    encoding_libraries = []
+    extra_compile_args = ["-DPy_BUILD_CORE"]
+    if "DD_COMPILE_DEBUG" in os.environ and platform.system() == "Linux":
+        debug_compile_args = ["-g", "-Werror", "-Wall", "-Wextra", "-Wpedantic", "-fanalyzer"]
+    else:
+        debug_compile_args = []
+
 
 if sys.version_info[:2] >= (3, 4):
     ext_modules = [
         Extension(
             "ddtrace.profiling.collector._memalloc",
             sources=["ddtrace/profiling/collector/_memalloc.c"],
+            extra_compile_args=debug_compile_args,
         ),
     ]
 else:


### PR DESCRIPTION
## ci: do not install already installed clang-format

## ci: upgrade cimg base image to stable

Use the latest stable version rather than an old snapshot.

## ci: rename cformat to ccheck and add more C checks

This adds more C checks to the C-written module that we own such as the
profiling memalloc collector.

It leverages GCC 10 static analyzer and enable a bunch of warning-as-errors.

This also upgrade to a more recent version of clang-format.
