### PR TITLE
chore: format pyi files

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -37,6 +37,7 @@ venv = Venv(
                 "flake8-logging-format": latest,
                 "flake8-rst-docstrings": latest,
                 "flake8-isort": latest,
+                "flake8-pyi": latest,
                 "pygments": latest,
             },
         ),


### PR DESCRIPTION
Running `isort` formats these files so we should probably check in the
changes.
