### PR TITLE
ci: fix deploy_master and deploy_staging jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -743,7 +743,7 @@ jobs:
 
   deploy_master:
     # build the master branch releasing development docs and wheels
-    <<: *machine_executor
+    executor: ddtrace_dev
     steps:
       - checkout
       - *pyenv-set-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,9 @@ commands:
         default: *s3_bucket
     steps:
       - setup_tox
+      - run: |
+          apt-get update
+          apt-get install -y --no-install-recommends libenchant-dev
       - run: pip install awscli
       - run: tox -e docs
       - run:
@@ -743,7 +746,7 @@ jobs:
 
   deploy_master:
     # build the master branch releasing development docs and wheels
-    executor: ddtrace_dev
+    <<: *machine_executor
     steps:
       - checkout
       - *pyenv-set-global


### PR DESCRIPTION
# Bug fix

## Description
The job fails because the required library for building the docs is not
installed in the machine executor:
https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/3046/workflows/012e69de-b4e2-470a-8762-98d32fbe4804/jobs/357586

## Fix
Use the dev executor which has it installed.

# Checklist
- [x] ~~Entry added to `CHANGELOG.md`~~
- [x] ~~Regression test added; or~~
- [x] ~~Description of manual testing performed and explanation is included in the code and/or PR.~~
- [x] ~~Added to the correct milestone.~~
