### PR TITLE
ci: use riot for psycopg and sqlalchemy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -863,9 +863,9 @@ jobs:
       - *postgres_server
       - *mysql_server
     steps:
-      - run_tox_scenario:
+      - run_test:
           wait: postgres mysql
-          pattern: '^sqlalchemy_contrib-'
+          pattern: "sqlalchemy"
 
   dbapi:
     <<: *contrib_job
@@ -879,9 +879,9 @@ jobs:
       - image: *ddtrace_dev_image
       - *postgres_server
     steps:
-      - run_tox_scenario:
+      - run_test:
           wait: postgres
-          pattern: '^psycopg_contrib-'
+          pattern: "psycopg"
 
   aiobotocore:
     <<: *contrib_job

--- a/riotfile.py
+++ b/riotfile.py
@@ -267,6 +267,30 @@ venv = Venv(
             ],
         ),
         Venv(
+            name="psycopg",
+            command="pytest {cmdargs} tests/contrib/psycopg",
+            venvs = [
+                Venv(
+                    pys=select_pys(min_version=2.7, max_version=3.6),
+                    pkgs={
+                        "psycopg2": ["~=2.4.0", "~=2.5.0", "~=2.6.0", "~=2.7.0", "~=2.8.0", latest]
+                    },
+                ),
+                Venv(
+                    pys=[3.7],
+                    pkgs={
+                        "psycopg2": ["~=2.7.0", "~=2.8.0", latest]
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version=3.8, max_version=3.9),
+                    pkgs={
+                        "psycopg2": ["~=2.8.0", latest]
+                    },
+                ),
+            ],
+        ),
+        Venv(
             name="pynamodb",
             command="pytest tests/contrib/pynamodb",
             venvs=[
@@ -294,6 +318,20 @@ venv = Venv(
                         "sqlalchemy": latest,
                         "aiosqlite": latest,
                         "databases": latest,
+                    },
+                ),
+            ],
+        ),
+        Venv(
+            name="sqlalchemy",
+            command="pytest {cmdargs} tests/contrib/sqlalchemy",
+            venvs = [
+                Venv(
+                    pys=select_pys(),
+                    pkgs={
+                        "sqlalchemy": ["~=1.0.0", "~=1.1.0", "~=1.2.0", "~=1.3.0", latest],
+                        "psycopg2": ["~=2.8.0"],
+                        "mysql-connector-python": latest,
                     },
                 ),
             ],

--- a/tox.ini
+++ b/tox.ini
@@ -81,10 +81,6 @@ envlist =
     mysql_contrib-py{27,35,36,37,38,39}-mysqlconnector{80,}
     mysqldb_contrib-py27-mysqldb{12,}
     mysqldb_contrib-py{27,35,36,37,38,39}-mysqlclient{13,14,}
-    psycopg_contrib-py{27,35,36}-psycopg2{24,25,26,27,28}
-    psycopg_contrib-py37-psycopg2{27,28}
-# psycopg <2.7 doesn't support Python 3.8: https://github.com/psycopg/psycopg2/issues/854
-    psycopg_contrib-py{38,39}-psycopg2{28}
     pylibmc_contrib-py{27,35,36,37,38,39}-pylibmc{140,150,}
     pylons_contrib-py27-pylons{096,097,010,10,}
     pymemcache_contrib{,_autopatch}-{py27,py35,py36,py37,py38}-pymemcache{130,140}
@@ -109,7 +105,6 @@ envlist =
     redis_contrib-py{27,35,36,37,38,39}-redis{210,30,32,33,34,35,}
     rediscluster_contrib-py{27,35,36,37,38,39}-rediscluster{135,136,200,}-redis210
     sanic_contrib-py{36,37,38,39}-sanic{1906,1909,1912,2003,2006}
-    sqlalchemy_contrib-py{27,35,36,37,38,39}-sqlalchemy{10,11,12,13,}-psycopg228-mysqlconnector
     sqlite3_contrib-py{27,35,36,37,38,39}-sqlite3
     tornado_contrib-py{27,35,36,37,38,39}-tornado{44,45}
     tornado_contrib-py{37,38,39}-tornado{50,51,60,}
@@ -316,11 +311,6 @@ deps =
     pyramid18: pyramid>=1.8,<1.9
     pyramid19: pyramid>=1.9,<1.10
     pyramid110: pyramid>=1.10,<1.11
-    psycopg224: psycopg2>=2.4,<2.5
-    psycopg225: psycopg2>=2.5,<2.6
-    psycopg226: psycopg2>=2.6,<2.7
-    psycopg227: psycopg2>=2.7,<2.8
-    psycopg228: psycopg2>=2.8,<2.9
     pyodbc: pyodbc
     pyodbc4: pyodbc>=4.0,<5.0
     pyodbc3: pyodbc>=3.0,<4.0
@@ -352,10 +342,6 @@ deps =
     sanic2006: sanic~=20.6.0
     sanic: sanic
     sqlalchemy: sqlalchemy
-    sqlalchemy10: sqlalchemy>=1.0,<1.1
-    sqlalchemy11: sqlalchemy>=1.1,<1.2
-    sqlalchemy12: sqlalchemy>=1.2,<1.3
-    sqlalchemy13: sqlalchemy>=1.3,<1.4
     sslmodules3: aiohttp
     sslmodules3: aiobotocore
     sslmodules: botocore
@@ -419,7 +405,6 @@ commands =
     molten_contrib: pytest {posargs} tests/contrib/molten
     mysql_contrib: pytest {posargs} tests/contrib/mysql
     mysqldb_contrib: pytest {posargs} tests/contrib/mysqldb
-    psycopg_contrib: pytest {posargs} tests/contrib/psycopg
     pylibmc_contrib: pytest {posargs} tests/contrib/pylibmc
     pylons_contrib: pytest {posargs} tests/contrib/pylons
     pymemcache_contrib: pytest {posargs} --ignore="tests/contrib/pymemcache/autopatch" tests/contrib/pymemcache/
@@ -434,7 +419,6 @@ commands =
     kombu_contrib: pytest {posargs} tests/contrib/kombu
     sanic_contrib: pytest {posargs} tests/contrib/sanic/test_sanic.py
     sanic_contrib: pytest {posargs} tests/contrib/sanic/test_sanic_server.py
-    sqlalchemy_contrib: pytest {posargs} tests/contrib/sqlalchemy
     sqlite3_contrib: pytest {posargs} tests/contrib/sqlite3
     tornado_contrib: pytest {posargs} tests/contrib/tornado
     vertica_contrib: pytest {posargs} tests/contrib/vertica/


### PR DESCRIPTION
## Description

Use riot for psycopg (adding the 6 tests for latest to the test matrix) and sqlalchemy

```
$ tox -l | grep psycopg_contrib
psycopg_contrib-py27-psycopg224
psycopg_contrib-py27-psycopg225
psycopg_contrib-py27-psycopg226
psycopg_contrib-py27-psycopg227
psycopg_contrib-py27-psycopg228
psycopg_contrib-py35-psycopg224
psycopg_contrib-py35-psycopg225
psycopg_contrib-py35-psycopg226
psycopg_contrib-py35-psycopg227
psycopg_contrib-py35-psycopg228
psycopg_contrib-py36-psycopg224
psycopg_contrib-py36-psycopg225
psycopg_contrib-py36-psycopg226
psycopg_contrib-py36-psycopg227
psycopg_contrib-py36-psycopg228
psycopg_contrib-py37-psycopg227
psycopg_contrib-py37-psycopg228
psycopg_contrib-py38-psycopg228
psycopg_contrib-py39-psycopg228
$ tox -l | grep psycopg_contrib | wc -l
19
$ tox -l | grep sqlalchemy_contrib
sqlalchemy_contrib-py27-sqlalchemy10-psycopg228-mysqlconnector
sqlalchemy_contrib-py27-sqlalchemy11-psycopg228-mysqlconnector
sqlalchemy_contrib-py27-sqlalchemy12-psycopg228-mysqlconnector
sqlalchemy_contrib-py27-sqlalchemy13-psycopg228-mysqlconnector
sqlalchemy_contrib-py27-sqlalchemy-psycopg228-mysqlconnector
sqlalchemy_contrib-py35-sqlalchemy10-psycopg228-mysqlconnector
sqlalchemy_contrib-py35-sqlalchemy11-psycopg228-mysqlconnector
sqlalchemy_contrib-py35-sqlalchemy12-psycopg228-mysqlconnector
sqlalchemy_contrib-py35-sqlalchemy13-psycopg228-mysqlconnector
sqlalchemy_contrib-py35-sqlalchemy-psycopg228-mysqlconnector
sqlalchemy_contrib-py36-sqlalchemy10-psycopg228-mysqlconnector
sqlalchemy_contrib-py36-sqlalchemy11-psycopg228-mysqlconnector
sqlalchemy_contrib-py36-sqlalchemy12-psycopg228-mysqlconnector
sqlalchemy_contrib-py36-sqlalchemy13-psycopg228-mysqlconnector
sqlalchemy_contrib-py36-sqlalchemy-psycopg228-mysqlconnector
sqlalchemy_contrib-py37-sqlalchemy10-psycopg228-mysqlconnector
sqlalchemy_contrib-py37-sqlalchemy11-psycopg228-mysqlconnector
sqlalchemy_contrib-py37-sqlalchemy12-psycopg228-mysqlconnector
sqlalchemy_contrib-py37-sqlalchemy13-psycopg228-mysqlconnector
sqlalchemy_contrib-py37-sqlalchemy-psycopg228-mysqlconnector
sqlalchemy_contrib-py38-sqlalchemy10-psycopg228-mysqlconnector
sqlalchemy_contrib-py38-sqlalchemy11-psycopg228-mysqlconnector
sqlalchemy_contrib-py38-sqlalchemy12-psycopg228-mysqlconnector
sqlalchemy_contrib-py38-sqlalchemy13-psycopg228-mysqlconnector
sqlalchemy_contrib-py38-sqlalchemy-psycopg228-mysqlconnector
sqlalchemy_contrib-py39-sqlalchemy10-psycopg228-mysqlconnector
sqlalchemy_contrib-py39-sqlalchemy11-psycopg228-mysqlconnector
sqlalchemy_contrib-py39-sqlalchemy12-psycopg228-mysqlconnector
sqlalchemy_contrib-py39-sqlalchemy13-psycopg228-mysqlconnector
sqlalchemy_contrib-py39-sqlalchemy-psycopg228-mysqlconnector
$ tox -l | grep sqlalchemy_contrib | wc -l
30
```

```
$ riot list | grep "^psycopg"
psycopg  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.4.0'
psycopg  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.5.0'
psycopg  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.6.0'
psycopg  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.7.0'
psycopg  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.8.0'
psycopg  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2'
psycopg  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.4.0'
psycopg  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.5.0'
psycopg  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.6.0'
psycopg  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.7.0'
psycopg  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.8.0'
psycopg  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2'
psycopg  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.4.0'
psycopg  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.5.0'
psycopg  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.6.0'
psycopg  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.7.0'
psycopg  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.8.0'
psycopg  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2'
psycopg  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.7.0'
psycopg  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.8.0'
psycopg  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2'
psycopg  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.8.0'
psycopg  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2'
psycopg  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2~=2.8.0'
psycopg  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'psycopg2'
$ riot list | grep "^psycopg" | wc -l
25
$ riot list | grep "^sqlalchemy"
sqlalchemy  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.0.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.1.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.2.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.3.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='2.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.0.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.1.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.2.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.3.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.5') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.0.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.1.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.2.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.3.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.6') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.0.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.1.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.2.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.3.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.7') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.0.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.1.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.2.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.3.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.8') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.0.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.1.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.2.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy~=1.3.0' 'psycopg2~=2.8.0' 'mysql-connector-python'
sqlalchemy  Interpreter(_hint='3.9') 'mock' 'pytest' 'coverage' 'pytest-cov' 'opentracing' 'sqlalchemy' 'psycopg2~=2.8.0' 'mysql-connector-python'
$ riot list | grep "^sqlalchemy" | wc -l
30
```