### PR TITLE
writer: raise RuntimeError when writing after stop()

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -317,10 +317,12 @@ class AgentWriter(_worker.PeriodicWorkerThread):
         # Start the AgentWriter on first write.
         # Starting it earlier might be an issue with gevent, see:
         # https://github.com/DataDog/dd-trace-py/issues/1192
-        if self.started is False:
+        if not self.started:
             with self._started_lock:
-                if self.started is False:
+                if not self.started:
                     self.start()
+        elif not self.is_alive():
+            raise RuntimeError("Writer thread is shutdown")
 
         self._metrics_dist("writer.accepted.traces")
         self._set_keep_rate(spans)

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -444,12 +444,9 @@ class Span(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        try:
-            if exc_type:
-                self.set_exc_info(exc_type, exc_val, exc_tb)
-            self.finish()
-        except Exception:
-            log.exception("error closing trace")
+        if exc_type:
+            self.set_exc_info(exc_type, exc_val, exc_tb)
+        self.finish()
 
     def __repr__(self):
         return "<Span(id=%s,trace_id=%s,parent_id=%s,name=%s)>" % (

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -761,7 +761,13 @@ class Tracer(object):
     def shutdown(self, timeout=None):
         """Shutdown the tracer.
 
-        This will stop the background writer/worker and flush any finished traces in the buffer.
+        This will stop the background writer/worker and flush any finished
+        traces in the buffer.
+
+        Note that the tracer *cannot* be used after it has been shutdown. Any
+        traces generated after a shutdown will result in a ``RuntimeError``
+        being raised on ``span.finish()`` (or when the span context manager
+        exits).
 
         :param timeout: How long in seconds to wait for the background worker to flush traces
             before exiting or :obj:`None` to block until flushing has successfully completed (default: :obj:`None`)

--- a/releasenotes/notes/writer-after-stop-dba54dc75d5f6aaf.yaml
+++ b/releasenotes/notes/writer-after-stop-dba54dc75d5f6aaf.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    Generating traces after a `tracer.shutdown()` will now result in a
+    `RuntimeError` instead of silently failing.

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1511,3 +1511,16 @@ def test_configure_url_partial():
     assert tracer.writer.agent_url == "http://abc:123"
     tracer.configure(port=431)
     assert tracer.writer.agent_url == "http://abc:431"
+
+
+def test_trace_after_shutdown():
+    tracer = Tracer()
+
+    with tracer.trace("test"):
+        pass
+
+    tracer.shutdown()
+
+    with pytest.raises(RuntimeError):
+        with tracer.trace("test2"):
+            pass

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -452,3 +452,17 @@ def test_flush_queue_raise():
     with pytest.raises(error):
         writer.write([])
         writer.flush_queue(raise_exc=True)
+
+
+def test_stop_start():
+    writer = AgentWriter(agent_url="http://dne:1234")
+
+    writer.write([])
+    assert writer.started
+    assert writer.is_alive()
+    writer.stop()
+    writer.join()
+
+    with pytest.raises(RuntimeError):
+        writer.write([])
+


### PR DESCRIPTION
# Bug fix

## Description
<!-- Please briefly describe the bug. -->
Prior to this patch it was possible to continue writing traces to a
stopped writer. This would silently fail as the writing thread can only
be started once and so traces would be buffered indefinitely as no
flushing would occur.

## Fix
<!-- Please provide a succinct overview of the fix. -->
Raise a `RuntimeError` to ensure the error is dealt with.

# Checklist
- [x] Regression test added; or
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [x] Added to the correct milestone.
