### PR TITLE
fix(profiling): fix thread join() hang after fork() with gevent

### DIFF
--- a/releasenotes/notes/profiling-fix-deadlock-gevent-1e6192828238def3.yaml
+++ b/releasenotes/notes/profiling-fix-deadlock-gevent-1e6192828238def3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The profiler won't deadlock on fork when gevent monkey patch is enabled.

--- a/tests/profiling/gevent_fork.py
+++ b/tests/profiling/gevent_fork.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+import gevent.monkey
+
+gevent.monkey.patch_all()
+
+from ddtrace.profiling import profiler  # noqa
+
+p = profiler.Profiler().start(profile_children=True)
+
+pid = os.fork()
+if pid == 0:
+    print("Exiting")
+else:
+    print(pid)
+    pid, status = os.waitpid(pid, 0)
+    print("Exited")
+    sys.exit(os.WEXITSTATUS(status))

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -79,3 +79,10 @@ def test_fork(tmp_path, monkeypatch):
     child_pid = stdout.decode().strip()
     check_pprof_file(filename + "." + str(pid) + ".1")
     check_pprof_file(filename + "." + str(child_pid) + ".1")
+
+
+@pytest.mark.skipif(not os.getenv("DD_PROFILE_TEST_GEVENT", False), reason="Not testing gevent")
+def test_fork_gevent(monkeypatch):
+    monkeypatch.setenv("DD_PROFILING_API_TIMEOUT", "0.1")
+    stdout, stderr, exitcode, pid = call_program("python", os.path.join(os.path.dirname(__file__), "gevent_fork.py"))
+    assert exitcode == 0

--- a/tests/profiling/test_periodic.py
+++ b/tests/profiling/test_periodic.py
@@ -54,12 +54,24 @@ def test_periodic():
     t.start()
     thread_started.wait()
     thread_continue.set()
+    assert t.is_alive()
     t.stop()
     t.join()
+    assert not t.is_alive()
     assert x["OK"]
     assert x["DOWN"]
     if hasattr(threading, "get_native_id"):
         assert t.native_id is not None
+
+
+def test_periodic_double_start():
+    def _run_periodic():
+        pass
+
+    t = _periodic.PeriodicRealThread(0.1, _run_periodic)
+    t.start()
+    with pytest.raises(RuntimeError):
+        t.start()
 
 
 def test_periodic_error():
@@ -114,3 +126,11 @@ def test_periodic_join_stop_no_start():
     t.stop()
     t.join()
     t.stop()
+
+
+def test_is_alive_before_start():
+    def x():
+        pass
+
+    t = _periodic.PeriodicRealThread(1, x)
+    assert not t.is_alive()


### PR DESCRIPTION
In gevent when profile_childre is True, the child process will try to stop the
parent profiler. This can hang forever since the thread is not running: it will
never set the `quit` value to True.

To avoid this, we use `self.is_alive` to check if the thread is alive; on fork,
the thread is marked as dead by Python via the _reset_internal_locks() method.

This is a fix similar to 6836e1f05d58649b16e8e5a668bce85cfd1238a5

In order to `is_alive` to work, the thread now set the Thread._started event
correctly. It's set in __bootstrap normally, but this uses Locks in Python 3
which are now gevent-Lock, so we can't use this method. We use our own variable
and a busy loop to make sure the thread booted.

This can avoid a race condition when the process fork just after the thread
starts and where it'd not be in threading._active. You never know!

Fixes #1414
