### PR TITLE
test(profiling): fix potential failure in test_collect_truncate with gevent

### DIFF
--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -48,8 +48,7 @@ def test_collect_truncate():
     c.stop()
     for e in r.events[stack.StackSampleEvent]:
         if e.thread_name == "MainThread":
-            assert e.nframes > c.nframes
-            assert len(e.frames) == c.nframes
+            assert len(e.frames) <= c.nframes
             break
     else:
         pytest.fail("Unable to find the main thread")
@@ -296,7 +295,7 @@ def test_exception_collection():
     assert e.sampling_period > 0
     assert e.thread_id == _nogevent.thread_get_ident()
     assert e.thread_name == "MainThread"
-    assert e.frames == [(__file__, 290, "test_exception_collection")]
+    assert e.frames == [(__file__, 289, "test_exception_collection")]
     assert e.nframes == 1
     assert e.exc_type == ValueError
 


### PR DESCRIPTION
The number of frames in the events is only > than the number of max frames if
the captured thread runs code that needs truncation.

With gevent, it happens that the MainThread runs the gevent main loop function
which is only 1 stack trace long, so no truncation happens.