### PR TITLE
ci: remove install steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,9 +583,6 @@ jobs:
     docker:
       - image: *ddtrace_dev_image
     steps:
-      - run: |
-          apt-get update
-          apt-get install -y --no-install-recommends unixodbc-dev libsqliteodbc
       - run_tox_scenario:
           pattern: '^pyodbc_contrib-'
 
@@ -950,7 +947,7 @@ workflows:
       - pymemcache: *requires_pre_test
       - pymongo: *requires_pre_test
       - pymysql: *requires_pre_test
-      - pynamodb: *requires_pre_test      
+      - pynamodb: *requires_pre_test
       - pyodbc: *requires_pre_test
       - pyramid: *requires_pre_test
       - redis: *requires_pre_test


### PR DESCRIPTION
## Description
This was included since the docker image is be built after merging. It is no
longer required.


## Checklist
- [x] ~~Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)~~
- [x] ~~Tests provided; and/or~~
- [x] ~~Description of manual testing performed and explanation is included in the code and/or PR.~~
- [x] ~~Library documentation is updated.~~
- [x] ~~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~~
