### PR TITLE
django: add measured tag to root span

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -12,7 +12,7 @@ from inspect import isclass, isfunction, getmro
 
 from ddtrace import config, Pin
 from ddtrace.vendor import debtcollector, six, wrapt
-from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY, SPAN_MEASURED_KEY
 from ddtrace.contrib import func_name, dbapi
 from ddtrace.ext import http, sql as sqlx, SpanTypes
 from ddtrace.internal.logger import get_logger
@@ -366,6 +366,7 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
             service=trace_utils.int_service(pin, config.django),
             span_type=SpanTypes.WEB,
         ) as span:
+            span.metrics[SPAN_MEASURED_KEY] = 1
             analytics_sr = config.django.get_analytics_sample_rate(use_global_config=True)
             if analytics_sr is not None:
                 span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, analytics_sr)

--- a/releasenotes/notes/django-2ebd5565ee27d4d1.yaml
+++ b/releasenotes/notes/django-2ebd5565ee27d4d1.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    django: tag root spans as measured.

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions.snap
@@ -6,9 +6,9 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1606875759623332453
-   "duration" 10684014
-   "meta" {"runtime-id" "c81279f5dd4c4c43a1e5aab4f9cb69df"
+   "start" 1612561069977386000
+   "duration" 2446000
+   "meta" {"runtime-id" "ed399477c62a49f8a3205405cacc59c9"
            "http.route" "^404-view/$"
            "http.url" "http://testserver/404-view/"
            "django.user.is_authenticated" "False"
@@ -18,8 +18,9 @@
            "django.request.class" "django.core.handlers.wsgi.WSGIRequest"
            "django.view" "404-view"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 5117}}
+              "system.pid" 97933}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.__call__"
@@ -27,8 +28,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1606875759623852622
-       "duration" 9715658}
+       "start" 1612561069977477000
+       "duration" 1801000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -36,8 +37,8 @@
            "span_id" 2
            "trace_id" 0
            "parent_id" 1
-           "start" 1606875759623889130
-           "duration" 296715}
+           "start" 1612561069977504000
+           "duration" 58000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.middleware.common.CommonMiddleware.__call__"
@@ -45,8 +46,8 @@
            "span_id" 3
            "trace_id" 0
            "parent_id" 1
-           "start" 1606875759624220786
-           "duration" 9306315}
+           "start" 1612561069977586000
+           "duration" 1604000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -54,8 +55,8 @@
                "span_id" 5
                "trace_id" 0
                "parent_id" 3
-               "start" 1606875759624251876
-               "duration" 456852}
+               "start" 1612561069977609000
+               "duration" 47000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.csrf.CsrfViewMiddleware.__call__"
@@ -63,8 +64,8 @@
                "span_id" 6
                "trace_id" 0
                "parent_id" 3
-               "start" 1606875759624738903
-               "duration" 8745117}
+               "start" 1612561069977679000
+               "duration" 1431000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -72,8 +73,8 @@
                    "span_id" 8
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1606875759624769663
-                   "duration" 15016}
+                   "start" 1612561069977702000
+                   "duration" 12000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.__call__"
@@ -81,8 +82,8 @@
                    "span_id" 9
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1606875759624807370
-                   "duration" 8642412}
+                   "start" 1612561069977733000
+                   "duration" 1346000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -90,8 +91,8 @@
                        "span_id" 11
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1606875759624833203
-                       "duration" 12853}
+                       "start" 1612561069977754000
+                       "duration" 15000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.messages.middleware.MessageMiddleware.__call__"
@@ -99,8 +100,8 @@
                        "span_id" 12
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1606875759624868562
-                       "duration" 8575085}
+                       "start" 1612561069977787000
+                       "duration" 1287000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -108,8 +109,8 @@
                            "span_id" 13
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1606875759624893088
-                           "duration" 1562764}
+                           "start" 1612561069977807000
+                           "duration" 53000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__"
@@ -117,8 +118,8 @@
                            "span_id" 14
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1606875759626486711
-                           "duration" 6915828}
+                           "start" 1612561069977881000
+                           "duration" 1157000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.security.SecurityMiddleware.__call__"
@@ -126,8 +127,8 @@
                                "span_id" 16
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1606875759626521476
-                               "duration" 6835129}
+                               "start" 1612561069977904000
+                               "duration" 1092000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -135,8 +136,8 @@
                                    "span_id" 18
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1606875759626548320
-                                   "duration" 9846}
+                                   "start" 1612561069977924000
+                                   "duration" 9000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "tests.contrib.django.middleware.ClsMiddleware.__call__"
@@ -144,8 +145,8 @@
                                    "span_id" 19
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1606875759626579601
-                                   "duration" 6723494}
+                                   "start" 1612561069977951000
+                                   "duration" 1007000}
                                       {"name" "django.middleware"
                                        "service" "django"
                                        "resource" "tests.contrib.django.middleware.EverythingMiddleware"
@@ -153,8 +154,8 @@
                                        "span_id" 21
                                        "trace_id" 0
                                        "parent_id" 19
-                                       "start" 1606875759626602608
-                                       "duration" 6694914}
+                                       "start" 1612561069977972000
+                                       "duration" 981000}
                                           {"name" "django.middleware"
                                            "service" "django"
                                            "resource" "tests.contrib.django.middleware.EverythingMiddleware.__call__"
@@ -162,8 +163,8 @@
                                            "span_id" 22
                                            "trace_id" 0
                                            "parent_id" 21
-                                           "start" 1606875759626623283
-                                           "duration" 6667630}
+                                           "start" 1612561069977998000
+                                           "duration" 949000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -171,8 +172,8 @@
                                                "span_id" 23
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606875759626703042
-                                               "duration" 13086}
+                                               "start" 1612561069978095000
+                                               "duration" 13000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_view"
@@ -180,8 +181,8 @@
                                                "span_id" 24
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606875759626736144
-                                               "duration" 9924}
+                                               "start" 1612561069978126000
+                                               "duration" 9000}
                                               {"name" "django.view"
                                                "service" "django"
                                                "resource" "tests.contrib.django.views.not_found_view"
@@ -189,8 +190,8 @@
                                                "span_id" 25
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606875759626803479
-                                               "duration" 13950}
+                                               "start" 1612561069978168000
+                                               "duration" 22000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_exception"
@@ -198,8 +199,8 @@
                                                "span_id" 26
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606875759626839151
-                                               "duration" 10504}
+                                               "start" 1612561069978212000
+                                               "duration" 9000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -207,8 +208,8 @@
                                                "span_id" 27
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606875759626904835
-                                               "duration" 10719}
+                                               "start" 1612561069978272000
+                                               "duration" 12000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -216,8 +217,8 @@
                                                "span_id" 28
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606875759626936393
-                                               "duration" 8767}
+                                               "start" 1612561069978302000
+                                               "duration" 8000}
                                               {"name" "django.template.render"
                                                "service" "django"
                                                "resource" "django.template.base.Template.render"
@@ -226,8 +227,8 @@
                                                "span_id" 29
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606875759632832321
-                                               "duration" 163590
+                                               "start" 1612561069978672000
+                                               "duration" 188000
                                                "meta" {"django.template.engine.class" "django.template.engine.Engine"}}
                                               {"name" "django.middleware"
                                                "service" "django"
@@ -236,8 +237,8 @@
                                                "span_id" 30
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606875759633267006
-                                               "duration" 13071}
+                                               "start" 1612561069978926000
+                                               "duration" 13000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -245,8 +246,8 @@
                                    "span_id" 20
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1606875759633325351
-                                   "duration" 24222}
+                                   "start" 1612561069978978000
+                                   "duration" 13000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -254,8 +255,8 @@
                                "span_id" 17
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1606875759633377978
-                               "duration" 17997}
+                               "start" 1612561069979015000
+                               "duration" 18000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -263,8 +264,8 @@
                            "span_id" 15
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1606875759633423098
-                           "duration" 14278}
+                           "start" 1612561069979057000
+                           "duration" 13000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -272,8 +273,8 @@
                    "span_id" 10
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1606875759633469380
-                   "duration" 8792}
+                   "start" 1612561069979097000
+                   "duration" 9000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -281,8 +282,8 @@
                "span_id" 7
                "trace_id" 0
                "parent_id" 3
-               "start" 1606875759633503644
-               "duration" 17178}
+               "start" 1612561069979128000
+               "duration" 47000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -290,5 +291,5 @@
            "span_id" 4
            "trace_id" 0
            "parent_id" 1
-           "start" 1606875759633547149
-           "duration" 14974}]]
+           "start" 1612561069979230000
+           "duration" 41000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_111x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_111x.snap
@@ -6,9 +6,9 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1606877734043376000
-   "duration" 1585000
-   "meta" {"runtime-id" "bddaabb21d4f47838a28412a130065e7"
+   "start" 1612560766398833000
+   "duration" 2891000
+   "meta" {"runtime-id" "93145384bb364e9c90d9a9309fc26349"
            "http.method" "GET"
            "django.response.class" "django.http.response.HttpResponseNotFound"
            "http.url" "http://testserver/404-view/"
@@ -16,8 +16,9 @@
            "http.status_code" "404"
            "django.user.is_authenticated" "False"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 8472}}
+              "system.pid" 96813}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -25,8 +26,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734043448000
-       "duration" 41000}
+       "start" 1612560766398948000
+       "duration" 61000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -34,8 +35,8 @@
        "span_id" 2
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734043521000
-       "duration" 44000}
+       "start" 1612560766399042000
+       "duration" 70000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -43,8 +44,8 @@
        "span_id" 3
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734043593000
-       "duration" 14000}
+       "start" 1612560766399150000
+       "duration" 22000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -52,8 +53,8 @@
        "span_id" 4
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734043631000
-       "duration" 16000}
+       "start" 1612560766399208000
+       "duration" 21000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.SessionAuthenticationMiddleware.process_request"
@@ -61,8 +62,8 @@
        "span_id" 5
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734043670000
-       "duration" 9000}
+       "start" 1612560766399254000
+       "duration" 13000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -70,8 +71,8 @@
        "span_id" 6
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734043701000
-       "duration" 34000}
+       "start" 1612560766399292000
+       "duration" 41000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -79,8 +80,8 @@
        "span_id" 7
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734043758000
-       "duration" 11000}
+       "start" 1612560766399362000
+       "duration" 12000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -88,8 +89,8 @@
        "span_id" 8
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734043870000
-       "duration" 13000}
+       "start" 1612560766399923000
+       "duration" 32000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -97,8 +98,8 @@
        "span_id" 9
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734043911000
-       "duration" 16000}
+       "start" 1612560766399997000
+       "duration" 31000}
       {"name" "django.template.render"
        "service" "django"
        "resource" "django.template.base.Template.render"
@@ -107,8 +108,8 @@
        "span_id" 10
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734044178000
-       "duration" 111000
+       "start" 1612560766400725000
+       "duration" 199000
        "meta" {"django.template.engine.class" "django.template.engine.Engine"}}
       {"name" "django.middleware"
        "service" "django"
@@ -117,8 +118,8 @@
        "span_id" 11
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734044364000
-       "duration" 14000}
+       "start" 1612560766401026000
+       "duration" 17000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -126,8 +127,8 @@
        "span_id" 12
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734044409000
-       "duration" 11000}
+       "start" 1612560766401088000
+       "duration" 15000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -135,8 +136,8 @@
        "span_id" 13
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734044443000
-       "duration" 49000}
+       "start" 1612560766401126000
+       "duration" 25000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -144,8 +145,8 @@
        "span_id" 14
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734044543000
-       "duration" 12000}
+       "start" 1612560766401172000
+       "duration" 14000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -153,8 +154,8 @@
        "span_id" 15
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734044577000
-       "duration" 23000}
+       "start" 1612560766401207000
+       "duration" 11000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -162,8 +163,8 @@
        "span_id" 16
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734044621000
-       "duration" 21000}
+       "start" 1612560766401238000
+       "duration" 25000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -171,5 +172,5 @@
        "span_id" 17
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877734044664000
-       "duration" 15000}]]
+       "start" 1612560766401284000
+       "duration" 17000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_18x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_18x.snap
@@ -6,9 +6,9 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1606877719264242000
-   "duration" 1798000
-   "meta" {"runtime-id" "9ef1e4b9b98748cea9337b9d914a8163"
+   "start" 1612560735121783000
+   "duration" 4825000
+   "meta" {"runtime-id" "1fb211269d1b4df3abdb69544b7d6716"
            "http.method" "GET"
            "django.response.class" "django.http.response.HttpResponseNotFound"
            "http.url" "http://testserver/404-view/"
@@ -16,8 +16,9 @@
            "http.status_code" "404"
            "django.user.is_authenticated" "False"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 8273}}
+              "system.pid" 96676}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -25,8 +26,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719264325000
-       "duration" 46000}
+       "start" 1612560735121924000
+       "duration" 80000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -34,8 +35,8 @@
        "span_id" 2
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719264409000
-       "duration" 38000}
+       "start" 1612560735122055000
+       "duration" 70000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -43,8 +44,8 @@
        "span_id" 3
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719264512000
-       "duration" 18000}
+       "start" 1612560735122172000
+       "duration" 32000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.SessionAuthenticationMiddleware.process_request"
@@ -52,8 +53,8 @@
        "span_id" 4
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719264568000
-       "duration" 10000}
+       "start" 1612560735122249000
+       "duration" 21000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -61,8 +62,8 @@
        "span_id" 5
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719264601000
-       "duration" 31000}
+       "start" 1612560735122314000
+       "duration" 63000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -70,8 +71,8 @@
        "span_id" 6
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719264663000
-       "duration" 11000}
+       "start" 1612560735122423000
+       "duration" 22000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -79,8 +80,8 @@
        "span_id" 7
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719264827000
-       "duration" 125000}
+       "start" 1612560735122751000
+       "duration" 512000}
       {"name" "django.template.render"
        "service" "django"
        "resource" "django.template.base.Template.render"
@@ -89,8 +90,8 @@
        "span_id" 8
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719265370000
-       "duration" 169000
+       "start" 1612560735124928000
+       "duration" 363000
        "meta" {"django.template.engine.class" "django.template.engine.Engine"}}
       {"name" "django.middleware"
        "service" "django"
@@ -99,8 +100,8 @@
        "span_id" 9
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719265618000
-       "duration" 15000}
+       "start" 1612560735125489000
+       "duration" 33000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -108,8 +109,8 @@
        "span_id" 10
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719265662000
-       "duration" 12000}
+       "start" 1612560735125582000
+       "duration" 26000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -117,8 +118,8 @@
        "span_id" 11
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719265698000
-       "duration" 22000}
+       "start" 1612560735125663000
+       "duration" 54000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -126,8 +127,8 @@
        "span_id" 12
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719265744000
-       "duration" 14000}
+       "start" 1612560735125772000
+       "duration" 33000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -135,8 +136,8 @@
        "span_id" 13
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719265782000
-       "duration" 11000}
+       "start" 1612560735125861000
+       "duration" 29000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -144,8 +145,8 @@
        "span_id" 14
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719265815000
-       "duration" 11000}
+       "start" 1612560735125944000
+       "duration" 31000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -153,5 +154,5 @@
        "span_id" 15
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877719265849000
-       "duration" 18000}]]
+       "start" 1612560735126029000
+       "duration" 46000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_21x.snap
@@ -6,9 +6,9 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1606877874181336142
-   "duration" 2069611
-   "meta" {"runtime-id" "df2f384ab5c14aebbd427098639d616e"
+   "start" 1612560992843406000
+   "duration" 2665000
+   "meta" {"runtime-id" "4bc93e60ccf14d5083d6c3a9172d4548"
            "django.view" "404-view"
            "django.request.class" "django.core.handlers.wsgi.WSGIRequest"
            "django.user.is_authenticated" "False"
@@ -17,8 +17,9 @@
            "http.url" "http://testserver/404-view/"
            "http.status_code" "404"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 9264}}
+              "system.pid" 97622}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.__call__"
@@ -26,8 +27,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1606877874181416819
-       "duration" 1714553}
+       "start" 1612560992843496000
+       "duration" 1778000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -35,8 +36,8 @@
            "span_id" 2
            "trace_id" 0
            "parent_id" 1
-           "start" 1606877874181446591
-           "duration" 52108}
+           "start" 1612560992843524000
+           "duration" 72000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.middleware.common.CommonMiddleware.__call__"
@@ -44,8 +45,8 @@
            "span_id" 3
            "trace_id" 0
            "parent_id" 1
-           "start" 1606877874181529538
-           "duration" 1559681}
+           "start" 1612560992843623000
+           "duration" 1610000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -53,8 +54,8 @@
                "span_id" 5
                "trace_id" 0
                "parent_id" 3
-               "start" 1606877874181554109
-               "duration" 38574}
+               "start" 1612560992843649000
+               "duration" 45000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.csrf.CsrfViewMiddleware.__call__"
@@ -62,8 +63,8 @@
                "span_id" 6
                "trace_id" 0
                "parent_id" 3
-               "start" 1606877874181618052
-               "duration" 1425492}
+               "start" 1612560992843718000
+               "duration" 1471000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -71,8 +72,8 @@
                    "span_id" 8
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1606877874181641475
-                   "duration" 11166}
+                   "start" 1612560992843742000
+                   "duration" 13000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.__call__"
@@ -80,8 +81,8 @@
                    "span_id" 9
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1606877874181674822
-                   "duration" 1333542}
+                   "start" 1612560992843775000
+                   "duration" 1380000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -89,8 +90,8 @@
                        "span_id" 11
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1606877874181697065
-                       "duration" 15384}
+                       "start" 1612560992843798000
+                       "duration" 15000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.messages.middleware.MessageMiddleware.__call__"
@@ -98,8 +99,8 @@
                        "span_id" 12
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1606877874181735503
-                       "duration" 1266582}
+                       "start" 1612560992843833000
+                       "duration" 1316000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -107,8 +108,8 @@
                            "span_id" 13
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1606877874181757178
-                           "duration" 190112}
+                           "start" 1612560992843855000
+                           "duration" 53000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__"
@@ -116,8 +117,8 @@
                            "span_id" 14
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1606877874181976378
-                           "duration" 987394}
+                           "start" 1612560992843930000
+                           "duration" 1183000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.security.SecurityMiddleware.__call__"
@@ -125,8 +126,8 @@
                                "span_id" 16
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1606877874182001674
-                               "duration" 917112}
+                               "start" 1612560992843957000
+                               "duration" 1113000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -134,8 +135,8 @@
                                    "span_id" 18
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1606877874182024031
-                                   "duration" 9589}
+                                   "start" 1612560992843980000
+                                   "duration" 10000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "tests.contrib.django.middleware.ClsMiddleware.__call__"
@@ -143,8 +144,8 @@
                                    "span_id" 19
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1606877874182055504
-                                   "duration" 823445}
+                                   "start" 1612560992844009000
+                                   "duration" 1023000}
                                       {"name" "django.middleware"
                                        "service" "django"
                                        "resource" "tests.contrib.django.middleware.EverythingMiddleware"
@@ -152,8 +153,8 @@
                                        "span_id" 21
                                        "trace_id" 0
                                        "parent_id" 19
-                                       "start" 1606877874182077958
-                                       "duration" 794966}
+                                       "start" 1612560992844034000
+                                       "duration" 994000}
                                           {"name" "django.middleware"
                                            "service" "django"
                                            "resource" "tests.contrib.django.middleware.EverythingMiddleware.__call__"
@@ -161,8 +162,8 @@
                                            "span_id" 22
                                            "trace_id" 0
                                            "parent_id" 21
-                                           "start" 1606877874182098960
-                                           "duration" 766990}
+                                           "start" 1612560992844058000
+                                           "duration" 964000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -170,8 +171,8 @@
                                                "span_id" 23
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606877874182180385
-                                               "duration" 13461}
+                                               "start" 1612560992844205000
+                                               "duration" 19000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_view"
@@ -179,8 +180,8 @@
                                                "span_id" 24
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606877874182215035
-                                               "duration" 8644}
+                                               "start" 1612560992844245000
+                                               "duration" 9000}
                                               {"name" "django.view"
                                                "service" "django"
                                                "resource" "tests.contrib.django.views.not_found_view"
@@ -188,8 +189,8 @@
                                                "span_id" 25
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606877874182259212
-                                               "duration" 21564}
+                                               "start" 1612560992844287000
+                                               "duration" 24000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_exception"
@@ -197,8 +198,8 @@
                                                "span_id" 26
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606877874182304438
-                                               "duration" 10496}
+                                               "start" 1612560992844334000
+                                               "duration" 12000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -206,8 +207,8 @@
                                                "span_id" 27
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606877874182366104
-                                               "duration" 11250}
+                                               "start" 1612560992844403000
+                                               "duration" 12000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -215,8 +216,8 @@
                                                "span_id" 28
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606877874182400608
-                                               "duration" 9069}
+                                               "start" 1612560992844435000
+                                               "duration" 9000}
                                               {"name" "django.template.render"
                                                "service" "django"
                                                "resource" "django.template.base.Template.render"
@@ -225,8 +226,8 @@
                                                "span_id" 29
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606877874182681463
-                                               "duration" 106237
+                                               "start" 1612560992844809000
+                                               "duration" 130000
                                                "meta" {"django.template.engine.class" "django.template.engine.Engine"}}
                                               {"name" "django.middleware"
                                                "service" "django"
@@ -235,8 +236,8 @@
                                                "span_id" 30
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1606877874182844380
-                                               "duration" 11571}
+                                               "start" 1612560992844998000
+                                               "duration" 14000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -244,8 +245,8 @@
                                    "span_id" 20
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1606877874182902170
-                                   "duration" 9945}
+                                   "start" 1612560992845055000
+                                   "duration" 10000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -253,8 +254,8 @@
                                "span_id" 17
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1606877874182940073
-                               "duration" 16845}
+                               "start" 1612560992845091000
+                               "duration" 17000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -262,8 +263,8 @@
                            "span_id" 15
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1606877874182984757
-                           "duration" 10958}
+                           "start" 1612560992845133000
+                           "duration" 11000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -271,8 +272,8 @@
                    "span_id" 10
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1606877874183028417
-                   "duration" 8876}
+                   "start" 1612560992845174000
+                   "duration" 10000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -280,8 +281,8 @@
                "span_id" 7
                "trace_id" 0
                "parent_id" 3
-               "start" 1606877874183063794
-               "duration" 18114}
+               "start" 1612560992845208000
+               "duration" 20000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -289,5 +290,5 @@
            "span_id" 4
            "trace_id" 0
            "parent_id" 1
-           "start" 1606877874183110368
-           "duration" 14381}]]
+           "start" 1612560992845252000
+           "duration" 16000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view.snap
@@ -6,9 +6,9 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603387537981077078
-   "duration" 12518733
-   "meta" {"runtime-id" "6626318d980f452db5ef923e305e302b"
+   "start" 1612561069912934000
+   "duration" 3947000
+   "meta" {"runtime-id" "ed399477c62a49f8a3205405cacc59c9"
            "http.route" "^feed-view/$"
            "http.url" "http://testserver/feed-view/"
            "django.user.is_authenticated" "False"
@@ -18,8 +18,9 @@
            "django.request.class" "django.core.handlers.wsgi.WSGIRequest"
            "django.view" "feed-view"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 9240}}
+              "system.pid" 97933}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.__call__"
@@ -27,8 +28,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387537981333022
-       "duration" 12081847}
+       "start" 1612561069913054000
+       "duration" 3528000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -36,8 +37,8 @@
            "span_id" 2
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387537981362298
-           "duration" 108942}
+           "start" 1612561069913081000
+           "duration" 77000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.middleware.common.CommonMiddleware.__call__"
@@ -45,8 +46,8 @@
            "span_id" 3
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387537981922055
-           "duration" 11450306}
+           "start" 1612561069913201000
+           "duration" 3342000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -54,8 +55,8 @@
                "span_id" 5
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387537982024553
-               "duration" 288117}
+               "start" 1612561069913256000
+               "duration" 96000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.csrf.CsrfViewMiddleware.__call__"
@@ -63,8 +64,8 @@
                "span_id" 6
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387537982356318
-               "duration" 10971589}
+               "start" 1612561069913401000
+               "duration" 3094000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -72,8 +73,8 @@
                    "span_id" 8
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387537982387131
-                   "duration" 19057}
+                   "start" 1612561069913431000
+                   "duration" 13000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.__call__"
@@ -81,8 +82,8 @@
                    "span_id" 9
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387537982432259
-                   "duration" 10861447}
+                   "start" 1612561069913465000
+                   "duration" 2998000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -90,8 +91,8 @@
                        "span_id" 11
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603387537982455436
-                       "duration" 20127}
+                       "start" 1612561069913519000
+                       "duration" 23000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.messages.middleware.MessageMiddleware.__call__"
@@ -99,8 +100,8 @@
                        "span_id" 12
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603387537982499900
-                       "duration" 10787406}
+                       "start" 1612561069913569000
+                       "duration" 2889000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -108,8 +109,8 @@
                            "span_id" 13
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387537983430354
-                           "duration" 240491}
+                           "start" 1612561069913595000
+                           "duration" 82000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__"
@@ -117,8 +118,8 @@
                            "span_id" 14
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387537983738614
-                           "duration" 9509671}
+                           "start" 1612561069913715000
+                           "duration" 2706000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.security.SecurityMiddleware.__call__"
@@ -126,8 +127,8 @@
                                "span_id" 16
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603387537983816111
-                               "duration" 9385983}
+                               "start" 1612561069913750000
+                               "duration" 2626000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -135,8 +136,8 @@
                                    "span_id" 18
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387537983886312
-                                   "duration" 34035}
+                                   "start" 1612561069913786000
+                                   "duration" 15000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "tests.contrib.django.middleware.ClsMiddleware.__call__"
@@ -144,8 +145,8 @@
                                    "span_id" 19
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387537983958473
-                                   "duration" 9170761}
+                                   "start" 1612561069913825000
+                                   "duration" 2500000}
                                       {"name" "django.middleware"
                                        "service" "django"
                                        "resource" "tests.contrib.django.middleware.EverythingMiddleware"
@@ -153,8 +154,8 @@
                                        "span_id" 21
                                        "trace_id" 0
                                        "parent_id" 19
-                                       "start" 1603387537984021282
-                                       "duration" 9102195}
+                                       "start" 1612561069913853000
+                                       "duration" 2466000}
                                           {"name" "django.middleware"
                                            "service" "django"
                                            "resource" "tests.contrib.django.middleware.EverythingMiddleware.__call__"
@@ -162,8 +163,8 @@
                                            "span_id" 22
                                            "trace_id" 0
                                            "parent_id" 21
-                                           "start" 1603387537984094297
-                                           "duration" 9020516}
+                                           "start" 1612561069913882000
+                                           "duration" 2431000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -171,8 +172,8 @@
                                                "span_id" 23
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387537984847085
-                                               "duration" 143153}
+                                               "start" 1612561069913971000
+                                               "duration" 21000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_view"
@@ -180,8 +181,8 @@
                                                "span_id" 24
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387537985202934
-                                               "duration" 291333}
+                                               "start" 1612561069914022000
+                                               "duration" 31000}
                                               {"name" "django.view"
                                                "service" "django"
                                                "resource" "tests.contrib.django.views.FeedView"
@@ -189,8 +190,8 @@
                                                "span_id" 25
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387537986619432
-                                               "duration" 6467168}
+                                               "start" 1612561069914126000
+                                               "duration" 2175000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -198,8 +199,8 @@
                                    "span_id" 20
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387537993179460
-                                   "duration" 16376}
+                                   "start" 1612561069916356000
+                                   "duration" 15000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -207,8 +208,8 @@
                                "span_id" 17
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603387537993225251
-                               "duration" 16978}
+                               "start" 1612561069916397000
+                               "duration" 19000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -216,8 +217,8 @@
                            "span_id" 15
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387537993269176
-                           "duration" 12437}
+                           "start" 1612561069916442000
+                           "duration" 12000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -225,8 +226,8 @@
                    "span_id" 10
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387537993313655
-                   "duration" 8593}
+                   "start" 1612561069916481000
+                   "duration" 10000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -234,8 +235,8 @@
                "span_id" 7
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387537993347700
-               "duration" 18656}
+               "start" 1612561069916517000
+               "duration" 21000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -243,5 +244,5 @@
            "span_id" 4
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387537993392510
-           "duration" 16539}]]
+           "start" 1612561069916562000
+           "duration" 15000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_111x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_111x.snap
@@ -6,19 +6,20 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603387527580024000
-   "duration" 18146000
-   "meta" {"runtime-id" "0ca9b922c7db48a3be1024f5f5df4815"
+   "start" 1612560766293833000
+   "duration" 3966000
+   "meta" {"runtime-id" "93145384bb364e9c90d9a9309fc26349"
            "django.view" "feed-view"
+           "http.method" "GET"
+           "django.response.class" "django.http.response.HttpResponse"
            "http.url" "http://testserver/feed-view/"
            "django.request.class" "django.core.handlers.wsgi.WSGIRequest"
-           "http.method" "GET"
-           "django.user.is_authenticated" "False"
            "http.status_code" "200"
-           "django.response.class" "django.http.response.HttpResponse"}
+           "django.user.is_authenticated" "False"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 9230}}
+              "system.pid" 96813}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -26,8 +27,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527580251000
-       "duration" 2833000}
+       "start" 1612560766294087000
+       "duration" 109000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -35,8 +36,8 @@
        "span_id" 2
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527583308000
-       "duration" 148000}
+       "start" 1612560766294245000
+       "duration" 86000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -44,8 +45,8 @@
        "span_id" 3
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527583494000
-       "duration" 27000}
+       "start" 1612560766294362000
+       "duration" 23000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -53,8 +54,8 @@
        "span_id" 4
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527583604000
-       "duration" 26000}
+       "start" 1612560766294410000
+       "duration" 25000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.SessionAuthenticationMiddleware.process_request"
@@ -62,8 +63,8 @@
        "span_id" 5
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527583669000
-       "duration" 8000}
+       "start" 1612560766294459000
+       "duration" 10000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -71,8 +72,8 @@
        "span_id" 6
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527583698000
-       "duration" 10548000}
+       "start" 1612560766294491000
+       "duration" 53000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -80,8 +81,8 @@
        "span_id" 7
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527594498000
-       "duration" 25000}
+       "start" 1612560766294567000
+       "duration" 15000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -89,8 +90,8 @@
        "span_id" 8
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527594692000
-       "duration" 18000}
+       "start" 1612560766294681000
+       "duration" 24000}
       {"name" "django.view"
        "service" "django"
        "resource" "tests.contrib.django.views.FeedView"
@@ -98,8 +99,8 @@
        "span_id" 9
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527594764000
-       "duration" 3008000}
+       "start" 1612560766294751000
+       "duration" 2480000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -107,8 +108,8 @@
        "span_id" 10
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527597826000
-       "duration" 13000}
+       "start" 1612560766297273000
+       "duration" 18000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -116,8 +117,8 @@
        "span_id" 11
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527597873000
-       "duration" 21000}
+       "start" 1612560766297317000
+       "duration" 30000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -125,8 +126,8 @@
        "span_id" 12
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527597912000
-       "duration" 13000}
+       "start" 1612560766297372000
+       "duration" 17000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -134,8 +135,8 @@
        "span_id" 13
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527597942000
-       "duration" 12000}
+       "start" 1612560766297411000
+       "duration" 14000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -143,8 +144,8 @@
        "span_id" 14
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527597971000
-       "duration" 19000}
+       "start" 1612560766297446000
+       "duration" 27000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -152,5 +153,5 @@
        "span_id" 15
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527598009000
-       "duration" 21000}]]
+       "start" 1612560766297497000
+       "duration" 23000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_18x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_18x.snap
@@ -6,19 +6,20 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603387459862448000
-   "duration" 12163000
-   "meta" {"runtime-id" "5c6cfa4df5cb486fb21f1db1c00b06fc"
+   "start" 1612560734671417000
+   "duration" 4963000
+   "meta" {"runtime-id" "1fb211269d1b4df3abdb69544b7d6716"
            "django.view" "feed-view"
+           "http.method" "GET"
+           "django.response.class" "django.http.response.HttpResponse"
            "http.url" "http://testserver/feed-view/"
            "django.request.class" "django.core.handlers.wsgi.WSGIRequest"
-           "http.method" "GET"
-           "django.user.is_authenticated" "False"
            "http.status_code" "200"
-           "django.response.class" "django.http.response.HttpResponse"}
+           "django.user.is_authenticated" "False"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 9224}}
+              "system.pid" 96676}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -26,8 +27,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459862685000
-       "duration" 2233000}
+       "start" 1612560734671700000
+       "duration" 124000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -35,8 +36,8 @@
        "span_id" 2
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459865066000
-       "duration" 94000}
+       "start" 1612560734671884000
+       "duration" 89000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -44,8 +45,8 @@
        "span_id" 3
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459865210000
-       "duration" 30000}
+       "start" 1612560734672030000
+       "duration" 40000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.SessionAuthenticationMiddleware.process_request"
@@ -53,8 +54,8 @@
        "span_id" 4
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459865274000
-       "duration" 10000}
+       "start" 1612560734672114000
+       "duration" 23000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -62,8 +63,8 @@
        "span_id" 5
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459865313000
-       "duration" 6016000}
+       "start" 1612560734672177000
+       "duration" 87000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -71,8 +72,8 @@
        "span_id" 6
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459871432000
-       "duration" 29000}
+       "start" 1612560734672309000
+       "duration" 22000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -80,8 +81,8 @@
        "span_id" 7
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459871710000
-       "duration" 311000}
+       "start" 1612560734672547000
+       "duration" 269000}
       {"name" "django.view"
        "service" "django"
        "resource" "tests.contrib.django.views.FeedView"
@@ -89,8 +90,8 @@
        "span_id" 8
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459872081000
-       "duration" 2001000}
+       "start" 1612560734672900000
+       "duration" 2578000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -98,8 +99,8 @@
        "span_id" 9
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459874144000
-       "duration" 27000}
+       "start" 1612560734675543000
+       "duration" 43000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -107,8 +108,8 @@
        "span_id" 10
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459874241000
-       "duration" 29000}
+       "start" 1612560734675653000
+       "duration" 41000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -116,8 +117,8 @@
        "span_id" 11
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459874291000
-       "duration" 10000}
+       "start" 1612560734675726000
+       "duration" 22000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -125,8 +126,8 @@
        "span_id" 12
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459874321000
-       "duration" 9000}
+       "start" 1612560734675776000
+       "duration" 20000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -134,8 +135,8 @@
        "span_id" 13
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459874347000
-       "duration" 9000}
+       "start" 1612560734675822000
+       "duration" 17000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -143,5 +144,5 @@
        "span_id" 14
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459874372000
-       "duration" 16000}]]
+       "start" 1612560734675865000
+       "duration" 29000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_21x.snap
@@ -6,19 +6,20 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603387533941228034
-   "duration" 4060239
-   "meta" {"runtime-id" "0758e559eba14ff2b34eb29faa85c427"
+   "start" 1612560992736369000
+   "duration" 5986000
+   "meta" {"runtime-id" "4bc93e60ccf14d5083d6c3a9172d4548"
            "django.view" "feed-view"
-           "http.url" "http://testserver/feed-view/"
            "django.request.class" "django.core.handlers.wsgi.WSGIRequest"
-           "http.method" "GET"
            "django.user.is_authenticated" "False"
-           "http.status_code" "200"
-           "django.response.class" "django.http.response.HttpResponse"}
+           "django.response.class" "django.http.response.HttpResponse"
+           "http.method" "GET"
+           "http.url" "http://testserver/feed-view/"
+           "http.status_code" "200"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 9236}}
+              "system.pid" 97622}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.__call__"
@@ -26,8 +27,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387533941395009
-       "duration" 3751739}
+       "start" 1612560992736477000
+       "duration" 5644000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -35,8 +36,8 @@
            "span_id" 2
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387533941416431
-           "duration" 62180}
+           "start" 1612560992736513000
+           "duration" 147000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.middleware.common.CommonMiddleware.__call__"
@@ -44,8 +45,8 @@
            "span_id" 3
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387533941530490
-           "duration" 3578998}
+           "start" 1612560992736699000
+           "duration" 5375000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -53,8 +54,8 @@
                "span_id" 5
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387533941547273
-               "duration" 43038}
+               "start" 1612560992736731000
+               "duration" 85000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.csrf.CsrfViewMiddleware.__call__"
@@ -62,8 +63,8 @@
                "span_id" 6
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387533941609192
-               "duration" 3457030}
+               "start" 1612560992736853000
+               "duration" 5156000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -71,8 +72,8 @@
                    "span_id" 8
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387533941627695
-                   "duration" 8559}
+                   "start" 1612560992736901000
+                   "duration" 24000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.__call__"
@@ -80,8 +81,8 @@
                    "span_id" 9
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387533941653645
-                   "duration" 3352225}
+                   "start" 1612560992736964000
+                   "duration" 5006000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -89,8 +90,8 @@
                        "span_id" 11
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603387533941668099
-                       "duration" 13394}
+                       "start" 1612560992737065000
+                       "duration" 66000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.messages.middleware.MessageMiddleware.__call__"
@@ -98,8 +99,8 @@
                        "span_id" 12
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603387533941696387
-                       "duration" 3304148}
+                       "start" 1612560992737203000
+                       "duration" 4761000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -107,8 +108,8 @@
                            "span_id" 13
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387533941714087
-                           "duration" 42614}
+                           "start" 1612560992737253000
+                           "duration" 114000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__"
@@ -116,8 +117,8 @@
                            "span_id" 14
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387533941775008
-                           "duration" 3191748}
+                           "start" 1612560992737410000
+                           "duration" 4505000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.security.SecurityMiddleware.__call__"
@@ -125,8 +126,8 @@
                                "span_id" 16
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603387533941791080
-                               "duration" 3133482}
+                               "start" 1612560992737447000
+                               "duration" 4402000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -134,8 +135,8 @@
                                    "span_id" 18
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387533941804822
-                                   "duration" 5786}
+                                   "start" 1612560992737477000
+                                   "duration" 12000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "tests.contrib.django.middleware.ClsMiddleware.__call__"
@@ -143,8 +144,8 @@
                                    "span_id" 19
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387533941825663
-                                   "duration" 3040949}
+                                   "start" 1612560992737514000
+                                   "duration" 4249000}
                                       {"name" "django.middleware"
                                        "service" "django"
                                        "resource" "tests.contrib.django.middleware.EverythingMiddleware"
@@ -152,8 +153,8 @@
                                        "span_id" 21
                                        "trace_id" 0
                                        "parent_id" 19
-                                       "start" 1603387533941840183
-                                       "duration" 3022156}
+                                       "start" 1612560992737559000
+                                       "duration" 4198000}
                                           {"name" "django.middleware"
                                            "service" "django"
                                            "resource" "tests.contrib.django.middleware.EverythingMiddleware.__call__"
@@ -161,8 +162,8 @@
                                            "span_id" 22
                                            "trace_id" 0
                                            "parent_id" 21
-                                           "start" 1603387533941856995
-                                           "duration" 2997763}
+                                           "start" 1612560992737628000
+                                           "duration" 4121000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -170,8 +171,8 @@
                                                "span_id" 23
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387533941912426
-                                               "duration" 11274}
+                                               "start" 1612560992737789000
+                                               "duration" 28000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_view"
@@ -179,8 +180,8 @@
                                                "span_id" 24
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387533941936409
-                                               "duration" 5003}
+                                               "start" 1612560992737847000
+                                               "duration" 11000}
                                               {"name" "django.view"
                                                "service" "django"
                                                "resource" "tests.contrib.django.views.FeedView"
@@ -188,8 +189,8 @@
                                                "span_id" 25
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387533941971605
-                                               "duration" 2860663}
+                                               "start" 1612560992737921000
+                                               "duration" 3808000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -197,8 +198,8 @@
                                    "span_id" 20
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387533944904960
-                                   "duration" 14847}
+                                   "start" 1612560992741824000
+                                   "duration" 19000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -206,8 +207,8 @@
                                "span_id" 17
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603387533944943358
-                               "duration" 18569}
+                               "start" 1612560992741873000
+                               "duration" 35000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -215,8 +216,8 @@
                            "span_id" 15
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387533944984418
-                           "duration" 11499}
+                           "start" 1612560992741942000
+                           "duration" 15000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -224,8 +225,8 @@
                    "span_id" 10
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387533945052263
-                   "duration" 8600}
+                   "start" 1612560992741992000
+                   "duration" 12000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -233,8 +234,8 @@
                "span_id" 7
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387533945082784
-               "duration" 21627}
+               "start" 1612560992742046000
+               "duration" 23000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -242,5 +243,5 @@
            "span_id" 4
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387533945126166
-           "duration" 15619}]]
+           "start" 1612560992742097000
+           "duration" 19000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view.snap
@@ -6,9 +6,9 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603387538031067468
-   "duration" 4931819
-   "meta" {"runtime-id" "6626318d980f452db5ef923e305e302b"
+   "start" 1612561069947281000
+   "duration" 1942000
+   "meta" {"runtime-id" "ed399477c62a49f8a3205405cacc59c9"
            "http.route" "^partial-view/$"
            "http.url" "http://testserver/partial-view/"
            "django.user.is_authenticated" "False"
@@ -18,8 +18,9 @@
            "django.request.class" "django.core.handlers.wsgi.WSGIRequest"
            "django.view" "partial-view"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 9240}}
+              "system.pid" 97933}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.__call__"
@@ -27,8 +28,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387538031335119
-       "duration" 4296672}
+       "start" 1612561069947368000
+       "duration" 1673000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -36,8 +37,8 @@
            "span_id" 2
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387538031363392
-           "duration" 88941}
+           "start" 1612561069947393000
+           "duration" 55000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.middleware.common.CommonMiddleware.__call__"
@@ -45,8 +46,8 @@
            "span_id" 3
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387538031489065
-           "duration" 4051381}
+           "start" 1612561069947473000
+           "duration" 1531000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -54,8 +55,8 @@
                "span_id" 5
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387538031510605
-               "duration" 53564}
+               "start" 1612561069947496000
+               "duration" 42000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.csrf.CsrfViewMiddleware.__call__"
@@ -63,8 +64,8 @@
                "span_id" 6
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387538031586241
-               "duration" 3897793}
+               "start" 1612561069947562000
+               "duration" 1402000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -72,8 +73,8 @@
                    "span_id" 8
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387538031609773
-                   "duration" 10247}
+                   "start" 1612561069947585000
+                   "duration" 11000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.__call__"
@@ -81,8 +82,8 @@
                    "span_id" 9
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387538031639798
-                   "duration" 3726997}
+                   "start" 1612561069947614000
+                   "duration" 1318000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -90,8 +91,8 @@
                        "span_id" 11
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603387538031674655
-                       "duration" 14623}
+                       "start" 1612561069947635000
+                       "duration" 14000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.messages.middleware.MessageMiddleware.__call__"
@@ -99,8 +100,8 @@
                        "span_id" 12
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603387538031711103
-                       "duration" 3644672}
+                       "start" 1612561069947667000
+                       "duration" 1260000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -108,8 +109,8 @@
                            "span_id" 13
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387538031729969
-                           "duration" 51036}
+                           "start" 1612561069947839000
+                           "duration" 53000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__"
@@ -117,8 +118,8 @@
                            "span_id" 14
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387538031805869
-                           "duration" 3346457}
+                           "start" 1612561069947913000
+                           "duration" 980000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.security.SecurityMiddleware.__call__"
@@ -126,8 +127,8 @@
                                "span_id" 16
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603387538031826622
-                               "duration" 3066349}
+                               "start" 1612561069947936000
+                               "duration" 915000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -135,8 +136,8 @@
                                    "span_id" 18
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387538031844613
-                                   "duration" 7478}
+                                   "start" 1612561069947959000
+                                   "duration" 9000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "tests.contrib.django.middleware.ClsMiddleware.__call__"
@@ -144,8 +145,8 @@
                                    "span_id" 19
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387538031869207
-                                   "duration" 2779554}
+                                   "start" 1612561069947986000
+                                   "duration" 826000}
                                       {"name" "django.middleware"
                                        "service" "django"
                                        "resource" "tests.contrib.django.middleware.EverythingMiddleware"
@@ -153,8 +154,8 @@
                                        "span_id" 21
                                        "trace_id" 0
                                        "parent_id" 19
-                                       "start" 1603387538031887611
-                                       "duration" 2751466}
+                                       "start" 1612561069948007000
+                                       "duration" 801000}
                                           {"name" "django.middleware"
                                            "service" "django"
                                            "resource" "tests.contrib.django.middleware.EverythingMiddleware.__call__"
@@ -162,8 +163,8 @@
                                            "span_id" 22
                                            "trace_id" 0
                                            "parent_id" 21
-                                           "start" 1603387538031908230
-                                           "duration" 2713789}
+                                           "start" 1612561069948027000
+                                           "duration" 775000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -171,8 +172,8 @@
                                                "span_id" 23
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387538031985665
-                                               "duration" 13119}
+                                               "start" 1612561069948101000
+                                               "duration" 13000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_view"
@@ -180,8 +181,8 @@
                                                "span_id" 24
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387538032015035
-                                               "duration" 6002}
+                                               "start" 1612561069948131000
+                                               "duration" 9000}
                                               {"name" "django.view"
                                                "service" "django"
                                                "resource" "partial"
@@ -189,8 +190,8 @@
                                                "span_id" 25
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387538032058408
-                                               "duration" 2510141}
+                                               "start" 1612561069948169000
+                                               "duration" 625000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -198,8 +199,8 @@
                                    "span_id" 20
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387538034845024
-                                   "duration" 34599}
+                                   "start" 1612561069948836000
+                                   "duration" 11000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -207,8 +208,8 @@
                                "span_id" 17
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603387538035008986
-                               "duration" 126320}
+                               "start" 1612561069948871000
+                               "duration" 15000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -216,8 +217,8 @@
                            "span_id" 15
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387538035223267
-                           "duration" 114140}
+                           "start" 1612561069948912000
+                           "duration" 11000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -225,8 +226,8 @@
                    "span_id" 10
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387538035447990
-                   "duration" 27145}
+                   "start" 1612561069948950000
+                   "duration" 10000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -234,8 +235,8 @@
                "span_id" 7
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387538035508307
-               "duration" 23622}
+               "start" 1612561069948982000
+               "duration" 17000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -243,5 +244,5 @@
            "span_id" 4
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387538035569395
-           "duration" 25053}]]
+           "start" 1612561069949022000
+           "duration" 15000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_111x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_111x.snap
@@ -6,19 +6,20 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603387527647486000
-   "duration" 1407000
-   "meta" {"runtime-id" "0ca9b922c7db48a3be1024f5f5df4815"
+   "start" 1612560766367326000
+   "duration" 980000
+   "meta" {"runtime-id" "93145384bb364e9c90d9a9309fc26349"
            "django.view" "partial-view"
+           "http.method" "GET"
+           "django.response.class" "django.http.response.HttpResponse"
            "http.url" "http://testserver/partial-view/"
            "django.request.class" "django.core.handlers.wsgi.WSGIRequest"
-           "http.method" "GET"
-           "django.user.is_authenticated" "False"
            "http.status_code" "200"
-           "django.response.class" "django.http.response.HttpResponse"}
+           "django.user.is_authenticated" "False"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 9230}}
+              "system.pid" 96813}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -26,8 +27,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527647636000
-       "duration" 64000}
+       "start" 1612560766367421000
+       "duration" 43000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -35,8 +36,8 @@
        "span_id" 2
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527647735000
-       "duration" 53000}
+       "start" 1612560766367491000
+       "duration" 47000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -44,8 +45,8 @@
        "span_id" 3
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527647814000
-       "duration" 11000}
+       "start" 1612560766367561000
+       "duration" 16000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -53,8 +54,8 @@
        "span_id" 4
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527647846000
-       "duration" 16000}
+       "start" 1612560766367598000
+       "duration" 19000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.SessionAuthenticationMiddleware.process_request"
@@ -62,8 +63,8 @@
        "span_id" 5
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527647882000
-       "duration" 7000}
+       "start" 1612560766367638000
+       "duration" 10000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -71,8 +72,8 @@
        "span_id" 6
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527647909000
-       "duration" 51000}
+       "start" 1612560766367667000
+       "duration" 31000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -80,8 +81,8 @@
        "span_id" 7
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527647983000
-       "duration" 9000}
+       "start" 1612560766367719000
+       "duration" 10000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -89,8 +90,8 @@
        "span_id" 8
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527648070000
-       "duration" 17000}
+       "start" 1612560766367803000
+       "duration" 19000}
       {"name" "django.view"
        "service" "django"
        "resource" "partial"
@@ -98,8 +99,8 @@
        "span_id" 9
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527648136000
-       "duration" 82000}
+       "start" 1612560766367858000
+       "duration" 41000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -107,7 +108,7 @@
        "span_id" 10
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527648259000
+       "start" 1612560766367923000
        "duration" 11000}
       {"name" "django.middleware"
        "service" "django"
@@ -116,8 +117,8 @@
        "span_id" 11
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527648297000
-       "duration" 23000}
+       "start" 1612560766367953000
+       "duration" 22000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -125,8 +126,8 @@
        "span_id" 12
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527648346000
-       "duration" 14000}
+       "start" 1612560766367995000
+       "duration" 13000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -134,8 +135,8 @@
        "span_id" 13
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527648385000
-       "duration" 16000}
+       "start" 1612560766368027000
+       "duration" 12000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -143,8 +144,8 @@
        "span_id" 14
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527648547000
-       "duration" 49000}
+       "start" 1612560766368057000
+       "duration" 25000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -152,5 +153,5 @@
        "span_id" 15
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387527648640000
-       "duration" 23000}]]
+       "start" 1612560766368102000
+       "duration" 16000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_18x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_18x.snap
@@ -6,19 +6,20 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603387459923603000
-   "duration" 2350000
-   "meta" {"runtime-id" "5c6cfa4df5cb486fb21f1db1c00b06fc"
+   "start" 1612560735080111000
+   "duration" 1472000
+   "meta" {"runtime-id" "1fb211269d1b4df3abdb69544b7d6716"
            "django.view" "partial-view"
+           "http.method" "GET"
+           "django.response.class" "django.http.response.HttpResponse"
            "http.url" "http://testserver/partial-view/"
            "django.request.class" "django.core.handlers.wsgi.WSGIRequest"
-           "http.method" "GET"
-           "django.user.is_authenticated" "False"
            "http.status_code" "200"
-           "django.response.class" "django.http.response.HttpResponse"}
+           "django.user.is_authenticated" "False"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 9224}}
+              "system.pid" 96676}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -26,8 +27,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459924066000
-       "duration" 143000}
+       "start" 1612560735080242000
+       "duration" 56000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -35,8 +36,8 @@
        "span_id" 2
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459924268000
-       "duration" 72000}
+       "start" 1612560735080336000
+       "duration" 53000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -44,8 +45,8 @@
        "span_id" 3
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459924401000
-       "duration" 27000}
+       "start" 1612560735080423000
+       "duration" 24000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.SessionAuthenticationMiddleware.process_request"
@@ -53,8 +54,8 @@
        "span_id" 4
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459924462000
-       "duration" 11000}
+       "start" 1612560735080484000
+       "duration" 19000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -62,8 +63,8 @@
        "span_id" 5
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459924514000
-       "duration" 103000}
+       "start" 1612560735080567000
+       "duration" 51000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -71,8 +72,8 @@
        "span_id" 6
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459924722000
-       "duration" 19000}
+       "start" 1612560735080656000
+       "duration" 20000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -80,8 +81,8 @@
        "span_id" 7
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459925138000
-       "duration" 258000}
+       "start" 1612560735080821000
+       "duration" 155000}
       {"name" "django.view"
        "service" "django"
        "resource" "partial"
@@ -89,8 +90,8 @@
        "span_id" 8
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459925455000
-       "duration" 55000}
+       "start" 1612560735081028000
+       "duration" 60000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -98,8 +99,8 @@
        "span_id" 9
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459925540000
-       "duration" 10000}
+       "start" 1612560735081121000
+       "duration" 15000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -107,8 +108,8 @@
        "span_id" 10
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459925574000
-       "duration" 22000}
+       "start" 1612560735081166000
+       "duration" 27000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -116,8 +117,8 @@
        "span_id" 11
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459925621000
-       "duration" 11000}
+       "start" 1612560735081220000
+       "duration" 16000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -125,8 +126,8 @@
        "span_id" 12
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459925655000
-       "duration" 11000}
+       "start" 1612560735081260000
+       "duration" 14000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -134,8 +135,8 @@
        "span_id" 13
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459925688000
-       "duration" 11000}
+       "start" 1612560735081297000
+       "duration" 14000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -143,5 +144,5 @@
        "span_id" 14
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387459925721000
-       "duration" 63000}]]
+       "start" 1612560735081334000
+       "duration" 20000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_21x.snap
@@ -6,19 +6,20 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603387534002600446
-   "duration" 2590873
-   "meta" {"runtime-id" "0758e559eba14ff2b34eb29faa85c427"
+   "start" 1612560992785223000
+   "duration" 1876000
+   "meta" {"runtime-id" "4bc93e60ccf14d5083d6c3a9172d4548"
            "django.view" "partial-view"
-           "http.url" "http://testserver/partial-view/"
            "django.request.class" "django.core.handlers.wsgi.WSGIRequest"
-           "http.method" "GET"
            "django.user.is_authenticated" "False"
-           "http.status_code" "200"
-           "django.response.class" "django.http.response.HttpResponse"}
+           "django.response.class" "django.http.response.HttpResponse"
+           "http.method" "GET"
+           "http.url" "http://testserver/partial-view/"
+           "http.status_code" "200"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 9236}}
+              "system.pid" 97622}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.__call__"
@@ -26,8 +27,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387534002874888
-       "duration" 2128974}
+       "start" 1612560992785337000
+       "duration" 1548000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -35,8 +36,8 @@
            "span_id" 2
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387534002929453
-           "duration" 135545}
+           "start" 1612560992785371000
+           "duration" 76000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.middleware.common.CommonMiddleware.__call__"
@@ -44,8 +45,8 @@
            "span_id" 3
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387534003180908
-           "duration" 1777257}
+           "start" 1612560992785481000
+           "duration" 1347000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -53,8 +54,8 @@
                "span_id" 5
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387534003224264
-               "duration" 89090}
+               "start" 1612560992785511000
+               "duration" 58000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.csrf.CsrfViewMiddleware.__call__"
@@ -62,8 +63,8 @@
                "span_id" 6
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387534003383005
-               "duration" 1529446}
+               "start" 1612560992785605000
+               "duration" 1144000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -71,8 +72,8 @@
                    "span_id" 8
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387534003454852
-                   "duration" 39859}
+                   "start" 1612560992785633000
+                   "duration" 21000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.__call__"
@@ -80,8 +81,8 @@
                    "span_id" 9
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387534003566486
-                   "duration" 1312753}
+                   "start" 1612560992785679000
+                   "duration" 1025000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -89,8 +90,8 @@
                        "span_id" 11
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603387534003616824
-                       "duration" 41931}
+                       "start" 1612560992785704000
+                       "duration" 16000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.messages.middleware.MessageMiddleware.__call__"
@@ -98,8 +99,8 @@
                        "span_id" 12
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603387534003707603
-                       "duration" 1166059}
+                       "start" 1612560992785741000
+                       "duration" 957000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -107,8 +108,8 @@
                            "span_id" 13
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387534003743991
-                           "duration" 122124}
+                           "start" 1612560992785765000
+                           "duration" 105000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__"
@@ -116,8 +117,8 @@
                            "span_id" 14
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387534003907165
-                           "duration" 928109}
+                           "start" 1612560992785910000
+                           "duration" 723000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.security.SecurityMiddleware.__call__"
@@ -125,8 +126,8 @@
                                "span_id" 16
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603387534003947231
-                               "duration" 846403}
+                               "start" 1612560992785950000
+                               "duration" 571000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -134,8 +135,8 @@
                                    "span_id" 18
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387534003975117
-                                   "duration" 15944}
+                                   "start" 1612560992785977000
+                                   "duration" 11000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "tests.contrib.django.middleware.ClsMiddleware.__call__"
@@ -143,8 +144,8 @@
                                    "span_id" 19
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387534004026729
-                                   "duration" 729924}
+                                   "start" 1612560992786011000
+                                   "duration" 471000}
                                       {"name" "django.middleware"
                                        "service" "django"
                                        "resource" "tests.contrib.django.middleware.EverythingMiddleware"
@@ -152,8 +153,8 @@
                                        "span_id" 21
                                        "trace_id" 0
                                        "parent_id" 19
-                                       "start" 1603387534004314394
-                                       "duration" 436843}
+                                       "start" 1612560992786041000
+                                       "duration" 436000}
                                           {"name" "django.middleware"
                                            "service" "django"
                                            "resource" "tests.contrib.django.middleware.EverythingMiddleware.__call__"
@@ -161,8 +162,8 @@
                                            "span_id" 22
                                            "trace_id" 0
                                            "parent_id" 21
-                                           "start" 1603387534004417487
-                                           "duration" 328008}
+                                           "start" 1612560992786090000
+                                           "duration" 381000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -170,8 +171,8 @@
                                                "span_id" 23
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387534004548257
-                                               "duration" 17657}
+                                               "start" 1612560992786290000
+                                               "duration" 44000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_view"
@@ -179,8 +180,8 @@
                                                "span_id" 24
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387534004599101
-                                               "duration" 11020}
+                                               "start" 1612560992786363000
+                                               "duration" 12000}
                                               {"name" "django.view"
                                                "service" "django"
                                                "resource" "partial"
@@ -188,8 +189,8 @@
                                                "span_id" 25
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387534004682566
-                                               "duration" 54732}
+                                               "start" 1612560992786416000
+                                               "duration" 47000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -197,8 +198,8 @@
                                    "span_id" 20
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387534004778651
-                                   "duration" 9236}
+                                   "start" 1612560992786505000
+                                   "duration" 11000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -206,8 +207,8 @@
                                "span_id" 17
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603387534004813898
-                               "duration" 15324}
+                               "start" 1612560992786578000
+                               "duration" 45000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -215,8 +216,8 @@
                            "span_id" 15
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387534004855040
-                           "duration" 13082}
+                           "start" 1612560992786674000
+                           "duration" 18000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -224,8 +225,8 @@
                    "span_id" 10
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387534004897969
-                   "duration" 8658}
+                   "start" 1612560992786731000
+                   "duration" 12000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -233,8 +234,8 @@
                "span_id" 7
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387534004931505
-               "duration" 20394}
+               "start" 1612560992786790000
+               "duration" 30000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -242,5 +243,5 @@
            "span_id" 4
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387534004977914
-           "duration" 19810}]]
+           "start" 1612560992786860000
+           "duration" 19000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding.snap
@@ -6,9 +6,9 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603822795483779500
-   "duration" 12512000
-   "meta" {"runtime-id" "22ad22ac444647c5bd708b98d4feab5b"
+   "start" 1612561051984568000
+   "duration" 6336000
+   "meta" {"runtime-id" "ed399477c62a49f8a3205405cacc59c9"
            "django.response.template.0" "cached_list.html"
            "http.route" "^safe-template/$"
            "http.url" "http://testserver/safe-template/"
@@ -20,8 +20,9 @@
            "django.view" "safe-template-list"
            "django.response.template.1" "auth/user_list.html"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 1374}}
+              "system.pid" 97933}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.__call__"
@@ -29,8 +30,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603822795483992200
-       "duration" 11844300}
+       "start" 1612561051984782000
+       "duration" 5905000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -38,8 +39,8 @@
            "span_id" 2
            "trace_id" 0
            "parent_id" 1
-           "start" 1603822795484234600
-           "duration" 105500}
+           "start" 1612561051984809000
+           "duration" 56000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.middleware.common.CommonMiddleware.__call__"
@@ -47,8 +48,8 @@
            "span_id" 3
            "trace_id" 0
            "parent_id" 1
-           "start" 1603822795484509700
-           "duration" 11199500}
+           "start" 1612561051984888000
+           "duration" 5759000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -56,8 +57,8 @@
                "span_id" 5
                "trace_id" 0
                "parent_id" 3
-               "start" 1603822795484570200
-               "duration" 90800}
+               "start" 1612561051984912000
+               "duration" 47000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.csrf.CsrfViewMiddleware.__call__"
@@ -65,8 +66,8 @@
                "span_id" 6
                "trace_id" 0
                "parent_id" 3
-               "start" 1603822795484720600
-               "duration" 10844300}
+               "start" 1612561051984981000
+               "duration" 5624000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -74,8 +75,8 @@
                    "span_id" 8
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603822795484787100
-                   "duration" 38600}
+                   "start" 1612561051985004000
+                   "duration" 12000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.__call__"
@@ -83,8 +84,8 @@
                    "span_id" 9
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603822795484882000
-                   "duration" 10573200}
+                   "start" 1612561051985034000
+                   "duration" 5537000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -92,8 +93,8 @@
                        "span_id" 11
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603822795484940800
-                       "duration" 44000}
+                       "start" 1612561051985057000
+                       "duration" 14000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.messages.middleware.MessageMiddleware.__call__"
@@ -101,8 +102,8 @@
                        "span_id" 12
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603822795485041000
-                       "duration" 10388400}
+                       "start" 1612561051985090000
+                       "duration" 5475000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -110,8 +111,8 @@
                            "span_id" 13
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603822795485099700
-                           "duration" 104700}
+                           "start" 1612561051985111000
+                           "duration" 70000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__"
@@ -119,8 +120,8 @@
                            "span_id" 14
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603822795485262600
-                           "duration" 10043200}
+                           "start" 1612561051985228000
+                           "duration" 5295000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.security.SecurityMiddleware.__call__"
@@ -128,8 +129,8 @@
                                "span_id" 16
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603822795485320800
-                               "duration" 9757500}
+                               "start" 1612561051985293000
+                               "duration" 5188000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -137,8 +138,8 @@
                                    "span_id" 18
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603822795485482600
-                                   "duration" 34700}
+                                   "start" 1612561051985321000
+                                   "duration" 10000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "tests.contrib.django.middleware.ClsMiddleware.__call__"
@@ -146,8 +147,8 @@
                                    "span_id" 19
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603822795485573600
-                                   "duration" 9421300}
+                                   "start" 1612561051985350000
+                                   "duration" 5091000}
                                       {"name" "django.middleware"
                                        "service" "django"
                                        "resource" "tests.contrib.django.middleware.EverythingMiddleware"
@@ -155,8 +156,8 @@
                                        "span_id" 21
                                        "trace_id" 0
                                        "parent_id" 19
-                                       "start" 1603822795485631500
-                                       "duration" 9336000}
+                                       "start" 1612561051985372000
+                                       "duration" 5065000}
                                           {"name" "django.middleware"
                                            "service" "django"
                                            "resource" "tests.contrib.django.middleware.EverythingMiddleware.__call__"
@@ -164,8 +165,8 @@
                                            "span_id" 22
                                            "trace_id" 0
                                            "parent_id" 21
-                                           "start" 1603822795485688800
-                                           "duration" 9247400}
+                                           "start" 1612561051985395000
+                                           "duration" 5037000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -173,8 +174,8 @@
                                                "span_id" 23
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603822795485804900
-                                               "duration" 35900}
+                                               "start" 1612561051985459000
+                                               "duration" 14000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_view"
@@ -182,8 +183,8 @@
                                                "span_id" 24
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603822795485893900
-                                               "duration" 31900}
+                                               "start" 1612561051985491000
+                                               "duration" 8000}
                                               {"name" "django.view"
                                                "service" "django"
                                                "resource" "tests.contrib.django.views.SafeTemplateUserList"
@@ -191,8 +192,8 @@
                                                "span_id" 25
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603822795485995700
-                                               "duration" 6667500}
+                                               "start" 1612561051985534000
+                                               "duration" 4411000}
                                                   {"name" "django.view.setup"
                                                    "service" "django"
                                                    "resource" "django.views.generic.base.View.setup"
@@ -200,8 +201,8 @@
                                                    "span_id" 28
                                                    "trace_id" 0
                                                    "parent_id" 25
-                                                   "start" 1603822795486080000
-                                                   "duration" 39900}
+                                                   "start" 1612561051985566000
+                                                   "duration" 9000}
                                                   {"name" "django.view.dispatch"
                                                    "service" "django"
                                                    "resource" "django.views.generic.base.View.dispatch"
@@ -209,8 +210,8 @@
                                                    "span_id" 29
                                                    "trace_id" 0
                                                    "parent_id" 25
-                                                   "start" 1603822795486177700
-                                                   "duration" 6472700}
+                                                   "start" 1612561051985594000
+                                                   "duration" 4345000}
                                                       {"name" "django.view.get"
                                                        "service" "django"
                                                        "resource" "django.views.generic.list.BaseListView.get"
@@ -218,8 +219,8 @@
                                                        "span_id" 31
                                                        "trace_id" 0
                                                        "parent_id" 29
-                                                       "start" 1603822795486346100
-                                                       "duration" 6263000}
+                                                       "start" 1612561051985618000
+                                                       "duration" 4307000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_template_response"
@@ -227,8 +228,8 @@
                                                "span_id" 26
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603822795492754300
-                                               "duration" 239100}
+                                               "start" 1612561051989992000
+                                               "duration" 18000}
                                               {"name" "django.response.render"
                                                "service" "django"
                                                "resource" "django.template.response.TemplateResponse.render"
@@ -236,8 +237,8 @@
                                                "span_id" 27
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603822795493767900
-                                               "duration" 1141400}
+                                               "start" 1612561051990032000
+                                               "duration" 393000}
                                                   {"name" "django.template.render"
                                                    "service" "django"
                                                    "resource" "cached_list.html"
@@ -246,8 +247,8 @@
                                                    "span_id" 30
                                                    "trace_id" 0
                                                    "parent_id" 27
-                                                   "start" 1603822795494091100
-                                                   "duration" 760100
+                                                   "start" 1612561051990124000
+                                                   "duration" 283000
                                                    "meta" {"django.template.name" "cached_list.html"
                                                            "django.template.engine.class" "django.template.engine.Engine"}}
                                                       {"name" "django.cache"
@@ -258,8 +259,8 @@
                                                        "span_id" 32
                                                        "trace_id" 0
                                                        "parent_id" 30
-                                                       "start" 1603822795494620700
-                                                       "duration" 170800
+                                                       "start" 1612561051990314000
+                                                       "duration" 73000
                                                        "meta" {"django.cache.backend" "django.core.cache.backends.locmem.LocMemCache"
                                                                "django.cache.key" "template.cache.users_list.d41d8cd98f00b204e9800998ecf8427e"}}
                                   {"name" "django.middleware"
@@ -269,8 +270,8 @@
                                    "span_id" 20
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603822795495044500
-                                   "duration" 22400}
+                                   "start" 1612561051990465000
+                                   "duration" 11000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -278,8 +279,8 @@
                                "span_id" 17
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603822795495124600
-                               "duration" 157400}
+                               "start" 1612561051990501000
+                               "duration" 17000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -287,8 +288,8 @@
                            "span_id" 15
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603822795495358800
-                           "duration" 40200}
+                           "start" 1612561051990545000
+                           "duration" 15000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -296,8 +297,8 @@
                    "span_id" 10
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603822795495506600
-                   "duration" 33700}
+                   "start" 1612561051990591000
+                   "duration" 10000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -305,8 +306,8 @@
                "span_id" 7
                "trace_id" 0
                "parent_id" 3
-               "start" 1603822795495624100
-               "duration" 54000}
+               "start" 1612561051990624000
+               "duration" 19000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -314,5 +315,5 @@
            "span_id" 4
            "trace_id" 0
            "parent_id" 1
-           "start" 1603822795495760000
-           "duration" 47100}]]
+           "start" 1612561051990667000
+           "duration" 16000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_111x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_111x.snap
@@ -6,9 +6,9 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603830197372502000
-   "duration" 2194000
-   "meta" {"runtime-id" "0be8dac7e4464fc095b6bd5b88b4b7d9"
+   "start" 1612560746028316000
+   "duration" 2375000
+   "meta" {"runtime-id" "93145384bb364e9c90d9a9309fc26349"
            "django.response.template.0" "cached_list.html"
            "http.url" "http://testserver/safe-template/"
            "django.user.is_authenticated" "False"
@@ -19,8 +19,9 @@
            "django.view" "safe-template-list"
            "django.response.template.1" "auth/user_list.html"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 660}}
+              "system.pid" 96813}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -28,8 +29,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197372601000
-       "duration" 93000}
+       "start" 1612560746028482000
+       "duration" 49000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -37,8 +38,8 @@
        "span_id" 2
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197372726000
-       "duration" 47000}
+       "start" 1612560746028564000
+       "duration" 50000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -46,8 +47,8 @@
        "span_id" 3
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197372849000
-       "duration" 20000}
+       "start" 1612560746028669000
+       "duration" 41000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -55,8 +56,8 @@
        "span_id" 4
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197372894000
-       "duration" 19000}
+       "start" 1612560746028771000
+       "duration" 41000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.SessionAuthenticationMiddleware.process_request"
@@ -64,8 +65,8 @@
        "span_id" 5
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197372941000
-       "duration" 16000}
+       "start" 1612560746028857000
+       "duration" 13000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -73,8 +74,8 @@
        "span_id" 6
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197372983000
-       "duration" 40000}
+       "start" 1612560746028894000
+       "duration" 54000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -82,8 +83,8 @@
        "span_id" 7
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197373051000
-       "duration" 16000}
+       "start" 1612560746028983000
+       "duration" 20000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -91,7 +92,7 @@
        "span_id" 8
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197373133000
+       "start" 1612560746029127000
        "duration" 25000}
       {"name" "django.view"
        "service" "django"
@@ -100,8 +101,8 @@
        "span_id" 9
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197373200000
-       "duration" 224000}
+       "start" 1612560746029194000
+       "duration" 418000}
           {"name" "django.view.dispatch"
            "service" "django"
            "resource" "django.views.generic.base.View.dispatch"
@@ -109,8 +110,8 @@
            "span_id" 17
            "trace_id" 0
            "parent_id" 9
-           "start" 1603830197373243000
-           "duration" 167000}
+           "start" 1612560746029237000
+           "duration" 369000}
               {"name" "django.view.get"
                "service" "django"
                "resource" "django.views.generic.list.BaseListView.get"
@@ -118,8 +119,8 @@
                "span_id" 19
                "trace_id" 0
                "parent_id" 17
-               "start" 1603830197373280000
-               "duration" 112000}
+               "start" 1612560746029268000
+               "duration" 329000}
       {"name" "django.response.render"
        "service" "django"
        "resource" "django.template.response.TemplateResponse.render"
@@ -127,8 +128,8 @@
        "span_id" 10
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197373456000
-       "duration" 812000}
+       "start" 1612560746029643000
+       "duration" 472000}
           {"name" "django.template.render"
            "service" "django"
            "resource" "cached_list.html"
@@ -137,8 +138,8 @@
            "span_id" 18
            "trace_id" 0
            "parent_id" 10
-           "start" 1603830197373866000
-           "duration" 367000
+           "start" 1612560746029756000
+           "duration" 331000
            "meta" {"django.template.name" "cached_list.html"
                    "django.template.engine.class" "django.template.engine.Engine"}}
               {"name" "django.cache"
@@ -149,8 +150,8 @@
                "span_id" 20
                "trace_id" 0
                "parent_id" 18
-               "start" 1603830197374084000
-               "duration" 114000
+               "start" 1612560746029957000
+               "duration" 104000
                "meta" {"django.cache.key" "template.cache.users_list.d41d8cd98f00b204e9800998ecf8427e"
                        "django.cache.backend" "django.core.cache.backends.locmem.LocMemCache"}}
       {"name" "django.middleware"
@@ -160,8 +161,8 @@
        "span_id" 11
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197374299000
-       "duration" 17000}
+       "start" 1612560746030143000
+       "duration" 15000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -169,8 +170,8 @@
        "span_id" 12
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197374344000
-       "duration" 29000}
+       "start" 1612560746030182000
+       "duration" 26000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -178,8 +179,8 @@
        "span_id" 13
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197374400000
-       "duration" 18000}
+       "start" 1612560746030231000
+       "duration" 15000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -187,8 +188,8 @@
        "span_id" 14
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197374445000
-       "duration" 19000}
+       "start" 1612560746030267000
+       "duration" 12000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -196,8 +197,8 @@
        "span_id" 15
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197374491000
-       "duration" 30000}
+       "start" 1612560746030301000
+       "duration" 24000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -205,5 +206,5 @@
        "span_id" 16
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830197374548000
-       "duration" 23000}]]
+       "start" 1612560746030401000
+       "duration" 34000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_18x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_18x.snap
@@ -6,9 +6,9 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603830174088384000
-   "duration" 4761000
-   "meta" {"runtime-id" "88f6dbbd1a9a4bc6ad0fa7f28eb70f15"
+   "start" 1612560776565942000
+   "duration" 3147000
+   "meta" {"runtime-id" "1af879a590fc4b66a4fc96a2133c8332"
            "django.response.template.0" "cached_list.html"
            "http.url" "http://testserver/safe-template/"
            "django.user.is_authenticated" "False"
@@ -19,8 +19,9 @@
            "django.view" "safe-template-list"
            "django.response.template.1" "auth/user_list.html"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 7}}
+              "system.pid" 96919}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -28,8 +29,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174088608000
-       "duration" 272000}
+       "start" 1612560776566108000
+       "duration" 55000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -37,8 +38,8 @@
        "span_id" 2
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174088938000
-       "duration" 66000}
+       "start" 1612560776566198000
+       "duration" 38000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -46,8 +47,8 @@
        "span_id" 3
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174089043000
-       "duration" 28000}
+       "start" 1612560776566261000
+       "duration" 16000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.auth.middleware.SessionAuthenticationMiddleware.process_request"
@@ -55,8 +56,8 @@
        "span_id" 4
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174089101000
-       "duration" 16000}
+       "start" 1612560776566300000
+       "duration" 11000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -64,8 +65,8 @@
        "span_id" 5
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174089145000
-       "duration" 45000}
+       "start" 1612560776566373000
+       "duration" 62000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -73,8 +74,8 @@
        "span_id" 6
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174089219000
-       "duration" 19000}
+       "start" 1612560776566477000
+       "duration" 16000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -82,8 +83,8 @@
        "span_id" 7
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174089337000
-       "duration" 211000}
+       "start" 1612560776566594000
+       "duration" 137000}
       {"name" "django.view"
        "service" "django"
        "resource" "tests.contrib.django.views.SafeTemplateUserList"
@@ -91,8 +92,8 @@
        "span_id" 8
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174089596000
-       "duration" 304000}
+       "start" 1612560776566782000
+       "duration" 449000}
           {"name" "django.view.dispatch"
            "service" "django"
            "resource" "django.views.generic.base.View.dispatch"
@@ -100,8 +101,8 @@
            "span_id" 16
            "trace_id" 0
            "parent_id" 8
-           "start" 1603830174089700000
-           "duration" 186000}
+           "start" 1612560776566829000
+           "duration" 397000}
               {"name" "django.view.get"
                "service" "django"
                "resource" "django.views.generic.list.BaseListView.get"
@@ -109,8 +110,8 @@
                "span_id" 18
                "trace_id" 0
                "parent_id" 16
-               "start" 1603830174089740000
-               "duration" 129000}
+               "start" 1612560776566862000
+               "duration" 355000}
       {"name" "django.response.render"
        "service" "django"
        "resource" "django.template.response.TemplateResponse.render"
@@ -118,8 +119,8 @@
        "span_id" 9
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174089935000
-       "duration" 2769000}
+       "start" 1612560776567265000
+       "duration" 1118000}
           {"name" "django.template.render"
            "service" "django"
            "resource" "cached_list.html"
@@ -128,8 +129,8 @@
            "span_id" 17
            "trace_id" 0
            "parent_id" 9
-           "start" 1603830174092004000
-           "duration" 665000
+           "start" 1612560776567765000
+           "duration" 557000
            "meta" {"django.template.name" "cached_list.html"
                    "django.template.engine.class" "django.template.engine.Engine"}}
               {"name" "django.cache"
@@ -140,8 +141,8 @@
                "span_id" 19
                "trace_id" 0
                "parent_id" 17
-               "start" 1603830174092384000
-               "duration" 249000
+               "start" 1612560776568149000
+               "duration" 124000
                "meta" {"django.cache.key" "template.cache.users_list.d41d8cd98f00b204e9800998ecf8427e"
                        "django.cache.backend" "django.core.cache.backends.locmem.LocMemCache"}}
       {"name" "django.middleware"
@@ -151,8 +152,8 @@
        "span_id" 10
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174092738000
-       "duration" 18000}
+       "start" 1612560776568426000
+       "duration" 17000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -160,8 +161,8 @@
        "span_id" 11
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174092785000
-       "duration" 31000}
+       "start" 1612560776568488000
+       "duration" 40000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -169,8 +170,8 @@
        "span_id" 12
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174092847000
-       "duration" 20000}
+       "start" 1612560776568576000
+       "duration" 29000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -178,8 +179,8 @@
        "span_id" 13
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174092890000
-       "duration" 18000}
+       "start" 1612560776568637000
+       "duration" 15000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -187,8 +188,8 @@
        "span_id" 14
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174092935000
-       "duration" 18000}
+       "start" 1612560776568675000
+       "duration" 15000}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -196,5 +197,5 @@
        "span_id" 15
        "trace_id" 0
        "parent_id" 0
-       "start" 1603830174092980000
-       "duration" 26000}]]
+       "start" 1612560776568712000
+       "duration" 25000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_21x.snap
@@ -6,9 +6,9 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603824455602230100
-   "duration" 2655500
-   "meta" {"runtime-id" "00c68f9f587449a991d0e44a861a7e5e"
+   "start" 1612560970276727000
+   "duration" 3363000
+   "meta" {"runtime-id" "4bc93e60ccf14d5083d6c3a9172d4548"
            "django.response.template.0" "cached_list.html"
            "http.url" "http://testserver/safe-template/"
            "django.user.is_authenticated" "False"
@@ -19,8 +19,9 @@
            "django.view" "safe-template-list"
            "django.response.template.1" "auth/user_list.html"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 1375}}
+              "system.pid" 97622}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.__call__"
@@ -28,8 +29,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603824455602369300
-       "duration" 2362000}
+       "start" 1612560970276960000
+       "duration" 2655000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -37,8 +38,8 @@
            "span_id" 2
            "trace_id" 0
            "parent_id" 1
-           "start" 1603824455602502100
-           "duration" 55900}
+           "start" 1612560970277015000
+           "duration" 63000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.middleware.common.CommonMiddleware.__call__"
@@ -46,8 +47,8 @@
            "span_id" 3
            "trace_id" 0
            "parent_id" 1
-           "start" 1603824455602591200
-           "duration" 2074900}
+           "start" 1612560970277104000
+           "duration" 2469000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -55,8 +56,8 @@
                "span_id" 5
                "trace_id" 0
                "parent_id" 3
-               "start" 1603824455602621200
-               "duration" 46900}
+               "start" 1612560970277129000
+               "duration" 45000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.csrf.CsrfViewMiddleware.__call__"
@@ -64,8 +65,8 @@
                "span_id" 6
                "trace_id" 0
                "parent_id" 3
-               "start" 1603824455602697200
-               "duration" 1900300}
+               "start" 1612560970277198000
+               "duration" 2326000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -73,8 +74,8 @@
                    "span_id" 8
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603824455602726400
-                   "duration" 18400}
+                   "start" 1612560970277224000
+                   "duration" 12000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.__call__"
@@ -82,8 +83,8 @@
                    "span_id" 9
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603824455602773100
-                   "duration" 1763700}
+                   "start" 1612560970277256000
+                   "duration" 2229000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -91,8 +92,8 @@
                        "span_id" 11
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603824455602802700
-                       "duration" 23400}
+                       "start" 1612560970277277000
+                       "duration" 14000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.messages.middleware.MessageMiddleware.__call__"
@@ -100,8 +101,8 @@
                        "span_id" 12
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603824455602851100
-                       "duration" 1671100}
+                       "start" 1612560970277310000
+                       "duration" 2170000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -109,8 +110,8 @@
                            "span_id" 13
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603824455602878700
-                           "duration" 54900}
+                           "start" 1612560970277331000
+                           "duration" 50000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__"
@@ -118,8 +119,8 @@
                            "span_id" 14
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603824455602962700
-                           "duration" 1497700}
+                           "start" 1612560970277404000
+                           "duration" 2036000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.security.SecurityMiddleware.__call__"
@@ -127,8 +128,8 @@
                                "span_id" 16
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603824455602992900
-                               "duration" 1400600}
+                               "start" 1612560970277431000
+                               "duration" 1958000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -136,8 +137,8 @@
                                    "span_id" 18
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603824455603021700
-                                   "duration" 16300}
+                                   "start" 1612560970277459000
+                                   "duration" 29000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "tests.contrib.django.middleware.ClsMiddleware.__call__"
@@ -145,8 +146,8 @@
                                    "span_id" 19
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603824455603067100
-                                   "duration" 1264000}
+                                   "start" 1612560970277564000
+                                   "duration" 1775000}
                                       {"name" "django.middleware"
                                        "service" "django"
                                        "resource" "tests.contrib.django.middleware.EverythingMiddleware"
@@ -154,8 +155,8 @@
                                        "span_id" 21
                                        "trace_id" 0
                                        "parent_id" 19
-                                       "start" 1603824455603145000
-                                       "duration" 1171900}
+                                       "start" 1612560970277643000
+                                       "duration" 1691000}
                                           {"name" "django.middleware"
                                            "service" "django"
                                            "resource" "tests.contrib.django.middleware.EverythingMiddleware.__call__"
@@ -163,8 +164,8 @@
                                            "span_id" 22
                                            "trace_id" 0
                                            "parent_id" 21
-                                           "start" 1603824455603174900
-                                           "duration" 1127200}
+                                           "start" 1612560970277709000
+                                           "duration" 1619000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -172,8 +173,8 @@
                                                "span_id" 23
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603824455603240100
-                                               "duration" 21500}
+                                               "start" 1612560970277865000
+                                               "duration" 28000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_view"
@@ -181,8 +182,8 @@
                                                "span_id" 24
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603824455603289200
-                                               "duration" 15600}
+                                               "start" 1612560970277938000
+                                               "duration" 35000}
                                               {"name" "django.view"
                                                "service" "django"
                                                "resource" "tests.contrib.django.views.SafeTemplateUserList"
@@ -190,8 +191,8 @@
                                                "span_id" 25
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603824455603346500
-                                               "duration" 281300}
+                                               "start" 1612560970278026000
+                                               "duration" 478000}
                                                   {"name" "django.view.dispatch"
                                                    "service" "django"
                                                    "resource" "django.views.generic.base.View.dispatch"
@@ -199,8 +200,8 @@
                                                    "span_id" 28
                                                    "trace_id" 0
                                                    "parent_id" 25
-                                                   "start" 1603824455603405200
-                                                   "duration" 208200}
+                                                   "start" 1612560970278112000
+                                                   "duration" 384000}
                                                       {"name" "django.view.get"
                                                        "service" "django"
                                                        "resource" "django.views.generic.list.BaseListView.get"
@@ -208,8 +209,8 @@
                                                        "span_id" 30
                                                        "trace_id" 0
                                                        "parent_id" 28
-                                                       "start" 1603824455603439900
-                                                       "duration" 156400}
+                                                       "start" 1612560970278163000
+                                                       "duration" 320000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_template_response"
@@ -217,8 +218,8 @@
                                                "span_id" 26
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603824455603660000
-                                               "duration" 16300}
+                                               "start" 1612560970278569000
+                                               "duration" 26000}
                                               {"name" "django.response.render"
                                                "service" "django"
                                                "resource" "django.template.response.TemplateResponse.render"
@@ -226,8 +227,8 @@
                                                "span_id" 27
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603824455603704600
-                                               "duration" 581600}
+                                               "start" 1612560970278626000
+                                               "duration" 695000}
                                                   {"name" "django.template.render"
                                                    "service" "django"
                                                    "resource" "cached_list.html"
@@ -236,8 +237,8 @@
                                                    "span_id" 29
                                                    "trace_id" 0
                                                    "parent_id" 27
-                                                   "start" 1603824455603871300
-                                                   "duration" 385200
+                                                   "start" 1612560970278731000
+                                                   "duration" 546000
                                                    "meta" {"django.template.name" "cached_list.html"
                                                            "django.template.engine.class" "django.template.engine.Engine"}}
                                                       {"name" "django.cache"
@@ -248,8 +249,8 @@
                                                        "span_id" 31
                                                        "trace_id" 0
                                                        "parent_id" 29
-                                                       "start" 1603824455604082100
-                                                       "duration" 144400
+                                                       "start" 1612560970279087000
+                                                       "duration" 136000
                                                        "meta" {"django.cache.backend" "django.core.cache.backends.locmem.LocMemCache"
                                                                "django.cache.key" "template.cache.users_list.d41d8cd98f00b204e9800998ecf8427e"}}
                                   {"name" "django.middleware"
@@ -259,8 +260,8 @@
                                    "span_id" 20
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603824455604361900
-                                   "duration" 17100}
+                                   "start" 1612560970279369000
+                                   "duration" 15000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -268,8 +269,8 @@
                                "span_id" 17
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603824455604421900
-                               "duration" 23400}
+                               "start" 1612560970279414000
+                               "duration" 21000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -277,8 +278,8 @@
                            "span_id" 15
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603824455604488100
-                           "duration" 19500}
+                           "start" 1612560970279462000
+                           "duration" 13000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -286,8 +287,8 @@
                    "span_id" 10
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603824455604565100
-                   "duration" 17900}
+                   "start" 1612560970279503000
+                   "duration" 16000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -295,8 +296,8 @@
                "span_id" 7
                "trace_id" 0
                "parent_id" 3
-               "start" 1603824455604625500
-               "duration" 25900}
+               "start" 1612560970279546000
+               "duration" 20000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -304,5 +305,5 @@
            "span_id" 4
            "trace_id" 0
            "parent_id" 1
-           "start" 1603824455604694300
-           "duration" 22400}]]
+           "start" 1612560970279594000
+           "duration" 16000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.snap
@@ -6,9 +6,9 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603387537908847729
-   "duration" 38038773
-   "meta" {"runtime-id" "6626318d980f452db5ef923e305e302b"
+   "start" 1612561069871795000
+   "duration" 3702000
+   "meta" {"runtime-id" "ed399477c62a49f8a3205405cacc59c9"
            "http.route" "include/test/"
            "http.url" "http://testserver/include/test/"
            "django.user.is_authenticated" "False"
@@ -18,8 +18,9 @@
            "django.request.class" "django.core.handlers.wsgi.WSGIRequest"
            "django.view" "tests.contrib.django.django_app.extra_urls.include_view"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 9240}}
+              "system.pid" 97933}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.__call__"
@@ -27,8 +28,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387537909045000
-       "duration" 37639314}
+       "start" 1612561069871976000
+       "duration" 3156000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -36,8 +37,8 @@
            "span_id" 2
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387537909199429
-           "duration" 1181530}
+           "start" 1612561069872023000
+           "duration" 91000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.middleware.common.CommonMiddleware.__call__"
@@ -45,8 +46,8 @@
            "span_id" 3
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387537910453615
-           "duration" 36190074}
+           "start" 1612561069872168000
+           "duration" 2912000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -54,8 +55,8 @@
                "span_id" 5
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387537910518212
-               "duration" 107969}
+               "start" 1612561069872228000
+               "duration" 83000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.csrf.CsrfViewMiddleware.__call__"
@@ -63,8 +64,8 @@
                "span_id" 6
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387537910665740
-               "duration" 35942066}
+               "start" 1612561069872343000
+               "duration" 2685000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -72,8 +73,8 @@
                    "span_id" 8
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387537910703392
-                   "duration" 64373}
+                   "start" 1612561069872377000
+                   "duration" 17000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.__call__"
@@ -81,8 +82,8 @@
                    "span_id" 9
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387537910818022
-                   "duration" 35760147}
+                   "start" 1612561069872424000
+                   "duration" 2564000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -90,8 +91,8 @@
                        "span_id" 11
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603387537910861489
-                       "duration" 39944}
+                       "start" 1612561069872452000
+                       "duration" 26000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.messages.middleware.MessageMiddleware.__call__"
@@ -99,8 +100,8 @@
                        "span_id" 12
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603387537910950384
-                       "duration" 35621220}
+                       "start" 1612561069872502000
+                       "duration" 2480000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -108,8 +109,8 @@
                            "span_id" 13
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387537910996288
-                           "duration" 8931596}
+                           "start" 1612561069872531000
+                           "duration" 101000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__"
@@ -117,8 +118,8 @@
                            "span_id" 14
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387537919986228
-                           "duration" 26550363}
+                           "start" 1612561069872657000
+                           "duration" 2280000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.security.SecurityMiddleware.__call__"
@@ -126,8 +127,8 @@
                                "span_id" 16
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603387537920013220
-                               "duration" 26448729}
+                               "start" 1612561069872687000
+                               "duration" 2200000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -135,8 +136,8 @@
                                    "span_id" 18
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387537920111977
-                                   "duration" 11220}
+                                   "start" 1612561069872713000
+                                   "duration" 12000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "tests.contrib.django.middleware.ClsMiddleware.__call__"
@@ -144,8 +145,8 @@
                                    "span_id" 19
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387537920143057
-                                   "duration" 26206242}
+                                   "start" 1612561069872748000
+                                   "duration" 2086000}
                                       {"name" "django.middleware"
                                        "service" "django"
                                        "resource" "tests.contrib.django.middleware.EverythingMiddleware"
@@ -153,8 +154,8 @@
                                        "span_id" 21
                                        "trace_id" 0
                                        "parent_id" 19
-                                       "start" 1603387537920196641
-                                       "duration" 26144513}
+                                       "start" 1612561069872778000
+                                       "duration" 2051000}
                                           {"name" "django.middleware"
                                            "service" "django"
                                            "resource" "tests.contrib.django.middleware.EverythingMiddleware.__call__"
@@ -162,8 +163,8 @@
                                            "span_id" 22
                                            "trace_id" 0
                                            "parent_id" 21
-                                           "start" 1603387537920213235
-                                           "duration" 26115796}
+                                           "start" 1612561069872808000
+                                           "duration" 2014000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -171,8 +172,8 @@
                                                "span_id" 23
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387537920408755
-                                               "duration" 28925}
+                                               "start" 1612561069872930000
+                                               "duration" 19000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_view"
@@ -180,8 +181,8 @@
                                                "span_id" 24
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387537920451875
-                                               "duration" 4969}
+                                               "start" 1612561069872972000
+                                               "duration" 12000}
                                               {"name" "django.view"
                                                "service" "django"
                                                "resource" "tests.contrib.django.django_app.extra_urls.include_view"
@@ -189,8 +190,8 @@
                                                "span_id" 25
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387537920508605
-                                               "duration" 25781099}
+                                               "start" 1612561069873025000
+                                               "duration" 1786000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -198,8 +199,8 @@
                                    "span_id" 20
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387537946419695
-                                   "duration" 29006}
+                                   "start" 1612561069874865000
+                                   "duration" 16000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -207,8 +208,8 @@
                                "span_id" 17
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603387537946506947
-                               "duration" 23769}
+                               "start" 1612561069874911000
+                               "duration" 20000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -216,8 +217,8 @@
                            "span_id" 15
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387537946556284
-                           "duration" 10636}
+                           "start" 1612561069874961000
+                           "duration" 15000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -225,8 +226,8 @@
                    "span_id" 10
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387537946594986
-                   "duration" 8588}
+                   "start" 1612561069875010000
+                   "duration" 13000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -234,8 +235,8 @@
                "span_id" 7
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387537946623643
-               "duration" 15572}
+               "start" 1612561069875050000
+               "duration" 25000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -243,5 +244,5 @@
            "span_id" 4
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387537946659595
-           "duration" 19969}]]
+           "start" 1612561069875103000
+           "duration" 24000}]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include_21x.snap
@@ -6,19 +6,20 @@
    "span_id" 0
    "trace_id" 0
    "parent_id" nil
-   "start" 1603387533897093045
-   "duration" 10309737
-   "meta" {"runtime-id" "0758e559eba14ff2b34eb29faa85c427"
+   "start" 1612560992691794000
+   "duration" 1719000
+   "meta" {"runtime-id" "4bc93e60ccf14d5083d6c3a9172d4548"
            "django.view" "tests.contrib.django.django_app.extra_urls.include_view"
-           "http.url" "http://testserver/include/test/"
            "django.request.class" "django.core.handlers.wsgi.WSGIRequest"
-           "http.method" "GET"
            "django.user.is_authenticated" "False"
-           "http.status_code" "200"
-           "django.response.class" "django.http.response.HttpResponse"}
+           "django.response.class" "django.http.response.HttpResponse"
+           "http.method" "GET"
+           "http.url" "http://testserver/include/test/"
+           "http.status_code" "200"}
    "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
               "_sampling_priority_v1" 1
-              "system.pid" 9236}}
+              "system.pid" 97622}}
       {"name" "django.middleware"
        "service" "django"
        "resource" "django.contrib.sessions.middleware.SessionMiddleware.__call__"
@@ -26,8 +27,8 @@
        "span_id" 1
        "trace_id" 0
        "parent_id" 0
-       "start" 1603387533897300098
-       "duration" 9962826}
+       "start" 1612560992691956000
+       "duration" 1271000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_request"
@@ -35,8 +36,8 @@
            "span_id" 2
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387533897454211
-           "duration" 1887903}
+           "start" 1612560992691992000
+           "duration" 85000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.middleware.common.CommonMiddleware.__call__"
@@ -44,8 +45,8 @@
            "span_id" 3
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387533899400022
-           "duration" 7822962}
+           "start" 1612560992692106000
+           "duration" 1074000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_request"
@@ -53,8 +54,8 @@
                "span_id" 5
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387533899425552
-               "duration" 169248}
+               "start" 1612560992692136000
+               "duration" 63000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.csrf.CsrfViewMiddleware.__call__"
@@ -62,8 +63,8 @@
                "span_id" 6
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387533899663091
-               "duration" 7525060}
+               "start" 1612560992692226000
+               "duration" 895000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_request"
@@ -71,8 +72,8 @@
                    "span_id" 8
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387533899683232
-                   "duration" 16345}
+                   "start" 1612560992692257000
+                   "duration" 20000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.__call__"
@@ -80,8 +81,8 @@
                    "span_id" 9
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387533899721092
-                   "duration" 7441399}
+                   "start" 1612560992692301000
+                   "duration" 784000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
@@ -89,8 +90,8 @@
                        "span_id" 11
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603387533899737957
-                       "duration" 13277}
+                       "start" 1612560992692330000
+                       "duration" 27000}
                       {"name" "django.middleware"
                        "service" "django"
                        "resource" "django.contrib.messages.middleware.MessageMiddleware.__call__"
@@ -98,8 +99,8 @@
                        "span_id" 12
                        "trace_id" 0
                        "parent_id" 9
-                       "start" 1603387533899766876
-                       "duration" 7390563}
+                       "start" 1612560992692381000
+                       "duration" 698000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_request"
@@ -107,8 +108,8 @@
                            "span_id" 13
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387533899783255
-                           "duration" 6700866}
+                           "start" 1612560992692412000
+                           "duration" 92000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__"
@@ -116,8 +117,8 @@
                            "span_id" 14
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387533906538773
-                           "duration" 589932}
+                           "start" 1612560992692528000
+                           "duration" 512000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.security.SecurityMiddleware.__call__"
@@ -125,8 +126,8 @@
                                "span_id" 16
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603387533906574842
-                               "duration" 518289}
+                               "start" 1612560992692559000
+                               "duration" 438000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_request"
@@ -134,8 +135,8 @@
                                    "span_id" 18
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387533906595177
-                                   "duration" 8341}
+                                   "start" 1612560992692585000
+                                   "duration" 10000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "tests.contrib.django.middleware.ClsMiddleware.__call__"
@@ -143,8 +144,8 @@
                                    "span_id" 19
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387533906622282
-                                   "duration" 437063}
+                                   "start" 1612560992692618000
+                                   "duration" 340000}
                                       {"name" "django.middleware"
                                        "service" "django"
                                        "resource" "tests.contrib.django.middleware.EverythingMiddleware"
@@ -152,8 +153,8 @@
                                        "span_id" 21
                                        "trace_id" 0
                                        "parent_id" 19
-                                       "start" 1603387533906639312
-                                       "duration" 414366}
+                                       "start" 1612560992692644000
+                                       "duration" 309000}
                                           {"name" "django.middleware"
                                            "service" "django"
                                            "resource" "tests.contrib.django.middleware.EverythingMiddleware.__call__"
@@ -161,8 +162,8 @@
                                            "span_id" 22
                                            "trace_id" 0
                                            "parent_id" 21
-                                           "start" 1603387533906658146
-                                           "duration" 383658}
+                                           "start" 1612560992692675000
+                                           "duration" 272000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "django.middleware.csrf.CsrfViewMiddleware.process_view"
@@ -170,8 +171,8 @@
                                                "span_id" 23
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387533906869019
-                                               "duration" 25469}
+                                               "start" 1612560992692783000
+                                               "duration" 20000}
                                               {"name" "django.middleware"
                                                "service" "django"
                                                "resource" "tests.contrib.django.middleware.EverythingMiddleware.process_view"
@@ -179,8 +180,8 @@
                                                "span_id" 24
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387533906915258
-                                               "duration" 7068}
+                                               "start" 1612560992692824000
+                                               "duration" 10000}
                                               {"name" "django.view"
                                                "service" "django"
                                                "resource" "tests.contrib.django.django_app.extra_urls.include_view"
@@ -188,8 +189,8 @@
                                                "span_id" 25
                                                "trace_id" 0
                                                "parent_id" 22
-                                               "start" 1603387533906960021
-                                               "duration" 48347}
+                                               "start" 1612560992692873000
+                                               "duration" 67000}
                                   {"name" "django.middleware"
                                    "service" "django"
                                    "resource" "django.middleware.security.SecurityMiddleware.process_response"
@@ -197,8 +198,8 @@
                                    "span_id" 20
                                    "trace_id" 0
                                    "parent_id" 16
-                                   "start" 1603387533907081325
-                                   "duration" 7433}
+                                   "start" 1612560992692980000
+                                   "duration" 12000}
                               {"name" "django.middleware"
                                "service" "django"
                                "resource" "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response"
@@ -206,8 +207,8 @@
                                "span_id" 17
                                "trace_id" 0
                                "parent_id" 14
-                               "start" 1603387533907108847
-                               "duration" 15108}
+                               "start" 1612560992693018000
+                               "duration" 17000}
                           {"name" "django.middleware"
                            "service" "django"
                            "resource" "django.contrib.messages.middleware.MessageMiddleware.process_response"
@@ -215,8 +216,8 @@
                            "span_id" 15
                            "trace_id" 0
                            "parent_id" 12
-                           "start" 1603387533907144816
-                           "duration" 8196}
+                           "start" 1612560992693060000
+                           "duration" 14000}
                   {"name" "django.middleware"
                    "service" "django"
                    "resource" "django.middleware.csrf.CsrfViewMiddleware.process_response"
@@ -224,8 +225,8 @@
                    "span_id" 10
                    "trace_id" 0
                    "parent_id" 6
-                   "start" 1603387533907177054
-                   "duration" 6843}
+                   "start" 1612560992693105000
+                   "duration" 11000}
               {"name" "django.middleware"
                "service" "django"
                "resource" "django.middleware.common.CommonMiddleware.process_response"
@@ -233,8 +234,8 @@
                "span_id" 7
                "trace_id" 0
                "parent_id" 3
-               "start" 1603387533907202779
-               "duration" 15472}
+               "start" 1612560992693143000
+               "duration" 31000}
           {"name" "django.middleware"
            "service" "django"
            "resource" "django.contrib.sessions.middleware.SessionMiddleware.process_response"
@@ -242,5 +243,5 @@
            "span_id" 4
            "trace_id" 0
            "parent_id" 1
-           "start" 1603387533907238622
-           "duration" 19434}]]
+           "start" 1612560992693203000
+           "duration" 19000}]]


### PR DESCRIPTION
This in general is fine but if there is a parent span of the same
service (eg. WSGI) then metrics won't be calculated for django spans.

With this change metrics will be generated regardless.