### PR TITLE
ci: fix riot tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,8 +148,8 @@ commands:
                   - run:
                       name: "Waiting for << parameters.wait >>"
                       command: pip install tox && tox -e 'wait' << parameters.wait >>
-                  - run:
-                      command: "echo -p2.7,-p3.5,-p3.6,-p3.7,-p3.8,-p3.9 | tr ',' '\n' | circleci tests split | xargs riot -v run -s '<< parameters.pattern >>'"
+            - run:
+                command: "echo -p2.7,-p3.5,-p3.6,-p3.7,-p3.8,-p3.9 | tr ',' '\n' | circleci tests split | xargs riot -v run -s '<< parameters.pattern >>'"
 
   run_tox_scenario:
     description: "Run scripts/run-tox-scenario with setup, caching and persistence"


### PR DESCRIPTION
The actual test running was being skipped if parameters.wait was not defined