### PR TITLE
tests: exclude py27 grpc 1.14, 1.18

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,8 @@ envlist =
 # py27,py35,py36: grpcio>=1.13.0
 # py37: grpcio>=1.13.0
 # py38: grpcio>=1.24.3
-    grpc_contrib-py{27,35,36}-grpc{112,114,118,120,121,122}-googleapis-common-protos
+    grpc_contrib-py{27}-grpc{112,120,121,122}-googleapis-common-protos
+    grpc_contrib-py{35,36}-grpc{112,114,118,120,121,122}-googleapis-common-protos
     grpc_contrib-py{37}-grpc{114,118,120,121,122,124,126,128,}-googleapis-common-protos
     grpc_contrib-py{38}-grpc{124,126,128,}-googleapis-common-protos
     httplib_contrib-py{27,35,36,37,38,39}


### PR DESCRIPTION
## Description
<!-- Please briefly describe the change and why it was required. -->
Seems like Python 2.7 and grpc 1.14, 1.18 results in deadlocks in the tests:

- https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/4758/workflows/b7bd6cb9-a2ec-49c7-a4e6-9c24d9766c4b/jobs/457578
- https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/4758/workflows/afff6b43-5296-4372-b120-3e72a5f1aa0b/jobs/457579
- https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/4758/workflows/6f8551e3-a8ee-4250-a13c-bcc146c03c36/jobs/457502


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
