### PR TITLE
ci: remove Sanic support for Python 3.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -104,7 +104,7 @@ envlist =
     pyramid_contrib{,_autopatch}-py{27,35,36,37,38,39}-pyramid{17,18,19,110,}-webtest
     redis_contrib-py{27,35,36,37,38,39}-redis{210,30,32,33,34,35,}
     rediscluster_contrib-py{27,35,36,37,38,39}-rediscluster{135,136,200,}-redis210
-    sanic_contrib-py{36,37,38,39}-sanic{1906,1909,1912,2003,2006}
+    sanic_contrib-py{37,38,39}-sanic{1906,1909,1912,2003,2006}
     sqlite3_contrib-py{27,35,36,37,38,39}-sqlite3
     tornado_contrib-py{27,35,36,37,38,39}-tornado{44,45}
     tornado_contrib-py{37,38,39}-tornado{50,51,60,}


### PR DESCRIPTION
We can't test Sanic on Python 3.6 as uvloop is pulled and requires
Python  >= 3.7.