### PR TITLE
ci: fix deploy_master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,12 +53,8 @@ commands:
         type: string
         default: *s3_bucket
     steps:
-      - setup_tox
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libenchant-dev
+      - build_docs
       - run: pip install awscli
-      - run: tox -e docs
       - run:
           name: Release docs
           command: aws s3 cp --recursive docs/_build/html/ "s3://<< parameters.s3_bucket >>/<< parameters.s3_dir >>/docs/"
@@ -162,6 +158,14 @@ commands:
       - run:
           name: Run test build
           command: .circleci/scripts/test_build.sh
+
+  build_docs:
+    steps:
+      - setup_tox
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libenchant-dev
+      - run: tox -e docs
 
 executors:
   cimg_base:
@@ -814,11 +818,11 @@ jobs:
 
   build_docs:
     # deploy official documentation
-    executor: ddtrace_dev
+    <<: *machine_executor
     steps:
       - checkout
-      - setup_tox
-      - run: tox -e docs
+      - *pyenv-set-global
+      - build_docs
       - run:
           command: |
              mkdir -p /tmp/docs

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -49,6 +49,7 @@ kwarg
 lifecycle
 mako
 memcached
+metadata
 microservices
 middleware
 mongoengine
@@ -85,12 +86,14 @@ starlette
 stringable
 subdomains
 submodules
+timestamp
 tweens
 uWSGI
 unix
 unregister
 url
 urls
+username
 uvicorn
 vertica
 whitelist


### PR DESCRIPTION
## Description
We have two jobs where docs are built: `build_docs` and `deploy_master`. Unfortunately there are spelling errors that only arise in `deploy_master` because of underlying library dependencies that are different between the machine executor used in `deploy_master` and the `datadog/dd-trace-py` image we use for `build_docs`. This PR makes both use the same machine executor and refactors some code to re-use the same command in both.

This PR does not address the inconsistencies between the `datadog/dd-trace-py` image and the machine executor, which mean local runs of `tox -e docs` will not match exactly results in CI. 

**Failing before updated wordlist**: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/3381/workflows/157bdb73-54b7-41d2-be19-16940ae77e80/jobs/375447

**Passing after updated wordlist**: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/3382/workflows/1f421ddc-23d3-4336-93cc-c696ad21f151/jobs/375523

## Checklist
- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
