### PR TITLE
gevent: remove implementation dependent tests

### DIFF
--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -40,75 +40,6 @@ class TestGeventTracer(TracerTestCase):
         # untrace gevent
         unpatch()
 
-    def test_main_greenlet(self):
-        # the main greenlet must not be affected by the tracer
-        main_greenlet = gevent.getcurrent()
-        ctx = getattr(main_greenlet, "__datadog_context", None)
-        assert ctx is None
-
-    def test_main_greenlet_context(self):
-        # the main greenlet must have a ``Context`` if called
-        ctx_tracer = self.tracer.get_call_context()
-        main_greenlet = gevent.getcurrent()
-        ctx_greenlet = getattr(main_greenlet, "__datadog_context", None)
-        assert ctx_tracer is ctx_greenlet
-        assert len(ctx_tracer._trace) == 0
-
-    def test_get_call_context(self):
-        # it should return the context attached to the provider
-        def greenlet():
-            return self.tracer.get_call_context()
-
-        g = gevent.spawn(greenlet)
-        g.join()
-        ctx = g.value
-        stored_ctx = getattr(g, "__datadog_context", None)
-        assert stored_ctx is not None
-        assert ctx == stored_ctx
-
-    def test_get_call_context_twice(self):
-        # it should return the same Context if called twice
-        def greenlet():
-            assert self.tracer.get_call_context() == self.tracer.get_call_context()
-            return True
-
-        g = gevent.spawn(greenlet)
-        g.join()
-        assert g.value
-
-    def test_spawn_greenlet_no_context(self):
-        # a greenlet will not have a context if the tracer is not used
-        def greenlet():
-            gevent.sleep(0.01)
-
-        g = gevent.spawn(greenlet)
-        g.join()
-        ctx = getattr(g, "__datadog_context", None)
-        assert ctx is None
-
-    def test_spawn_greenlet(self):
-        # a greenlet will have a context if the tracer is used
-        def greenlet():
-            self.tracer.get_call_context()
-
-        g = gevent.spawn(greenlet)
-        g.join()
-        ctx = getattr(g, "__datadog_context", None)
-        assert ctx is not None
-        assert 0 == len(ctx._trace)
-
-    def test_spawn_later_greenlet(self):
-        # a greenlet will have a context if the tracer is used even
-        # if it's spawned later
-        def greenlet():
-            self.tracer.get_call_context()
-
-        g = gevent.spawn_later(0.01, greenlet)
-        g.join()
-        ctx = getattr(g, "__datadog_context", None)
-        assert ctx is not None
-        assert 0 == len(ctx._trace)
-
     def test_trace_greenlet(self):
         # a greenlet can be traced using the trace API
         def greenlet():
@@ -121,6 +52,24 @@ class TestGeventTracer(TracerTestCase):
         assert 1 == len(traces[0])
         assert "greenlet" == traces[0][0].name
         assert "base" == traces[0][0].resource
+
+    def test_trace_greenlet_twice(self):
+        # a greenlet can be traced using the trace API
+        def greenlet():
+            with self.tracer.trace("greenlet") as span:
+                span.resource = "base"
+
+            with self.tracer.trace("greenlet2") as span:
+                span.resource = "base2"
+
+        gevent.spawn(greenlet).join()
+        traces = self.tracer.writer.pop_traces()
+        assert 2 == len(traces)
+        assert 1 == len(traces[0]) == len(traces[1])
+        assert "greenlet" == traces[0][0].name
+        assert "base" == traces[0][0].resource
+        assert "greenlet2" == traces[1][0].name
+        assert "base2" == traces[1][0].resource
 
     def test_trace_map_greenlet(self):
         # a greenlet can be traced using the trace API


### PR DESCRIPTION
These tests depended on the implementation details of the context
management for gevent. There exist very similar tests that assert the
correct context management behaviour which are less brittle.

(Part of #1936)
