### PR TITLE
ci(mergify): change label merge condition

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,13 +1,23 @@
 pull_request_rules:
   - name: automatic merge
     conditions:
-      - label=automerge
+      - label!=manual merge
       - check-success=test
-      - "#approved-reviews-by>=1"
+      - "#approved-reviews-by>=2"
     actions:
       merge:
         strict: smart
         method: squash
+  # This rule keep the PR updated with its base branch as soon as it has 1
+  # approval. This makes it more likely to be ready to be merged once the
+  # second approval comes.
+  - name: prepare for merge
+    conditions:
+      - label!=manual merge
+      - check-success=test
+      - "#approved-reviews-by>=1"
+    actions:
+      update: {}
   - name: warn on conflicts
     conditions:
       - conflict


### PR DESCRIPTION
As every PR is now labeled `automerge`, and people are now forgetting to add
the automerge label, let's change the merge rule to always automerge except
said otherwise.