### PR TITLE
fix(gevent/pynamodb): patch pynamodb on import

### DIFF
--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -85,6 +85,7 @@ _PATCH_ON_IMPORT = {
     "requests": ("requests",),
     "botocore": ("botocore",),
     "elasticsearch": ("elasticsearch",),
+    "pynamodb": ("pynamodb",),
 }
 
 

--- a/releasenotes/notes/gevent-pynamodb-fix-72ac7017e51fd4f9.yaml
+++ b/releasenotes/notes/gevent-pynamodb-fix-72ac7017e51fd4f9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Patch pynamodb on import to prevent patching conflicts with gevent.

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -457,6 +457,7 @@ class TestGeventTracer(TracerTestCase):
         import botocore  # noqa
         import requests  # noqa
         import elasticsearch  # noqa
+        import pynamodb  # noqa
 
         p = subprocess.Popen(
             ["ddtrace-run", "python", "tests/contrib/gevent/monkeypatch.py"],

--- a/tox.ini
+++ b/tox.ini
@@ -471,6 +471,7 @@ deps =
     sslmodules: botocore
     sslmodules: requests
     sslmodules: elasticsearch
+    sslmodules: pynamodb
     starlette_contrib: httpx
     starlette_contrib: pytest-asyncio
     starlette_contrib: requests


### PR DESCRIPTION
# Bug fix

## Description
As described in #1721.

## Fix
Add pynamodb to patch on import modules.

# Checklist
- [x] Entry added to `CHANGELOG.md`
- [x] Regression test added; or
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [x] Added to the correct milestone.

# Testing
- [x] Tests are run against all relevant library versions (or confirm that the relevant versions are already being tested in `tox.ini`)


Fixes #1721