### PR TITLE
tests: add racing start test for writer

### DIFF
--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -452,3 +452,19 @@ def test_flush_queue_raise():
     with pytest.raises(error):
         writer.write([])
         writer.flush_queue(raise_exc=True)
+
+
+def test_racing_start():
+    writer = AgentWriter(agent_url="http://dne:1234")
+
+    def do_write(i):
+        writer.write([Span(None, str(i))])
+
+    ts = [threading.Thread(target=do_write, args=(i,)) for i in range(100)]
+    for t in ts:
+        t.start()
+
+    for t in ts:
+        t.join()
+
+    assert len(writer._buffer) == 100


### PR DESCRIPTION
This covers the following lines in the writer:

https://github.com/DataDog/dd-trace-py/blob/716b2a6e90d44a42969a7697e9ead74fbd0e84c5/ddtrace/internal/writer.py#L350-L353