### PR TITLE
trace_utils: handle non-integer error codes

### DIFF
--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -157,6 +157,26 @@ def test_set_http_meta_custom_errors(mock_log, span, int_config, error_codes, st
         mock_log.exception.assert_not_called()
 
 
+@mock.patch("ddtrace.contrib.trace_utils.log")
+@pytest.mark.parametrize(
+    "val, bad",
+    [
+        ("asdf", True),
+        (object(), True),
+        ("234", False),
+        ("100.0", True),
+        ("-123", False),
+    ],
+)
+def test_bad_http_code(mock_log, span, int_config, val, bad):
+    trace_utils.set_http_meta(span, int_config, status_code=val)
+    if bad:
+        assert http.STATUS_CODE not in span.meta
+        mock_log.debug.assert_called_once_with("failed to convert http status code %r to int", val)
+    else:
+        assert span.meta[http.STATUS_CODE] == str(val)
+
+
 def test_activate_distributed_headers_enabled(int_config):
     tracer = Tracer()
     int_config.myint["distributed_tracing_enabled"] = True


### PR DESCRIPTION
The log is `debug`-level since `set_http_meta` will run on possibly many requests that may be impacted by this issue if it does occur. I could see an argument be made about warning/error level as well if we think that it's more likely that this would be really rare and the user should be alerted to the issue.
