### PR TITLE
fix(ci): flake8 ignore B902

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -540,7 +540,7 @@ exclude=
 # G201 Logging: .exception(...) should be used instead of .error(..., exc_info=True)
 # E231,W503: not respected by black
 # We ignore most of the D errors because there are too many; the goal is to fix them eventually
-ignore = W503,E231,A003,G201,D100,D101,D102,D103,D104,D105,D106,D107,D200,D202,D204,D205,D208,D210,D300,D400,D401,D403,D413,RST301
+ignore = W503,E231,A003,G201,D100,D101,D102,D103,D104,D105,D106,D107,D200,D202,D204,D205,D208,D210,D300,D400,D401,D403,D413,RST301,B902
 enable-extensions=G
 rst-roles = class,meth,obj,ref
 rst-directives = py:data


### PR DESCRIPTION
## Description

B902 was added in https://github.com/elijahandrews/flake8-blind-except/releases/tag/v0.2.0 but we can safely ignore it for now.

## Checklist
- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
