### PR TITLE
logging: remove logging for parent closing before child

### DIFF
--- a/tests/contrib/logging/test_logging.py
+++ b/tests/contrib/logging/test_logging.py
@@ -176,26 +176,3 @@ class LoggingTestCase(TracerTestCase):
 
         with self.override_global_config(dict(version="global.version", env="global.env")):
             self._test_logging(create_span=create_span, version="global.version", env="global.env")
-
-    def test_unfinished_child(self):
-        """
-        Check that closing a span with unfinished children correctly logs out
-        unfinished spans.
-        """
-        # unfinished child spans only logged if tracer log level is debug
-        self.tracer.log.setLevel(logging.DEBUG)
-
-        # the actual logger used for these message is ddtrace.context logger,
-        # so debug logging has to be enabled here as well.
-        context_logger = logging.getLogger("ddtrace.context")
-        context_logger.setLevel(logging.DEBUG)
-
-        # finish parent span without finishing child span
-        parent = self.tracer.trace("parent")
-        child = self.tracer.trace("child")
-        out, span = capture_function_log(parent.finish, logger_override=context_logger)
-
-        assert 'Root span "parent" closed, but the trace has 1 unfinished spans' in out
-        assert "parent_id {}".format(parent.span_id) in out
-        assert "trace_id {}".format(child.trace_id) in out
-        assert "id {}".format(child.span_id) in out

--- a/tests/tracer/test_context.py
+++ b/tests/tracer/test_context.py
@@ -25,32 +25,6 @@ def tracer_with_debug_logging():
         tracer.log.setLevel(level)
 
 
-@mock.patch("logging.Logger.debug")
-def test_log_unfinished_spans(log, tracer_with_debug_logging):
-    # when the root parent is finished, notify if there are spans still pending
-    tracer = tracer_with_debug_logging
-    ctx = Context()
-    # manually create a root-child trace
-    root = Span(tracer=tracer, name="root")
-    child_1 = Span(tracer=tracer, name="child_1", trace_id=root.trace_id, parent_id=root.span_id)
-    child_2 = Span(tracer=tracer, name="child_2", trace_id=root.trace_id, parent_id=root.span_id)
-    child_1._parent = root
-    child_2._parent = root
-    ctx.add_span(root)
-    ctx.add_span(child_1)
-    ctx.add_span(child_2)
-    # close only the parent
-    root.finish()
-    unfinished_spans_log = log.call_args_list[-3][0][2]
-    child_1_log = log.call_args_list[-2][0][1]
-    child_2_log = log.call_args_list[-1][0][1]
-    assert 2 == unfinished_spans_log
-    assert "name child_1" in child_1_log
-    assert "name child_2" in child_2_log
-    assert "duration 0.000000s" in child_1_log
-    assert "duration 0.000000s" in child_2_log
-
-
 class TestTracingContext(BaseTestCase):
     """
     Tests related to the ``Context`` class that hosts the trace for the


### PR DESCRIPTION
This is a valid use-case in async and I don't think we've ever used
this log message for debugging.


(Part of #1936)