### PR TITLE
Move changelog check to its own script

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
   pull_request:
+    # Important that we run on `labeled` and `unlabeled` to pick up `changelog/no-changelog` being added/removed
+    types: [opened, reopened, labeled, unlabeled, ready_for_review]
 jobs:
   validate:
     name: Validate changelog

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Ensure release note added
         # Only run this on pull requests
         if: github.event_name == 'pull_request'
-        run: scripts/check-releasenotes "${{github.base_ref}}" "${{github.event_path}}"
+        run: scripts/check-releasenotes
 
       - uses: actions/setup-python@v2
         name: Install Python

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,7 +5,8 @@ on:
       - master
   pull_request:
     # Important that we run on `labeled` and `unlabeled` to pick up `changelog/no-changelog` being added/removed
-    types: [opened, reopened, labeled, unlabeled, ready_for_review]
+    # DEV: [opened, reopened, synchronize] is the default
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
 jobs:
   validate:
     name: Validate changelog

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,9 +20,7 @@ jobs:
       - name: Ensure release note added
         # Only run this on pull requests
         if: github.event_name == 'pull_request'
-        run: |
-          jq -e '.pull_request?.labels[]?.name | select(. == "changelog/no-changelog")' ${{github.event_path}} \
-          || git diff origin/${{github.base_ref}}... releasenotes/notes
+        run: scripts/check-releasenotes "${{github.base_ref}}" "${{github.event_path}}"
 
       - uses: actions/setup-python@v2
         name: Install Python

--- a/scripts/check-releasenotes
+++ b/scripts/check-releasenotes
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-# scripts/check-releasenotes <base-ref> [github event path]
-BASE_REF="${1:-master}"
-GITHUB_EVENT_PATH="$2"
+# If we are running outside a GitHub action, default to `master`
+BASE_REF="${GITHUB_BASE_REF:-master}"
 
 # Print input data
 echo "Base ref: origin/${BASE_REF}"
@@ -11,7 +10,7 @@ echo "GitHub event path: ${GITHUB_EVENT_PATH}"
 echo "JQ: $(which jq)"
 
 
-# Skip if the label 'changelog/no-changelog' is on the PR
+# Skip the label check if we do not have a GitHub event path
 if [[ -f "${GITHUB_EVENT_PATH}" ]] && jq -e '.pull_request?.labels[]?.name | select(. == "changelog/no-changelog")' "${GITHUB_EVENT_PATH}";
 then
     echo "PR has label 'changelog/no-changelog', skipping validation"

--- a/scripts/check-releasenotes
+++ b/scripts/check-releasenotes
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+
+# scripts/check-releasenotes <base-ref> [github event path]
+BASE_REF="${1:-master}"
+GITHUB_EVENT_PATH="$2"
+
+# Print input data
+echo "Base ref: origin/${BASE_REF}"
+echo "GitHub event path: ${GITHUB_EVENT_PATH}"
+echo "JQ: $(which jq)"
+
+
+# Skip if the label 'changelog/no-changelog' is on the PR
+if [[ -f "${GITHUB_EVENT_PATH}" ]] && jq -e '.pull_request?.labels[]?.name | select(. == "changelog/no-changelog")' "${GITHUB_EVENT_PATH}";
+then
+    echo "PR has label 'changelog/no-changelog', skipping validation"
+    exit 0
+fi
+
+# Check if they added a new file to releasenotes/notes
+if git diff --name-only --diff-filter=A "origin/${BASE_REF}" | grep releasenotes/notes;
+then
+    echo "New release note found, success"
+    exit 0
+else
+    echo "Release note not found."
+    echo "Use 'reno new <slug>' to add a new note to 'releasenotes/notes', or add the label 'changelog/no-changelog' to skip this validation"
+    exit 1
+fi


### PR DESCRIPTION
## Description
The changelog validation workflow we introduced didn't actually block PRs that didn't have a changelog entry aded.

This is because we were checking against `git diff origin/master... releasenotes/notes`, but if you didn't add anything the command would still succeed.

The main change here is moving to `git diff --name-only --diff-filter=A origin/master... | grep releasenotes/notes` which will succeed if there was a new filed _added_ in `releasenotes/notes`, but fail if not.

We also moved this check to it's own script to help readability and to add some logging output to help analyze success/failures.


## Checklist
- [ ] ~Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)~
- [ ] ~Tests provided; and/or~
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] ~Library documentation is updated.~
- [ ] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
