### PR TITLE
ci: fix missing msgpack on tracer scenario

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -186,6 +186,7 @@ deps =
     mock
 # used to test our custom msgpack encoder
     integration: msgpack
+    tracer: msgpack
     benchmarks: pytest-benchmark
     profile: pytest-benchmark
     profile-minreqs: protobuf==3.0.0


### PR DESCRIPTION
The integration target does not import msgpack, but the tracer one does.