### PR TITLE
Fix starlette tests

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -447,7 +447,8 @@ venv = Venv(
                         "pytest-asyncio": latest,
                         "requests": latest,
                         "aiofiles": latest,
-                        "sqlalchemy": latest,
+                        # Pinned until https://github.com/encode/databases/issues/298 is resolved.
+                        "sqlalchemy": "~=1.3.0",
                         "aiosqlite": latest,
                         "databases": latest,
                     },


### PR DESCRIPTION
As per https://github.com/encode/databases/issues/298, sqlalchemy 1.4 removed `RowProxy` which causes `databases` to fail.

Pin sqlalchemy to 1.3.x for until the issue is resolved upstream. 
