### PR TITLE
ci: upgrade riot in docker ci image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,6 @@ RUN \
   && pyenv global 3.8.6 2.7.17 3.5.10 3.6.12 3.7.9 3.9.0 \
   && pip install --upgrade pip
 
-RUN pip install tox riot
+RUN pip install tox riot==0.4.0
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Description

Upgrade docker image to unblock #1828 

## Checklist
- ~[ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)~
- ~[ ] Tests provided; and/or~
- ~[ ] Description of manual testing performed and explanation is included in the code and/or PR.~
- ~[ ] Library documentation is updated.~
- ~[ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
