### PR TITLE
docs: fix release notes release_tag_re

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,3 +1,2 @@
 ---
 unreleased_version_title: Unreleased
-release_tag_re: "v[0-9]+\\.[0-9]+\\.[0-9]+$"


### PR DESCRIPTION
This exclude rc releases which is not a good thing to have a proper release
notes generated on every branch.