### PR TITLE
tests: pin pytest-django

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,8 @@ envlist =
 # 3.0   3.6, 3.7, 3.8
 # 3.1   3.6, 3.7, 3.8
 # Source: https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
-    django_contrib{,_migration}-py{27,35,36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached-test_django
+    django_contrib{,_migration}-py27-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached-test_django
+    django_contrib{,_migration}-py{35,36}-django111-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached-test_django
     django_contrib{,_migration}-py35-django{20,21,22}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached-test_django
     django_contrib{,_migration}-py{36,37,38}-django{20,21,22,30,}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached-test_django
     django_drf_contrib-py{27,35,36}-django{111}-djangorestframework{34,37}-test_django

--- a/tox.ini
+++ b/tox.ini
@@ -70,8 +70,7 @@ envlist =
 # 3.0   3.6, 3.7, 3.8
 # 3.1   3.6, 3.7, 3.8
 # Source: https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
-    django_contrib{,_migration}-py27-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached-test_django
-    django_contrib{,_migration}-py{35,36}-django111-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached-test_django
+    django_contrib{,_migration}-py{27,35,36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached-test_django
     django_contrib{,_migration}-py35-django{20,21,22}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached-test_django
     django_contrib{,_migration}-py{36,37,38}-django{20,21,22,30,}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached-test_django
     django_drf_contrib-py{27,35,36}-django{111}-djangorestframework{34,37}-test_django
@@ -270,7 +269,7 @@ deps =
     consul10: python-consul>=1.0,<1.1
     consul11: python-consul>=1.1,<1.2
     ddtracerun: redis
-    test_django: pytest-django
+    test_django: pytest-django==3.10.0
     django: django
     django18: django>=1.8,<1.9
     django111: django>=1.11,<1.12


### PR DESCRIPTION
## Description
For some reason the pytest-django plugin is failing for the python 35/36 django
1.8 tests.
- https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/3059/workflows/d4cb4f16-aeaa-4c53-add2-3fc9892652cf/jobs/358261
- https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/3064/workflows/cfe60445-67b9-4b7a-a567-a8b7f0a0b3ae/jobs/358550

Let's pin pytest-django until this can be resolved.

## Checklist
- [x] ~~Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)~~
- [x] ~~Tests provided; and/or~~
- [x] ~~Description of manual testing performed and explanation is included in the code and/or PR.~~
- [x] ~~Library documentation is updated.~~
- [x] ~~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~~
