### PR TITLE
tests: handle failing trace flushes

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -802,10 +802,6 @@ class SnapshotFailed(Exception):
     pass
 
 
-class SnapshotUnexpectedError(Exception):
-    pass
-
-
 def snapshot(ignores=None, tracer=ddtrace.tracer, variants=None):
     """Performs a snapshot integration test with the testing agent.
 


### PR DESCRIPTION
If flushing the queue fails then the closing request to the test agent will not
be sent which leaves the test token active in the test agent.

This makes sure that the test agent always gets the final request.
