### PR TITLE
Pin cryptography package to <3.4

### DIFF
--- a/.circleci/scripts/test_build.sh
+++ b/.circleci/scripts/test_build.sh
@@ -14,7 +14,10 @@ fi
 
 # Install required dependencies
 # DEV: `wheel` is needed to run `bdist_wheel`
-pip install twine readme_renderer[md] wheel cython
+# DEV: `cryoptography==3.4` dropped support for Python 2.7 and now requires Rust to build from source
+#      This version constraint only applies to Alpine builds where wheels are not available
+#      https://cryptography.io/en/3.4/changelog.html#v3-4
+pip install twine readme_renderer[md] wheel cython "cryptography<3.4"
 # Ensure we didn't cache from previous runs
 rm -rf build/ dist/
 # Manually build any extensions to ensure they succeed


### PR DESCRIPTION
3.4 dropped support for Python 2 and introduced Rust for build time dependency
https://cryptography.io/en/3.4/changelog.html#v3-4
https://github.com/pyca/cryptography/issues/5771


Our only dependency which needs cryptography is `twine`, which is only used here as part of the CircleCI job to test building.
