### PR TITLE
core: remove health metrics

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -1,5 +1,4 @@
 # stdlib
-import itertools
 import os
 import sys
 import threading
@@ -10,7 +9,6 @@ from .. import compat
 from .. import _worker
 from ..internal.logger import get_logger
 from ..sampler import BasePrioritySampler
-from ..settings import config
 from ..encoding import JSONEncoderV2
 from ..payload import PayloadFull
 from . import _queue
@@ -94,7 +92,6 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         filters=None,
         sampler=None,
         priority_sampler=None,
-        dogstatsd=None,
     ):
         super(AgentWriter, self).__init__(
             interval=self.QUEUE_PROCESSING_INTERVAL, exit_timeout=shutdown_timeout, name=self.__class__.__name__
@@ -106,7 +103,6 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         self._sampler = sampler
         self._priority_sampler = priority_sampler
         self._last_error_ts = 0
-        self.dogstatsd = dogstatsd
         self.api = api.API(
             hostname, port, uds_path=uds_path, https=https, priority_sampling=priority_sampler is not None
         )
@@ -129,14 +125,8 @@ class AgentWriter(_worker.PeriodicWorkerThread):
             shutdown_timeout=self.exit_timeout,
             filters=self._filters,
             priority_sampler=self._priority_sampler,
-            dogstatsd=self.dogstatsd,
         )
         return writer
-
-    @property
-    def _send_stats(self):
-        """Determine if we're sending stats or not."""
-        return bool(config.health_metrics_enabled and self.dogstatsd)
 
     def write(self, spans=None, services=None):
         # Start the AgentWriter on first write.
@@ -156,10 +146,6 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         if not traces:
             return
 
-        if self._send_stats:
-            traces_queue_length = len(traces)
-            traces_queue_spans = sum(map(len, traces))
-
         # Before sending the traces, make them go through the
         # filters
         try:
@@ -167,9 +153,6 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         except Exception:
             log.error("error while filtering traces", exc_info=True)
             return
-
-        if self._send_stats:
-            traces_filtered = len(traces) - traces_queue_length
 
         # If we have data, let's try to send it.
         traces_responses = self.api.send_traces(traces)
@@ -189,76 +172,11 @@ class AgentWriter(_worker.PeriodicWorkerThread):
                                 result_traces_json["rate_by_service"],
                             )
 
-        # Dump statistics
-        # NOTE: Do not use the buffering of dogstatsd as it's not thread-safe
-        # https://github.com/DataDog/datadogpy/issues/439
-        if self._send_stats:
-            # Statistics about the queue length, size and number of spans
-            self.dogstatsd.increment("datadog.tracer.flushes")
-            self._histogram_with_total("datadog.tracer.flush.traces", traces_queue_length)
-            self._histogram_with_total("datadog.tracer.flush.spans", traces_queue_spans)
-
-            # Statistics about the filtering
-            self._histogram_with_total("datadog.tracer.flush.traces_filtered", traces_filtered)
-
-            # Statistics about API
-            self._histogram_with_total("datadog.tracer.api.requests", len(traces_responses))
-
-            self._histogram_with_total(
-                "datadog.tracer.api.errors",
-                len(list(t for t in traces_responses if isinstance(t, Exception) and not isinstance(t, PayloadFull))),
-            )
-
-            self._histogram_with_total(
-                "datadog.tracer.api.traces_payloadfull",
-                len(list(t for t in traces_responses if isinstance(t, PayloadFull))),
-            )
-
-            for status, grouped_responses in itertools.groupby(
-                sorted((t for t in traces_responses if not isinstance(t, Exception)), key=lambda r: r.status),
-                key=lambda r: r.status,
-            ):
-                self._histogram_with_total(
-                    "datadog.tracer.api.responses", len(list(grouped_responses)), tags=["status:%d" % status]
-                )
-
-            # Statistics about the writer thread
-            if hasattr(time, "thread_time"):
-                new_thread_time = time.thread_time()
-                diff = new_thread_time - self._last_thread_time
-                self._last_thread_time = new_thread_time
-                self.dogstatsd.histogram("datadog.tracer.writer.cpu_time", diff)
-
-    def _histogram_with_total(self, name, value, tags=None):
-        """Helper to add metric as a histogram and with a `.total` counter"""
-        self.dogstatsd.histogram(name, value, tags=tags)
-        self.dogstatsd.increment("%s.total" % (name,), value, tags=tags)
-
     def run_periodic(self):
-        if self._send_stats:
-            self.dogstatsd.gauge("datadog.tracer.heartbeat", 1)
-
-        try:
-            self.flush_queue()
-        finally:
-            if not self._send_stats:
-                return
-
-            # Statistics about the rate at which spans are inserted in the queue
-            dropped, enqueued, enqueued_lengths = self._trace_queue.pop_stats()
-            self.dogstatsd.gauge("datadog.tracer.queue.max_length", self._trace_queue.maxsize)
-            self.dogstatsd.increment("datadog.tracer.queue.dropped.traces", dropped)
-            self.dogstatsd.increment("datadog.tracer.queue.enqueued.traces", enqueued)
-            self.dogstatsd.increment("datadog.tracer.queue.enqueued.spans", enqueued_lengths)
+        self.flush_queue()
 
     def on_shutdown(self):
-        try:
-            self.run_periodic()
-        finally:
-            if not self._send_stats:
-                return
-
-            self.dogstatsd.increment("datadog.tracer.shutdown")
+        self.run_periodic()
 
     def _log_error_status(self, response):
         log_level = log.debug

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -320,11 +320,7 @@ class Tracer(object):
                 filters=filters,
                 sampler=self.sampler,
                 priority_sampler=self.priority_sampler,
-                dogstatsd=self._dogstatsd_client,
             )
-
-        # HACK: since we recreated our dogstatsd agent, replace the old write one
-        self.writer.dogstatsd = self._dogstatsd_client
 
         if context_provider is not None:
             self.context_provider = context_provider

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -1,5 +1,3 @@
-import time
-
 import mock
 
 from ddtrace.span import Span
@@ -82,36 +80,22 @@ class AgentWriterTests(BaseTestCase):
     N_TRACES = 11
 
     def create_worker(
-        self, filters=None, api_class=DummyAPI, enable_stats=False, num_traces=N_TRACES, num_spans=MAX_NUM_SPANS
+        self, filters=None, api_class=DummyAPI, num_traces=N_TRACES, num_spans=MAX_NUM_SPANS
     ):
-        with self.override_global_config(dict(health_metrics_enabled=enable_stats)):
-            self.dogstatsd = mock.Mock()
-            worker = AgentWriter(dogstatsd=self.dogstatsd, filters=filters)
-            worker._STATS_EVERY_INTERVAL = 1
-            self.api = api_class()
-            worker.api = self.api
-            for i in range(num_traces):
-                worker.write(
-                    [
-                        Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None)
-                        for j in range(num_spans)
-                    ]
-                )
-            worker.stop()
-            worker.join()
-            return worker
-
-    def test_send_stats(self):
-        dogstatsd = mock.Mock()
-        worker = AgentWriter(dogstatsd=dogstatsd)
-        assert worker._send_stats is False
-        with self.override_global_config(dict(health_metrics_enabled=True)):
-            assert worker._send_stats is True
-
-        worker = AgentWriter(dogstatsd=None)
-        assert worker._send_stats is False
-        with self.override_global_config(dict(health_metrics_enabled=True)):
-            assert worker._send_stats is False
+        worker = AgentWriter(filters=filters)
+        worker._STATS_EVERY_INTERVAL = 1
+        self.api = api_class()
+        worker.api = self.api
+        for i in range(num_traces):
+            worker.write(
+                [
+                    Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None)
+                    for j in range(num_spans)
+                ]
+            )
+        worker.stop()
+        worker.join()
+        return worker
 
     def test_filters_keep_all(self):
         filtr = KeepAllFilter()
@@ -141,116 +125,6 @@ class AgentWriterTests(BaseTestCase):
         self.create_worker(filters)
         self.assertEqual(len(self.api.traces), 0)
         self.assertEqual(filtr.filtered_traces, 0)
-
-    def test_no_dogstats(self):
-        worker = self.create_worker()
-        assert worker._send_stats is False
-        assert [] == self.dogstatsd.gauge.mock_calls
-
-    def test_dogstatsd(self):
-        self.create_worker(enable_stats=True)
-        assert [
-            mock.call("datadog.tracer.heartbeat", 1),
-            mock.call("datadog.tracer.queue.max_length", 1000),
-        ] == self.dogstatsd.gauge.mock_calls
-
-        assert [
-            mock.call("datadog.tracer.flushes"),
-            mock.call("datadog.tracer.flush.traces.total", 11, tags=None),
-            mock.call("datadog.tracer.flush.spans.total", 77, tags=None),
-            mock.call("datadog.tracer.flush.traces_filtered.total", 0, tags=None),
-            mock.call("datadog.tracer.api.requests.total", 11, tags=None),
-            mock.call("datadog.tracer.api.errors.total", 0, tags=None),
-            mock.call("datadog.tracer.api.traces_payloadfull.total", 0, tags=None),
-            mock.call("datadog.tracer.api.responses.total", 11, tags=["status:200"]),
-            mock.call("datadog.tracer.queue.dropped.traces", 0),
-            mock.call("datadog.tracer.queue.enqueued.traces", 11),
-            mock.call("datadog.tracer.queue.enqueued.spans", 77),
-            mock.call("datadog.tracer.shutdown"),
-        ] == self.dogstatsd.increment.mock_calls
-
-        histogram_calls = [
-            mock.call("datadog.tracer.flush.traces", 11, tags=None),
-            mock.call("datadog.tracer.flush.spans", 77, tags=None),
-            mock.call("datadog.tracer.flush.traces_filtered", 0, tags=None),
-            mock.call("datadog.tracer.api.requests", 11, tags=None),
-            mock.call("datadog.tracer.api.errors", 0, tags=None),
-            mock.call("datadog.tracer.api.traces_payloadfull", 0, tags=None),
-            mock.call("datadog.tracer.api.responses", 11, tags=["status:200"]),
-        ]
-        if hasattr(time, "thread_time"):
-            histogram_calls.append(mock.call("datadog.tracer.writer.cpu_time", mock.ANY))
-
-        assert histogram_calls == self.dogstatsd.histogram.mock_calls
-
-    def test_dogstatsd_traces_payloadfull(self):
-        num_spans = MAX_NUM_SPANS + 1
-        self.create_worker(enable_stats=True, num_traces=1, num_spans=num_spans)
-        assert [
-            mock.call("datadog.tracer.heartbeat", 1),
-            mock.call("datadog.tracer.queue.max_length", 1000),
-        ] == self.dogstatsd.gauge.mock_calls
-
-        assert [
-            mock.call("datadog.tracer.flushes"),
-            mock.call("datadog.tracer.flush.traces.total", 1, tags=None),
-            mock.call("datadog.tracer.flush.spans.total", num_spans, tags=None),
-            mock.call("datadog.tracer.flush.traces_filtered.total", 0, tags=None),
-            mock.call("datadog.tracer.api.requests.total", 1, tags=None),
-            mock.call("datadog.tracer.api.errors.total", 0, tags=None),
-            mock.call("datadog.tracer.api.traces_payloadfull.total", 1, tags=None),
-            mock.call("datadog.tracer.queue.dropped.traces", 0),
-            mock.call("datadog.tracer.queue.enqueued.traces", 1),
-            mock.call("datadog.tracer.queue.enqueued.spans", 8),
-            mock.call("datadog.tracer.shutdown"),
-        ] == self.dogstatsd.increment.mock_calls
-
-        histogram_calls = [
-            mock.call("datadog.tracer.flush.traces", 1, tags=None),
-            mock.call("datadog.tracer.flush.spans", num_spans, tags=None),
-            mock.call("datadog.tracer.flush.traces_filtered", 0, tags=None),
-            mock.call("datadog.tracer.api.requests", 1, tags=None),
-            mock.call("datadog.tracer.api.errors", 0, tags=None),
-            mock.call("datadog.tracer.api.traces_payloadfull", 1, tags=None),
-        ]
-        if hasattr(time, "thread_time"):
-            histogram_calls.append(mock.call("datadog.tracer.writer.cpu_time", mock.ANY))
-
-        assert histogram_calls == self.dogstatsd.histogram.mock_calls
-
-    def test_dogstatsd_failing_api(self):
-        self.create_worker(api_class=FailingAPI, enable_stats=True)
-        assert [
-            mock.call("datadog.tracer.heartbeat", 1),
-            mock.call("datadog.tracer.queue.max_length", 1000),
-        ] == self.dogstatsd.gauge.mock_calls
-
-        assert [
-            mock.call("datadog.tracer.flushes"),
-            mock.call("datadog.tracer.flush.traces.total", 11, tags=None),
-            mock.call("datadog.tracer.flush.spans.total", 77, tags=None),
-            mock.call("datadog.tracer.flush.traces_filtered.total", 0, tags=None),
-            mock.call("datadog.tracer.api.requests.total", 1, tags=None),
-            mock.call("datadog.tracer.api.errors.total", 1, tags=None),
-            mock.call("datadog.tracer.api.traces_payloadfull.total", 0, tags=None),
-            mock.call("datadog.tracer.queue.dropped.traces", 0),
-            mock.call("datadog.tracer.queue.enqueued.traces", 11),
-            mock.call("datadog.tracer.queue.enqueued.spans", 77),
-            mock.call("datadog.tracer.shutdown"),
-        ] == self.dogstatsd.increment.mock_calls
-
-        histogram_calls = [
-            mock.call("datadog.tracer.flush.traces", 11, tags=None),
-            mock.call("datadog.tracer.flush.spans", 77, tags=None),
-            mock.call("datadog.tracer.flush.traces_filtered", 0, tags=None),
-            mock.call("datadog.tracer.api.requests", 1, tags=None),
-            mock.call("datadog.tracer.api.errors", 1, tags=None),
-            mock.call("datadog.tracer.api.traces_payloadfull", 0, tags=None),
-        ]
-        if hasattr(time, "thread_time"):
-            histogram_calls.append(mock.call("datadog.tracer.writer.cpu_time", mock.ANY))
-
-        assert histogram_calls == self.dogstatsd.histogram.mock_calls
 
 
 class LogWriterTests(BaseTestCase):


### PR DESCRIPTION
## Description
These are not being used and are a hindrance to refactoring the agent
writer. Something like #1143 should provide a cleaner solution to
collecting metrics like these.


## Checklist
- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
