### PR TITLE
refactor(profiling): allow Collectors to run a function before flushing

### DIFF
--- a/ddtrace/profiling/collector/__init__.py
+++ b/ddtrace/profiling/collector/__init__.py
@@ -11,6 +11,13 @@ class Collector(_service.Service):
 
     recorder = attr.ib()
 
+    @staticmethod
+    def snapshot():
+        """Take a snapshot of collected data.
+
+        :return: A list of sample list to push in the recorder.
+        """
+
 
 @attr.s(slots=True)
 class PeriodicCollector(Collector, _periodic.PeriodicService):

--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -17,7 +17,7 @@ class Scheduler(_periodic.PeriodicService):
 
     recorder = attr.ib()
     exporters = attr.ib()
-    before_flush = attr.ib(default=None)
+    before_flush = attr.ib(default=None, eq=False)
     _interval = attr.ib(factory=_attr.from_env("DD_PROFILING_UPLOAD_INTERVAL", 60, float))
     _configured_interval = attr.ib(init=False)
     _last_export = attr.ib(init=False, default=None, eq=False)


### PR DESCRIPTION
This new snapshot() method allows collectors to implement a method to be
executed just before the scheduler is about to export data.

This allows to export data, e.g., every minute only.