### PR TITLE
fix(ci): pin riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ commands:
           condition:
               << parameters.snapshot >>
           steps:
-            - run: pip3 install riot
+            - run: pip3 install riot==0.2
             - when:
                 condition:
                   << parameters.wait >>


### PR DESCRIPTION
## Description

#1826 was missing pin for riot in `run_test` job.

## Checklist
- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
