### PR TITLE
Default CircleCI parallelism to 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ machine_executor: &machine_executor
 
 contrib_job: &contrib_job
   executor: ddtrace_dev
-  parallelism: 4
+  parallelism: 6
 
 commands:
   deploy_docs:


### PR DESCRIPTION
One for each version of Python.