### PR TITLE
refactor(profiling): allow to compare Profiler objects

### DIFF
--- a/ddtrace/profiling/_service.py
+++ b/ddtrace/profiling/_service.py
@@ -19,8 +19,8 @@ class ServiceAlreadyRunning(RuntimeError):
 class Service(object):
     """A service that can be started or stopped."""
 
-    status = attr.ib(default=ServiceStatus.STOPPED, type=ServiceStatus, init=False)
-    _service_lock = attr.ib(factory=threading.Lock, repr=False, init=False)
+    status = attr.ib(default=ServiceStatus.STOPPED, type=ServiceStatus, init=False, eq=False)
+    _service_lock = attr.ib(factory=threading.Lock, repr=False, init=False, eq=False)
 
     def __enter__(self):
         self.start()

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -456,9 +456,9 @@ class StackCollector(collector.PeriodicCollector):
     nframes = attr.ib(factory=_attr.from_env("DD_PROFILING_MAX_FRAMES", 64, int))
     ignore_profiler = attr.ib(factory=_attr.from_env("DD_PROFILING_IGNORE_PROFILER", True, formats.asbool))
     tracer = attr.ib(default=None)
-    _thread_time = attr.ib(init=False, repr=False)
-    _last_wall_time = attr.ib(init=False, repr=False)
-    _thread_span_links = attr.ib(default=None, init=False, repr=False)
+    _thread_time = attr.ib(init=False, repr=False, eq=False)
+    _last_wall_time = attr.ib(init=False, repr=False, eq=False)
+    _thread_span_links = attr.ib(default=None, init=False, repr=False, eq=False)
 
     @max_time_usage_pct.validator
     def _check_max_time_usage(self, attribute, value):

--- a/ddtrace/profiling/exporter/http.py
+++ b/ddtrace/profiling/exporter/http.py
@@ -46,7 +46,7 @@ class PprofHTTPExporter(pprof.PprofExporter):
     version = attr.ib(default=None)
     max_retry_delay = attr.ib(default=None)
     _container_info = attr.ib(factory=container.get_container_info, repr=False)
-    _retry_upload = attr.ib(init=None, default=None)
+    _retry_upload = attr.ib(init=None, default=None, eq=False)
     endpoint_path = attr.ib(default="/profiling/v1/input")
 
     def __attrs_post_init__(self):

--- a/ddtrace/profiling/recorder.py
+++ b/ddtrace/profiling/recorder.py
@@ -19,7 +19,7 @@ class _defaultdictkey(dict):
         raise KeyError(key)
 
 
-@attr.s(slots=True, eq=False)
+@attr.s(slots=True)
 class Recorder(object):
     """An object that records program activity."""
 
@@ -31,8 +31,8 @@ class Recorder(object):
     max_events = attr.ib(factory=dict)
     """A dict of {event_type_class: max events} to limit the number of events to record."""
 
-    events = attr.ib(init=False, repr=False)
-    _events_lock = attr.ib(init=False, repr=False, factory=_nogevent.DoubleLock)
+    events = attr.ib(init=False, repr=False, eq=False)
+    _events_lock = attr.ib(init=False, repr=False, factory=_nogevent.DoubleLock, eq=False)
     _pid = attr.ib(init=False, repr=False, factory=os.getpid)
 
     def __attrs_post_init__(self):

--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -19,7 +19,7 @@ class Scheduler(_periodic.PeriodicService):
     exporters = attr.ib()
     _interval = attr.ib(factory=_attr.from_env("DD_PROFILING_UPLOAD_INTERVAL", 60, float))
     _configured_interval = attr.ib(init=False)
-    _last_export = attr.ib(init=False, default=None)
+    _last_export = attr.ib(init=False, default=None, eq=False)
 
     def __attrs_post_init__(self):
         # Copy the value to use it later since we're going to adjust the real interval

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -195,6 +195,7 @@ def test_env_endpoint_url_no_agent(monkeypatch):
 def test_copy():
     p = profiler._ProfilerInstance(env="123", version="dwq", service="foobar")
     c = p.copy()
+    assert c == p
     assert p.env == c.env
     assert p.version == c.version
     assert p.service == c.service


### PR DESCRIPTION
This also makes sure that copy() works fine without checking all attributes
individually, just in case we'd forget some.