### PR TITLE
ci: remove tox/riot from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,4 @@ RUN \
   && pyenv global 3.8.6 2.7.17 3.5.10 3.6.12 3.7.9 3.9.0 \
   && pip install --upgrade pip
 
-RUN pip install tox riot
-
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Description

In light of issues with maintaining the ci image we use for running tests in a Docker container, this PR removes riot and tox from our Dockerfile. This avoids the problem of pinning or upgrading these packages as they are updated. Also, if we down the line want to pin, we pin them in the setup ci jobs rather than having to first push a change with the updated pinned version in the Dockerfile. The `scripts/ddtest` has already been updated in #1828 to silently install these packages before executing a command.

## Checklist
- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
