### PR TITLE
flask: don't shortcut on sampling decision

### DIFF
--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -120,7 +120,7 @@ class TraceMiddleware(object):
 
     def _process_response(self, response):
         span = getattr(g, "flask_datadog_span", None)
-        if not (span and span.sampled):
+        if not span:
             return
 
         code = response.status_code if response else ""
@@ -133,7 +133,7 @@ class TraceMiddleware(object):
             _set_error_on_span(span, exception)
 
     def _finish_span(self, span, exception=None):
-        if not span or not span.sampled:
+        if not span:
             return
 
         code = span.get_tag(http.STATUS_CODE) or 0

--- a/releasenotes/notes/flask-241a6dd8c17e2c12.yaml
+++ b/releasenotes/notes/flask-241a6dd8c17e2c12.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    flask: fix memory leak for unsampled spans.
+    flask: fix memory leak of sampled out traces.

--- a/releasenotes/notes/flask-241a6dd8c17e2c12.yaml
+++ b/releasenotes/notes/flask-241a6dd8c17e2c12.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    flask: fix memory leak for unsampled spans.


### PR DESCRIPTION
By shortcutting when the span isn't sampled, the span will not be
finished. By not finishing the span, the trace will never finish which
will keep it in memory indefinitely.
