### PR TITLE
refactor: use trace_utils distributed header extraction in django

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -314,10 +314,7 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
     try:
         request_headers = request.META
 
-        if config.django.distributed_tracing_enabled:
-            context = propagator.extract(request_headers)
-            if context.trace_id:
-                pin.tracer.context_provider.activate(context)
+        trace_utils.activate_distributed_headers(pin.tracer, config.django, request_headers=request_headers)
 
         # Determine the resolver and resource name for this request
         resolver = get_resolver(getattr(request, "urlconf", None))


### PR DESCRIPTION
## Description
Following #2058,  the django integration was refactored to use trace_utils' helper function which extracts and activates a distributed header's context (if enabled).

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
