### PR TITLE
fix(writer): logging request timing

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -249,15 +249,15 @@ class AgentWriter(_worker.PeriodicWorkerThread):
             try:
                 conn.request("PUT", self._endpoint, data, headers)
                 resp = compat.get_connection_response(conn)
+                t = sw.elapsed()
+                if t >= self.interval:
+                    log_level = logging.WARNING
+                else:
+                    log_level = logging.DEBUG
+                log.log(log_level, "sent %s in %.5fs", _human_size(len(data)), t)
                 return Response.from_http_response(resp)
             finally:
                 conn.close()
-            t = sw.elapsed()
-            if t >= self.interval:
-                log_level = logging.WARNING
-            else:
-                log_level = logging.DEBUG
-            log.log(log_level, "sent %s in %.5fs", _human_size(len(data)), t)
 
     def _downgrade(self, payload, response):
         if self._endpoint == "/v0.4/traces":

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -910,3 +910,8 @@ class AnyStr(object):
 class AnyInt(object):
     def __eq__(self, other):
         return isinstance(other, int)
+
+
+class AnyFloat(object):
+    def __eq__(self, other):
+        return isinstance(other, float)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import subprocess
 import sys
@@ -16,7 +17,9 @@ from ddtrace.sampler import DatadogSampler
 from ddtrace.sampler import RateSampler
 from ddtrace.sampler import SamplingRule
 from ddtrace.vendor import six
+from tests import AnyFloat
 from tests import AnyInt
+from tests import AnyStr
 from tests import TracerTestCase
 from tests import override_global_config
 from tests import snapshot
@@ -496,3 +499,16 @@ class TestTraces(TracerTestCase):
                 pass
 
         tracer.shutdown()
+
+
+@pytest.mark.skipif(AGENT_VERSION == "testagent", reason="Test agent doesn't support empty trace payloads.")
+def test_flush_log(caplog):
+    caplog.set_level(logging.INFO)
+
+    writer = AgentWriter()
+
+    with mock.patch("ddtrace.internal.writer.log") as log:
+        writer.write([])
+        writer.flush_queue(raise_exc=True)
+        calls = [mock.call(logging.DEBUG, "sent %s in %.5fs", AnyStr(), AnyFloat())]
+        log.log.assert_has_calls(calls)


### PR DESCRIPTION
The logging was moved around in a previous patch. Also add a regression
test for the logging.
