### PR TITLE
fix(ci): pin rsa for python 2.7

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -46,7 +46,11 @@ venv = Venv(
             pkgs={"pytest-benchmark": latest, "msgpack": latest},
             command="pytest --no-cov {cmdargs} tests/benchmarks",
         ),
-        Venv(name="tracer", command="pytest {cmdargs} tests/tracer/", venvs=[Venv(pys=select_pys(), pkgs={"msgpack": latest})]),
+        Venv(
+            name="tracer",
+            command="pytest {cmdargs} tests/tracer/",
+            venvs=[Venv(pys=select_pys(), pkgs={"msgpack": latest})],
+        ),
         Venv(
             name="cherrypy",
             command="pytest {cmdargs} tests/contrib/cherrypy",
@@ -54,7 +58,15 @@ venv = Venv(
                 Venv(
                     pys=select_pys(),
                     pkgs={
-                        "cherrypy": [">=11,<12", ">=12,<13", ">=13,<14", ">=14,<15", ">=15,<16", ">=16,<17", ">=17,<18"],
+                        "cherrypy": [
+                            ">=11,<12",
+                            ">=12,<13",
+                            ">=13,<14",
+                            ">=14,<15",
+                            ">=15,<16",
+                            ">=16,<17",
+                            ">=17,<18",
+                        ],
                     },
                 ),
                 Venv(
@@ -270,24 +282,18 @@ venv = Venv(
         Venv(
             name="psycopg",
             command="pytest {cmdargs} tests/contrib/psycopg",
-            venvs = [
+            venvs=[
                 Venv(
                     pys=select_pys(min_version=2.7, max_version=3.6),
-                    pkgs={
-                        "psycopg2": ["~=2.4.0", "~=2.5.0", "~=2.6.0", "~=2.7.0", "~=2.8.0", latest]
-                    },
+                    pkgs={"psycopg2": ["~=2.4.0", "~=2.5.0", "~=2.6.0", "~=2.7.0", "~=2.8.0", latest]},
                 ),
                 Venv(
                     pys=[3.7],
-                    pkgs={
-                        "psycopg2": ["~=2.7.0", "~=2.8.0", latest]
-                    },
+                    pkgs={"psycopg2": ["~=2.7.0", "~=2.8.0", latest]},
                 ),
                 Venv(
                     pys=select_pys(min_version=3.8, max_version=3.9),
-                    pkgs={
-                        "psycopg2": ["~=2.8.0", latest]
-                    },
+                    pkgs={"psycopg2": ["~=2.8.0", latest]},
                 ),
             ],
         ),
@@ -296,10 +302,18 @@ venv = Venv(
             command="pytest {cmdargs} tests/contrib/pynamodb",
             venvs=[
                 Venv(
-                    pys=select_pys(),
+                    pys=select_pys(min_version=3.5),
                     pkgs={
                         "pynamodb": [">=4.0,<4.1", ">=4.1,<4.2", ">=4.2,<4.3", ">=4.3,<4.4", latest],
                         "moto": ">=1.0,<2.0",
+                    },
+                ),
+                Venv(
+                    pys=["2.7"],
+                    pkgs={
+                        "pynamodb": [">=4.0,<4.1", ">=4.1,<4.2", ">=4.2,<4.3", ">=4.3,<4.4", latest],
+                        "moto": ">=1.0,<2.0",
+                        "rsa": "<4.7.1",
                     },
                 ),
             ],
@@ -326,7 +340,7 @@ venv = Venv(
         Venv(
             name="sqlalchemy",
             command="pytest {cmdargs} tests/contrib/sqlalchemy",
-            venvs = [
+            venvs=[
                 Venv(
                     pys=select_pys(),
                     pkgs={
@@ -379,7 +393,10 @@ venv = Venv(
         Venv(
             name="botocore",
             command="pytest {cmdargs} tests/contrib/botocore",
-            venvs=[Venv(pys=select_pys(), pkgs={"botocore": latest, "moto": [">=1.0,<2.0"]})],
+            venvs=[
+                Venv(pys=select_pys(min_version=3.5), pkgs={"botocore": latest, "moto": [">=1.0,<2.0"]}),
+                Venv(pys=["2.7"], pkgs={"botocore": latest, "moto": [">=1.0,<2.0"], "rsa": ["<4.7.1"]}),
+            ],
         ),
         Venv(
             name="mongoengine",


### PR DESCRIPTION
## Description

The `rsa` package dropped support for Python 2.7 starting with version 4.7.1.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
