### PR TITLE
Report tracer drop rate.

### DIFF
--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -13,6 +13,7 @@ SERVICE_KEY = "service.name"
 SERVICE_VERSION_KEY = "service.version"
 SPAN_KIND = "span.kind"
 SPAN_MEASURED_KEY = "_dd.measured"
+KEEP_SPANS_RATE_KEY = "_dd.tracer_kr"
 
 NUMERIC_TAGS = (ANALYTICS_SAMPLE_RATE_KEY,)
 

--- a/ddtrace/internal/sma.py
+++ b/ddtrace/internal/sma.py
@@ -1,0 +1,60 @@
+from __future__ import division
+
+DEFAULT_SMA_WINDOW = 10
+
+
+class SimpleMovingAverage(object):
+    """
+    Simple Moving Average implementation.
+    """
+
+    __slots__ = (
+        "size",
+        "index",
+        "counts",
+        "totals",
+        "sum_count",
+        "sum_total",
+    )
+
+    def __init__(self, size=None):
+        """
+        Constructor for SimpleMovingAverage.
+
+        :param size: The size of the window to calculate the moving average.
+        :type size: :obj:`int`
+        """
+        self.index = 0
+        self.size = size is None and DEFAULT_SMA_WINDOW or max(1, size)
+
+        self.sum_count = 0
+        self.sum_total = 0
+
+        self.counts = [0] * self.size
+        self.totals = [0] * self.size
+
+    def get(self):
+        """
+        Get the current SMA value.
+        """
+        if self.sum_total == 0:
+            return 0.0
+
+        return float(self.sum_count) / self.sum_total
+
+    def set(self, count, total):
+        """
+        Set the value of the next bucket and update the SMA value.
+
+        :param count: The valid quantity of the next bucket.
+        :type count: :obj:`unsigned int`
+        :param total: The total quantity of the next bucket.
+        :type total: :obj:`unsigned int`
+        """
+        self.sum_count += count - self.counts[self.index]
+        self.sum_total += total - self.totals[self.index]
+
+        self.counts[self.index] = count
+        self.totals[self.index] = total
+
+        self.index = (self.index + 1) % self.size

--- a/ddtrace/internal/sma.py
+++ b/ddtrace/internal/sma.py
@@ -1,6 +1,10 @@
 from __future__ import division
 
 
+# The window size should be chosen so that the look-back period is
+# greater-equal to the agent API's timeout. Although most tracers have a
+# 2s timeout, the java tracer has a 10s timeout, so we set the window size
+# to 10 buckets of 1s duration.
 DEFAULT_SMA_WINDOW = 10
 
 
@@ -51,9 +55,9 @@ class SimpleMovingAverage(object):
         Set the value of the next bucket and update the SMA value.
 
         :param count: The valid quantity of the next bucket.
-        :type count: :obj:`unsigned int`
+        :type count: :obj:`int`
         :param total: The total quantity of the next bucket.
-        :type total: :obj:`unsigned int`
+        :type total: :obj:`int`
         """
         if count > total:
             raise ValueError

--- a/ddtrace/internal/sma.py
+++ b/ddtrace/internal/sma.py
@@ -1,13 +1,6 @@
 from __future__ import division
 
 
-# The window size should be chosen so that the look-back period is
-# greater-equal to the agent API's timeout. Although most tracers have a
-# 2s timeout, the java tracer has a 10s timeout, so we set the window size
-# to 10 buckets of 1s duration.
-DEFAULT_SMA_WINDOW = 10
-
-
 class SimpleMovingAverage(object):
     """
     Simple Moving Average implementation.
@@ -22,7 +15,7 @@ class SimpleMovingAverage(object):
         "sum_total",
     )
 
-    def __init__(self, size=DEFAULT_SMA_WINDOW):
+    def __init__(self, size):
         """
         Constructor for SimpleMovingAverage.
 

--- a/ddtrace/internal/sma.py
+++ b/ddtrace/internal/sma.py
@@ -17,15 +17,18 @@ class SimpleMovingAverage(object):
         "sum_total",
     )
 
-    def __init__(self, size=None):
+    def __init__(self, size=DEFAULT_SMA_WINDOW):
         """
         Constructor for SimpleMovingAverage.
 
         :param size: The size of the window to calculate the moving average.
         :type size: :obj:`int`
         """
+        if size < 1:
+            raise ValueError
+
         self.index = 0
-        self.size = size is None and DEFAULT_SMA_WINDOW or max(1, size)
+        self.size = size
 
         self.sum_count = 0
         self.sum_total = 0
@@ -51,6 +54,9 @@ class SimpleMovingAverage(object):
         :param total: The total quantity of the next bucket.
         :type total: :obj:`unsigned int`
         """
+        if count > total:
+            raise ValueError
+
         self.sum_count += count - self.counts[self.index]
         self.sum_total += total - self.totals[self.index]
 

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -11,6 +11,7 @@ from ..api import Response
 from ..compat import httplib
 from ..encoding import Encoder
 from ..encoding import JSONEncoderV2
+from ..constants import KEEP_SPANS_RATE_KEY
 from ..sampler import BasePrioritySampler
 from ..utils.time import StopWatch
 from .buffer import BufferFull
@@ -19,6 +20,7 @@ from .buffer import TraceBuffer
 from .logger import get_logger
 from .runtime import container
 from .uds import UDSHTTPConnection
+from .sma import SimpleMovingAverage
 
 
 log = get_logger(__name__)
@@ -131,16 +133,27 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         self.dogstatsd = dogstatsd
         self._report_metrics = report_metrics
         self._metrics_reset()
+        self._drop_sma = SimpleMovingAverage()
 
     def _metrics_dist(self, name, count=1, tags=None):
-        if self._report_metrics:
-            self._metrics[name]["count"] += count
-            if tags:
-                self._metrics[name]["tags"].extend(tags)
+        self._metrics[name]["count"] += count
+        if tags:
+            self._metrics[name]["tags"].extend(tags)
 
     def _metrics_reset(self):
-        if self._report_metrics:
-            self._metrics = defaultdict(lambda: {"count": 0, "tags": []})
+        self._metrics = defaultdict(lambda: {"count": 0, "tags": []})
+
+    def _set_drop_rate(self):
+        dropped = sum(
+            self._metrics[metric]["count"]
+            for metric in ("encoder.dropped.traces", "buffer.dropped.traces", "http.dropped.traces")
+        )
+
+        self._drop_sma.set(dropped, self._metrics["writer.accepted.traces"]["count"])
+
+    def _set_keep_rate(self, trace):
+        if trace:
+            trace[0].set_metric(KEEP_SPANS_RATE_KEY, 1.0 - self._drop_sma.get())
 
     def recreate(self):
         writer = self.__class__(
@@ -205,9 +218,9 @@ class AgentWriter(_worker.PeriodicWorkerThread):
             response = self._put(payload, headers)
         except (httplib.HTTPException, OSError, IOError):
             log.error("failed to send traces to Datadog Agent at %s", self.agent_url, exc_info=True)
-            if self._report_metrics:
-                self._metrics_dist("http.errors", tags=["type:err"])
-                self._metrics_dist("http.dropped.bytes", len(payload))
+            self._metrics_dist("http.errors", tags=["type:err"])
+            self._metrics_dist("http.dropped.traces", count)
+            self._metrics_dist("http.dropped.bytes", len(payload))
         else:
             if response.status >= 400:
                 self._metrics_dist("http.errors", tags=["type:%s" % response.status])
@@ -233,6 +246,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
                     response.status,
                     response.reason,
                 )
+                self._metrics_dist("http.dropped.traces", count)
                 self._metrics_dist("http.dropped.bytes", len(payload))
             elif self._priority_sampler or isinstance(self._sampler, BasePrioritySampler):
                 result_traces_json = response.get_json()
@@ -258,10 +272,15 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         if not spans:
             return
 
+        self._metrics_dist("writer.accepted.traces")
+
+        self._set_keep_rate(spans)
+
         try:
             encoded = self._encoder.encode_trace(spans)
         except Exception:
             log.error("failed to encode trace with encoder %r", self._encoder, exc_info=True)
+            self._metrics_dist("encoder.dropped.traces", 1)
         else:
             try:
                 self._buffer.put(encoded)
@@ -289,25 +308,27 @@ class AgentWriter(_worker.PeriodicWorkerThread):
 
     def flush_queue(self):
         enc_traces = self._buffer.get()
-        if not enc_traces:
-            return
+        if enc_traces:
+            encoded = self._encoder.join_encoded(enc_traces)
+            self._send_payload(encoded, len(enc_traces))
 
-        encoded = self._encoder.join_encoded(enc_traces)
-        self._send_payload(encoded, len(enc_traces))
+            if self._report_metrics:
+                # Note that we cannot use the batching functionality of dogstatsd because
+                # it's not thread-safe.
+                # https://github.com/DataDog/datadogpy/issues/439
+                # This really isn't ideal as now we're going to do a ton of socket calls.
+                try:
+                    self.dogstatsd.increment("datadog.tracer.http.requests")
+                    self.dogstatsd.distribution("datadog.tracer.http.sent.bytes", len(encoded))
+                    self.dogstatsd.distribution("datadog.tracer.http.sent.traces", len(enc_traces))
+                    for name, metric in self._metrics.items():
+                        self.dogstatsd.distribution("datadog.tracer.%s" % name, metric["count"], tags=metric["tags"])
+                finally:
+                    pass
 
-        if self._report_metrics:
-            # Note that we cannot use the batching functionality of dogstatsd because
-            # it's not thread-safe.
-            # https://github.com/DataDog/datadogpy/issues/439
-            # This really isn't ideal as now we're going to do a ton of socket calls.
-            try:
-                self.dogstatsd.increment("datadog.tracer.http.requests")
-                self.dogstatsd.distribution("datadog.tracer.http.sent.bytes", len(encoded))
-                self.dogstatsd.distribution("datadog.tracer.http.sent.traces", len(enc_traces))
-                for name, metric in self._metrics.items():
-                    self.dogstatsd.distribution("datadog.tracer.%s" % name, metric["count"], tags=metric["tags"])
-            finally:
-                self._metrics_reset()
+        self._set_drop_rate()
+
+        self._metrics_reset()
 
     def run_periodic(self):
         self.flush_queue()

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -28,6 +28,12 @@ log = get_logger(__name__)
 DEFAULT_TIMEOUT = 5
 LOG_ERR_INTERVAL = 60
 
+# The window size should be chosen so that the look-back period is
+# greater-equal to the agent API's timeout. Although most tracers have a
+# 2s timeout, the java tracer has a 10s timeout, so we set the window size
+# to 10 buckets of 1s duration.
+DEFAULT_SMA_WINDOW = 10
+
 
 def _human_size(nbytes):
     """Return a human-readable size."""
@@ -133,7 +139,7 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         self.dogstatsd = dogstatsd
         self._report_metrics = report_metrics
         self._metrics_reset()
-        self._drop_sma = SimpleMovingAverage()
+        self._drop_sma = SimpleMovingAverage(DEFAULT_SMA_WINDOW)
 
     def _metrics_dist(self, name, count=1, tags=None):
         self._metrics[name]["count"] += count

--- a/tests/snapshots/test_starlette.test_table_query_snapshot.snap
+++ b/tests/snapshots/test_starlette.test_table_query_snapshot.snap
@@ -15,6 +15,7 @@
            "http.status_code" "200"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 2574}}
       {"name" "sqlite.query"
        "service" "sqlite"
@@ -45,6 +46,7 @@
            "http.version" "1.1"
            "http.status_code" "200"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" 1
               "system.pid" 2574}}
       {"name" "sqlite.query"

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.snap
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.snap
@@ -15,6 +15,7 @@
            "http.request.headers.host" "127.0.0.1:54583"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 13276}}
       {"name" "child"
        "service" "test.cherrypy.service"

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_error.snap
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_error.snap
@@ -18,4 +18,5 @@
            "http.request.headers.host" "127.0.0.1:54583"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 12166}}]]

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_fatal.snap
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_fatal.snap
@@ -18,4 +18,5 @@
            "http.request.headers.host" "127.0.0.1:54583"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 12166}}]]

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_success.snap
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_success.snap
@@ -15,4 +15,5 @@
            "http.request.headers.host" "127.0.0.1:54583"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 12166}}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions.snap
@@ -19,6 +19,7 @@
            "django.view" "404-view"}
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" 1
               "system.pid" 97933}}
       {"name" "django.middleware"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_111x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_111x.snap
@@ -18,6 +18,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 96813}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_18x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_18x.snap
@@ -18,6 +18,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 96676}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_21x.snap
@@ -19,6 +19,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 97622}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view.snap
@@ -20,6 +20,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 97933}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_111x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_111x.snap
@@ -19,6 +19,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 96813}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_18x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_18x.snap
@@ -19,6 +19,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 96676}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_21x.snap
@@ -19,6 +19,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 97622}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view.snap
@@ -20,6 +20,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 97933}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_111x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_111x.snap
@@ -19,6 +19,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 96813}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_18x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_18x.snap
@@ -19,6 +19,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 96676}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_21x.snap
@@ -19,6 +19,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 97622}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding.snap
@@ -22,6 +22,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 97933}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_111x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_111x.snap
@@ -21,6 +21,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 96813}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_18x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_18x.snap
@@ -21,6 +21,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 96919}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_21x.snap
@@ -21,6 +21,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 97622}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.snap
@@ -20,6 +20,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 97933}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include_21x.snap
@@ -19,6 +19,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 97622}}
       {"name" "django.middleware"
        "service" "django"

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_table_query_snapshot.snap
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_table_query_snapshot.snap
@@ -15,6 +15,7 @@
            "http.status_code" "200"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 30232}}]
  [{"name" "fastapi.request"
    "service" "fastapi"
@@ -33,4 +34,5 @@
            "http.status_code" "200"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 30232}}]]

--- a/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_composed_query_encoding.snap
+++ b/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_composed_query_encoding.snap
@@ -15,6 +15,7 @@
            "db.application" "None"}
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" 1
               "system.pid" 10003
               "out.port" 5432

--- a/tests/snapshots/tests.contrib.redis.test.test_analytics_with_rate.snap
+++ b/tests/snapshots/tests.contrib.redis.test.test_analytics_with_rate.snap
@@ -15,6 +15,7 @@
               "_dd.measured" 1
               "_dd1.sr.eausr" 0.5
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 68083
               "out.port" 6379
               "out.redis_db" 0

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_analytics_with_rate.snap
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_analytics_with_rate.snap
@@ -15,6 +15,7 @@
               "_dd.measured" 1
               "_dd1.sr.eausr" 0.5
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 76411
               "out.port" 6379
               "out.redis_db" 0

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_analytics_without_rate.snap
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_analytics_without_rate.snap
@@ -14,6 +14,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_dd1.sr.eausr" 1.0
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" 1
               "system.pid" 48090
               "out.port" 6379

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_basics.snap
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_basics.snap
@@ -14,6 +14,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 50399
               "out.port" 6379
               "out.redis_db" 0

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_env_user_specified_redis_service.snap
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_env_user_specified_redis_service.snap
@@ -14,6 +14,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 76423
               "out.port" 6379
               "out.redis_db" 0
@@ -34,6 +35,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 76423
               "out.port" 6379
               "out.redis_db" 0

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_long_command.snap
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_long_command.snap
@@ -13,6 +13,7 @@
            "out.host" "localhost"}
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" 1
               "system.pid" 76411
               "out.port" 6379

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_meta_override.snap
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_meta_override.snap
@@ -15,6 +15,7 @@
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 76411
               "out.port" 6379
               "out.redis_db" 0

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_opentracing.snap
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_opentracing.snap
@@ -9,6 +9,7 @@
    "duration" 3061080
    "meta" {"runtime-id" "601815e8709646a9ac897c59376c80b6"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" 1
               "system.pid" 76411}}
       {"name" "redis.command"

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_pipeline_immediate.snap
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_pipeline_immediate.snap
@@ -13,6 +13,7 @@
            "out.host" "localhost"}
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" 1
               "system.pid" 76411
               "out.port" 6379
@@ -33,6 +34,7 @@
            "out.host" "localhost"}
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" 1
               "system.pid" 76411
               "out.port" 6379

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_pipeline_traced.snap
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_pipeline_traced.snap
@@ -13,6 +13,7 @@
            "out.host" "localhost"}
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" 1
               "system.pid" 76411
               "out.port" 6379

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_service_precedence.snap
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_service_precedence.snap
@@ -13,6 +13,7 @@
            "out.host" "localhost"}
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" 1
               "system.pid" 76424
               "out.port" 6379

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_user_specified_service.snap
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_user_specified_service.snap
@@ -13,6 +13,7 @@
            "out.host" "localhost"}
    "metrics" {"_dd.agent_psr" 1.0
               "_dd.measured" 1
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" 1
               "system.pid" 76425
               "out.port" 6379

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_200.snap
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_200.snap
@@ -16,6 +16,7 @@
            "http.url" "http://localhost:80/"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 8522}}
       {"name" "wsgi.application"
        "service" "wsgi"

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py2.snap
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py2.snap
@@ -14,6 +14,7 @@
            "error.type" "exceptions.Exception"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 708744}}
       {"name" "wsgi.application"
        "service" "wsgi"

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py3.snap
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py3.snap
@@ -14,6 +14,7 @@
            "error.stack" "Traceback (most recent call last):\n  File \"/home/kyle/dev/dd-trace-py/ddtrace/contrib/wsgi/wsgi.py\", line 66, in __call__\n    result = self.app(environ, intercept_start_response)\n  File \"/home/kyle/dev/dd-trace-py/tests/contrib/wsgi/test_wsgi.py\", line 19, in application\n    raise Exception(\"Oops!\")\nException: Oops!\n"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 707775}}
       {"name" "wsgi.application"
        "service" "wsgi"

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_chunked.snap
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_chunked.snap
@@ -15,6 +15,7 @@
            "http.url" "http://localhost:80/chunked"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 86586}}
       {"name" "wsgi.application"
        "service" "wsgi"

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_in_top_level_span_snapshot_py2.snap
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_in_top_level_span_snapshot_py2.snap
@@ -13,6 +13,7 @@
            "http.status_msg" "OK"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 20739}}
       {"name" "wsgi.application"
        "service" "wsgi"

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_in_top_level_span_snapshot_py3.snap
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_in_top_level_span_snapshot_py3.snap
@@ -13,6 +13,7 @@
            "http.status_code" "200"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 20499}}
       {"name" "wsgi.application"
        "service" "wsgi"

--- a/tests/snapshots/tests.integration.test_integration.test_filters.snap
+++ b/tests/snapshots/tests.integration.test_integration.test_filters.snap
@@ -11,6 +11,7 @@
            "boop" "beep"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 42296}}
       {"name" "child"
        "service" nil

--- a/tests/snapshots/tests.integration.test_integration.test_multiple_traces.snap
+++ b/tests/snapshots/tests.integration.test_integration.test_multiple_traces.snap
@@ -11,6 +11,7 @@
            "k" "v"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 42296
               "num" 1234
               "float_metric" 12.34
@@ -37,6 +38,7 @@
            "k" "v"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 42296
               "num" 1234
               "float_metric" 12.34

--- a/tests/snapshots/tests.integration.test_integration.test_sampling.snap
+++ b/tests/snapshots/tests.integration.test_integration.test_sampling.snap
@@ -10,6 +10,7 @@
    "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 10144}}
       {"name" "child"
        "service" nil
@@ -32,6 +33,7 @@
    "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
    "metrics" {"_dd.limit_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 10144
               "_dd.rule_psr" 1.0}}
       {"name" "child"
@@ -55,6 +57,7 @@
    "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
    "metrics" {"_sampling_priority_v1" 0
               "system.pid" 10144
+              "_dd.tracer_kr" 1.0
               "_dd.rule_psr" 1.0E-6}}
       {"name" "child"
        "service" nil
@@ -76,6 +79,7 @@
    "duration" 50000
    "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
    "metrics" {"_dd.limit_psr" 1.0
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" 1
               "system.pid" 10144
               "_dd.rule_psr" 1.0}}
@@ -99,6 +103,7 @@
    "duration" 41000
    "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
    "metrics" {"_sampling_priority_v1" 0
+              "_dd.tracer_kr" 1.0
               "system.pid" 10144
               "_dd.rule_psr" 0}}
       {"name" "child"
@@ -121,6 +126,7 @@
    "duration" 55000
    "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
    "metrics" {"_dd.limit_psr" 1.0
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" -1
               "system.pid" 10144
               "_dd.rule_psr" 1}}
@@ -144,6 +150,7 @@
    "duration" 48000
    "meta" {"runtime-id" "88c29c5e9e1445a8bcce78bd1238a4d4"}
    "metrics" {"_dd.limit_psr" 1.0
+              "_dd.tracer_kr" 1.0
               "_sampling_priority_v1" 2
               "system.pid" 10144
               "_dd.rule_psr" 1}}

--- a/tests/snapshots/tests.integration.test_integration.test_single_trace_single_span.snap
+++ b/tests/snapshots/tests.integration.test_integration.test_single_trace_single_span.snap
@@ -11,6 +11,7 @@
            "k" "v"}
    "metrics" {"_dd.agent_psr" 1.0
               "_sampling_priority_v1" 1
+              "_dd.tracer_kr" 1.0
               "system.pid" 42296
               "num" 1234
               "float_metric" 12.34

--- a/tests/tracer/test_sma.py
+++ b/tests/tracer/test_sma.py
@@ -1,0 +1,27 @@
+from ddtrace.internal.sma import SimpleMovingAverage
+
+
+def test_min_size():
+    sma = SimpleMovingAverage(0)
+
+    assert 1 == sma.size
+    assert 1 == len(sma.counts)
+    assert 1 == len(sma.totals)
+
+
+def test_moving_average():
+    sma = SimpleMovingAverage(4)
+
+    assert 0.0 == sma.get()
+    sma.set(1, 2)
+    assert 0.5 == sma.get()
+    sma.set(2, 2)
+    assert 0.75 == sma.get()
+    sma.set(1, 4)
+    assert 0.5 == sma.get()
+    sma.set(0, 12)
+    assert 0.2 == sma.get()
+    sma.set(2, 2)
+    assert 0.25 == sma.get()
+    sma.set(15, 18)
+    assert 0.5 == sma.get()

--- a/tests/tracer/test_sma.py
+++ b/tests/tracer/test_sma.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ddtrace.internal.sma import DEFAULT_SMA_WINDOW
 from ddtrace.internal.sma import SimpleMovingAverage
 
@@ -9,19 +11,15 @@ def test_min_size():
     assert DEFAULT_SMA_WINDOW == len(sma.counts)
     assert DEFAULT_SMA_WINDOW == len(sma.totals)
 
-    try:
+    with pytest.raises(ValueError):
         sma = SimpleMovingAverage(size=0)
-    except Exception as e:
-        assert isinstance(e, ValueError)
 
 
 def test_count_greater_than_total():
     sma = SimpleMovingAverage()
 
-    try:
+    with pytest.raises(ValueError):
         sma.set(2, 1)
-    except Exception as e:
-        assert isinstance(e, ValueError)
 
 
 def test_moving_average():

--- a/tests/tracer/test_sma.py
+++ b/tests/tracer/test_sma.py
@@ -1,12 +1,26 @@
-from ddtrace.internal.sma import SimpleMovingAverage
+from ddtrace.internal.sma import SimpleMovingAverage, DEFAULT_SMA_WINDOW
 
 
 def test_min_size():
-    sma = SimpleMovingAverage(0)
+    sma = SimpleMovingAverage()
 
-    assert 1 == sma.size
-    assert 1 == len(sma.counts)
-    assert 1 == len(sma.totals)
+    assert DEFAULT_SMA_WINDOW == sma.size
+    assert DEFAULT_SMA_WINDOW == len(sma.counts)
+    assert DEFAULT_SMA_WINDOW == len(sma.totals)
+
+    try:
+        sma = SimpleMovingAverage(size=0)
+    except Exception as e:
+        assert isinstance(e, ValueError)
+
+
+def test_count_greater_than_total():
+    sma = SimpleMovingAverage()
+
+    try:
+        sma.set(2, 1)
+    except Exception as e:
+        assert isinstance(e, ValueError)
 
 
 def test_moving_average():
@@ -24,4 +38,42 @@ def test_moving_average():
     sma.set(2, 2)
     assert 0.25 == sma.get()
     sma.set(15, 18)
+    assert 0.5 == sma.get()
+
+    sma = SimpleMovingAverage(1)
+
+    assert 0.0 == sma.get()
+    sma.set(1, 2)
+    assert 0.5 == sma.get()
+    sma.set(2, 2)
+    assert 1.0 == sma.get()
+    sma.set(0, 0)
+    assert 0.0 == sma.get()
+
+    sma = SimpleMovingAverage()
+
+    assert 0.0 == sma.get()
+    sma.set(1, 1)
+    assert 1.0 == sma.get()
+    sma.set(0, 0)
+    assert 1.0 == sma.get()
+    sma.set(0, 0)
+    assert 1.0 == sma.get()
+    sma.set(0, 4)
+    assert 0.2 == sma.get()
+    sma.set(1, 3)
+    assert 0.25 == sma.get()
+    sma.set(1, 4)
+    assert 0.25 == sma.get()
+    sma.set(0, 0)
+    assert 0.25 == sma.get()
+    sma.set(0, 0)
+    assert 0.25 == sma.get()
+    sma.set(0, 0)
+    assert 0.25 == sma.get()
+    sma.set(7, 8)
+    assert 0.5 == sma.get()
+    sma.set(1, 1)
+    assert 0.5 == sma.get()
+    sma.set(10, 20)
     assert 0.5 == sma.get()

--- a/tests/tracer/test_sma.py
+++ b/tests/tracer/test_sma.py
@@ -1,22 +1,22 @@
 import pytest
 
-from ddtrace.internal.sma import DEFAULT_SMA_WINDOW
 from ddtrace.internal.sma import SimpleMovingAverage
+from ddtrace.internal.writer import DEFAULT_SMA_WINDOW
 
 
 def test_min_size():
-    sma = SimpleMovingAverage()
+    sma = SimpleMovingAverage(DEFAULT_SMA_WINDOW)
 
     assert DEFAULT_SMA_WINDOW == sma.size
     assert DEFAULT_SMA_WINDOW == len(sma.counts)
     assert DEFAULT_SMA_WINDOW == len(sma.totals)
 
     with pytest.raises(ValueError):
-        sma = SimpleMovingAverage(size=0)
+        sma = SimpleMovingAverage(0)
 
 
 def test_count_greater_than_total():
-    sma = SimpleMovingAverage()
+    sma = SimpleMovingAverage(DEFAULT_SMA_WINDOW)
 
     with pytest.raises(ValueError):
         sma.set(2, 1)
@@ -49,7 +49,7 @@ def test_moving_average():
     sma.set(0, 0)
     assert 0.0 == sma.get()
 
-    sma = SimpleMovingAverage()
+    sma = SimpleMovingAverage(DEFAULT_SMA_WINDOW)
 
     assert 0.0 == sma.get()
     sma.set(1, 1)

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -1,8 +1,11 @@
 import mock
+import msgpack
 
 from ddtrace.internal.writer import AgentWriter
 from ddtrace.internal.writer import LogWriter
 from ddtrace.internal.writer import _human_size
+from ddtrace.api import Response
+from ddtrace.constants import KEEP_SPANS_RATE_KEY
 from ddtrace.span import Span
 from tests import AnyInt
 from tests import BaseTestCase
@@ -146,6 +149,157 @@ class AgentWriterTests(BaseTestCase):
             ],
             any_order=True,
         )
+
+    def test_drop_reason_bad_endpoint(self):
+        statsd = mock.Mock()
+        writer_metrics_reset = mock.Mock()
+        writer = AgentWriter(dogstatsd=statsd, report_metrics=False, hostname="asdf", port=1234)
+        writer._metrics_reset = writer_metrics_reset
+        for i in range(10):
+            writer.write(
+                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
+            )
+        writer.stop()
+        writer.join()
+
+        writer_metrics_reset.assert_called_once()
+
+        assert 1 == writer._metrics["http.errors"]["count"]
+        assert 10 == writer._metrics["http.dropped.traces"]["count"]
+
+    def test_drop_reason_trace_too_big(self):
+        statsd = mock.Mock()
+        writer_metrics_reset = mock.Mock()
+        writer = AgentWriter(dogstatsd=statsd, report_metrics=False, hostname="asdf", port=1234)
+        writer._metrics_reset = writer_metrics_reset
+        for i in range(10):
+            writer.write(
+                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
+            )
+        writer.write(
+            [Span(tracer=None, name="a" * 5000, trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(2 ** 10)]
+        )
+        writer.stop()
+        writer.join()
+
+        writer_metrics_reset.assert_called_once()
+
+        assert 1 == writer._metrics["buffer.dropped.traces"]["count"]
+        assert ["reason:t_too_big"] == writer._metrics["buffer.dropped.traces"]["tags"]
+
+    def test_drop_reason_buffer_full(self):
+        statsd = mock.Mock()
+        writer_metrics_reset = mock.Mock()
+        writer = AgentWriter(buffer_size=5300, dogstatsd=statsd, report_metrics=False, hostname="asdf", port=1234)
+        writer._metrics_reset = writer_metrics_reset
+        for i in range(10):
+            writer.write(
+                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
+            )
+        writer.write([Span(tracer=None, name="a", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
+        writer.stop()
+        writer.join()
+
+        writer_metrics_reset.assert_called_once()
+
+        assert 1 == writer._metrics["buffer.dropped.traces"]["count"]
+        assert ["reason:full"] == writer._metrics["buffer.dropped.traces"]["tags"]
+
+    def test_drop_reason_encoding_error(self):
+        statsd = mock.Mock()
+        writer_encoder = mock.Mock()
+        writer_metrics_reset = mock.Mock()
+        writer_encoder.encode_trace.side_effect = Exception
+        writer = AgentWriter(dogstatsd=statsd, report_metrics=False, hostname="asdf", port=1234)
+        writer._encoder = writer_encoder
+        writer._metrics_reset = writer_metrics_reset
+        for i in range(10):
+            writer.write(
+                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
+            )
+
+        writer.stop()
+        writer.join()
+
+        writer_metrics_reset.assert_called_once()
+
+        assert 10 == writer._metrics["encoder.dropped.traces"]["count"]
+
+    def test_keep_rate(self):
+        statsd = mock.Mock()
+        writer_run_periodic = mock.Mock()
+        writer_put = mock.Mock()
+        writer_put.return_value = Response(status=200)
+        writer = AgentWriter(dogstatsd=statsd, report_metrics=False, hostname="asdf", port=1234)
+        writer.run_periodic = writer_run_periodic
+        writer._put = writer_put
+
+        traces = [
+            [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
+            for i in range(4)
+        ]
+
+        traces_too_big = [
+            [Span(tracer=None, name="a" * 5000, trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(2 ** 10)]
+            for i in range(4)
+        ]
+
+        # 1. We write 4 traces successfully.
+        for trace in traces:
+            writer.write(trace)
+        writer.flush_queue()
+
+        payload = msgpack.unpackb(writer_put.call_args.args[0])
+        # No previous drops.
+        assert 0.0 == writer._drop_sma.get()
+        # 4 traces written.
+        assert 4 == len(payload)
+        # 100% of traces kept (refers to the past).
+        # No traces sent before now so 100% kept.
+        for trace in payload:
+            assert 1.0 == trace[0]["metrics"].get(KEEP_SPANS_RATE_KEY, -1)
+
+        # 2. We fail to write 4 traces because of size limitation.
+        for trace in traces_too_big:
+            writer.write(trace)
+        writer.flush_queue()
+
+        # 50% of traces were dropped historically.
+        # 4 successfully written before and 4 dropped now.
+        assert 0.5 == writer._drop_sma.get()
+        # put not called since no new traces are available.
+        writer_put.assert_called_once()
+
+        # 3. We write 2 traces successfully.
+        for trace in traces[:2]:
+            writer.write(trace)
+        writer.flush_queue()
+
+        payload = msgpack.unpackb(writer_put.call_args.args[0])
+        # 40% of traces were dropped historically.
+        assert 0.4 == writer._drop_sma.get()
+        # 2 traces written.
+        assert 2 == len(payload)
+        # 50% of traces kept (refers to the past).
+        # We had 4 successfully written and 4 dropped.
+        for trace in payload:
+            assert 0.5 == trace[0]["metrics"].get(KEEP_SPANS_RATE_KEY, -1)
+
+        # 4. We write 1 trace successfully and fail to write 3.
+        writer.write(traces[0])
+        for trace in traces_too_big[:3]:
+            writer.write(trace)
+        writer.flush_queue()
+
+        payload = msgpack.unpackb(writer_put.call_args.args[0])
+        # 50% of traces were dropped historically.
+        assert 0.5 == writer._drop_sma.get()
+        # 1 trace written.
+        assert 1 == len(payload)
+        # 60% of traces kept (refers to the past).
+        # We had 4 successfully written, then 4 dropped, then 2 written.
+        for trace in payload:
+            assert 0.6 == trace[0]["metrics"].get(KEEP_SPANS_RATE_KEY, -1)
 
 
 class LogWriterTests(BaseTestCase):


### PR DESCRIPTION
## Description
<!-- Please briefly describe the change and why it was required. -->

- Modify the tracer to count the number of dropped traces and report to the backend the rate of kept traces by attaching it as a tag to root spans.
- To make spikes smoother use a Simple Moving Average when calculating and reporting the rate.
- Count traces dropped because of encoding errors, reaching max traces-per-second, reaching max-trace-size, failure to communicate with the agent.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
