### PR TITLE
fix(core): handle failed encoding

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -341,6 +341,24 @@ def test_bad_payload():
     log.error.assert_has_calls(calls)
 
 
+def test_bad_encoder():
+    t = Tracer()
+
+    class BadEncoder:
+        def encode_trace(self, spans):
+            raise Exception()
+
+        def join_encoded(self, traces):
+            pass
+
+    t.writer._encoder = BadEncoder()
+    with mock.patch("ddtrace.internal.writer.log") as log:
+        t.trace("asdf").finish()
+        t.shutdown()
+    calls = [mock.call("failed to encode trace with encoder %r" % (t.writer._encoder))]
+    log.error.assert_has_calls(calls)
+
+
 @pytest.mark.skipif(AGENT_VERSION == "testagent", reason="Test agent doesn't support v0.3")
 def test_downgrade():
     t = Tracer()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -355,7 +355,7 @@ def test_bad_encoder():
     with mock.patch("ddtrace.internal.writer.log") as log:
         t.trace("asdf").finish()
         t.shutdown()
-    calls = [mock.call("failed to encode trace with encoder %r" % (t.writer._encoder))]
+    calls = [mock.call("failed to encode trace with encoder %r", t.writer._encoder, exc_info=True)]
     log.error.assert_has_calls(calls)
 
 


### PR DESCRIPTION
## Description
<!-- Please briefly describe the change and why it was required. -->
Looks like there was a typo/oversight with the error handling for encoding in which we'd continue to try to send the trace after encoding failed.

## Checklist
- [x] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] ~Library documentation is updated.~
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
