### PR TITLE
Added return type hint to compat.get_connection_response()

### DIFF
--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -193,7 +193,7 @@ def to_unicode(s):
 
 
 def get_connection_response(
-        conn  # type: httplib.HTTPConnection  # type: ignore
+    conn,  # type: httplib.HTTPConnection  # type: ignore
 ):
     # type: (...) -> Response
     """Returns the response for a connection.

--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -6,9 +6,14 @@ import textwrap
 import threading
 from typing import Any
 from typing import AnyStr
+from typing import TYPE_CHECKING
 from typing import Text
 
 from ddtrace.vendor import six
+
+
+if TYPE_CHECKING:
+    from .internal.writer import Response
 
 
 __all__ = [
@@ -187,7 +192,10 @@ def to_unicode(s):
     return six.text_type(s)
 
 
-def get_connection_response(conn):
+def get_connection_response(
+        conn  # type: httplib.HTTPConnection  # type: ignore
+):
+    # type: (...) -> Response
     """Returns the response for a connection.
 
     If using Python 2 enable buffering.


### PR DESCRIPTION
## Description
From #2163,  the return type for `compat.get_connection_response()` was added after it was found that `typing.TYPE_CHECK` can be used to bypass circular imports for mypy. It should be noted though that the input type for `compat.get_connection_response()` is `six.moves.http_client.HTTPConnection`, which is currently not able to be properly type hinted via mypy due to the `six` library being vendored in the tracing library.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
