### PR TITLE
refactor: add helper for analytics rate to trace_utils

### DIFF
--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -6,7 +6,6 @@ from ddtrace import config
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from .. import trace_utils
-from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanTypes
 from ...internal.logger import get_logger
@@ -36,6 +35,7 @@ config._add(
         distributed_tracing_enabled=True,
         template_default_name="<memory>",
         trace_signals=True,
+        _analytics_use_global_config=True,
     ),
 )
 
@@ -274,10 +274,7 @@ def traced_wsgi_app(pin, wrapped, instance, args, kwargs):
         span_type=SpanTypes.WEB,
     ) as s:
         s.set_tag(SPAN_MEASURED_KEY)
-        # set analytics sample rate with global config enabled
-        sample_rate = config.flask.get_analytics_sample_rate(use_global_config=True)
-        if sample_rate is not None:
-            s.set_tag(ANALYTICS_SAMPLE_RATE_KEY, sample_rate)
+        trace_utils.set_analytics_sample_rate(s, config.flask)
 
         s.set_tag(FLASK_VERSION, flask_version_str)
 

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from ddtrace import Pin
 from ddtrace import config
+from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.ext import http
 import ddtrace.http
 from ddtrace.internal.logger import get_logger
@@ -241,3 +242,13 @@ def flatten_dict(
         else:
             flat[p] = v
     return flat
+
+
+def set_analytics_sample_rate(span, integration_config):
+    analytics_sample_rate = integration_config.analytics_sample_rate
+    if integration_config._is_analytics_enabled():
+        # set rate to True if none set but analytics has been enabled
+        if analytics_sample_rate is None:
+            analytics_sample_rate = True
+        if analytics_sample_rate:
+            span.set_metric(ANALYTICS_SAMPLE_RATE_KEY, analytics_sample_rate)

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -93,7 +93,8 @@ class IntegrationConfig(AttrDict):
             else self.global_config.header_is_traced(header_name)
         )
 
-    def _is_analytics_enabled(self, use_global_config):
+    def _is_analytics_enabled(self, use_global_config=None):
+        use_global_config = use_global_config or getattr(self, "_analytics_use_global_config", False)
         # DEV: analytics flag can be None which should not be taken as
         # enabled when global flag is disabled
         if use_global_config and self.global_config.analytics_enabled:

--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -124,9 +124,10 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
             return "Hello Flask", 200
 
         with self.override_global_config(dict(analytics_enabled=True)):
-            res = self.client.get("/")
-            self.assertEqual(res.status_code, 200)
-            self.assertEqual(res.data, b"Hello Flask")
+            with self.override_config("flask", dict()):
+                res = self.client.get("/")
+                self.assertEqual(res.status_code, 200)
+                self.assertEqual(res.data, b"Hello Flask")
 
         root = self.get_root_span()
         root.assert_matches(
@@ -183,9 +184,10 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
             return "Hello Flask", 200
 
         with self.override_global_config(dict(analytics_enabled=False)):
-            res = self.client.get("/")
-            self.assertEqual(res.status_code, 200)
-            self.assertEqual(res.data, b"Hello Flask")
+            with self.override_config("flask", dict()):
+                res = self.client.get("/")
+                self.assertEqual(res.status_code, 200)
+                self.assertEqual(res.data, b"Hello Flask")
 
         root = self.get_root_span()
         self.assertIsNone(root.get_metric(ANALYTICS_SAMPLE_RATE_KEY))

--- a/tests/tracer/test_settings.py
+++ b/tests/tracer/test_settings.py
@@ -235,37 +235,6 @@ class TestIntegrationConfig(BaseTestCase):
             ic = IntegrationConfig(self.config, "foo", analytics_enabled=False)
             self.assertFalse(ic.analytics_enabled)
 
-    def test_get_analytics_sample_rate(self):
-        """" Check method for accessing sample rate based on configuration """
-        ic = IntegrationConfig(self.config, "foo", analytics_enabled=True, analytics_sample_rate=0.5)
-        self.assertEqual(ic.get_analytics_sample_rate(), 0.5)
-
-        ic = IntegrationConfig(self.config, "foo", analytics_enabled=True)
-        self.assertEqual(ic.get_analytics_sample_rate(), 1.0)
-
-        ic = IntegrationConfig(self.config, "foo", analytics_enabled=False)
-        self.assertIsNone(ic.get_analytics_sample_rate())
-
-        with self.override_env(dict(DD_ANALYTICS_ENABLED="True")):
-            config = Config()
-            ic = IntegrationConfig(config, "foo")
-            self.assertEqual(ic.get_analytics_sample_rate(use_global_config=True), 1.0)
-
-        with self.override_env(dict(DD_TRACE_ANALYTICS_ENABLED="True")):
-            config = Config()
-            ic = IntegrationConfig(config, "foo")
-            self.assertEqual(ic.get_analytics_sample_rate(use_global_config=True), 1.0)
-
-        with self.override_env(dict(DD_ANALYTICS_ENABLED="False")):
-            config = Config()
-            ic = IntegrationConfig(config, "foo")
-            self.assertIsNone(ic.get_analytics_sample_rate(use_global_config=True))
-
-        with self.override_env(dict(DD_TRACE_ANALYTICS_ENABLED="False")):
-            config = Config()
-            ic = IntegrationConfig(config, "foo")
-            self.assertIsNone(ic.get_analytics_sample_rate(use_global_config=True))
-
     def test_deepcopy(self):
         ic = IntegrationConfig(
             self.config, "foo", analytics_enabled=True, analytics_sample_rate=0.5, deep={"field": "sodeep"}


### PR DESCRIPTION
Introduces a helper for setting analytics rates on integration spans and moves a two integrations (one which should default to the global analytics configuration and the other should not) to use this new helper.