### PR TITLE
tests: mark as flaky

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -9,7 +9,14 @@ def select_pys(min_version=min(SUPPORTED_PYTHON_VERSIONS), max_version=max(SUPPO
 
 
 venv = Venv(
-    pkgs={"mock": latest, "pytest": latest, "coverage": latest, "pytest-cov": latest, "opentracing": latest},
+    pkgs={
+        "mock": latest,
+        "pytest": latest,
+        "coverage": latest,
+        "pytest-cov": latest,
+        "opentracing": latest,
+        "flaky": latest,
+    },
     venvs=[
         Venv(
             pys="3",

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -4,6 +4,7 @@ import threading
 import time
 import timeit
 
+from flaky import flaky
 import pytest
 
 from ddtrace.vendor import six
@@ -173,6 +174,7 @@ def test_ignore_profiler_gevent_task(profiler):
     assert collector_thread_ids.isdisjoint({e.task_id for e in events})
 
 
+@flaky(max_runs=4, min_passes=1)
 @pytest.mark.skipif(not stack.FEATURES["gevent-tasks"], reason="gevent-tasks not supported")
 def test_not_ignore_profiler_gevent_task(monkeypatch):
     monkeypatch.setenv("DD_PROFILING_API_TIMEOUT", "0.1")

--- a/tests/tracer/test_api.py
+++ b/tests/tracer/test_api.py
@@ -8,6 +8,7 @@ import warnings
 
 from unittest import TestCase
 
+from flaky import flaky
 import pytest
 
 from ddtrace.api import API, Response
@@ -272,6 +273,7 @@ def test_flush_connection_reset(endpoint_test_reset_server):
         assert isinstance(response, httplib.BadStatusLine)
 
 
+@flaky
 def test_flush_connection_uds(endpoint_uds_server):
     payload = mock.Mock()
     payload.get_payload.return_value = "foobar"

--- a/tox.ini
+++ b/tox.ini
@@ -169,6 +169,7 @@ deps =
     pytest-cov
     pytest-mock
     opentracing
+    flaky
 # test dependencies installed in all envs
     mock
 # used to test our custom msgpack encoder


### PR DESCRIPTION
Introduce [`flaky`](https://github.com/box/flaky) for retrying flaky tests.

Unfortunately the flaky grpc test locks the process so this approach
can't be used for it :/

