### PR TITLE
docs: fix missing cython dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -445,6 +445,7 @@ ignore_outcome=true
 extras=
   opentracing
 deps=
+  cython
   reno[sphinx]
   sphinx
   sphinxcontrib-spelling


### PR DESCRIPTION
This prevents the job to be run twice as cython is not installed in the venv
otherwise.