### PR TITLE
flask: remove extra_error_codes

### DIFF
--- a/releasenotes/notes/flask-codes-f0841d78ec847807.yaml
+++ b/releasenotes/notes/flask-codes-f0841d78ec847807.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    flask: deprecated configuration option `extra_error_codes` has been removed.

--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -833,13 +833,3 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
 
         span = traces[0][0]
         assert span.get_tag("http.response.headers.my-response-header") == "my_response_value"
-
-    def test_extra_error_codes(self):
-        with self.override_config("flask", dict(extra_error_codes=[404])):
-            res = self.client.get("/not-found")
-            self.assertEqual(res.status_code, 404)
-
-        spans = self.get_spans()
-        req_span = spans[0]
-        assert_span_http_status_code(req_span, 404)
-        self.assertEqual(req_span.error, 1)


### PR DESCRIPTION
This was supposed to be removed in 0.47
