### PR TITLE
test(profiling): increase tolerance for accuracy testing

### DIFF
--- a/tests/profiling/test_accuracy.py
+++ b/tests/profiling/test_accuracy.py
@@ -52,9 +52,9 @@ def spend_cpu_3():
         pass
 
 
-# We allow 3% error:
+# We allow 4% error:
 # The profiler might not be precise, but time.sleep is not either.
-TOLERANCE = 0.03
+TOLERANCE = 0.04
 # Use 5% accuracy for CPU usage, it's way less precise
 CPU_TOLERANCE = 0.05
 


### PR DESCRIPTION
The test failed in the ci with 3.3% drift:

E       AssertionError: assert False
E        +  where False = almost_equal(2067426803, 2000000000.0)
E        +    where 2067426803 = total_time(defaultdict(<function test_accuracy.<locals>.<lambda> at 0x7f04011c5c80>, {0: defaultdict(<function test_accuracy.<loc...acy.<locals>.<lambda>.<locals>.<lambda> at 0x7f03fbabc510>, {'spend_1': 0, 'spend_3': 0, 'monotonic_ns': 1614057035})}), 'spend_1')

Increase the value to 4% to be safe.