### PR TITLE
chore(black): black pyx files too

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,15 @@ version_scheme = "release-branch-semver"
 [tool.black]
 line-length = 120
 target_version = ['py27', 'py35', 'py36', 'py37', 'py38']
+include = '''\.py[ix]?$'''
 exclude = '''
 (
-  \.eggs
+  ddtrace/internal/_encoding.pyx$
+  | ddtrace/internal/_rand.pyx$
+  | ddtrace/profiling/collector/_traceback.pyx$
+  | ddtrace/profiling/collector/_threading.pyx$
+  | ddtrace/profiling/collector/stack.pyx$
+  | \.eggs
   | \.git
   | \.hg
   | \.mypy_cache


### PR DESCRIPTION
Some of our Cython files are actually Python files compiled down to C.
This makes black format them by default, adding to the ignore list only the few
ones we know contains Cython-specific language.
