### PR TITLE
fix: don't spawn a _MainThread if in main thread

### DIFF
--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -103,7 +103,10 @@ else:
 
 
 if sys.version_info.major < 3:
-    main_thread = threading._MainThread()
+    if isinstance(threading.current_thread(), threading._MainThread):
+        main_thread = threading.current_thread()
+    else:
+        main_thread = threading._MainThread()
 else:
     main_thread = threading.main_thread()
 

--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -106,7 +106,7 @@ if sys.version_info.major < 3:
     if isinstance(threading.current_thread(), threading._MainThread):
         main_thread = threading.current_thread()
     else:
-        main_thread = threading._MainThread()
+        main_thread = threading._shutdown.im_self
 else:
     main_thread = threading.main_thread()
 


### PR DESCRIPTION
Instantiating a `_MainThread` is causing Python 2 applications to spawn another thread instance which conflicts with the actual MainThread that is already running causing Python 2 applications to output
```
 Exception RuntimeError: RuntimeError('cannot join current thread',)
```

