### PR TITLE
dogpile: safe-guard current_span

### DIFF
--- a/ddtrace/contrib/dogpile_cache/lock.py
+++ b/ddtrace/contrib/dogpile_cache/lock.py
@@ -32,6 +32,7 @@ def _wrap_lock_ctor(func, instance, args, kwargs):
             # should really be false (ie. if any are 'negative', then the tag value
             # should be). This means ANDing all hit values and ORing all expired values.
             span = pin.tracer.current_span()
-            span.set_tag('hit', asbool(span.get_tag('hit') or 'True') and hit)
-            span.set_tag('expired', asbool(span.get_tag('expired') or 'False') or expired)
+            if span:
+                span.set_tag('hit', asbool(span.get_tag('hit') or 'True') and hit)
+                span.set_tag('expired', asbool(span.get_tag('expired') or 'False') or expired)
     instance.value_and_created_fn = wrapped_backend_fetcher


### PR DESCRIPTION
## Description
`tracer.current_span()` can potentially return None. This adds a check to make
sure that we won't get a NoneType error.


## Checklist
- [x] ~Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)~
- [x] ~Tests provided; and/or~
- [x] ~Description of manual testing performed and explanation is included in the code and/or PR.~
- [x] ~Library documentation is updated.~
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
