### PR TITLE
ci(mergify): add more conditions before trying to merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,6 +2,8 @@ pull_request_rules:
   - name: automatic merge
     conditions:
       - label=automerge
+      - check-success=test
+      - "#approved-reviews-by>=1"
     actions:
       merge:
         strict: smart


### PR DESCRIPTION
Mergify is a little bit too aggressive on updating the PR and trying to merge.
This copies the content of branch protection settings so it does not try to
merge before at least the CI and an approval are there.