### PR TITLE
test(profiling): make test_not_ignore_profiler_gevent_task more robust

### DIFF
--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -180,14 +180,14 @@ def test_not_ignore_profiler_gevent_task(monkeypatch):
     p = profiler.Profiler()
     p.start()
     # This test is particularly useful with gevent enabled: create a test collector that run often and for long so we're
-    # sure to catch it with the StackProfiler and that it's ignored.
+    # sure to catch it with the StackProfiler and that it's not ignored.
     c = CollectorTest(p._profiler._recorder, interval=0.00001)
     c.start()
-    events = p._profiler._recorder.events[stack.StackSampleEvent]
     time.sleep(3)
+    events = p._profiler._recorder.reset()
     c.stop()
-    p.stop()
-    assert c._worker.ident in {e.task_id for e in events}
+    p.stop(flush=False)
+    assert c._worker.ident in {e.task_id for e in events[stack.StackSampleEvent]}
 
 
 def test_collect():


### PR DESCRIPTION
The current code is subject to a race condition as the data is flushed out via
the scheduler before the assertion is run.

This fixes the test 🤞 by making it clear that the flush must not occur and by
getting the events out before we stop the profiler anyway by using the `reset`
method.