### PR TITLE
ci: fix flaky cherrypy tests, use riot, snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -595,10 +595,12 @@ jobs:
           pattern: '^celery_contrib-'
 
   cherrypy:
-    <<: *contrib_job
+    <<: *machine_executor
+    parallelism: 6
     steps:
-      - run_tox_scenario:
-          pattern: '^cherrypy_contrib-'
+      - run_test:
+          pattern: 'cherrypy'
+          snapshot: true
 
   consul:
     <<: *contrib_job

--- a/riotfile.py
+++ b/riotfile.py
@@ -45,6 +45,24 @@ venv = Venv(
             pkgs={"pytest-benchmark": latest, "msgpack": latest},
             command="pytest --no-cov {cmdargs} tests/benchmarks",
         ),
+        Venv(
+            name="cherrypy",
+            command="pytest {cmdargs} tests/contrib/cherrypy",
+            venvs=[
+                Venv(
+                    pys=select_pys(),
+                    pkgs={
+                        "cherrypy": [">=11,<12", ">=12,<13", ">=13,<14", ">=14,<15", ">=15,<16", ">=16,<17", ">=17,<18"],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version=3.5),
+                    pkgs={
+                        "cherrypy": [">=18.0,<19", latest],
+                    },
+                ),
+            ],
+        ),
         Venv(name="tracer", command="pytest tests/tracer/", venvs=[Venv(pys=select_pys(), pkgs={"msgpack": latest})]),
         Venv(
             name="pymongo",

--- a/tests/contrib/cherrypy/test_middleware.py
+++ b/tests/contrib/cherrypy/test_middleware.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-import time
 import re
+import time
 
 from ddtrace.contrib.cherrypy import TraceMiddleware
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
@@ -46,7 +46,6 @@ class TestCherrypy(helper.CPWebCase):
         # problem (the test scope must keep a strong reference)
         traced_app = TraceMiddleware(cherrypy, self.tracer)  # noqa: F841
         self.getPage("/")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
 
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertStatus("200 OK")
@@ -65,7 +64,6 @@ class TestCherrypy(helper.CPWebCase):
             service="new-intake",
         )
         self.getPage("/")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
 
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertStatus("200 OK")
@@ -78,7 +76,6 @@ class TestCherrypy(helper.CPWebCase):
     def test_child(self):
         start = time.time()
         self.getPage("/child")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
         end = time.time()
 
         # ensure request worked
@@ -115,7 +112,6 @@ class TestCherrypy(helper.CPWebCase):
     def test_success(self):
         start = time.time()
         self.getPage("/")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
         end = time.time()
 
         # ensure request worked
@@ -139,7 +135,6 @@ class TestCherrypy(helper.CPWebCase):
     def test_alias(self):
         start = time.time()
         self.getPage("/aliases")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
         end = time.time()
 
         # ensure request worked
@@ -163,7 +158,6 @@ class TestCherrypy(helper.CPWebCase):
     def test_handleme(self):
         start = time.time()
         self.getPage("/handleme")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
         end = time.time()
 
         # ensure request worked
@@ -185,7 +179,6 @@ class TestCherrypy(helper.CPWebCase):
     def test_error(self):
         start = time.time()
         self.getPage("/error")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
         end = time.time()
 
         # ensure the request itself worked
@@ -207,7 +200,6 @@ class TestCherrypy(helper.CPWebCase):
     def test_fatal(self):
         start = time.time()
         self.getPage("/fatal")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
         end = time.time()
 
         self.assertErrorPage(500)
@@ -233,7 +225,6 @@ class TestCherrypy(helper.CPWebCase):
         # Here, the URL is encoded in utf8 and then %HEX
         # See https://docs.cherrypy.org/en/latest/_modules/cherrypy/test/test_encoding.html for more
         self.getPage(url_quote(u"/üŋïĉóđē".encode("utf-8")))
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
         end = time.time()
 
         # ensure request worked
@@ -258,7 +249,6 @@ class TestCherrypy(helper.CPWebCase):
     def test_404(self):
         start = time.time()
         self.getPage(u"/404/test")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
         end = time.time()
 
         # ensure request worked
@@ -287,7 +277,6 @@ class TestCherrypy(helper.CPWebCase):
                 ("x-datadog-sampling-priority", "2"),
             ],
         )
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
 
         # ensure request worked
         self.assertStatus("200 OK")
@@ -305,8 +294,8 @@ class TestCherrypy(helper.CPWebCase):
         assert s.parent_id == 4567
         assert s.get_metric(SAMPLING_PRIORITY_KEY) == 2
 
-    def test_disabled_distrobuted_tracing_config(self):
-        previous_distrobuted_tracing = config.cherrypy["distributed_tracing"]
+    def test_disabled_distributed_tracing_config(self):
+        previous_distributed_tracing = config.cherrypy["distributed_tracing"]
         config.cherrypy["distributed_tracing"] = False
         self.getPage(
             "/",
@@ -316,7 +305,6 @@ class TestCherrypy(helper.CPWebCase):
                 ("x-datadog-sampling-priority", "2"),
             ],
         )
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
 
         # ensure request worked
         self.assertStatus("200 OK")
@@ -334,10 +322,10 @@ class TestCherrypy(helper.CPWebCase):
         assert s.parent_id != 4567
         assert s.get_metric(SAMPLING_PRIORITY_KEY) != 2
 
-        config.cherrypy["distributed_tracing"] = previous_distrobuted_tracing
+        config.cherrypy["distributed_tracing"] = previous_distributed_tracing
 
-    def test_disabled_distrobuted_tracing_middleware(self):
-        previous_distrobuted_tracing = cherrypy.tools.tracer.use_distributed_tracing
+    def test_disabled_distributed_tracing_middleware(self):
+        previous_distributed_tracing = cherrypy.tools.tracer.use_distributed_tracing
         cherrypy.tools.tracer.use_distributed_tracing = False
         self.getPage(
             "/",
@@ -347,7 +335,6 @@ class TestCherrypy(helper.CPWebCase):
                 ("x-datadog-sampling-priority", "2"),
             ],
         )
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
 
         # ensure request worked
         self.assertStatus("200 OK")
@@ -365,11 +352,10 @@ class TestCherrypy(helper.CPWebCase):
         assert s.parent_id != 4567
         assert s.get_metric(SAMPLING_PRIORITY_KEY) != 2
 
-        cherrypy.tools.tracer.use_distributed_tracing = previous_distrobuted_tracing
+        cherrypy.tools.tracer.use_distributed_tracing = previous_distributed_tracing
 
     def test_custom_span(self):
         self.getPage(u"/custom_span")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
 
         self.assertStatus("200 OK")
         self.assertBody("hiya")
@@ -395,8 +381,6 @@ class TestCherrypy(helper.CPWebCase):
                 ("x-datadog-sampling-priority", "2"),
             ],
         )
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
-
         traces = self.tracer.writer.pop_traces()
 
         assert len(traces) == 1
@@ -410,7 +394,6 @@ class TestCherrypy(helper.CPWebCase):
         config.cherrypy.http.trace_headers(["my-response-header"])
 
         self.getPage("/response_headers")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
 
         traces = self.tracer.writer.pop_traces()
 
@@ -423,7 +406,6 @@ class TestCherrypy(helper.CPWebCase):
     def test_variable_resource(self):
         start = time.time()
         self.getPage("/dispatch/abc123/")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
         end = time.time()
 
         # ensure request worked
@@ -450,7 +432,6 @@ class TestCherrypy(helper.CPWebCase):
     def test_post(self):
         start = time.time()
         self.getPage("/", method="POST")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
         end = time.time()
 
         # ensure request worked
@@ -476,7 +457,6 @@ class TestCherrypy(helper.CPWebCase):
         config.cherrypy["service"] = "my_cherrypy_service"
         start = time.time()
         self.getPage("/")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
         end = time.time()
 
         # ensure request worked
@@ -504,7 +484,7 @@ class TestCherrypy(helper.CPWebCase):
         cherrypy.tools.tracer.service = "my_cherrypy_service2"
         start = time.time()
         self.getPage("/")
-        time.sleep(0.01)  # Without this here, span may not be ready for inspection, and timings can be incorrect.
+        time.sleep(0.01)
         end = time.time()
 
         # ensure request worked

--- a/tests/contrib/cherrypy/test_middleware.py
+++ b/tests/contrib/cherrypy/test_middleware.py
@@ -1,25 +1,31 @@
 # -*- coding: utf-8 -*-
 import re
+import logging
 import time
-
-from ddtrace.contrib.cherrypy import TraceMiddleware
-from ddtrace.constants import SAMPLING_PRIORITY_KEY
-from ddtrace.ext import http, errors
-from ddtrace import config
 
 import cherrypy
 from cherrypy.test import helper
-from .web import TestApp
-from tests.tracer.test_tracer import get_dummy_tracer
-from ... import assert_span_http_status_code
 from six.moves.urllib.parse import quote as url_quote
-import logging
+
+import ddtrace
+from ddtrace import config
+from ddtrace.contrib.cherrypy import TraceMiddleware
+from ddtrace.constants import SAMPLING_PRIORITY_KEY
+from ddtrace.ext import http, errors
+
+from tests import assert_span_http_status_code, DummyTracer, snapshot
+from .web import TestApp
 
 logger = logging.getLogger()
 logger.level = logging.DEBUG
 
 
 class TestCherrypy(helper.CPWebCase):
+    """
+    FIXME: the tests using getPage() are not synchronous and so require a
+           delay afterwards.
+    """
+
     @staticmethod
     def setup_server():
         cherrypy.tree.mount(
@@ -31,7 +37,7 @@ class TestCherrypy(helper.CPWebCase):
         )
 
     def setUp(self):
-        self.tracer = get_dummy_tracer()
+        self.tracer = DummyTracer()
         self.traced_app = TraceMiddleware(
             cherrypy,
             self.tracer,
@@ -46,7 +52,7 @@ class TestCherrypy(helper.CPWebCase):
         # problem (the test scope must keep a strong reference)
         traced_app = TraceMiddleware(cherrypy, self.tracer)  # noqa: F841
         self.getPage("/")
-
+        time.sleep(0.1)
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertStatus("200 OK")
 
@@ -64,7 +70,7 @@ class TestCherrypy(helper.CPWebCase):
             service="new-intake",
         )
         self.getPage("/")
-
+        time.sleep(0.1)
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertStatus("200 OK")
 
@@ -74,11 +80,8 @@ class TestCherrypy(helper.CPWebCase):
         assert cherrypy.tools.tracer.service == "new-intake"
 
     def test_child(self):
-        start = time.time()
         self.getPage("/child")
-        end = time.time()
-
-        # ensure request worked
+        time.sleep(0.1)
         self.assertStatus("200 OK")
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertBody("child")
@@ -95,8 +98,6 @@ class TestCherrypy(helper.CPWebCase):
         assert not s.parent_id
         assert s.service == "test.cherrypy.service"
         assert s.resource == "GET /child"
-        assert s.start >= start
-        assert s.duration <= end - start
         assert s.error == 0
 
         c = spans_by_name["child"]
@@ -105,62 +106,45 @@ class TestCherrypy(helper.CPWebCase):
         assert c.parent_id == s.span_id
         assert c.service == "test.cherrypy.service"
         assert c.resource == "child"
-        assert c.start >= start
-        assert c.duration <= end - start
         assert c.error == 0
 
     def test_success(self):
-        start = time.time()
         self.getPage("/")
-        end = time.time()
-
-        # ensure request worked
+        time.sleep(0.1)
         self.assertStatus("200 OK")
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertBody("Hello world!")
 
-        # ensure trace worked
         assert not self.tracer.current_span(), self.tracer.current_span().pprint()
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         s = spans[0]
         assert s.service == "test.cherrypy.service"
         assert s.resource == "GET /"
-        assert s.start >= start
-        assert s.duration <= end - start
         assert s.error == 0
         assert_span_http_status_code(s, 200)
         assert s.meta.get(http.METHOD) == "GET"
 
     def test_alias(self):
-        start = time.time()
         self.getPage("/aliases")
-        end = time.time()
-
-        # ensure request worked
+        time.sleep(0.1)
         self.assertStatus("200 OK")
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertBody("alias")
 
-        # ensure trace worked
         assert not self.tracer.current_span(), self.tracer.current_span().pprint()
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
         s = spans[0]
         assert s.service == "test.cherrypy.service"
         assert s.resource == "GET /aliases"
-        assert s.start >= start
-        assert s.duration <= end - start
         assert s.error == 0
         assert_span_http_status_code(s, 200)
         assert s.meta.get(http.METHOD) == "GET"
 
     def test_handleme(self):
-        start = time.time()
         self.getPage("/handleme")
-        end = time.time()
-
-        # ensure request worked
+        time.sleep(0.1)
         self.assertErrorPage(418, message="handled")
 
         # ensure trace worked
@@ -170,18 +154,13 @@ class TestCherrypy(helper.CPWebCase):
         s = spans[0]
         assert s.service == "test.cherrypy.service"
         assert s.resource == "GET /handleme"
-        assert s.start >= start
-        assert s.duration <= end - start
         assert s.error == 0
         assert_span_http_status_code(s, 418)
         assert s.meta.get(http.METHOD) == "GET"
 
     def test_error(self):
-        start = time.time()
         self.getPage("/error")
-        end = time.time()
-
-        # ensure the request itself worked
+        time.sleep(0.1)
         self.assertErrorPage(500)
 
         # ensure the request was traced.
@@ -191,16 +170,13 @@ class TestCherrypy(helper.CPWebCase):
         s = spans[0]
         assert s.service == "test.cherrypy.service"
         assert s.resource == "GET /error"
-        assert s.start >= start
-        assert s.duration <= end - start
         assert_span_http_status_code(s, 500)
         assert s.error == 1
         assert s.meta.get(http.METHOD) == "GET"
 
     def test_fatal(self):
-        start = time.time()
         self.getPage("/fatal")
-        end = time.time()
+        time.sleep(0.1)
 
         self.assertErrorPage(500)
 
@@ -210,8 +186,6 @@ class TestCherrypy(helper.CPWebCase):
         s = spans[0]
         assert s.service == "test.cherrypy.service"
         assert s.resource == "GET /fatal"
-        assert s.start >= start
-        assert s.duration <= end - start
         assert_span_http_status_code(s, 500)
         assert s.error == 1
         assert s.meta.get(http.METHOD) == "GET"
@@ -220,14 +194,11 @@ class TestCherrypy(helper.CPWebCase):
         assert re.search('File ".*/contrib/cherrypy/web.py", line [0-9]+, in fatal', s.meta.get(errors.ERROR_STACK))
 
     def test_unicode(self):
-        start = time.time()
         # Encoded utf8 query strings MUST be parsed correctly.
         # Here, the URL is encoded in utf8 and then %HEX
         # See https://docs.cherrypy.org/en/latest/_modules/cherrypy/test/test_encoding.html for more
         self.getPage(url_quote(u"/üŋïĉóđē".encode("utf-8")))
-        end = time.time()
-
-        # ensure request worked
+        time.sleep(0.1)
         self.assertStatus("200 OK")
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertBody(b"\xc3\xbc\xc5\x8b\xc3\xaf\xc4\x89\xc3\xb3\xc4\x91\xc4\x93")
@@ -239,19 +210,14 @@ class TestCherrypy(helper.CPWebCase):
         s = spans[0]
         assert s.service == "test.cherrypy.service"
         assert s.resource == u"GET /üŋïĉóđē"
-        assert s.start >= start
-        assert s.duration <= end - start
         assert s.error == 0
         assert_span_http_status_code(s, 200)
         assert s.meta.get(http.METHOD) == "GET"
         assert s.meta.get(http.URL) == u"http://127.0.0.1:54583/üŋïĉóđē"
 
     def test_404(self):
-        start = time.time()
         self.getPage(u"/404/test")
-        end = time.time()
-
-        # ensure request worked
+        time.sleep(0.1)
         self.assertStatus("404 Not Found")
 
         # ensure trace worked
@@ -261,8 +227,6 @@ class TestCherrypy(helper.CPWebCase):
         s = spans[0]
         assert s.service == "test.cherrypy.service"
         assert s.resource == u"GET /404/test"
-        assert s.start >= start
-        assert s.duration <= end - start
         assert s.error == 0
         assert_span_http_status_code(s, 404)
         assert s.meta.get(http.METHOD) == "GET"
@@ -277,13 +241,11 @@ class TestCherrypy(helper.CPWebCase):
                 ("x-datadog-sampling-priority", "2"),
             ],
         )
-
-        # ensure request worked
+        time.sleep(0.1)
         self.assertStatus("200 OK")
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertBody("Hello world!")
 
-        # ensure trace worked
         assert not self.tracer.current_span(), self.tracer.current_span().pprint()
         spans = self.tracer.writer.pop()
         assert len(spans) == 1
@@ -305,8 +267,7 @@ class TestCherrypy(helper.CPWebCase):
                 ("x-datadog-sampling-priority", "2"),
             ],
         )
-
-        # ensure request worked
+        time.sleep(0.1)
         self.assertStatus("200 OK")
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertBody("Hello world!")
@@ -335,8 +296,7 @@ class TestCherrypy(helper.CPWebCase):
                 ("x-datadog-sampling-priority", "2"),
             ],
         )
-
-        # ensure request worked
+        time.sleep(0.1)
         self.assertStatus("200 OK")
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertBody("Hello world!")
@@ -356,7 +316,7 @@ class TestCherrypy(helper.CPWebCase):
 
     def test_custom_span(self):
         self.getPage(u"/custom_span")
-
+        time.sleep(0.1)
         self.assertStatus("200 OK")
         self.assertBody("hiya")
 
@@ -381,22 +341,21 @@ class TestCherrypy(helper.CPWebCase):
                 ("x-datadog-sampling-priority", "2"),
             ],
         )
-        traces = self.tracer.writer.pop_traces()
+        time.sleep(0.1)
 
+        traces = self.tracer.writer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 1
         span = traces[0][0]
-
         assert span.get_tag("http.request.headers.my-header") == "my_value"
         assert span.get_tag("http.request.headers.host") == "127.0.0.1:54583"
 
     def test_http_response_header_tracing(self):
         config.cherrypy.http.trace_headers(["my-response-header"])
-
         self.getPage("/response_headers")
+        time.sleep(0.1)
 
         traces = self.tracer.writer.pop_traces()
-
         assert len(traces) == 1
         assert len(traces[0]) == 1
         span = traces[0][0]
@@ -404,11 +363,8 @@ class TestCherrypy(helper.CPWebCase):
         assert span.get_tag("http.response.headers.my-response-header") == "my_response_value"
 
     def test_variable_resource(self):
-        start = time.time()
         self.getPage("/dispatch/abc123/")
-        end = time.time()
-
-        # ensure request worked
+        time.sleep(0.1)
         self.assertStatus("200 OK")
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertBody("dispatch with abc123")
@@ -423,18 +379,13 @@ class TestCherrypy(helper.CPWebCase):
         # Once CherryPy returns sensible results for virtual path components, this
         # can be: "GET /dispatch/{{test_value}}/"
         assert s.resource == "GET /dispatch/abc123/"
-        assert s.start >= start
-        assert s.duration <= end - start
         assert s.error == 0
         assert_span_http_status_code(s, 200)
         assert s.meta.get(http.METHOD) == "GET"
 
     def test_post(self):
-        start = time.time()
         self.getPage("/", method="POST")
-        end = time.time()
-
-        # ensure request worked
+        time.sleep(0.1)
         self.assertStatus("200 OK")
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertBody("Hello world!")
@@ -446,8 +397,6 @@ class TestCherrypy(helper.CPWebCase):
         s = spans[0]
         assert s.service == "test.cherrypy.service"
         assert s.resource == "POST /"
-        assert s.start >= start
-        assert s.duration <= end - start
         assert s.error == 0
         assert_span_http_status_code(s, 200)
         assert s.meta.get(http.METHOD) == "POST"
@@ -455,11 +404,8 @@ class TestCherrypy(helper.CPWebCase):
     def test_service_configuration_config(self):
         previous_service = config.cherrypy.get("service", "test.cherrypy.service")
         config.cherrypy["service"] = "my_cherrypy_service"
-        start = time.time()
         self.getPage("/")
-        end = time.time()
-
-        # ensure request worked
+        time.sleep(0.1)
         self.assertStatus("200 OK")
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertBody("Hello world!")
@@ -471,8 +417,6 @@ class TestCherrypy(helper.CPWebCase):
         s = spans[0]
         assert s.service == "my_cherrypy_service"
         assert s.resource == "GET /"
-        assert s.start >= start
-        assert s.duration <= end - start
         assert s.error == 0
         assert_span_http_status_code(s, 200)
         assert s.meta.get(http.METHOD) == "GET"
@@ -482,12 +426,8 @@ class TestCherrypy(helper.CPWebCase):
     def test_service_configuration_middleware(self):
         previous_service = cherrypy.tools.tracer.service
         cherrypy.tools.tracer.service = "my_cherrypy_service2"
-        start = time.time()
         self.getPage("/")
-        time.sleep(0.01)
-        end = time.time()
-
-        # ensure request worked
+        time.sleep(0.1)
         self.assertStatus("200 OK")
         self.assertHeader("Content-Type", "text/html;charset=utf-8")
         self.assertBody("Hello world!")
@@ -499,10 +439,56 @@ class TestCherrypy(helper.CPWebCase):
         s = spans[0]
         assert s.service == "my_cherrypy_service2"
         assert s.resource == "GET /"
-        assert s.start >= start
-        assert s.duration <= end - start
         assert s.error == 0
         assert_span_http_status_code(s, 200)
         assert s.meta.get(http.METHOD) == "GET"
 
         cherrypy.tools.tracer.service = previous_service
+
+
+class TestCherrypySnapshot(helper.CPWebCase):
+    @staticmethod
+    def setup_server():
+        cherrypy.tree.mount(
+            TestApp(),
+            "/",
+            {
+                "/": {"tools.tracer.on": True},
+            },
+        )
+
+    def setUp(self):
+        self.traced_app = TraceMiddleware(
+            cherrypy,
+            tracer=ddtrace.tracer,
+            service="test.cherrypy.service",
+            distributed_tracing=True,
+        )
+
+    @snapshot()
+    def test_child(self):
+        self.getPage("/child")
+        time.sleep(0.1)
+        self.assertStatus("200 OK")
+        self.assertHeader("Content-Type", "text/html;charset=utf-8")
+        self.assertBody("child")
+
+    @snapshot(ignores=["meta.error.stack", "meta.error.type", "meta.error.msg"])
+    def test_success(self):
+        self.getPage("/")
+        time.sleep(0.1)
+        self.assertStatus("200 OK")
+        self.assertHeader("Content-Type", "text/html;charset=utf-8")
+        self.assertBody("Hello world!")
+
+    @snapshot(ignores=["meta.error.stack", "meta.error.type", "meta.error.msg"])
+    def test_error(self):
+        self.getPage("/error")
+        time.sleep(0.1)
+        self.assertErrorPage(500)
+
+    @snapshot(ignores=["meta.error.stack", "meta.error.type", "meta.error.msg"])
+    def test_fatal(self):
+        self.getPage("/fatal")
+        time.sleep(0.1)
+        self.assertErrorPage(500)

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.snap
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.snap
@@ -1,0 +1,28 @@
+[[{"name" "cherrypy.request"
+   "service" "test.cherrypy.service"
+   "resource" "GET /child"
+   "type" "web"
+   "error" 0
+   "span_id" 0
+   "trace_id" 0
+   "parent_id" nil
+   "start" 1612565466747391000
+   "duration" 3020000
+   "meta" {"runtime-id" "1e4bde87e00244cabc8e80e84a42ecb7"
+           "http.method" "GET"
+           "http.url" "http://127.0.0.1:54583/child"
+           "http.status_code" "200"
+           "http.request.headers.host" "127.0.0.1:54583"}
+   "metrics" {"_dd.agent_psr" 1.0
+              "_sampling_priority_v1" 1
+              "system.pid" 13276}}
+      {"name" "child"
+       "service" "test.cherrypy.service"
+       "resource" "child"
+       "error" 0
+       "span_id" 1
+       "trace_id" 0
+       "parent_id" 0
+       "start" 1612565466747971000
+       "duration" 98000
+       "meta" {"a" "b"}}]]

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_error.snap
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_error.snap
@@ -1,0 +1,21 @@
+[[{"name" "cherrypy.request"
+   "service" "test.cherrypy.service"
+   "resource" "GET /error"
+   "type" "web"
+   "error" 1
+   "span_id" 0
+   "trace_id" 0
+   "parent_id" nil
+   "start" 1612565277547713000
+   "duration" 1117000
+   "meta" {"runtime-id" "9ec4e861797b401289c15e82e1a86a76"
+           "error.type" "<class 'tests.contrib.cherrypy.web.TestError'>"
+           "error.msg" ""
+           "error.stack" "Traceback (most recent call last):\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/.venv_py377/lib/python3.7/site-packages/cherrypy/_cprequest.py\", line 634, in respond\n    self._do_respond(path_info)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/.venv_py377/lib/python3.7/site-packages/cherrypy/_cprequest.py\", line 693, in _do_respond\n    response.body = self.handler()\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/.venv_py377/lib/python3.7/site-packages/cherrypy/lib/encoding.py\", line 221, in __call__\n    self.body = self.oldhandler(*args, **kwargs)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/.venv_py377/lib/python3.7/site-packages/cherrypy/_cpdispatch.py\", line 60, in __call__\n    return self.callable(*self.args, **self.kwargs)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/tests/contrib/cherrypy/web.py\", line 55, in error\n    raise TestError()\ntests.contrib.cherrypy.web.TestError\n"
+           "http.method" "GET"
+           "http.url" "http://127.0.0.1:54583/error"
+           "http.status_code" "500"
+           "http.request.headers.host" "127.0.0.1:54583"}
+   "metrics" {"_dd.agent_psr" 1.0
+              "_sampling_priority_v1" 1
+              "system.pid" 12166}}]]

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_fatal.snap
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_fatal.snap
@@ -1,0 +1,21 @@
+[[{"name" "cherrypy.request"
+   "service" "test.cherrypy.service"
+   "resource" "GET /fatal"
+   "type" "web"
+   "error" 1
+   "span_id" 0
+   "trace_id" 0
+   "parent_id" nil
+   "start" 1612565277591986000
+   "duration" 1596000
+   "meta" {"runtime-id" "9ec4e861797b401289c15e82e1a86a76"
+           "error.type" "<class 'ZeroDivisionError'>"
+           "error.msg" "division by zero"
+           "error.stack" "Traceback (most recent call last):\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/.venv_py377/lib/python3.7/site-packages/cherrypy/_cprequest.py\", line 634, in respond\n    self._do_respond(path_info)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/.venv_py377/lib/python3.7/site-packages/cherrypy/_cprequest.py\", line 693, in _do_respond\n    response.body = self.handler()\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/.venv_py377/lib/python3.7/site-packages/cherrypy/lib/encoding.py\", line 221, in __call__\n    self.body = self.oldhandler(*args, **kwargs)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/.venv_py377/lib/python3.7/site-packages/cherrypy/_cpdispatch.py\", line 60, in __call__\n    return self.callable(*self.args, **self.kwargs)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/tests/contrib/cherrypy/web.py\", line 64, in fatal\n    1 / 0\nZeroDivisionError: division by zero\n"
+           "http.method" "GET"
+           "http.url" "http://127.0.0.1:54583/fatal"
+           "http.status_code" "500"
+           "http.request.headers.host" "127.0.0.1:54583"}
+   "metrics" {"_dd.agent_psr" 1.0
+              "_sampling_priority_v1" 1
+              "system.pid" 12166}}]]

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_success.snap
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_success.snap
@@ -1,0 +1,18 @@
+[[{"name" "cherrypy.request"
+   "service" "test.cherrypy.service"
+   "resource" "GET /"
+   "type" "web"
+   "error" 0
+   "span_id" 0
+   "trace_id" 0
+   "parent_id" nil
+   "start" 1612565277618230000
+   "duration" 1676000
+   "meta" {"runtime-id" "9ec4e861797b401289c15e82e1a86a76"
+           "http.method" "GET"
+           "http.url" "http://127.0.0.1:54583/"
+           "http.status_code" "200"
+           "http.request.headers.host" "127.0.0.1:54583"}
+   "metrics" {"_dd.agent_psr" 1.0
+              "_sampling_priority_v1" 1
+              "system.pid" 12166}}]]

--- a/tox.ini
+++ b/tox.ini
@@ -53,9 +53,6 @@ envlist =
 # Celery 4.3 wants Kombu >= 4.4 and Redis >= 3.2
 # Python 3.7 needs Celery 4.3
     celery_contrib-py{27,35,36,37,38,39}-celery43-redis32-kombu44
-    cherrypy_contrib-py{27,35,36,37,38,39}-cherrypy{11,12,13,14,15,16,17}
-# CherryPy v18 dropped support for Python 2
-    cherrypy_contrib-py{35,36,37,38,39}-cherrypy{18}
     consul_contrib-py{27,35,36,37,38,39}-consul{07,10,11,}
     dbapi_contrib-py{27,35,36,37,38,39}
     dogpile_contrib-py{27,35}-dogpilecache{06,07,08,09}
@@ -239,14 +236,6 @@ deps =
     celery42: celery>=4.2,<4.3
     celery43: celery>=4.3,<4.4
     celery43: vine==1.3
-    cherrypy11: cherrypy>=11,<12
-    cherrypy12: cherrypy>=12,<13
-    cherrypy13: cherrypy>=13,<14
-    cherrypy14: cherrypy>=14,<15
-    cherrypy15: cherrypy>=15,<16
-    cherrypy16: cherrypy>=16,<17
-    cherrypy17: cherrypy>=17,<18
-    cherrypy18: cherrypy>=18,<19
     consul: python-consul
     consul07: python-consul>=0.7,<1.0
     consul10: python-consul>=1.0,<1.1
@@ -469,7 +458,6 @@ commands =
     bottle_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/bottle/test_autopatch.py
     cassandra_contrib: pytest {posargs} tests/contrib/cassandra
     celery_contrib: pytest {posargs} tests/contrib/celery
-    cherrypy_contrib: pytest {posargs} tests/contrib/cherrypy
     consul_contrib: pytest {posargs} tests/contrib/consul
     dbapi_contrib: pytest {posargs} tests/contrib/dbapi
     dogpile_contrib: pytest {posargs} tests/contrib/dogpile_cache


### PR DESCRIPTION
The cherrypy test cases were a little flaky due to the test server configuration that the cherrypy test case uses. 

This PR increases the wait time, removes the time assertions and introduces snapshot testing and ports the tests from tox to riot.