### PR TITLE
refactor,perf: avoid multiple dbapi configs

### DIFF
--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -43,6 +43,7 @@ class TracedCursor(wrapt.ObjectProxy):
                 ),
                 removal_version="0.49.0",
             )
+            cfg = config.dbapi2
         self._self_config = cfg
 
     def _trace_method(self, method, name, resource, extra_tags, *args, **kwargs):

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -1,6 +1,7 @@
 """
 Generic dbapi tracing code.
 """
+from ddtrace.vendor import debtcollector
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_MEASURED_KEY
@@ -34,7 +35,15 @@ class TracedCursor(wrapt.ObjectProxy):
         name = pin.app or 'sql'
         self._self_datadog_name = '{}.query'.format(name)
         self._self_last_execute_operation = None
-        self._self_config = cfg or config.dbapi2
+        if not cfg:
+            debtcollector.deprecate(
+                (
+                    "ddtrace.config.dbapi2 is now deprecated as the default integration config for TracedConnection. "
+                    "Use integration config specific to dbapi-compliant library."
+                ),
+                removal_version="0.49.0",
+            )
+        self._self_config = cfg
 
     def _trace_method(self, method, name, resource, extra_tags, *args, **kwargs):
         """
@@ -167,11 +176,21 @@ class TracedConnection(wrapt.ObjectProxy):
     """ TracedConnection wraps a Connection with tracing code. """
 
     def __init__(self, conn, pin=None, cfg=None, cursor_cls=None):
+        if not cfg:
+            debtcollector.deprecate(
+                (
+                    "ddtrace.config.dbapi2 is now deprecated as the default integration config for TracedConnection. "
+                    "Use integration config specific to dbapi-compliant library."
+                ),
+                removal_version="0.49.0",
+            )
+            cfg = config.dbapi2
         # Set default cursor class if one was not provided
         if not cursor_cls:
             # Do not trace `fetch*` methods by default
             cursor_cls = TracedCursor
-            if config.dbapi2.trace_fetch_methods:
+            # Deprecation of config.dbapi2 requires we add a check
+            if cfg.trace_fetch_methods or config.dbapi2.trace_fetch_methods:
                 cursor_cls = FetchTracedCursor
 
         super(TracedConnection, self).__init__(conn)
@@ -182,7 +201,7 @@ class TracedConnection(wrapt.ObjectProxy):
         # wrapt requires prefix of `_self` for attributes that are only in the
         # proxy (since some of our source objects will use `__slots__`)
         self._self_cursor_cls = cursor_cls
-        self._self_config = cfg or config.dbapi2
+        self._self_config = cfg
 
     def __enter__(self):
         """Context management is not defined by the dbapi spec.

--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -71,6 +71,14 @@ Configuration
 
    Default: ``''``
 
+.. py:data:: ddtrace.config.django["trace_fetch_methods"]
+
+   Whether or not to trace fetch methods.
+
+   Can also configured via the ``DD_DJANGO_TRACE_FETCH_METHODS`` environment variable.
+
+   Default: ``False``
+
 .. py:data:: ddtrace.config.django['instrument_middleware']
 
    Whether or not to instrument middleware.

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -45,6 +45,7 @@ config._add(
         cache_service_name=get_env("django", "cache_service_name") or "django",
         database_service_name_prefix=get_env("django", "database_service_name_prefix", default=""),
         database_service_name=get_env("django", "database_service_name", default=""),
+        trace_fetch_methods=asbool(get_env("django", "trace_fetch_methods", default=False)),
         distributed_tracing_enabled=True,
         instrument_middleware=asbool(get_env("django", "instrument_middleware", default=True)),
         instrument_databases=True,

--- a/ddtrace/contrib/mysql/__init__.py
+++ b/ddtrace/contrib/mysql/__init__.py
@@ -26,6 +26,14 @@ Global Configuration
 
    Default: ``"mysql"``
 
+.. py:data:: ddtrace.config.mysql["trace_fetch_methods"]
+
+   Whether or not to trace fetch methods.
+
+   Can also configured via the ``DD_MYSQL_TRACE_FETCH_METHODS`` environment variable.
+
+   Default: ``False``
+
 
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -7,12 +7,15 @@ from ddtrace.vendor import wrapt
 
 from ...ext import db
 from ...ext import net
+from ...utils.formats import asbool
+from ...utils.formats import get_env
 
 
 config._add(
     "mysql",
     dict(
         _default_service="mysql",
+        trace_fetch_methods=asbool(get_env("mysql", "trace_fetch_methods", default=False)),
     ),
 )
 

--- a/ddtrace/contrib/mysqldb/__init__.py
+++ b/ddtrace/contrib/mysqldb/__init__.py
@@ -26,6 +26,14 @@ Global Configuration
 
    Default: ``"mysql"``
 
+.. py:data:: ddtrace.config.mysqldb["trace_fetch_methods"]
+
+   Whether or not to trace fetch methods.
+
+   Can also configured via the ``DD_MYSQLDB_TRACE_FETCH_METHODS`` environment variable.
+
+   Default: ``False``
+
 
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -9,6 +9,8 @@ from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from ...ext import db
 from ...ext import net
+from ...utils.formats import asbool
+from ...utils.formats import get_env
 from ...utils.wrappers import unwrap as _u
 
 
@@ -16,6 +18,7 @@ config._add(
     "mysqldb",
     dict(
         _default_service="mysql",
+        trace_fetch_methods=asbool(get_env("mysqldb", "trace_fetch_methods", default=False)),
     ),
 )
 

--- a/ddtrace/contrib/psycopg/__init__.py
+++ b/ddtrace/contrib/psycopg/__init__.py
@@ -26,6 +26,14 @@ Global Configuration
 
    Default: ``"postgres"``
 
+.. py:data:: ddtrace.config.psycopg["trace_fetch_methods"]
+
+   Whether or not to trace fetch methods.
+
+   Can also configured via the ``DD_PSYCOPG_TRACE_FETCH_METHODS`` environment variable.
+
+   Default: ``False``
+
 
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -10,9 +10,13 @@ from ddtrace.ext import net
 from ddtrace.ext import sql
 from ddtrace.vendor import wrapt
 
+from ...utils.formats import asbool
+from ...utils.formats import get_env
+
 
 config._add("psycopg", dict(
-    _default_service="postgres"
+    _default_service="postgres",
+    trace_fetch_methods=asbool(get_env("psycopg", "trace_fetch_methods", default=False)),
 ))
 
 # Original connect method
@@ -70,7 +74,7 @@ class Psycopg2TracedConnection(dbapi.TracedConnection):
         if not cursor_cls:
             # Do not trace `fetch*` methods by default
             cursor_cls = Psycopg2TracedCursor
-            if config.dbapi2.trace_fetch_methods:
+            if config.psycopg.trace_fetch_methods or config.dbapi2.trace_fetch_methods:
                 cursor_cls = Psycopg2FetchTracedCursor
 
         super(Psycopg2TracedConnection, self).__init__(conn, pin, config.psycopg, cursor_cls=cursor_cls)

--- a/ddtrace/contrib/pymysql/__init__.py
+++ b/ddtrace/contrib/pymysql/__init__.py
@@ -26,6 +26,14 @@ Global Configuration
 
    Default: ``"mysql"``
 
+.. py:data:: ddtrace.config.pymysql["trace_fetch_methods"]
+
+   Whether or not to trace fetch methods.
+
+   Can also configured via the ``DD_PYMYSQL_TRACE_FETCH_METHODS`` environment variable.
+
+   Default: ``False``
+
 
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/ddtrace/contrib/pymysql/patch.py
+++ b/ddtrace/contrib/pymysql/patch.py
@@ -9,6 +9,8 @@ from ddtrace.vendor import wrapt
 
 from ...ext import db
 from ...ext import net
+from ...utils.formats import asbool
+from ...utils.formats import get_env
 
 
 config._add(
@@ -16,6 +18,7 @@ config._add(
     dict(
         # TODO[v1.0] this should be "mysql"
         _default_service="pymysql",
+        trace_fetch_methods=asbool(get_env("pymysql", "trace_fetch_methods", default=False)),
     ),
 )
 

--- a/ddtrace/contrib/pyodbc/__init__.py
+++ b/ddtrace/contrib/pyodbc/__init__.py
@@ -26,6 +26,14 @@ Global Configuration
 
    Default: ``"pyodbc"``
 
+.. py:data:: ddtrace.config.pyodbc["trace_fetch_methods"]
+
+   Whether or not to trace fetch methods.
+
+   Can also configured via the ``DD_PYODBC_TRACE_FETCH_METHODS`` environment variable.
+
+   Default: ``False``
+
 
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/ddtrace/contrib/pyodbc/patch.py
+++ b/ddtrace/contrib/pyodbc/patch.py
@@ -2,6 +2,8 @@ import pyodbc
 
 from ... import Pin
 from ... import config
+from ...utils.formats import asbool
+from ...utils.formats import get_env
 from ..dbapi import TracedConnection
 from ..dbapi import TracedCursor
 from ..trace_utils import unwrap
@@ -12,6 +14,7 @@ config._add(
     "pyodbc",
     dict(
         _default_service="pyodbc",
+        trace_fetch_methods=asbool(get_env("pyodbc", "trace_fetch_methods", default=False)),
     ),
 )
 

--- a/ddtrace/contrib/sqlite3/__init__.py
+++ b/ddtrace/contrib/sqlite3/__init__.py
@@ -26,6 +26,14 @@ Global Configuration
 
    Default: ``"sqlite"``
 
+.. py:data:: ddtrace.config.sqlite["trace_fetch_methods"]
+
+   Whether or not to trace fetch methods.
+
+   Can also configured via the ``DD_SQLITE_TRACE_FETCH_METHODS`` environment variable.
+
+   Default: ``False``
+
 
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/ddtrace/contrib/sqlite3/patch.py
+++ b/ddtrace/contrib/sqlite3/patch.py
@@ -10,6 +10,8 @@ from ...contrib.dbapi import TracedConnection
 from ...contrib.dbapi import TracedCursor
 from ...pin import Pin
 from ...settings import config
+from ...utils.formats import asbool
+from ...utils.formats import get_env
 
 
 # Original connect method
@@ -19,6 +21,7 @@ config._add(
     "sqlite",
     dict(
         _default_service="sqlite",
+        trace_fetch_methods=asbool(get_env("sqlite", "trace_fetch_methods", default=False)),
     ),
 )
 
@@ -67,7 +70,7 @@ class TracedSQLite(TracedConnection):
         if not cursor_cls:
             # Do not trace `fetch*` methods by default
             cursor_cls = TracedSQLiteCursor
-            if config.dbapi2.trace_fetch_methods:
+            if config.sqlite.trace_fetch_methods or config.dbapi2.trace_fetch_methods:
                 cursor_cls = TracedSQLiteFetchCursor
 
             super(TracedSQLite, self).__init__(conn, pin=pin, cfg=config.sqlite, cursor_cls=cursor_cls)

--- a/releasenotes/notes/avoid-dbapi-config-9d3c2ebb673d48d6.yaml
+++ b/releasenotes/notes/avoid-dbapi-config-9d3c2ebb673d48d6.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Replace all `DD_*_DBAPI2_*` environment variables and `config.dbapi2` configuration with the equivalent configuration option for specific dbapi-compliant library.

--- a/releasenotes/notes/deprecate-dbapi-config-0fc5b1acfc4aded2.yaml
+++ b/releasenotes/notes/deprecate-dbapi-config-0fc5b1acfc4aded2.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    Deprecate `ddtrace.config.dbapi2` as default for `TracedCursor` and `TracedConnection` as well as `DD_DBAPI2_TRACE_FETCH_METHOD`. Use `IntegrationConfig` and `DD_<INTEGRATION>_TRACE_FETCH_METHODS` specific to each dbapi-compliant library.

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -6,8 +6,9 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.dbapi import FetchTracedCursor
 from ddtrace.contrib.dbapi import TracedConnection
 from ddtrace.contrib.dbapi import TracedCursor
+from ddtrace.settings import config as global_config
+from ddtrace.settings.integration import IntegrationConfig
 from ddtrace.span import Span
-from ddtrace.utils.attrdict import AttrDict
 
 from ... import TracerTestCase
 from ... import assert_is_measured
@@ -193,7 +194,7 @@ class TestTracedCursor(TracerTestCase):
         tracer = self.tracer
         cursor.rowcount = 123
         pin = Pin(None, app='my_app', tracer=tracer, tags={'pin1': 'value_pin1'})
-        cfg = AttrDict(service="cfg-service")
+        cfg = IntegrationConfig(global_config, "test", service="cfg-service")
         traced_cursor = TracedCursor(cursor, pin, cfg)
 
         def method():
@@ -222,7 +223,7 @@ class TestTracedCursor(TracerTestCase):
         tracer = self.tracer
         cursor.rowcount = 123
         pin = Pin(None, app='my_app', tracer=tracer, tags={'pin1': 'value_pin1'})
-        cfg = AttrDict(_default_service="default-svc")
+        cfg = IntegrationConfig(global_config, "test", _default_service="default-svc")
         traced_cursor = TracedCursor(cursor, pin, cfg)
 
         def method():
@@ -237,7 +238,7 @@ class TestTracedCursor(TracerTestCase):
         tracer = self.tracer
         cursor.rowcount = 123
         pin = Pin("pin-svc", app='my_app', tracer=tracer, tags={'pin1': 'value_pin1'})
-        cfg = AttrDict(_default_service="cfg-svc")
+        cfg = IntegrationConfig(global_config, "test", _default_service="cfg-svc")
         traced_cursor = TracedCursor(cursor, pin, cfg)
 
         def method():

--- a/tests/contrib/mysql/test_mysql.py
+++ b/tests/contrib/mysql/test_mysql.py
@@ -61,7 +61,7 @@ class MySQLCore(object):
         )
 
     def test_simple_query_fetchll(self):
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("mysql", dict(trace_fetch_methods=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
@@ -103,7 +103,7 @@ class MySQLCore(object):
         assert span.get_tag("sql.query") is None
 
     def test_query_with_several_rows_fetchall(self):
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("mysql", dict(trace_fetch_methods=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
@@ -154,7 +154,7 @@ class MySQLCore(object):
         cursor.execute("drop table if exists dummy")
 
     def test_query_many_fetchall(self):
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("mysql", dict(trace_fetch_methods=True)):
             # tests that the executemany method is correctly wrapped.
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
@@ -280,7 +280,7 @@ class MySQLCore(object):
 
     def test_simple_query_ot_fetchall(self):
         """OpenTracing version of test_simple_query."""
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("mysql", dict(trace_fetch_methods=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
 
@@ -355,7 +355,7 @@ class MySQLCore(object):
         self.assertIsNone(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY))
 
     def test_analytics_with_rate(self):
-        with self.override_config("dbapi2", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
+        with self.override_config("mysql", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
@@ -369,7 +369,7 @@ class MySQLCore(object):
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 0.5)
 
     def test_analytics_without_rate(self):
-        with self.override_config("dbapi2", dict(analytics_enabled=True)):
+        with self.override_config("mysql", dict(analytics_enabled=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()

--- a/tests/contrib/mysqldb/test_mysqldb.py
+++ b/tests/contrib/mysqldb/test_mysqldb.py
@@ -68,7 +68,7 @@ class MySQLCore(object):
         )
 
     def test_simple_query_fetchall(self):
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("mysqldb", dict(trace_fetch_methods=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
@@ -123,7 +123,7 @@ class MySQLCore(object):
         )
 
     def test_simple_query_with_positional_args_fetchall(self):
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("mysqldb", dict(trace_fetch_methods=True)):
             conn, tracer = self._get_conn_tracer_with_positional_args()
             writer = tracer.writer
             cursor = conn.cursor()
@@ -165,7 +165,7 @@ class MySQLCore(object):
         assert span.get_tag("sql.query") is None
 
     def test_query_with_several_rows_fetchall(self):
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("mysqldb", dict(trace_fetch_methods=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
@@ -217,7 +217,7 @@ class MySQLCore(object):
         cursor.execute("drop table if exists dummy")
 
     def test_query_many_fetchall(self):
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("mysqldb", dict(trace_fetch_methods=True)):
             # tests that the executemany method is correctly wrapped.
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
@@ -343,7 +343,7 @@ class MySQLCore(object):
 
     def test_simple_query_ot_fetchall(self):
         """OpenTracing version of test_simple_query."""
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("mysqldb", dict(trace_fetch_methods=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             ot_tracer = init_tracer("mysql_svc", tracer)
@@ -415,7 +415,7 @@ class MySQLCore(object):
         self.assertIsNone(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY))
 
     def test_analytics_with_rate(self):
-        with self.override_config("dbapi2", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
+        with self.override_config("mysqldb", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
@@ -429,7 +429,7 @@ class MySQLCore(object):
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 0.5)
 
     def test_analytics_without_rate(self):
-        with self.override_config("dbapi2", dict(analytics_enabled=True)):
+        with self.override_config("mysqldb", dict(analytics_enabled=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -163,7 +163,7 @@ class PsycopgCore(TracerTestCase):
         assert_is_measured(self.get_spans()[1])
         self.reset()
 
-        with self.override_config('dbapi2', dict(trace_fetch_methods=True)):
+        with self.override_config('psycopg', dict(trace_fetch_methods=True)):
             db = self._get_conn()
             ot_tracer = init_tracer('psycopg-svc', self.tracer)
 
@@ -321,7 +321,7 @@ class PsycopgCore(TracerTestCase):
 
     def test_analytics_with_rate(self):
         with self.override_config(
-                'dbapi2',
+                'psycopg',
                 dict(analytics_enabled=True, analytics_sample_rate=0.5)
         ):
             conn = self._get_conn()
@@ -334,7 +334,7 @@ class PsycopgCore(TracerTestCase):
 
     def test_analytics_without_rate(self):
         with self.override_config(
-                'dbapi2',
+                'psycopg',
                 dict(analytics_enabled=True)
         ):
             conn = self._get_conn()

--- a/tests/contrib/pymysql/test_pymysql.py
+++ b/tests/contrib/pymysql/test_pymysql.py
@@ -72,7 +72,7 @@ class PyMySQLCore(object):
         assert_dict_issuperset(span.meta, meta)
 
     def test_simple_query_fetchall(self):
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("pymysql", dict(trace_fetch_methods=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
@@ -109,7 +109,7 @@ class PyMySQLCore(object):
         self.assertEqual(spans[0].name, "pymysql.query")
 
     def test_query_with_several_rows_fetchall(self):
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("pymysql", dict(trace_fetch_methods=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
@@ -159,7 +159,7 @@ class PyMySQLCore(object):
         cursor.execute("drop table if exists dummy")
 
     def test_query_many_fetchall(self):
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("pymysql", dict(trace_fetch_methods=True)):
             # tests that the executemany method is correctly wrapped.
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
@@ -277,7 +277,7 @@ class PyMySQLCore(object):
 
     def test_simple_query_ot_fetchall(self):
         """OpenTracing version of test_simple_query."""
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("pymysql", dict(trace_fetch_methods=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             ot_tracer = init_tracer("mysql_svc", tracer)
@@ -344,7 +344,7 @@ class PyMySQLCore(object):
         self.assertIsNone(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY))
 
     def test_analytics_with_rate(self):
-        with self.override_config("dbapi2", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
+        with self.override_config("pymysql", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
@@ -358,7 +358,7 @@ class PyMySQLCore(object):
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 0.5)
 
     def test_analytics_without_rate(self):
-        with self.override_config("dbapi2", dict(analytics_enabled=True)):
+        with self.override_config("pymysql", dict(analytics_enabled=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()

--- a/tests/contrib/pyodbc/test_pyodbc.py
+++ b/tests/contrib/pyodbc/test_pyodbc.py
@@ -54,7 +54,7 @@ class PyODBCTest(object):
         assert span.error == 0
 
     def test_simple_query_fetchall(self):
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("pyodbc", dict(trace_fetch_methods=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
@@ -86,7 +86,7 @@ class PyODBCTest(object):
         self.assertEqual(spans[0].name, "pyodbc.query")
 
     def test_query_with_several_rows_fetchall(self):
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("pyodbc", dict(trace_fetch_methods=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
@@ -133,7 +133,7 @@ class PyODBCTest(object):
         cursor.execute("drop table if exists dummy")
 
     def test_query_many_fetchall(self):
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("pyodbc", dict(trace_fetch_methods=True)):
             # tests that the executemany method is correctly wrapped.
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
@@ -201,7 +201,7 @@ class PyODBCTest(object):
         self.assertIsNone(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY))
 
     def test_analytics_with_rate(self):
-        with self.override_config("dbapi2", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
+        with self.override_config("pyodbc", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()
@@ -215,7 +215,7 @@ class PyODBCTest(object):
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 0.5)
 
     def test_analytics_without_rate(self):
-        with self.override_config("dbapi2", dict(analytics_enabled=True)):
+        with self.override_config("pyodbc", dict(analytics_enabled=True)):
             conn, tracer = self._get_conn_tracer()
             writer = tracer.writer
             cursor = conn.cursor()

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -99,7 +99,7 @@ class TestSQLite(TracerTestCase):
         self.assert_structure(dict(name="sqlite.query", resource=q))
         self.reset()
 
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("sqlite", dict(trace_fetch_methods=True)):
             connection = self._given_a_traced_connection(self.tracer)
             cursor = connection.execute(q)
             cursor.fetchall()
@@ -126,7 +126,7 @@ class TestSQLite(TracerTestCase):
         self.assert_structure(dict(name="sqlite.query", resource=q))
         self.reset()
 
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("sqlite", dict(trace_fetch_methods=True)):
             connection = self._given_a_traced_connection(self.tracer)
             cursor = connection.execute(q)
             cursor.fetchone()
@@ -160,7 +160,7 @@ class TestSQLite(TracerTestCase):
         self.assert_structure(dict(name="sqlite.query", resource=q))
         self.reset()
 
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("sqlite", dict(trace_fetch_methods=True)):
             connection = self._given_a_traced_connection(self.tracer)
             cursor = connection.execute(q)
             cursor.fetchmany(123)
@@ -207,7 +207,7 @@ class TestSQLite(TracerTestCase):
         assert_is_measured(self.get_spans()[1])
         self.reset()
 
-        with self.override_config("dbapi2", dict(trace_fetch_methods=True)):
+        with self.override_config("sqlite", dict(trace_fetch_methods=True)):
             with ot_tracer.start_active_span("sqlite_op"):
                 db = sqlite3.connect(":memory:")
                 pin = Pin.get_from(db)
@@ -295,7 +295,7 @@ class TestSQLite(TracerTestCase):
         self.assertIsNone(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY))
 
     def test_analytics_with_rate(self):
-        with self.override_config("dbapi2", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
+        with self.override_config("sqlite", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
             q = "select * from sqlite_master"
             connection = self._given_a_traced_connection(self.tracer)
             cursor = connection.execute(q)
@@ -307,7 +307,7 @@ class TestSQLite(TracerTestCase):
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 0.5)
 
     def test_analytics_without_rate(self):
-        with self.override_config("dbapi2", dict(analytics_enabled=True)):
+        with self.override_config("sqlite", dict(analytics_enabled=True)):
             q = "select * from sqlite_master"
             connection = self._given_a_traced_connection(self.tracer)
             cursor = connection.execute(q)


### PR DESCRIPTION
## Description

The dbapi integration currently does a copy and merge of config objects whenever a traced method is called. This was required because we had to juggle both `config.dbapi2` and configs for each dbapi-compliant library, i.e. `config.psycopg`. This can be refactored by rolling the `trace_fetch_methods` into the dbapi-complant library integrations. Since these configs are passed to the dbapi `TracedCursor` and `TracedConnection` we can use them. This PR also documents the `trace_fetch_methods` configuration.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [X] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
