### PR TITLE
chore: use riot for django tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,21 +115,40 @@ commands:
       wait:
         type: string
         default: ""
+      snapshot:
+        type: boolean
+        default: false
+      docker_services:
+        type: string
+        default: ""
     steps:
       - attach_workspace:
           at: .
       - checkout
-      - run: pip3 install riot
       - when:
           condition:
-            << parameters.wait >>
+              << parameters.snapshot >>
           steps:
+            - run: SNAPSHOT_CI=1 docker-compose up -d testagent << parameters.docker_services >>
             - run:
-                name: "Waiting for << parameters.wait >>"
-                command: pip install tox && tox -e 'wait' << parameters.wait >>
-      - run:
-          name: "Running tests matching '<< parameters.pattern >>'"
-          command: "echo -p2.7,-p3.5,-p3.6,-p3.7,-p3.8,-p3.9 | tr ',' '\n' | circleci tests split | xargs riot -v run -s '<< parameters.pattern >>'"
+                command: docker-compose logs -f
+                background: true
+            - run:
+                command: "echo -p2.7,-p3.5,-p3.6,-p3.7,-p3.8,-p3.9 | tr ',' '\n' | circleci tests split | xargs ./scripts/ddtest riot -v run -s '<< parameters.pattern >>'"
+      - unless:
+          condition:
+              << parameters.snapshot >>
+          steps:
+            - run: pip3 install riot
+            - when:
+                condition:
+                  << parameters.wait >>
+                steps:
+                  - run:
+                      name: "Waiting for << parameters.wait >>"
+                      command: pip install tox && tox -e 'wait' << parameters.wait >>
+                  - run:
+                      command: "echo -p2.7,-p3.5,-p3.6,-p3.7,-p3.8,-p3.9 | tr ',' '\n' | circleci tests split | xargs riot -v run -s '<< parameters.pattern >>'"
 
   run_tox_scenario:
     description: "Run scripts/run-tox-scenario with setup, caching and persistence"
@@ -490,31 +509,21 @@ jobs:
 
   django:
     <<: *machine_executor
-    parallelism: 4
+    parallelism: 6
     steps:
-      - attach_workspace:
-          at: .
-      - checkout
-      - run: SNAPSHOT_CI=1 docker-compose up -d memcached redis testagent
-      - run:
-          command: docker-compose logs -f
-          background: true
-      - run:
-          command: "./scripts/ddtest riot -v run -s 'django$'"
+      - run_test:
+          pattern: 'django$'
+          snapshot: true
+          docker_services: "memcached redis"
 
   djangorestframework:
     <<: *machine_executor
-    parallelism: 4
+    parallelism: 6
     steps:
-      - attach_workspace:
-          at: .
-      - checkout
-      - run: SNAPSHOT_CI=1 docker-compose up -d memcached redis testagent
-      - run:
-          command: docker-compose logs -f
-          background: true
-      - run:
-          command: "./scripts/ddtest riot -v run -s 'djangorestframework'"
+      - run_test:
+          pattern: 'djangorestframework'
+          snapshot: true
+          docker_services: "memcached redis"
 
   flask:
     <<: *contrib_job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,24 +494,28 @@ jobs:
   django:
     <<: *machine_executor
     steps:
+      - attach_workspace:
+          at: .
       - checkout
       - run: SNAPSHOT_CI=1 docker-compose up -d memcached redis testagent
       - run:
           command: docker-compose logs -f
           background: true
       - run:
-          command: ./scripts/ddtest scripts/run-tox-scenario '^django_contrib-'
+          command: "./scripts/ddtest riot -v run -s 'django$'"
 
   djangorestframework:
-    executor: ddtrace_dev
-    docker:
-      - image: *ddtrace_dev_image
-      - image: *redis_image
-      - image: *memcached_image
-      - *datadog_agent
+    <<: *machine_executor
     steps:
-      - run_tox_scenario:
-          pattern: '^django_drf_contrib'
+      - attach_workspace:
+          at: .
+      - checkout
+      - run: SNAPSHOT_CI=1 docker-compose up -d memcached redis testagent
+      - run:
+          command: docker-compose logs -f
+          background: true
+      - run:
+          command: "./scripts/ddtest riot -v run -s 'djangorestframework'"
 
   flask:
     executor: ddtrace_dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,26 +108,26 @@ services:
             - TEST_DATADOG_INTEGRATION=1
             - TEST_DATADOG_INTEGRATION_UDS=1
         network_mode: host
-        working_dir: /src
+        working_dir: /root/project/
         volumes:
             - ddagent:/tmp/ddagent
             # DEV: Make ddtrace rw so setup.py can build C-extensions
-            - ./ddtrace:/src/ddtrace:rw
-            - ./tests:/src/tests:ro
-            - ./setup.cfg:/src/setup.cfg:ro
-            - ./setup.py:/src/setup.py:ro
-            - ./conftest.py:/src/conftest.py:ro
-            - ./tox.ini:/src/tox.ini:ro
-            - ./riotfile.py:/src/riotfile.py:ro
-            - ./docs:/src/docs:rw
-            - ./pyproject.toml:/src/pyproject.toml:ro
-            - ./.riot:/src/.riot
-            - ./.ddtox:/src/.tox
-            - ./scripts:/src/scripts
+            - ./ddtrace:/root/project/ddtrace:rw
+            - ./tests:/root/project/tests:ro
+            - ./setup.cfg:/root/project/setup.cfg:ro
+            - ./setup.py:/root/project/setup.py:ro
+            - ./conftest.py:/root/project/conftest.py:ro
+            - ./tox.ini:/root/project/tox.ini:ro
+            - ./riotfile.py:/root/project/riotfile.py:ro
+            - ./docs:/root/project/docs:rw
+            - ./pyproject.toml:/root/project/pyproject.toml:ro
+            - ./.riot:/root/project/.riot
+            - ./.ddtox:/root/project/.tox
+            - ./scripts:/root/project/scripts
             # setuptools_scm needs `.git` to figure out what version we are on
             # DEV: We could use `SETUPTOOLS_SCM_PRETEND_VERSION` but prefer `.git`
             #      to get the same behavior as during releases
-            - ./.git:/src/.git:ro
+            - ./.git:/root/project/.git:ro
         command: bash
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,8 +118,10 @@ services:
             - ./setup.py:/src/setup.py:ro
             - ./conftest.py:/src/conftest.py:ro
             - ./tox.ini:/src/tox.ini:ro
+            - ./riotfile.py:/src/riotfile.py:ro
             - ./docs:/src/docs:rw
             - ./pyproject.toml:/src/pyproject.toml:ro
+            - ./.riot:/src/.riot
             - ./.ddtox:/src/.tox
             - ./scripts:/src/scripts
             # setuptools_scm needs `.git` to figure out what version we are on

--- a/riotfile.py
+++ b/riotfile.py
@@ -2,6 +2,7 @@ from riot import Suite, Case
 
 global_deps = [
     "mock",
+    "opentracing",
     "pytest<4",
     "opentracing",
 ]
@@ -111,6 +112,130 @@ suites = [
                         ],
                     ),
                     ("mongoengine", [""]),
+                ],
+            ),
+        ],
+    ),
+    # Django  Python version support
+    # 1.11    2.7, 3.4, 3.5, 3.6, 3.7 (added in 1.11.17)
+    # 2.0     3.4, 3.5, 3.6, 3.7
+    # 2.1     3.5, 3.6, 3.7
+    # 2.2     3.5, 3.6, 3.7, 3.8 (added in 2.2.8)
+    # 3.0     3.6, 3.7, 3.8
+    # 3.1     3.6, 3.7, 3.8
+    # Source: https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
+    Suite(
+        name="django",
+        command='pytest tests/contrib/django',
+        cases=[
+            Case(
+                pys=[2.7, 3.5, 3.6],
+                pkgs=[
+                    ("django", [">=1.8,<1.9", ">=1.11,<1.12"]),
+                    ("django-pylibmc", [">=0.6,<0.7"]),
+                    ("django-redis", [">=4.5,<4.6"]),
+                    ("pylibmc", [""]),
+                    ("pytest-django", ["==3.10.0"]),
+                    ("python-memcached", [""]),
+                    ("redis", [">=2.10,<2.11"]),
+                ],
+            ),
+            Case(
+                pys=[3.5],
+                pkgs=[
+                    ("django", [">=2.0,<2.1", ">=2.1,<2.2", ">=2.2,<2.3"]),
+                    ("django-pylibmc", [">=0.6,<0.7"]),
+                    ("django-redis", [">=4.5,<4.6"]),
+                    ("pylibmc", [""]),
+                    ("pytest-django", ["==3.10.0"]),
+                    ("python-memcached", [""]),
+                    ("redis", [">=2.10,<2.11"]),
+                ],
+            ),
+            Case(
+                pys=[3.6, 3.7, 3.8],
+                pkgs=[
+                    (
+                        "django",
+                        [">=2.0,<2.1", ">=2.1,<2.2", ">=2.2,<2.3", ">=3.0,<3.1", ""],
+                    ),
+                    ("django-pylibmc", [">=0.6,<0.7"]),
+                    ("django-redis", [">=4.5,<4.6"]),
+                    ("pylibmc", [""]),
+                    ("pytest-django", ["==3.10.0"]),
+                    ("python-memcached", [""]),
+                    ("redis", [">=2.10,<2.11"]),
+                ],
+            ),
+            Case(
+                pys=[2.7, 3.5, 3.6],
+                env=[("TEST_DATADOG_DJANGO_MIGRATION", "1")],
+                pkgs=[
+                    ("pytest-django", ["==3.10.0"]),
+                    (
+                        "django",
+                        [">=1.8,<1.9", ">=1.11,<1.12"],
+                    ),
+                ],
+            ),
+            Case(
+                pys=[3.5],
+                env=[("TEST_DATADOG_DJANGO_MIGRATION", "1")],
+                pkgs=[
+                    ("pytest-django", ["==3.10.0"]),
+                    (
+                        "django",
+                        [">=2.0,<2.1", ">=2.1,<2.2", ">=2.2,<2.3"],
+                    ),
+                ],
+            ),
+            Case(
+                pys=[3.6, 3.7, 3.8],
+                env=[("TEST_DATADOG_DJANGO_MIGRATION", "1")],
+                pkgs=[
+                    ("pytest-django", ["==3.10.0"]),
+                    (
+                        "django",
+                        [">=2.0,<2.1", ">=2.1,<2.2", ">=2.2,<2.3", ">=3.0,<3.1", ""],
+                    ),
+                ],
+            ),
+        ],
+    ),
+    Suite(
+        name="djangorestframework",
+        command="pytest tests/contrib/djangorestframework",
+        cases=[
+            Case(
+                pys=[2.7, 3.5, 3.6],
+                pkgs=[
+                    ("django", ["==1.11"]),
+                    ("djangorestframework", [">=3.4,<3.5", ">=3.7,<3.8"]),
+                    ("pytest-django", ["==3.10.0"]),
+                ],
+            ),
+            Case(
+                pys=[3.5, 3.6, 3.7],
+                pkgs=[
+                    ("django", [">=2.2,<2.3"]),
+                    ("djangorestframework", [">=3.8,<3.9", ">=3.9,<3.10", ""]),
+                    ("pytest-django", ["==3.10.0"]),
+                ],
+            ),
+            Case(
+                pys=[3.6, 3.7, 3.8],
+                pkgs=[
+                    ("django", [">=3.0,<3.1"]),
+                    ("djangorestframework", [">=3.10,<3.11"]),
+                    ("pytest-django", ["==3.10.0"]),
+                ],
+            ),
+            Case(
+                pys=[3.6, 3.7, 3.8],
+                pkgs=[
+                    ("django", [""]),
+                    ("djangorestframework", [">=3.11,<3.12"]),
+                    ("pytest-django", ["==3.10.0"]),
                 ],
             ),
         ],

--- a/riotfile.py
+++ b/riotfile.py
@@ -4,7 +4,6 @@ global_deps = [
     "mock",
     "opentracing",
     "pytest<4",
-    "opentracing",
 ]
 
 global_env = [("PYTEST_ADDOPTS", "--color=yes")]

--- a/tests/contrib/django/test_django_snapshots.py
+++ b/tests/contrib/django/test_django_snapshots.py
@@ -1,7 +1,11 @@
+import os
+
 import django
 import pytest
 
 from tests import snapshot
+
+pytestmark = pytest.mark.skipif("TEST_DATADOG_DJANGO_MIGRATION" in os.environ, reason="test only without migration")
 
 
 @pytest.mark.skipif(django.VERSION < (2, 0), reason="")

--- a/tox.ini
+++ b/tox.ini
@@ -59,22 +59,6 @@ envlist =
     celery_contrib-py{27,35,36,37,38,39}-celery43-redis32-kombu44
     consul_contrib-py{27,35,36,37,38,39}-consul{07,10,11,}
     dbapi_contrib-py{27,35,36,37,38,39}
-# Django  Python version support
-# 1.11  2.7, 3.4, 3.5, 3.6, 3.7 (added in 1.11.17)
-# 2.0   3.4, 3.5, 3.6, 3.7
-# 2.1   3.5, 3.6, 3.7
-# 2.2   3.5, 3.6, 3.7, 3.8 (added in 2.2.8)
-# 3.0   3.6, 3.7, 3.8
-# 3.1   3.6, 3.7, 3.8
-# Source: https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
-    django_contrib{,_migration}-py{27,35,36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached-test_django
-    django_contrib{,_migration}-py35-django{20,21,22}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached-test_django
-    django_contrib{,_migration}-py{36,37,38,39}-django{20,21,22,30,}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached-test_django
-    django_drf_contrib-py{27,35,36}-django{111}-djangorestframework{34,37}-test_django
-    django_drf_contrib-py35-django{22}-djangorestframework{38,310,}-test_django
-    django_drf_contrib-py{36,37}-django{22}-djangorestframework{38,310,}-test_django
-    django_drf_contrib-py{36,37,38,39}-django30-djangorestframework310-test_django
-    django_drf_contrib-py{36,37,38,39}-django-djangorestframework311-test_django
     dogpile_contrib-py{27,35}-dogpilecache{06,07,08,09}
     dogpile_contrib-py{36,37,38,39}-dogpilecache{06,07,08,09,10,}
     elasticsearch_contrib-{py27,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63,64}
@@ -159,8 +143,6 @@ usedevelop = true
 
 setenv =
     profile-gevent: DD_PROFILE_TEST_GEVENT=1
-    # DEV: envs to test migration of django instrumentation to ddtrace config api
-    django_contrib_migration: TEST_DATADOG_DJANGO_MIGRATION=1
     bottle_contrib_autopatch: DATADOG_SERVICE_NAME=bottle-app
     flask_contrib_autopatch: DATADOG_SERVICE_NAME=test.flask.service
     flask_contrib_autopatch: DATADOG_PATCH_MODULES=jinja2:false
@@ -261,23 +243,6 @@ deps =
     consul10: python-consul>=1.0,<1.1
     consul11: python-consul>=1.1,<1.2
     ddtracerun: redis
-    test_django: pytest-django==3.10.0
-    django: django
-    django18: django>=1.8,<1.9
-    django111: django>=1.11,<1.12
-    django20: django>=2.0,<2.1
-    django21: django>=2.1,<2.2
-    django22: django>=2.2,<2.3
-    django30: django>=3.0,<3.1
-    djangopylibmc06: django-pylibmc>=0.6,<0.7
-    djangoredis45: django-redis>=4.5,<4.6
-    djangorestframework: djangorestframework
-    djangorestframework34: djangorestframework>=3.4,<3.5
-    djangorestframework37: djangorestframework>=3.7,<3.8
-    djangorestframework38: djangorestframework>=3.8,<3.9
-    djangorestframework39: djangorestframework>=3.9,<3.10
-    djangorestframework310: djangorestframework>=3.10,<3.11
-    djangorestframework311: djangorestframework>=3.11,<3.12
     dogpilecache: dogpile.cache
     dogpilecache06: dogpile.cache==0.6.*
     dogpilecache07: dogpile.cache==0.7.*
@@ -503,9 +468,6 @@ commands =
     celery_contrib: pytest {posargs} tests/contrib/celery
     consul_contrib: pytest {posargs} tests/contrib/consul
     dbapi_contrib: pytest {posargs} tests/contrib/dbapi
-    django_contrib: pytest {posargs} tests/contrib/django
-    django_contrib_migration: pytest {posargs} tests/contrib/django
-    django_drf_contrib: pytest {posargs} tests/contrib/djangorestframework
     dogpile_contrib: pytest {posargs} tests/contrib/dogpile_cache
     elasticsearch_contrib: pytest {posargs} tests/contrib/elasticsearch
     falcon_contrib: pytest {posargs} tests/contrib/falcon/test_middleware.py tests/contrib/falcon/test_distributed_tracing.py


### PR DESCRIPTION
## Description

Replaces tox with riot for django tests.

Also re-enables migration tests which were mistakenly missed with changes in #1744 with filter on `^django_contrib-` rather than `^django_contrib` which would capture `django_contrib_migration`. 

Total duration of the django CI job goes down from 26 minutes to 11 minutes (before parallelism) and 10 mins to 5 mins (after parallelism).

List of tox envs (=69):

```
$ tox -l | grep django
django_contrib-py27-django18-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py27-django111-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py35-django18-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py35-django111-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py36-django18-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py36-django111-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py27-django18-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py27-django111-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py35-django18-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py35-django111-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py36-django18-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py36-django111-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py35-django20-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py35-django21-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py35-django22-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py35-django20-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py35-django21-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py35-django22-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py36-django20-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py36-django21-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py36-django22-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py36-django30-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py36-django-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py37-django20-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py37-django21-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py37-django22-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py37-django30-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py37-django-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py38-django20-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py38-django21-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py38-django22-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py38-django30-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib-py38-django-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py36-django20-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py36-django21-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py36-django22-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py36-django30-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py36-django-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py37-django20-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py37-django21-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py37-django22-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py37-django30-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py37-django-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py38-django20-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py38-django21-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py38-django22-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py38-django30-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_contrib_migration-py38-django-djangopylibmc06-djangoredis45-pylibmc-redis210-memcached-test_django
django_drf_contrib-py27-django111-djangorestframework34-test_django
django_drf_contrib-py27-django111-djangorestframework37-test_django
django_drf_contrib-py35-django111-djangorestframework34-test_django
django_drf_contrib-py35-django111-djangorestframework37-test_django
django_drf_contrib-py36-django111-djangorestframework34-test_django
django_drf_contrib-py36-django111-djangorestframework37-test_django
django_drf_contrib-py35-django22-djangorestframework38-test_django
django_drf_contrib-py35-django22-djangorestframework310-test_django
django_drf_contrib-py35-django22-djangorestframework-test_django
django_drf_contrib-py36-django22-djangorestframework38-test_django
django_drf_contrib-py36-django22-djangorestframework310-test_django
django_drf_contrib-py36-django22-djangorestframework-test_django
django_drf_contrib-py37-django22-djangorestframework38-test_django
django_drf_contrib-py37-django22-djangorestframework310-test_django
django_drf_contrib-py37-django22-djangorestframework-test_django
django_drf_contrib-py36-django30-djangorestframework310-test_django
django_drf_contrib-py37-django30-djangorestframework310-test_django
django_drf_contrib-py38-django30-djangorestframework310-test_django
django_drf_contrib-py36-django-djangorestframework311-test_django
django_drf_contrib-py37-django-djangorestframework311-test_django
django_drf_contrib-py38-django-djangorestframework311-test_django
```

List of riot cases (=69):

```
$ riot list | grep "django"
  Python 2.7 'django>=1.8,<1.9' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 2.7 'django>=1.11,<1.12' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.5 'django>=1.8,<1.9' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.5 'django>=1.11,<1.12' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.6 'django>=1.8,<1.9' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.6 'django>=1.11,<1.12' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.5 'django>=2.0,<2.1' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.5 'django>=2.1,<2.2' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.5 'django>=2.2,<2.3' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.6 'django>=2.0,<2.1' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.6 'django>=2.1,<2.2' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.6 'django>=2.2,<2.3' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.6 'django>=3.0,<3.1' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.6 'django' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.7 'django>=2.0,<2.1' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.7 'django>=2.1,<2.2' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.7 'django>=2.2,<2.3' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.7 'django>=3.0,<3.1' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.7 'django' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.8 'django>=2.0,<2.1' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.8 'django>=2.1,<2.2' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.8 'django>=2.2,<2.3' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.8 'django>=3.0,<3.1' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
  Python 3.8 'django' 'django-pylibmc>=0.6,<0.7' 'django-redis>=4.5,<4.6' 'pylibmc' 'pytest-django==3.10.0' 'python-memcached' 'redis>=2.10,<2.11'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 2.7 'pytest-django==3.10.0' 'django>=1.8,<1.9'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 2.7 'pytest-django==3.10.0' 'django>=1.11,<1.12'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.5 'pytest-django==3.10.0' 'django>=1.8,<1.9'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.5 'pytest-django==3.10.0' 'django>=1.11,<1.12'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.6 'pytest-django==3.10.0' 'django>=1.8,<1.9'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.6 'pytest-django==3.10.0' 'django>=1.11,<1.12'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.5 'pytest-django==3.10.0' 'django>=2.0,<2.1'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.5 'pytest-django==3.10.0' 'django>=2.1,<2.2'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.5 'pytest-django==3.10.0' 'django>=2.2,<2.3'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.6 'pytest-django==3.10.0' 'django>=2.0,<2.1'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.6 'pytest-django==3.10.0' 'django>=2.1,<2.2'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.6 'pytest-django==3.10.0' 'django>=2.2,<2.3'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.6 'pytest-django==3.10.0' 'django>=3.0,<3.1'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.6 'pytest-django==3.10.0' 'django'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.7 'pytest-django==3.10.0' 'django>=2.0,<2.1'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.7 'pytest-django==3.10.0' 'django>=2.1,<2.2'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.7 'pytest-django==3.10.0' 'django>=2.2,<2.3'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.7 'pytest-django==3.10.0' 'django>=3.0,<3.1'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.7 'pytest-django==3.10.0' 'django'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.8 'pytest-django==3.10.0' 'django>=2.0,<2.1'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.8 'pytest-django==3.10.0' 'django>=2.1,<2.2'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.8 'pytest-django==3.10.0' 'django>=2.2,<2.3'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.8 'pytest-django==3.10.0' 'django>=3.0,<3.1'
 TEST_DATADOG_DJANGO_MIGRATION=1 Python 3.8 'pytest-django==3.10.0' 'django'
djangorestframework:
  Python 2.7 'django==1.11' 'djangorestframework>=3.4,<3.5' 'pytest-django==3.10.0'
  Python 2.7 'django==1.11' 'djangorestframework>=3.7,<3.8' 'pytest-django==3.10.0'
  Python 3.5 'django==1.11' 'djangorestframework>=3.4,<3.5' 'pytest-django==3.10.0'
  Python 3.5 'django==1.11' 'djangorestframework>=3.7,<3.8' 'pytest-django==3.10.0'
  Python 3.6 'django==1.11' 'djangorestframework>=3.4,<3.5' 'pytest-django==3.10.0'
  Python 3.6 'django==1.11' 'djangorestframework>=3.7,<3.8' 'pytest-django==3.10.0'
  Python 3.5 'django>=2.2,<2.3' 'djangorestframework>=3.8,<3.9' 'pytest-django==3.10.0'
  Python 3.5 'django>=2.2,<2.3' 'djangorestframework>=3.9,<3.10' 'pytest-django==3.10.0'
  Python 3.5 'django>=2.2,<2.3' 'djangorestframework' 'pytest-django==3.10.0'
  Python 3.6 'django>=2.2,<2.3' 'djangorestframework>=3.8,<3.9' 'pytest-django==3.10.0'
  Python 3.6 'django>=2.2,<2.3' 'djangorestframework>=3.9,<3.10' 'pytest-django==3.10.0'
  Python 3.6 'django>=2.2,<2.3' 'djangorestframework' 'pytest-django==3.10.0'
  Python 3.7 'django>=2.2,<2.3' 'djangorestframework>=3.8,<3.9' 'pytest-django==3.10.0'
  Python 3.7 'django>=2.2,<2.3' 'djangorestframework>=3.9,<3.10' 'pytest-django==3.10.0'
  Python 3.7 'django>=2.2,<2.3' 'djangorestframework' 'pytest-django==3.10.0'
  Python 3.6 'django>=3.0,<3.1' 'djangorestframework>=3.10,<3.11' 'pytest-django==3.10.0'
  Python 3.7 'django>=3.0,<3.1' 'djangorestframework>=3.10,<3.11' 'pytest-django==3.10.0'
  Python 3.8 'django>=3.0,<3.1' 'djangorestframework>=3.10,<3.11' 'pytest-django==3.10.0'
  Python 3.6 'django' 'djangorestframework>=3.11,<3.12' 'pytest-django==3.10.0'
  Python 3.7 'django' 'djangorestframework>=3.11,<3.12' 'pytest-django==3.10.0'
  Python 3.8 'django' 'djangorestframework>=3.11,<3.12' 'pytest-django==3.10.0'
```

## Checklist
- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
