### PR TITLE
docs(uwsgi): workaround for uwgi worker initialization

### DIFF
--- a/ddtrace/commands/ddtrace_run.py
+++ b/ddtrace/commands/ddtrace_run.py
@@ -31,7 +31,6 @@ and profiles.
 
 Examples
 ddtrace-run python app.py
-ddtrace-run uwsgi app.py
 ddtrace-run gunicorn myproject.wsgi
 """
 
@@ -104,6 +103,15 @@ def main():
         sys.exit(1)
 
     log.debug("program executable: %s", executable)
+
+    if os.path.basename(executable) == "uwsgi":
+        print(
+            (
+                "ddtrace-run is not supported with uwsgi. "
+                "See https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#uwsgi for details."
+            )
+        )
+        sys.exit(1)
 
     try:
         # Raises OSError for permissions errors in Python 2

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -62,6 +62,7 @@ microservices
 middleware
 mongoengine
 multiprocess
+multithreaded
 mysql
 mysqlclient
 mysqldb
@@ -87,6 +88,7 @@ redis
 rediscluster
 renderers
 repo
+respawn
 runnable
 runtime
 sanic

--- a/releasenotes/notes/uwsgi-workaround-6fbfde6c19691d8b.yaml
+++ b/releasenotes/notes/uwsgi-workaround-6fbfde6c19691d8b.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    **uWSGI** is no longer supported with ``ddtrace-run`` due to a limitation of how tracer initialization occurs. See the updated instructions for enabling tracing in the library :ref:`uWSGI documentation<uwsgi>`.
+fixes:
+  - |
+    A workaround is provided for the problem with uWSGI worker processes failing to respawn. This can occur when using ``ddtrace-run`` for automatic instrumentation and configuration or manual instrumentation and configuration without the necessary uWSGI options. The problem is caused by how the tracer can end up starting threads in the master process before uWSGI forks to initialize the workers processes. To avoid this, we have provided updated instructions for enabling tracing in the library :ref:`uWSGI documentation<uwsgi>`.


### PR DESCRIPTION
## Description

The `ddtrace-run` script does not correctly support tracer initialization in uWSGI workers. Instead, users of the library can use a uWSGI configuration option to ensure the tracer is initialized in the uWSGI worker processes. There is upcoming work that will allow uWSGI users to use `ddtrace-run` but given the limitations of the library a workaround is being provided in the documentation.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [X] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
