### PR TITLE
writer: enable flush_queue to raise

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -277,11 +277,8 @@ class AgentWriter(_worker.PeriodicWorkerThread):
             with self._started_lock:
                 if self.started is False:
                     self.start()
-        if not spans:
-            return
 
         self._metrics_dist("writer.accepted.traces")
-
         self._set_keep_rate(spans)
 
         try:
@@ -316,30 +313,31 @@ class AgentWriter(_worker.PeriodicWorkerThread):
 
     def flush_queue(self):
         enc_traces = self._buffer.get()
-        if enc_traces:
+        try:
+            if not enc_traces:
+                return
+
             encoded = self._encoder.join_encoded(enc_traces)
             try:
                 self._send_payload(encoded, len(enc_traces))
             except (httplib.HTTPException, OSError, IOError):
-                log.error("failed to send traces to Datadog Agent at %s", self.agent_url, exc_info=True)
                 self._metrics_dist("http.errors", tags=["type:err"])
                 self._metrics_dist("http.dropped.bytes", len(encoded))
                 self._metrics_dist("http.dropped.traces", len(enc_traces))
-
-            if self._report_metrics:
-                # Note that we cannot use the batching functionality of dogstatsd because
-                # it's not thread-safe.
-                # https://github.com/DataDog/datadogpy/issues/439
-                # This really isn't ideal as now we're going to do a ton of socket calls.
-                self.dogstatsd.increment("datadog.tracer.http.requests")
-                self.dogstatsd.distribution("datadog.tracer.http.sent.bytes", len(encoded))
-                self.dogstatsd.distribution("datadog.tracer.http.sent.traces", len(enc_traces))
-                for name, metric in self._metrics.items():
-                    self.dogstatsd.distribution("datadog.tracer.%s" % name, metric["count"], tags=metric["tags"])
-
-        self._set_drop_rate()
-
-        self._metrics_reset()
+                log.error("failed to send traces to Datadog Agent at %s", self.agent_url, exc_info=True)
+            finally:
+                if self._report_metrics:
+                    # Note that we cannot use the batching functionality of dogstatsd because
+                    # it's not thread-safe.
+                    # https://github.com/DataDog/datadogpy/issues/439
+                    # This really isn't ideal as now we're going to do a ton of socket calls.
+                    self.dogstatsd.distribution("datadog.tracer.http.sent.bytes", len(encoded))
+                    self.dogstatsd.distribution("datadog.tracer.http.sent.traces", len(enc_traces))
+                    for name, metric in self._metrics.items():
+                        self.dogstatsd.distribution("datadog.tracer.%s" % name, metric["count"], tags=metric["tags"])
+        finally:
+            self._set_drop_rate()
+            self._metrics_reset()
 
     def run_periodic(self):
         self.flush_queue()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -208,11 +208,6 @@ def test_metrics():
             log.warning.assert_not_called()
             log.error.assert_not_called()
 
-        statsd_mock.increment.assert_has_calls(
-            [
-                mock.call("datadog.tracer.http.requests"),
-            ]
-        )
         statsd_mock.distribution.assert_has_calls(
             [
                 mock.call("datadog.tracer.buffer.accepted.traces", 5, tags=[]),

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -439,3 +439,16 @@ def test_flush_connection_reset(endpoint_test_reset_server):
 def test_flush_connection_uds(endpoint_uds_server):
     writer = AgentWriter(_HOST, 2019, uds_path=endpoint_uds_server.server_address)
     writer._send_payload("foobar", 12)
+
+
+def test_flush_queue_raise():
+    writer = AgentWriter(hostname="dne", port=1234)
+
+    # Should not raise
+    writer.write([])
+    writer.flush_queue(raise_exc=False)
+
+    error = OSError if PY3 else IOError
+    with pytest.raises(error):
+        writer.write([])
+        writer.flush_queue(raise_exc=True)

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -61,11 +61,6 @@ class AgentWriterTests(BaseTestCase):
         writer.stop()
         writer.join()
 
-        statsd.increment.assert_has_calls(
-            [
-                mock.call("datadog.tracer.http.requests"),
-            ]
-        )
         statsd.distribution.assert_has_calls(
             [
                 mock.call("datadog.tracer.buffer.accepted.traces", 10, tags=[]),
@@ -90,11 +85,6 @@ class AgentWriterTests(BaseTestCase):
         writer.stop()
         writer.join()
 
-        statsd.increment.assert_has_calls(
-            [
-                mock.call("datadog.tracer.http.requests"),
-            ]
-        )
         statsd.distribution.assert_has_calls(
             [
                 mock.call("datadog.tracer.buffer.accepted.traces", 10, tags=[]),
@@ -116,11 +106,6 @@ class AgentWriterTests(BaseTestCase):
                 [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
             )
         writer.flush_queue()
-        statsd.increment.assert_has_calls(
-            [
-                mock.call("datadog.tracer.http.requests"),
-            ]
-        )
         statsd.distribution.assert_has_calls(
             [
                 mock.call("datadog.tracer.buffer.accepted.traces", 10, tags=[]),
@@ -141,11 +126,6 @@ class AgentWriterTests(BaseTestCase):
         writer.stop()
         writer.join()
 
-        statsd.increment.assert_has_calls(
-            [
-                mock.call("datadog.tracer.http.requests"),
-            ]
-        )
         statsd.distribution.assert_has_calls(
             [
                 mock.call("datadog.tracer.buffer.accepted.traces", 10, tags=[]),


### PR DESCRIPTION
This will allow easier testing as well as better reuse as debug logging
can now use the AgentWriter to perform and introspect requests to the
Agent.

Based off of and follows #2050.