### PR TITLE
refactor(profiling/uwsgi): reusable run uwsgi for tests

### DIFF
--- a/tests/contrib/uwsgi/__init__.py
+++ b/tests/contrib/uwsgi/__init__.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+import sys
+
+
+def run_uwsgi(cmd):
+    def _run(*args):
+        env = os.environ.copy()
+        if sys.version_info[0] == 2:
+            # On Python2, it's impossible to import uwsgidecorators without this hack
+            env["PYTHONPATH"] = os.path.join(
+                os.environ.get("VIRTUAL_ENV", ""),
+                "lib",
+                "python%s.%s" % (sys.version_info[0], sys.version_info[1]),
+                "site-packages",
+            )
+
+        return subprocess.Popen(cmd + list(args), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
+
+    return _run

--- a/tests/profiling/test_uwsgi.py
+++ b/tests/profiling/test_uwsgi.py
@@ -2,12 +2,13 @@
 import os
 import re
 import signal
-import subprocess
 import sys
 import tempfile
 import time
 
 import pytest
+
+from tests.contrib.uwsgi import run_uwsgi
 
 
 uwsgi_app = os.path.join(os.path.dirname(__file__), "uwsgi-app.py")
@@ -19,21 +20,8 @@ def uwsgi():
     socket_name = tempfile.mktemp()
     cmd = ["uwsgi", "--need-app", "--die-on-term", "--socket", socket_name, "--wsgi-file", uwsgi_app]
 
-    def _run_uwsgi(*args):
-        env = os.environ.copy()
-        if sys.version_info[0] == 2:
-            # On Python 2, it's impossible to import uwsgidecorators without this hack
-            env["PYTHONPATH"] = os.path.join(
-                os.environ.get("VIRTUAL_ENV", ""),
-                "lib",
-                "python%s.%s" % (sys.version_info[0], sys.version_info[1]),
-                "site-packages",
-            )
-
-        return subprocess.Popen(cmd + list(args), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
-
     try:
-        yield _run_uwsgi
+        yield run_uwsgi(cmd)
     finally:
         os.unlink(socket_name)
 


### PR DESCRIPTION
## Description

Refactor the running of uwsgi to make it useful for other components, like the tracer in #1992, as suggested here https://github.com/DataDog/dd-trace-py/pull/1992#discussion_r574647006.

I left the fixtures as specific to each use case and factored out the subprocess code for running uwsgi.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
