### PR TITLE
feat(profiling): profiler uses tracer configuration if no configuration given

### DIFF
--- a/ddtrace/profiling/exporter/http.py
+++ b/ddtrace/profiling/exporter/http.py
@@ -47,8 +47,7 @@ class PprofHTTPExporter(pprof.PprofExporter):
     max_retry_delay = attr.ib(default=None)
     _container_info = attr.ib(factory=container.get_container_info, repr=False)
     _retry_upload = attr.ib(init=None, default=None)
-
-    ENDPOINT_PATH = "/profiling/v1/input"
+    endpoint_path = attr.ib(default="/profiling/v1/input")
 
     def __attrs_post_init__(self):
         if self.max_retry_delay is None:
@@ -170,7 +169,7 @@ class PprofHTTPExporter(pprof.PprofExporter):
         else:
             raise ValueError("Unknown connection scheme %s" % parsed.scheme)
 
-        self._upload(client, self.ENDPOINT_PATH, body, headers)
+        self._upload(client, self.endpoint_path, body, headers)
 
     def _upload(self, client, path, body, headers):
         self._retry_upload(self._upload_once, client, path, body, headers)

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -2,6 +2,7 @@
 import atexit
 import logging
 import os
+from typing import Optional, List
 
 import ddtrace
 from ddtrace.profiling import recorder
@@ -13,6 +14,7 @@ from ddtrace.profiling.collector import memalloc
 from ddtrace.profiling.collector import memory
 from ddtrace.profiling.collector import stack
 from ddtrace.profiling.collector import threading
+from ddtrace.profiling import exporter
 from ddtrace.profiling.exporter import file
 from ddtrace.profiling.exporter import http
 
@@ -125,19 +127,45 @@ class Profiler(object):
         return self._profiler.url
 
 
-def _get_default_url(api_key):
+def _get_default_url(
+    tracer,  # type: Optional[ddtrace.Tracer]
+    api_key,  # type: str
+):
+    # type: (...) -> str
     """Get default profiler exporter URL.
 
     If an API key is not specified, the URL will default to the agent location configured via the environment variables.
 
     If an API key is specified, the profiler goes into agentless mode and uses `DD_SITE` to upload directly to Datadog
     backend.
+
+    :param api_key: The API key provided by the user.
+    :param tracer: The tracer object to use to find default URL.
     """
     # Default URL changes if an API_KEY is provided in the env
     if api_key is None:
-        hostname = os.environ.get("DD_AGENT_HOST", os.environ.get("DATADOG_TRACE_AGENT_HOSTNAME", "localhost"))
-        port = int(os.environ.get("DD_TRACE_AGENT_PORT", 8126))
-        return os.environ.get("DD_TRACE_AGENT_URL", "http://%s:%d" % (hostname, port))
+        if tracer is None:
+            default_hostname = "localhost"
+            default_port = 8126
+            scheme = "http"
+            path = ""
+        else:
+            default_hostname = tracer.writer.api.hostname
+            default_port = tracer.writer.api.port
+            if tracer.writer.api.https:
+                scheme = "https"
+                path = ""
+            elif tracer.writer.api.uds_path is not None:
+                scheme = "unix"
+                path = tracer.writer.api.uds_path
+            else:
+                scheme = "http"
+                path = ""
+
+        hostname = os.environ.get("DD_AGENT_HOST", os.environ.get("DATADOG_TRACE_AGENT_HOSTNAME", default_hostname))
+        port = int(os.environ.get("DD_TRACE_AGENT_PORT", default_port))
+
+        return os.environ.get("DD_TRACE_AGENT_URL", "%s://%s:%d%s" % (scheme, hostname, port, path))
 
     # Agentless mode
     legacy = os.environ.get("DD_PROFILING_API_URL")
@@ -169,7 +197,14 @@ class _ProfilerInstance(object):
     status = attr.ib(init=False, type=ProfilerStatus, default=ProfilerStatus.STOPPED)
 
     @staticmethod
-    def _build_default_exporters(url, service, env, version):
+    def _build_default_exporters(
+        tracer,  # type: Optional[ddtrace.Tracer]
+        url,  # type: Optional[str]
+        service,  # type: Optional[str]
+        env,  # type: Optional[str]
+        version,  # type: Optional[str]
+    ):
+        # type: (...) -> List[exporter.Exporter]
         _OUTPUT_PPROF = os.environ.get("DD_PROFILING_OUTPUT_PPROF")
         if _OUTPUT_PPROF:
             return [
@@ -177,10 +212,24 @@ class _ProfilerInstance(object):
             ]
 
         api_key = _get_api_key()
-        endpoint = _get_default_url(api_key) if url is None else url
+
+        if api_key is None:
+            # Agent mode
+            endpoint_path = "/profiling/v1/input"
+        else:
+            endpoint_path = "/v1/input"
+
+        endpoint = _get_default_url(tracer, api_key) if url is None else url
 
         return [
-            http.PprofHTTPExporter(service=service, env=env, version=version, api_key=api_key, endpoint=endpoint),
+            http.PprofHTTPExporter(
+                service=service,
+                env=env,
+                version=version,
+                api_key=api_key,
+                endpoint=endpoint,
+                endpoint_path=endpoint_path,
+            ),
         ]
 
     def __attrs_post_init__(self):
@@ -209,7 +258,7 @@ class _ProfilerInstance(object):
             threading.LockCollector(r, tracer=self.tracer),
         ]
 
-        exporters = self._build_default_exporters(self.url, self.service, self.env, self.version)
+        exporters = self._build_default_exporters(self.tracer, self.url, self.service, self.env, self.version)
 
         if exporters:
             self._scheduler = scheduler.Scheduler(recorder=r, exporters=exporters)

--- a/releasenotes/notes/profiling-use-tracer-config-83aa0ae0c2c53086.yaml
+++ b/releasenotes/notes/profiling-use-tracer-config-83aa0ae0c2c53086.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    The profiler now uses the tracer configuration is no configuration is provided.
+upgrade:
+  - |
+    The profiler now uses the tracer configuration is no configuration is provided.

--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,7 @@ setup(
         install_requires=[
             "enum34; python_version<'3.4'",
             "funcsigs>=1.0.0; python_version=='2.7'",
+            "typing; python_version<'3.5'",
             "protobuf>=3",
             "intervaltree",
             "tenacity>=5",

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -113,61 +113,79 @@ def test_env_api():
 def test_env_api_key(name_var, monkeypatch):
     monkeypatch.setenv(name_var, "foobar")
     prof = profiler.Profiler()
-    for exporter in prof._profiler._scheduler.exporters:
-        if isinstance(exporter, http.PprofHTTPExporter):
-            assert exporter.api_key == "foobar"
-            assert exporter.endpoint == "https://intake.profile.datadoghq.com/v1/input"
-            break
-    else:
-        pytest.fail("Unable to find HTTP exporter")
+    _check_url(prof, "https://intake.profile.datadoghq.com/v1/input", "foobar", endpoint_path="/v1/input")
 
 
 def test_url():
     prof = profiler.Profiler(url="https://foobar:123")
+    _check_url(prof, "https://foobar:123")
+
+
+def _check_url(prof, url, api_key=None, endpoint_path="/profiling/v1/input"):
     for exporter in prof._profiler._scheduler.exporters:
         if isinstance(exporter, http.PprofHTTPExporter):
-            assert exporter.api_key is None
-            assert exporter.endpoint == "https://foobar:123"
+            assert exporter.api_key == api_key
+            assert exporter.endpoint == url
+            assert exporter.endpoint_path == endpoint_path
             break
     else:
         pytest.fail("Unable to find HTTP exporter")
+
+
+def test_default_tracer_and_url():
+    try:
+        ddtrace.tracer.configure(hostname="foobar")
+        prof = profiler.Profiler(url="https://foobaz:123")
+        _check_url(prof, "https://foobaz:123")
+    finally:
+        ddtrace.tracer.configure(hostname=ddtrace.Tracer.DEFAULT_HOSTNAME)
+
+
+def test_tracer_and_url():
+    t = ddtrace.Tracer()
+    t.configure(hostname="foobar")
+    prof = profiler.Profiler(tracer=t, url="https://foobaz:123")
+    _check_url(prof, "https://foobaz:123")
+
+
+def test_tracer_url():
+    t = ddtrace.Tracer()
+    t.configure(hostname="foobar")
+    prof = profiler.Profiler(tracer=t)
+    _check_url(prof, "http://foobar:8126")
+
+
+def test_tracer_url_https():
+    t = ddtrace.Tracer()
+    t.configure(hostname="foobar", https=True)
+    prof = profiler.Profiler(tracer=t)
+    _check_url(prof, "https://foobar:8126")
+
+
+def test_tracer_url_uds():
+    t = ddtrace.Tracer()
+    t.configure(hostname="foobar", https=True, uds_path="/foobar")
+    prof = profiler.Profiler(tracer=t)
+    _check_url(prof, "https://foobar:8126")
 
 
 def test_env_no_api_key():
     prof = profiler.Profiler()
-    for exporter in prof._profiler._scheduler.exporters:
-        if isinstance(exporter, http.PprofHTTPExporter):
-            assert exporter.api_key is None
-            assert exporter.endpoint == "http://localhost:8126"
-            break
-    else:
-        pytest.fail("Unable to find HTTP exporter")
+    _check_url(prof, "http://localhost:8126")
 
 
 def test_env_endpoint_url(monkeypatch):
     monkeypatch.setenv("DD_AGENT_HOST", "foobar")
     monkeypatch.setenv("DD_TRACE_AGENT_PORT", "123")
     prof = profiler.Profiler()
-    for exporter in prof._profiler._scheduler.exporters:
-        if isinstance(exporter, http.PprofHTTPExporter):
-            assert exporter.api_key is None
-            assert exporter.endpoint == "http://foobar:123"
-            break
-    else:
-        pytest.fail("Unable to find HTTP exporter")
+    _check_url(prof, "http://foobar:123")
 
 
 def test_env_endpoint_url_no_agent(monkeypatch):
     monkeypatch.setenv("DD_SITE", "datadoghq.eu")
     monkeypatch.setenv("DD_API_KEY", "123")
     prof = profiler.Profiler()
-    for exporter in prof._profiler._scheduler.exporters:
-        if isinstance(exporter, http.PprofHTTPExporter):
-            assert exporter.api_key == "123"
-            assert exporter.endpoint == "https://intake.profile.datadoghq.eu/v1/input"
-            break
-    else:
-        pytest.fail("Unable to find HTTP exporter")
+    _check_url(prof, "https://intake.profile.datadoghq.eu/v1/input", "123", endpoint_path="/v1/input")
 
 
 def test_copy():


### PR DESCRIPTION
If the user does not pass any configuration to the Profiler object, it will by
default copy the configuration from the provided Tracer.

This makes sure that users only configuring the Tracer will see the Profiler
work the same way by default.