### PR TITLE
ci: fix spelling

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,9 @@
 
 from datetime import datetime
 
+from docs.ext.filters import VersionTagFilter
+
+
 # append the ddtrace path to syspath
 # this is required when building the docs manually
 # import os
@@ -35,6 +38,9 @@ from datetime import datetime
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.extlinks", "reno.sphinxext", "sphinxcontrib.spelling"]
+
+# Add filters for sphinxcontrib.spelling
+spelling_filters = [VersionTagFilter]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/ext/filters.py
+++ b/docs/ext/filters.py
@@ -1,0 +1,16 @@
+import re
+
+from enchant.tokenize import Filter
+
+
+# from setuptools-scm
+# https://github.com/pypa/setuptools_scm/blob/69b88a20c5cd4632ef0c97b3ddd2bd0d3f8f7df8/src/setuptools_scm/config.py#L9
+VERSION_TAG_REGEX_STRING = r"^(?:[\w-]+-)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$"
+VERSION_TAG_REGEX = re.compile(VERSION_TAG_REGEX_STRING)
+
+
+class VersionTagFilter(Filter):
+    """If a word matches a version tag used for the repository"""
+
+    def _skip(self, word):
+        return VERSION_TAG_REGEX.match(word)


### PR DESCRIPTION
Versions with "rc" in them seem to register as spelling mistakes.

https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/3057/workflows/ab9bf51f-d338-4bff-8549-08e02d4cbcf1/jobs/358186

@majorgreys introduced this fix to solve the issue in #1714.