### PR TITLE
feat(profiling): support most uwsgi modes

### DIFF
--- a/ddtrace/internal/uwsgi.py
+++ b/ddtrace/internal/uwsgi.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import
+
+
+class uWSGIConfigError(Exception):
+    """uWSGI configuration error.
+
+    This is raised when uwsgi configuration is incompatible with the library.
+    """
+
+
+class uWSGIMasterProcess(Exception):
+    """The process is uWSGI master process."""
+
+
+def check_uwsgi(worker_callback=None, atexit=None):
+    """Check whetever uwsgi is running and what needs to be done.
+
+    :param worker_callback: Callback function to call in uWSGI worker processes.
+    """
+    try:
+        import uwsgi
+    except ImportError:
+        return
+
+    if not uwsgi.opt.get("enable-threads"):
+        raise uWSGIConfigError("enable-threads option must be set to true")
+
+    # If uwsgi has more than one process, it is running in prefork operational mode: uwsgi is going to fork multiple
+    # sub-processes.
+    # If lazy-app is enabled, then the app is loaded in each subprocess independently. This is fine.
+    # If it's not enabled, then the app will be loaded in the master process, and uwsgi will `fork()` abruptly,
+    # bypassing Python sanity checks. We need to handle this case properly.
+    # The proper way to handle that is to allow to register a callback function to run in the subprocess at their
+    # startup, and warn the caller that this is the master process and that (probably) nothing should be done.
+    if uwsgi.numproc > 1 and not uwsgi.opt.get("lazy-apps") and uwsgi.worker_id() == 0:
+
+        if not uwsgi.opt.get("master"):
+            # Having multiple workers without the master process is not supported:
+            # the postfork hooks are not available, so there's no way to start a different profiler in each
+            # worker
+            raise uWSGIConfigError("master option must be enabled when multiple processes are used")
+
+        # Register the function to be called in child process at startup
+        if worker_callback is not None:
+            try:
+                import uwsgidecorators
+            except ImportError:
+                raise uWSGIConfigError("Running under uwsgi but uwsgidecorators cannot be imported")
+            uwsgidecorators.postfork(worker_callback)
+
+        if atexit is not None:
+
+            original_atexit = getattr(uwsgi, "atexit", None)
+
+            def _atexit():
+                try:
+                    atexit()
+                except Exception:
+                    pass
+
+                if original_atexit is not None:
+                    original_atexit()
+
+            uwsgi.atexit = _atexit
+
+        raise uWSGIMasterProcess()

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -7,6 +7,7 @@ import warnings
 import sys
 
 import ddtrace
+from ddtrace.internal import uwsgi
 from ddtrace.profiling import recorder
 from ddtrace.profiling import scheduler
 from ddtrace.utils import deprecation
@@ -66,6 +67,13 @@ class Profiler(object):
         :param stop_on_exit: Whether to stop the profiler and flush the profile on exit.
         :param profile_children: Whether to start a profiler in child processes.
         """
+
+        if profile_children:
+            try:
+                uwsgi.check_uwsgi(self.start, atexit=self.stop if stop_on_exit else None)
+            except uwsgi.uWSGIMasterProcess:
+                # Do nothing, the start() method will be called in each worker subprocess
+                return
 
         self._profiler.start()
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -56,6 +56,7 @@ metadata
 microservices
 middleware
 mongoengine
+multiprocess
 mysql
 mysqlclient
 mysqldb

--- a/releasenotes/notes/profiling-uwsgi-faaeb38f11bd287b.yaml
+++ b/releasenotes/notes/profiling-uwsgi-faaeb38f11bd287b.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    The profiler now supports most operation mode from uWSGI without much
+    configuration. It will automatically plug itself in post fork hooks when
+    multiprocess mode is used.
+upgrade:
+  - |
+    The profiler now automatically sets up uWSGI compatibility in auto mode
+    or with `profile_children=True`. Make sure that you don't have custom code
+    instrumenting the profiler in those cases.

--- a/tests/profiling/conftest.py
+++ b/tests/profiling/conftest.py
@@ -1,0 +1,5 @@
+import os
+
+@pytest.fixture(scope="session", autouse=True)
+def disable_coverage_for_subprocess():
+    del os.environ["COV_CORE_SOURCE"]

--- a/tests/profiling/conftest.py
+++ b/tests/profiling/conftest.py
@@ -1,5 +1,8 @@
 import os
 
+import pytest
+
+
 @pytest.fixture(scope="session", autouse=True)
 def disable_coverage_for_subprocess():
     del os.environ["COV_CORE_SOURCE"]

--- a/tests/profiling/test_uwsgi.py
+++ b/tests/profiling/test_uwsgi.py
@@ -1,0 +1,168 @@
+# -*- encoding: utf-8 -*-
+import os
+import subprocess
+import tempfile
+import signal
+import time
+import re
+import sys
+
+import pytest
+
+uwsgi_app = os.path.join(os.path.dirname(__file__), "uwsgi-app.py")
+
+
+@pytest.fixture
+def uwsgi():
+    # Do not use pytest tmpdir fixtures which generate directories longer than allowed for a socket file name
+    socket_name = tempfile.mktemp()
+    cmd = ["uwsgi", "--need-app", "--die-on-term", "--socket", socket_name, "--wsgi-file", uwsgi_app]
+
+    def _run_uwsgi(*args):
+        env = os.environ.copy()
+        if sys.version_info[0] == 2:
+            # On Python 2, it's impossible to import uwsgidecorators without this hack
+            env["PYTHONPATH"] = os.path.join(
+                os.environ.get("VIRTUAL_ENV", ""),
+                "lib",
+                "python%s.%s" % (sys.version_info[0], sys.version_info[1]),
+                "site-packages",
+            )
+
+        return subprocess.Popen(cmd + list(args), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
+
+    try:
+        yield _run_uwsgi
+    finally:
+        os.unlink(socket_name)
+
+
+def test_uwsgi_threads_disabled(uwsgi):
+    proc = uwsgi()
+    stdout, _ = proc.communicate()
+    assert proc.wait() != 0
+    assert b"ddtrace.internal.uwsgi.uWSGIConfigError: enable-threads option must be set to true" in stdout
+
+
+def test_uwsgi_threads_enabled(uwsgi, tmp_path, monkeypatch):
+    filename = str(tmp_path / "uwsgi.pprof")
+    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
+    proc = uwsgi("--enable-threads")
+    worker_pids = _get_worker_pids(proc.stdout, 1)
+    # Give some time to the process to actually startup
+    time.sleep(3)
+    proc.terminate()
+    assert proc.wait() == 30
+    for pid in worker_pids:
+        assert os.path.exists("%s.%d.1" % (filename, pid))
+
+
+def test_uwsgi_threads_processes_no_master(uwsgi, monkeypatch):
+    proc = uwsgi("--enable-threads", "--processes", "2")
+    stdout, _ = proc.communicate()
+    assert (
+        b"ddtrace.internal.uwsgi.uWSGIConfigError: master option must be enabled when multiple processes are used"
+        in stdout
+    )
+
+
+def _get_worker_pids(stdout, num_worker, num_app_started=1):
+    worker_pids = []
+    started = 0
+    while True:
+        line = stdout.readline()
+        if line == b"":
+            break
+        elif b"WSGI app 0 (mountpoint='') ready" in line:
+            started += 1
+        else:
+            m = re.match(r"^spawned uWSGI worker \d+ .*\(pid: (\d+),", line.decode())
+            if m:
+                worker_pids.append(int(m.group(1)))
+
+        if len(worker_pids) == num_worker and num_app_started == started:
+            break
+
+    return worker_pids
+
+
+def test_uwsgi_threads_processes_master(uwsgi, tmp_path, monkeypatch):
+    filename = str(tmp_path / "uwsgi.pprof")
+    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
+    proc = uwsgi("--enable-threads", "--master", "--processes", "2")
+    worker_pids = _get_worker_pids(proc.stdout, 2)
+    # Give some time to child to actually startup
+    time.sleep(3)
+    proc.terminate()
+    assert proc.wait() == 0
+    for pid in worker_pids:
+        assert os.path.exists("%s.%d.1" % (filename, pid))
+
+
+def test_uwsgi_threads_processes_master_lazy_apps(uwsgi, tmp_path, monkeypatch):
+    filename = str(tmp_path / "uwsgi.pprof")
+    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
+    proc = uwsgi("--enable-threads", "--master", "--processes", "2", "--lazy-apps")
+    worker_pids = _get_worker_pids(proc.stdout, 2, 2)
+    # Give some time to child to actually startup
+    time.sleep(3)
+    proc.terminate()
+    assert proc.wait() == 0
+    for pid in worker_pids:
+        assert os.path.exists("%s.%d.1" % (filename, pid))
+
+
+# For whatever reason this crashes easily on Python 2.7 with a segfault, and hangs on Python before 3.7.
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(uwsgi_backtrace+0x35) [0x561586ca5a85]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(uwsgi_segfault+0x23) [0x561586ca5e33]
+# /lib/x86_64-linux-gnu/libc.so.6(+0x33060) [0x7f8325888060]
+# /root/project/.tox/py27-profile-minreqs-gevent/lib/python2.7/site-packages/
+#         google/protobuf/pyext/_message.so(+0x8d450) [0x7f831ed20450]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(+0x14ddb7) [0x561586d36db7]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(PyDict_SetItem+0x67) [0x561586d38327]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(_PyModule_Clear+0x14e) [0x561586d3d21e]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(PyImport_Cleanup+0x380) [0x561586daf440]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(+0x1db008) [0x561586dc4008]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(uwsgi_plugins_atexit+0x81) [0x561586ca2b51]
+# /lib/x86_64-linux-gnu/libc.so.6(+0x35940) [0x7f832588a940]
+# /lib/x86_64-linux-gnu/libc.so.6(+0x3599a) [0x7f832588a99a]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(+0x7172f) [0x561586c5a72f]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(end_me+0x25) [0x561586ca2b95]
+# /lib/x86_64-linux-gnu/libpthread.so.0(+0x110e0) [0x7f83270a50e0]
+# /lib/x86_64-linux-gnu/libc.so.6(epoll_wait+0x33) [0x7f832593e303]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(event_queue_wait+0x25) [0x561586c98d55]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(wsgi_req_accept+0x13a) [0x561586c57eba]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(simple_loop_run+0xb6) [0x561586ca1916]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(simple_loop+0x10) [0x561586ca1740]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(uwsgi_ignition+0x1b3) [0x561586ca60a3]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(uwsgi_worker_run+0x28d) [0x561586caaa6d]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(+0xc206c) [0x561586cab06c]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(+0x6e24e) [0x561586c5724e]
+# /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf1) [0x7f83258752e1]
+# /root/project/.tox/py27-profile-minreqs-gevent/bin/uwsgi(_start+0x2a) [0x561586c5727a]
+@pytest.mark.skipif(
+    not (sys.version_info[0] >= 3 and sys.version_info[1] >= 7), reason="this test crashes on old Python versions"
+)
+def test_uwsgi_threads_processes_no_master_lazy_apps(uwsgi, tmp_path, monkeypatch):
+    filename = str(tmp_path / "uwsgi.pprof")
+    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
+    proc = uwsgi("--enable-threads", "--processes", "2", "--lazy-apps")
+    worker_pids = _get_worker_pids(proc.stdout, 2, 2)
+    # Give some time to child to actually startup
+    time.sleep(3)
+    # The processes are started without a master/parent so killing one does not kill the other:
+    # Kill them all and wait until they die.
+    for pid in worker_pids:
+        os.kill(pid, signal.SIGTERM)
+    # The first worker is our child, we can wait for it "normally"
+    os.waitpid(worker_pids[0], 0)
+    # The other ones are grandchildren, we can't wait for it with `waitpid`
+    for pid in worker_pids[1:]:
+        # Wait for the uwsgi workers to all die
+        while True:
+            try:
+                os.kill(pid, 0)
+            except OSError:
+                break
+    for pid in worker_pids:
+        assert os.path.exists("%s.%d.1" % (filename, pid))

--- a/tests/profiling/uwsgi-app.py
+++ b/tests/profiling/uwsgi-app.py
@@ -1,0 +1,5 @@
+import ddtrace.profiling.auto  # noqa
+
+
+def application():
+    pass

--- a/tox.ini
+++ b/tox.ini
@@ -174,6 +174,7 @@ deps =
 # used to test our custom msgpack encoder
     integration: msgpack
     profile: pytest-benchmark
+    profile: uwsgi
     profile-minreqs: protobuf==3.0.0
     profile-minreqs: tenacity==5.0.1
     profile-!minreqs-gevent: gevent


### PR DESCRIPTION
## tests(profiling): disable coverage for subprocesses

Profiling tests use subprocesses in several cases which might mess with
coverage. Let's disable coverage in Python subprocesses.

## feat(profiling): support most uwsgi modes

This adds support for many of the uWSGI configuration mode (master, lazy-apps,
multi process, etc) by introspecting uWSGI options and leveraging its hooks.