### PR TITLE
tests: run snapshots in parallel mode

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -850,7 +850,10 @@ def snapshot(ignores=None, tracer=ddtrace.tracer, variants=None):
             tracer.writer.api._headers["X-Datadog-Test-Token"] = token
 
             # Run the test.
-            ret = wrapped(*args, **kwargs)
+            try:
+                ret = wrapped(*args, **kwargs)
+            finally:
+                del tracer.writer.api._headers["X-Datadog-Test-Token"]
 
             # Force a flush so all traces are submitted.
             tracer.writer.flush_queue()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -846,16 +846,8 @@ def snapshot(ignores=None, tracer=ddtrace.tracer, variants=None):
             except Exception as e:
                 pytest.fail("Could not flush the queue before test case: %s" % str(e), pytrace=True)
 
-            # Signal the start of this test case to the test agent.
-            try:
-                conn.request("GET", "/test/start?token=%s" % token)
-            except Exception as e:
-                pytest.fail("Could not connect to test agent: %s" % str(e), pytrace=False)
-
-            r = conn.getresponse()
-            if r.status != 200:
-                # The test agent returns nice error messages we can forward to the user.
-                raise SnapshotFailed(r.read())
+            # Patch the tracer writer to include the test token header for all requests.
+            tracer.writer.api._headers["X-Datadog-Test-Token"] = token
 
             # Run the test.
             ret = wrapped(*args, **kwargs)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -852,11 +852,10 @@ def snapshot(ignores=None, tracer=ddtrace.tracer, variants=None):
             # Run the test.
             try:
                 ret = wrapped(*args, **kwargs)
+                # Force a flush so all traces are submitted.
+                tracer.writer.flush_queue()
             finally:
                 del tracer.writer.api._headers["X-Datadog-Test-Token"]
-
-            # Force a flush so all traces are submitted.
-            tracer.writer.flush_queue()
 
             # Query for the results of the test.
             conn = httplib.HTTPConnection(tracer.writer.api.hostname, tracer.writer.api.port)


### PR DESCRIPTION
Since the tests are run in parallel now parallel mode should be used for snapshot tests.

The test agent supports receiving trace payloads in two modes, synchronous and parallel. In synchronous (which we were using) the trace payloads are attributed to the active test token. The active test token is set with the `/start` endpoint. The parallel mode associates payloads with a test token which is included as an http header on the request.