### PR TITLE
chore(mergify): warn on PR conflict

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,3 +8,19 @@ pull_request_rules:
       merge:
         strict: smart
         method: squash
+  - name: warn on conflicts
+    conditions:
+      - conflict
+    actions:
+      comment:
+        message: "@{{author}} this pull request is now in conflict 😩"
+      label:
+        add:
+          - conflict
+  - name: remove conflict label if not needed
+    conditions:
+      - -conflict
+    actions:
+      label:
+        remove:
+          - conflict


### PR DESCRIPTION
I find it handy to be able to notice at a glance PR that are in conflict with a
label, so we know there's, e.g., no point in reviewing them now.
This also notifies the author they need to update the PR to get it working.