### PR TITLE
django: use configure for agent settings

### DIFF
--- a/ddtrace/contrib/django/conf.py
+++ b/ddtrace/contrib/django/conf.py
@@ -194,7 +194,7 @@ def configure_from_settings(pin, config, settings):
         pin.tracer.enabled = settings["ENABLED"]
 
     if "AGENT_HOSTNAME" in settings:
-        pin.tracer.writer._hostname = settings["AGENT_HOSTNAME"]
+        pin.tracer.configure(hostname=settings["AGENT_HOSTNAME"])
 
     if "AGENT_PORT" in settings:
-        pin.tracer.writer._port = settings["AGENT_PORT"]
+        pin.tracer.configure(port=settings["AGENT_PORT"])

--- a/tests/contrib/django/test_django_migration.py
+++ b/tests/contrib/django/test_django_migration.py
@@ -40,5 +40,4 @@ def test_configure_from_settings(tracer):
 
         assert pin.tracer.enabled is True
         assert pin.tracer.tags["env"] == "env-test"
-        assert pin.tracer.writer._hostname == "host-test"
-        assert pin.tracer.writer._port == 1234
+        assert pin.tracer.writer.agent_url == "http://host-test:1234"


### PR DESCRIPTION
Pulled out of #1848 since these attributes are being removed.
