### PR TITLE
fix(profiling): handle failed collectors

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -302,12 +302,15 @@ class _ProfilerInstance(_service.Service):
     def start(self):
         """Start the profiler."""
         super(_ProfilerInstance, self).start()
+        collectors = []
         for col in self._collectors:
             try:
                 col.start()
             except RuntimeError:
-                # `tracemalloc` is unavailable?
-                pass
+                LOG.error("Failed to start collector %r, disabling.", col, exc_info=True)
+            else:
+                collectors.append(col)
+        self._collectors = collectors
 
         if self._scheduler is not None:
             self._scheduler.start()


### PR DESCRIPTION
The profiler checks if collectors fail, but ignores the error and continues. In the case of `_memalloc.MemoryCollector`, the [`_memalloc` module could fail to load](https://github.com/DataDog/dd-trace-py/blob/e1ad1731be0bef70b29339a652ad5e1437c02a94/ddtrace/profiling/collector/memalloc.py#L4-L7). Since the [`RuntimeError`](https://github.com/DataDog/dd-trace-py/blob/e1ad1731be0bef70b29339a652ad5e1437c02a94/ddtrace/profiling/collector/memalloc.py#L64-L65) is [ignored](https://github.com/DataDog/dd-trace-py/blob/e1ad1731be0bef70b29339a652ad5e1437c02a94/ddtrace/profiling/profiler.py#L306-L310) the `snapshot` method can be called and [will fail](https://github.com/DataDog/dd-trace-py/blob/e1ad1731be0bef70b29339a652ad5e1437c02a94/ddtrace/profiling/collector/memalloc.py#L89) repeatedly since the module is `None`. 


## Checklist
- [x] ~Added to the correct milestone.~ Internal change
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] ~Library documentation is updated.~
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
