### PR TITLE
ci: lower max pool of workers for grpc server

### DIFF
--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -54,7 +54,7 @@ class GrpcTestCase(TracerTestCase):
         return spans
 
     def _start_server(self):
-        self._server_pool = logging_pool.pool(2)
+        self._server_pool = logging_pool.pool(1)
         self._server = grpc.server(self._server_pool)
         self._server.add_insecure_port('[::]:%d' % (_GRPC_PORT))
         add_HelloServicer_to_server(_HelloServicer(), self._server)


### PR DESCRIPTION
## Description

Followup on #1961 to further reduce the number of threads in the server pool as another attempt to avoid the deadlocks that are causing the grpc job to hang in CI.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
