### PR TITLE
Remove coverage as a dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -162,7 +162,6 @@ extras =
 
 deps =
     cython
-    coverage
     pytest-cov
     pytest-mock
     opentracing


### PR DESCRIPTION
pytest-cov should be sufficient.
