### PR TITLE
refactor(profiling): split memalloc in 2 parts

### DIFF
--- a/ddtrace/profiling/collector/_memalloc.c
+++ b/ddtrace/profiling/collector/_memalloc.c
@@ -6,21 +6,8 @@
 #include <Python.h>
 #include <frameobject.h>
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 9
-#define _PY39_AND_LATER
-#endif
-
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 8
-#define _PY38_AND_LATER
-#endif
-
-#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 8
-#define _PY38
-#endif
-
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 7
-#define _PY37_AND_LATER
-#endif
+#include "_memalloc_tb.h"
+#include "_pymacro.h"
 
 typedef struct
 {
@@ -35,185 +22,13 @@ typedef struct
 */
 static memalloc_context_t global_memalloc_ctx;
 
-typedef struct
-#ifdef __GNUC__
-  __attribute__((packed))
-#elif defined(_MSC_VER)
-#pragma pack(push, 4)
-#endif
-{
-    PyObject* filename;
-    PyObject* name;
-    unsigned int lineno;
-} frame_t;
-
-typedef struct
-{
-    /* Total number of frames in the traceback */
-    uint16_t total_nframe;
-    /* Number of frames in the traceback */
-    uint16_t nframe;
-    /* Memory size allocated in bytes */
-    size_t size;
-    /* Thread ID */
-    unsigned long thread_id;
-    /* List of frames, top frame first */
-    frame_t frames[1];
-} traceback_t;
-
-/* The maximum number of frames we can store in `traceback_t.nframe` */
-#define MAX_NFRAME UINT16_MAX
-
-/* The maximum number of events we can store in `traceback_list_t.count` */
-#define MAX_EVENTS UINT16_MAX
-
-/* Temporary traceback buffer to store new traceback */
-static traceback_t* traceback_buffer = NULL;
-
-/* List of current traceback */
-typedef struct
-{
-    traceback_t** tracebacks;
-    uint16_t count;
-    uint64_t alloc_count;
-} traceback_list_t;
-
 static traceback_list_t* global_traceback_list;
-
-/* A string containing "<unknown>" just in case we can't store the real function
- * or file name. */
-static PyObject* unknown_name = NULL;
-/* The number 1 */
-static PyObject* number_one = NULL;
-
-static void
-traceback_free(traceback_t* tb)
-{
-    for (uint16_t nframe = 0; nframe < tb->nframe; nframe++) {
-        Py_DECREF(tb->frames[nframe].filename);
-        Py_DECREF(tb->frames[nframe].name);
-    }
-    PyMem_RawFree(tb);
-}
-
-/* Convert PyFrameObject to a frame_t that we can store in memory */
-static void
-memalloc_convert_frame(PyFrameObject* pyframe, frame_t* frame)
-{
-    int lineno = PyFrame_GetLineNumber(pyframe);
-    if (lineno < 0)
-        lineno = 0;
-
-    frame->lineno = (unsigned int)lineno;
-
-    PyObject *filename, *name;
-
-#ifdef _PY39_AND_LATER
-    PyCodeObject* code = PyFrame_GetCode(pyframe);
-#else
-    PyCodeObject* code = pyframe->f_code;
-#endif
-
-    if (code == NULL) {
-        filename = unknown_name;
-        name = unknown_name;
-    } else {
-        filename = code->co_filename;
-        name = code->co_name;
-    }
-
-#ifdef _PY39_AND_LATER
-    Py_DECREF(code);
-#endif
-
-    if (name)
-        frame->name = name;
-    else
-        frame->name = unknown_name;
-
-    Py_INCREF(frame->name);
-
-    if (filename)
-        frame->filename = filename;
-    else
-        frame->filename = unknown_name;
-
-    Py_INCREF(frame->filename);
-}
-
-#define TRACEBACK_SIZE(NFRAME) (sizeof(traceback_t) + sizeof(frame_t) * (NFRAME - 1))
-
-static traceback_t*
-memalloc_frame_to_traceback(PyFrameObject* pyframe, uint16_t max_nframe)
-{
-    traceback_buffer->total_nframe = 0;
-    traceback_buffer->nframe = 0;
-
-    for (; pyframe != NULL;) {
-        if (traceback_buffer->nframe < max_nframe) {
-            memalloc_convert_frame(pyframe, &traceback_buffer->frames[traceback_buffer->nframe]);
-            traceback_buffer->nframe++;
-        }
-        /* Make sure we don't overflow */
-        if (traceback_buffer->total_nframe < UINT16_MAX)
-            traceback_buffer->total_nframe++;
-
-#ifdef _PY39_AND_LATER
-        PyFrameObject* back = PyFrame_GetBack(pyframe);
-        Py_DECREF(pyframe);
-        pyframe = back;
-#else
-        pyframe = pyframe->f_back;
-#endif
-    }
-
-    size_t traceback_size = TRACEBACK_SIZE(traceback_buffer->nframe);
-    traceback_t* traceback = PyMem_RawMalloc(traceback_size);
-
-    if (traceback)
-        memcpy(traceback, traceback_buffer, traceback_size);
-
-    return traceback;
-}
 
 static uint64_t
 random_range(uint64_t max)
 {
     /* Return a random number between [0, max[ */
     return (uint64_t)((double)rand() / ((double)RAND_MAX + 1) * max);
-}
-
-static traceback_t*
-memalloc_get_traceback(uint16_t max_nframe, size_t size)
-{
-    PyThreadState* tstate = PyThreadState_Get();
-
-    if (tstate == NULL)
-        return NULL;
-
-#ifdef _PY39_AND_LATER
-    PyFrameObject* pyframe = PyThreadState_GetFrame(tstate);
-#else
-    PyFrameObject* pyframe = tstate->frame;
-#endif
-
-    if (pyframe == NULL)
-        return NULL;
-
-    traceback_t* traceback = memalloc_frame_to_traceback(pyframe, max_nframe);
-
-    if (traceback == NULL)
-        return NULL;
-
-    traceback->size = size;
-
-#ifdef _PY37_AND_LATER
-    traceback->thread_id = PyThread_get_thread_ident();
-#else
-    traceback->thread_id = tstate->thread_id;
-#endif
-
-    return traceback;
 }
 
 static void
@@ -317,25 +132,6 @@ traceback_list_free(traceback_list_t* tb_list)
     PyMem_RawFree(tb_list);
 }
 
-static int
-_memalloc_init_constants(void)
-{
-    if (unknown_name == NULL) {
-        unknown_name = PyUnicode_FromString("<unknown>");
-        if (unknown_name == NULL)
-            return -1;
-        PyUnicode_InternInPlace(&unknown_name);
-    }
-
-    if (number_one == NULL) {
-        number_one = PyLong_FromLong(1);
-        if (number_one == NULL)
-            return -1;
-    }
-
-    return 0;
-}
-
 PyDoc_STRVAR(memalloc_start__doc__,
              "start($module, max_nframe, max_events)\n"
              "--\n"
@@ -358,15 +154,15 @@ memalloc_start(PyObject* Py_UNUSED(module), PyObject* args)
     if (!PyArg_ParseTuple(args, "ll", &max_nframe, &max_events))
         return NULL;
 
-    if (max_nframe < 1 || max_nframe > MAX_NFRAME) {
-        PyErr_Format(PyExc_ValueError, "the number of frames must be in range [1; %lu]", MAX_NFRAME);
+    if (max_nframe < 1 || max_nframe > TRACEBACK_MAX_NFRAME) {
+        PyErr_Format(PyExc_ValueError, "the number of frames must be in range [1; %lu]", TRACEBACK_MAX_NFRAME);
         return NULL;
     }
 
     global_memalloc_ctx.max_nframe = (uint16_t)max_nframe;
 
-    if (max_events < 1 || max_events > MAX_EVENTS) {
-        PyErr_Format(PyExc_ValueError, "the number of events must be in range [1; %lu]", MAX_EVENTS);
+    if (max_events < 1 || max_events > TRACEBACK_LIST_MAX_COUNT) {
+        PyErr_Format(PyExc_ValueError, "the number of events must be in range [1; %lu]", TRACEBACK_LIST_MAX_COUNT);
         return NULL;
     }
 
@@ -380,20 +176,13 @@ memalloc_start(PyObject* Py_UNUSED(module), PyObject* args)
     alloc.free = memalloc_free;
 
     alloc.ctx = &global_memalloc_ctx;
-    PyMem_GetAllocator(PYMEM_DOMAIN_OBJ, &global_memalloc_ctx.pymem_allocator_obj);
-    PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &alloc);
 
     global_traceback_list = traceback_list_new();
 
-    /* Allocate a buffer that can handle the largest traceback possible.
-       This will be used a temporary buffer when converting stack traces. */
-    traceback_buffer = PyMem_RawMalloc(TRACEBACK_SIZE(global_memalloc_ctx.max_nframe));
+    memalloc_tb_init(global_memalloc_ctx.max_nframe);
 
-    if (_memalloc_init_constants()) {
-        PyMem_RawFree(traceback_buffer);
-        traceback_list_free(global_traceback_list);
-        return NULL;
-    }
+    PyMem_GetAllocator(PYMEM_DOMAIN_OBJ, &global_memalloc_ctx.pymem_allocator_obj);
+    PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &alloc);
 
     Py_RETURN_NONE;
 }
@@ -450,7 +239,7 @@ memalloc_stop(PyObject* Py_UNUSED(module), PyObject* Py_UNUSED(args))
     }
 
     PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &global_memalloc_ctx.pymem_allocator_obj);
-    PyMem_RawFree(traceback_buffer);
+    memalloc_tb_deinit();
     traceback_list_free_tracebacks(global_traceback_list);
     traceback_list_free(global_traceback_list);
     global_traceback_list = NULL;

--- a/ddtrace/profiling/collector/_memalloc_tb.c
+++ b/ddtrace/profiling/collector/_memalloc_tb.c
@@ -1,0 +1,168 @@
+#include <string.h>
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <frameobject.h>
+
+#include "_memalloc_tb.h"
+#include "_pymacro.h"
+
+/* Temporary traceback buffer to store new traceback */
+static traceback_t* traceback_buffer = NULL;
+
+/* A string containing "<unknown>" just in case we can't store the real function
+ * or file name. */
+static PyObject* unknown_name = NULL;
+/* The number 1 */
+static PyObject* number_one = NULL;
+
+#define TRACEBACK_SIZE(NFRAME) (sizeof(traceback_t) + sizeof(frame_t) * (NFRAME - 1))
+
+int
+memalloc_tb_init(uint16_t max_nframe)
+{
+    if (unknown_name == NULL) {
+        unknown_name = PyUnicode_FromString("<unknown>");
+        if (unknown_name == NULL)
+            return -1;
+        PyUnicode_InternInPlace(&unknown_name);
+    }
+
+    if (number_one == NULL) {
+        number_one = PyLong_FromLong(1);
+        if (number_one == NULL)
+            return -1;
+    }
+    /* Allocate a buffer that can handle the largest traceback possible.
+       This will be used a temporary buffer when converting stack traces. */
+    traceback_buffer = PyMem_RawMalloc(TRACEBACK_SIZE(max_nframe));
+
+    return 0;
+}
+
+void
+memalloc_tb_deinit(void)
+{
+    PyMem_RawFree(traceback_buffer);
+}
+
+void
+traceback_free(traceback_t* tb)
+{
+    for (uint16_t nframe = 0; nframe < tb->nframe; nframe++) {
+        Py_DECREF(tb->frames[nframe].filename);
+        Py_DECREF(tb->frames[nframe].name);
+    }
+    PyMem_RawFree(tb);
+}
+
+/* Convert PyFrameObject to a frame_t that we can store in memory */
+static void
+memalloc_convert_frame(PyFrameObject* pyframe, frame_t* frame)
+{
+    int lineno = PyFrame_GetLineNumber(pyframe);
+    if (lineno < 0)
+        lineno = 0;
+
+    frame->lineno = (unsigned int)lineno;
+
+    PyObject *filename, *name;
+
+#ifdef _PY39_AND_LATER
+    PyCodeObject* code = PyFrame_GetCode(pyframe);
+#else
+    PyCodeObject* code = pyframe->f_code;
+#endif
+
+    if (code == NULL) {
+        filename = unknown_name;
+        name = unknown_name;
+    } else {
+        filename = code->co_filename;
+        name = code->co_name;
+    }
+
+#ifdef _PY39_AND_LATER
+    Py_DECREF(code);
+#endif
+
+    if (name)
+        frame->name = name;
+    else
+        frame->name = unknown_name;
+
+    Py_INCREF(frame->name);
+
+    if (filename)
+        frame->filename = filename;
+    else
+        frame->filename = unknown_name;
+
+    Py_INCREF(frame->filename);
+}
+
+static traceback_t*
+memalloc_frame_to_traceback(PyFrameObject* pyframe, uint16_t max_nframe)
+{
+    traceback_buffer->total_nframe = 0;
+    traceback_buffer->nframe = 0;
+
+    for (; pyframe != NULL;) {
+        if (traceback_buffer->nframe < max_nframe) {
+            memalloc_convert_frame(pyframe, &traceback_buffer->frames[traceback_buffer->nframe]);
+            traceback_buffer->nframe++;
+        }
+        /* Make sure we don't overflow */
+        if (traceback_buffer->total_nframe < UINT16_MAX)
+            traceback_buffer->total_nframe++;
+
+#ifdef _PY39_AND_LATER
+        PyFrameObject* back = PyFrame_GetBack(pyframe);
+        Py_DECREF(pyframe);
+        pyframe = back;
+#else
+        pyframe = pyframe->f_back;
+#endif
+    }
+
+    size_t traceback_size = TRACEBACK_SIZE(traceback_buffer->nframe);
+    traceback_t* traceback = PyMem_RawMalloc(traceback_size);
+
+    if (traceback)
+        memcpy(traceback, traceback_buffer, traceback_size);
+
+    return traceback;
+}
+
+traceback_t*
+memalloc_get_traceback(uint16_t max_nframe, size_t size)
+{
+    PyThreadState* tstate = PyThreadState_Get();
+
+    if (tstate == NULL)
+        return NULL;
+
+#ifdef _PY39_AND_LATER
+    PyFrameObject* pyframe = PyThreadState_GetFrame(tstate);
+#else
+    PyFrameObject* pyframe = tstate->frame;
+#endif
+
+    if (pyframe == NULL)
+        return NULL;
+
+    traceback_t* traceback = memalloc_frame_to_traceback(pyframe, max_nframe);
+
+    if (traceback == NULL)
+        return NULL;
+
+    traceback->size = size;
+
+#ifdef _PY37_AND_LATER
+    traceback->thread_id = PyThread_get_thread_ident();
+#else
+    traceback->thread_id = tstate->thread_id;
+#endif
+
+    return traceback;
+}

--- a/ddtrace/profiling/collector/_memalloc_tb.h
+++ b/ddtrace/profiling/collector/_memalloc_tb.h
@@ -1,0 +1,64 @@
+#ifndef _DDTRACE_MEMALLOC_TB_H
+#define _DDTRACE_MEMALLOC_TB_H
+
+#include <stdint.h>
+
+#include <Python.h>
+
+typedef struct
+#ifdef __GNUC__
+  __attribute__((packed))
+#elif defined(_MSC_VER)
+#pragma pack(push, 4)
+#endif
+{
+    PyObject* filename;
+    PyObject* name;
+    unsigned int lineno;
+} frame_t;
+
+typedef struct
+{
+    /* Total number of frames in the traceback */
+    uint16_t total_nframe;
+    /* Number of frames in the traceback */
+    uint16_t nframe;
+    /* Memory pointer allocated */
+    void* ptr;
+    /* Memory size allocated in bytes */
+    size_t size;
+    /* Thread ID */
+    unsigned long thread_id;
+    /* List of frames, top frame first */
+    frame_t frames[1];
+} traceback_t;
+
+/* The maximum number of frames we can store in `traceback_t.nframe` */
+#define TRACEBACK_MAX_NFRAME UINT16_MAX
+
+/* List of tracebacks */
+typedef struct
+{
+    /* List of traceback */
+    traceback_t** tracebacks;
+    /* Number of traceback in the list of traceback */
+    uint16_t count;
+    /* Total number of allocations */
+    uint64_t alloc_count;
+} traceback_list_t;
+
+/* The maximum number of events we can store in `traceback_list_t.count` */
+#define TRACEBACK_LIST_MAX_COUNT UINT16_MAX
+
+int
+memalloc_tb_init(uint16_t max_nframe);
+void
+memalloc_tb_deinit();
+
+void
+traceback_free(traceback_t* tb);
+
+traceback_t*
+memalloc_get_traceback(uint16_t max_nframe, size_t size);
+
+#endif

--- a/ddtrace/profiling/collector/_pymacro.h
+++ b/ddtrace/profiling/collector/_pymacro.h
@@ -1,0 +1,20 @@
+#ifndef _DDTRACE_MEMALLOC_PYMACRO
+#define _DDTRACE_MEMALLOC_PYMACRO
+
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 9
+#define _PY39_AND_LATER
+#endif
+
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 8
+#define _PY38_AND_LATER
+#endif
+
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 8
+#define _PY38
+#endif
+
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 7
+#define _PY37_AND_LATER
+#endif
+
+#endif

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ if sys.version_info[:2] >= (3, 4):
     ext_modules = [
         Extension(
             "ddtrace.profiling.collector._memalloc",
-            sources=["ddtrace/profiling/collector/_memalloc.c"],
+            sources=["ddtrace/profiling/collector/_memalloc.c", "ddtrace/profiling/collector/_memalloc_tb.c"],
             extra_compile_args=debug_compile_args,
         ),
     ]


### PR DESCRIPTION
This splits the memory allocation profiler in 2 different files. The new file
contains everything related to traceback management.

This should make it easier to comprehend and hack on the memalloc profiler in
the future.