### PR TITLE
Move Flask and Flask-Cache tests to riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -707,7 +707,7 @@ jobs:
     steps:
       - run_test:
           # Run both flask and flask_cache test suites
-          pattern: 'flask(_cache)?
+          pattern: 'flask(_cache)?'
 
   gevent:
     <<: *contrib_job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -705,8 +705,9 @@ jobs:
       - image: *redis_image
       - image: *memcached_image
     steps:
-      - run_tox_scenario:
-          pattern: '^flask_\(cache_\)\?contrib\(_autopatch\)\?-'
+      - run_test:
+          # Run both flask and flask_cache test suites
+          pattern: 'flask(_cache)?
 
   gevent:
     <<: *contrib_job

--- a/riotfile.py
+++ b/riotfile.py
@@ -299,6 +299,7 @@ venv = Venv(
                     pys=select_pys(),
                     pkgs={
                         "flask": ["~=0.10.0", "~=0.11.0"],
+                        "pytest": "~=3.0",
                         "Werkzeug": "<1.0",
                     },
                 ),
@@ -311,14 +312,16 @@ venv = Venv(
                     },
                     pkgs={
                         "flask": ["~=0.10.0", "~=0.11.0"],
+                        "pytest": "~=3.0",
                         "Werkzeug": "<1.0",
                     },
                 ),
-                # Flask >= 0.12.0
+                # Flask == 0.12.0
                 Venv(
                     pys=select_pys(),
                     pkgs={
-                        "flask": ["~=0.12.0", "~=1.0.0", "~=1.1.0", latest],
+                        "flask": ["~=0.12.0"],
+                        "pytest": "~=3.0",
                     },
                 ),
                 Venv(
@@ -329,7 +332,26 @@ venv = Venv(
                         "DATADOG_PATCH_MODULES": "jinja2:false",
                     },
                     pkgs={
-                        "flask": ["~=0.12.0", "~=1.0.0", "~=1.1.0", latest],
+                        "flask": ["~=0.12.0"],
+                        "pytest": "~=3.0",
+                    },
+                ),
+                # Flask >= 1.0.0
+                Venv(
+                    pys=select_pys(),
+                    pkgs={
+                        "flask": ["~=1.0.0", "~=1.1.0", latest],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(),
+                    command="python tests/ddtrace_run.py pytest {cmdargs} tests/contrib/flask_autopatch",
+                    env={
+                        "DATADOG_SERVICE_NAME": "test.flask.service",
+                        "DATADOG_PATCH_MODULES": "jinja2:false",
+                    },
+                    pkgs={
+                        "flask": ["~=1.0.0", "~=1.1.0", latest],
                     },
                 ),
             ],

--- a/riotfile.py
+++ b/riotfile.py
@@ -288,6 +288,80 @@ venv = Venv(
             ],
         ),
         Venv(
+            name="flask",
+            command="pytest {cmdargs} tests/contrib/flask",
+            pkgs={
+                "blinker": latest,
+                "pytest": "~=3.0",
+            },
+            venvs=[
+                # Flask 0.10, 0.11
+                Venv(
+                    pys=select_pys(),
+                    pkgs={
+                        "flask": ["~=0.10.0", "~=0.11.0"],
+                        "Werkzeug": "<1.0",
+                    },
+                ),
+                Venv(
+                    pys=select_pys(),
+                    command="python tests/ddtrace_run.py pytest {posargs} tests/contrib/flask_autopatch",
+                    env={
+                        "DATADOG_SERVICE_NAME": "test.flask.service",
+                        "DATADOG_PATCH_MODULES": "jinja2:false",
+                    },
+                    pkgs={
+                        "flask": ["~=0.10.0", "~=0.11.0"],
+                        "Werkzeug": "<1.0",
+                    },
+                ),
+                # Flask >= 0.12.0
+                Venv(
+                    pys=select_pys(),
+                    pkgs={
+                        "flask": ["~=0.12.0", "~=1.0.0", "~=1.1.0", latest],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(),
+                    command="python tests/ddtrace_run.py pytest {posargs} tests/contrib/flask_autopatch",
+                    env={
+                        "DATADOG_SERVICE_NAME": "test.flask.service",
+                        "DATADOG_PATCH_MODULES": "jinja2:false",
+                    },
+                    pkgs={
+                        "flask": ["~=0.12.0", "~=1.0.0", "~=1.1.0", latest],
+                    },
+                ),
+            ],
+        ),
+        Venv(
+            name="flask_cache",
+            command="pytest {cmdargs} tests/contrib/flask_cache",
+            pkgs={
+                "python-memcached": latest,
+                "redis": "~=2.0",
+                "blinker": latest,
+                "pytest": "~=3.0",
+            },
+            venvs=[
+                Venv(
+                    pys=select_pys(),
+                    pkgs={
+                        "flask": ["~=0.10.0", "~=0.11.0", "~=0.12.0"],
+                        "Flask-Cache": ["~=0.13.0", latest],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(max_version=2.7),
+                    pkgs={
+                        "flask": ["~=0.10.0", "~=0.11.0"],
+                        "Flask-Cache": ["~=0.12.0"],
+                    },
+                ),
+            ],
+        ),
+        Venv(
             name="psycopg",
             command="pytest {cmdargs} tests/contrib/psycopg",
             venvs=[

--- a/riotfile.py
+++ b/riotfile.py
@@ -292,7 +292,6 @@ venv = Venv(
             command="pytest {cmdargs} tests/contrib/flask",
             pkgs={
                 "blinker": latest,
-                "pytest": "~=3.0",
             },
             venvs=[
                 # Flask 0.10, 0.11
@@ -342,21 +341,20 @@ venv = Venv(
                 "python-memcached": latest,
                 "redis": "~=2.0",
                 "blinker": latest,
-                "pytest": "~=3.0",
             },
             venvs=[
-                Venv(
-                    pys=select_pys(),
-                    pkgs={
-                        "flask": ["~=0.10.0", "~=0.11.0", "~=0.12.0"],
-                        "Flask-Cache": ["~=0.13.0", latest],
-                    },
-                ),
                 Venv(
                     pys=select_pys(max_version=2.7),
                     pkgs={
                         "flask": ["~=0.10.0", "~=0.11.0"],
                         "Flask-Cache": ["~=0.12.0"],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(),
+                    pkgs={
+                        "flask": ["~=0.10.0", "~=0.11.0", "~=0.12.0"],
+                        "Flask-Cache": ["~=0.13.0", latest],
                     },
                 ),
             ],

--- a/riotfile.py
+++ b/riotfile.py
@@ -305,7 +305,7 @@ venv = Venv(
                 ),
                 Venv(
                     pys=select_pys(),
-                    command="python tests/ddtrace_run.py pytest {posargs} tests/contrib/flask_autopatch",
+                    command="python tests/ddtrace_run.py pytest {cmdargs} tests/contrib/flask_autopatch",
                     env={
                         "DATADOG_SERVICE_NAME": "test.flask.service",
                         "DATADOG_PATCH_MODULES": "jinja2:false",
@@ -324,7 +324,7 @@ venv = Venv(
                 ),
                 Venv(
                     pys=select_pys(),
-                    command="python tests/ddtrace_run.py pytest {posargs} tests/contrib/flask_autopatch",
+                    command="python tests/ddtrace_run.py pytest {cmdargs} tests/contrib/flask_autopatch",
                     env={
                         "DATADOG_SERVICE_NAME": "test.flask.service",
                         "DATADOG_PATCH_MODULES": "jinja2:false",

--- a/tox.ini
+++ b/tox.ini
@@ -59,11 +59,6 @@ envlist =
     dogpile_contrib-py{36,37,38,39}-dogpilecache{06,07,08,09,10,}
     falcon_contrib{,_autopatch}-{py27,py35,py36,py37}-falcon{10,11,12,13,14}
     falcon_contrib{,_autopatch}-{py35,py36,py37}-falcon{20}
-    flask_contrib{,_autopatch}-{py27,py35,py36,py37,py38,py39}-flask{010,011,012,10,11,}-blinker-pytest3
-# Flask <=0.9 does not support Python 3
-    flask_contrib{,_autopatch}-{py27}-flask{09}-blinker-pytest3
-    flask_cache_contrib-py{27,35,36,37,38,39}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker-pytest3
-    flask_cache_contrib-py27-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker-pytest3
     futures_contrib-py27-futures{30,31,32,}
     futures_contrib-py{35,36,37,38,39}
     gevent_contrib-py27-gevent{11,12,13}-sslmodules
@@ -133,8 +128,6 @@ setenv =
     integration-latest: AGENT_VERSION=latest
     integration-snapshot: AGENT_VERSION=testagent
     bottle_contrib_autopatch: DATADOG_SERVICE_NAME=bottle-app
-    flask_contrib_autopatch: DATADOG_SERVICE_NAME=test.flask.service
-    flask_contrib_autopatch: DATADOG_PATCH_MODULES=jinja2:false
     pyramid_contrib_autopatch: DATADOG_SERVICE_NAME=foobar
     pyramid_contrib_autopatch: DATADOG_PYRAMID_DISTRIBUTED_TRACING=True
     falcon_contrib_autopatch: DATADOG_SERVICE_NAME=my-falcon
@@ -235,18 +228,6 @@ deps =
     falcon13: falcon>=1.3,<1.4
     falcon14: falcon>=1.4,<1.5
     falcon20: falcon>=2.0,<2.1
-    flask09: flask>=0.9,<0.10
-    flask09: Werkzeug<1
-    flask010: flask>=0.10,<0.11
-    flask010: Werkzeug<1
-    flask011: flask>=0.11,<0.12
-    flask011: Werkzeug<1
-    flask012: flask>=0.12,<0.13
-    flask10: flask>=1.0,<1.1
-    flask11: flask>=1.1,<1.2
-    flask: flask>=1.1
-    flaskcache012: flask_cache>=0.12,<0.13
-    flaskcache013: flask_cache>=0.13,<0.14
     futures: futures
     futures30: futures>=3.0,<3.1
     futures31: futures>=3.1,<3.2
@@ -396,9 +377,6 @@ commands =
     dogpile_contrib: pytest {posargs} tests/contrib/dogpile_cache
     falcon_contrib: pytest {posargs} tests/contrib/falcon/test_middleware.py tests/contrib/falcon/test_distributed_tracing.py
     falcon_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/falcon/test_autopatch.py
-    flask_contrib: pytest {posargs} tests/contrib/flask
-    flask_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/flask_autopatch
-    flask_cache_contrib: pytest {posargs} tests/contrib/flask_cache
     futures_contrib: pytest {posargs} tests/contrib/futures
     gevent_contrib: pytest {posargs} tests/contrib/gevent
     httplib_contrib: pytest {posargs} tests/contrib/httplib


### PR DESCRIPTION
This change also drops testing Flask 0.9 since that version is from 2012.