### PR TITLE
core: move filters from writers to tracer

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -296,7 +296,6 @@ class Tracer(object):
             or port is not None
             or uds_path is not None
             or https is not None
-            or filters is not None
             or priority_sampling is not None
             or sampler is not None
         ):

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -300,7 +300,7 @@ class Tracer(object):
             or priority_sampling is not None
             or sampler is not None
         ):
-            # Preserve hostname and port when overriding filters or priority sampling
+            # Preserve hostname and port when overriding priority sampling
             # This is clumsy and a good reason to get rid of this configure() API
             if hasattr(self, 'writer') and hasattr(self.writer, 'api'):
                 default_hostname = self.writer.api.hostname

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -449,14 +449,12 @@ class DummyTracer(Tracer):
             self.writer = DummyWriter(
                 hostname=self.writer.api.hostname,
                 port=self.writer.api.port,
-                filters=self.writer._filters,
                 priority_sampler=self.writer._priority_sampler,
             )
         else:
             self.writer = DummyWriter(
                 hostname="",
                 port=0,
-                filters=self.writer._filters,
                 priority_sampler=self.writer._priority_sampler,
             )
 

--- a/tests/contrib/tornado/test_config.py
+++ b/tests/contrib/tornado/test_config.py
@@ -31,9 +31,8 @@ class TestTornadoSettings(TornadoTestCase):
         assert self.tracer.writer.api.hostname == 'dd-agent.service.consul'
         assert self.tracer.writer.api.port == 8126
         # settings are properly passed
-        assert self.tracer.writer._filters is not None
-        assert len(self.tracer.writer._filters) == 1
-        assert isinstance(self.tracer.writer._filters[0], FilterRequestsOnUrl)
+        assert len(self.tracer._filters) == 1
+        assert isinstance(self.tracer._filters[0], FilterRequestsOnUrl)
 
 
 class TestTornadoSettingsEnabled(TornadoTestCase):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -206,9 +206,6 @@ class TestWorkers(TestCase):
     def test_worker_filter_request(self):
         self.tracer.configure(settings={FILTERS_KEY: [FilterRequestsOnUrl(r"http://example\.com/health")]})
         # spy the send() method
-        self.api = self.tracer.writer.api
-        self.api._put = mock.Mock(self.api._put, wraps=self.api._put)
-
         span = self.tracer.trace("testing.filteredurl")
         span.set_tag(http.URL, "http://example.com/health")
         span.finish()

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -29,27 +29,27 @@ def get_dummy_tracer():
 
 class TracerTestCases(TracerTestCase):
     def test_tracer_vars(self):
-        span = self.trace('a', service='s', resource='r', span_type='t')
-        span.assert_matches(name='a', service='s', resource='r', span_type='t')
+        span = self.trace("a", service="s", resource="r", span_type="t")
+        span.assert_matches(name="a", service="s", resource="r", span_type="t")
         # DEV: Finish to ensure we don't leak `service` between spans
         span.finish()
 
-        span = self.trace('a')
-        span.assert_matches(name='a', service=None, resource='a', span_type=None)
+        span = self.trace("a")
+        span.assert_matches(name="a", service=None, resource="a", span_type=None)
 
     def test_tracer(self):
         def _mix():
-            with self.trace('cake.mix'):
+            with self.trace("cake.mix"):
                 pass
 
         def _bake():
-            with self.trace('cake.bake'):
+            with self.trace("cake.bake"):
                 pass
 
         def _make_cake():
-            with self.trace('cake.make') as span:
-                span.service = 'baker'
-                span.resource = 'cake'
+            with self.trace("cake.make") as span:
+                span.service = "baker"
+                span.resource = "cake"
                 _mix()
                 _bake()
 
@@ -63,12 +63,12 @@ class TracerTestCases(TracerTestCase):
         # Assert structure of this trace
         self.assert_structure(
             # Root span with 2 children
-            dict(name='cake.make', resource='cake', service='baker', parent_id=None),
+            dict(name="cake.make", resource="cake", service="baker", parent_id=None),
             (
                 # Span with no children
-                dict(name='cake.mix', resource='cake.mix', service='baker'),
+                dict(name="cake.mix", resource="cake.mix", service="baker"),
                 # Span with no children
-                dict(name='cake.bake', resource='cake.bake', service='baker'),
+                dict(name="cake.bake", resource="cake.bake", service="baker"),
             ),
         )
 
@@ -80,23 +80,23 @@ class TracerTestCases(TracerTestCase):
             assert s.trace_id != root_trace_id
 
     def test_tracer_wrap(self):
-        @self.tracer.wrap('decorated_function', service='s', resource='r', span_type='t')
+        @self.tracer.wrap("decorated_function", service="s", resource="r", span_type="t")
         def f(tag_name, tag_value):
             # make sure we can still set tags
             span = self.tracer.current_span()
             span.set_tag(tag_name, tag_value)
 
-        f('a', 'b')
+        f("a", "b")
 
         self.assert_span_count(1)
         span = self.get_root_span()
         span.assert_matches(
-            name='decorated_function', service='s', resource='r', span_type='t', meta=dict(a='b'),
+            name="decorated_function", service="s", resource="r", span_type="t", meta=dict(a="b"),
         )
 
     def test_tracer_pid(self):
-        with self.trace('root') as root_span:
-            with self.trace('child') as child_span:
+        with self.trace("root") as root_span:
+            with self.trace("child") as child_span:
                 pass
 
         # Root span should contain the pid of the current process
@@ -112,24 +112,21 @@ class TracerTestCases(TracerTestCase):
 
         f()
 
-        self.assert_structure(dict(name='tests.tracer.test_tracer.f'))
+        self.assert_structure(dict(name="tests.tracer.test_tracer.f"))
 
     def test_tracer_wrap_exception(self):
         @self.tracer.wrap()
         def f():
-            raise Exception('bim')
+            raise Exception("bim")
 
         with self.assertRaises(Exception) as ex:
             f()
 
             self.assert_structure(
                 dict(
-                    name='tests.test_tracer.f',
+                    name="tests.test_tracer.f",
                     error=1,
-                    meta={
-                        'error.msg': ex.message,
-                        'error.type': ex.__class__.__name__,
-                    },
+                    meta={"error.msg": ex.message, "error.type": ex.__class__.__name__,},
                 ),
             )
 
@@ -145,52 +142,43 @@ class TracerTestCases(TracerTestCase):
         assert self.spans[0].span_id != self.spans[1].span_id
 
     def test_tracer_wrap_span_nesting_current_root_span(self):
-        @self.tracer.wrap('inner')
+        @self.tracer.wrap("inner")
         def inner():
             root_span = self.tracer.current_root_span()
-            self.assertEqual(root_span.name, 'outer')
+            self.assertEqual(root_span.name, "outer")
 
-        @self.tracer.wrap('outer')
+        @self.tracer.wrap("outer")
         def outer():
             root_span = self.tracer.current_root_span()
-            self.assertEqual(root_span.name, 'outer')
+            self.assertEqual(root_span.name, "outer")
 
-            with self.trace('mid'):
+            with self.trace("mid"):
                 root_span = self.tracer.current_root_span()
-                self.assertEqual(root_span.name, 'outer')
+                self.assertEqual(root_span.name, "outer")
 
                 inner()
 
         outer()
 
     def test_tracer_wrap_span_nesting(self):
-        @self.tracer.wrap('inner')
+        @self.tracer.wrap("inner")
         def inner():
             pass
 
-        @self.tracer.wrap('outer')
+        @self.tracer.wrap("outer")
         def outer():
-            with self.trace('mid'):
+            with self.trace("mid"):
                 inner()
 
         outer()
 
         self.assert_span_count(3)
         self.assert_structure(
-            dict(name='outer'),
-            (
-                (
-                    dict(name='mid'),
-                    (
-                        dict(name='inner'),
-                    )
-                ),
-            ),
+            dict(name="outer"), ((dict(name="mid"), (dict(name="inner"),)),),
         )
 
     def test_tracer_wrap_class(self):
         class Foo(object):
-
             @staticmethod
             @self.tracer.wrap()
             def s():
@@ -211,15 +199,15 @@ class TracerTestCases(TracerTestCase):
         self.assertEqual(f.i(), 3)
 
         self.assert_span_count(3)
-        self.spans[0].assert_matches(name='tests.tracer.test_tracer.s')
-        self.spans[1].assert_matches(name='tests.tracer.test_tracer.c')
-        self.spans[2].assert_matches(name='tests.tracer.test_tracer.i')
+        self.spans[0].assert_matches(name="tests.tracer.test_tracer.s")
+        self.spans[1].assert_matches(name="tests.tracer.test_tracer.c")
+        self.spans[2].assert_matches(name="tests.tracer.test_tracer.i")
 
     def test_tracer_wrap_factory(self):
         def wrap_executor(tracer, fn, args, kwargs, span_name=None, service=None, resource=None, span_type=None):
-            with tracer.trace('wrap.overwrite') as span:
-                span.set_tag('args', args)
-                span.set_tag('kwargs', kwargs)
+            with tracer.trace("wrap.overwrite") as span:
+                span.set_tag("args", args)
+                span.set_tag("kwargs", kwargs)
                 return fn(*args, **kwargs)
 
         @self.tracer.wrap()
@@ -235,15 +223,14 @@ class TracerTestCases(TracerTestCase):
 
         self.assert_span_count(1)
         self.spans[0].assert_matches(
-            name='wrap.overwrite',
-            meta=dict(args='(42,)', kwargs='{\'kw_param\': 42}'),
+            name="wrap.overwrite", meta=dict(args="(42,)", kwargs="{'kw_param': 42}"),
         )
 
     def test_tracer_wrap_factory_nested(self):
         def wrap_executor(tracer, fn, args, kwargs, span_name=None, service=None, resource=None, span_type=None):
-            with tracer.trace('wrap.overwrite') as span:
-                span.set_tag('args', args)
-                span.set_tag('kwargs', kwargs)
+            with tracer.trace("wrap.overwrite") as span:
+                span.set_tag("args", args)
+                span.set_tag("kwargs", kwargs)
                 return fn(*args, **kwargs)
 
         @self.tracer.wrap()
@@ -255,87 +242,81 @@ class TracerTestCases(TracerTestCase):
         self.tracer.configure(wrap_executor=wrap_executor)
 
         # call the function expecting that the custom tracing wrapper is used
-        with self.trace('wrap.parent', service='webserver'):
+        with self.trace("wrap.parent", service="webserver"):
             wrapped_function(42, kw_param=42)
 
         self.assert_structure(
-            dict(name='wrap.parent', service='webserver'),
-            (
-                dict(
-                    name='wrap.overwrite',
-                    service='webserver',
-                    meta=dict(args='(42,)', kwargs='{\'kw_param\': 42}')
-                ),
-            ),
+            dict(name="wrap.parent", service="webserver"),
+            (dict(name="wrap.overwrite", service="webserver", meta=dict(args="(42,)", kwargs="{'kw_param': 42}")),),
         )
 
     def test_tracer_disabled(self):
         self.tracer.enabled = True
-        with self.trace('foo') as s:
-            s.set_tag('a', 'b')
+        with self.trace("foo") as s:
+            s.set_tag("a", "b")
 
         self.assert_has_spans()
         self.reset()
 
         self.tracer.enabled = False
-        with self.trace('foo') as s:
-            s.set_tag('a', 'b')
+        with self.trace("foo") as s:
+            s.set_tag("a", "b")
         self.assert_has_no_spans()
 
     def test_unserializable_span_with_finish(self):
         try:
             import numpy as np
         except ImportError:
-            raise SkipTest('numpy not installed')
+            raise SkipTest("numpy not installed")
 
         # a weird case where manually calling finish with an unserializable
         # span was causing an loop of serialization.
-        with self.trace('parent') as span:
-            span.metrics['as'] = np.int64(1)  # circumvent the data checks
+        with self.trace("parent") as span:
+            span.metrics["as"] = np.int64(1)  # circumvent the data checks
             span.finish()
 
     def test_tracer_disabled_mem_leak(self):
         # ensure that if the tracer is disabled, we still remove things from the
         # span buffer upon finishing.
         self.tracer.enabled = False
-        s1 = self.trace('foo')
+        s1 = self.trace("foo")
         s1.finish()
 
         p1 = self.tracer.current_span()
-        s2 = self.trace('bar')
+        s2 = self.trace("bar")
 
         self.assertIsNone(s2._parent)
         s2.finish()
         self.assertIsNone(p1)
 
     def test_tracer_global_tags(self):
-        s1 = self.trace('brie')
+        s1 = self.trace("brie")
         s1.finish()
-        self.assertIsNone(s1.get_tag('env'))
-        self.assertIsNone(s1.get_tag('other'))
+        self.assertIsNone(s1.get_tag("env"))
+        self.assertIsNone(s1.get_tag("other"))
 
-        self.tracer.set_tags({'env': 'prod'})
-        s2 = self.trace('camembert')
+        self.tracer.set_tags({"env": "prod"})
+        s2 = self.trace("camembert")
         s2.finish()
-        self.assertEqual(s2.get_tag('env'), 'prod')
-        self.assertIsNone(s2.get_tag('other'))
+        self.assertEqual(s2.get_tag("env"), "prod")
+        self.assertIsNone(s2.get_tag("other"))
 
-        self.tracer.set_tags({'env': 'staging', 'other': 'tag'})
-        s3 = self.trace('gruyere')
+        self.tracer.set_tags({"env": "staging", "other": "tag"})
+        s3 = self.trace("gruyere")
         s3.finish()
-        self.assertEqual(s3.get_tag('env'), 'staging')
-        self.assertEqual(s3.get_tag('other'), 'tag')
+        self.assertEqual(s3.get_tag("env"), "staging")
+        self.assertEqual(s3.get_tag("other"), "tag")
 
     def test_global_context(self):
         # the tracer uses a global thread-local Context
-        span = self.trace('fake_span')
+        span = self.trace("fake_span")
         ctx = self.tracer.get_call_context()
         self.assertEqual(len(ctx._trace), 1)
         self.assertEqual(ctx._trace[0], span)
 
     def test_tracer_current_span(self):
         # the current span is in the local Context()
-        span = self.trace('fake_span')
+        span = self.trace("fake_span")
         self.assertEqual(self.tracer.current_span(), span)
 
     def test_tracer_current_span_missing_context(self):
@@ -356,61 +337,50 @@ class TracerTestCases(TracerTestCase):
         # this could happen in distributed tracing
         ctx = Context(trace_id=42, span_id=100)
         self.tracer.context_provider.activate(ctx)
-        span = self.trace('web.request')
-        span.assert_matches(name='web.request', trace_id=42, parent_id=100)
+        span = self.trace("web.request")
+        span.assert_matches(name="web.request", trace_id=42, parent_id=100)
 
     def test_default_provider_trace(self):
         # Context handled by a default provider must be used
         # when creating a trace
-        span = self.trace('web.request')
+        span = self.trace("web.request")
         ctx = self.tracer.context_provider.active()
         self.assertEqual(len(ctx._trace), 1)
         self.assertEqual(span._context, ctx)
 
     def test_start_span(self):
         # it should create a root Span
-        span = self.start_span('web.request')
+        span = self.start_span("web.request")
         span.assert_matches(
-            name='web.request',
-            tracer=self.tracer,
-            _parent=None,
-            parent_id=None,
+            name="web.request", tracer=self.tracer, _parent=None, parent_id=None,
         )
         self.assertIsNotNone(span._context)
         self.assertEqual(span._context._current_span, span)
 
     def test_start_span_optional(self):
         # it should create a root Span with arguments
-        span = self.start_span('web.request', service='web', resource='/', span_type='http')
+        span = self.start_span("web.request", service="web", resource="/", span_type="http")
         span.assert_matches(
-            name='web.request',
-            service='web',
-            resource='/',
-            span_type='http',
+            name="web.request", service="web", resource="/", span_type="http",
         )
 
     def test_start_span_service_default(self):
         span = self.start_span("")
-        span.assert_matches(
-            service=None
-        )
+        span.assert_matches(service=None)
 
     def test_start_span_service_from_parent(self):
         with self.start_span("parent", service="mysvc") as parent:
             child = self.start_span("child", child_of=parent)
 
         child.assert_matches(
-            name="child",
-            service="mysvc",
+            name="child", service="mysvc",
         )
 
     def test_start_span_service_global_config(self):
         # When no service is provided a default
         with self.override_global_config(dict(service="mysvc")):
             span = self.start_span("")
-            span.assert_matches(
-                service="mysvc"
-            )
+            span.assert_matches(service="mysvc")
 
     def test_start_span_service_global_config_parent(self):
         # Parent should have precedence over global config
@@ -419,46 +389,37 @@ class TracerTestCases(TracerTestCase):
                 child = self.start_span("child", child_of=parent)
 
         child.assert_matches(
-            name="child",
-            service="parentsvc",
+            name="child", service="parentsvc",
         )
 
     def test_start_child_span(self):
         # it should create a child Span for the given parent
-        parent = self.start_span('web.request')
-        child = self.start_span('web.worker', child_of=parent)
+        parent = self.start_span("web.request")
+        child = self.start_span("web.worker", child_of=parent)
 
         parent.assert_matches(
-            name='web.request',
-            parent_id=None,
-            _context=child._context,
-            _parent=None,
-            tracer=self.tracer,
+            name="web.request", parent_id=None, _context=child._context, _parent=None, tracer=self.tracer,
         )
         child.assert_matches(
-            name='web.worker',
-            parent_id=parent.span_id,
-            _context=parent._context,
-            _parent=parent,
-            tracer=self.tracer,
+            name="web.worker", parent_id=parent.span_id, _context=parent._context, _parent=parent, tracer=self.tracer,
         )
 
         self.assertEqual(child._context._current_span, child)
 
     def test_start_child_span_attributes(self):
         # it should create a child Span with parent's attributes
-        parent = self.start_span('web.request', service='web', resource='/', span_type='http')
-        child = self.start_span('web.worker', child_of=parent)
-        child.assert_matches(name='web.worker', service='web')
+        parent = self.start_span("web.request", service="web", resource="/", span_type="http")
+        child = self.start_span("web.worker", child_of=parent)
+        child.assert_matches(name="web.worker", service="web")
 
     def test_start_child_from_context(self):
         # it should create a child span with a populated Context
-        root = self.start_span('web.request')
+        root = self.start_span("web.request")
         context = root.context
-        child = self.start_span('web.worker', child_of=context)
+        child = self.start_span("web.worker", child_of=context)
 
         child.assert_matches(
-            name='web.worker',
+            name="web.worker",
             parent_id=root.span_id,
             trace_id=root.trace_id,
             _context=root._context,
@@ -469,11 +430,11 @@ class TracerTestCases(TracerTestCase):
 
     def test_adding_services(self):
         self.assertEqual(self.tracer._services, set())
-        root = self.start_span('root', service='one')
+        root = self.start_span("root", service="one")
         context = root.context
-        self.assertSetEqual(self.tracer._services, set(['one']))
-        self.start_span('child', service='two', child_of=context)
-        self.assertSetEqual(self.tracer._services, set(['one', 'two']))
+        self.assertSetEqual(self.tracer._services, set(["one"]))
+        self.start_span("child", service="two", child_of=context)
+        self.assertSetEqual(self.tracer._services, set(["one", "two"]))
 
     def test_configure_runtime_worker(self):
         # by default runtime worker not started though runtime id is set
@@ -485,105 +446,117 @@ class TracerTestCases(TracerTestCase):
 
     def test_configure_dogstatsd_host(self):
         with warnings.catch_warnings(record=True) as ws:
-            warnings.simplefilter('always')
-            self.tracer.configure(dogstatsd_host='foo')
-            assert self.tracer._dogstatsd_client.host == 'foo'
+            warnings.simplefilter("always")
+            self.tracer.configure(dogstatsd_host="foo")
+            assert self.tracer._dogstatsd_client.host == "foo"
             assert self.tracer._dogstatsd_client.port == 8125
             # verify warnings triggered
             assert len(ws) >= 1
             for w in ws:
                 if issubclass(w.category, ddtrace.utils.deprecation.RemovedInDDTrace10Warning):
-                    assert 'Use `dogstatsd_url`' in str(w.message)
+                    assert "Use `dogstatsd_url`" in str(w.message)
                     break
             else:
                 assert 0, "dogstatsd warning not found"
 
     def test_configure_dogstatsd_host_port(self):
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.tracer.configure(dogstatsd_host='foo', dogstatsd_port='1234')
-            assert self.tracer._dogstatsd_client.host == 'foo'
+            warnings.simplefilter("always")
+            self.tracer.configure(dogstatsd_host="foo", dogstatsd_port="1234")
+            assert self.tracer._dogstatsd_client.host == "foo"
             assert self.tracer._dogstatsd_client.port == 1234
             # verify warnings triggered
             assert len(w) >= 2
             assert issubclass(w[0].category, ddtrace.utils.deprecation.RemovedInDDTrace10Warning)
-            assert 'Use `dogstatsd_url`' in str(w[0].message)
+            assert "Use `dogstatsd_url`" in str(w[0].message)
             assert issubclass(w[1].category, ddtrace.utils.deprecation.RemovedInDDTrace10Warning)
-            assert 'Use `dogstatsd_url`' in str(w[1].message)
+            assert "Use `dogstatsd_url`" in str(w[1].message)
 
     def test_configure_dogstatsd_url_host_port(self):
-        self.tracer.configure(dogstatsd_url='foo:1234')
-        assert self.tracer._dogstatsd_client.host == 'foo'
+        self.tracer.configure(dogstatsd_url="foo:1234")
+        assert self.tracer._dogstatsd_client.host == "foo"
         assert self.tracer._dogstatsd_client.port == 1234
 
     def test_configure_dogstatsd_url_socket(self):
-        self.tracer.configure(dogstatsd_url='unix:///foo.sock')
+        self.tracer.configure(dogstatsd_url="unix:///foo.sock")
         assert self.tracer._dogstatsd_client.host is None
         assert self.tracer._dogstatsd_client.port is None
-        assert self.tracer._dogstatsd_client.socket_path == '/foo.sock'
+        assert self.tracer._dogstatsd_client.socket_path == "/foo.sock"
 
     def test_span_no_runtime_tags(self):
         self.tracer.configure(collect_metrics=False)
 
-        root = self.start_span('root')
+        root = self.start_span("root")
         context = root.context
-        child = self.start_span('child', child_of=context)
+        child = self.start_span("child", child_of=context)
 
-        self.assertIsNone(root.get_tag('language'))
+        self.assertIsNone(root.get_tag("language"))
 
-        self.assertIsNone(child.get_tag('language'))
+        self.assertIsNone(child.get_tag("language"))
 
     def test_only_root_span_runtime_internal_span_types(self):
         self.tracer.configure(collect_metrics=True)
 
         for span_type in ("custom", "template", "web", "worker"):
-            root = self.start_span('root', span_type=span_type)
+            root = self.start_span("root", span_type=span_type)
             context = root.context
-            child = self.start_span('child', child_of=context)
+            child = self.start_span("child", child_of=context)
 
-            self.assertEqual(root.get_tag('language'), 'python')
+            self.assertEqual(root.get_tag("language"), "python")
 
-            self.assertIsNone(child.get_tag('language'))
+            self.assertIsNone(child.get_tag("language"))
 
     def test_only_root_span_runtime_external_span_types(self):
         self.tracer.configure(collect_metrics=True)
 
-        for span_type in ("algoliasearch.search", "boto", "cache", "cassandra", "elasticsearch",
-                          "grpc", "kombu", "http", "memcached", "redis", "sql", "vertica"):
-            root = self.start_span('root', span_type=span_type)
+        for span_type in (
+            "algoliasearch.search",
+            "boto",
+            "cache",
+            "cassandra",
+            "elasticsearch",
+            "grpc",
+            "kombu",
+            "http",
+            "memcached",
+            "redis",
+            "sql",
+            "vertica",
+        ):
+            root = self.start_span("root", span_type=span_type)
             context = root.context
-            child = self.start_span('child', child_of=context)
+            child = self.start_span("child", child_of=context)
 
-            self.assertIsNone(root.get_tag('language'))
+            self.assertIsNone(root.get_tag("language"))
 
-            self.assertIsNone(child.get_tag('language'))
+            self.assertIsNone(child.get_tag("language"))
 
 
 def test_tracer_url():
     t = ddtrace.Tracer()
-    assert t.writer.api.hostname == 'localhost'
+    assert t.writer.api.hostname == "localhost"
     assert t.writer.api.port == 8126
 
-    t = ddtrace.Tracer(url='http://foobar:12')
-    assert t.writer.api.hostname == 'foobar'
+    t = ddtrace.Tracer(url="http://foobar:12")
+    assert t.writer.api.hostname == "foobar"
     assert t.writer.api.port == 12
 
-    t = ddtrace.Tracer(url='unix:///foobar')
-    assert t.writer.api.uds_path == '/foobar'
+    t = ddtrace.Tracer(url="unix:///foobar")
+    assert t.writer.api.uds_path == "/foobar"
 
-    t = ddtrace.Tracer(url='http://localhost')
-    assert t.writer.api.hostname == 'localhost'
+    t = ddtrace.Tracer(url="http://localhost")
+    assert t.writer.api.hostname == "localhost"
     assert t.writer.api.port == 80
     assert not t.writer.api.https
 
-    t = ddtrace.Tracer(url='https://localhost')
-    assert t.writer.api.hostname == 'localhost'
+    t = ddtrace.Tracer(url="https://localhost")
+    assert t.writer.api.hostname == "localhost"
     assert t.writer.api.port == 443
     assert t.writer.api.https
 
     with pytest.raises(ValueError) as e:
-        t = ddtrace.Tracer(url='foo://foobar:12')
-        assert str(e) == 'Unknown scheme `https` for agent URL'
+        t = ddtrace.Tracer(url="foo://foobar:12")
+        assert str(e) == "Unknown scheme `https` for agent URL"
 
 
 def test_tracer_shutdown_no_timeout():
@@ -640,26 +613,26 @@ def test_tracer_shutdown_timeout():
 
 def test_tracer_dogstatsd_url():
     t = ddtrace.Tracer()
-    assert t._dogstatsd_client.host == 'localhost'
+    assert t._dogstatsd_client.host == "localhost"
     assert t._dogstatsd_client.port == 8125
 
-    t = ddtrace.Tracer(dogstatsd_url='foobar:12')
-    assert t._dogstatsd_client.host == 'foobar'
+    t = ddtrace.Tracer(dogstatsd_url="foobar:12")
+    assert t._dogstatsd_client.host == "foobar"
     assert t._dogstatsd_client.port == 12
 
-    t = ddtrace.Tracer(dogstatsd_url='udp://foobar:12')
-    assert t._dogstatsd_client.host == 'foobar'
+    t = ddtrace.Tracer(dogstatsd_url="udp://foobar:12")
+    assert t._dogstatsd_client.host == "foobar"
     assert t._dogstatsd_client.port == 12
 
-    t = ddtrace.Tracer(dogstatsd_url='/var/run/statsd.sock')
-    assert t._dogstatsd_client.socket_path == '/var/run/statsd.sock'
+    t = ddtrace.Tracer(dogstatsd_url="/var/run/statsd.sock")
+    assert t._dogstatsd_client.socket_path == "/var/run/statsd.sock"
 
-    t = ddtrace.Tracer(dogstatsd_url='unix:///var/run/statsd.sock')
-    assert t._dogstatsd_client.socket_path == '/var/run/statsd.sock'
+    t = ddtrace.Tracer(dogstatsd_url="unix:///var/run/statsd.sock")
+    assert t._dogstatsd_client.socket_path == "/var/run/statsd.sock"
 
     with pytest.raises(ValueError) as e:
-        t = ddtrace.Tracer(dogstatsd_url='foo://foobar:12')
-        assert str(e) == 'Unknown url format for `foo://foobar:12`'
+        t = ddtrace.Tracer(dogstatsd_url="foo://foobar:12")
+        assert str(e) == "Unknown url format for `foo://foobar:12`"
 
 
 def test_tracer_fork():
@@ -676,7 +649,7 @@ def test_tracer_fork():
 
     def task(t, errors):
         # Start a new span to trigger process checking
-        with t.trace('test', service='test') as span:
+        with t.trace("test", service="test") as span:
 
             # Assert we recreated the writer and have a new queue
             with capture_failures(errors):
@@ -700,7 +673,7 @@ def test_tracer_fork():
     assert errors.empty(), errors.get()
 
     # Ensure writing into the tracer in this process still works as expected
-    with t.trace('test', service='test') as span:
+    with t.trace("test", service="test") as span:
         assert t._pid == original_pid
         assert t.writer == original_writer
         assert t.writer._trace_queue == original_writer._trace_queue
@@ -735,7 +708,7 @@ def test_tracer_trace_across_fork():
 
     children = q.get()
     assert len(children) == 1
-    child, = children
+    (child,) = children
     assert parent.trace_id == child["trace_id"]
     assert child["parent_id"] == parent.span_id
 
@@ -770,10 +743,7 @@ def test_tracer_trace_across_multiple_forks():
 
         task2_spans = q2.get()
         spans = tracer.writer.pop()
-        q.put([
-            dict(trace_id=s.trace_id, parent_id=s.parent_id, span_id=s.span_id)
-            for s in spans
-        ] + task2_spans)
+        q.put([dict(trace_id=s.trace_id, parent_id=s.parent_id, span_id=s.span_id) for s in spans] + task2_spans)
 
     # Assert tracer in a new process correctly recreates the writer
     q = multiprocessing.Queue()
@@ -794,59 +764,60 @@ def test_tracer_with_version():
     t = ddtrace.Tracer()
 
     # With global `config.version` defined
-    with override_global_config(dict(version='1.2.3')):
-        with t.trace('test.span') as span:
-            assert span.get_tag(VERSION_KEY) == '1.2.3'
+    with override_global_config(dict(version="1.2.3")):
+        with t.trace("test.span") as span:
+            assert span.get_tag(VERSION_KEY) == "1.2.3"
 
             # override manually
-            span.set_tag(VERSION_KEY, '4.5.6')
-            assert span.get_tag(VERSION_KEY) == '4.5.6'
+            span.set_tag(VERSION_KEY, "4.5.6")
+            assert span.get_tag(VERSION_KEY) == "4.5.6"
 
     # With no `config.version` defined
-    with t.trace('test.span') as span:
+    with t.trace("test.span") as span:
         assert span.get_tag(VERSION_KEY) is None
 
         # explicitly set in the span
-        span.set_tag(VERSION_KEY, '1.2.3')
-        assert span.get_tag(VERSION_KEY) == '1.2.3'
+        span.set_tag(VERSION_KEY, "1.2.3")
+        assert span.get_tag(VERSION_KEY) == "1.2.3"
 
     # With global tags set
-    t.set_tags({VERSION_KEY: 'tags.version'})
-    with override_global_config(dict(version='config.version')):
-        with t.trace('test.span') as span:
-            assert span.get_tag(VERSION_KEY) == 'config.version'
+    t.set_tags({VERSION_KEY: "tags.version"})
+    with override_global_config(dict(version="config.version")):
+        with t.trace("test.span") as span:
+            assert span.get_tag(VERSION_KEY) == "config.version"
 
 
 def test_tracer_with_env():
     t = ddtrace.Tracer()
 
     # With global `config.env` defined
-    with override_global_config(dict(env='prod')):
-        with t.trace('test.span') as span:
-            assert span.get_tag(ENV_KEY) == 'prod'
+    with override_global_config(dict(env="prod")):
+        with t.trace("test.span") as span:
+            assert span.get_tag(ENV_KEY) == "prod"
 
             # override manually
-            span.set_tag(ENV_KEY, 'prod-staging')
-            assert span.get_tag(ENV_KEY) == 'prod-staging'
+            span.set_tag(ENV_KEY, "prod-staging")
+            assert span.get_tag(ENV_KEY) == "prod-staging"
 
     # With no `config.env` defined
-    with t.trace('test.span') as span:
+    with t.trace("test.span") as span:
         assert span.get_tag(ENV_KEY) is None
 
         # explicitly set in the span
-        span.set_tag(ENV_KEY, 'prod-staging')
-        assert span.get_tag(ENV_KEY) == 'prod-staging'
+        span.set_tag(ENV_KEY, "prod-staging")
+        assert span.get_tag(ENV_KEY) == "prod-staging"
 
     # With global tags set
-    t.set_tags({ENV_KEY: 'tags.env'})
-    with override_global_config(dict(env='config.env')):
-        with t.trace('test.span') as span:
-            assert span.get_tag(ENV_KEY) == 'config.env'
+    t.set_tags({ENV_KEY: "tags.env"})
+    with override_global_config(dict(env="config.env")):
+        with t.trace("test.span") as span:
+            assert span.get_tag(ENV_KEY) == "config.env"
 
 
 class EnvTracerTestCase(TracerTestCase):
     """Tracer test cases requiring environment variables.
     """
+
     @run_in_subprocess(env_overrides=dict(DATADOG_SERVICE_NAME="mysvc"))
     def test_service_name_legacy_DATADOG_SERVICE_NAME(self):
         """
@@ -855,6 +826,7 @@ class EnvTracerTestCase(TracerTestCase):
             It should be used with config._get_service()
         """
         from ddtrace import config
+
         assert config.service is None
         with self.start_span("") as s:
             s.assert_matches(service=None)
@@ -869,6 +841,7 @@ class EnvTracerTestCase(TracerTestCase):
             It should be used with config._get_service()
         """
         from ddtrace import config
+
         assert config.service is None
         with self.start_span("") as s:
             s.assert_matches(service=None)
@@ -878,28 +851,20 @@ class EnvTracerTestCase(TracerTestCase):
     @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_service_name_env(self):
         span = self.start_span("")
-        span.assert_matches(
-            service="mysvc",
-        )
+        span.assert_matches(service="mysvc",)
 
     @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_service_name_env_global_config(self):
         # Global config should have higher precedence than the environment variable
         with self.override_global_config(dict(service="overridesvc")):
             span = self.start_span("")
-        span.assert_matches(
-            service="overridesvc",
-        )
+        span.assert_matches(service="overridesvc",)
 
     @run_in_subprocess(env_overrides=dict(DD_VERSION="0.1.2"))
     def test_version_no_global_service(self):
         # Version should be set if no service name is present
         with self.trace("") as span:
-            span.assert_matches(
-                meta={
-                    VERSION_KEY: "0.1.2",
-                },
-            )
+            span.assert_matches(meta={VERSION_KEY: "0.1.2",},)
 
         # The version will not be tagged if the service is not globally
         # configured.
@@ -959,12 +924,9 @@ class EnvTracerTestCase(TracerTestCase):
             assert s.get_tag("env") == "myenv"
             assert s.get_tag("version") == "myvers"
 
-    @run_in_subprocess(env_overrides=dict(
-        DD_TAGS="service:s,env:e,version:v",
-        DD_ENV="env",
-        DD_SERVICE="svc",
-        DD_VERSION="0.123",
-    ))
+    @run_in_subprocess(
+        env_overrides=dict(DD_TAGS="service:s,env:e,version:v", DD_ENV="env", DD_SERVICE="svc", DD_VERSION="0.123",)
+    )
     def test_tags_from_DD_TAGS_precedence(self):
         t = ddtrace.Tracer()
         with t.trace("test") as s:
@@ -1027,7 +989,7 @@ def test_start_span_hooks():
 
     @t.on_start_span
     def store_span(span):
-        result['span'] = span
+        result["span"] = span
 
     span = t.start_span("hello")
 
@@ -1041,7 +1003,7 @@ def test_deregister_start_span_hooks():
 
     @t.on_start_span
     def store_span(span):
-        result['span'] = span
+        result["span"] = span
 
     t.deregister_on_start_span(store_span)
 
@@ -1124,9 +1086,9 @@ def test_filters():
         def process_trace(self, trace):
             return None
 
-    t.configure(settings={
-        "FILTERS": [FilterAll()],
-        })
+    t.configure(
+        settings={"FILTERS": [FilterAll()],}
+    )
     t.writer = DummyWriter()
 
     with t.trace("root"):
@@ -1146,9 +1108,9 @@ def test_filters():
                 s.set_tag(self.key, self.value)
             return trace
 
-    t.configure(settings={
-        "FILTERS": [FilterMutate("boop", "beep")],
-        })
+    t.configure(
+        settings={"FILTERS": [FilterMutate("boop", "beep")],}
+    )
     t.writer = DummyWriter()
 
     with t.trace("root"):
@@ -1161,11 +1123,10 @@ def test_filters():
     assert s1.get_tag("boop") == "beep"
     assert s2.get_tag("boop") == "beep"
 
-
     # Test multiple filters
-    t.configure(settings={
-        "FILTERS": [FilterMutate("boop", "beep"),FilterMutate("mats", "sundin")],
-        })
+    t.configure(
+        settings={"FILTERS": [FilterMutate("boop", "beep"), FilterMutate("mats", "sundin")],}
+    )
     t.writer = DummyWriter()
 
     with t.trace("root"):

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -11,36 +11,6 @@ from tests import BaseTestCase
 MAX_NUM_SPANS = 7
 
 
-class RemoveAllFilter:
-    def __init__(self):
-        self.filtered_traces = 0
-
-    def process_trace(self, trace):
-        self.filtered_traces += 1
-        return None
-
-
-class KeepAllFilter:
-    def __init__(self):
-        self.filtered_traces = 0
-
-    def process_trace(self, trace):
-        self.filtered_traces += 1
-        return trace
-
-
-class AddTagFilter:
-    def __init__(self, tag_name):
-        self.tag_name = tag_name
-        self.filtered_traces = 0
-
-    def process_trace(self, trace):
-        self.filtered_traces += 1
-        for span in trace:
-            span.set_tag(self.tag_name, "A value")
-        return trace
-
-
 class DummyAPI(API):
     def __init__(self):
         # Call API.__init__ to setup required properties
@@ -84,7 +54,7 @@ class AgentWriterTests(BaseTestCase):
     def create_worker(self, api_class=DummyAPI, enable_stats=False, num_traces=N_TRACES, num_spans=MAX_NUM_SPANS):
         with self.override_global_config(dict(health_metrics_enabled=enable_stats)):
             self.dogstatsd = mock.Mock()
-            worker = AgentWriter(dogstatsd=self.dogstatsd, filters=filters)
+            worker = AgentWriter(dogstatsd=self.dogstatsd)
             worker._STATS_EVERY_INTERVAL = 1
             self.api = api_class()
             worker.api = self.api

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -97,7 +97,6 @@ class AgentWriterTests(BaseTestCase):
             mock.call("datadog.tracer.flushes"),
             mock.call("datadog.tracer.flush.traces.total", 11, tags=None),
             mock.call("datadog.tracer.flush.spans.total", 77, tags=None),
-            mock.call("datadog.tracer.flush.traces_filtered.total", 0, tags=None),
             mock.call("datadog.tracer.api.requests.total", 11, tags=None),
             mock.call("datadog.tracer.api.errors.total", 0, tags=None),
             mock.call("datadog.tracer.api.traces_payloadfull.total", 0, tags=None),
@@ -111,7 +110,6 @@ class AgentWriterTests(BaseTestCase):
         histogram_calls = [
             mock.call("datadog.tracer.flush.traces", 11, tags=None),
             mock.call("datadog.tracer.flush.spans", 77, tags=None),
-            mock.call("datadog.tracer.flush.traces_filtered", 0, tags=None),
             mock.call("datadog.tracer.api.requests", 11, tags=None),
             mock.call("datadog.tracer.api.errors", 0, tags=None),
             mock.call("datadog.tracer.api.traces_payloadfull", 0, tags=None),
@@ -134,7 +132,6 @@ class AgentWriterTests(BaseTestCase):
             mock.call("datadog.tracer.flushes"),
             mock.call("datadog.tracer.flush.traces.total", 1, tags=None),
             mock.call("datadog.tracer.flush.spans.total", num_spans, tags=None),
-            mock.call("datadog.tracer.flush.traces_filtered.total", 0, tags=None),
             mock.call("datadog.tracer.api.requests.total", 1, tags=None),
             mock.call("datadog.tracer.api.errors.total", 0, tags=None),
             mock.call("datadog.tracer.api.traces_payloadfull.total", 1, tags=None),
@@ -147,7 +144,6 @@ class AgentWriterTests(BaseTestCase):
         histogram_calls = [
             mock.call("datadog.tracer.flush.traces", 1, tags=None),
             mock.call("datadog.tracer.flush.spans", num_spans, tags=None),
-            mock.call("datadog.tracer.flush.traces_filtered", 0, tags=None),
             mock.call("datadog.tracer.api.requests", 1, tags=None),
             mock.call("datadog.tracer.api.errors", 0, tags=None),
             mock.call("datadog.tracer.api.traces_payloadfull", 1, tags=None),
@@ -168,7 +164,6 @@ class AgentWriterTests(BaseTestCase):
             mock.call("datadog.tracer.flushes"),
             mock.call("datadog.tracer.flush.traces.total", 11, tags=None),
             mock.call("datadog.tracer.flush.spans.total", 77, tags=None),
-            mock.call("datadog.tracer.flush.traces_filtered.total", 0, tags=None),
             mock.call("datadog.tracer.api.requests.total", 1, tags=None),
             mock.call("datadog.tracer.api.errors.total", 1, tags=None),
             mock.call("datadog.tracer.api.traces_payloadfull.total", 0, tags=None),
@@ -181,7 +176,6 @@ class AgentWriterTests(BaseTestCase):
         histogram_calls = [
             mock.call("datadog.tracer.flush.traces", 11, tags=None),
             mock.call("datadog.tracer.flush.spans", 77, tags=None),
-            mock.call("datadog.tracer.flush.traces_filtered", 0, tags=None),
             mock.call("datadog.tracer.api.requests", 1, tags=None),
             mock.call("datadog.tracer.api.errors", 1, tags=None),
             mock.call("datadog.tracer.api.traces_payloadfull", 0, tags=None),

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -81,9 +81,7 @@ class FailingAPI(object):
 class AgentWriterTests(BaseTestCase):
     N_TRACES = 11
 
-    def create_worker(
-        self, filters=None, api_class=DummyAPI, enable_stats=False, num_traces=N_TRACES, num_spans=MAX_NUM_SPANS
-    ):
+    def create_worker(self, api_class=DummyAPI, enable_stats=False, num_traces=N_TRACES, num_spans=MAX_NUM_SPANS):
         with self.override_global_config(dict(health_metrics_enabled=enable_stats)):
             self.dogstatsd = mock.Mock()
             worker = AgentWriter(dogstatsd=self.dogstatsd, filters=filters)
@@ -112,35 +110,6 @@ class AgentWriterTests(BaseTestCase):
         assert worker._send_stats is False
         with self.override_global_config(dict(health_metrics_enabled=True)):
             assert worker._send_stats is False
-
-    def test_filters_keep_all(self):
-        filtr = KeepAllFilter()
-        self.create_worker([filtr])
-        self.assertEqual(len(self.api.traces), self.N_TRACES)
-        self.assertEqual(filtr.filtered_traces, self.N_TRACES)
-
-    def test_filters_remove_all(self):
-        filtr = RemoveAllFilter()
-        self.create_worker([filtr])
-        self.assertEqual(len(self.api.traces), 0)
-        self.assertEqual(filtr.filtered_traces, self.N_TRACES)
-
-    def test_filters_add_tag(self):
-        tag_name = "Tag"
-        filtr = AddTagFilter(tag_name)
-        self.create_worker([filtr])
-        self.assertEqual(len(self.api.traces), self.N_TRACES)
-        self.assertEqual(filtr.filtered_traces, self.N_TRACES)
-        for trace in self.api.traces:
-            for span in trace:
-                self.assertIsNotNone(span.get_tag(tag_name))
-
-    def test_filters_short_circuit(self):
-        filtr = KeepAllFilter()
-        filters = [RemoveAllFilter(), filtr]
-        self.create_worker(filters)
-        self.assertEqual(len(self.api.traces), 0)
-        self.assertEqual(filtr.filtered_traces, 0)
 
     def test_no_dogstats(self):
         worker = self.create_worker()
@@ -256,23 +225,11 @@ class AgentWriterTests(BaseTestCase):
 class LogWriterTests(BaseTestCase):
     N_TRACES = 11
 
-    def create_writer(self, filters=None):
+    def create_writer(self):
         self.output = DummyOutput()
-        writer = LogWriter(out=self.output, filters=filters)
+        writer = LogWriter(out=self.output)
         for i in range(self.N_TRACES):
             writer.write(
                 [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(7)]
             )
         return writer
-
-    def test_filters_keep_all(self):
-        filtr = KeepAllFilter()
-        self.create_writer([filtr])
-        self.assertEqual(len(self.output.entries), self.N_TRACES)
-        self.assertEqual(filtr.filtered_traces, self.N_TRACES)
-
-    def test_filters_remove_all(self):
-        filtr = RemoveAllFilter()
-        self.create_writer([filtr])
-        self.assertEqual(len(self.output.entries), 0)
-        self.assertEqual(filtr.filtered_traces, self.N_TRACES)


### PR DESCRIPTION
## Description
This cleans up the design and prevents potentially filtered traces from
being counted towards the trace queue limit.

Filtering being done in the writers was probably done as an attempt at
optimization given that they'd run in the thread (presumably in parallel
to the main application code) however due to the GIL python code is only
ever run once.


## Checklist
- [x] ~~Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)~~
- [x] Tests provided; and/or
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [x] ~~Library documentation is updated.~~
- [x] ~~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~~
