### PR TITLE
refactor(profiling/memalloc): track allocated ptr

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_tb.c
+++ b/ddtrace/profiling/collector/_memalloc_tb.c
@@ -128,7 +128,7 @@ memalloc_frame_to_traceback(PyFrameObject* pyframe, uint16_t max_nframe)
 }
 
 traceback_t*
-memalloc_get_traceback(uint16_t max_nframe, size_t size)
+memalloc_get_traceback(uint16_t max_nframe, void* ptr, size_t size)
 {
     PyThreadState* tstate = PyThreadState_Get();
 
@@ -150,6 +150,7 @@ memalloc_get_traceback(uint16_t max_nframe, size_t size)
         return NULL;
 
     traceback->size = size;
+    traceback->ptr = ptr;
 
 #ifdef _PY37_AND_LATER
     traceback->thread_id = PyThread_get_thread_ident();

--- a/ddtrace/profiling/collector/_memalloc_tb.h
+++ b/ddtrace/profiling/collector/_memalloc_tb.h
@@ -59,6 +59,6 @@ void
 traceback_free(traceback_t* tb);
 
 traceback_t*
-memalloc_get_traceback(uint16_t max_nframe, size_t size);
+memalloc_get_traceback(uint16_t max_nframe, void* ptr, size_t size);
 
 #endif


### PR DESCRIPTION
This stores the allocated ptr address into the traceback_t struct.