### PR TITLE
use riot to test pynamodb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -646,8 +646,8 @@ jobs:
   pynamodb:
     <<: *contrib_job
     steps:
-      - run_tox_scenario:
-          pattern: '^pynamodb_contrib-'
+      - run_test:
+          pattern: "pynamodb"
 
   pyodbc:
     <<: *contrib_job

--- a/riotfile.py
+++ b/riotfile.py
@@ -239,4 +239,17 @@ suites = [
             ),
         ],
     ),
+    Suite(
+        name="pynamodb",
+        command="pytest tests/contrib/pynamodb",
+        cases=[
+            Case(
+                pys=[2.7, 3.5, 3.6, 3.7, 3.8, 3.9],
+                pkgs=[
+                    ("pynamodb", [">=4.0,<4.1", ">=4.1,<4.2", ">=4.2,<4.3", ">=4.3,<4.4", ""]),
+                    ("moto", [">=1.0,<2.0"]),
+                ],
+            ),
+        ],
+    ),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -106,7 +106,6 @@ envlist =
     pylons_contrib-py27-pylons{096,097,010,10,}
     pymemcache_contrib{,_autopatch}-py{27,35,36,37,38,39}-pymemcache{130,140}
     pymysql_contrib-py{27,35,36,37,38,39}-pymysql{07,08,09,}
-    pynamodb_contrib-py{27,35,36,37,38,39}-pynamodb{40,41,42,43,}-moto1
     pyodbc_contrib-py{27,35,36,37,38,39}-pyodbc{3,4}
     pyramid_contrib{,_autopatch}-py{27,35,36,37,38,39}-pyramid{17,18,19,110,}-webtest
     redis_contrib-py{27,35,36,37,38,39}-redis{210,30,32,33,34,35,}
@@ -371,11 +370,6 @@ deps =
     psycopg226: psycopg2>=2.6,<2.7
     psycopg227: psycopg2>=2.7,<2.8
     psycopg228: psycopg2>=2.8,<2.9
-    pynamodb: pynamodb
-    pynamodb40: pynamodb>=4.0,<4.1
-    pynamodb41: pynamodb>=4.1,<4.2
-    pynamodb42: pynamodb>=4.2,<4.3
-    pynamodb43: pynamodb>=4.3
     pyodbc: pyodbc
     pyodbc4: pyodbc>=4.0,<5.0
     pyodbc3: pyodbc>=3.0,<4.0
@@ -494,7 +488,6 @@ commands =
     pymemcache_contrib: pytest {posargs} --ignore="tests/contrib/pymemcache/autopatch" tests/contrib/pymemcache/
     pymemcache_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/pymemcache/autopatch/
     pymysql_contrib: pytest {posargs} tests/contrib/pymysql
-    pynamodb_contrib: pytest {posargs} tests/contrib/pynamodb
     pyodbc_contrib: pytest {posargs} tests/contrib/pyodbc
     pyramid_contrib: pytest {posargs} tests/contrib/pyramid/test_pyramid.py
     pyramid_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py


### PR DESCRIPTION
```
  Python 2.7 'pynamodb>=4.0,<4.1' 'moto>=1.0,<2.0'
  Python 2.7 'pynamodb>=4.1,<4.2' 'moto>=1.0,<2.0'
  Python 2.7 'pynamodb>=4.2,<4.3' 'moto>=1.0,<2.0'
  Python 2.7 'pynamodb>=4.3,<4.4' 'moto>=1.0,<2.0'
  Python 2.7 'pynamodb' 'moto>=1.0,<2.0'
  Python 3.5 'pynamodb>=4.0,<4.1' 'moto>=1.0,<2.0'
  Python 3.5 'pynamodb>=4.1,<4.2' 'moto>=1.0,<2.0'
  Python 3.5 'pynamodb>=4.2,<4.3' 'moto>=1.0,<2.0'
  Python 3.5 'pynamodb>=4.3,<4.4' 'moto>=1.0,<2.0'
  Python 3.5 'pynamodb' 'moto>=1.0,<2.0'
  Python 3.6 'pynamodb>=4.0,<4.1' 'moto>=1.0,<2.0'
  Python 3.6 'pynamodb>=4.1,<4.2' 'moto>=1.0,<2.0'
  Python 3.6 'pynamodb>=4.2,<4.3' 'moto>=1.0,<2.0'
  Python 3.6 'pynamodb>=4.3,<4.4' 'moto>=1.0,<2.0'
  Python 3.6 'pynamodb' 'moto>=1.0,<2.0'
  Python 3.7 'pynamodb>=4.0,<4.1' 'moto>=1.0,<2.0'
  Python 3.7 'pynamodb>=4.1,<4.2' 'moto>=1.0,<2.0'
  Python 3.7 'pynamodb>=4.2,<4.3' 'moto>=1.0,<2.0'
  Python 3.7 'pynamodb>=4.3,<4.4' 'moto>=1.0,<2.0'
  Python 3.7 'pynamodb' 'moto>=1.0,<2.0'
  Python 3.8 'pynamodb>=4.0,<4.1' 'moto>=1.0,<2.0'
  Python 3.8 'pynamodb>=4.1,<4.2' 'moto>=1.0,<2.0'
  Python 3.8 'pynamodb>=4.2,<4.3' 'moto>=1.0,<2.0'
  Python 3.8 'pynamodb>=4.3,<4.4' 'moto>=1.0,<2.0'
  Python 3.8 'pynamodb' 'moto>=1.0,<2.0'
  Python 3.9 'pynamodb>=4.0,<4.1' 'moto>=1.0,<2.0'
  Python 3.9 'pynamodb>=4.1,<4.2' 'moto>=1.0,<2.0'
  Python 3.9 'pynamodb>=4.2,<4.3' 'moto>=1.0,<2.0'
  Python 3.9 'pynamodb>=4.3,<4.4' 'moto>=1.0,<2.0'
  Python 3.9 'pynamodb' 'moto>=1.0,<2.0'
(.venv3.7) ~/d/dd-trace-py ❯❯❯ riot list pynamodb | wc -l
30
```


```
pynamodb_contrib-py27-pynamodb40-moto1
pynamodb_contrib-py27-pynamodb41-moto1
pynamodb_contrib-py27-pynamodb42-moto1
pynamodb_contrib-py27-pynamodb43-moto1
pynamodb_contrib-py27-pynamodb-moto1
pynamodb_contrib-py35-pynamodb40-moto1
pynamodb_contrib-py35-pynamodb41-moto1
pynamodb_contrib-py35-pynamodb42-moto1
pynamodb_contrib-py35-pynamodb43-moto1
pynamodb_contrib-py35-pynamodb-moto1
pynamodb_contrib-py36-pynamodb40-moto1
pynamodb_contrib-py36-pynamodb41-moto1
pynamodb_contrib-py36-pynamodb42-moto1
pynamodb_contrib-py36-pynamodb43-moto1
pynamodb_contrib-py36-pynamodb-moto1
pynamodb_contrib-py37-pynamodb40-moto1
pynamodb_contrib-py37-pynamodb41-moto1
pynamodb_contrib-py37-pynamodb42-moto1
pynamodb_contrib-py37-pynamodb43-moto1
pynamodb_contrib-py37-pynamodb-moto1
pynamodb_contrib-py38-pynamodb40-moto1
pynamodb_contrib-py38-pynamodb41-moto1
pynamodb_contrib-py38-pynamodb42-moto1
pynamodb_contrib-py38-pynamodb43-moto1
pynamodb_contrib-py38-pynamodb-moto1
pynamodb_contrib-py39-pynamodb40-moto1
pynamodb_contrib-py39-pynamodb41-moto1
pynamodb_contrib-py39-pynamodb42-moto1
pynamodb_contrib-py39-pynamodb43-moto1
pynamodb_contrib-py39-pynamodb-moto1
(.venv3.7) ~/d/dd-trace-py ❯❯❯ tox -l | grep pynamodb_contrib | wc -l
30
```