### PR TITLE
PR template fix-ups

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,7 @@
 
 
 ## Checklist
-- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
-- [ ] Tests provided; and/or
-- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
+- [ ] Added to the correct milestone.
+- [ ] Tests provided or description of manual testing performed is included in the code or PR.
 - [ ] Library documentation is updated.
 - [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -7,7 +7,6 @@
 <!-- Please provide a succinct overview of the fix. -->
 
 # Checklist
-- [ ] Entry added to `CHANGELOG.md`
 - [ ] Regression test added; or
 - [ ] Description of manual testing performed and explanation is included in the code and/or PR.
 - [ ] Added to the correct milestone.

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -2,10 +2,9 @@
 <!-- Please add a brief description of the feature -->
 
 ## Checklist
-- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html)
-- [ ] Docs are updated.
-- [ ] [Corp docs](https://github.com/Datadog/documentation) are updated (if applicable).
 - [ ] Added to the correct milestone.
+- [ ] Library documentation is updated.
+- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
 
 ### Testing
 - [ ] Tests are run against all relevant library versions (or confirm that the relevant versions are already being tested in `tox.ini`)

--- a/.github/PULL_REQUEST_TEMPLATE/integration.md
+++ b/.github/PULL_REQUEST_TEMPLATE/integration.md
@@ -10,8 +10,10 @@ This PR adds support for [`<integration>`](<!--link to relevant integration docs
 ## Checklist
 - [ ] Usage and configuration documentation added in `__init__.py`.
 - [ ] [Corp docs](https://github.com/Datadog/documentation) are updated.
-- [ ] Entry added to release notes using [reno](https://docs.openstack.org/reno/latest/user/usage.html).
 - [ ] Distributed tracing propagation is implemented (if applicable).
+- [ ] Span metadata
+  - [ ] Span type
+  - [ ] Resource
 - [ ] Global configuration
   - [ ] Inherits `DD_SERVICE` (if applicable).
   - [ ] Environment variables are provided for config options.
@@ -24,9 +26,8 @@ This PR adds support for [`<integration>`](<!--link to relevant integration docs
   - [ ] Context propagation across async boundaries.
 - [ ] HTTP (if applicable)
   - [ ] 500-level responses are tagged as errors.
-- [ ] Web (if applicable) 
+- [ ] Web (if applicable)
   - [ ] Request headers specified in the config are stored.
-  - [ ] Use SpanTypes.WEB for request span of trace.
 - [ ] Tests
   - [ ] Tests are provided for all of the above.
   - [ ] Tests are added to CI (`.circleci/config.yml`).


### PR DESCRIPTION
changelog management is now done through CI so we don't need it in the checklist; along with a few other touch-ups