### PR TITLE
fix: snapshot decorator for pytest fixtures

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -831,6 +831,10 @@ def snapshot(ignores=None, tracer=ddtrace.tracer):
 
         conn = httplib.HTTPConnection(tracer.writer.api.hostname, tracer.writer.api.port)
         try:
+            # clear queue in case traces have been generated before test case is
+            # itself run
+            tracer.writer.flush_queue()
+
             # Signal the start of this test case to the test agent.
             try:
                 conn.request("GET", "/test/start?token=%s" % token)


### PR DESCRIPTION
## Description

In using `snapshot` decorator with pytest tests with fixtures, a `TypeError` error is raised. This is due to a known limitation of `functools.wraps` with Python 2.7 and pytest: https://github.com/pytest-dev/pytest/issues/2782. This fix uses `wrapt.decorator` instead.


## Checklist
- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
