### PR TITLE
readthedocs: update python version, don't fail on warning

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,10 +3,10 @@ version: 2
 sphinx:
   builder: html
   configuration: docs/conf.py
-  fail_on_warning: true
+  fail_on_warning: false
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: setuptools


### PR DESCRIPTION
Note that the failing doc build should be resolved as of October 31:
https://github.com/readthedocs/readthedocs.org/issues/7605#issuecomment-717900199
