### PR TITLE
fix(django): add safe guards in get_request_uri

### DIFF
--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -88,20 +88,21 @@ def get_request_uri(request):
             host = "unknown"
 
     # If request scheme is missing, possible in case where wsgi.url_scheme
-    # environ has not been set, then default to http
-    scheme = request.scheme or "http"
+    # environ has not been set, return None and skip providing a uri
+    if request.scheme is None:
+        return
 
     # Build request url from the information available
     # DEV: We are explicitly omitting query strings since they may contain sensitive information
-    urlparts = dict(scheme=scheme, netloc=host, path=request.path, params=None, query=None, fragment=None)
+    urlparts = dict(scheme=request.scheme, netloc=host, path=request.path, params=None, query=None, fragment=None)
 
     # If any url part is a SimpleLazyObject, use it's __class__ property to cast
     # str/bytes and allow for _setup() to execute
     for (k, v) in urlparts.items():
         if isinstance(v, SimpleLazyObject):
-            if v.__class__ == str:
+            if issubclass(v.__class__, str):
                 v = str(v)
-            elif v.__class__ == bytes:
+            elif issubclass(v.__class__, bytes):
                 v = bytes(v)
         urlparts[k] = v
 

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -107,6 +107,9 @@ def get_request_uri(request):
             else:
                 # lazy object that is not str or bytes should not happen here
                 # but if it does skip providing a uri
+                log.debug(
+                    "Skipped building Django request uri, %s is SimpleLazyObject wrapping a %s class", k, v.__class__.__name__
+                )
                 return None
         urlparts[k] = v
 

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -85,9 +85,13 @@ def get_request_uri(request):
             log.debug("Failed to build Django request host", exc_info=True)
             host = "unknown"
 
+    # If request scheme is missing, possible in case where wsgi.url_scheme
+    # environ has not been set, then default to http
+    scheme = request.scheme or "http"
+
     # Build request url from the information available
     # DEV: We are explicitly omitting query strings since they may contain sensitive information
-    urlparts = dict(scheme=request.scheme, netloc=host, path=request.path, params=None, query=None, fragment=None)
+    urlparts = dict(scheme=scheme, netloc=host, path=request.path, params=None, query=None, fragment=None)
 
     # DEV: With PY3 urlunparse calls urllib.parse._coerce_args which uses the
     # type of the scheme to check the type to expect from all url parts, raising

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -108,7 +108,9 @@ def get_request_uri(request):
                 # lazy object that is not str or bytes should not happen here
                 # but if it does skip providing a uri
                 log.debug(
-                    "Skipped building Django request uri, %s is SimpleLazyObject wrapping a %s class", k, v.__class__.__name__
+                    "Skipped building Django request uri, %s is SimpleLazyObject wrapping a %s class",
+                    k,
+                    v.__class__.__name__,
                 )
                 return None
         urlparts[k] = v

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -96,7 +96,7 @@ def get_request_uri(request):
     # DEV: We are explicitly omitting query strings since they may contain sensitive information
     urlparts = dict(scheme=request.scheme, netloc=host, path=request.path, params=None, query=None, fragment=None)
 
-    # If any url part is a SimpleLazyObject, use it's __class__ property to cast
+    # If any url part is a SimpleLazyObject, use its __class__ property to cast
     # str/bytes and allow for _setup() to execute
     for (k, v) in urlparts.items():
         if isinstance(v, SimpleLazyObject):

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -100,11 +100,14 @@ def get_request_uri(request):
     # str/bytes and allow for _setup() to execute
     for (k, v) in urlparts.items():
         if isinstance(v, SimpleLazyObject):
-            if issubclass(v.__class__, bytes):
+            if issubclass(v.__class__, str):
+                v = str(v)
+            elif issubclass(v.__class__, bytes):
                 v = bytes(v)
             else:
-                # default to casting to str
-                v = str(v)
+                # lazy object that is not str or bytes should not happen here
+                # but if it does skip providing a uri
+                return None
         urlparts[k] = v
 
     # DEV: With PY3 urlunparse calls urllib.parse._coerce_args which uses the

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -100,10 +100,11 @@ def get_request_uri(request):
     # str/bytes and allow for _setup() to execute
     for (k, v) in urlparts.items():
         if isinstance(v, SimpleLazyObject):
-            if issubclass(v.__class__, str):
-                v = str(v)
-            elif issubclass(v.__class__, bytes):
+            if issubclass(v.__class__, bytes):
                 v = bytes(v)
+            else:
+                # default to casting to str
+                v = str(v)
         urlparts[k] = v
 
     # DEV: With PY3 urlunparse calls urllib.parse._coerce_args which uses the

--- a/releasenotes/notes/django-request-uri-safe-guards-fdd8bd664374ded1.yaml
+++ b/releasenotes/notes/django-request-uri-safe-guards-fdd8bd664374ded1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Add safe guards for building Django http.url span tag

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -1481,11 +1481,12 @@ def test_helper_get_request_uri(request_cls, request_path, http_host):
     request.META = {"HTTP_HOST": http_host}
     request_uri = get_request_uri(request)
     assert (
-        request_cls == _HttpRequest
-        and isinstance(request_path, binary_type)
-        and isinstance(http_host, binary_type)
-        and isinstance(request_uri, binary_type)
-    ) or (
-        request_cls == _MissingSchemeRequest
-        and request_uri is None
-    ) or isinstance(request_uri, string_type)
+        (
+            request_cls == _HttpRequest
+            and isinstance(request_path, binary_type)
+            and isinstance(http_host, binary_type)
+            and isinstance(request_uri, binary_type)
+        )
+        or (request_cls == _MissingSchemeRequest and request_uri is None)
+        or isinstance(request_uri, string_type)
+    )

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -2,6 +2,7 @@ import itertools
 import django
 from django.views.generic import TemplateView
 from django.test import modify_settings, override_settings
+from django.utils.functional import SimpleLazyObject
 import os
 import pytest
 
@@ -1454,6 +1455,12 @@ def test_template_view_patching():
     assert "dispatch" not in vars(TemplateView)
 
 
+class _MissingSchemeRequest(django.http.HttpRequest):
+    @property
+    def scheme(self):
+        pass
+
+
 class _HttpRequest(django.http.HttpRequest):
     @property
     def scheme(self):
@@ -1463,9 +1470,9 @@ class _HttpRequest(django.http.HttpRequest):
 @pytest.mark.parametrize(
     "request_cls,request_path,http_host",
     itertools.product(
-        [django.http.HttpRequest, _HttpRequest],
+        [django.http.HttpRequest, _HttpRequest, _MissingSchemeRequest],
         [u"/;some/?awful/=path/foo:bar/", b"/;some/?awful/=path/foo:bar/"],
-        [u"testserver", b"testserver"],
+        [u"testserver", b"testserver", SimpleLazyObject(lambda: "testserver")],
     ),
 )
 def test_helper_get_request_uri(request_cls, request_path, http_host):
@@ -1474,7 +1481,7 @@ def test_helper_get_request_uri(request_cls, request_path, http_host):
     request.META = {"HTTP_HOST": http_host}
     request_uri = get_request_uri(request)
     assert (
-        request_cls == _HttpRequest
+        (request_cls == _HttpRequest or request_cls == _MissingSchemeRequest)
         and isinstance(request_path, binary_type)
         and isinstance(http_host, binary_type)
         and isinstance(request_uri, binary_type)

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -1481,8 +1481,11 @@ def test_helper_get_request_uri(request_cls, request_path, http_host):
     request.META = {"HTTP_HOST": http_host}
     request_uri = get_request_uri(request)
     assert (
-        (request_cls == _HttpRequest or request_cls == _MissingSchemeRequest)
+        request_cls == _HttpRequest
         and isinstance(request_path, binary_type)
         and isinstance(http_host, binary_type)
         and isinstance(request_uri, binary_type)
+    ) or (
+        request_cls == _MissingSchemeRequest
+        and request_uri is None
     ) or isinstance(request_uri, string_type)


### PR DESCRIPTION
## Description

This fix addresses a problem that arises if a request is handled that is missing a url scheme. An example of this case is seen in [saleor's wsgi code](https://github.com/mirumee/saleor/blob/a82166ce550eb4baefbc7ffb1c1514d710500f60/saleor/wsgi/__init__.py#L33-L45) where a warmup request is made when the wsgi application is started:

```
application(
    {
        "REQUEST_METHOD": "GET",
        "SERVER_NAME": SimpleLazyObject(get_allowed_host_lazy),
        "REMOTE_ADDR": "127.0.0.1",
        "SERVER_PORT": 80,
        "PATH_INFO": "/graphql/",
        "wsgi.input": b"",
        "wsgi.multiprocess": True,
    },
    lambda x, y: None,
)
```

Additionally, this fix addresses the use of a `SimpleLazyObject` for a request attribute.

I have added this to the [majorgreys/django-tutorial-uwsgi-warmup](https://github.com/DataDog/trace-examples/tree/majorgreys/django-tutorial-uwsgi-warmup) branch of the django-tutorial trace example. This can serve as a manual test to confirm the fix.

Tests:
* [add test for get_request_uri](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/3562/workflows/77918051-8df4-4473-bdaa-5af76e4827ec/jobs/385600/parallel-runs/0?filterBy=FAILED) [failed]
* [default missing scheme to http and support SimpleLazyObject]() []

## Checklist
- [x] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [x] Tests provided; and/or
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
