### PR TITLE
use contextvars for context management

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -1,11 +1,4 @@
-import logging
-import threading
-
-from .constants import HOSTNAME_KEY, SAMPLING_PRIORITY_KEY, ORIGIN_KEY, LOG_SPAN_KEY
 from .internal.logger import get_logger
-from .internal import hostname
-from .settings import config
-from .utils.formats import asbool, get_env
 
 log = get_logger(__name__)
 
@@ -26,9 +19,6 @@ class Context(object):
     This data structure is thread-safe.
     """
 
-    _partial_flush_enabled = asbool(get_env("tracer", "partial_flush_enabled", default=False))
-    _partial_flush_min_spans = int(get_env("tracer", "partial_flush_min_spans", default=500))
-
     def __init__(self, trace_id=None, span_id=None, sampling_priority=None, _dd_origin=None):
         """
         Initialize a new thread-safe ``Context``.
@@ -36,10 +26,8 @@ class Context(object):
         :param int trace_id: trace_id of parent span
         :param int span_id: span_id of parent span
         """
-        self._trace = []
         self._finished_spans = 0
         self._current_span = None
-        self._lock = threading.Lock()
 
         self._parent_trace_id = trace_id
         self._parent_span_id = span_id
@@ -49,46 +37,49 @@ class Context(object):
     @property
     def trace_id(self):
         """Return current context trace_id."""
-        with self._lock:
-            return self._parent_trace_id
+        return self._parent_trace_id
 
     @property
     def span_id(self):
         """Return current context span_id."""
-        with self._lock:
-            return self._parent_span_id
+        return self._parent_span_id
 
     @property
     def sampling_priority(self):
         """Return current context sampling priority."""
-        with self._lock:
-            return self._sampling_priority
+        return self._sampling_priority
 
     @sampling_priority.setter
     def sampling_priority(self, value):
         """Set sampling priority."""
-        with self._lock:
-            self._sampling_priority = value
+        self._sampling_priority = value
+
+    def __eq__(self, other):
+        return (
+            self.span_id == other.span_id
+            and self.trace_id == other.trace_id
+            and self.sampling_priority == other.sampling_priority
+            and self._dd_origin == other._dd_origin
+        )
 
     def clone(self):
         """
         Partially clones the current context.
         It copies everything EXCEPT the registered and finished spans.
         """
-        with self._lock:
-            new_ctx = Context(
-                trace_id=self._parent_trace_id,
-                span_id=self._parent_span_id,
-                sampling_priority=self._sampling_priority,
-            )
-            new_ctx._current_span = self._current_span
-            return new_ctx
+        new_ctx = Context(
+            trace_id=self._parent_trace_id,
+            span_id=self._parent_span_id,
+            sampling_priority=self._sampling_priority,
+        )
+        new_ctx._current_span = self._current_span
+        return new_ctx
 
     def get_current_root_span(self):
         """
         Return the root span of the context or None if it does not exist.
         """
-        return self._trace[0] if len(self._trace) > 0 else None
+        return None
 
     def get_current_span(self):
         """
@@ -97,123 +88,17 @@ class Context(object):
         span in asynchronous environments, because some spans can be closed
         earlier while child spans still need to finish their traced execution.
         """
-        with self._lock:
-            return self._current_span
-
-    def _set_current_span(self, span):
-        """
-        Set current span internally.
-
-        Non-safe if not used with a lock. For internal Context usage only.
-        """
-        self._current_span = span
-        if span:
-            self._parent_trace_id = span.trace_id
-            self._parent_span_id = span.span_id
-        else:
-            self._parent_span_id = None
+        return None
 
     def add_span(self, span):
         """
         Add a span to the context trace list, keeping it as the last active span.
         """
-        with self._lock:
-            self._set_current_span(span)
-
-            self._trace.append(span)
-            span._context = self
+        pass
 
     def close_span(self, span):
         """
         Mark a span as a finished, increasing the internal counter to prevent
         cycles inside _trace list.
         """
-        with self._lock:
-            self._finished_spans += 1
-
-            # Safe-guard: prevent the last current span from being set to the parent
-            # of any span but the top-level span.
-            # The situation this avoids is when a parent closes before a child
-            # and the child is the last to close in the trace. When this happens
-            # the current_span would otherwise be set to the child's parent which
-            # has already closed. The context will be reset but the current_span
-            # will still point to that child's parent which would cause subsequent
-            # spans to be parented incorrectly.
-            if self._finished_spans != len(self._trace) or span == self._trace[0]:
-                self._set_current_span(span._parent)
-
-            # notify if the trace is not closed properly; this check is executed only
-            # if the debug logging is enabled and when the root span is closed
-            # for an unfinished trace. This logging is meant to be used for debugging
-            # reasons, and it doesn't mean that the trace is wrongly generated.
-            # In asynchronous environments, it's legit to close the root span before
-            # some children. On the other hand, asynchronous web frameworks still expect
-            # to close the root span after all the children.
-            if span.tracer and span.tracer.log.isEnabledFor(logging.DEBUG) and span._parent is None:
-                extra = {LOG_SPAN_KEY: span}
-                unfinished_spans = [x for x in self._trace if not x.finished]
-                if unfinished_spans:
-                    log.debug(
-                        'Root span "%s" closed, but the trace has %d unfinished spans:',
-                        span.name,
-                        len(unfinished_spans),
-                        extra=extra,
-                    )
-                    for wrong_span in unfinished_spans:
-                        log.debug("\n%s", wrong_span.pprint(), extra=extra)
-
-            if self._finished_spans == len(self._trace):
-                # get the trace
-                trace = self._trace
-                sampled = self._is_sampled()
-                sampling_priority = self._sampling_priority
-                # attach the sampling priority to the context root span
-                if sampled and sampling_priority is not None and trace:
-                    trace[0].set_metric(SAMPLING_PRIORITY_KEY, sampling_priority)
-                origin = self._dd_origin
-                # attach the origin to the root span tag
-                if sampled and origin is not None and trace:
-                    trace[0].meta[ORIGIN_KEY] = str(origin)
-
-                # Set hostname tag if they requested it
-                if config.report_hostname:
-                    # DEV: `get_hostname()` value is cached
-                    trace[0].meta[HOSTNAME_KEY] = hostname.get_hostname()
-
-                # clean the current state
-                self._trace = []
-                self._finished_spans = 0
-                self._parent_trace_id = None
-                self._parent_span_id = None
-                self._sampling_priority = None
-                return trace, sampled
-            elif self._partial_flush_enabled:
-                finished_spans = [t for t in self._trace if t.finished]
-                if len(finished_spans) >= self._partial_flush_min_spans:
-                    # partial flush when enabled and we have more than the minimal required spans
-                    trace = self._trace
-                    sampled = self._is_sampled()
-                    sampling_priority = self._sampling_priority
-                    # attach the sampling priority to the context root span
-                    if sampled and sampling_priority is not None and trace:
-                        trace[0].set_metric(SAMPLING_PRIORITY_KEY, sampling_priority)
-                    origin = self._dd_origin
-                    # attach the origin to the root span tag
-                    if sampled and origin is not None and trace:
-                        trace[0].meta[ORIGIN_KEY] = str(origin)
-
-                    # Set hostname tag if they requested it
-                    if config.report_hostname:
-                        # DEV: `get_hostname()` value is cached
-                        trace[0].meta[HOSTNAME_KEY] = hostname.get_hostname()
-
-                    self._finished_spans = 0
-
-                    # Any open spans will remain as `self._trace`
-                    # Any finished spans will get returned to be flushed
-                    self._trace = [t for t in self._trace if not t.finished]
-                    return finished_spans, sampled
-            return None, None
-
-    def _is_sampled(self):
-        return any(span.sampled for span in self._trace)
+        pass

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -14,8 +14,7 @@ class Span(OpenTracingSpan):
 
     def __init__(self, tracer, context, operation_name):
         if context is not None:
-            context = SpanContext(ddcontext=context._dd_context,
-                                  baggage=context.baggage)
+            context = SpanContext(baggage=context.baggage)
         else:
             context = SpanContext()
 
@@ -24,8 +23,7 @@ class Span(OpenTracingSpan):
         self.finished = False
         self._lock = threading.Lock()
         # use a datadog span
-        self._dd_span = DatadogSpan(tracer._dd_tracer, operation_name,
-                                    context=context._dd_context)
+        self._dd_span = DatadogSpan(tracer._dd_tracer, operation_name)
 
     def finish(self, finish_time=None):
         """Finish the span.

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -11,6 +11,7 @@ from .ext.priority import AUTO_KEEP, AUTO_REJECT
 from .internal.logger import get_logger
 from .internal.rate_limiter import RateLimiter
 from .utils.formats import get_env
+from .span import Span
 from .vendor import six
 
 log = get_logger(__name__)
@@ -170,9 +171,10 @@ class DatadogSampler(BaseSampler, BasePrioritySampler):
             self.default_sampler.update_rate_by_service_sample_rates(sample_rates)
 
     def _set_priority(self, span, priority):
-        if span._context:
-            span._context.sampling_priority = priority
-        span.sampled = priority is AUTO_KEEP
+        # type: (Span, str) -> None
+        if span.trace_id in span.tracer._traces:
+            trace = span.tracer._traces[span.trace_id]
+            trace.sampling_priority = priority
 
     def sample(self, span):
         """
@@ -186,7 +188,6 @@ class DatadogSampler(BaseSampler, BasePrioritySampler):
         :rtype: :obj:`bool`
         """
         # If there are rules defined, then iterate through them and find one that wants to sample
-        matching_rule = None
         # Go through all rules and grab the first one that matched
         # DEV: This means rules should be ordered by the user from most specific to least specific
         for rule in self.rules:
@@ -203,7 +204,7 @@ class DatadogSampler(BaseSampler, BasePrioritySampler):
                     self._set_priority(span, AUTO_REJECT)
                     return False
 
-            # If no rules match, use our defualt sampler
+            # If no rules match, use our default sampler
             matching_rule = self.default_sampler
 
         # Sample with the matching sampling rule

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -3,7 +3,9 @@ import sys
 import traceback
 from typing import Optional, List
 
-from .vendor import six
+import ddtrace
+from .context import Context
+from .vendor import debtcollector, six
 from .compat import StringIO, stringify, iteritems, numeric_types, time_ns, is_integer
 from .constants import (
     NUMERIC_TAGS,
@@ -38,10 +40,7 @@ class Span(object):
         "start_ns",
         "duration_ns",
         "tracer",
-        # Sampler attributes
-        "sampled",
         # Internal attributes
-        "_context",
         "_parent",
         "_ignored_exceptions",
         "__weakref__",
@@ -58,7 +57,6 @@ class Span(object):
         span_id=None,
         parent_id=None,
         start=None,
-        context=None,
         _check_pid=True,
     ):
         """
@@ -77,7 +75,6 @@ class Span(object):
         :param int span_id: the id of this span.
 
         :param int start: the start time of request as a unix epoch in seconds
-        :param object context: the Context of the span.
         """
         # required span info
         self.name = name
@@ -101,12 +98,29 @@ class Span(object):
         self.parent_id = parent_id
         self.tracer = tracer
 
-        # sampling
-        self.sampled = True
-
-        self._context = context
         self._parent = None
         self._ignored_exceptions = None  # type: Optional[List[Exception]]
+
+    @debtcollector.removals.removed_property(message="Context is deprecated.", version="0.47")
+    def context(self):
+        # type: () -> Context
+        return self.tracer.active()
+
+    @property
+    def sampled(self):
+        # Have to inline the import because of circular dependency.
+        from .tracer import _get_trace
+        # This is not thread-safe.
+        trace = _get_trace(self.trace_id)
+        return trace.sampled if trace else True
+
+    @sampled.setter
+    def sampled(self, sampled):
+        # Have to inline the import because of circular dependency.
+        from .tracer import _get_trace
+        # This is not thread-safe.
+        trace = _get_trace(self.trace_id)
+        trace.sampled = sampled
 
     def _ignore_exception(self, exc):
         # type: (Exception) -> None
@@ -174,10 +188,10 @@ class Span(object):
             # be defensive so we don't die if start isn't set
             self.duration_ns = ft - (self.start_ns or ft)
 
-        if self._context:
-            trace, sampled = self._context.close_span(self)
-            if self.tracer and trace and sampled:
-                self.tracer.write(trace)
+        # FIXME: self.tracer should always be defined, only reason it's
+        # optional seems to be for testing.
+        if self.tracer:
+            self.tracer._finish_span(self)
 
     def set_tag(self, key, value=None):
         """Set a tag key/value pair on the span.
@@ -234,10 +248,12 @@ class Span(object):
             return
 
         elif key == MANUAL_KEEP_KEY:
-            self.context.sampling_priority = priority.USER_KEEP
+            if self.tracer and self.trace_id in self.tracer._traces:
+                self.tracer._traces[self.trace_id].sampling_priority = priority.USER_KEEP
             return
         elif key == MANUAL_DROP_KEY:
-            self.context.sampling_priority = priority.USER_REJECT
+            if self.tracer and self.trace_id in self.tracer._traces:
+                self.tracer._traces[self.trace_id].sampling_priority = priority.USER_REJECT
             return
         elif key == SERVICE_KEY:
             self.service = value
@@ -290,7 +306,7 @@ class Span(object):
         # This method sets a numeric tag value for the given key. It acts
         # like `set_meta()` and it simply add a tag without further processing.
 
-        # Enforce a specific connstant for `_dd.measured`
+        # Enforce a specific constant for `_dd.measured`
         if key == SPAN_MEASURED_KEY:
             try:
                 value = int(bool(value))
@@ -421,15 +437,6 @@ class Span(object):
 
         lines.extend((" ", "%s:%s" % kv) for kv in sorted(self.meta.items()))
         return "\n".join("%10s %s" % line for line in lines)
-
-    @property
-    def context(self):
-        """
-        Property that provides access to the ``Context`` associated with this ``Span``.
-        The ``Context`` contains state that propagates from span to span in a
-        larger trace.
-        """
-        return self._context
 
     def __enter__(self):
         return self

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -3,19 +3,30 @@ import logging
 import json
 from os import environ, getpid
 import sys
+import threading
+from typing import Dict, List, Optional, Union
 
+from ddtrace.vendor import attr
 from ddtrace.vendor import debtcollector
+from ddtrace.compat import contextvars
 
-from .constants import FILTERS_KEY, SAMPLE_RATE_METRIC_KEY, VERSION_KEY, ENV_KEY
-from .ext import system
+from .constants import (
+    FILTERS_KEY,
+    SAMPLING_PRIORITY_KEY,
+    SAMPLE_RATE_METRIC_KEY,
+    VERSION_KEY,
+    ENV_KEY,
+    ORIGIN_KEY,
+    HOSTNAME_KEY,
+)
+from .context import Context
+from .ext import system, SpanTypes
 from .ext.priority import AUTO_REJECT, AUTO_KEEP
-from .internal import debug
+from .internal import debug, hostname
 from .internal.logger import get_logger, hasHandlers
 from .internal.runtime import RuntimeTags, RuntimeWorker, get_runtime_id
 from .internal.writer import AgentWriter, LogWriter
 from .internal import _rand
-from .provider import DefaultContextProvider
-from .context import Context
 from .sampler import DatadogSampler, RateSampler, RateByServiceSampler
 from .settings import config
 from .span import Span
@@ -30,6 +41,9 @@ log = get_logger(__name__)
 
 debug_mode = asbool(get_env("trace", "debug", default=False))
 
+partial_flush_enabled = asbool(get_env("tracer", "partial_flush_enabled", default=False))
+partial_flush_min_spans = int(get_env("tracer", "partial_flush_min_spans", default=500))
+
 DD_LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] {}- %(message)s".format(
     "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s"
     " dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] "
@@ -39,6 +53,135 @@ if debug_mode and not hasHandlers(log):
         logging.basicConfig(level=logging.DEBUG, format=DD_LOG_FORMAT)
     else:
         logging.basicConfig(level=logging.DEBUG)
+
+
+# The value is of type Optional[Union[Context, Span]]
+CONTEXTVAR = contextvars.ContextVar("ddtrace_contextvar", default=None)
+
+
+@attr.s()
+class _Trace(object):
+    trace_id = attr.ib(type=int)  # type: int
+    sampled = attr.ib(type=bool, default=True)  # type: bool
+    num_finished = attr.ib(type=int, default=0)  # type: int
+    sampling_priority = attr.ib(default=None)  # type: Optional[int]
+    dd_origin = attr.ib(default=None)  # type: Optional[str]
+    local_root_span = attr.ib(default=None)  # type: Optional[Span]
+    _spans = attr.ib(default=attr.Factory(list))  # type: List[Span]
+
+    def __len__(self):
+        return len(self._spans)
+
+    def add_span(self, span):
+        # type: (Span) -> None
+        self._spans.append(span)
+
+    def pop_finished_spans(self):
+        # type: () -> List[Span]
+        local_root_span = self.local_root_span
+        if local_root_span and self.sampling_priority is not None and self.sampled:
+            local_root_span.set_metric(SAMPLING_PRIORITY_KEY, self.sampling_priority)
+            local_root_span.meta[ORIGIN_KEY] = str(self.dd_origin)
+
+        finished_spans = [span for span in self._spans if span.finished]
+        self._spans = [span for span in self._spans if not span.finished]
+        self.num_finished -= len(finished_spans)
+        return finished_spans
+
+
+_traces = {}  # type: Dict[int, _Trace]
+_traces_lock = threading.Lock()
+
+
+def _get_trace(trace_id):
+    # type: (int) -> Optional[_Trace]
+    if trace_id in _traces:
+        return _traces[trace_id]
+    return None
+
+
+def _active_trace():
+    # type: () -> Optional[_Trace]
+    active = _active()
+    if active and active.trace_id:
+        return _get_trace(active.trace_id)
+    return None
+
+
+def _active():
+    # type: () -> Optional[Union[Context, Span]]
+    return CONTEXTVAR.get()
+
+
+def _get_or_create_trace(trace_id):
+    # type: (int) -> _Trace
+    if trace_id in _traces:
+        return _traces[trace_id]
+    else:
+        trace = _Trace(trace_id=trace_id)
+        _traces[trace_id] = trace
+        return trace
+
+
+def _local_root_span(trace_id):
+    # type: (int) -> Optional[Span]
+    trace = _get_trace(trace_id)
+    if trace and len(trace):
+        return trace[0]
+    return None
+
+
+def _add_span(span, activate):
+    # type: (Span, bool) -> None
+    trace = _get_or_create_trace(span.trace_id)
+    trace.add_span(span)
+
+    if span._parent is None:
+        # Duplicate root spans in a trace is an error.
+        if trace.local_root_span:
+            raise NotImplementedError
+        trace.local_root_span = span
+
+    if activate:
+        CONTEXTVAR.set(span)
+
+
+def _close_span(span):
+    # type: (Span) -> List[Span]
+
+    # It's possible that a span can be created from a trace that has already
+    # been finished and deleted. So _get_or_create_trace has to be used instead
+    # of _get_trace.
+    trace = _get_or_create_trace(span.trace_id)
+    trace.num_finished += 1
+
+    # Safe-guard: only set the next active span to the parent if it is not
+    # finished.
+    if not span.parent_id or (span._parent and not span._parent.finished):
+        CONTEXTVAR.set(span._parent)
+    else:
+        CONTEXTVAR.set(None)
+
+    if trace.num_finished == len(trace) or (partial_flush_enabled and trace.num_finished >= partial_flush_min_spans):
+        spans = trace.pop_finished_spans()
+        root_span = spans[0]
+
+        if root_span.parent_id is not None:
+            log.debug("Using span %r as a root span even though it has a parent", root_span)
+
+        if len(trace) == 0:
+            del _traces[span.trace_id]
+        return spans
+
+    return []
+
+
+def _activate_context(context):
+    # type: (Context) -> None
+    trace = _get_or_create_trace(context.trace_id)
+    trace.sampling_priority = context.sampling_priority
+    trace.dd_origin = context._dd_origin
+    CONTEXTVAR.set(context)
 
 
 def _parse_dogstatsd_url(url):
@@ -100,6 +243,7 @@ class Tracer(object):
         self.priority_sampler = None
         self._runtime_worker = None
         self._filters = []
+        self._traces = _traces
 
         uds_path = None
         https = None
@@ -149,7 +293,6 @@ class Tracer(object):
             https=https,
             uds_path=uds_path,
             sampler=DatadogSampler(),
-            context_provider=DefaultContextProvider(),
             dogstatsd_url=dogstatsd_url,
             writer=writer,
         )
@@ -195,7 +338,40 @@ class Tracer(object):
     def global_excepthook(self, tp, value, traceback):
         """The global tracer except hook."""
 
+    def context_provider(self):
+        """Added to make the removal of ContextProviders less painful.
+
+        Previously context_provider was an attribute that would be assigned an
+        instance of ContextProvider.
+        """
+        return self
+
+    def active(self):
+        # type: () -> Optional[Context]
+        """Implement the active method for ContextProvider."""
+        span = CONTEXTVAR.get()
+        if span:
+            ctx = Context(
+                trace_id=span.trace_id,
+                span_id=span.span_id,
+            )
+            return ctx
+        else:
+            return Context()
+
+    def activate(self, context):
+        # type: (Context) -> None
+        """Activate a Context in the given execution.
+
+        Implement the activate method for ContextProvider.
+        """
+        if context.trace_id is None:
+            return
+
+        _activate_context(context)
+
     def get_call_context(self, *args, **kwargs):
+        # type (...) -> Optional[Context]
         """
         Return the current active ``Context`` for this traced execution. This method is
         automatically called in the ``tracer.trace()``, but it can be used in the application
@@ -211,7 +387,18 @@ class Tracer(object):
         This method makes use of a ``ContextProvider`` that is automatically set during the tracer
         initialization, or while using a library instrumentation.
         """
-        return self.context_provider.active(*args, **kwargs)
+        span = _active()
+        trace = _active_trace()
+        if span:
+            ctx = Context(
+                span_id=span.span_id,
+                trace_id=span.trace_id,
+                sampling_priority=trace.sampling_priority,
+                _dd_origin=trace.dd_origin,
+            )
+            return ctx
+        else:
+            return Context()
 
     # TODO: deprecate this method and make sure users create a new tracer if they need different parameters
     @debtcollector.removals.removed_kwarg(
@@ -219,6 +406,11 @@ class Tracer(object):
     )
     @debtcollector.removals.removed_kwarg(
         "dogstatsd_port", "Use `dogstatsd_url` instead", category=RemovedInDDTrace10Warning
+    )
+    @debtcollector.removals.removed_kwarg(
+        "context_provider",
+        "context_provider is no longer needed",
+        removal_version="0.48",
     )
     def configure(
         self,
@@ -228,11 +420,11 @@ class Tracer(object):
         uds_path=None,
         https=None,
         sampler=None,
-        context_provider=None,
         wrap_executor=None,
         priority_sampling=None,
         settings=None,
         collect_metrics=None,
+        context_provider=None,
         dogstatsd_host=None,
         dogstatsd_port=None,
         dogstatsd_url=None,
@@ -249,9 +441,6 @@ class Tracer(object):
         :param str uds_path: The Unix Domain Socket path of the agent.
         :param bool https: Whether to use HTTPS or HTTP.
         :param object sampler: A custom Sampler instance, locally deciding to totally drop the trace or not.
-        :param object context_provider: The ``ContextProvider`` that will be used to retrieve
-            automatically the current call context. This is an advanced option that usually
-            doesn't need to be changed from the default value
         :param object wrap_executor: callable that is used when a function is decorated with
             ``Tracer.wrap()``. This is an advanced option that usually doesn't need to be changed
             from the default value
@@ -324,9 +513,6 @@ class Tracer(object):
                 report_metrics=config.health_metrics_enabled,
             )
 
-        if context_provider is not None:
-            self.context_provider = context_provider
-
         if wrap_executor is not None:
             self._wrap_executor = wrap_executor
 
@@ -360,7 +546,8 @@ class Tracer(object):
                     msg = "- DATADOG TRACER DIAGNOSTIC - %s" % agent_error
                     self._log_compat(logging.WARNING, msg)
 
-    def start_span(self, name, child_of=None, service=None, resource=None, span_type=None):
+    def start_span(self, name, child_of=None, service=None, resource=None, span_type=None, activate=True):
+        # type: (str, Optional[Union[Context, Span]], Optional[str], Optional[str], Optional[SpanTypes], bool) -> Span
         """
         Return a span that will trace an operation called `name`. This method allows
         parenting using the ``child_of`` kwarg. If it's missing, the newly created span is a
@@ -375,36 +562,25 @@ class Tracer(object):
         To start a new root span, simply::
 
             span = tracer.start_span('web.request')
+            span.finish()
 
         If you want to create a child for a root span, just::
 
             root_span = tracer.start_span('web.request')
             span = tracer.start_span('web.decoder', child_of=root_span)
+            span.finish()
 
-        Or if you have a ``Context`` object::
-
-            context = tracer.get_call_context()
-            span = tracer.start_span('web.worker', child_of=context)
+        Ensure to finish all spans to avoid memory leaks and incorrect
+        parenting of spans.
         """
-        new_ctx = self._check_new_process()
+        self._check_new_process()
 
         if child_of is not None:
-            if isinstance(child_of, Context):
-                context = new_ctx or child_of
-                parent = child_of.get_current_span()
-            else:
-                context = child_of.context
-                parent = child_of
+            trace_id = child_of.trace_id
+            parent_id = child_of.span_id
+            parent = child_of if isinstance(child_of, Span) else None  # type: Optional[Span]
         else:
-            context = Context()
-            parent = None
-
-        if parent:
-            trace_id = parent.trace_id
-            parent_span_id = parent.span_id
-        else:
-            trace_id = context.trace_id
-            parent_span_id = context.span_id
+            trace_id = parent = parent_id = None
 
         # The following precedence is used for a new span's service:
         # 1. Explicitly provided service name
@@ -424,7 +600,7 @@ class Tracer(object):
                 self,
                 name,
                 trace_id=trace_id,
-                parent_id=parent_span_id,
+                parent_id=parent_id,
                 service=service,
                 resource=resource,
                 span_type=span_type,
@@ -433,9 +609,9 @@ class Tracer(object):
 
             # Extra attributes when from a local parent
             if parent:
-                span.sampled = parent.sampled
                 span._parent = parent
 
+            _add_span(span, activate=True)
         else:
             # this is the root span of a new trace
             span = Span(
@@ -446,12 +622,21 @@ class Tracer(object):
                 span_type=span_type,
                 _check_pid=False,
             )
+            span.metrics[system.PID] = self._pid or getpid()
+            span.meta["runtime-id"] = get_runtime_id()
+            if config.report_hostname:
+                span.meta[HOSTNAME_KEY] = hostname.get_hostname()
+            # add tags to root span to correlate trace with runtime metrics
+            # only applied to spans with types that are internal to applications
+            if self._runtime_worker and self._is_span_internal(span):
+                span.meta["language"] = "python"
 
-            span.sampled = self.sampler.sample(span)
+            sampled = self.sampler.sample(span)
+            sampling_priority = None
             # Old behavior
             # DEV: The new sampler sets metrics and priority sampling on the span for us
             if not isinstance(self.sampler, DatadogSampler):
-                if span.sampled:
+                if sampled:
                     # When doing client sampling in the client, keep the sample rate so that we can
                     # scale up statistics in the next steps of the pipeline.
                     if isinstance(self.sampler, RateSampler):
@@ -462,22 +647,22 @@ class Tracer(object):
                         # priority sampler will use the default sampling rate, which might
                         # lead to oversampling (that is, dropping too many traces).
                         if self.priority_sampler.sample(span):
-                            context.sampling_priority = AUTO_KEEP
+                            sampling_priority = AUTO_KEEP
                         else:
-                            context.sampling_priority = AUTO_REJECT
+                            sampling_priority = AUTO_REJECT
                 else:
                     if self.priority_sampler:
                         # If dropped by the local sampler, distributed instrumentation can drop it too.
-                        context.sampling_priority = AUTO_REJECT
+                        sampling_priority = AUTO_REJECT
             else:
-                context.sampling_priority = AUTO_KEEP if span.sampled else AUTO_REJECT
+                sampling_priority = AUTO_KEEP if sampled else AUTO_REJECT
                 # We must always mark the span as sampled so it is forwarded to the agent
-                span.sampled = True
+                sampled = True
 
-            # add tags to root span to correlate trace with runtime metrics
-            # only applied to spans with types that are internal to applications
-            if self._runtime_worker and self._is_span_internal(span):
-                span.meta["language"] = "python"
+            if sampling_priority is not None and sampled:
+                span.metrics[SAMPLING_PRIORITY_KEY] = sampling_priority
+
+            _add_span(span, activate=activate)
 
         # Apply default global tags.
         if self.tags:
@@ -488,7 +673,7 @@ class Tracer(object):
 
         # Only set the version tag on internal spans.
         if config.version:
-            root_span = self.current_root_span()
+            root_span = self.active_root_span()
             # if: 1. the span is the root span and the span's service matches the global config; or
             #     2. the span is not the root, but the root span's service matches the span's service
             #        and the root span has a version tag
@@ -497,13 +682,6 @@ class Tracer(object):
                 root_span and root_span.service == service and VERSION_KEY in root_span.meta
             ):
                 span._set_str_tag(VERSION_KEY, config.version)
-
-        if not span._parent:
-            span.metrics[system.PID] = self._pid or getpid()
-            span.meta["runtime-id"] = get_runtime_id()
-
-        # add it to the current context
-        context.add_span(span)
 
         # update set of services handled by tracer
         if service and service not in self._services and self._is_span_internal(span):
@@ -515,7 +693,14 @@ class Tracer(object):
 
         self._hooks.emit(self.__class__.start_span, span)
 
+        CONTEXTVAR.set(span)
+
         return span
+
+    def _finish_span(self, span):
+        # type: (Span) -> None
+        spans = _close_span(span)
+        self.write(spans)
 
     def _update_dogstatsd_constant_tags(self):
         """Prepare runtime tags for ddstatsd."""
@@ -542,18 +727,10 @@ class Tracer(object):
         # they will share the seed and generate the same random numbers.
         _rand.seed()
 
-        ctx = self.get_call_context()
-        # The spans remaining in the context can not and will not be finished
-        # in this new process. So we need to copy out the trace metadata needed
-        # to continue the trace.
-        # Also, note that because we're in a forked process, the lock that the
-        # context has might be permanently locked so we can't use ctx.clone().
-        new_ctx = Context(
-            sampling_priority=ctx._sampling_priority,
-            span_id=ctx._parent_span_id,
-            trace_id=ctx._parent_trace_id,
-        )
-        self.context_provider.activate(new_ctx)
+        # The previous process is responsible for flushing the spans it created.
+        for trace_id, trace in _traces:
+            # Note that the remaining metadata (like active span id) is left in place.
+            trace.spans = []
 
         # Assume that the services of the child are not necessarily a subset of those
         # of the parent.
@@ -568,8 +745,6 @@ class Tracer(object):
 
         # Re-create the background writer thread
         self.writer = self.writer.recreate()
-
-        return new_ctx
 
     def _log_compat(self, level, msg):
         """Logs a message for the given level.
@@ -624,45 +799,41 @@ class Tracer(object):
             parent2.finish()
         """
 
-        # retrieve the Context using the context provider and create
-        # a new Span that could be a root or a nested span
-        context = self.get_call_context()
+        active = _active()
         return self.start_span(
             name,
-            child_of=context,
+            child_of=active,
             service=service,
             resource=resource,
             span_type=span_type,
+            activate=True,
         )
 
-    def current_root_span(self):
-        """Returns the root span of the current context.
+    def active_root_span(self):
+        # type: () -> Optional[Span]
+        """Returns the root span of the current execution.
 
         This is useful for attaching information related to the trace as a
         whole without needing to add to child spans.
 
-        Usage is simple, for example::
-
+        For example::
             # get the root span
-            root_span = tracer.current_root_span()
+            root_span = tracer.active_root_span()
             # set the host just once on the root span
             if root_span:
                 root_span.set_tag('host', '127.0.0.1')
         """
-        ctx = self.get_call_context()
-        if ctx:
-            return ctx.get_current_root_span()
-        return None
+        trace = _active_trace()
+        return trace.local_root_span if trace else None
 
-    def current_span(self):
-        """
-        Return the active span for the current call context or ``None``
-        if no spans are available.
-        """
-        ctx = self.get_call_context()
-        if ctx:
-            return ctx.get_current_span()
-        return None
+    current_root_span = active_root_span
+
+    def active_span(self):
+        # type: () -> Optional[Span]
+        active = CONTEXTVAR.get()
+        return active if isinstance(active, Span) else None
+
+    current_span = active_span
 
     def write(self, spans):
         """

--- a/releasenotes/notes/context-d43f1c79c78cb923.yaml
+++ b/releasenotes/notes/context-d43f1c79c78cb923.yaml
@@ -1,0 +1,16 @@
+---
+prelude: >
+    Major breaking changes to context management. See the upgrade section for
+    the specifics. Note that only advanced users of the library should be
+    affected by the changes.
+deprecations:
+  - Context has been deprecated from the public API. Any continued usage of
+    Context is discouraged.
+upgrade:
+  - Tracer
+    - Context providers are no longer used by Tracer.
+    - tracer.get_call_context() will return a new instance of Context with each
+      invocation.
+  - Span
+    - `context` parameter to Span has been removed.
+    - `sampled` and `context` attributes have been removed from Span.


### PR DESCRIPTION
Instead of storing a mutable Context object in the contextvar, the
active span/context is stored instead. ContextProviders are replaced
with contextvars equivalent patches.

Previously the context management was split between a custom solution
and contextvars. Having both made the code harder to reason about which
led to errors. By depending solely on the contextvars API, context
management is made clearer and is standardized as of Python 3.7.

By storing the active span/context in the contextvar directly comes with
several other advantages:

  - No need to manually configure a ContextProvider.
  - Traces can be built up and managed globally rather than implicitly
    in the Context which leads to less indirection.
  - A lock is no longer required to get the active span/context as it's
    execution dependent.

## Description
<!-- Please briefly describe the change and why it was required. -->


## Checklist
- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
