### PR TITLE
ci: disable output buffering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,8 @@ machine_executor: &machine_executor
     image: ubuntu-1604:201903-01
   environment:
     - BOTO_CONFIG: /dev/null
+    # https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-
+    - PYTHONUNBUFFERED: 1
   steps:
     - &pyenv-set-global
       run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ FROM debian:stretch-slim
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-
+ENV PYTHONUNBUFFERED=1
+
 RUN \
   # Install system dependencies
   apt-get update \


### PR DESCRIPTION
## Description

To help address timeout errors with CircleCI: https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
