### PR TITLE
refactor(tracer): separate dogstatsd for AgentWriter and RuntimeWorker

### DIFF
--- a/ddtrace/internal/dogstatsd.py
+++ b/ddtrace/internal/dogstatsd.py
@@ -1,0 +1,31 @@
+from ddtrace.compat import parse
+from ddtrace.vendor.dogstatsd import DogStatsd
+
+
+def parse_dogstatsd_url(url):
+    if url is None:
+        return
+
+    # url can be either of the form `udp://<host>:<port>` or `unix://<path>`
+    # also support without url scheme included
+    if url.startswith("/"):
+        url = "unix://" + url
+    elif "://" not in url:
+        url = "udp://" + url
+
+    parsed = parse.urlparse(url)
+
+    if parsed.scheme == "unix":
+        return dict(socket_path=parsed.path)
+    elif parsed.scheme == "udp":
+        return dict(host=parsed.hostname, port=parsed.port)
+    else:
+        raise ValueError("Unknown scheme `%s` for DogStatsD URL `{}`".format(parsed.scheme))
+
+
+def get_dogstatsd_client(dogstatsd_url):
+    if not dogstatsd_url:
+        return
+
+    dogstatsd_kwargs = parse_dogstatsd_url(dogstatsd_url)
+    return DogStatsd(**dogstatsd_kwargs)

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -22,9 +22,9 @@ from .internal import _rand
 from .internal import agent
 from .internal import debug
 from .internal import hostname
+from .internal.dogstatsd import get_dogstatsd_client
 from .internal.logger import get_logger
 from .internal.logger import hasHandlers
-from .internal.runtime import RuntimeTags
 from .internal.runtime import RuntimeWorker
 from .internal.runtime import get_runtime_id
 from .internal.writer import AgentWriter
@@ -39,7 +39,6 @@ from .utils.deprecation import RemovedInDDTrace10Warning
 from .utils.deprecation import deprecated
 from .utils.formats import asbool
 from .utils.formats import get_env
-from .vendor.dogstatsd import DogStatsd
 
 
 log = get_logger(__name__)
@@ -57,27 +56,6 @@ if debug_mode and not hasHandlers(log):
         logging.basicConfig(level=logging.DEBUG)
 
 
-def _parse_dogstatsd_url(url):
-    if url is None:
-        return
-
-    # url can be either of the form `udp://<host>:<port>` or `unix://<path>`
-    # also support without url scheme included
-    if url.startswith("/"):
-        url = "unix://" + url
-    elif "://" not in url:
-        url = "udp://" + url
-
-    parsed = compat.parse.urlparse(url)
-
-    if parsed.scheme == "unix":
-        return dict(socket_path=parsed.path)
-    elif parsed.scheme == "udp":
-        return dict(host=parsed.hostname, port=parsed.port)
-    else:
-        raise ValueError("Unknown scheme `%s` for DogStatsD URL `{}`".format(parsed.scheme))
-
-
 _INTERNAL_APPLICATION_SPAN_TYPES = ["custom", "template", "web", "worker"]
 
 
@@ -92,8 +70,6 @@ class Tracer(object):
         from ddtrace import tracer
         trace = tracer.trace('app.request', 'web-server').finish()
     """
-
-    _RUNTIME_METRICS_INTERVAL = 10
 
     def __init__(self, url=None, dogstatsd_url=None):
         """
@@ -291,14 +267,12 @@ class Tracer(object):
         if dogstatsd_host is not None and dogstatsd_url is None:
             dogstatsd_url = "udp://{}:{}".format(dogstatsd_host, dogstatsd_port or agent.get_stats_port())
 
-        if dogstatsd_url is not None:
-            dogstatsd_kwargs = _parse_dogstatsd_url(dogstatsd_url)
-            self.log.debug("Connecting to DogStatsd(%s)", dogstatsd_url)
-            self._dogstatsd_client = DogStatsd(**dogstatsd_kwargs)
+        self._dogstatsd_url = dogstatsd_url or self._dogstatsd_url
 
         if writer:
             self.writer = writer
-            self.writer.dogstatsd = self._dogstatsd_client
+            # Ensure dogstatsd client has been created for the writer being configured
+            self.writer.dogstatsd = get_dogstatsd_client(self._dogstatsd_url)
         elif (
             hostname is not None
             or port is not None
@@ -328,7 +302,7 @@ class Tracer(object):
                 https=https,
                 sampler=self.sampler,
                 priority_sampler=self.priority_sampler,
-                dogstatsd=self._dogstatsd_client,
+                dogstatsd=get_dogstatsd_client(self._dogstatsd_url),
                 report_metrics=config.health_metrics_enabled,
             )
 
@@ -341,8 +315,7 @@ class Tracer(object):
         # Since we've recreated our dogstatsd agent, we need to restart metric collection with that new agent
         if self._runtime_worker:
             runtime_metrics_was_running = True
-            self._runtime_worker.stop()
-            self._runtime_worker.join()
+            self._shutdown_runtime_worker()
             self._runtime_worker = None
         else:
             runtime_metrics_was_running = False
@@ -520,22 +493,21 @@ class Tracer(object):
 
             # The constant tags for the dogstatsd client needs to updated with any new
             # service(s) that may have been added.
-            self._update_dogstatsd_constant_tags()
+            if self._runtime_worker:
+                self._runtime_worker.update_runtime_tags()
 
         self._hooks.emit(self.__class__.start_span, span)
 
         return span
 
-    def _update_dogstatsd_constant_tags(self):
-        """Prepare runtime tags for ddstatsd."""
-        # DEV: ddstatsd expects tags in the form ['key1:value1', 'key2:value2', ...]
-        tags = ["{}:{}".format(k, v) for k, v in RuntimeTags()]
-        self.log.debug("Updating constant tags %s", tags)
-        self._dogstatsd_client.constant_tags = tags
-
     def _start_runtime_worker(self):
-        self._runtime_worker = RuntimeWorker(self._dogstatsd_client, self._RUNTIME_METRICS_INTERVAL)
-        self._runtime_worker.start()
+        if not self._dogstatsd_url:
+            return
+
+        self._runtime_worker = RuntimeWorker(self._dogstatsd_url)
+        # force an immediate update constant tags since we have reset services
+        # and generated a new runtime id
+        self._runtime_worker.update_runtime_tags()
 
     def _check_new_process(self):
         """Checks if the tracer is in a new process (was forked) and performs
@@ -570,10 +542,6 @@ class Tracer(object):
 
         if self._runtime_worker is not None:
             self._start_runtime_worker()
-
-        # force an immediate update constant tags since we have reset services
-        # and generated a new runtime id
-        self._update_dogstatsd_constant_tags()
 
         # Re-create the background writer thread
         self.writer = self.writer.recreate()
@@ -814,6 +782,16 @@ class Tracer(object):
 
         self.writer.stop()
         self.writer.join(timeout=timeout)
+
+        if self._runtime_worker:
+            self._shutdown_runtime_worker()
+
+    def _shutdown_runtime_worker(self, timeout=None):
+        if not self._runtime_worker.is_alive():
+            return
+
+        self._runtime_worker.stop()
+        self._runtime_worker.join(timeout=timeout)
 
     @staticmethod
     def _is_agentless_environment():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,6 +15,7 @@ from ddtrace.constants import SPAN_MEASURED_KEY
 from ddtrace.encoding import JSONEncoder
 from ddtrace.ext import http
 from ddtrace.internal._encoding import MsgpackEncoder
+from ddtrace.internal.dogstatsd import get_dogstatsd_client
 from ddtrace.internal.writer import AgentWriter
 from ddtrace.vendor import wrapt
 from tests.subprocesstest import SubprocessTestCase
@@ -452,6 +453,7 @@ class DummyTracer(Tracer):
                 hostname=self.writer._hostname,
                 port=self.writer._port,
                 priority_sampler=self.writer._priority_sampler,
+                dogstatsd=get_dogstatsd_client(self._dogstatsd_url),
             )
         else:
             self.writer = DummyWriter(

--- a/tests/commands/ddtrace_run_dogstatsd.py
+++ b/tests/commands/ddtrace_run_dogstatsd.py
@@ -5,9 +5,9 @@ from ddtrace import tracer
 
 if __name__ == "__main__":
     # check both configurations with host:port or unix socket
-    if tracer._dogstatsd_client.socket_path is None:
-        assert tracer._dogstatsd_client.host == "172.10.0.1"
-        assert tracer._dogstatsd_client.port == 8120
+    if tracer.writer.dogstatsd.socket_path is None:
+        assert tracer.writer.dogstatsd.host == "172.10.0.1"
+        assert tracer.writer.dogstatsd.port == 8120
     else:
-        assert tracer._dogstatsd_client.socket_path.endswith("dogstatsd.sock")
+        assert tracer.writer.dogstatsd.socket_path.endswith("dogstatsd.sock")
     print("Test success")

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -479,8 +479,8 @@ class TracerTestCases(TracerTestCase):
         with warnings.catch_warnings(record=True) as ws:
             warnings.simplefilter("always")
             self.tracer.configure(dogstatsd_host="foo")
-            assert self.tracer._dogstatsd_client.host == "foo"
-            assert self.tracer._dogstatsd_client.port == 8125
+            assert self.tracer.writer.dogstatsd.host == "foo"
+            assert self.tracer.writer.dogstatsd.port == 8125
             # verify warnings triggered
             assert len(ws) >= 1
             for w in ws:
@@ -494,8 +494,8 @@ class TracerTestCases(TracerTestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             self.tracer.configure(dogstatsd_host="foo", dogstatsd_port="1234")
-            assert self.tracer._dogstatsd_client.host == "foo"
-            assert self.tracer._dogstatsd_client.port == 1234
+            assert self.tracer.writer.dogstatsd.host == "foo"
+            assert self.tracer.writer.dogstatsd.port == 1234
             # verify warnings triggered
             assert len(w) >= 2
             assert issubclass(w[0].category, ddtrace.utils.deprecation.RemovedInDDTrace10Warning)
@@ -505,14 +505,14 @@ class TracerTestCases(TracerTestCase):
 
     def test_configure_dogstatsd_url_host_port(self):
         self.tracer.configure(dogstatsd_url="foo:1234")
-        assert self.tracer._dogstatsd_client.host == "foo"
-        assert self.tracer._dogstatsd_client.port == 1234
+        assert self.tracer.writer.dogstatsd.host == "foo"
+        assert self.tracer.writer.dogstatsd.port == 1234
 
     def test_configure_dogstatsd_url_socket(self):
         self.tracer.configure(dogstatsd_url="unix:///foo.sock")
-        assert self.tracer._dogstatsd_client.host is None
-        assert self.tracer._dogstatsd_client.port is None
-        assert self.tracer._dogstatsd_client.socket_path == "/foo.sock"
+        assert self.tracer.writer.dogstatsd.host is None
+        assert self.tracer.writer.dogstatsd.port is None
+        assert self.tracer.writer.dogstatsd.socket_path == "/foo.sock"
 
     def test_span_no_runtime_tags(self):
         self.tracer.configure(collect_metrics=False)
@@ -639,22 +639,22 @@ def test_tracer_shutdown_timeout():
 
 def test_tracer_dogstatsd_url():
     t = ddtrace.Tracer()
-    assert t._dogstatsd_client.host == "localhost"
-    assert t._dogstatsd_client.port == 8125
+    assert t.writer.dogstatsd.host == "localhost"
+    assert t.writer.dogstatsd.port == 8125
 
     t = ddtrace.Tracer(dogstatsd_url="foobar:12")
-    assert t._dogstatsd_client.host == "foobar"
-    assert t._dogstatsd_client.port == 12
+    assert t.writer.dogstatsd.host == "foobar"
+    assert t.writer.dogstatsd.port == 12
 
     t = ddtrace.Tracer(dogstatsd_url="udp://foobar:12")
-    assert t._dogstatsd_client.host == "foobar"
-    assert t._dogstatsd_client.port == 12
+    assert t.writer.dogstatsd.host == "foobar"
+    assert t.writer.dogstatsd.port == 12
 
     t = ddtrace.Tracer(dogstatsd_url="/var/run/statsd.sock")
-    assert t._dogstatsd_client.socket_path == "/var/run/statsd.sock"
+    assert t.writer.dogstatsd.socket_path == "/var/run/statsd.sock"
 
     t = ddtrace.Tracer(dogstatsd_url="unix:///var/run/statsd.sock")
-    assert t._dogstatsd_client.socket_path == "/var/run/statsd.sock"
+    assert t.writer.dogstatsd.socket_path == "/var/run/statsd.sock"
 
     with pytest.raises(ValueError) as e:
         t = ddtrace.Tracer(dogstatsd_url="foo://foobar:12")


### PR DESCRIPTION
The tracer initializes a single dogstatsd client and shares it between the two worker threads. This would better be handled separately. The flush interval for the runtime metrics worker is also decoupled from the tracer and exposed as an environment variable.