### PR TITLE
ci: fix deploy_master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,8 @@ commands:
     steps:
       - setup_tox
       - run: |
-          apt-get update
-          apt-get install -y --no-install-recommends libenchant-dev
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libenchant-dev
       - run: pip install awscli
       - run: tox -e docs
       - run:


### PR DESCRIPTION
## Description
Forgot to `sudo`. Tested it out this time:
https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/3130/workflows/20ef583e-b828-4b4d-9cb5-b3bb4dae8042


## Checklist
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
