### PR TITLE
ci: fix flaky grpc tests

### DIFF
--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -54,13 +54,15 @@ class GrpcTestCase(TracerTestCase):
         return spans
 
     def _start_server(self):
-        self._server = grpc.server(logging_pool.pool(2))
+        self._server_pool = logging_pool.pool(2)
+        self._server = grpc.server(self._server_pool)
         self._server.add_insecure_port('[::]:%d' % (_GRPC_PORT))
         add_HelloServicer_to_server(_HelloServicer(), self._server)
         self._server.start()
 
     def _stop_server(self):
-        self._server.stop(0)
+        self._server.stop(None)
+        self._server_pool.shutdown(wait=True)
 
     def _check_client_span(self, span, service, method_name, method_kind):
         self.assert_is_not_measured(span)


### PR DESCRIPTION
## Description

#1949 attempted to address flaky grpc tests but this issue remains https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/4835/workflows/c27376c4-9d7b-458c-a0b3-c290bfcad48f/jobs/462372.

Follow same approach in grpcio tests for shutting down thread pool executor created when starting server:

https://github.com/grpc/grpc/blob/94c653aaf5d8094204de79e2a67070c2825b7d9b/src/python/grpcio_tests/tests/unit/_interceptor_test.py#L369

If this resolves the problem, we can revert the previous attempt.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
