### PR TITLE
perf(dbapi): avoid copy config

### DIFF
--- a/releasenotes/notes/perf-dbapi-config-3e5b5d0185571d4c.yaml
+++ b/releasenotes/notes/perf-dbapi-config-3e5b5d0185571d4c.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    The dbapi integration allows other dbapi-compatible integrations to override the base dbapi config. The existing implementation repeatedly copied the base config whenever a traced method was called. Instead, this can be performed once at the initialization of a traced connection or cursor.


### PR DESCRIPTION
The `dbapi` integration currently does a copy and merge of config objects whenever a traced method is called. This is not required as this is meant to be set when a traced connection or cursor is initialized within a dbapi-compliant library.  
