### PR TITLE
requests: fix TracedSession usage when not patching 

### DIFF
--- a/ddtrace/contrib/requests/session.py
+++ b/ddtrace/contrib/requests/session.py
@@ -2,6 +2,8 @@ import requests
 
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
+from ddtrace import config, Pin
+
 from .connection import _wrap_send
 
 
@@ -16,3 +18,4 @@ class TracedSession(requests.Session):
 
 # always patch our `TracedSession` when imported
 _w(TracedSession, "send", _wrap_send)
+Pin(_config=config.requests).onto(TracedSession)

--- a/releasenotes/notes/traced-session-1f2134ac99449b91.yaml
+++ b/releasenotes/notes/traced-session-1f2134ac99449b91.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    requests: fix TracedSession when patches are not applied.

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -1,7 +1,11 @@
+import subprocess
+import sys
+
 import pytest
 import requests
 from requests import Session
 from requests.exceptions import MissingSchema
+from ddtrace.vendor import six
 
 from ddtrace import config
 from ddtrace import Pin
@@ -495,3 +499,26 @@ class TestRequests(BaseRequestTestCase, TracerTestCase):
         self.assertEqual(len(spans), 1)
         s = spans[0]
         self.assertEqual(s.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
+
+
+def test_traced_session_no_patch_all(tmpdir):
+    f = tmpdir.join("test.py")
+    f.write(
+        """
+import ddtrace
+import ddtrace.contrib.requests
+
+session = ddtrace.contrib.requests.TracedSession()
+session.get("{}")
+""".lstrip().format(URL_200)
+    )
+    p = subprocess.Popen(
+        [sys.executable, "test.py"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=str(tmpdir),
+    )
+    p.wait()
+    assert p.stderr.read() == six.b("")
+    assert p.stdout.read() == six.b("")
+    assert p.returncode == 0

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -505,12 +505,16 @@ def test_traced_session_no_patch_all(tmpdir):
     f = tmpdir.join("test.py")
     f.write(
         """
+import mock
 import ddtrace
-import ddtrace.contrib.requests
+from ddtrace.contrib.requests import TracedSession
 
-session = ddtrace.contrib.requests.TracedSession()
-session.get("{}")
-""".lstrip().format(URL_200)
+# disable tracer writing to agent
+ddtrace.tracer.writer.flush_queue = mock.Mock(return_value=None)
+
+session = TracedSession()
+session.get("http://httpbin.org/status/200")
+""".lstrip()
     )
     p = subprocess.Popen(
         [sys.executable, "test.py"],


### PR DESCRIPTION
## Description
`TracedSession` is broken unless patching is done.

Fixes #778

## Checklist
- [x] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [x] Tests provided; and/or
- [x] ~Description of manual testing performed and explanation is included in the code and/or PR.~
- [x] ~Library documentation is updated.~
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
