### PR TITLE
Resolve keyerror in Django traced_get_response

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -438,7 +438,7 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
                     method=request.method,
                     url=url,
                     status_code=status,
-                    query=request.META["QUERY_STRING"],
+                    query=request.META.get("QUERY_STRING", None),
                     request_headers=request_headers,
                     response_headers=response_headers,
                 )

--- a/releasenotes/notes/django-key-error-be8812133f0ef920.yaml
+++ b/releasenotes/notes/django-key-error-be8812133f0ef920.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Resolves an issue in Django tracing where,
+    if `query_string` is not present in request.META, a KeyError is raised, causing the request to 500


### PR DESCRIPTION
## Description
In some edge cases (preview mode in wagtail CMS for instance) the request meta object does not contain a query string attribute, so access it safely with a dictionary get rather than killing the request


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
