### PR TITLE
configure: fix dogstatsd configuration for existing writers

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -253,8 +253,8 @@ class Tracer(object):
             self.writer = writer
             # Ensure dogstatsd client has been created for the writer being configured
             self.writer.dogstatsd = get_dogstatsd_client(self._dogstatsd_url)
-        elif any([x is not None for x in [hostname, port, uds_path, https, priority_sampling, sampler]]):
-            if any([x is not None for x in [hostname, port, uds_path, https]]):
+        elif any(x is not None for x in [hostname, port, uds_path, https, priority_sampling, sampler]):
+            if any(x is not None for x in [hostname, port, uds_path, https]):
                 # If any of the parts of the URL have updated, merge them with
                 # the previous writer values.
                 if hasattr(self, "writer") and isinstance(self.writer, AgentWriter):
@@ -293,6 +293,8 @@ class Tracer(object):
                 dogstatsd=get_dogstatsd_client(self._dogstatsd_url),
                 report_metrics=config.health_metrics_enabled,
             )
+        elif self.writer:
+            self.writer.dogstatsd = get_dogstatsd_client(self._dogstatsd_url)
 
         if context_provider is not None:
             self.context_provider = context_provider

--- a/releasenotes/notes/configure-a39313ef4fed9028.yaml
+++ b/releasenotes/notes/configure-a39313ef4fed9028.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Tracer: fix configuring tracer with dogstatsd url.

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -470,15 +470,30 @@ class TracerTestCases(TracerTestCase):
         self.assertIsNotNone(self.tracer._runtime_worker)
 
     def test_configure_dogstatsd_url_host_port(self):
-        self.tracer.configure(dogstatsd_url="foo:1234")
-        assert self.tracer.writer.dogstatsd.host == "foo"
-        assert self.tracer.writer.dogstatsd.port == 1234
+        tracer = Tracer()
+        tracer.configure(dogstatsd_url="foo:1234")
+        assert tracer.writer.dogstatsd.host == "foo"
+        assert tracer.writer.dogstatsd.port == 1234
+
+        tracer = Tracer()
+        writer = AgentWriter()
+        tracer.configure(writer=writer, dogstatsd_url="foo:1234")
+        assert tracer.writer.dogstatsd.host == "foo"
+        assert tracer.writer.dogstatsd.port == 1234
 
     def test_configure_dogstatsd_url_socket(self):
-        self.tracer.configure(dogstatsd_url="unix:///foo.sock")
-        assert self.tracer.writer.dogstatsd.host is None
-        assert self.tracer.writer.dogstatsd.port is None
-        assert self.tracer.writer.dogstatsd.socket_path == "/foo.sock"
+        tracer = Tracer()
+        tracer.configure(dogstatsd_url="unix:///foo.sock")
+        assert tracer.writer.dogstatsd.host is None
+        assert tracer.writer.dogstatsd.port is None
+        assert tracer.writer.dogstatsd.socket_path == "/foo.sock"
+
+        tracer = Tracer()
+        writer = AgentWriter()
+        tracer.configure(writer=writer, dogstatsd_url="unix:///foo.sock")
+        assert tracer.writer.dogstatsd.host is None
+        assert tracer.writer.dogstatsd.port is None
+        assert tracer.writer.dogstatsd.socket_path == "/foo.sock"
 
     def test_span_no_runtime_tags(self):
         self.tracer.configure(collect_metrics=False)


### PR DESCRIPTION
# Bug fix

## Description
<!-- Please briefly describe the bug. -->
Using tracer.configure() is broken when a dogstatsd configuration is given as the existing writer is not updated unless an agent configuration setting (eg. hostname, port, url) is given (which creates a new AgentWriter).

## Fix
<!-- Please provide a succinct overview of the fix. -->
Handle the case of when a writer exists and the dogstatsd url is updated.

# Checklist
- [x] Regression test added; or
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [x] Added to the correct milestone.

# Testing
- [x] Tests are run against all relevant library versions (or confirm that the relevant versions are already being tested in `tox.ini`)
