### PR TITLE
feat(profiling): allow to export memory heap to Python

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.h
+++ b/ddtrace/profiling/collector/_memalloc_heap.h
@@ -4,6 +4,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <Python.h>
+
+#include "_utils.h"
+
 /* The maximum heap sample size is the maximum value we can store in a heap_tracker_t.allocated_memory */
 #define MAX_HEAP_SAMPLE_SIZE UINT32_MAX
 
@@ -12,9 +16,15 @@ memalloc_heap_tracker_init(void);
 void
 memalloc_heap_tracker_deinit(void);
 
+PyObject*
+memalloc_heap();
+
 void
 memalloc_heap_track(uint32_t heap_sample_size, uint16_t max_nframe, void* ptr, size_t size);
 void
 memalloc_heap_untrack(void* ptr);
+
+#define MEMALLOC_HEAP_PTR_ARRAY_MAX UINT64_MAX
+DO_ARRAY(void *, ptr, uint64_t, DO_NOTHING)
 
 #endif

--- a/ddtrace/profiling/collector/_memalloc_tb.c
+++ b/ddtrace/profiling/collector/_memalloc_tb.c
@@ -163,3 +163,32 @@ memalloc_get_traceback(uint16_t max_nframe, void* ptr, size_t size)
 
     return traceback;
 }
+
+PyObject*
+traceback_to_tuple(traceback_t* tb)
+{
+    /* Convert stack into a tuple of tuple */
+    PyObject* stack = PyTuple_New(tb->nframe);
+
+    for (uint16_t nframe = 0; nframe < tb->nframe; nframe++) {
+        PyObject* frame_tuple = PyTuple_New(3);
+
+        frame_t* frame = &tb->frames[nframe];
+
+        PyTuple_SET_ITEM(frame_tuple, 0, frame->filename);
+        Py_INCREF(frame->filename);
+        PyTuple_SET_ITEM(frame_tuple, 1, PyLong_FromUnsignedLong(frame->lineno));
+        PyTuple_SET_ITEM(frame_tuple, 2, frame->name);
+        Py_INCREF(frame->name);
+
+        PyTuple_SET_ITEM(stack, nframe, frame_tuple);
+    }
+
+    PyObject* tuple = PyTuple_New(3);
+
+    PyTuple_SET_ITEM(tuple, 0, stack);
+    PyTuple_SET_ITEM(tuple, 1, PyLong_FromUnsignedLong(tb->total_nframe));
+    PyTuple_SET_ITEM(tuple, 2, PyLong_FromUnsignedLong(tb->thread_id));
+
+    return tuple;
+}

--- a/ddtrace/profiling/collector/_memalloc_tb.h
+++ b/ddtrace/profiling/collector/_memalloc_tb.h
@@ -52,9 +52,12 @@ traceback_free(traceback_t* tb);
 traceback_t*
 memalloc_get_traceback(uint16_t max_nframe, void* ptr, size_t size);
 
-#define TRACEBACK_ARRAY_COUNT_TYPE uint16_t
+PyObject*
+traceback_to_tuple(traceback_t* tb);
+
 /* The maximum number of events we can store in `traceback_array_t.count` */
 #define TRACEBACK_ARRAY_MAX_COUNT UINT16_MAX
+#define TRACEBACK_ARRAY_COUNT_TYPE uint16_t
 
 DO_ARRAY(traceback_t *, traceback, TRACEBACK_ARRAY_COUNT_TYPE, traceback_free)
 

--- a/ddtrace/profiling/collector/_utils.h
+++ b/ddtrace/profiling/collector/_utils.h
@@ -4,6 +4,8 @@
 #include <Python.h>
 #include <stdlib.h>
 
+#define DO_NOTHING(...)
+
 #define p_new(type, count) PyMem_RawMalloc(sizeof(type) * (count))
 #define p_delete(mem_p) PyMem_Free(mem_p);
 // Allocate at least 16 and 50% more than requested to avoid allocating items one by one.

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -247,6 +247,8 @@ class _ProfilerInstance(_service.Service):
                 memalloc.MemoryAllocSampleEvent: int(
                     (memalloc.MemoryCollector._DEFAULT_MAX_EVENTS / memalloc.MemoryCollector._DEFAULT_INTERVAL) * 60
                 ),
+                # Do not limit the heap sample size as the number of events is relative to allocated memory anyway
+                memalloc.MemoryHeapSampleEvent: None,
             },
             default_max_events=int(os.environ.get("DD_PROFILING_MAX_EVENTS", recorder.Recorder._DEFAULT_MAX_EVENTS)),
         )


### PR DESCRIPTION
Adds a _memalloc.heap() method that returns a list of traceback using memory
right now with their allocated size.