### PR TITLE
test(profiling): fix possible race condition in thread_id test

### DIFF
--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -69,9 +69,9 @@ def test_iter_events():
         assert 0 < len(stack) <= max_nframe
         assert nframe >= len(stack)
         last_call = stack[0]
-        assert thread_id == _nogevent.main_thread_id
         assert size >= 1  # size depends on the object size
         if last_call[2] == "_allocate_1k" and last_call[1] == _ALLOC_LINE_NUMBER:
+            assert thread_id == _nogevent.main_thread_id
             assert last_call[0] == __file__
             assert stack[1][0] == __file__
             assert stack[1][1] == 60


### PR DESCRIPTION
The thread_id might not be the main thread is there's another thread for
another test laying around.
Move the assert in a piece of code where we are sure what the thread_id is.