### PR TITLE
Use riot for mongoengine tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -669,13 +669,13 @@ jobs:
           pattern: '^pymemcache_contrib\(_autopatch\)\?-'
 
   mongoengine:
-    <<: *contrib_job
-    docker:
-      - image: *ddtrace_dev_image
-      - image: *mongo_image
+    <<: *machine_executor
+    parallelism: 1
     steps:
-      - run_tox_scenario:
-          pattern: '^mongoengine_contrib-'
+      - run_test:
+          pattern: 'mongoengine'
+          snapshot: true
+          docker_services: 'mongo'
 
   pymongo:
     <<: *contrib_job

--- a/riotfile.py
+++ b/riotfile.py
@@ -252,5 +252,25 @@ venv = Venv(
             command="pytest tests/contrib/botocore",
             venvs=[Venv(pys=select_pys(), pkgs={"botocore": latest, "moto": [">=1.0,<2.0"]})],
         ),
+        Venv(
+            name="mongoengine",
+            command="pytest tests/contrib/mongoengine",
+            pkgs={
+                "pymongo": latest,
+            },
+            venvs=[
+                Venv(
+                    pys=select_pys(),
+                    pkgs={
+                        # 0.20 dropped support for Python 2.7
+                        "mongoengine": [">=0.15,<0.16", ">=0.16,<0.17", ">=0.17,<0.18", ">=0.18,<0.19"]
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version=3.6),
+                    pkgs={"mongoengine": [">=0.20,<0.21", ">=0.21,<0.22", ">=0.22,<0.23", latest]},
+                ),
+            ],
+        ),
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,6 @@ envlist =
     kombu_contrib-py{37,38,39}-kombu{42,43,44,45,46,}
     mako_contrib-py{27,35,36,37,38,39}-mako{010,100,110,}
     molten_contrib-py{36,37,38,39}-molten{06,07,10,}
-    mongoengine_contrib-py{27,35,36,37,38,39}-mongoengine{015,016,017,018,}-pymongo
     mysql_contrib-py{27,35,36,37,38,39}-mysqlconnector{80,}
     mysqldb_contrib-py27-mysqldb{12,}
     mysqldb_contrib-py{27,35,36,37,38,39}-mysqlclient{13,14,}
@@ -335,11 +334,6 @@ deps =
     molten07: molten>=0.7,<0.8
     molten10: molten>=1.0,<1.1
     mongoengine: mongoengine
-    mongoengine015: mongoengine>=0.15<0.16
-    mongoengine016: mongoengine>=0.16<0.17
-    mongoengine017: mongoengine>=0.17<0.18
-    mongoengine018: mongoengine>=0.18<0.19
-    mongoengine019: mongoengine>=0.19<0.20
     mysqlconnector: mysql-connector-python
     mysqlconnector80: mysql-connector-python>=8.0<8.1
     mysqldb: mysql-python
@@ -471,7 +465,6 @@ commands =
     jinja2_contrib: pytest {posargs} tests/contrib/jinja2
     mako_contrib: pytest {posargs} tests/contrib/mako
     molten_contrib: pytest {posargs} tests/contrib/molten
-    mongoengine_contrib: pytest {posargs} tests/contrib/mongoengine
     mysql_contrib: pytest {posargs} tests/contrib/mysql
     mysqldb_contrib: pytest {posargs} tests/contrib/mysqldb
     psycopg_contrib: pytest {posargs} tests/contrib/psycopg


### PR DESCRIPTION
Two reasons:

1) The 0.22 release of mongoengine introduced syntax [that breaks Python 3.5](https://github.com/MongoEngine/mongoengine/pull/2448). So we need to work around this
2) It appears as though tox is broken for our mongoengine tests. It pulls in the latest version of pymongo for each of the tests as seen here: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/4286/workflows/6a8db7e2-36fc-4679-8e65-8a87896bf46b/jobs/427577

