### PR TITLE
refactor(profiling): fix stop() flush argument

### DIFF
--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -56,5 +56,3 @@ class Scheduler(_periodic.PeriodicService):
             self.flush()
         finally:
             self.interval = max(0, self._configured_interval - (compat.monotonic() - start_time))
-
-    on_shutdown = flush

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -290,15 +290,15 @@ def test_env_profiling_enabled(monkeypatch):
 
     monkeypatch.setenv("DD_PROFILING_ENABLED", "true")
     out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_profiling.py"])
-    assert out.strip() == b"RUNNING"
+    assert out.strip() == b"ServiceStatus.RUNNING"
 
     monkeypatch.setenv("DD_PROFILING_ENABLED", "false")
     out = subprocess.check_output(["ddtrace-run", "--profiling", "python", "tests/commands/ddtrace_run_profiling.py"])
-    assert out.strip() == b"RUNNING"
+    assert out.strip() == b"ServiceStatus.RUNNING"
 
     monkeypatch.setenv("DD_PROFILING_ENABLED", "false")
     out = subprocess.check_output(["ddtrace-run", "-p", "python", "tests/commands/ddtrace_run_profiling.py"])
-    assert out.strip() == b"RUNNING"
+    assert out.strip() == b"ServiceStatus.RUNNING"
 
     monkeypatch.setenv("DD_PROFILING_ENABLED", "false")
     out = subprocess.check_output(["ddtrace-run", "python", "tests/commands/ddtrace_run_profiling.py"])

--- a/tests/profiling/simple_program_fork.py
+++ b/tests/profiling/simple_program_fork.py
@@ -5,16 +5,17 @@ import threading
 import ddtrace.profiling.auto
 import ddtrace.profiling.bootstrap
 import ddtrace.profiling.profiler
+from ddtrace.profiling import _service
 from ddtrace.profiling.collector import stack
 from ddtrace.profiling.collector import threading as cthreading
 
 
 lock = threading.Lock()
 lock.acquire()
-test_lock_name = "simple_program_fork.py:12"
+test_lock_name = "simple_program_fork.py:13"
 
 
-assert ddtrace.profiling.bootstrap.profiler.status == ddtrace.profiling.profiler.ProfilerStatus.RUNNING
+assert ddtrace.profiling.bootstrap.profiler.status == _service.ServiceStatus.RUNNING
 
 parent_recorder = ddtrace.profiling.bootstrap.profiler._profiler._recorder
 
@@ -37,7 +38,7 @@ if child_pid == 0:
 
     # We track this one though
     lock = threading.Lock()
-    test_lock_name = "simple_program_fork.py:39"
+    test_lock_name = "simple_program_fork.py:40"
     assert test_lock_name not in set(e.lock_name for e in recorder.events[cthreading.LockAcquireEvent])
     lock.acquire()
     assert test_lock_name in set(e.lock_name for e in recorder.events[cthreading.LockAcquireEvent])
@@ -59,7 +60,7 @@ else:
     assert test_lock_name not in set(e.lock_name for e in recorder.events[cthreading.LockReleaseEvent])
     lock.release()
     assert test_lock_name in set(e.lock_name for e in recorder.events[cthreading.LockReleaseEvent])
-    assert ddtrace.profiling.bootstrap.profiler.status == ddtrace.profiling.profiler.ProfilerStatus.RUNNING
+    assert ddtrace.profiling.bootstrap.profiler.status == _service.ServiceStatus.RUNNING
     print(child_pid)
     pid, status = os.waitpid(child_pid, 0)
     sys.exit(os.WEXITSTATUS(status))

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -12,11 +12,11 @@ from ddtrace.profiling.exporter import http
 
 def test_status():
     p = profiler.Profiler()
-    assert repr(p.status) == "STOPPED"
+    assert repr(p.status) == "<ServiceStatus.STOPPED: 'stopped'>"
     p.start()
-    assert repr(p.status) == "RUNNING"
+    assert repr(p.status) == "<ServiceStatus.RUNNING: 'running'>"
     p.stop(flush=False)
-    assert repr(p.status) == "STOPPED"
+    assert repr(p.status) == "<ServiceStatus.STOPPED: 'stopped'>"
 
 
 def test_restart():


### PR DESCRIPTION
This argument controlled only the exit time, but not the fact that it exported
or no a last profile.

This makes sure the scheduler is fully stopped before stopping collector, and
then flush or not a last profile.

This fixes an issue where on fork() a profile could be still sent when the
parent profiler would be stopped.