### PR TITLE
ext: update ci specs

### DIFF
--- a/ddtrace/ext/ci.py
+++ b/ddtrace/ext/ci.py
@@ -53,7 +53,6 @@ def tags(env=None):
     if tags.get(git.TAG) and git.BRANCH in tags:
         del tags[git.BRANCH]
     tags[git.BRANCH] = _normalize_ref(tags.get(git.BRANCH))
-    tags[git.DEPRECATED_COMMIT_SHA] = tags.get(git.COMMIT_SHA)
     tags[git.REPOSITORY_URL] = _filter_sensitive_info(tags.get(git.REPOSITORY_URL))
 
     # Expand ~

--- a/ddtrace/ext/git.py
+++ b/ddtrace/ext/git.py
@@ -7,7 +7,6 @@ BRANCH = "git.branch"
 
 # Git Commit SHA
 COMMIT_SHA = "git.commit.sha"
-DEPRECATED_COMMIT_SHA = "git.commit_sha"
 
 # Git Repository URL
 REPOSITORY_URL = "git.repository_url"

--- a/tests/tracer/fixtures/ci/appveyor.json
+++ b/tests/tracer/fixtures/ci/appveyor.json
@@ -20,7 +20,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -45,7 +44,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -70,7 +68,6 @@
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -95,7 +92,6 @@
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -120,7 +116,6 @@
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -147,7 +142,6 @@
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -172,7 +166,6 @@
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -199,7 +192,6 @@
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -244,7 +236,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -269,7 +260,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -294,7 +284,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -320,7 +309,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "pr",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -346,7 +334,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "pr",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -371,7 +358,6 @@
       "ci.provider.name": "appveyor",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git",
       "git.tag": "0.1.0"
     }
@@ -397,7 +383,6 @@
       "ci.provider.name": "appveyor",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "appveyor-repo-commit",
-      "git.commit_sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git",
       "git.tag": "0.1.0"
     }

--- a/tests/tracer/fixtures/ci/azurepipelines.json
+++ b/tests/tracer/fixtures/ci/azurepipelines.json
@@ -23,7 +23,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample"
     }
   ],
@@ -51,7 +50,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample"
     }
   ],
@@ -80,7 +78,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample2"
     }
   ],
@@ -108,7 +105,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample"
     }
   ],
@@ -136,7 +132,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample"
     }
   ],
@@ -164,7 +159,6 @@
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample"
     }
   ],
@@ -194,7 +188,6 @@
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample"
     }
   ],
@@ -224,7 +217,6 @@
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample"
     }
   ],
@@ -254,7 +246,6 @@
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample"
     }
   ],
@@ -284,7 +275,6 @@
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample"
     }
   ],
@@ -314,7 +304,6 @@
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample"
     }
   ],
@@ -342,7 +331,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample"
     }
   ],
@@ -370,7 +358,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample"
     }
   ],
@@ -398,7 +385,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample"
     }
   ],
@@ -425,7 +411,6 @@
       "ci.provider.name": "azurepipelines",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample",
       "git.tag": "0.1.0"
     }
@@ -453,7 +438,6 @@
       "ci.provider.name": "azurepipelines",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "commit",
-      "git.commit_sha": "commit",
       "git.repository_url": "sample",
       "git.tag": "0.1.0"
     }
@@ -484,7 +468,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "pr",
       "git.commit.sha": "commitPR",
-      "git.commit_sha": "commitPR",
       "git.repository_url": "sample"
     }
   ],
@@ -514,7 +497,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "pr",
       "git.commit.sha": "commitPR",
-      "git.commit_sha": "commitPR",
       "git.repository_url": "sample"
     }
   ],
@@ -544,7 +526,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "pr",
       "git.commit.sha": "commitPR",
-      "git.commit_sha": "commitPR",
       "git.repository_url": "sample"
     }
   ]

--- a/tests/tracer/fixtures/ci/bitbucket.json
+++ b/tests/tracer/fixtures/ci/bitbucket.json
@@ -19,7 +19,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -43,7 +42,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -67,7 +65,6 @@
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -91,7 +88,6 @@
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -115,7 +111,6 @@
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -141,7 +136,6 @@
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -165,7 +159,6 @@
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -191,7 +184,6 @@
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -215,7 +207,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -239,7 +230,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -263,7 +253,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -287,7 +276,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -311,7 +299,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -335,7 +322,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url"
     }
   ],
@@ -358,7 +344,6 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url",
       "git.tag": "0.1.0"
     }
@@ -382,7 +367,6 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "bitbucket-commit",
-      "git.commit_sha": "bitbucket-commit",
       "git.repository_url": "bitbucket-repo-url",
       "git.tag": "0.1.0"
     }

--- a/tests/tracer/fixtures/ci/bitrise.json
+++ b/tests/tracer/fixtures/ci/bitrise.json
@@ -18,7 +18,6 @@
       "ci.provider.name": "bitrise",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "gitcommit",
-      "git.commit_sha": "gitcommit",
       "git.repository_url": "sample"
     }
   ],
@@ -42,7 +41,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -66,7 +64,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -90,7 +87,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -114,7 +110,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -138,7 +133,6 @@
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -162,7 +156,6 @@
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -186,7 +179,6 @@
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -212,7 +204,6 @@
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -238,7 +229,6 @@
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -264,7 +254,6 @@
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -288,7 +277,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -312,7 +300,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -336,7 +323,6 @@
       "ci.provider.name": "bitrise",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample",
       "git.tag": "0.1.0"
     }
@@ -361,7 +347,6 @@
       "ci.provider.name": "bitrise",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample",
       "git.tag": "0.1.0"
     }
@@ -386,7 +371,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -410,7 +394,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -434,7 +417,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -458,7 +440,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "git@hostname.com:org/repo.git"
     }
   ],
@@ -482,7 +463,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "git@hostname.com:org/repo.git"
     }
   ],
@@ -507,7 +487,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "notmaster",
       "git.commit.sha": "bitrise-git-commit",
-      "git.commit_sha": "bitrise-git-commit",
       "git.repository_url": "git@hostname.com:org/repo.git"
     }
   ]

--- a/tests/tracer/fixtures/ci/buildkite.json
+++ b/tests/tracer/fixtures/ci/buildkite.json
@@ -22,7 +22,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -49,7 +48,6 @@
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -76,7 +74,6 @@
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -103,7 +100,6 @@
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -132,7 +128,6 @@
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -161,7 +156,6 @@
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -190,7 +184,6 @@
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -217,7 +210,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -244,7 +236,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -271,7 +262,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -298,7 +288,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "git@hostname.com:org/repo.git"
     }
   ],
@@ -325,7 +314,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -352,7 +340,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -379,7 +366,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -405,7 +391,6 @@
       "ci.provider.name": "buildkite",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git",
       "git.tag": "0.1.0"
     }
@@ -432,7 +417,6 @@
       "ci.provider.name": "buildkite",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git",
       "git.tag": "0.1.0"
     }
@@ -459,7 +443,6 @@
       "ci.provider.name": "buildkite",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "buildkite-git-commit",
-      "git.commit_sha": "buildkite-git-commit",
       "git.repository_url": "http://hostname.com/repo.git",
       "git.tag": "0.1.0"
     }

--- a/tests/tracer/fixtures/ci/circleci.json
+++ b/tests/tracer/fixtures/ci/circleci.json
@@ -21,7 +21,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -47,7 +46,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -73,7 +71,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -99,7 +96,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -125,7 +121,6 @@
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -151,7 +146,6 @@
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -177,7 +171,6 @@
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -205,7 +198,6 @@
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -233,7 +225,6 @@
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -261,7 +252,6 @@
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -287,7 +277,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -313,7 +302,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -339,7 +327,6 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample",
       "git.tag": "0.1.0"
     }
@@ -366,7 +353,6 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample",
       "git.tag": "0.1.0"
     }
@@ -393,7 +379,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -419,7 +404,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -445,7 +429,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -471,7 +454,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -497,7 +479,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -523,7 +504,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -549,7 +529,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit",
       "git.repository_url": "git@hostname.com:org/repo.git"
     }
   ]

--- a/tests/tracer/fixtures/ci/github.json
+++ b/tests/tracer/fixtures/ci/github.json
@@ -20,7 +20,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -45,7 +44,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -70,7 +68,6 @@
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -95,7 +92,6 @@
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -120,7 +116,6 @@
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -147,7 +142,6 @@
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -174,7 +168,6 @@
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -201,7 +194,6 @@
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -226,7 +218,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -251,7 +242,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -276,7 +266,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -300,7 +289,6 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git",
       "git.tag": "0.1.0"
     }
@@ -325,7 +313,6 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git",
       "git.tag": "0.1.0"
     }
@@ -352,7 +339,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "other",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -378,7 +364,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "other",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -404,7 +389,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/other",
       "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ]

--- a/tests/tracer/fixtures/ci/gitlab.json
+++ b/tests/tracer/fixtures/ci/gitlab.json
@@ -20,7 +20,6 @@
       "ci.provider.name": "gitlab",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -45,7 +44,6 @@
       "ci.provider.name": "gitlab",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -72,7 +70,6 @@
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -99,7 +96,6 @@
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -126,7 +122,6 @@
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -155,7 +150,6 @@
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -184,7 +178,6 @@
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -213,7 +206,6 @@
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -240,7 +232,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -265,7 +256,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -290,7 +280,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -317,7 +306,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -344,7 +332,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -370,7 +357,6 @@
       "ci.provider.name": "gitlab",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample",
       "git.tag": "0.1.0"
     }
@@ -397,7 +383,6 @@
       "ci.provider.name": "gitlab",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample",
       "git.tag": "0.1.0"
     }
@@ -424,7 +409,6 @@
       "ci.provider.name": "gitlab",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "sample",
       "git.tag": "0.1.0"
     }
@@ -452,7 +436,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -479,7 +462,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -506,7 +488,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -533,7 +514,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -560,7 +540,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit",
       "git.repository_url": "git@hostname.com:org/repo.git"
     }
   ]

--- a/tests/tracer/fixtures/ci/jenkins.json
+++ b/tests/tracer/fixtures/ci/jenkins.json
@@ -19,7 +19,6 @@
       "ci.provider.name": "jenkins",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -43,7 +42,6 @@
       "ci.provider.name": "jenkins",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -69,7 +67,6 @@
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -95,7 +92,6 @@
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -121,7 +117,6 @@
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -149,7 +144,6 @@
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -177,7 +171,6 @@
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -205,7 +198,6 @@
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -231,7 +223,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -257,7 +248,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -283,7 +273,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -309,7 +298,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -335,7 +323,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -361,7 +348,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample"
     }
   ],
@@ -384,7 +370,6 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample",
       "git.tag": "0.1.0"
     }
@@ -408,7 +393,6 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "sample",
       "git.tag": "0.1.0"
     }
@@ -435,7 +419,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -461,7 +444,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -487,7 +469,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -513,7 +494,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -539,7 +519,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit",
       "git.repository_url": "git@hostname.com:org/repo.git"
     }
   ]

--- a/tests/tracer/fixtures/ci/travisci.json
+++ b/tests/tracer/fixtures/ci/travisci.json
@@ -21,7 +21,6 @@
       "ci.provider.name": "travisci",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git",
       "git.tag": "0.1.0"
     }
@@ -48,7 +47,6 @@
       "ci.provider.name": "travisci",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git",
       "git.tag": "0.1.0"
     }
@@ -73,7 +71,6 @@
       "ci.provider.name": "travisci",
       "git.branch": "master",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -97,33 +94,6 @@
       "ci.provider.name": "travisci",
       "git.branch": "master",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
-      "git.repository_url": "https://github.com/user/repo.git"
-    }
-  ],
-  [
-    {
-      "TRAVIS": "travisCI",
-      "TRAVIS_BRANCH": "origin/master",
-      "TRAVIS_BUILD_DIR": "foo/bar",
-      "TRAVIS_BUILD_ID": "travis-pipeline-id",
-      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
-      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
-      "TRAVIS_COMMIT": "travis-git-commit",
-      "TRAVIS_JOB_WEB_URL": "travis-job-url",
-      "TRAVIS_REPO_SLUG": "user/repo"
-    },
-    {
-      "ci.job.url": "travis-job-url",
-      "ci.pipeline.id": "travis-pipeline-id",
-      "ci.pipeline.name": "user/repo",
-      "ci.pipeline.number": "travis-pipeline-number",
-      "ci.pipeline.url": "travis-pipeline-url",
-      "ci.provider.name": "travisci",
-      "ci.workspace_path": "foo/bar",
-      "git.branch": "master",
-      "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -149,7 +119,6 @@
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -175,7 +144,31 @@
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/master",
+      "TRAVIS_BUILD_DIR": "foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -201,7 +194,6 @@
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -227,7 +219,6 @@
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -255,7 +246,6 @@
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -281,7 +271,6 @@
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -309,7 +298,6 @@
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -335,7 +323,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -361,7 +348,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -387,7 +373,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -415,7 +400,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -443,7 +427,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -471,7 +454,6 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.sha": "travis-git-commit",
-      "git.commit_sha": "travis-git-commit",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ]


### PR DESCRIPTION
## Description
<!-- Please briefly describe the change and why it was required. -->
Update the CI specs removing deprecated CI tags based on DataDog/datadog-ci-spec#38

## Checklist
- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
