### PR TITLE
Migrate elasticsearch from tox to riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -623,8 +623,8 @@ jobs:
       - image: *ddtrace_dev_image
       - image: *elasticsearch_image
     steps:
-      - run_tox_scenario:
-          pattern: '^elasticsearch_contrib-'
+      - run_test:
+          pattern: 'elasticsearch'
 
   falcon:
     <<: *contrib_job

--- a/riotfile.py
+++ b/riotfile.py
@@ -204,6 +204,46 @@ venv = Venv(
             ],
         ),
         Venv(
+            name="elasticsearch",
+            command="pytest {cmdargs} tests/contrib/elasticsearch",
+            venvs=[
+                Venv(
+                    pys=select_pys(max_version=3.6),
+                    pkgs={
+                        "elasticsearch": [
+                            "~=1.6.0",
+                            "~=1.7.0",
+                            "~=1.8.0",
+                            "~=1.9.0",
+                            "~=2.3.0",
+                            "~=2.4.0",
+                            "~=5.1.0",
+                            "~=5.2.0",
+                            "~=5.3.0",
+                            "~=5.4.0",
+                            "~=6.3.0",
+                            "~=6.4.0",
+                            "~=6.8.0",
+                            "~=7.0.0",
+                            "~=7.1.0",
+                            "~=7.5.0",
+                            "~=7.6.0",
+                            "~=7.8.0",
+                            "~=7.10.0",
+                            latest,
+                        ]
+                    },
+                ),
+                Venv(pys=select_pys(max_version=3.6), pkgs={"elasticsearch1": ["~=1.10.0"]}),
+                Venv(pys=select_pys(max_version=3.6), pkgs={"elasticsearch2": ["~=2.5.0"]}),
+                Venv(pys=select_pys(max_version=3.6), pkgs={"elasticsearch5": ["~=5.5.0"]}),
+                Venv(pys=select_pys(max_version=3.6), pkgs={"elasticsearch6": ["~=6.4.0", "~=6.8.0", latest]}),
+                Venv(
+                    pys=select_pys(min_version=3.5), pkgs={"elasticsearch7": ["~=7.6.0", "~=7.8.0", "~=7.10.0", latest]}
+                ),
+            ],
+        ),
+        Venv(
             name="pynamodb",
             command="pytest tests/contrib/pynamodb",
             venvs=[

--- a/riotfile.py
+++ b/riotfile.py
@@ -208,7 +208,7 @@ venv = Venv(
             command="pytest {cmdargs} tests/contrib/elasticsearch",
             venvs=[
                 Venv(
-                    pys=select_pys(),
+                    pys=select_pys(max_version=3.8),
                     pkgs={
                         "elasticsearch": [
                             "~=1.6.0",
@@ -227,6 +227,13 @@ venv = Venv(
                             "~=7.0.0",
                             "~=7.1.0",
                             "~=7.5.0",
+                        ]
+                    },
+                ),
+                Venv(
+                    pys=select_pys(),
+                    pkgs={
+                        "elasticsearch": [
                             "~=7.6.0",
                             "~=7.8.0",
                             "~=7.10.0",

--- a/riotfile.py
+++ b/riotfile.py
@@ -208,7 +208,7 @@ venv = Venv(
             command="pytest {cmdargs} tests/contrib/elasticsearch",
             venvs=[
                 Venv(
-                    pys=select_pys(max_version=3.6),
+                    pys=select_pys(),
                     pkgs={
                         "elasticsearch": [
                             "~=1.6.0",
@@ -234,13 +234,11 @@ venv = Venv(
                         ]
                     },
                 ),
-                Venv(pys=select_pys(max_version=3.6), pkgs={"elasticsearch1": ["~=1.10.0"]}),
-                Venv(pys=select_pys(max_version=3.6), pkgs={"elasticsearch2": ["~=2.5.0"]}),
-                Venv(pys=select_pys(max_version=3.6), pkgs={"elasticsearch5": ["~=5.5.0"]}),
-                Venv(pys=select_pys(max_version=3.6), pkgs={"elasticsearch6": ["~=6.4.0", "~=6.8.0", latest]}),
-                Venv(
-                    pys=select_pys(min_version=3.5), pkgs={"elasticsearch7": ["~=7.6.0", "~=7.8.0", "~=7.10.0", latest]}
-                ),
+                Venv(pys=select_pys(), pkgs={"elasticsearch1": ["~=1.10.0"]}),
+                Venv(pys=select_pys(), pkgs={"elasticsearch2": ["~=2.5.0"]}),
+                Venv(pys=select_pys(), pkgs={"elasticsearch5": ["~=5.5.0"]}),
+                Venv(pys=select_pys(), pkgs={"elasticsearch6": ["~=6.4.0", "~=6.8.0", latest]}),
+                Venv(pys=select_pys(), pkgs={"elasticsearch7": ["~=7.6.0", "~=7.8.0", "~=7.10.0", latest]}),
             ],
         ),
         Venv(

--- a/tox.ini
+++ b/tox.ini
@@ -60,13 +60,6 @@ envlist =
     dbapi_contrib-py{27,35,36,37,38,39}
     dogpile_contrib-py{27,35}-dogpilecache{06,07,08,09}
     dogpile_contrib-py{36,37,38,39}-dogpilecache{06,07,08,09,10,}
-    elasticsearch_contrib-py{27,35,36}-elasticsearch{16,17,18,23,24,51,52,53,54,63,64,68,70,71,75,76,78,710,}
-    elasticsearch_contrib-py{27,35,36}-elasticsearch1{100}
-    elasticsearch_contrib-py{27,35,36}-elasticsearch2{50}
-    elasticsearch_contrib-py{27,35,36}-elasticsearch5{50}
-    elasticsearch_contrib-py{27,35,36}-elasticsearch6{40}
-    elasticsearch_contrib-py{37,38}-elasticsearch77{6,8,10,}
-    elasticsearch_contrib-py{39}-elasticsearch77{10,}
     falcon_contrib{,_autopatch}-{py27,py35,py36,py37}-falcon{10,11,12,13,14}
     falcon_contrib{,_autopatch}-{py35,py36,py37}-falcon{20}
     flask_contrib{,_autopatch}-{py27,py35,py36}-flask{010,011,012,10}-blinker-pytest3
@@ -259,36 +252,6 @@ deps =
     dogpilecache08: dogpile.cache==0.8.*
     dogpilecache09: dogpile.cache==0.9.*
     dogpilecache10: dogpile.cache==1.0.*
-    elasticsearch: elasticsearch
-    elasticsearch16: elasticsearch>=1.6,<1.7
-    elasticsearch17: elasticsearch>=1.7,<1.8
-    elasticsearch18: elasticsearch>=1.8,<1.9
-    elasticsearch23: elasticsearch>=2.3,<2.4
-    elasticsearch24: elasticsearch>=2.4,<2.5
-    elasticsearch51: elasticsearch>=5.1,<5.2
-    elasticsearch52: elasticsearch>=5.2,<5.3
-    elasticsearch53: elasticsearch>=5.3,<5.4
-    elasticsearch54: elasticsearch>=5.4,<5.5
-    elasticsearch63: elasticsearch>=6.3,<6.4
-    elasticsearch64: elasticsearch>=6.4,<6.5
-    elasticsearch68: elasticsearch>=6.8,<6.9
-    elasticsearch70: elasticsearch>=7.0,<7.1
-    elasticsearch71: elasticsearch>=7.1,<7.2
-    elasticsearch75: elasticsearch>=7.5,<7.6
-    elasticsearch76: elasticsearch>=7.6,<7.7
-    elasticsearch78: elasticsearch>=7.8,<7.9
-    elasticsearch710: elasticsearch>=7.10,<7.11
-    elasticsearch1100: elasticsearch1>=1.10.0,<1.11.0
-    elasticsearch250: elasticsearch2>=2.5.0,<2.6.0
-    elasticsearch550: elasticsearch5>=5.5.0,<5.6.0
-    elasticsearch640: elasticsearch6>=6.4.0,<6.5.0
-    elasticsearch770: elasticsearch7>=7.0,<7.1
-    elasticsearch771: elasticsearch7>=7.1,<7.2
-    elasticsearch775: elasticsearch7>=7.5,<7.6
-    elasticsearch776: elasticsearch7>=7.6,<7.7
-    elasticsearch778: elasticsearch7>=7.8,<7.9
-    elasticsearch7710: elasticsearch7>=7.10,<7.11
-    elasticsearch77: elasticsearch7
     falcon10: falcon>=1.0,<1.1
     falcon11: falcon>=1.1,<1.2
     falcon12: falcon>=1.2,<1.3
@@ -473,7 +436,6 @@ commands =
     consul_contrib: pytest {posargs} tests/contrib/consul
     dbapi_contrib: pytest {posargs} tests/contrib/dbapi
     dogpile_contrib: pytest {posargs} tests/contrib/dogpile_cache
-    elasticsearch_contrib: pytest {posargs} tests/contrib/elasticsearch
     falcon_contrib: pytest {posargs} tests/contrib/falcon/test_middleware.py tests/contrib/falcon/test_distributed_tracing.py
     falcon_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/falcon/test_autopatch.py
     flask_contrib: pytest {posargs} tests/contrib/flask


### PR DESCRIPTION
Moving from tox to riot cuts runtime down from 20+ minutes to <10 mins.


```
# tox -l | grep elasticsearch
elasticsearch_contrib-py27-elasticsearch16
elasticsearch_contrib-py27-elasticsearch17
elasticsearch_contrib-py27-elasticsearch18
elasticsearch_contrib-py27-elasticsearch23
elasticsearch_contrib-py27-elasticsearch24
elasticsearch_contrib-py27-elasticsearch51
elasticsearch_contrib-py27-elasticsearch52
elasticsearch_contrib-py27-elasticsearch53
elasticsearch_contrib-py27-elasticsearch54
elasticsearch_contrib-py27-elasticsearch63
elasticsearch_contrib-py27-elasticsearch64
elasticsearch_contrib-py27-elasticsearch68
elasticsearch_contrib-py27-elasticsearch70
elasticsearch_contrib-py27-elasticsearch71
elasticsearch_contrib-py27-elasticsearch75
elasticsearch_contrib-py27-elasticsearch76
elasticsearch_contrib-py27-elasticsearch78
elasticsearch_contrib-py27-elasticsearch710
elasticsearch_contrib-py27-elasticsearch
elasticsearch_contrib-py35-elasticsearch16
elasticsearch_contrib-py35-elasticsearch17
elasticsearch_contrib-py35-elasticsearch18
elasticsearch_contrib-py35-elasticsearch23
elasticsearch_contrib-py35-elasticsearch24
elasticsearch_contrib-py35-elasticsearch51
elasticsearch_contrib-py35-elasticsearch52
elasticsearch_contrib-py35-elasticsearch53
elasticsearch_contrib-py35-elasticsearch54
elasticsearch_contrib-py35-elasticsearch63
elasticsearch_contrib-py35-elasticsearch64
elasticsearch_contrib-py35-elasticsearch68
elasticsearch_contrib-py35-elasticsearch70
elasticsearch_contrib-py35-elasticsearch71
elasticsearch_contrib-py35-elasticsearch75
elasticsearch_contrib-py35-elasticsearch76
elasticsearch_contrib-py35-elasticsearch78
elasticsearch_contrib-py35-elasticsearch710
elasticsearch_contrib-py35-elasticsearch
elasticsearch_contrib-py36-elasticsearch16
elasticsearch_contrib-py36-elasticsearch17
elasticsearch_contrib-py36-elasticsearch18
elasticsearch_contrib-py36-elasticsearch23
elasticsearch_contrib-py36-elasticsearch24
elasticsearch_contrib-py36-elasticsearch51
elasticsearch_contrib-py36-elasticsearch52
elasticsearch_contrib-py36-elasticsearch53
elasticsearch_contrib-py36-elasticsearch54
elasticsearch_contrib-py36-elasticsearch63
elasticsearch_contrib-py36-elasticsearch64
elasticsearch_contrib-py36-elasticsearch68
elasticsearch_contrib-py36-elasticsearch70
elasticsearch_contrib-py36-elasticsearch71
elasticsearch_contrib-py36-elasticsearch75
elasticsearch_contrib-py36-elasticsearch76
elasticsearch_contrib-py36-elasticsearch78
elasticsearch_contrib-py36-elasticsearch710
elasticsearch_contrib-py36-elasticsearch
elasticsearch_contrib-py27-elasticsearch1100
elasticsearch_contrib-py35-elasticsearch1100
elasticsearch_contrib-py36-elasticsearch1100
elasticsearch_contrib-py27-elasticsearch250
elasticsearch_contrib-py35-elasticsearch250
elasticsearch_contrib-py36-elasticsearch250
elasticsearch_contrib-py27-elasticsearch550
elasticsearch_contrib-py35-elasticsearch550
elasticsearch_contrib-py36-elasticsearch550
elasticsearch_contrib-py27-elasticsearch640
elasticsearch_contrib-py35-elasticsearch640
elasticsearch_contrib-py36-elasticsearch640
elasticsearch_contrib-py37-elasticsearch776
elasticsearch_contrib-py37-elasticsearch778
elasticsearch_contrib-py37-elasticsearch7710
elasticsearch_contrib-py37-elasticsearch77
elasticsearch_contrib-py38-elasticsearch776
elasticsearch_contrib-py38-elasticsearch778
elasticsearch_contrib-py38-elasticsearch7710
elasticsearch_contrib-py38-elasticsearch77
elasticsearch_contrib-py39-elasticsearch7710
elasticsearch_contrib-py39-elasticsearch77

# tox -l | grep elasticsearch | wc -l
78
```

```
# riot list elasticsearch
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.6.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.7.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.8.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.9.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=2.3.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=2.4.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.1.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.2.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.3.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.4.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.3.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.4.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.8.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.0.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.1.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.5.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.6.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.7.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.8.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.9.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=2.3.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=2.4.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.1.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.2.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.3.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.4.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.3.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.4.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.8.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.0.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.1.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.5.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.6.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.7.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.8.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.9.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=2.3.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=2.4.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.1.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.2.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.3.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.4.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.3.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.4.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.8.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.0.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.1.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.5.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.6.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.7.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.8.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.9.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=2.3.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=2.4.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.1.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.2.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.3.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.4.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.3.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.4.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.8.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.0.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.1.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.5.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.6.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.7.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.8.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=1.9.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=2.3.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=2.4.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.1.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.2.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.3.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=5.4.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.3.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.4.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=6.8.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.0.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.1.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.5.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.6.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.8.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.10.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.6.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.8.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.10.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.6.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.8.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.10.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.6.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.8.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.10.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.6.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.8.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.10.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.6.0'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.8.0'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch~=7.10.0'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch1~=1.10.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch1~=1.10.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch1~=1.10.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch1~=1.10.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch1~=1.10.0'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch1~=1.10.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch2~=2.5.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch2~=2.5.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch2~=2.5.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch2~=2.5.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch2~=2.5.0'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch2~=2.5.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch5~=5.5.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch5~=5.5.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch5~=5.5.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch5~=5.5.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch5~=5.5.0'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch5~=5.5.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6~=6.4.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6~=6.8.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6~=6.4.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6~=6.8.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6~=6.4.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6~=6.8.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6~=6.4.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6~=6.8.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6~=6.4.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6~=6.8.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6~=6.4.0'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6~=6.8.0'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch6'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.6.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.8.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.10.0'
elasticsearch  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.6.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.8.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.10.0'
elasticsearch  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.6.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.8.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.10.0'
elasticsearch  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.6.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.8.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.10.0'
elasticsearch  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.6.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.8.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.10.0'
elasticsearch  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.6.0'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.8.0'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7~=7.10.0'
elasticsearch  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'elasticsearch7'

riot list elasticsearch | wc -l
164
```