### PR TITLE
ci: build base venvs in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,14 +263,15 @@ jobs:
       - run_test:
           pattern: "flake8"
 
-  build_base:
+  build_base_venvs:
     executor: ddtrace_dev
+    parallelism: 6
     steps:
       - checkout
-      - run: pip3 install riot
+      - run: pip install riot
       - run:
           name: "Generate base virtual environments."
-          command: "riot -v generate"
+          command: "echo '2.7,3.5,3.6,3.7,3.8,3.9' | tr ',' '\n' | circleci tests split | xargs -I PY riot -v generate --python=PY"
       - persist_to_workspace:
           root: .
           paths:
@@ -850,7 +851,7 @@ requires_pre_test: &requires_pre_test
     - black
     - flake8
     - ccheck
-    - build_base
+    - build_base_venvs
 
 requires_tests: &requires_tests
   - build_docs
@@ -941,7 +942,7 @@ workflows:
       - black
       - flake8
       - ccheck
-      - build_base
+      - build_base_venvs
 
       # Test building the package
       - test_build_alpine: *requires_pre_test


### PR DESCRIPTION
This cuts down the time to build the bases from [~4 minutes](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/3473/workflows/fb677bdd-59a6-4505-9d21-6b1862c58668/jobs/379958) -> [~1 minute](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/3505/workflows/6e7ceef4-3100-466b-9897-50c9581527ca/jobs/381409)