### PR TITLE
docs: add spelling dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 cython
 sphinx
 opentracing
+sphinxcontrib-spelling
+PyEnchant


### PR DESCRIPTION
# Bug fix

## Description
The docs build is failing with

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/latest/lib/python3.7/site-packages/sphinx/registry.py", line 472, in load_extension
    mod = __import__(extname, None, None, ['setup'])
ModuleNotFoundError: No module named 'sphinxcontrib.spelling'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/latest/lib/python3.7/site-packages/sphinx/cmd/build.py", line 303, in build_main
    args.tags, args.verbosity, args.jobs, args.keep_going)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 228, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 449, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/latest/lib/python3.7/site-packages/sphinx/registry.py", line 475, in load_extension
    raise ExtensionError(__('Could not import extension %s') % extname, err)
sphinx.errors.ExtensionError: Could not import extension sphinxcontrib.spelling (exception: No module named 'sphinxcontrib.spelling')

Extension error:
Could not import extension sphinxcontrib.spelling (exception: No module named 'sphinxcontrib.spelling')
```

adding the sphinx spelling dependencies to docs/requirements.txt should fix this.

# Checklist
- [x] ~~Entry added to `CHANGELOG.md`~~
- [x] ~~Regression test added; or~~
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
