### PR TITLE
Dynamically set JUnit XML results filename

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -20,7 +20,7 @@ PY_DIR_PATTERN = re.compile(r"^py[23][0-9]$")
 # Hook for dynamic configuration of pytest in CI
 # https://docs.pytest.org/en/6.2.1/reference.html#pytest.hookspec.pytest_configure
 def pytest_configure(config):
-    if not os.getenv("CI") == "true":
+    if os.getenv("CI") != "true":
         return
 
     # Write JUnit xml results to a file that contains this proceses PID

--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,21 @@ pytest_plugins = ("pytester",)
 PY_DIR_PATTERN = re.compile(r"^py[23][0-9]$")
 
 
+# Hook for dynamic configuration of pytest in CI
+# https://docs.pytest.org/en/6.2.1/reference.html#pytest.hookspec.pytest_configure
+def pytest_configure(config):
+    if not os.getenv("CI") == "true":
+        return
+
+    # Write JUnit xml results to a file that contains this proceses PID
+    # This ensures running pytest multiple times does not overwrite previous results
+    # e.g. test-results/junit.xml -> test-results/junit.1797.xml
+    if config.option.xmlpath:
+        fname, ext = os.path.splitext(config.option.xmlpath)
+        # DEV: `ext` will contain the `.`, e.g. `.xml`
+        config.option.xmlpath = "{0}.{1}{2}".format(fname, os.getpid(), ext)
+
+
 # Determine if the folder should be ignored
 # https://docs.pytest.org/en/3.10.1/reference.html#_pytest.hookspec.pytest_ignore_collect
 # DEV: We can only ignore folders/modules, we cannot ignore individual files

--- a/conftest.py
+++ b/conftest.py
@@ -23,7 +23,7 @@ def pytest_configure(config):
     if os.getenv("CI") != "true":
         return
 
-    # Write JUnit xml results to a file that contains this proceses PID
+    # Write JUnit xml results to a file that contains this process' PID
     # This ensures running pytest multiple times does not overwrite previous results
     # e.g. test-results/junit.xml -> test-results/junit.1797.xml
     if config.option.xmlpath:

--- a/tox.ini
+++ b/tox.ini
@@ -418,6 +418,11 @@ deps =
 # pass along test env variables
 passenv=
     TEST_*
+    # https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+    CI
+    CI_*
+    CIRCLECI
+    CIRCLE_*
 
 
 commands =


### PR DESCRIPTION
## Description
Noticed an issue in CircleCI where we do not get all of the test results in the junit.xml file. This is because pytest doesn't append, it'll overwrite. This has issues when we run multiple test scenarios in one container in CircleCI.

This PR adds a configuration hook to `conftest.py` to dynamically set the JUnit `xmlpath` to include the pid in the filename.

In order for this to work properly we also have to pass through the `CI_*` and `CIRCLE_*` env variables (well, I am only using `CI=true`, but figured doesn't hurt to pass the others through, probably useful for tools like Codecov/etc if we ever run them in tox env).

Results end up looking like this: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/4520/workflows/6cf32f06-dd5c-4d22-833f-0790fa9b9008/jobs/442582/artifacts