### PR TITLE
ci: bump celery parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,6 +478,7 @@ jobs:
 
   celery:
     <<: *contrib_job
+    parallelism: 6
     docker:
       - image: *ddtrace_dev_image
       - image: redis:4.0-alpine


### PR DESCRIPTION
Celery is the slowest job so let's speed it up a bit.