### PR TITLE
refactor(runtime_metrics): update the tags on init

### DIFF
--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -63,6 +63,8 @@ class RuntimeWorker(_worker.PeriodicWorkerThread):
         self._dogstatsd_client = get_dogstatsd_client(dogstatsd_url)
         # Initialize collector
         self._runtime_metrics = RuntimeMetrics()
+        # force an immediate update constant tags
+        self.update_runtime_tags()
         # Start worker thread
         self.start()
 

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -495,9 +495,6 @@ class Tracer(object):
             return
 
         self._runtime_worker = RuntimeWorker(self._dogstatsd_url)
-        # force an immediate update constant tags since we have reset services
-        # and generated a new runtime id
-        self._runtime_worker.update_runtime_tags()
 
     def _check_new_process(self):
         """Checks if the tracer is in a new process (was forked) and performs


### PR DESCRIPTION
The tracer shouldn't have to do that itself.