### PR TITLE
ext: update ci specs - GitLab

### DIFF
--- a/ddtrace/ext/ci.py
+++ b/ddtrace/ext/ci.py
@@ -6,6 +6,12 @@ import re
 
 from . import git
 
+# Stage Name
+STAGE_NAME = "ci.stage.name"
+
+# Job Name
+JOB_NAME = "ci.job.name"
+
 # Job URL
 JOB_URL = "ci.job.url"
 
@@ -202,6 +208,8 @@ def extract_gitlab(env):
         git.COMMIT_SHA: env.get("CI_COMMIT_SHA"),
         git.REPOSITORY_URL: env.get("CI_REPOSITORY_URL"),
         git.TAG: env.get("CI_COMMIT_TAG"),
+        STAGE_NAME: env.get("CI_JOB_STAGE"),
+        JOB_NAME: env.get("CI_JOB_NAME"),
         JOB_URL: env.get("CI_JOB_URL"),
         PIPELINE_ID: env.get("CI_PIPELINE_ID"),
         PIPELINE_NAME: env.get("CI_PROJECT_PATH"),

--- a/tests/tracer/fixtures/ci/gitlab.json
+++ b/tests/tracer/fixtures/ci/gitlab.json
@@ -3,6 +3,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -12,12 +14,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
       "git.repository_url": "sample"
@@ -27,6 +31,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -36,12 +42,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
       "git.repository_url": "sample"
@@ -51,6 +59,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -61,12 +71,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -77,6 +89,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -87,12 +101,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -103,6 +119,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -113,12 +131,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -129,6 +149,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -141,12 +163,14 @@
       "USERPROFILE": "/not-my-home"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -157,6 +181,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -169,12 +195,14 @@
       "USERPROFILE": "/not-my-home"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -185,6 +213,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -197,12 +227,14 @@
       "USERPROFILE": "/not-my-home"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -213,6 +245,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -223,12 +257,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -239,6 +275,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -248,11 +286,13 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -263,6 +303,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -272,11 +314,13 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -287,6 +331,8 @@
     {
       "CI_COMMIT_BRANCH": "refs/heads/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -297,12 +343,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -313,6 +361,8 @@
     {
       "CI_COMMIT_BRANCH": "refs/heads/feature/one",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -323,12 +373,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.sha": "gitlab-git-commit",
@@ -339,6 +391,8 @@
     {
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TAG": "origin/tags/0.1.0",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -349,12 +403,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "gitlab-git-commit",
       "git.repository_url": "sample",
@@ -365,6 +421,8 @@
     {
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TAG": "refs/heads/tags/0.1.0",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -375,12 +433,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "gitlab-git-commit",
       "git.repository_url": "sample",
@@ -391,6 +451,8 @@
     {
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TAG": "0.1.0",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -401,12 +463,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "gitlab-git-commit",
       "git.repository_url": "sample",
@@ -417,6 +481,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -427,12 +493,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -443,6 +511,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -453,12 +523,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -469,6 +541,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -479,12 +553,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -495,6 +571,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -505,12 +583,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",
@@ -521,6 +601,8 @@
     {
       "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
       "CI_JOB_URL": "gitlab-job-url",
       "CI_PIPELINE_ID": "gitlab-pipeline-id",
       "CI_PIPELINE_IID": "gitlab-pipeline-number",
@@ -531,12 +613,14 @@
       "GITLAB_CI": "gitlab"
     },
     {
+      "ci.job.name": "gitlab-job-name",
       "ci.job.url": "gitlab-job-url",
       "ci.pipeline.id": "gitlab-pipeline-id",
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.pipeline.url": "https://foo/repo/pipelines/1234",
       "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.sha": "gitlab-git-commit",


### PR DESCRIPTION
## Description
Update the CI specs adding new CI tags for GitLab


## Checklist
- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
- [ ] Tests provided; and/or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
