### PR TITLE
tests: make context independent

### DIFF
--- a/tests/contrib/futures/test_propagation.py
+++ b/tests/contrib/futures/test_propagation.py
@@ -29,9 +29,6 @@ class PropagationTestCase(TracerTestCase):
         # it must propagate the tracing context if available
 
         def fn():
-            # an active context must be available
-            # DEV: With `ContextManager` `.active()` will never be `None`
-            self.assertIsNotNone(self.tracer.context_provider.active())
             with self.tracer.trace("executor.thread"):
                 return 42
 
@@ -53,8 +50,6 @@ class PropagationTestCase(TracerTestCase):
         # instrumentation must proxy arguments if available
 
         def fn(value, key=None):
-            # an active context must be available
-            self.assertIsNotNone(self.tracer.context_provider.active())
             with self.tracer.trace("executor.thread"):
                 return value, key
 
@@ -78,8 +73,6 @@ class PropagationTestCase(TracerTestCase):
         unpatch()
 
         def fn():
-            # an active context must be available
-            self.assertIsNotNone(self.tracer.context_provider.active())
             with self.tracer.trace("executor.thread"):
                 return 42
 
@@ -300,7 +293,7 @@ class PropagationTestCase(TracerTestCase):
                 future = executor.submit(fn)
                 time.sleep(0.01)
 
-        # assert main thread span is fniished first
+        # assert main thread span is finished first
         self.assert_span_count(1)
         self.assert_structure(dict(name="main.thread"))
 

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from ddtrace.context import Context
 from ddtrace.propagation.utils import get_wsgi_header
 from ddtrace.propagation.http import (
     HTTPPropagator,
@@ -20,9 +21,9 @@ class TestHttpPropagation(TestCase):
     def test_inject(self):
         tracer = get_dummy_tracer()
 
+        ctx = Context(trace_id=1234, sampling_priority=2, _dd_origin="synthetics")
+        tracer.context_provider.activate(ctx)
         with tracer.trace("global_root_span") as span:
-            span.context.sampling_priority = 2
-            span.context._dd_origin = "synthetics"
             headers = {}
             propagator = HTTPPropagator()
             propagator.inject(span.context, headers)


### PR DESCRIPTION
These tests depended on implementation details of the context which are
not described in our public API. In my opinion it's safe to remove
the dependence so long as the functionality is still asserted.

(Part of #1936)
