### PR TITLE
ci: parallelism for celery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,9 @@ commands:
     parameters:
       pattern:
         type: string
+      split:
+        type: string
+        default: "false"
       wait:
         type: string
         default: ""
@@ -149,6 +152,8 @@ commands:
       - run:
           name: "Run scripts/run-tox-scenario"
           command: scripts/run-tox-scenario '<< parameters.pattern >>'
+          environment:
+            CI_SPLIT: << parameters.split >>
       - save_tox_cache
 
   test_build:
@@ -449,9 +454,11 @@ jobs:
     docker:
       - image: *ddtrace_dev_image
       - image: redis:4.0-alpine
+    parallelism: 4
     steps:
       - run_tox_scenario:
           pattern: '^celery_contrib-'
+          split: 'true'
 
   consul:
     executor: ddtrace_dev

--- a/scripts/run-tox-scenario
+++ b/scripts/run-tox-scenario
@@ -5,4 +5,9 @@ shift
 
 # CircleCI has a bug in its workspace code where it can't handle filenames with some chars
 CLEANED_PATTERN=`echo $PATTERN | tr '^?()$' '_'`
-exec tox -l | grep "$PATTERN" | tr '\n' ',' | xargs -I ARGS tox --result-json /tmp/"$CLEANED_PATTERN".results -e ARGS -- $@
+
+if [[ "$CI_SPLIT" == 'true' ]]; then
+    exec tox -l | grep "$PATTERN" | circleci tests split | tr '\n' ',' | xargs -I ARGS tox --result-json /tmp/"$CLEANED_PATTERN".results -e ARGS -- $@
+else
+    exec tox -l | grep "$PATTERN" | tr '\n' ',' | xargs -I ARGS tox --result-json /tmp/"$CLEANED_PATTERN".results -e ARGS -- $@
+fi


### PR DESCRIPTION
## Description

Use CircleCI job parallelism to run celery tox envs in parallel. The speed up with 4 executors brings down total runtime from ~45min to ~15min, as to be expected.

**Before** from master:

```
celery_contrib-py27-celery31-redis210: commands succeeded
celery_contrib-py35-celery31-redis210: commands succeeded
celery_contrib-py36-celery31-redis210: commands succeeded
celery_contrib-py27-celery40-redis210-kombu43: commands succeeded
celery_contrib-py27-celery40-redis32-kombu44: commands succeeded
celery_contrib-py27-celery41-redis210-kombu43: commands succeeded
celery_contrib-py27-celery41-redis32-kombu44: commands succeeded
celery_contrib-py35-celery40-redis210-kombu43: commands succeeded
celery_contrib-py35-celery40-redis32-kombu44: commands succeeded
celery_contrib-py35-celery41-redis210-kombu43: commands succeeded
celery_contrib-py35-celery41-redis32-kombu44: commands succeeded
celery_contrib-py36-celery40-redis210-kombu43: commands succeeded
celery_contrib-py36-celery40-redis32-kombu44: commands succeeded
celery_contrib-py36-celery41-redis210-kombu43: commands succeeded
celery_contrib-py36-celery41-redis32-kombu44: commands succeeded
celery_contrib-py27-celery42-redis210-kombu43: commands succeeded
celery_contrib-py35-celery42-redis210-kombu43: commands succeeded
celery_contrib-py36-celery42-redis210-kombu43: commands succeeded
celery_contrib-py27-celery43-redis32-kombu44: commands succeeded
celery_contrib-py35-celery43-redis32-kombu44: commands succeeded
celery_contrib-py36-celery43-redis32-kombu44: commands succeeded
celery_contrib-py37-celery43-redis32-kombu44: commands succeeded
celery_contrib-py38-celery43-redis32-kombu44: commands succeeded
celery_contrib-py39-celery43-redis32-kombu44: commands succeeded
```

**After** tox envs run in parallel:

```
celery_contrib-py27-celery31-redis210: commands succeeded
celery_contrib-py35-celery31-redis210: commands succeeded
celery_contrib-py36-celery31-redis210: commands succeeded
celery_contrib-py27-celery40-redis210-kombu43: commands succeeded
celery_contrib-py27-celery40-redis32-kombu44: commands succeeded
celery_contrib-py27-celery41-redis210-kombu43: commands succeeded
celery_contrib-py27-celery41-redis32-kombu44: commands succeeded
celery_contrib-py27-celery42-redis210-kombu43: commands succeeded
celery_contrib-py27-celery43-redis32-kombu44: commands succeeded
celery_contrib-py35-celery40-redis210-kombu43: commands succeeded
celery_contrib-py35-celery40-redis32-kombu44: commands succeeded
celery_contrib-py35-celery41-redis210-kombu43: commands succeeded
celery_contrib-py35-celery41-redis32-kombu44: commands succeeded
celery_contrib-py35-celery42-redis210-kombu43: commands succeeded
celery_contrib-py35-celery43-redis32-kombu44: commands succeeded
celery_contrib-py36-celery40-redis210-kombu43: commands succeeded
celery_contrib-py36-celery40-redis32-kombu44: commands succeeded
celery_contrib-py36-celery41-redis210-kombu43: commands succeeded
celery_contrib-py36-celery41-redis32-kombu44: commands succeeded
celery_contrib-py36-celery42-redis210-kombu43: commands succeeded
celery_contrib-py36-celery43-redis32-kombu44: commands succeeded
celery_contrib-py37-celery43-redis32-kombu44: commands succeeded
celery_contrib-py38-celery43-redis32-kombu44: commands succeeded
celery_contrib-py39-celery43-redis32-kombu44: commands succeeded
```


## Checklist
- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
