### PR TITLE
tests(sanic): pin pytest-sanic version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -331,7 +331,7 @@ deps =
     rediscluster136: redis-py-cluster>=1.3.6,<1.3.7
     rediscluster200: redis-py-cluster>=2.0.0,<2.1.0
     rediscluster210: redis-py-cluster>=2.1.0,<2.2.0
-    sanic_contrib: pytest-sanic
+    sanic_contrib: pytest-sanic==1.6.2
     sanic_contrib: pytest-asyncio
     sanic1906: sanic~=19.6.0
     sanic1906: httpx


### PR DESCRIPTION
Looks like the latest pytest-sanic release 1.7.0 broke our tests: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/5517/workflows/42be3e31-9c4c-4792-814b-1d90d1ba2a1a/jobs/509128/steps