### PR TITLE
Coverage ignore couldnt-parse errors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,9 @@
 [run]
 omit = ddtrace/vendor/*
 
+# Ignore warnings when we run as Python 2.7 and have a Python 3.x file
+disable_warnings = couldnt-parse
+
 [paths]
 source =
     ./


### PR DESCRIPTION
## Description
https://coverage.readthedocs.io/en/coverage-5.3/cmd.html#warnings

```
Coverage.py warning: Couldn't parse Python file '/root/project/tests/contrib/molten/test_molten.py' (couldnt-parse)
Coverage.py warning: Couldn't parse Python file '/root/project/tests/contrib/sanic/test_sanic.py' (couldnt-parse)
Coverage.py warning: Couldn't parse Python file '/root/project/tests/contrib/sanic/test_sanic_server.py' (couldnt-parse)
```