### PR TITLE
Revert "tests: exclude py27 grpc 1.14, 1.18"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -82,8 +82,7 @@ envlist =
 # py27,py35,py36: grpcio>=1.13.0
 # py37: grpcio>=1.13.0
 # py38: grpcio>=1.24.3
-    grpc_contrib-py{27}-grpc{112,120,121,122}-googleapis-common-protos
-    grpc_contrib-py{35,36}-grpc{112,114,118,120,121,122}-googleapis-common-protos
+    grpc_contrib-py{27,35,36}-grpc{112,114,118,120,121,122}-googleapis-common-protos
     grpc_contrib-py{37}-grpc{114,118,120,121,122,124,126,128,}-googleapis-common-protos
     grpc_contrib-py{38}-grpc{124,126,128,}-googleapis-common-protos
     httplib_contrib-py{27,35,36,37,38,39}


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#1949 since #1961 should have addressed the root cause.