### PR TITLE
fix(ci): re-enable botocore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -548,7 +548,16 @@ jobs:
     parallelism: 4
     steps:
       - run_test:
-          pattern: '^boto'  # run boto and botocore
+          pattern: 'boto'
+          snapshot: true
+          docker_services: "localstack"
+
+  botocore:
+    <<: *machine_executor
+    parallelism: 4
+    steps:
+      - run_test:
+          pattern: 'botocore'
           snapshot: true
           docker_services: "localstack"
 
@@ -1039,6 +1048,7 @@ requires_tests: &requires_tests
     - asgi
     - benchmarks
     - boto
+    - botocore
     - bottle
     - cassandra
     - celery
@@ -1147,6 +1157,7 @@ workflows:
       - asgi: *requires_pre_test
       - benchmarks: *requires_pre_test
       - boto: *requires_pre_test
+      - botocore: *requires_pre_test
       - bottle: *requires_pre_test
       - cassandra: *requires_pre_test
       - celery: *requires_pre_test


### PR DESCRIPTION
## Description

The move to riot in #1861 required separate jobs since riot does not support regex patterns. Should merge this after #2032.
