### PR TITLE
refactor: move agent variables to separate module

### DIFF
--- a/ddtrace/internal/agent.py
+++ b/ddtrace/internal/agent.py
@@ -1,0 +1,48 @@
+import os
+
+from ddtrace import compat
+from ddtrace.utils.formats import get_env
+
+from .uds import UDSHTTPConnection
+
+
+def get_hostname():
+    # type: () -> str
+    return os.environ.get("DD_AGENT_HOST", os.environ.get("DATADOG_TRACE_AGENT_HOSTNAME", "localhost"))
+
+
+def get_trace_port():
+    # type: () -> int
+    return int(os.environ.get("DD_AGENT_PORT", os.environ.get("DD_TRACE_AGENT_PORT", 8126)))
+
+
+def get_stats_port():
+    # type: () -> int
+    return int(get_env("dogstatsd", "port", default=8125))
+
+
+def get_trace_url():
+    # type: () -> str
+    return os.environ.get("DD_TRACE_AGENT_URL", "http://%s:%d" % (get_hostname(), get_trace_port()))
+
+
+def get_stats_url():
+    # type: () -> str
+    return get_env("dogstatsd", "url", default="udp://{}:{}".format(get_hostname(), get_stats_port()))
+
+
+def get_connection(url, timeout):
+    """Return an HTTP connection to the given URL."""
+    parsed = compat.parse.urlparse(url)
+    hostname = parsed.hostname or ""
+
+    if parsed.scheme == "https":
+        conn = compat.httplib.HTTPSConnection(hostname, parsed.port, timeout=timeout)
+    elif parsed.scheme == "http":
+        conn = compat.httplib.HTTPConnection(hostname, parsed.port, timeout=timeout)
+    elif parsed.scheme == "unix":
+        conn = UDSHTTPConnection(parsed.path, parsed.scheme == "https", hostname, parsed.port, timeout=timeout)
+    else:
+        raise ValueError("Unknown agent protocol %s" % parsed.scheme)
+
+    return conn

--- a/releasenotes/notes/tracer-200a66ebb04f6cb0.yaml
+++ b/releasenotes/notes/tracer-200a66ebb04f6cb0.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The ``Tracer`` class properties DEFAULT_HOSTNAME, DEFAULT_PORT,
+    DEFAULT_DOGSTATSD_PORT, DEFAULT_DOGSTATSD_URL, DEFAULT_AGENT_URL have been
+    removed.

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -162,7 +162,7 @@ def test_default_tracer_and_url():
         prof = profiler.Profiler(url="https://foobaz:123")
         _check_url(prof, "https://foobaz:123")
     finally:
-        ddtrace.tracer.configure(hostname=ddtrace.Tracer.DEFAULT_HOSTNAME)
+        ddtrace.tracer.configure(hostname="localhost")
 
 
 def test_tracer_and_url():

--- a/tests/tracer/test_agent.py
+++ b/tests/tracer/test_agent.py
@@ -1,0 +1,43 @@
+from ddtrace.internal import agent
+
+
+def test_hostname(monkeypatch):
+    assert agent.get_hostname() == "localhost"
+    monkeypatch.setenv("DD_AGENT_HOST", "host")
+    assert agent.get_hostname() == "host"
+
+
+def test_trace_port(monkeypatch):
+    assert agent.get_trace_port() == 8126
+    monkeypatch.setenv("DD_TRACE_AGENT_PORT", "1235")
+    assert agent.get_trace_port() == 1235
+    monkeypatch.setenv("DD_AGENT_PORT", "1234")
+    assert agent.get_trace_port() == 1234
+
+
+def test_stats_port(monkeypatch):
+    assert agent.get_stats_port() == 8125
+    monkeypatch.setenv("DD_DOGSTATSD_PORT", "1235")
+    assert agent.get_stats_port() == 1235
+
+
+def test_trace_url(monkeypatch):
+    assert agent.get_trace_url() == "http://localhost:8126"
+    monkeypatch.setenv("DD_TRACE_AGENT_PORT", "1235")
+    assert agent.get_trace_url() == "http://localhost:1235"
+    monkeypatch.setenv("DD_AGENT_HOST", "mars")
+    assert agent.get_trace_url() == "http://mars:1235"
+
+    monkeypatch.setenv("DD_TRACE_AGENT_URL", "http://saturn:1111")
+    assert agent.get_trace_url() == "http://saturn:1111"
+
+
+def test_stats_url(monkeypatch):
+    assert agent.get_stats_url() == "udp://localhost:8125"
+    monkeypatch.setenv("DD_AGENT_HOST", "saturn")
+    assert agent.get_stats_url() == "udp://saturn:8125"
+    monkeypatch.setenv("DD_DOGSTATSD_PORT", "1235")
+    assert agent.get_stats_url() == "udp://saturn:1235"
+
+    monkeypatch.setenv("DD_DOGSTATSD_URL", "udp://mars:1234")
+    assert agent.get_stats_url() == "udp://mars:1234"


### PR DESCRIPTION
## Description
This centralizes the agent configuration into a single module which can
be shared across the library. It also changes the environment variable
look ups to be done at runtime as opposed to import-time.

(Changes ported from #1848 and #2041)

## Checklist
- [x] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Library documentation is updated.
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
