### PR TITLE
fix(monkey): multiple patch on import targets

### DIFF
--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -108,8 +108,14 @@ def _on_import_factory(module, raise_errors=True):
     def on_import(hook):
         # Import and patch module
         path = "ddtrace.contrib.%s" % module
-        imported_module = importlib.import_module(path)
-        imported_module.patch()
+        try:
+            imported_module = importlib.import_module(path)
+        except ImportError:
+            if raise_errors:
+                raise
+            log.error("Failed to import ddtrace module when patching on import", exc_info=True)
+        else:
+            imported_module.patch()
 
     return on_import
 
@@ -154,18 +160,20 @@ def patch(raise_errors=True, **patch_modules):
     modules = [m for (m, should_patch) in patch_modules.items() if should_patch]
     for module in modules:
         if module in _PATCH_ON_IMPORT:
-            # If the module has already been imported then patch immediately
-            if module in sys.modules:
-                patch_module(module, raise_errors=raise_errors)
+            modules_to_poi = _PATCH_ON_IMPORT[module]
+            for m in modules_to_poi:
+                # If the module has already been imported then patch immediately
+                if m in sys.modules:
+                    patch_module(m, raise_errors=raise_errors)
+                # Otherwise, add a hook to patch when it is imported for the first time
+                else:
+                    # Use factory to create handler to close over `module` and `raise_errors` values from this loop
+                    when_imported(m)(_on_import_factory(module, raise_errors))
 
-            # Otherwise, add a hook to patch when it is imported for the first time
-            else:
-                # Use factory to create handler to close over `module` and `raise_errors` values from this loop
-                when_imported(module)(_on_import_factory(module, raise_errors))
+            # manually add module to patched modules
+            with _LOCK:
+                _PATCHED_MODULES.add(module)
 
-                # manually add module to patched modules
-                with _LOCK:
-                    _PATCHED_MODULES.add(module)
         else:
             patch_module(module, raise_errors=raise_errors)
 


### PR DESCRIPTION
# Bug fix

## Description
<!-- Please briefly describe the bug. -->
The key of the `_PATCH_ON_IMPORT` was never used which means that multiple module targets for patching on import would not work (nor would specifying any other module name).

## Fix
<!-- Please provide a succinct overview of the fix. -->
Handle the values of the `_PATCH_ON_IMPORT` dict and also install the patch on import hook for them.

# Checklist
- [ ] Regression test added; or
- [ ] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Added to the correct milestone.

# Testing
- [ ] Tests are run against all relevant library versions (or confirm that the relevant versions are already being tested in `tox.ini`)
