### PR TITLE
Update cgroup parsing for Fargate 1.4

### DIFF
--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -23,10 +23,13 @@ class CGroupInfo(object):
 
     UUID_SOURCE_PATTERN = r"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}"
     CONTAINER_SOURCE_PATTERN = r"[0-9a-f]{64}"
+    TASK_PATTERN = r"[0-9a-f]{32}-\d+"
 
     LINE_RE = re.compile(r"^(\d+):([^:]*):(.+)$")
     POD_RE = re.compile(r"pod({0})(?:\.slice)?$".format(UUID_SOURCE_PATTERN))
-    CONTAINER_RE = re.compile(r"({0}|{1})(?:\.scope)?$".format(UUID_SOURCE_PATTERN, CONTAINER_SOURCE_PATTERN))
+    CONTAINER_RE = re.compile(
+        r"({0}|{1}|{2})(?:\.scope)?$".format(UUID_SOURCE_PATTERN, CONTAINER_SOURCE_PATTERN, TASK_PATTERN)
+    )
 
     @classmethod
     def from_line(cls, line):

--- a/tests/tracer/runtime/test_container.py
+++ b/tests/tracer/runtime/test_container.py
@@ -58,6 +58,18 @@ def test_cgroup_info_init():
                 pod_id=None,
             ),
         ),
+        # Valid, fargate >= 1.4.0
+        (
+            "1:name=systemd:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890",
+            CGroupInfo(
+                id="1",
+                groups="name=systemd",
+                controllers=["name=systemd"],
+                path="/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890",
+                container_id="34dc0b5e626f2c5c4c5170e34b10e765-1234567890",
+                pod_id=None,
+            ),
+        ),
         # Invalid container_ids
         (
             # One character too short
@@ -213,6 +225,7 @@ def test_cgroup_info_from_line(line, expected_info):
 3:blkio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
 2:memory:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
 1:name=systemd:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+1:name=systemd:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890
             """,
             "432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da",
         ),


### PR DESCRIPTION
## Description
As per [APMPY-465](https://datadoghq.atlassian.net/jira/software/projects/APMPY/boards/136?selectedIssue=APMPY-465), the Python tracer was updated to parse the task ID from the cgroups file and send that to the agent as the container ID header.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
