### PR TITLE
context: _dd_origin -> dd_origin

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -28,7 +28,7 @@ class Context(object):
     _partial_flush_enabled = asbool(get_env("tracer", "partial_flush_enabled", default=False))
     _partial_flush_min_spans = int(get_env("tracer", "partial_flush_min_spans", default=500))
 
-    def __init__(self, trace_id=None, span_id=None, sampling_priority=None, _dd_origin=None):
+    def __init__(self, trace_id=None, span_id=None, sampling_priority=None, dd_origin=None):
         """
         Initialize a new thread-safe ``Context``.
 
@@ -43,7 +43,7 @@ class Context(object):
         self._parent_trace_id = trace_id
         self._parent_span_id = span_id
         self._sampling_priority = sampling_priority
-        self._dd_origin = _dd_origin
+        self.dd_origin = dd_origin
 
     @property
     def trace_id(self):
@@ -149,7 +149,7 @@ class Context(object):
                 # attach the sampling priority to the context root span
                 if sampled and sampling_priority is not None and trace:
                     trace[0].set_metric(SAMPLING_PRIORITY_KEY, sampling_priority)
-                origin = self._dd_origin
+                origin = self.dd_origin
                 # attach the origin to the root span tag
                 if sampled and origin is not None and trace:
                     trace[0].meta[ORIGIN_KEY] = str(origin)
@@ -176,7 +176,7 @@ class Context(object):
                     # attach the sampling priority to the context root span
                     if sampled and sampling_priority is not None and trace:
                         trace[0].set_metric(SAMPLING_PRIORITY_KEY, sampling_priority)
-                    origin = self._dd_origin
+                    origin = self.dd_origin
                     # attach the origin to the root span tag
                     if sampled and origin is not None and trace:
                         trace[0].meta[ORIGIN_KEY] = str(origin)

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -58,8 +58,8 @@ class HTTPPropagator(object):
         if sampling_priority is not None:
             headers[HTTP_HEADER_SAMPLING_PRIORITY] = str(span_context.sampling_priority)
         # Propagate origin only if defined
-        if span_context._dd_origin is not None:
-            headers[HTTP_HEADER_ORIGIN] = str(span_context._dd_origin)
+        if span_context.dd_origin is not None:
+            headers[HTTP_HEADER_ORIGIN] = str(span_context.dd_origin)
 
     @staticmethod
     def extract_header_value(possible_header_names, headers, default=None):
@@ -133,7 +133,7 @@ class HTTPPropagator(object):
                 trace_id=trace_id,
                 span_id=parent_span_id,
                 sampling_priority=sampling_priority,
-                _dd_origin=origin,
+                dd_origin=origin,
             )
         # If headers are invalid and cannot be parsed, return a new context and log the issue.
         except Exception:

--- a/tests/tracer/test_context.py
+++ b/tests/tracer/test_context.py
@@ -237,6 +237,6 @@ class TestTracingContext(BaseTestCase):
         assert cloned_ctx._parent_trace_id == ctx._parent_trace_id
         assert cloned_ctx._parent_span_id == ctx._parent_span_id
         assert cloned_ctx._sampling_priority == ctx._sampling_priority
-        assert cloned_ctx._dd_origin == ctx._dd_origin
+        assert cloned_ctx.dd_origin == ctx.dd_origin
         assert cloned_ctx._current_span == ctx._current_span
         assert cloned_ctx._trace == []

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -22,7 +22,7 @@ class TestHttpPropagation(TestCase):
 
         with tracer.trace("global_root_span") as span:
             span.context.sampling_priority = 2
-            span.context._dd_origin = "synthetics"
+            span.context.dd_origin = "synthetics"
             headers = {}
             propagator = HTTPPropagator()
             propagator.inject(span.context, headers)
@@ -30,7 +30,7 @@ class TestHttpPropagation(TestCase):
             assert int(headers[HTTP_HEADER_TRACE_ID]) == span.trace_id
             assert int(headers[HTTP_HEADER_PARENT_ID]) == span.span_id
             assert int(headers[HTTP_HEADER_SAMPLING_PRIORITY]) == span.context.sampling_priority
-            assert headers[HTTP_HEADER_ORIGIN] == span.context._dd_origin
+            assert headers[HTTP_HEADER_ORIGIN] == span.context.dd_origin
 
     def test_extract(self):
         tracer = get_dummy_tracer()
@@ -50,7 +50,7 @@ class TestHttpPropagation(TestCase):
             assert span.trace_id == 1234
             assert span.parent_id == 5678
             assert span.context.sampling_priority == 1
-            assert span.context._dd_origin == "synthetics"
+            assert span.context.dd_origin == "synthetics"
 
     def test_WSGI_extract(self):
         """Ensure we support the WSGI formatted headers as well."""
@@ -71,7 +71,7 @@ class TestHttpPropagation(TestCase):
             assert span.trace_id == 1234
             assert span.parent_id == 5678
             assert span.context.sampling_priority == 1
-            assert span.context._dd_origin == "synthetics"
+            assert span.context.dd_origin == "synthetics"
 
 
 class TestPropagationUtils(object):

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1397,7 +1397,7 @@ def test_ctx_distributed():
     assert len(trace) == 1
 
     # Test activating a valid context.
-    ctx = Context(span_id=1234, trace_id=4321, sampling_priority=2, _dd_origin="somewhere")
+    ctx = Context(span_id=1234, trace_id=4321, sampling_priority=2, dd_origin="somewhere")
     tracer.context_provider.activate(ctx)
     assert tracer.current_span() is None
 


### PR DESCRIPTION
Really no reason for it to be "private" since it's in the initializer. Also noticed that it's not thread-safe, not sure it's worth doing anything about it now.


(Part of #1936)