### PR TITLE
fix(tornado): handle current span being None

### DIFF
--- a/ddtrace/contrib/tornado/handlers.py
+++ b/ddtrace/contrib/tornado/handlers.py
@@ -92,6 +92,9 @@ def log_exception(func, handler, args, kwargs):
     tracer = handler.settings[CONFIG_KEY]['tracer']
     current_span = tracer.current_span()
 
+    if not current_span:
+        return func(*args, **kwargs)
+
     if isinstance(value, HTTPError):
         # Tornado uses HTTPError exceptions to stop and return a status code that
         # is not a 2xx. In this case we want to check the status code to be sure that

--- a/releasenotes/notes/tornado-none-bug-85faed75c859f5e5.yaml
+++ b/releasenotes/notes/tornado-none-bug-85faed75c859f5e5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Handle when the current span is None in log_exception().


### PR DESCRIPTION
# Bug fix

## Description
It is possible that the current span in the log_exception function can be None.
This was formerly not handled and would cause an error.

## Fix
Handle the case when the current span does not exist.

# Checklist
- [x] Entry added to `CHANGELOG.md`
- [x] ~~Regression test added; or~~
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [x] Added to the correct milestone.
