### PR TITLE
test(profiling): fix flaky test_ignore_profiler_gevent_task

### DIFF
--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -161,7 +161,6 @@ def test_ignore_profiler_gevent_task(profiler):
     # sure to catch it with the StackProfiler and that it's ignored.
     c = CollectorTest(profiler._profiler._recorder, interval=0.00001)
     c.start()
-    events = profiler._profiler._recorder.events[stack.StackSampleEvent]
     collector_thread_ids = {
         col._worker.ident
         for col in profiler._profiler._collectors
@@ -170,7 +169,8 @@ def test_ignore_profiler_gevent_task(profiler):
     collector_thread_ids.add(c._worker.ident)
     time.sleep(3)
     c.stop()
-    assert collector_thread_ids.isdisjoint({e.task_id for e in events})
+    events = profiler._profiler._recorder.reset()
+    assert collector_thread_ids.isdisjoint({e.task_id for e in events[stack.StackSampleEvent]})
 
 
 @pytest.mark.skipif(not stack.FEATURES["gevent-tasks"], reason="gevent-tasks not supported")


### PR DESCRIPTION
The test can fail with the following error:

.0 = <deque_iterator object at 0x7f0a80ce3b30>

>   assert collector_thread_ids.isdisjoint({e.task_id for e in events})
E   RuntimeError: deque mutated during iteration

Which makes sense since the event deque is not frozen and still used by the
profiler object. Calling the `reset` method makes sure we get the current
event list and can assert on it without having it being modified.