### PR TITLE
Add span on finish callbacks

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -2,6 +2,7 @@ import math
 import sys
 import traceback
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -62,6 +63,7 @@ class Span(object):
         "_context",
         "_parent",
         "_ignored_exceptions",
+        "_on_finish_callbacks",
         "__weakref__",
     ]
 
@@ -77,6 +79,7 @@ class Span(object):
         parent_id=None,  # type: Optional[int]
         start=None,  # type: Optional[int]
         context=None,  # type: Optional[Context]
+        on_finish=None,  # type: List[Callable[[Span], None]]
         _check_pid=True,  # type: bool
     ):
         # type: (...) -> None
@@ -97,6 +100,7 @@ class Span(object):
 
         :param int start: the start time of request as a unix epoch in seconds
         :param object context: the Context of the span.
+        :param on_finish: list of functions called when the span finishes.
         """
         # required span info
         self.name = name
@@ -119,6 +123,7 @@ class Span(object):
         self.span_id = span_id or _rand.rand64bits(check_pid=_check_pid)  # type: int
         self.parent_id = parent_id  # type: Optional[int]
         self.tracer = tracer
+        self._on_finish_callbacks = [] if on_finish is None else on_finish
 
         # sampling
         self.sampled = True  # type: bool
@@ -205,6 +210,9 @@ class Span(object):
             trace, sampled = self._context.close_span(self)
             if self.tracer and trace and sampled:
                 self.tracer.write(trace)
+
+        for cb in self._on_finish_callbacks:
+            cb(self)
 
     def set_tag(self, key, value=None):
         # type: (str, Any) -> None

--- a/releasenotes/notes/span-22c2917b9580c0e6.yaml
+++ b/releasenotes/notes/span-22c2917b9580c0e6.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    ``Span`` now accepts a ``on_finish`` argument used for specifying
+    functions to call when a span finishes.

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -544,3 +544,20 @@ def test_span_ignored_exception_subclass():
     assert s.get_tag(errors.ERROR_MSG) is None
     assert s.get_tag(errors.ERROR_TYPE) is None
     assert s.get_tag(errors.ERROR_STACK) is None
+
+
+def test_on_finish_single_callback():
+    m = mock.Mock()
+    s = Span(None, "test", on_finish=[m])
+    m.assert_not_called()
+    s.finish()
+    m.assert_called_once_with(s)
+
+
+def test_on_finish_multi_callback():
+    m1 = mock.Mock()
+    m2 = mock.Mock()
+    s = Span(None, "test", on_finish=[m1, m2])
+    s.finish()
+    m1.assert_called_once_with(s)
+    m2.assert_called_once_with(s)


### PR DESCRIPTION
## Description
<!-- Please briefly describe the change and why it was required. -->
With these callbacks we could eventually remove the need to specify a
tracer or context instance to ``Span``.


## Checklist
- [x] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Library documentation is updated.
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
