### PR TITLE
fix(profiling): use correct path for UDS support

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -137,7 +137,7 @@ def _get_default_url(api_key):
     if api_key is None:
         hostname = os.environ.get("DD_AGENT_HOST", os.environ.get("DATADOG_TRACE_AGENT_HOSTNAME", "localhost"))
         port = int(os.environ.get("DD_TRACE_AGENT_PORT", 8126))
-        return os.environ.get("DD_TRACE_AGENT_URL", "http://%s:%d" % (hostname, port)) + "/profiling/v1/input"
+        return os.environ.get("DD_TRACE_AGENT_URL", "http://%s:%d" % (hostname, port))
 
     # Agentless mode
     legacy = os.environ.get("DD_PROFILING_API_URL")
@@ -177,7 +177,7 @@ class _ProfilerInstance(object):
             ]
 
         api_key = _get_api_key()
-        endpoint = _get_default_url(api_key) if url is None else url + "/profiling/v1/input"
+        endpoint = _get_default_url(api_key) if url is None else url
 
         return [
             http.PprofHTTPExporter(service=service, env=env, version=version, api_key=api_key, endpoint=endpoint),

--- a/releasenotes/notes/profiling-fix-uds-ebf0ea0587c8a23c.yaml
+++ b/releasenotes/notes/profiling-fix-uds-ebf0ea0587c8a23c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix UDS upload for profiling not using the correct path.

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -127,7 +127,7 @@ def test_url():
     for exporter in prof._profiler._scheduler.exporters:
         if isinstance(exporter, http.PprofHTTPExporter):
             assert exporter.api_key is None
-            assert exporter.endpoint == "https://foobar:123/profiling/v1/input"
+            assert exporter.endpoint == "https://foobar:123"
             break
     else:
         pytest.fail("Unable to find HTTP exporter")
@@ -138,7 +138,7 @@ def test_env_no_api_key():
     for exporter in prof._profiler._scheduler.exporters:
         if isinstance(exporter, http.PprofHTTPExporter):
             assert exporter.api_key is None
-            assert exporter.endpoint == "http://localhost:8126/profiling/v1/input"
+            assert exporter.endpoint == "http://localhost:8126"
             break
     else:
         pytest.fail("Unable to find HTTP exporter")
@@ -151,7 +151,7 @@ def test_env_endpoint_url(monkeypatch):
     for exporter in prof._profiler._scheduler.exporters:
         if isinstance(exporter, http.PprofHTTPExporter):
             assert exporter.api_key is None
-            assert exporter.endpoint == "http://foobar:123/profiling/v1/input"
+            assert exporter.endpoint == "http://foobar:123"
             break
     else:
         pytest.fail("Unable to find HTTP exporter")


### PR DESCRIPTION
This fixes the UDS class creation which was wrongly using the hostname as path.
This also simplify the profiler/http code to hardcode the endpoint since it's
not possible to pass it via UDS anyway (and has no interest).