### PR TITLE
perf(tracer): Use set for faster lookup

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -56,7 +56,7 @@ if debug_mode and not hasHandlers(log):
         logging.basicConfig(level=logging.DEBUG)
 
 
-_INTERNAL_APPLICATION_SPAN_TYPES = ["custom", "template", "web", "worker"]
+_INTERNAL_APPLICATION_SPAN_TYPES = {"custom", "template", "web", "worker"}
 
 
 class Tracer(object):


### PR DESCRIPTION
## Description

Use a set for collecting the span types for quicker lookups.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
