### PR TITLE
refactor(profiling/memalloc): reduce max number of events in memory to 65535

### DIFF
--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -32,7 +32,7 @@ def test_start_wrong_arg():
     with pytest.raises(ValueError, match="the number of frames must be in range \\[1; 65535\\]"):
         _memalloc.start(-1, 1000)
 
-    with pytest.raises(ValueError, match="the number of events must be in range \\[1; 4294967295\\]"):
+    with pytest.raises(ValueError, match="the number of events must be in range \\[1; 65535\\]"):
         _memalloc.start(64, -1)
 
 


### PR DESCRIPTION
This ought to be enough as in practice we use something like 32 or 64. The goal
being to buffer data in C before exporting to Python regularly, there's no need
to store gigabytes of stack trace in C anyway.