### PR TITLE
Added explicit NoneType return for mypy in span.duration

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -174,10 +174,11 @@ class Span(object):
 
     @property
     def duration(self):
+        # type: () -> Optional[float]
         """The span duration in seconds."""
         if self.duration_ns is not None:
             return self.duration_ns / 1e9
-        # TODO: add return None if self.duration_ns is None
+        return None
 
     @duration.setter
     def duration(self, value):

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -171,6 +171,10 @@ class SpanTestCase(TracerTestCase):
         assert s.duration_ns == 3200000000
         assert isinstance(s.duration_ns, int)
 
+    def test_get_span_returns_none_by_default(self):
+        s = Span(tracer=None, name="test.span")
+        assert s.duration is None
+
     def test_traceback_with_error(self):
         s = Span(None, "test.span")
         try:


### PR DESCRIPTION
## Description
From #2180, the mypy check to `span.py` found a missing return in the case that a duration was not set yet to a span. Although trivial, it is good practice to have explicit returns. A test case was added to ensure the `span.duration` property is None by default.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
