### PR TITLE
Add WSGI to integration docs

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -345,3 +345,10 @@ Tornado
 Vertica
 ^^^^^^^
 .. automodule:: ddtrace.contrib.vertica
+
+
+.. _wsgi:
+
+WSGI
+^^^^
+.. automodule:: ddtrace.contrib.wsgi


### PR DESCRIPTION
Since WSGI was merged a checklist item was added to the integration checklist (https://github.com/DataDog/dd-trace-py/pull/1979) to make sure this doesn't happen again.