### PR TITLE
ci: don't require passing tests for dev deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1023,12 +1023,10 @@ workflows:
       - vertica: *requires_pre_test
       - build-docker-ci-image: *requires_pre_test
       - deploy_master:
-          requires: *requires_tests
           filters:
             branches:
               only: master
       - deploy_staging:
-          requires: *requires_tests
           filters:
             branches:
               only: staging


### PR DESCRIPTION
If changes are merged to these branches then we want them deployed whether or
not the tests pass.
