### PR TITLE
fix(botocore) Ensure the presence of ResponseMetadata key in the result

### DIFF
--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -157,16 +157,16 @@ def patched_api_call(original_func, instance, args, kwargs):
 
         result = original_func(*args, **kwargs)
 
-        response_meta = result["ResponseMetadata"]
+        response_meta = result.get("ResponseMetadata")
+        if response_meta:
+            if "HTTPStatusCode" in response_meta:
+                span.set_tag(http.STATUS_CODE, response_meta["HTTPStatusCode"])
 
-        if "HTTPStatusCode" in response_meta:
-            span.set_tag(http.STATUS_CODE, response_meta["HTTPStatusCode"])
+            if "RetryAttempts" in response_meta:
+                span.set_tag("retry_attempts", response_meta["RetryAttempts"])
 
-        if "RetryAttempts" in response_meta:
-            span.set_tag("retry_attempts", response_meta["RetryAttempts"])
-
-        if "RequestId" in response_meta:
-            span.set_tag("aws.requestid", response_meta["RequestId"])
+            if "RequestId" in response_meta:
+                span.set_tag("aws.requestid", response_meta["RequestId"])
 
         # set analytics sample rate
         span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, config.botocore.get_analytics_sample_rate())

--- a/releasenotes/notes/fix-botocore-missing-response-meta-e80c1cfb34ec0881.yaml
+++ b/releasenotes/notes/fix-botocore-missing-response-meta-e80c1cfb34ec0881.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    botocore: Do not assume that ResponseMeta exists in the results.


### PR DESCRIPTION
## Description
Fixes #2116

When using `botocore.stub.Stubber` if no `ResponseMetadata` is provided in the response then our instrumentation raises a `KeyError`.

While this is not likely to happen from calling a non-stubbed version of `botocore` we should still be defensive in our instrumentation code to ensure if our expectations from `botocore` ever change we will continue to work.


## Checklist
- [x] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- ~[ ] Library documentation is updated.~
- ~[ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
