### PR TITLE
tests: remove explicit writer usage from opentracing tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 import inspect
 import os
 import sys
+from typing import List
 
 import pytest
 
@@ -458,6 +459,14 @@ class DummyTracer(Tracer):
                 priority_sampler=self.writer._priority_sampler,
             )
 
+    def pop(self):
+        # type: () -> List[Span]
+        return self.writer.pop()
+
+    def pop_traces(self):
+        # type: () -> List[List[Span]]
+        return self.writer.pop_traces()
+
     def configure(self, *args, **kwargs):
         super(DummyTracer, self).configure(*args, **kwargs)
         # `.configure()` may reset the writer
@@ -668,6 +677,12 @@ class TracerSpanContainer(TestSpanContainer):
         :rtype: list
         """
         return self.tracer.writer.spans
+
+    def pop(self):
+        return self.tracer.writer.pop()
+
+    def pop_traces(self):
+        return self.tracer.writer.pop_traces()
 
     def reset(self):
         """Helper to reset the existing list of spans created"""

--- a/tests/opentracer/conftest.py
+++ b/tests/opentracer/conftest.py
@@ -9,6 +9,7 @@ import pytest
 from ddtrace.opentracer import Tracer
 from ddtrace.opentracer import set_global_tracer
 from tests import DummyTracer
+from tests import TracerSpanContainer
 
 
 @pytest.fixture()
@@ -37,6 +38,13 @@ def ot_tracer(ot_tracer_factory):
     return ot_tracer_factory()
 
 
+@pytest.fixture
+def test_spans(ot_tracer):
+    container = TracerSpanContainer(ot_tracer._dd_tracer)
+    yield container
+    container.reset()
+
+
 @pytest.fixture()
 def global_tracer(ot_tracer):
     """A function similar to one OpenTracing users would write to initialize
@@ -45,11 +53,6 @@ def global_tracer(ot_tracer):
     set_global_tracer(ot_tracer)
 
     return ot_tracer
-
-
-@pytest.fixture()
-def writer(ot_tracer):
-    return ot_tracer._dd_tracer.writer
 
 
 @pytest.fixture()

--- a/tests/opentracer/core/test_dd_compatibility.py
+++ b/tests/opentracer/core/test_dd_compatibility.py
@@ -33,13 +33,13 @@ class TestTracerCompatibility(object):
         assert ot_tracer._dd_tracer is dd_tracer
         assert dd_tracer is ddtrace.tracer
 
-    def test_ot_dd_nested_trace(self, ot_tracer, dd_tracer, writer):
+    def test_ot_dd_nested_trace(self, ot_tracer, dd_tracer, test_spans):
         """Ensure intertwined usage of the opentracer and ddtracer."""
 
         with ot_tracer.start_span("my_ot_span") as ot_span:
             with dd_tracer.trace("my_dd_span") as dd_span:
                 pass
-        spans = writer.pop()
+        spans = test_spans.pop()
         assert len(spans) == 2
 
         # confirm the ordering
@@ -50,12 +50,12 @@ class TestTracerCompatibility(object):
         assert spans[0].parent_id is None
         assert spans[1].parent_id == spans[0].span_id
 
-    def test_dd_ot_nested_trace(self, ot_tracer, dd_tracer, writer):
+    def test_dd_ot_nested_trace(self, ot_tracer, dd_tracer, test_spans):
         """Ensure intertwined usage of the opentracer and ddtracer."""
         with dd_tracer.trace("my_dd_span") as dd_span:
             with ot_tracer.start_span("my_ot_span") as ot_span:
                 pass
-        spans = writer.pop()
+        spans = test_spans.pop()
         assert len(spans) == 2
 
         # confirm the ordering
@@ -66,7 +66,7 @@ class TestTracerCompatibility(object):
         assert spans[0].parent_id is None
         assert spans[1].parent_id is spans[0].span_id
 
-    def test_ot_dd_ot_dd_nested_trace(self, ot_tracer, dd_tracer, writer):
+    def test_ot_dd_ot_dd_nested_trace(self, ot_tracer, dd_tracer, test_spans):
         """Ensure intertwined usage of the opentracer and ddtracer."""
         with ot_tracer.start_span("my_ot_span") as ot_span:
             with dd_tracer.trace("my_dd_span") as dd_span:
@@ -74,7 +74,7 @@ class TestTracerCompatibility(object):
                     with dd_tracer.trace("my_dd_span") as dd_span2:
                         pass
 
-        spans = writer.pop()
+        spans = test_spans.pop()
         assert len(spans) == 4
 
         # confirm the ordering
@@ -89,7 +89,7 @@ class TestTracerCompatibility(object):
         assert spans[2].parent_id is spans[1].span_id
         assert spans[3].parent_id is spans[2].span_id
 
-    def test_ot_ot_dd_ot_dd_nested_trace_active(self, ot_tracer, dd_tracer, writer):
+    def test_ot_ot_dd_ot_dd_nested_trace_active(self, ot_tracer, dd_tracer, test_spans):
         """Ensure intertwined usage of the opentracer and ddtracer."""
         with ot_tracer.start_active_span("my_ot_span") as ot_scope:
             with ot_tracer.start_active_span("my_ot_span") as ot_scope2:
@@ -98,7 +98,7 @@ class TestTracerCompatibility(object):
                         with dd_tracer.trace("my_dd_span") as dd_span2:
                             pass
 
-        spans = writer.pop()
+        spans = test_spans.pop()
         assert len(spans) == 5
 
         # confirm the ordering
@@ -115,7 +115,7 @@ class TestTracerCompatibility(object):
         assert spans[3].parent_id == spans[2].span_id
         assert spans[4].parent_id == spans[3].span_id
 
-    def test_consecutive_trace(self, ot_tracer, dd_tracer, writer):
+    def test_consecutive_trace(self, ot_tracer, dd_tracer, test_spans):
         """Ensure consecutive usage of the opentracer and ddtracer."""
         with ot_tracer.start_active_span("my_ot_span") as ot_scope:
             pass
@@ -129,7 +129,7 @@ class TestTracerCompatibility(object):
         with dd_tracer.trace("my_dd_span") as dd_span2:
             pass
 
-        spans = writer.pop()
+        spans = test_spans.pop()
         assert len(spans) == 4
 
         # confirm the ordering
@@ -144,7 +144,7 @@ class TestTracerCompatibility(object):
         assert spans[2].parent_id is None
         assert spans[3].parent_id is None
 
-    def test_ddtrace_wrapped_fn(self, ot_tracer, dd_tracer, writer):
+    def test_ddtrace_wrapped_fn(self, ot_tracer, dd_tracer, test_spans):
         """Ensure ddtrace wrapped functions work with the opentracer"""
 
         @dd_tracer.wrap()
@@ -155,7 +155,7 @@ class TestTracerCompatibility(object):
         with ot_tracer.start_active_span("ot_span_outer"):
             fn()
 
-        spans = writer.pop()
+        spans = test_spans.pop()
         assert len(spans) == 3
 
         # confirm the ordering
@@ -168,7 +168,7 @@ class TestTracerCompatibility(object):
         assert spans[1].parent_id is spans[0].span_id
         assert spans[2].parent_id is spans[1].span_id
 
-    def test_distributed_trace_propagation(self, ot_tracer, dd_tracer, writer):
+    def test_distributed_trace_propagation(self, ot_tracer, dd_tracer, test_spans):
         """Ensure that a propagated span context is properly activated."""
         span_ctx = SpanContext(trace_id=123, span_id=456)
         carrier = {}
@@ -184,5 +184,5 @@ class TestTracerCompatibility(object):
         assert span.parent_id == 456
         assert span.trace_id == 123
 
-        spans = writer.pop()
+        spans = test_spans.pop()
         assert len(spans) == 1

--- a/tests/opentracer/core/test_span.py
+++ b/tests/opentracer/core/test_span.py
@@ -111,7 +111,7 @@ class TestSpan(object):
         assert nop_span.finished
 
         # there should be no traces (see above comment)
-        spans = nop_span.tracer._tracer.writer.pop()
+        spans = nop_span.tracer._tracer.pop()
         assert len(spans) == 0
 
     def test_immutable_span_context(self, nop_span):

--- a/tests/opentracer/test_tracer_tornado.py
+++ b/tests/opentracer/test_tracer_tornado.py
@@ -14,12 +14,12 @@ class TestTracerTornado(object):
     whether it exists and works for a very simple use-case.
     """
 
-    def test_sanity(self, ot_tracer, writer):
+    def test_sanity(self, ot_tracer, test_spans):
         with ot_tracer.start_active_span("one"):
             with ot_tracer.start_active_span("two"):
                 pass
 
-        traces = writer.pop_traces()
+        traces = test_spans.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 2
         assert traces[0][0].name == "one"


### PR DESCRIPTION
As per title.

Cleans up #2071 slightly