### PR TITLE
tracer: move hostname tagging to start_span

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -1,9 +1,7 @@
 import threading
 
-from .constants import HOSTNAME_KEY, SAMPLING_PRIORITY_KEY, ORIGIN_KEY
+from .constants import SAMPLING_PRIORITY_KEY, ORIGIN_KEY
 from .internal.logger import get_logger
-from .internal import hostname
-from .settings import config
 from .utils.formats import asbool, get_env
 
 log = get_logger(__name__)
@@ -154,11 +152,6 @@ class Context(object):
                 if sampled and origin is not None and trace:
                     trace[0].meta[ORIGIN_KEY] = str(origin)
 
-                # Set hostname tag if they requested it
-                if config.report_hostname:
-                    # DEV: `get_hostname()` value is cached
-                    trace[0].meta[HOSTNAME_KEY] = hostname.get_hostname()
-
                 # clean the current state
                 self._trace = []
                 self._finished_spans = 0
@@ -180,11 +173,6 @@ class Context(object):
                     # attach the origin to the root span tag
                     if sampled and origin is not None and trace:
                         trace[0].meta[ORIGIN_KEY] = str(origin)
-
-                    # Set hostname tag if they requested it
-                    if config.report_hostname:
-                        # DEV: `get_hostname()` value is cached
-                        trace[0].meta[HOSTNAME_KEY] = hostname.get_hostname()
 
                     self._finished_spans = 0
 

--- a/tests/tracer/test_context.py
+++ b/tests/tracer/test_context.py
@@ -6,7 +6,6 @@ import pytest
 
 from ddtrace.span import Span
 from ddtrace.context import Context
-from ddtrace.constants import HOSTNAME_KEY
 from ddtrace.ext.priority import USER_REJECT, AUTO_REJECT, AUTO_KEEP, USER_KEEP
 
 from .test_tracer import get_dummy_tracer
@@ -108,55 +107,6 @@ class TestTracingContext(BaseTestCase):
         # the context should be empty
         assert 0 == len(ctx._trace)
         assert ctx._current_span is None
-
-    @mock.patch("ddtrace.internal.hostname.get_hostname")
-    def test_get_report_hostname_enabled(self, get_hostname):
-        get_hostname.return_value = "test-hostname"
-
-        with self.override_global_config(dict(report_hostname=True)):
-            # Create a context and add a span and finish it
-            ctx = Context()
-            span = Span(tracer=None, name="fake_span")
-            ctx.add_span(span)
-            span.finish()
-            assert span.get_tag(HOSTNAME_KEY) == "test-hostname"
-
-    @mock.patch("ddtrace.internal.hostname.get_hostname")
-    def test_get_report_hostname_disabled(self, get_hostname):
-        get_hostname.return_value = "test-hostname"
-
-        with self.override_global_config(dict(report_hostname=False)):
-            # Create a context and add a span and finish it
-            ctx = Context()
-            span = Span(tracer=None, name="fake_span")
-            ctx.add_span(span)
-            span.finished = True
-
-            # Assert that we have not added the tag to the span yet
-            assert span.get_tag(HOSTNAME_KEY) is None
-
-            # Assert that retrieving the trace does not set the tag
-            trace, _ = ctx.close_span(span)
-            assert trace[0].get_tag(HOSTNAME_KEY) is None
-            assert span.get_tag(HOSTNAME_KEY) is None
-
-    @mock.patch("ddtrace.internal.hostname.get_hostname")
-    def test_get_report_hostname_default(self, get_hostname):
-        get_hostname.return_value = "test-hostname"
-
-        # Create a context and add a span and finish it
-        ctx = Context()
-        span = Span(tracer=None, name="fake_span")
-        ctx.add_span(span)
-        span.finished = True
-
-        # Assert that we have not added the tag to the span yet
-        assert span.get_tag(HOSTNAME_KEY) is None
-
-        # Assert that retrieving the trace does not set the tag
-        trace, _ = ctx.close_span(span)
-        assert trace[0].get_tag(HOSTNAME_KEY) is None
-        assert span.get_tag(HOSTNAME_KEY) is None
 
     def test_finished(self):
         # a Context is finished if all spans inside are finished


### PR DESCRIPTION
This gets it out of the context which will help with refactoring.

(Part of #1936)
