### PR TITLE
ci: update cibuildwheel to deploy 3.9 wheels

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_SKIP: pp* cp27-win*
+          CIBW_SKIP: pp* cp27-win* cp39-win*
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.5.5
+          python -m pip install cibuildwheel==1.6.4
 
       - name: Build wheels
         run: |

--- a/releasenotes/notes/build-deploy-py39-wheels-6524f77277e3c788.yaml
+++ b/releasenotes/notes/build-deploy-py39-wheels-6524f77277e3c788.yaml
@@ -1,0 +1,3 @@
+---
+prelude: >
+    Build and deploy Python 3.9 wheels for releases


### PR DESCRIPTION
## Description

Update `cibuildwheel` to latest release (1.6.4) to add building and deploying wheels for Python 3.9, support for which was added in #1750.

## Checklist
- [x] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
