### PR TITLE
chore(docs): Update deprecated env variable name

### DIFF
--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -39,7 +39,7 @@ Configuration
 
    The service name reported for your Django app.
 
-   Can also be configured via the ``DD_SERVICE_NAME`` environment variable.
+   Can also be configured via the ``DD_SERVICE`` environment variable.
 
    Default: ``'django'``
 


### PR DESCRIPTION


## Description

`DD_SERVICE_NAME` was deprecated in #1320, but it still appears in the Django integration docs. This PR replaces it with `DD_SERVICE`.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
