### PR TITLE
refactor(profiling): remove global periodic thread list

### DIFF
--- a/ddtrace/profiling/collector/_threading.pyx
+++ b/ddtrace/profiling/collector/_threading.pyx
@@ -16,19 +16,15 @@ cpdef get_thread_name(thread_id):
     if thread_id == _nogevent.main_thread_id:
         return "MainThread"
 
-    # Try to look if this is one of our periodic threads
+    # We don't want to bother to lock anything here, especially with eventlet involved 😓. We make a best effort to
+    # get the thread name; if we fail, it'll just be an anonymous thread because it's either starting or dying.
     try:
-        return _periodic.PERIODIC_THREADS[thread_id].name
+        return threading._active[thread_id].name
     except KeyError:
-        # We don't want to bother to lock anything here, especially with eventlet involved 😓. We make a best effort to
-        # get the thread name; if we fail, it'll just be an anonymous thread because it's either starting or dying.
         try:
-            return threading._active[thread_id].name
+            return threading._limbo[thread_id].name
         except KeyError:
-            try:
-                return threading._limbo[thread_id].name
-            except KeyError:
-                return None
+            return None
 
 
 cpdef get_thread_native_id(thread_id):

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -249,7 +249,7 @@ cdef get_task(thread_id):
     return task_id, task_name
 
 
-cdef collect_threads(ignore_profiler, thread_time, thread_span_links) with gil:
+cdef collect_threads(thread_id_ignore_list, thread_time, thread_span_links) with gil:
     cdef dict current_exceptions = {}
 
     IF UNAME_SYSNAME != "Windows" and PY_MAJOR_VERSION >= 3 and PY_MINOR_VERSION >= 7:
@@ -305,14 +305,22 @@ cdef collect_threads(ignore_profiler, thread_time, thread_span_links) with gil:
             cpu_time,
         )
         for (pthread_id, native_thread_id), cpu_time in cpu_times.items()
-        if not ignore_profiler or pthread_id not in _periodic.PERIODIC_THREADS
+        if pthread_id not in thread_id_ignore_list
     )
 
 
 
 cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_time, thread_span_links):
 
-    running_threads = collect_threads(ignore_profiler, thread_time, thread_span_links)
+    if ignore_profiler:
+        # Do not use `threading.enumerate` to not mess with locking (gevent!)
+        thread_id_ignore_list = {thread_id
+                                 for thread_id, thread in threading._active.items()
+                                 if getattr(thread, "_ddtrace_profiling_ignore", False)}
+    else:
+        thread_id_ignore_list = set()
+
+    running_threads = collect_threads(thread_id_ignore_list, thread_time, thread_span_links)
 
     if thread_span_links:
         # FIXME also use native thread id

--- a/tests/profiling/test_periodic.py
+++ b/tests/profiling/test_periodic.py
@@ -53,13 +53,11 @@ def test_periodic():
     t = _periodic.PeriodicRealThread(0.001, _run_periodic, on_shutdown=_on_shutdown)
     t.start()
     thread_started.wait()
-    assert t.ident in _periodic.PERIODIC_THREADS
     thread_continue.set()
     t.stop()
     t.join()
     assert x["OK"]
     assert x["DOWN"]
-    assert t.ident not in _periodic.PERIODIC_THREADS
     if hasattr(threading, "get_native_id"):
         assert t.native_id is not None
 
@@ -81,12 +79,10 @@ def test_periodic_error():
     t = _periodic.PeriodicRealThread(0.001, _run_periodic, on_shutdown=_on_shutdown)
     t.start()
     thread_started.wait()
-    assert t.ident in _periodic.PERIODIC_THREADS
     thread_continue.set()
     t.stop()
     t.join()
     assert "DOWN" not in x
-    assert t.ident not in _periodic.PERIODIC_THREADS
 
 
 def test_gevent_class():


### PR DESCRIPTION
This list was used to track the periodic thread running on behalf of the
profiler, to ignore them when collecting data.

This mechanism is quite fragile and actually breaks on a fork: the threads are
dead and won't never be removed from the list.

In order to avoid that, we now use the list of active thread maintained by
Python in `threading._active` instead, and add a `_ddtrace_profiling_ignore`
flag to our `threading.Thread` class to indicate it should be ignored.

This has the perk of allowing anyone to write threads ignore by the profiler —
for better or for worse.