### PR TITLE
Fix: Explicitly cast span.duration_ns as int when setting

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -166,7 +166,7 @@ class Span(object):
 
     @duration.setter
     def duration(self, value):
-        self.duration_ns = value * 1e9
+        self.duration_ns = int(value * 1e9)
 
     def finish(self, finish_time=None):
         """Mark the end time of the span and submit it to the tracer.

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -163,6 +163,14 @@ class SpanTestCase(TracerTestCase):
         s.finish()
         assert s.duration == 1337.0
 
+    def test_setter_casts_duration_ns_as_int(self):
+        s = Span(tracer=None, name="test.span")
+        s.duration = 3.2
+        s.finish()
+        assert s.duration == 3.2
+        assert s.duration_ns == 3200000000
+        assert isinstance(s.duration_ns, int)
+
     def test_traceback_with_error(self):
         s = Span(None, "test.span")
         try:


### PR DESCRIPTION
## Description
As per [APMPY-511](https://datadoghq.atlassian.net/jira/software/projects/APMPY/boards/136?selectedIssue=APMPY-511), the setter for `span.duration()` was found to implicitly convert the value `duration_ns` into a float when multiplying by `1e9` to get the value in nanoseconds. Since the duration value must be an int when sending traces to the agent, this was explicitly cast.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
