### PR TITLE
ci: bump profiling parallelism to 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,6 +349,7 @@ jobs:
 
   profile:
     <<: *contrib_job
+    parallelism: 6
     steps:
       - run_tox_scenario:
           pattern: '^py..-profile'


### PR DESCRIPTION
this gets the CI time to under 10 minutes (from about 20)