### PR TITLE
add include_tracer option to snapshot

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -802,7 +802,7 @@ class SnapshotFailed(Exception):
     pass
 
 
-def snapshot(ignores=None, tracer=ddtrace.tracer, variants=None):
+def snapshot(ignores=None, include_tracer=False, variants=None):
     """Performs a snapshot integration test with the testing agent.
 
     All traces sent to the agent will be recorded and compared to a snapshot
@@ -814,6 +814,11 @@ def snapshot(ignores=None, tracer=ddtrace.tracer, variants=None):
     :param tracer: A tracer providing the agent connection information to use.
     """
     ignores = ignores or []
+
+    if include_tracer:
+        tracer = Tracer()
+    else:
+        tracer = ddtrace.tracer
 
     @wrapt.decorator
     def wrapper(wrapped, instance, args, kwargs):
@@ -850,6 +855,8 @@ def snapshot(ignores=None, tracer=ddtrace.tracer, variants=None):
 
             # Run the test.
             try:
+                if include_tracer:
+                    kwargs["tracer"] = tracer
                 ret = wrapped(*args, **kwargs)
                 # Force a flush so all traces are submitted.
                 tracer.writer.flush_queue()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -10,7 +10,7 @@ from ddtrace import Tracer, tracer
 from ddtrace.internal.writer import AgentWriter
 from ddtrace.internal.runtime import container
 
-from tests import TracerTestCase, snapshot
+from tests import TracerTestCase, snapshot, override_global_tracer
 
 agent_version = os.environ.get("AGENT_VERSION")
 if agent_version == "5":
@@ -309,21 +309,19 @@ class TestTraces(TracerTestCase):
     These snapshot tests ensure that trace payloads are being sent as expected.
     """
 
-    @snapshot()
-    def test_single_trace_single_span(self):
-        t = Tracer()
-        s = t.trace("operation", service="my-svc")
+    @snapshot(include_tracer=True)
+    def test_single_trace_single_span(self, tracer):
+        s = tracer.trace("operation", service="my-svc")
         s.set_tag("k", "v")
         # numeric tag
         s.set_tag("num", 1234)
         s.set_metric("float_metric", 12.34)
         s.set_metric("int_metric", 4321)
         s.finish()
-        t.shutdown()
+        tracer.shutdown()
 
-    @snapshot()
-    def test_multiple_traces(self):
-        tracer = Tracer()
+    @snapshot(include_tracer=True)
+    def test_multiple_traces(self, tracer):
         with tracer.trace("operation1", service="my-svc") as s:
             s.set_tag("k", "v")
             s.set_tag("num", 1234)
@@ -339,10 +337,8 @@ class TestTraces(TracerTestCase):
             tracer.trace("child").finish()
         tracer.shutdown()
 
-    @snapshot()
-    def test_filters(self):
-        t = Tracer()
-
+    @snapshot(include_tracer=True)
+    def test_filters(self, tracer):
         class FilterMutate(object):
             def __init__(self, key, value):
                 self.key = key
@@ -353,13 +349,13 @@ class TestTraces(TracerTestCase):
                     s.set_tag(self.key, self.value)
                 return trace
 
-        t.configure(
+        tracer.configure(
             settings={
                 "FILTERS": [FilterMutate("boop", "beep")],
             }
         )
 
-        with t.trace("root"):
-            with t.trace("child"):
+        with tracer.trace("root"):
+            with tracer.trace("child"):
                 pass
-        t.shutdown()
+        tracer.shutdown()


### PR DESCRIPTION
This allows a new tracer instance to be used and configured for snapshot test cases.