### PR TITLE
writer: remove falsy spans check

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -277,8 +277,6 @@ class AgentWriter(_worker.PeriodicWorkerThread):
             with self._started_lock:
                 if self.started is False:
                     self.start()
-        if not spans:
-            return
 
         self._metrics_dist("writer.accepted.traces")
 


### PR DESCRIPTION
This check is done in tracer.write() already so it's redundant to do it here again.
