### PR TITLE
riot: specify cmdargs for all pytest commands

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -64,7 +64,6 @@ venv = Venv(
                 ),
             ],
         ),
-        Venv(name="tracer", command="pytest tests/tracer/", venvs=[Venv(pys=select_pys(), pkgs={"msgpack": latest})]),
         Venv(
             name="pymongo",
             command="pytest {cmdargs} tests/contrib/pymongo",

--- a/riotfile.py
+++ b/riotfile.py
@@ -45,10 +45,10 @@ venv = Venv(
             pkgs={"pytest-benchmark": latest, "msgpack": latest},
             command="pytest --no-cov {cmdargs} tests/benchmarks",
         ),
-        Venv(name="tracer", command="pytest tests/tracer/", venvs=[Venv(pys=select_pys(), pkgs={"msgpack": latest})]),
+        Venv(name="tracer", command="pytest {cmdargs} tests/tracer/", venvs=[Venv(pys=select_pys(), pkgs={"msgpack": latest})]),
         Venv(
             name="pymongo",
-            command="pytest tests/contrib/pymongo",
+            command="pytest {cmdargs} tests/contrib/pymongo",
             venvs=[
                 Venv(
                     pys=select_pys(max_version=3.7),
@@ -101,7 +101,7 @@ venv = Venv(
         # Source: https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
         Venv(
             name="django",
-            command="pytest tests/contrib/django",
+            command="pytest {cmdargs} tests/contrib/django",
             venvs=[
                 Venv(
                     pys=select_pys(max_version=3.6),
@@ -167,7 +167,7 @@ venv = Venv(
         ),
         Venv(
             name="djangorestframework",
-            command="pytest tests/contrib/djangorestframework",
+            command="pytest {cmdargs} tests/contrib/djangorestframework",
             venvs=[
                 Venv(
                     pys=select_pys(max_version=3.6),
@@ -250,7 +250,7 @@ venv = Venv(
         ),
         Venv(
             name="pynamodb",
-            command="pytest tests/contrib/pynamodb",
+            command="pytest {cmdargs} tests/contrib/pynamodb",
             venvs=[
                 Venv(
                     pys=select_pys(),
@@ -263,7 +263,7 @@ venv = Venv(
         ),
         Venv(
             name="starlette",
-            command="pytest tests/contrib/starlette",
+            command="pytest {cmdargs} tests/contrib/starlette",
             venvs=[
                 Venv(
                     pys=select_pys(min_version=3.6),
@@ -282,7 +282,7 @@ venv = Venv(
         ),
         Venv(
             name="requests",
-            command="pytest tests/contrib/requests",
+            command="pytest {cmdargs} tests/contrib/requests",
             venvs=[
                 Venv(
                     pys=select_pys(),
@@ -304,7 +304,7 @@ venv = Venv(
         ),
         Venv(
             name="wsgi",
-            command="pytest tests/contrib/wsgi",
+            command="pytest {cmdargs} tests/contrib/wsgi",
             venvs=[
                 Venv(
                     pys=select_pys(),
@@ -316,17 +316,17 @@ venv = Venv(
         ),
         Venv(
             name="boto",
-            command="pytest tests/contrib/boto",
+            command="pytest {cmdargs} tests/contrib/boto",
             venvs=[Venv(pys=select_pys(max_version=3.6), pkgs={"boto": latest, "moto": ["<1.0"]})],
         ),
         Venv(
             name="botocore",
-            command="pytest tests/contrib/botocore",
+            command="pytest {cmdargs} tests/contrib/botocore",
             venvs=[Venv(pys=select_pys(), pkgs={"botocore": latest, "moto": [">=1.0,<2.0"]})],
         ),
         Venv(
             name="mongoengine",
-            command="pytest tests/contrib/mongoengine",
+            command="pytest {cmdargs} tests/contrib/mongoengine",
             pkgs={
                 "pymongo": latest,
             },
@@ -352,7 +352,7 @@ venv = Venv(
                 "asgiref": ["~=3.0.0", "~=3.0"],
             },
             pys=select_pys(min_version=3.6),
-            command="pytest tests/contrib/asgi",
+            command="pytest {cmdargs} tests/contrib/asgi",
         ),
         Venv(
             name="fastapi",


### PR DESCRIPTION
This enables the pass-through of additional command line flags and
arguments to pytest.