### PR TITLE
chore: add variants for snapshot tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -802,7 +802,7 @@ class SnapshotFailed(Exception):
     pass
 
 
-def snapshot(ignores=None, tracer=ddtrace.tracer):
+def snapshot(ignores=None, tracer=ddtrace.tracer, variants=None):
     """Performs a snapshot integration test with the testing agent.
 
     All traces sent to the agent will be recorded and compared to a snapshot
@@ -828,6 +828,14 @@ def snapshot(ignores=None, tracer=ddtrace.tracer):
         # Use the fully qualified function name as a unique test token to
         # identify the snapshot.
         token = "{}{}{}.{}".format(module.__name__, "." if clsname else "", clsname, wrapped.__name__)
+
+        # Use variant that applies to update test token. One must apply. If none
+        # apply, the test should have been marked as skipped.
+        if variants:
+            applicable_variant_ids = [k for (k, v) in variants.items() if v is True]
+            assert len(applicable_variant_ids) == 1
+            variant_id = applicable_variant_ids[0]
+            token = "{}_{}".format(token, variant_id) if variant_id else token
 
         conn = httplib.HTTPConnection(tracer.writer.api.hostname, tracer.writer.api.port)
         try:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -832,7 +832,7 @@ def snapshot(ignores=None, tracer=ddtrace.tracer, variants=None):
         # Use variant that applies to update test token. One must apply. If none
         # apply, the test should have been marked as skipped.
         if variants:
-            applicable_variant_ids = [k for (k, v) in variants.items() if v is True]
+            applicable_variant_ids = [k for (k, v) in variants.items() if v]
             assert len(applicable_variant_ids) == 1
             variant_id = applicable_variant_ids[0]
             token = "{}_{}".format(token, variant_id) if variant_id else token

--- a/tests/contrib/django/test_django_snapshots.py
+++ b/tests/contrib/django/test_django_snapshots.py
@@ -4,18 +4,8 @@ import pytest
 from tests import snapshot
 
 
-@pytest.mark.skipif(not (django.VERSION > (2, 0) and django.VERSION < (2, 2)), reason="")
-@snapshot()
-def test_urlpatterns_include_21x(client):
-    """
-    When a view is specified using `django.urls.include`
-        The view is traced
-    """
-    assert client.get("/include/test/").status_code == 200
-
-
-@pytest.mark.skipif(django.VERSION < (2, 2), reason="")
-@snapshot()
+@pytest.mark.skipif(django.VERSION < (2, 0), reason="")
+@snapshot(variants={"21x": django.VERSION >= (2, 0) and django.VERSION < (2, 2), "": django.VERSION >= (2, 2)})
 def test_urlpatterns_include(client):
     """
     When a view is specified using `django.urls.include`
@@ -24,57 +14,27 @@ def test_urlpatterns_include(client):
     assert client.get("/include/test/").status_code == 200
 
 
-@pytest.mark.skipif(django.VERSION >= (1, 9), reason="")
-@snapshot()
-def test_middleware_trace_callable_view_18x(client):
-    # ensures that the internals are properly traced when using callable views
-    assert client.get("/feed-view/").status_code == 200
-
-
-@pytest.mark.skipif(not (django.VERSION >= (1, 9) and django.VERSION < (1, 12)), reason="")
-@snapshot()
-def test_middleware_trace_callable_view_111x(client):
-    # ensures that the internals are properly traced when using callable views
-    assert client.get("/feed-view/").status_code == 200
-
-
-@pytest.mark.skipif(not (django.VERSION > (1, 12) and django.VERSION < (2, 2)), reason="")
-@snapshot()
-def test_middleware_trace_callable_view_21x(client):
-    # ensures that the internals are properly traced when using callable views
-    assert client.get("/feed-view/").status_code == 200
-
-
-@pytest.mark.skipif(django.VERSION < (2, 2), reason="")
-@snapshot()
+@snapshot(
+    variants={
+        "18x": django.VERSION < (1, 9),
+        "111x": django.VERSION >= (1, 9) and django.VERSION < (1, 12),
+        "21x": django.VERSION > (1, 12) and django.VERSION < (2, 2),
+        "": django.VERSION >= (2, 2),
+    }
+)
 def test_middleware_trace_callable_view(client):
     # ensures that the internals are properly traced when using callable views
     assert client.get("/feed-view/").status_code == 200
 
 
-@pytest.mark.skipif(django.VERSION >= (1, 9), reason="")
-@snapshot()
-def test_middleware_trace_partial_based_view_18x(client):
-    # ensures that the internals are properly traced when using a function views
-    assert client.get("/partial-view/").status_code == 200
-
-
-@pytest.mark.skipif(not (django.VERSION >= (1, 9) and django.VERSION < (1, 12)), reason="")
-@snapshot()
-def test_middleware_trace_partial_based_view_111x(client):
-    # ensures that the internals are properly traced when using a function views
-    assert client.get("/partial-view/").status_code == 200
-
-
-@pytest.mark.skipif(not (django.VERSION > (1, 12) and django.VERSION < (2, 2)), reason="")
-@snapshot()
-def test_middleware_trace_partial_based_view_21x(client):
-    # ensures that the internals are properly traced when using a function views
-    assert client.get("/partial-view/").status_code == 200
-
-
-@pytest.mark.skipif(django.VERSION < (2, 2), reason="")
-@snapshot()
+@snapshot(
+    variants={
+        "18x": django.VERSION < (1, 9),
+        "111x": django.VERSION >= (1, 9) and django.VERSION < (1, 12),
+        "21x": django.VERSION > (1, 12) and django.VERSION < (2, 2),
+        "": django.VERSION >= (2, 2),
+    }
+)
 def test_middleware_trace_partial_based_view(client):
     # ensures that the internals are properly traced when using a function views
     assert client.get("/partial-view/").status_code == 200

--- a/tests/contrib/django/test_django_snapshots.py
+++ b/tests/contrib/django/test_django_snapshots.py
@@ -30,7 +30,7 @@ def test_middleware_trace_callable_view(client):
 @snapshot(
     variants={
         "18x": django.VERSION < (1, 9),
-    "111x": (1, 9) <= django.VERSION < (1, 12),
+        "111x": (1, 9) <= django.VERSION < (1, 12),
         "21x": (1, 12) < django.VERSION < (2, 2),
         "": django.VERSION >= (2, 2),
     }

--- a/tests/contrib/django/test_django_snapshots.py
+++ b/tests/contrib/django/test_django_snapshots.py
@@ -5,7 +5,7 @@ from tests import snapshot
 
 
 @pytest.mark.skipif(django.VERSION < (2, 0), reason="")
-@snapshot(variants={"21x": django.VERSION >= (2, 0) and django.VERSION < (2, 2), "": django.VERSION >= (2, 2)})
+@snapshot(variants={"21x": (2, 0) <= django.VERSION < (2, 2), "": django.VERSION >= (2, 2)})
 def test_urlpatterns_include(client):
     """
     When a view is specified using `django.urls.include`
@@ -17,8 +17,8 @@ def test_urlpatterns_include(client):
 @snapshot(
     variants={
         "18x": django.VERSION < (1, 9),
-        "111x": django.VERSION >= (1, 9) and django.VERSION < (1, 12),
-        "21x": django.VERSION > (1, 12) and django.VERSION < (2, 2),
+        "111x": (1, 9) <= django.VERSION < (1, 12),
+        "21x": (1, 12) < django.VERSION < (2, 2),
         "": django.VERSION >= (2, 2),
     }
 )
@@ -30,8 +30,8 @@ def test_middleware_trace_callable_view(client):
 @snapshot(
     variants={
         "18x": django.VERSION < (1, 9),
-        "111x": django.VERSION >= (1, 9) and django.VERSION < (1, 12),
-        "21x": django.VERSION > (1, 12) and django.VERSION < (2, 2),
+    "111x": (1, 9) <= django.VERSION < (1, 12),
+        "21x": (1, 12) < django.VERSION < (2, 2),
         "": django.VERSION >= (2, 2),
     }
 )


### PR DESCRIPTION
## Description

The motivation for this PR is to simplify the way snapshot tests are written for different runs. The use case here is for when a test run produces a different trace depending on the version of a library being used. We currently have to use cumbersome `skipif` clauses alongside multiple versions of the same test function.

## Checklist
- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
