### PR TITLE
tests: force env values in CI tests

### DIFF
--- a/tests/tracer/test_ext.py
+++ b/tests/tracer/test_ext.py
@@ -31,4 +31,4 @@ def _updateenv(monkeypatch, env):
 @pytest.mark.parametrize("name,environment,tags", _ci_fixtures())
 def test_ci_providers(monkeypatch, name, environment, tags):
     _updateenv(monkeypatch, environment)
-    assert tags == ci.tags(), "wrong tags in {0} for {1}".format(name, environment)
+    assert tags == ci.tags(environment), "wrong tags in {0} for {1}".format(name, environment)


### PR DESCRIPTION
## Description
<!-- Please briefly describe the change and why it was required. -->


## Checklist
- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
