### PR TITLE
ci: move grpc to riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -680,8 +680,8 @@ jobs:
   grpc:
     <<: *contrib_job
     steps:
-      - run_tox_scenario:
-          pattern: '^grpc_contrib-'
+      - run_test:
+          pattern: "grpc"
 
   molten:
     <<: *contrib_job

--- a/riotfile.py
+++ b/riotfile.py
@@ -325,5 +325,42 @@ venv = Venv(
                 ),
             ],
         ),
+        Venv(
+            name="grpc",
+            command="pytest {cmdargs} tests/contrib/grpc",
+            pkgs={
+                "googleapis-common-protos": latest,
+            },
+            venvs=[
+                Venv(
+                    pys=select_pys(max_version=3.6),
+                    pkgs={
+                        "grpcio": ["~=1.12.0", "~=1.14.0", "~=1.18.0", "~=1.20.0", "~=1.21.0", "~=1.22.0"],
+                    },
+                ),
+                Venv(
+                    pys=["3.7"],
+                    pkgs={
+                        "grpcio": [
+                            "~=1.14.0",
+                            "~=1.18.0",
+                            "~=1.20.0",
+                            "~=1.21.0",
+                            "~=1.22.0",
+                            "~=1.24.0",
+                            "~=1.26.0",
+                            "~=1.28.0",
+                            latest,
+                        ],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version=3.8),
+                    pkgs={
+                        "grpcio": ["~=1.24.0", "~=1.26.0", "~=1.28.0", latest],
+                    },
+                ),
+            ],
+        ),
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -81,13 +81,6 @@ envlist =
     gevent_contrib-py{37,38}-gevent{13,14}-sslmodules3-sslmodules
 # gevent 1.0 is not python 3 compatible
     gevent_contrib-py27-gevent10-sslmodules
-# use grpcio versions with bdist_wheel packages for python versions
-# py27,py35,py36: grpcio>=1.13.0
-# py37: grpcio>=1.13.0
-# py38: grpcio>=1.24.3
-    grpc_contrib-py{27,35,36}-grpc{112,114,118,120,121,122}-googleapis-common-protos
-    grpc_contrib-py{37}-grpc{114,118,120,121,122,124,126,128,}-googleapis-common-protos
-    grpc_contrib-py{38}-grpc{124,126,128,}-googleapis-common-protos
     httplib_contrib-py{27,35,36,37,38,39}
     jinja2_contrib-py{27,35,36,37,38,39}-jinja{27,28,29,210,211,}
     kombu_contrib-py{27,35,36}-kombu{40,41,42,43,44,45,46,}
@@ -314,17 +307,6 @@ deps =
     gevent12: gevent>=1.2,<1.3
     gevent13: gevent>=1.3,<1.4
     gevent14: gevent>=1.4,<1.5
-    grpc: grpcio
-    googleapis-common-protos: googleapis-common-protos
-    grpc112: grpcio>=1.12,<1.13
-    grpc114: grpcio>=1.14,<1.15
-    grpc118: grpcio>=1.18,<1.19
-    grpc120: grpcio>=1.20,<1.21
-    grpc121: grpcio>=1.21,<1.22
-    grpc122: grpcio>=1.22,<1.23
-    grpc124: grpcio>=1.24,<1.25
-    grpc126: grpcio>=1.26,<1.27
-    grpc128: grpcio>=1.28,<1.29
     jinja: jinja2
     jinja27: jinja2>=2.7,<2.8
     jinja28: jinja2>=2.8,<2.9
@@ -481,7 +463,6 @@ commands =
     flask_cache_contrib: pytest {posargs} tests/contrib/flask_cache
     futures_contrib: pytest {posargs} tests/contrib/futures
     gevent_contrib: pytest {posargs} tests/contrib/gevent
-    grpc_contrib: pytest {posargs} tests/contrib/grpc
     httplib_contrib: pytest {posargs} tests/contrib/httplib
     jinja2_contrib: pytest {posargs} tests/contrib/jinja2
     mako_contrib: pytest {posargs} tests/contrib/mako


### PR DESCRIPTION
Use `riot` to run grpc test suite.

Number of tests running increased because of adding 3.9 testing.

```
# riot list grpc
grpc  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.12.0'
grpc  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.14.0'
grpc  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.18.0'
grpc  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.20.0'
grpc  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.21.0'
grpc  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.22.0'
grpc  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.12.0'
grpc  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.14.0'
grpc  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.18.0'
grpc  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.20.0'
grpc  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.21.0'
grpc  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.22.0'
grpc  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.12.0'
grpc  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.14.0'
grpc  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.18.0'
grpc  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.20.0'
grpc  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.21.0'
grpc  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.22.0'
grpc  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.14.0'
grpc  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.18.0'
grpc  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.20.0'
grpc  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.21.0'
grpc  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.22.0'
grpc  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.24.0'
grpc  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.26.0'
grpc  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.28.0'
grpc  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio'
grpc  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.24.0'
grpc  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.26.0'
grpc  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.28.0'
grpc  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio'
grpc  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.24.0'
grpc  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.26.0'
grpc  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio~=1.28.0'
grpc  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'googleapis-common-protos' 'grpcio'

# riot list grpc | wc -l
34
```


```
# tox -l | grep grpc
grpc_contrib-py27-grpc112-googleapis-common-protos
grpc_contrib-py27-grpc114-googleapis-common-protos
grpc_contrib-py27-grpc118-googleapis-common-protos
grpc_contrib-py27-grpc120-googleapis-common-protos
grpc_contrib-py27-grpc121-googleapis-common-protos
grpc_contrib-py27-grpc122-googleapis-common-protos
grpc_contrib-py35-grpc112-googleapis-common-protos
grpc_contrib-py35-grpc114-googleapis-common-protos
grpc_contrib-py35-grpc118-googleapis-common-protos
grpc_contrib-py35-grpc120-googleapis-common-protos
grpc_contrib-py35-grpc121-googleapis-common-protos
grpc_contrib-py35-grpc122-googleapis-common-protos
grpc_contrib-py36-grpc112-googleapis-common-protos
grpc_contrib-py36-grpc114-googleapis-common-protos
grpc_contrib-py36-grpc118-googleapis-common-protos
grpc_contrib-py36-grpc120-googleapis-common-protos
grpc_contrib-py36-grpc121-googleapis-common-protos
grpc_contrib-py36-grpc122-googleapis-common-protos
grpc_contrib-py37-grpc114-googleapis-common-protos
grpc_contrib-py37-grpc118-googleapis-common-protos
grpc_contrib-py37-grpc120-googleapis-common-protos
grpc_contrib-py37-grpc121-googleapis-common-protos
grpc_contrib-py37-grpc122-googleapis-common-protos
grpc_contrib-py37-grpc124-googleapis-common-protos
grpc_contrib-py37-grpc126-googleapis-common-protos
grpc_contrib-py37-grpc128-googleapis-common-protos
grpc_contrib-py37-grpc-googleapis-common-protos
grpc_contrib-py38-grpc124-googleapis-common-protos
grpc_contrib-py38-grpc126-googleapis-common-protos
grpc_contrib-py38-grpc128-googleapis-common-protos
grpc_contrib-py38-grpc-googleapis-common-protos

# tox -l | grep grpc | wc -l
30
```