### PR TITLE
flask: remove get_current_span helper

### DIFF
--- a/ddtrace/contrib/flask/helpers.py
+++ b/ddtrace/contrib/flask/helpers.py
@@ -34,17 +34,3 @@ def simple_tracer(name, span_type=None):
             return wrapped(*args, **kwargs)
 
     return wrapper
-
-
-def get_current_span(pin, root=False):
-    """Helper to get the current span from the provided pins current call context"""
-    if not pin or not pin.enabled():
-        return None
-
-    ctx = pin.tracer.get_call_context()
-    if not ctx:
-        return None
-
-    if root:
-        return ctx.get_current_root_span()
-    return ctx.get_current_span()


### PR DESCRIPTION
This helper was needlessly dependent on the context implementation
and could be simplified to using the tracer API.

(Part of #1936)