### PR TITLE
fix(logger): Use standard DD_TRACE_LOGGING_RATE variable

### DIFF
--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -2,8 +2,8 @@ import collections
 import logging
 import os
 
-from ..utils.formats import get_env
 from ..utils.deprecation import deprecation
+from ..utils.formats import get_env
 
 
 def get_logger(name):
@@ -110,7 +110,10 @@ class DDLogger(logging.Logger):
                     version="1.0.0",
                 )
 
-        self.rate_limit = rate_limit is not None and int(rate_limit) or 60
+        if rate_limit is not None:
+            self.rate_limit = int(rate_limit)
+        else:
+            self.rate_limit = 60
 
     def handle(self, record):
         """
@@ -125,7 +128,7 @@ class DDLogger(logging.Logger):
         :param record: The log record being logged
         :type record: ``logging.LogRecord``
         """
-        # If rate limiting has been disabled (`DD_LOGGING_RATE_LIMIT=0`) then apply no rate limit
+        # If rate limiting has been disabled (`DD_TRACE_LOGGING_RATE=0`) then apply no rate limit
         # If the logging is in debug, then do not apply any limits to any log
         if not self.rate_limit or self.getEffectiveLevel() == logging.DEBUG:
             super(DDLogger, self).handle(record)

--- a/releasenotes/notes/fix-logger-standard-logging-rate-envvar-155e113deea71e85.yaml
+++ b/releasenotes/notes/fix-logger-standard-logging-rate-envvar-155e113deea71e85.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Deprecate the DD_LOGGING_RATE_LIMIT variable in favor of the standard
+    DD_TRACE_LOGGING_RATE for configuring the logging rate limit.

--- a/tests/tracer/test_logger.py
+++ b/tests/tracer/test_logger.py
@@ -1,16 +1,11 @@
 import logging
 
-<<<<<<< HEAD
-from pytest import warns
-
-from ddtrace.internal.logger import DDLogger, get_logger
-from ddtrace.utils.deprecation import RemovedInDDTrace10Warning
-=======
 import mock
->>>>>>> master
+from pytest import warns
 
 from ddtrace.internal.logger import DDLogger
 from ddtrace.internal.logger import get_logger
+from ddtrace.utils.deprecation import RemovedInDDTrace10Warning
 from tests import BaseTestCase
 
 
@@ -154,6 +149,11 @@ class DDLoggerTestCase(BaseTestCase):
         with self.override_env(dict(DD_LOGGING_RATE_LIMIT="10")), warns(RemovedInDDTrace10Warning):
             log = DDLogger("test.logger")
             self.assertEqual(log.rate_limit, 10)
+
+        # Ensure correct precedence
+        with self.override_env(dict(DD_LOGGING_RATE_LIMIT="10", DD_TRACE_LOGGING_RATE="20")):
+            log = DDLogger("test.logger")
+            self.assertEqual(log.rate_limit, 20)
 
     def test_logger_log(self):
         """

--- a/tests/tracer/test_logger.py
+++ b/tests/tracer/test_logger.py
@@ -1,7 +1,10 @@
 import logging
 import mock
 
+from pytest import warns
+
 from ddtrace.internal.logger import DDLogger, get_logger
+from ddtrace.utils.deprecation import RemovedInDDTrace10Warning
 
 from tests import BaseTestCase
 
@@ -133,13 +136,18 @@ class DDLoggerTestCase(BaseTestCase):
         self.assertIsNone(log.parent)
 
         # Override rate limit from environment variable
-        with self.override_env(dict(DD_LOGGING_RATE_LIMIT="10")):
+        with self.override_env(dict(DD_TRACE_LOGGING_RATE="10")):
             log = DDLogger("test.logger")
             self.assertEqual(log.rate_limit, 10)
 
         # Set specific log level
         log = DDLogger("test.logger", level=logging.DEBUG)
         self.assertEqual(log.level, logging.DEBUG)
+
+    def test_logger_deprecated_rate_limit(self):
+        with self.override_env(dict(DD_LOGGING_RATE_LIMIT="10")), warns(RemovedInDDTrace10Warning):
+            log = DDLogger("test.logger")
+            self.assertEqual(log.rate_limit, 10)
 
     def test_logger_log(self):
         """


### PR DESCRIPTION
## Description

Deprecate the `(DD/DATADOG)_LOGGING_RATE_LIMIT` variable in favour of the standard `DD_TRACE_LOGGING_RATE` for configuring the logging rate limit (see DataDog/architecture#833)


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
