### PR TITLE
fix(profiling): use service lock to avoid race condition on start

### DIFF
--- a/ddtrace/internal/service.py
+++ b/ddtrace/internal/service.py
@@ -38,6 +38,14 @@ class Service(object):
             if self.status == ServiceStatus.RUNNING:
                 raise ServiceAlreadyRunning("%s is already running" % self.__class__.__name__)
             self.status = ServiceStatus.RUNNING
+            self._start()
+
+    def _start(self):
+        # type: () -> None
+        """Start the service for real.
+
+        This method uses the internal lock to be sure there's no race conditions.
+        """
 
     def stop(self):
         """Stop the service."""

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -276,9 +276,9 @@ class _ProfilerInstance(service.Service):
             service=self.service, env=self.env, version=self.version, tracer=self.tracer, tags=self.tags
         )
 
-    def start(self):
+    def _start(self):
+        # type: () -> None
         """Start the profiler."""
-        super(_ProfilerInstance, self).start()
         collectors = []
         for col in self._collectors:
             try:

--- a/tests/profiling/test_periodic.py
+++ b/tests/profiling/test_periodic.py
@@ -50,7 +50,7 @@ def test_periodic():
     def _on_shutdown():
         x["DOWN"] = True
 
-    t = _periodic.PeriodicRealThread(0.001, _run_periodic, on_shutdown=_on_shutdown)
+    t = _periodic.PeriodicRealThreadClass()(0.001, _run_periodic, on_shutdown=_on_shutdown)
     t.start()
     thread_started.wait()
     thread_continue.set()
@@ -68,7 +68,7 @@ def test_periodic_double_start():
     def _run_periodic():
         pass
 
-    t = _periodic.PeriodicRealThread(0.1, _run_periodic)
+    t = _periodic.PeriodicRealThreadClass()(0.1, _run_periodic)
     t.start()
     with pytest.raises(RuntimeError):
         t.start()
@@ -88,7 +88,7 @@ def test_periodic_error():
     def _on_shutdown():
         x["DOWN"] = True
 
-    t = _periodic.PeriodicRealThread(0.001, _run_periodic, on_shutdown=_on_shutdown)
+    t = _periodic.PeriodicRealThreadClass()(0.001, _run_periodic, on_shutdown=_on_shutdown)
     t.start()
     thread_started.wait()
     thread_continue.set()
@@ -99,9 +99,9 @@ def test_periodic_error():
 
 def test_gevent_class():
     if os.getenv("DD_PROFILE_TEST_GEVENT", False):
-        assert isinstance(_periodic.PeriodicRealThread(1, sum), _periodic._GeventPeriodicThread)
+        assert isinstance(_periodic.PeriodicRealThreadClass()(1, sum), _periodic._GeventPeriodicThread)
     else:
-        assert isinstance(_periodic.PeriodicRealThread(1, sum), _periodic.PeriodicThread)
+        assert isinstance(_periodic.PeriodicRealThreadClass()(1, sum), _periodic.PeriodicThread)
 
 
 def test_periodic_service_start_stop():
@@ -132,5 +132,5 @@ def test_is_alive_before_start():
     def x():
         pass
 
-    t = _periodic.PeriodicRealThread(1, x)
+    t = _periodic.PeriodicRealThreadClass()(1, x)
     assert not t.is_alive()


### PR DESCRIPTION
While unlikely, there's a possible race condition when starting a service
multiple times with multiple parallel threads.