### PR TITLE
core: set tags directly with str values

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -182,12 +182,12 @@ class Context(object):
                 origin = self._dd_origin
                 # attach the origin to the root span tag
                 if sampled and origin is not None and trace:
-                    trace[0].set_tag(ORIGIN_KEY, origin)
+                    trace[0].meta[ORIGIN_KEY] = str(origin)
 
                 # Set hostname tag if they requested it
                 if config.report_hostname:
                     # DEV: `get_hostname()` value is cached
-                    trace[0].set_tag(HOSTNAME_KEY, hostname.get_hostname())
+                    trace[0].meta[HOSTNAME_KEY] = hostname.get_hostname()
 
                 # clean the current state
                 self._trace = []
@@ -210,12 +210,12 @@ class Context(object):
                     origin = self._dd_origin
                     # attach the origin to the root span tag
                     if sampled and origin is not None and trace:
-                        trace[0].set_tag(ORIGIN_KEY, origin)
+                        trace[0].meta[ORIGIN_KEY] = str(origin)
 
                     # Set hostname tag if they requested it
                     if config.report_hostname:
                         # DEV: `get_hostname()` value is cached
-                        trace[0].set_tag(HOSTNAME_KEY, hostname.get_hostname())
+                        trace[0].meta[HOSTNAME_KEY] = hostname.get_hostname()
 
                     self._finished_spans = 0
 

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -365,7 +365,7 @@ class Span(object):
             self.set_exc_info(exc_type, exc_val, exc_tb)
         else:
             tb = "".join(traceback.format_stack(limit=limit + 1)[:-1])
-            self.set_tag(errors.ERROR_STACK, tb)  # FIXME[gabin] Want to replace 'error.stack' tag with 'python.stack'
+            self.meta[errors.ERROR_STACK] = tb
 
     def set_exc_info(self, exc_type, exc_val, exc_tb):
         """ Tag the span with an error tuple as from `sys.exc_info()`. """
@@ -382,9 +382,9 @@ class Span(object):
         # readable version of type (e.g. exceptions.ZeroDivisionError)
         exc_type_str = "%s.%s" % (exc_type.__module__, exc_type.__name__)
 
-        self.set_tag(errors.ERROR_MSG, exc_val)
-        self.set_tag(errors.ERROR_TYPE, exc_type_str)
-        self.set_tag(errors.ERROR_STACK, tb)
+        self.meta[errors.ERROR_MSG] = str(exc_val)
+        self.meta[errors.ERROR_TYPE] = exc_type_str
+        self.meta[errors.ERROR_STACK] = tb
 
     def _remove_exc_info(self):
         """ Remove all exception related information from the span. """

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -477,14 +477,14 @@ class Tracer(object):
             # add tags to root span to correlate trace with runtime metrics
             # only applied to spans with types that are internal to applications
             if self._runtime_worker and self._is_span_internal(span):
-                span.set_tag('language', 'python')
+                span.meta["language"] = "python"
 
         # Apply default global tags.
         if self.tags:
             span.set_tags(self.tags)
 
         if config.env:
-            span.set_tag(ENV_KEY, config.env)
+            span.meta[ENV_KEY] = str(config.env)
 
         # Only set the version tag on internal spans.
         if config.version:
@@ -495,11 +495,11 @@ class Tracer(object):
             # then the span belongs to the user application and so set the version tag
             if (root_span is None and service == config.service) or \
                (root_span and root_span.service == service and VERSION_KEY in root_span.meta):
-                span.set_tag(VERSION_KEY, config.version)
+                span.meta[VERSION_KEY] = str(config.version)
 
         if not span._parent:
-            span.set_tag(system.PID, getpid())
-            span.set_tag("runtime-id", get_runtime_id())
+            span.metrics[system.PID] = self._pid or getpid()
+            span.meta["runtime-id"] = get_runtime_id()
 
         # add it to the current context
         context.add_span(span)


### PR DESCRIPTION
## Description
span.set_tag() does a lot of checking which is not required when we know the values we're setting.

It's nearly 8x faster to bypass all these checks and set the value directly.

```
---------------------------------------------------------------------------------------------- benchmark: 2 tests ----------------------------------------------------------------------------------------------
Name (time in ns)                  Min                    Max                  Mean              StdDev                Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_span_set_str_tag_str     137.6588 (1.0)         493.0003 (1.0)        140.7354 (1.0)       13.0741 (1.0)        139.3002 (1.0)       1.1013 (1.0)      680;5502    7,105.5342 (1.0)       68701         100
test_span_set_tag_str         921.0780 (6.69)     15,719.0952 (31.88)    1,046.3883 (7.44)     338.0417 (25.86)    1,034.0009 (7.42)     33.0620 (30.02)    107;2822      955.6682 (0.13)      76215           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

```python
def test_span_set_tag_str(benchmark):
    s = Span(None, "asdf")
    benchmark(s.set_tag, "k" * 10, "v" * 20)

def test_span_set_str_tag_str(benchmark):
    s = Span(None, "asdf")
    benchmark(s.set_str_tag, "k" * 10, "v" * 20)

class Span:
    # ....
    def set_str_tag(self, k, v):
        self.meta[k] = v
```

## Checklist
- [x] ~Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)~
- [x] ~Tests provided; and/or~
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [x] ~Library documentation is updated.~
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
