### PR TITLE
refactor(api): use an URL

### DIFF
--- a/ddtrace/contrib/django/conf.py
+++ b/ddtrace/contrib/django/conf.py
@@ -17,6 +17,7 @@ import importlib
 
 from django.conf import settings as django_settings
 
+import ddtrace
 from ...internal.logger import get_logger
 
 
@@ -193,8 +194,9 @@ def configure_from_settings(pin, config, settings):
     if "ENABLED" in settings:
         pin.tracer.enabled = settings["ENABLED"]
 
-    if "AGENT_HOSTNAME" in settings:
-        pin.tracer.writer.api.hostname = settings["AGENT_HOSTNAME"]
-
-    if "AGENT_PORT" in settings:
-        pin.tracer.writer.api.port = settings["AGENT_PORT"]
+    if "AGENT_HOSTNAME" in settings or "AGENT_PORT" in settings:
+        # WTF changing the URL like that?
+        pin.tracer.writer.api.url = "http://%s:%d" % (
+            settings.get("AGENT_HOSTNAME", ddtrace.Tracer.DEFAULT_HOSTNAME),
+            settings.get("AGENT_PORT", ddtrace.Tracer.DEFAULT_PORT),
+        )

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -55,10 +55,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
 
     def __init__(
         self,
-        hostname="localhost",
-        port=8126,
-        uds_path=None,
-        https=False,
+        url,
         shutdown_timeout=DEFAULT_TIMEOUT,
         sampler=None,
         priority_sampler=None,
@@ -74,9 +71,8 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         self._priority_sampler = priority_sampler
         self._last_error_ts = 0
         self.dogstatsd = dogstatsd
-        self.api = api.API(
-            hostname, port, uds_path=uds_path, https=https, priority_sampling=priority_sampler is not None
-        )
+        self.url = url
+        self.api = api.API(url, priority_sampling=priority_sampler is not None)
         if hasattr(time, "thread_time"):
             self._last_thread_time = time.thread_time()
         self._started = False
@@ -89,10 +85,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         :returns: A new :class:`AgentWriter` instance
         """
         writer = self.__class__(
-            hostname=self.api.hostname,
-            port=self.api.port,
-            uds_path=self.api.uds_path,
-            https=self.api.https,
+            self.url,
             shutdown_timeout=self.exit_timeout,
             priority_sampler=self._priority_sampler,
             dogstatsd=self.dogstatsd,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ exclude = '''
   | build/
   | dist/
   | ddtrace/(
-    (?!(compat|monkey|span|__init__|_hooks)\.py$)[^/]+\.py$
+    (?!(api|compat|monkey|span|__init__|_hooks)\.py$)[^/]+\.py$
     | commands/
     | contrib/
     (
@@ -164,7 +164,9 @@ exclude = '''
     | ddtrace_run.py
     | profiling/_ast_test_file.py
     | subprocesstest.py
-    | tracer/
+    | tracer/ (
+      (?!(test_api|test_writer)\.py$).+\.py$
+    )
     | vendor
     | wait-for-services.py
   )

--- a/tests/commands/ddtrace_run_hostname.py
+++ b/tests/commands/ddtrace_run_hostname.py
@@ -1,6 +1,5 @@
 from ddtrace import tracer
 
 if __name__ == "__main__":
-    assert tracer.writer.api.hostname == "172.10.0.1"
-    assert tracer.writer.api.port == 8120
+    assert tracer.writer.url == "http://172.10.0.1:8120"
     print("Test success")

--- a/tests/contrib/django/test_django_migration.py
+++ b/tests/contrib/django/test_django_migration.py
@@ -39,5 +39,4 @@ def test_configure_from_settings(tracer):
 
         assert pin.tracer.enabled is True
         assert pin.tracer.tags["env"] == "env-test"
-        assert pin.tracer.writer.api.hostname == "host-test"
-        assert pin.tracer.writer.api.port == 1234
+        assert pin.tracer.writer.api.url == "http://host-test:1234"

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -8,7 +8,7 @@ import pytest
 
 # Project
 from ddtrace import config
-from ddtrace.compat import httplib, PY2
+from ddtrace.compat import httplib, PY2, urlparse
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.httplib import patch, unpatch
 from ddtrace.contrib.httplib.patch import should_skip_request
@@ -118,13 +118,14 @@ class HTTPLibTestCase(HTTPLibBaseMixin, TracerTestCase):
 
         # Enabled Pin and internal request
         self.tracer.enabled = True
-        request = self.get_http_connection(self.tracer.writer.api.hostname, self.tracer.writer.api.port)
+        parsed = urlparse(self.tracer.writer.api.url)
+        request = self.get_http_connection(parsed.hostname, parsed.port)
         pin = Pin.get_from(request)
         self.assertTrue(should_skip_request(pin, request))
 
         # Disabled Pin and internal request
         self.tracer.enabled = False
-        request = self.get_http_connection(self.tracer.writer.api.hostname, self.tracer.writer.api.port)
+        request = self.get_http_connection(parsed.hostname, parsed.port)
         pin = Pin.get_from(request)
         self.assertTrue(should_skip_request(pin, request))
 

--- a/tests/contrib/tornado/test_config.py
+++ b/tests/contrib/tornado/test_config.py
@@ -28,8 +28,7 @@ class TestTornadoSettings(TornadoTestCase):
         # the tracer must be properly configured
         assert self.tracer.tags == {'env': 'production', 'debug': 'false'}
         assert self.tracer.enabled is False
-        assert self.tracer.writer.api.hostname == 'dd-agent.service.consul'
-        assert self.tracer.writer.api.port == 8126
+        assert self.tracer.writer.api.url == 'http://dd-agent.service.consul:8126'
         # settings are properly passed
         assert len(self.tracer._filters) == 1
         assert isinstance(self.tracer._filters[0], FilterRequestsOnUrl)

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -126,7 +126,7 @@ def test_debug_post_configure():
     f = debug.collect(tracer)
 
     agent_url = f.get("agent_url")
-    assert agent_url == "uds:///file.sock"
+    assert agent_url == "unix:///file.sock"
 
     agent_error = f.get("agent_error")
     assert re.match("^Agent not reachable.*No such file or directory", agent_error)

--- a/tests/tracer/test_api.py
+++ b/tests/tracer/test_api.py
@@ -17,8 +17,8 @@ from ddtrace.vendor.six.moves import BaseHTTPServer, socketserver
 
 
 class _BaseHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
-    error_message_format = '%(message)s\n'
-    error_content_type = 'text/plain'
+    error_message_format = "%(message)s\n"
+    error_content_type = "text/plain"
 
     @staticmethod
     def log_message(format, *args):  # noqa: A002
@@ -26,9 +26,8 @@ class _BaseHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
 
 class _APIEndpointRequestHandlerTest(_BaseHTTPRequestHandler):
-
     def do_PUT(self):
-        self.send_error(200, 'OK')
+        self.send_error(200, "OK")
 
 
 class _TimeoutAPIEndpointRequestHandlerTest(_BaseHTTPRequestHandler):
@@ -38,12 +37,11 @@ class _TimeoutAPIEndpointRequestHandlerTest(_BaseHTTPRequestHandler):
 
 
 class _ResetAPIEndpointRequestHandlerTest(_BaseHTTPRequestHandler):
-
     def do_PUT(self):
         return
 
 
-_HOST = '0.0.0.0'
+_HOST = "0.0.0.0"
 _TIMEOUT_PORT = 8743
 _RESET_PORT = _TIMEOUT_PORT + 1
 
@@ -78,7 +76,7 @@ def _make_uds_server(path, request_handler):
 def endpoint_uds_server(tmp_path):
     # TODO: the tmp_path results in a path too long to be used as an address
     # https://github.com/pytest-dev/pytest/issues/5802
-    server, thread = _make_uds_server(str(tmp_path / 'uds_server_socket'), _APIEndpointRequestHandlerTest)
+    server, thread = _make_uds_server(str(tmp_path / "uds_server_socket"), _APIEndpointRequestHandlerTest)
     try:
         yield server
     finally:
@@ -95,7 +93,7 @@ def _make_server(port, request_handler):
     return server, t
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def endpoint_test_timeout_server():
     server, thread = _make_server(_TIMEOUT_PORT, _TimeoutAPIEndpointRequestHandlerTest)
     try:
@@ -105,7 +103,7 @@ def endpoint_test_timeout_server():
         thread.join()
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def endpoint_test_reset_server():
     server, thread = _make_server(_RESET_PORT, _ResetAPIEndpointRequestHandlerTest)
     try:
@@ -124,62 +122,51 @@ class ResponseMock:
         return self.content
 
 
-def test_api_str():
-    api = API('localhost', 8126, https=True)
-    assert str(api) == 'https://localhost:8126'
-    api = API('localhost', 8126, '/path/to/uds')
-    assert str(api) == 'unix:///path/to/uds'
-
-
 class APITests(TestCase):
-
     def setUp(self):
         # DEV: Mock here instead of in tests, before we have patched `httplib.HTTPConnection`
         self.conn = mock.MagicMock(spec=httplib.HTTPConnection)
-        self.api = API('localhost', 8126)
+        self.api = API("http://localhost:8126")
 
     def tearDown(self):
         del self.api
         del self.conn
 
-    def test_typecast_port(self):
-        api = API('localhost', u'8126')
-        self.assertEqual(api.port, 8126)
-
-    @mock.patch('logging.Logger.debug')
+    @mock.patch("logging.Logger.debug")
     def test_parse_response_json(self, log):
         test_cases = {
-            'OK': dict(
+            "OK": dict(
                 js=None,
-                log='Cannot parse Datadog Agent response, please make sure your Datadog Agent is up to date',
+                log="Cannot parse Datadog Agent response, please make sure your Datadog Agent is up to date",
             ),
-            'OK\n': dict(
+            "OK\n": dict(
                 js=None,
-                log='Cannot parse Datadog Agent response, please make sure your Datadog Agent is up to date',
+                log="Cannot parse Datadog Agent response, please make sure your Datadog Agent is up to date",
             ),
-            'error:unsupported-endpoint': dict(
+            "error:unsupported-endpoint": dict(
                 js=None,
-                log='Unable to parse Datadog Agent JSON response: \'error:unsupported-endpoint\'',
+                log="Unable to parse Datadog Agent JSON response: 'error:unsupported-endpoint'",
             ),
             42: dict(  # int as key to trigger TypeError
                 js=None,
-                log='Unable to parse Datadog Agent JSON response: 42',
+                log="Unable to parse Datadog Agent JSON response: 42",
             ),
-            '{}': dict(js={}),
-            '[]': dict(js=[]),
-
+            "{}": dict(js={}),
+            "[]": dict(js=[]),
             # Priority sampling "rate_by_service" response
-            ('{"rate_by_service": '
-             '{"service:,env:":0.5, "service:mcnulty,env:test":0.9, "service:postgres,env:test":0.6}}'): dict(
+            (
+                '{"rate_by_service": '
+                '{"service:,env:":0.5, "service:mcnulty,env:test":0.9, "service:postgres,env:test":0.6}}'
+            ): dict(
                 js=dict(
                     rate_by_service={
-                        'service:,env:': 0.5,
-                        'service:mcnulty,env:test': 0.9,
-                        'service:postgres,env:test': 0.6,
+                        "service:,env:": 0.5,
+                        "service:mcnulty,env:test": 0.9,
+                        "service:postgres,env:test": 0.6,
                     },
                 ),
             ),
-            ' [4,2,1] ': dict(js=[4, 2, 1]),
+            " [4,2,1] ": dict(js=[4, 2, 1]),
         }
 
         for k, v in iteritems(test_cases):
@@ -187,13 +174,13 @@ class APITests(TestCase):
 
             r = Response.from_http_response(ResponseMock(k))
             js = r.get_json()
-            assert v['js'] == js
-            if 'log' in v:
+            assert v["js"] == js
+            if "log" in v:
                 log.assert_called_once()
                 msg = log.call_args[0][0] % log.call_args[0][1:]
-                assert re.match(v['log'], msg), msg
+                assert re.match(v["log"], msg), msg
 
-    @mock.patch('ddtrace.compat.httplib.HTTPConnection')
+    @mock.patch("ddtrace.compat.httplib.HTTPConnection")
     def test_put_connection_close(self, HTTPConnection):
         """
         When calling API._put
@@ -202,14 +189,14 @@ class APITests(TestCase):
         HTTPConnection.return_value = self.conn
 
         with warnings.catch_warnings(record=True) as w:
-            self.api._put('/test', '<test data>', 1)
+            self.api._put("/test", "<test data>", 1)
 
-            self.assertEqual(len(w), 0, 'Test raised unexpected warnings: {0!r}'.format(w))
+            self.assertEqual(len(w), 0, "Test raised unexpected warnings: {0!r}".format(w))
 
         self.conn.request.assert_called_once()
         self.conn.close.assert_called_once()
 
-    @mock.patch('ddtrace.compat.httplib.HTTPConnection')
+    @mock.patch("ddtrace.compat.httplib.HTTPConnection")
     def test_put_connection_close_exception(self, HTTPConnection):
         """
         When calling API._put raises an exception
@@ -221,9 +208,9 @@ class APITests(TestCase):
 
         with warnings.catch_warnings(record=True) as w:
             with self.assertRaises(Exception):
-                self.api._put('/test', '<test data>', 1)
+                self.api._put("/test", "<test data>", 1)
 
-            self.assertEqual(len(w), 0, 'Test raised unexpected warnings: {0!r}'.format(w))
+            self.assertEqual(len(w), 0, "Test raised unexpected warnings: {0!r}".format(w))
 
         self.conn.request.assert_called_once()
         self.conn.close.assert_called_once()
@@ -231,19 +218,19 @@ class APITests(TestCase):
 
 def test_https():
     conn = mock.MagicMock(spec=httplib.HTTPSConnection)
-    api = API('localhost', 8126, https=True)
-    with mock.patch('ddtrace.compat.httplib.HTTPSConnection') as HTTPSConnection:
+    api = API("https://localhost:8126")
+    with mock.patch("ddtrace.compat.httplib.HTTPSConnection") as HTTPSConnection:
         HTTPSConnection.return_value = conn
-        api._put('/test', '<test data>', 1)
+        api._put("/test", "<test data>", 1)
     conn.request.assert_called_once()
     conn.close.assert_called_once()
 
 
 def test_flush_connection_timeout_connect():
     payload = mock.Mock()
-    payload.get_payload.return_value = 'foobar'
+    payload.get_payload.return_value = "foobar"
     payload.length = 12
-    api = API(_HOST, 2019)
+    api = API("http://%s:2019" % _HOST)
     response = api._flush(payload)
     if PY3:
         assert isinstance(response, (OSError, ConnectionRefusedError))  # noqa: F821
@@ -254,18 +241,18 @@ def test_flush_connection_timeout_connect():
 
 def test_flush_connection_timeout(endpoint_test_timeout_server):
     payload = mock.Mock()
-    payload.get_payload.return_value = 'foobar'
+    payload.get_payload.return_value = "foobar"
     payload.length = 12
-    api = API(_HOST, _TIMEOUT_PORT)
+    api = API("http://%s:%d" % (_HOST, _TIMEOUT_PORT))
     response = api._flush(payload)
     assert isinstance(response, socket.timeout)
 
 
 def test_flush_connection_reset(endpoint_test_reset_server):
     payload = mock.Mock()
-    payload.get_payload.return_value = 'foobar'
+    payload.get_payload.return_value = "foobar"
     payload.length = 12
-    api = API(_HOST, _RESET_PORT)
+    api = API("http://%s:%d" % (_HOST, _RESET_PORT))
     response = api._flush(payload)
     if PY3:
         assert isinstance(response, (httplib.BadStatusLine, ConnectionResetError))  # noqa: F821
@@ -275,27 +262,27 @@ def test_flush_connection_reset(endpoint_test_reset_server):
 
 def test_flush_connection_uds(endpoint_uds_server):
     payload = mock.Mock()
-    payload.get_payload.return_value = 'foobar'
+    payload.get_payload.return_value = "foobar"
     payload.length = 12
-    api = API(_HOST, 2019, uds_path=endpoint_uds_server.server_address)
+    api = API("unix://" + endpoint_uds_server.server_address)
     response = api._flush(payload)
     assert response.status == 200
 
 
-@mock.patch('ddtrace.internal.runtime.container.get_container_info')
+@mock.patch("ddtrace.internal.runtime.container.get_container_info")
 def test_api_container_info(get_container_info):
     # When we have container information
     # DEV: `get_container_info` will return a `CGroupInfo` with a `container_id` or `None`
-    info = CGroupInfo(container_id='test-container-id')
+    info = CGroupInfo(container_id="test-container-id")
     get_container_info.return_value = info
 
-    api = API(_HOST, 8126)
+    api = API("http://%s:8126" % _HOST)
     assert api._container_info is info
-    assert api._headers['Datadog-Container-Id'] == 'test-container-id'
+    assert api._headers["Datadog-Container-Id"] == "test-container-id"
 
     # When we do not have container information
     get_container_info.return_value = None
 
-    api = API(_HOST, 8126)
+    api = API("http://%s:8126" % _HOST)
     assert api._container_info is None
-    assert 'Datadog-Container-Id' not in api._headers
+    assert "Datadog-Container-Id" not in api._headers

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -14,7 +14,7 @@ MAX_NUM_SPANS = 7
 class DummyAPI(API):
     def __init__(self):
         # Call API.__init__ to setup required properties
-        super(DummyAPI, self).__init__(hostname="localhost", port=8126)
+        super(DummyAPI, self).__init__("http://localhost:8126")
 
         self.traces = []
 
@@ -54,7 +54,7 @@ class AgentWriterTests(BaseTestCase):
     def create_worker(self, api_class=DummyAPI, enable_stats=False, num_traces=N_TRACES, num_spans=MAX_NUM_SPANS):
         with self.override_global_config(dict(health_metrics_enabled=enable_stats)):
             self.dogstatsd = mock.Mock()
-            worker = AgentWriter(dogstatsd=self.dogstatsd)
+            worker = AgentWriter(None, dogstatsd=self.dogstatsd)
             worker._STATS_EVERY_INTERVAL = 1
             self.api = api_class()
             worker.api = self.api
@@ -71,12 +71,12 @@ class AgentWriterTests(BaseTestCase):
 
     def test_send_stats(self):
         dogstatsd = mock.Mock()
-        worker = AgentWriter(dogstatsd=dogstatsd)
+        worker = AgentWriter(None, dogstatsd=dogstatsd)
         assert worker._send_stats is False
         with self.override_global_config(dict(health_metrics_enabled=True)):
             assert worker._send_stats is True
 
-        worker = AgentWriter(dogstatsd=None)
+        worker = AgentWriter(None, dogstatsd=None)
         assert worker._send_stats is False
         with self.override_global_config(dict(health_metrics_enabled=True)):
             assert worker._send_stats is False


### PR DESCRIPTION
This makes the API object uses an URL rather than a list of
hostname/port/uds_path/ssl_flag.

There's still a unfortunate URL parse/unparse part in Tracer.configure sadly,
but once this part is gone, a single string URL can be used to determine where
the agent is from end to end.