### PR TITLE
span: add ignored exceptions

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -109,7 +109,7 @@ class Span(object):
         self._ignored_exceptions = None  # type: Optional[List[Exception]]
 
     def _ignore_exception(self, exc):
-        # (Exception) -> None
+        # type: (Exception) -> None
         if self._ignored_exceptions is None:
             self._ignored_exceptions = [exc]
         else:

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -386,7 +386,7 @@ class Span(object):
         if not (exc_type and exc_val and exc_tb):
             return  # nothing to do
 
-        if self._ignored_exceptions and exc_type in self._ignored_exceptions:
+        if self._ignored_exceptions and any([isinstance(exc_type, exc) for exc in self._ignored_exceptions]):
             return
 
         self.error = 1

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -378,7 +378,7 @@ class Span(object):
         if not (exc_type and exc_val and exc_tb):
             return  # nothing to do
 
-        if self._ignored_exceptions and any([isinstance(exc_type, exc) for exc in self._ignored_exceptions]):
+        if self._ignored_exceptions and any([issubclass(exc_type, e) for e in self._ignored_exceptions]):
             return
 
         self.error = 1

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -1,6 +1,7 @@
 import math
 import sys
 import traceback
+from typing import Optional, List
 
 from .vendor import six
 from .compat import StringIO, stringify, iteritems, numeric_types, time_ns, is_integer
@@ -42,6 +43,7 @@ class Span(object):
         # Internal attributes
         "_context",
         "_parent",
+        "_ignored_exceptions",
         "__weakref__",
     ]
 
@@ -104,6 +106,14 @@ class Span(object):
 
         self._context = context
         self._parent = None
+        self._ignored_exceptions = None  # type: Optional[List[Exception]]
+
+    def _ignore_exception(self, exc):
+        # (Exception) -> None
+        if self._ignored_exceptions is None:
+            self._ignored_exceptions = [exc]
+        else:
+            self._ignored_exceptions.append(exc)
 
     @property
     def start(self):
@@ -375,6 +385,9 @@ class Span(object):
         """ Tag the span with an error tuple as from `sys.exc_info()`. """
         if not (exc_type and exc_val and exc_tb):
             return  # nothing to do
+
+        if self._ignored_exceptions and exc_type in self._ignored_exceptions:
+            return
 
         self.error = 1
 

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -534,3 +534,52 @@ def test_span_unicode_set_tag():
     span.set_tag("😐", u"😌")
     span._set_str_tag("key", u"😌")
     span._set_str_tag(u"😐", u"😌")
+
+
+def test_span_ignored_exceptions():
+    s = Span(None, None)
+    s._ignore_exception(ValueError)
+
+    with pytest.raises(ValueError):
+        with s:
+            raise ValueError()
+
+    assert s.error == 0
+    assert s.get_tag(errors.ERROR_MSG) is None
+    assert s.get_tag(errors.ERROR_TYPE) is None
+    assert s.get_tag(errors.ERROR_STACK) is None
+
+    s = Span(None, None)
+    s._ignore_exception(ValueError)
+
+    with pytest.raises(ValueError):
+        with s:
+            raise ValueError()
+
+    with pytest.raises(RuntimeError):
+        with s:
+            raise RuntimeError()
+
+    assert s.error == 1
+    assert s.get_tag(errors.ERROR_MSG) is not None
+    assert "RuntimeError" in s.get_tag(errors.ERROR_TYPE)
+    assert s.get_tag(errors.ERROR_STACK) is not None
+
+
+def test_span_ignored_exception_multi():
+    s = Span(None, None)
+    s._ignore_exception(ValueError)
+    s._ignore_exception(RuntimeError)
+
+    with pytest.raises(ValueError):
+        with s:
+            raise ValueError()
+
+    with pytest.raises(RuntimeError):
+        with s:
+            raise RuntimeError()
+
+    assert s.error == 0
+    assert s.get_tag(errors.ERROR_MSG) is None
+    assert s.get_tag(errors.ERROR_TYPE) is None
+    assert s.get_tag(errors.ERROR_STACK) is None

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -583,3 +583,21 @@ def test_span_ignored_exception_multi():
     assert s.get_tag(errors.ERROR_MSG) is None
     assert s.get_tag(errors.ERROR_TYPE) is None
     assert s.get_tag(errors.ERROR_STACK) is None
+
+
+def test_span_ignored_exception_subclass():
+    s = Span(None, None)
+    s._ignore_exception(Exception)
+
+    with pytest.raises(ValueError):
+        with s:
+            raise ValueError()
+
+    with pytest.raises(RuntimeError):
+        with s:
+            raise RuntimeError()
+
+    assert s.error == 0
+    assert s.get_tag(errors.ERROR_MSG) is None
+    assert s.get_tag(errors.ERROR_TYPE) is None
+    assert s.get_tag(errors.ERROR_STACK) is None


### PR DESCRIPTION
## Description
Currently there is no way to ignore exceptions raised when a span is being used as a context manger however there are times when exceptions are used non-erroneously as in the case of [Http404 exceptions in Django](https://github.com/DataDog/dd-trace-py/pull/1834).

## Checklist
- [x] ~Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)~
- [x] Tests provided; and/or
- [x] ~Description of manual testing performed and explanation is included in the code and/or PR.~
- [x] ~Library documentation is updated.~
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
