### PR TITLE
refactor sampling tests to be context independent

### DIFF
--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -203,7 +203,7 @@ class DatadogSampler(BaseSampler, BasePrioritySampler):
                     self._set_priority(span, AUTO_REJECT)
                     return False
 
-            # If no rules match, use our defualt sampler
+            # If no rules match, use our default sampler
             matching_rule = self.default_sampler
 
         # Sample with the matching sampling rule

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -7,9 +7,14 @@ import pytest
 from ddtrace.vendor import six
 
 import ddtrace
+from ddtrace.constants import (
+    MANUAL_DROP_KEY,
+    MANUAL_KEEP_KEY,
+)
 from ddtrace import Tracer, tracer
 from ddtrace.internal.writer import AgentWriter
 from ddtrace.internal.runtime import container
+from ddtrace.sampler import DatadogSampler, RateSampler, SamplingRule
 
 from tests import TracerTestCase, snapshot, AnyInt, override_global_config
 
@@ -441,4 +446,55 @@ class TestTraces(TracerTestCase):
         with tracer.trace("root"):
             with tracer.trace("child"):
                 pass
+        tracer.shutdown()
+
+    @snapshot(include_tracer=True)
+    def test_sampling(self, tracer):
+        with tracer.trace("trace1"):
+            with tracer.trace("child"):
+                pass
+
+        sampler = DatadogSampler(default_sample_rate=1.0)
+        tracer.configure(sampler=sampler, writer=tracer.writer)
+        with tracer.trace("trace2"):
+            with tracer.trace("child"):
+                pass
+
+        sampler = DatadogSampler(default_sample_rate=0.000001)
+        tracer.configure(sampler=sampler, writer=tracer.writer)
+        with tracer.trace("trace3"):
+            with tracer.trace("child"):
+                pass
+
+        sampler = DatadogSampler(default_sample_rate=1, rules=[SamplingRule(1.0)])
+        tracer.configure(sampler=sampler, writer=tracer.writer)
+        with tracer.trace("trace4"):
+            with tracer.trace("child"):
+                pass
+
+        sampler = DatadogSampler(default_sample_rate=1, rules=[SamplingRule(0)])
+        tracer.configure(sampler=sampler, writer=tracer.writer)
+        with tracer.trace("trace5"):
+            with tracer.trace("child"):
+                pass
+
+        sampler = DatadogSampler(default_sample_rate=1)
+        tracer.configure(sampler=sampler, writer=tracer.writer)
+        with tracer.trace("trace6"):
+            with tracer.trace("child") as span:
+                span.set_tag(MANUAL_DROP_KEY)
+
+        sampler = DatadogSampler(default_sample_rate=1)
+        tracer.configure(sampler=sampler, writer=tracer.writer)
+        with tracer.trace("trace7"):
+            with tracer.trace("child") as span:
+                span.set_tag(MANUAL_KEEP_KEY)
+
+        sampler = RateSampler(0.0000000001)
+        tracer.configure(sampler=sampler, writer=tracer.writer)
+        # This trace should not appear in the snapshot
+        with tracer.trace("trace8"):
+            with tracer.trace("child"):
+                pass
+
         tracer.shutdown()

--- a/tests/snapshots/tests.integration.test_integration.test_sampling.snap
+++ b/tests/snapshots/tests.integration.test_integration.test_sampling.snap
@@ -1,0 +1,158 @@
+[[{"name" "trace1"
+   "service" nil
+   "resource" "trace1"
+   "error" 0
+   "span_id" 0
+   "trace_id" 0
+   "parent_id" nil
+   "start" 1611739614070324000
+   "duration" 69000
+   "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
+   "metrics" {"_dd.agent_psr" 1.0
+              "_sampling_priority_v1" 1
+              "system.pid" 10144}}
+      {"name" "child"
+       "service" nil
+       "resource" "child"
+       "error" 0
+       "span_id" 1
+       "trace_id" 0
+       "parent_id" 0
+       "start" 1611739614070374000
+       "duration" 10000}]
+ [{"name" "trace2"
+   "service" nil
+   "resource" "trace2"
+   "error" 0
+   "span_id" 0
+   "trace_id" 1
+   "parent_id" nil
+   "start" 1611739614070713000
+   "duration" 63000
+   "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
+   "metrics" {"_dd.limit_psr" 1.0
+              "_sampling_priority_v1" 1
+              "system.pid" 10144
+              "_dd.rule_psr" 1.0}}
+      {"name" "child"
+       "service" nil
+       "resource" "child"
+       "error" 0
+       "span_id" 1
+       "trace_id" 1
+       "parent_id" 0
+       "start" 1611739614070760000
+       "duration" 9000}]
+ [{"name" "trace3"
+   "service" nil
+   "resource" "trace3"
+   "error" 0
+   "span_id" 0
+   "trace_id" 2
+   "parent_id" nil
+   "start" 1611739614070850000
+   "duration" 41000
+   "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
+   "metrics" {"_sampling_priority_v1" 0
+              "system.pid" 10144
+              "_dd.rule_psr" 1.0E-6}}
+      {"name" "child"
+       "service" nil
+       "resource" "child"
+       "error" 0
+       "span_id" 1
+       "trace_id" 2
+       "parent_id" 0
+       "start" 1611739614070878000
+       "duration" 8000}]
+ [{"name" "trace4"
+   "service" nil
+   "resource" "trace4"
+   "error" 0
+   "span_id" 0
+   "trace_id" 3
+   "parent_id" nil
+   "start" 1611739614070959000
+   "duration" 50000
+   "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
+   "metrics" {"_dd.limit_psr" 1.0
+              "_sampling_priority_v1" 1
+              "system.pid" 10144
+              "_dd.rule_psr" 1.0}}
+      {"name" "child"
+       "service" nil
+       "resource" "child"
+       "error" 0
+       "span_id" 1
+       "trace_id" 3
+       "parent_id" 0
+       "start" 1611739614070996000
+       "duration" 8000}]
+ [{"name" "trace5"
+   "service" nil
+   "resource" "trace5"
+   "error" 0
+   "span_id" 0
+   "trace_id" 4
+   "parent_id" nil
+   "start" 1611739614071075000
+   "duration" 41000
+   "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
+   "metrics" {"_sampling_priority_v1" 0
+              "system.pid" 10144
+              "_dd.rule_psr" 0}}
+      {"name" "child"
+       "service" nil
+       "resource" "child"
+       "error" 0
+       "span_id" 1
+       "trace_id" 4
+       "parent_id" 0
+       "start" 1611739614071103000
+       "duration" 7000}]
+ [{"name" "trace6"
+   "service" nil
+   "resource" "trace6"
+   "error" 0
+   "span_id" 0
+   "trace_id" 5
+   "parent_id" nil
+   "start" 1611739614071176000
+   "duration" 55000
+   "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
+   "metrics" {"_dd.limit_psr" 1.0
+              "_sampling_priority_v1" -1
+              "system.pid" 10144
+              "_dd.rule_psr" 1}}
+      {"name" "child"
+       "service" nil
+       "resource" "child"
+       "error" 0
+       "span_id" 1
+       "trace_id" 5
+       "parent_id" 0
+       "start" 1611739614071208000
+       "duration" 17000}]
+ [{"name" "trace7"
+   "service" nil
+   "resource" "trace7"
+   "error" 0
+   "span_id" 0
+   "trace_id" 6
+   "parent_id" nil
+   "start" 1611739614071293000
+   "duration" 48000
+   "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
+   "metrics" {"_dd.limit_psr" 1.0
+              "_sampling_priority_v1" 2
+              "system.pid" 10144
+              "_dd.rule_psr" 1}}
+      {"name" "child"
+       "service" nil
+       "resource" "child"
+       "error" 0
+       "span_id" 1
+       "trace_id" 6
+       "parent_id" 0
+       "start" 1611739614071323000
+       "duration" 13000}]]

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -1,5 +1,4 @@
 from __future__ import division
-import contextlib
 import mock
 import re
 import unittest
@@ -232,9 +231,6 @@ def test_sampling_rule_init_defaults():
 
 def test_sampling_rule_init():
     name_regex = re.compile(r"\.request$")
-
-    def resource_check(resource):
-        return "healthcheck" in resource
 
     rule = SamplingRule(
         sample_rate=0.0,
@@ -705,7 +701,7 @@ def test_datadog_sampler_tracer_child(dummy_tracer):
     assert dummy_tracer.sampler is sampler_spy
 
     with dummy_tracer.trace("parent.span") as parent:
-        with dummy_tracer.trace("child.span") as child:
+        with dummy_tracer.trace("child.span"):
             # Assert all of our expected functions were called
             # DEV: `assert_called_once_with` ensures we didn't also call with the child span
             sampler_spy.sample.assert_called_once_with(parent)

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -30,13 +30,10 @@ def assert_sampling_decision_tags(span, agent=None, limit=None, rule=None):
     assert span.get_metric(SAMPLING_RULE_DECISION) == rule
 
 
-def create_span(tracer=None, name="test.span", meta=None, *args, **kwargs):
+def create_span(tracer=None, name="test.span", service=""):
     tracer = tracer or get_dummy_tracer()
-    if "context" not in kwargs:
-        kwargs["context"] = tracer.get_call_context()
-    span = Span(tracer=tracer, name=name, *args, **kwargs)
-    if meta:
-        span.set_tags(meta)
+    span = tracer.trace(name=name, service=service)
+    span.finish()
     return span
 
 
@@ -497,192 +494,115 @@ def test_datadog_sampler_sample_no_rules(mock_sample, dummy_tracer):
     assert span.sampled is False
 
 
-@mock.patch("ddtrace.internal.rate_limiter.RateLimiter.is_allowed")
-def test_datadog_sampler_sample_rules(mock_is_allowed, dummy_tracer):
-    # Do not let the limiter get in the way of our test
-    mock_is_allowed.return_value = True
+class MatchSample(SamplingRule):
+    def matches(self, span):
+        return True
 
-    rules = [
-        mock.Mock(spec=SamplingRule),
-        mock.Mock(spec=SamplingRule),
-        mock.Mock(spec=SamplingRule),
-    ]
-    sampler = DatadogSampler(rules=rules)
+    def sample(self, span):
+        return True
 
-    # Reset all of our mocks
-    @contextlib.contextmanager
-    def reset_mocks():
-        def reset():
-            mock_is_allowed.reset_mock()
-            for rule in rules:
-                rule.reset_mock()
-                rule.sample_rate = 0.5
 
-            default_rule = SamplingRule(sample_rate=1.0)
-            sampler.default_sampler = mock.Mock(spec=SamplingRule, wraps=default_rule)
-            # Mock has lots of problems with mocking/wrapping over class properties
-            sampler.default_sampler.sample_rate = default_rule.sample_rate
+class NoMatch(SamplingRule):
+    def matches(self, span):
+        return False
 
-        reset()  # Reset before, just in case
-        try:
-            yield
-        finally:
-            reset()  # Must reset after
+    def sample(self, span):
+        return True
 
-    # No rules want to sample
-    #   It is allowed because of default rate sampler
-    #   All rules SamplingRule.matches are called
-    #   No calls to SamplingRule.sample happen
-    with reset_mocks():
-        span = create_span(tracer=dummy_tracer)
-        for rule in rules:
-            rule.matches.return_value = False
 
-        assert sampler.sample(span) is True
-        assert span._context.sampling_priority is AUTO_KEEP
-        assert span.sampled is True
-        mock_is_allowed.assert_called_once_with()
-        for rule in rules:
-            rule.matches.assert_called_once_with(span)
-            rule.sample.assert_not_called()
-        sampler.default_sampler.matches.assert_not_called()
-        sampler.default_sampler.sample.assert_called_once_with(span)
-        assert_sampling_decision_tags(span, rule=1.0, limit=1.0)
+class MatchNoSample(SamplingRule):
+    def matches(self, span):
+        return True
 
-    # One rule thinks it should be sampled
-    #   All following rule's SamplingRule.matches are not called
-    #   It goes through limiter
-    #   It is allowed
-    with reset_mocks():
-        span = create_span(tracer=dummy_tracer)
+    def sample(self, span):
+        return False
 
-        rules[1].matches.return_value = True
-        rules[1].sample.return_value = True
 
-        assert sampler.sample(span) is True
-        assert span._context.sampling_priority is AUTO_KEEP
-        assert span.sampled is True
-        mock_is_allowed.assert_called_once_with()
-        sampler.default_sampler.sample.assert_not_called()
-        assert_sampling_decision_tags(span, rule=0.5, limit=1.0)
+@pytest.mark.parametrize(
+    "sampler, sampling_priority, rule, limit",
+    [
+        (
+            DatadogSampler(
+                default_sample_rate=1.0,
+                rules=[
+                    NoMatch(0.5),
+                    NoMatch(0.5),
+                    NoMatch(0.5),
+                ],
+            ),
+            AUTO_KEEP,
+            1.0,
+            1.0,
+        ),
+        (
+            DatadogSampler(
+                default_sample_rate=1.0,
+                rules=[
+                    NoMatch(0.5),
+                    NoMatch(0.5),
+                    MatchSample(0.5),
+                ],
+            ),
+            AUTO_KEEP,
+            0.5,
+            1.0,
+        ),
+        (
+            DatadogSampler(
+                default_sample_rate=1.0,
+                rules=[
+                    MatchSample(0.5),
+                    MatchNoSample(0.5),
+                    MatchNoSample(0.5),
+                ],
+            ),
+            AUTO_KEEP,
+            0.5,
+            1.0,
+        ),
+        (
+            DatadogSampler(
+                default_sample_rate=1.0,
+                rules=[
+                    NoMatch(0.5),
+                    MatchNoSample(0.5),
+                    NoMatch(0.5),
+                ],
+            ),
+            AUTO_REJECT,
+            0.5,
+            None,
+        ),
+        (
+            DatadogSampler(
+                default_sample_rate=1.0,
+                rules=[
+                    NoMatch(0.5),
+                    MatchNoSample(0.5),
+                    NoMatch(0.5),
+                ],
+            ),
+            AUTO_REJECT,
+            0.5,
+            None,
+        ),
+    ],
+)
+def test_datadog_sampler_sample_rules(sampler, sampling_priority, rule, limit, dummy_tracer):
+    dummy_tracer.configure(sampler=sampler)
+    with dummy_tracer.trace("span"):
+        pass
+    spans = dummy_tracer.writer.pop()
 
-        rules[0].matches.assert_called_once_with(span)
-        rules[0].sample.assert_not_called()
-
-        rules[1].matches.assert_called_once_with(span)
-        rules[1].sample.assert_called_once_with(span)
-
-        rules[2].matches.assert_not_called()
-        rules[2].sample.assert_not_called()
-
-    # All rules think it should be sampled
-    #   The first rule's SamplingRule.matches is called
-    #   It goes through limiter
-    #   It is allowed
-    with reset_mocks():
-        span = create_span(tracer=dummy_tracer)
-
-        for rule in rules:
-            rule.matches.return_value = True
-        rules[0].sample.return_value = True
-
-        assert sampler.sample(span) is True
-        assert span._context.sampling_priority is AUTO_KEEP
-        assert span.sampled is True
-        mock_is_allowed.assert_called_once_with()
-        sampler.default_sampler.sample.assert_not_called()
-        assert_sampling_decision_tags(span, rule=0.5, limit=1.0)
-
-        rules[0].matches.assert_called_once_with(span)
-        rules[0].sample.assert_called_once_with(span)
-        for rule in rules[1:]:
-            rule.matches.assert_not_called()
-            rule.sample.assert_not_called()
-
-    # Rule matches but does not think it should be sampled
-    #   The rule's SamplingRule.matches is called
-    #   The rule's SamplingRule.sample is called
-    #   Rate limiter is not called
-    #   The span is rejected
-    with reset_mocks():
-        span = create_span(tracer=dummy_tracer)
-
-        rules[0].matches.return_value = False
-        rules[2].matches.return_value = False
-
-        rules[1].matches.return_value = True
-        rules[1].sample.return_value = False
-
-        assert sampler.sample(span) is False
-        assert span._context.sampling_priority is AUTO_REJECT
-        assert span.sampled is False
-        mock_is_allowed.assert_not_called()
-        sampler.default_sampler.sample.assert_not_called()
-        assert_sampling_decision_tags(span, rule=0.5)
-
-        rules[0].matches.assert_called_once_with(span)
-        rules[0].sample.assert_not_called()
-
-        rules[1].matches.assert_called_once_with(span)
-        rules[1].sample.assert_called_once_with(span)
-
-        rules[2].matches.assert_not_called()
-        rules[2].sample.assert_not_called()
-
-    # No rules match and RateByServiceSampler is used
-    #   All rules SamplingRule.matches are called
-    #   Priority sampler's `sample` method is called
-    #   Result of priority sampler is returned
-    #   Rate limiter is not called
-    with reset_mocks():
-        span = create_span(tracer=dummy_tracer)
-
-        # Configure mock priority sampler
-        priority_sampler = RateByServiceSampler()
-        sampler.default_sampler = mock.Mock(spec=RateByServiceSampler, wraps=priority_sampler)
-
-        for rule in rules:
-            rule.matches.return_value = False
-            rule.sample.return_value = False
-
-        assert sampler.sample(span) is True
-        assert span._context.sampling_priority is AUTO_KEEP
-        assert span.sampled is True
-        mock_is_allowed.assert_not_called()
-        sampler.default_sampler.sample.assert_called_once_with(span)
-        assert_sampling_decision_tags(span, agent=1)
-
-        [r.matches.assert_called_once_with(span) for r in rules]
-        [r.sample.assert_not_called() for r in rules]
-
-    # No rules match and priority sampler is defined
-    #   All rules SamplingRule.matches are called
-    #   Priority sampler's `sample` method is called
-    #   Result of priority sampler is returned
-    #   Rate limiter is not called
-    with reset_mocks():
-        span = create_span(tracer=dummy_tracer)
-
-        # Configure mock priority sampler
-        priority_sampler = RateByServiceSampler()
-        for rate_sampler in priority_sampler._by_service_samplers.values():
-            rate_sampler.set_sample_rate(0)
-
-        sampler.default_sampler = mock.Mock(spec=RateByServiceSampler, wraps=priority_sampler)
-
-        for rule in rules:
-            rule.matches.return_value = False
-            rule.sample.return_value = False
-
-        assert sampler.sample(span) is False
-        assert span._context.sampling_priority is AUTO_REJECT
-        assert span.sampled is False
-        mock_is_allowed.assert_not_called()
-        sampler.default_sampler.sample.assert_called_once_with(span)
-        assert_sampling_decision_tags(span, agent=0)
-
-        [r.matches.assert_called_once_with(span) for r in rules]
-        [r.sample.assert_not_called() for r in rules]
+    # A span is always expected as DatadogSamplers are used.
+    assert len(spans) > 0
+    span = spans[0]
+    # Hence, it should always be "sampled" (sent to the agent)
+    # This is an implementation detail so we probably don't have to
+    # test it.
+    assert span.sampled
+    assert span.get_metric(SAMPLING_LIMIT_DECISION) == limit
+    assert span.get_metric(SAMPLING_RULE_DECISION) == rule
 
 
 def test_datadog_sampler_tracer(dummy_tracer):


### PR DESCRIPTION
The sampling tests previously depended on the implementation of `Context`. This patch removes the dependence by depending the resulting traces rather than the intermediate state of spans and context. A snapshot test for a variety of sampling scenarios is also added.

This will unblock #1936 