### PR TITLE
Add agent url to writer logs

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -281,7 +281,7 @@ class AgentWriter(_worker.PeriodicWorkerThread, TraceWriter):
                     log_level = logging.WARNING
                 else:
                     log_level = logging.DEBUG
-                log.log(log_level, "sent %s in %.5fs", _human_size(len(data)), t)
+                log.log(log_level, "sent %s in %.5fs to %s", _human_size(len(data)), t, self.agent_url)
                 return Response.from_http_response(resp)
             finally:
                 conn.close()
@@ -311,9 +311,10 @@ class AgentWriter(_worker.PeriodicWorkerThread, TraceWriter):
                 payload = self._downgrade(payload, response)
             except ValueError:
                 log.error(
-                    "unsupported endpoint '%s': received response %s from Datadog Agent",
+                    "unsupported endpoint '%s': received response %s from Datadog Agent (%s)",
                     self._endpoint,
                     response.status,
+                    self.agent_url,
                 )
             else:
                 return self._send_payload(payload, count)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -318,7 +318,14 @@ def test_bad_endpoint():
         s.set_tag("env", "my-env")
         s.finish()
         t.shutdown()
-    calls = [mock.call("unsupported endpoint '%s': received response %s from Datadog Agent", "/bad", 404)]
+    calls = [
+        mock.call(
+            "unsupported endpoint '%s': received response %s from Datadog Agent (%s)",
+            "/bad",
+            404,
+            t.writer.agent_url,
+        )
+    ]
     log.error.assert_has_calls(calls)
 
 
@@ -512,5 +519,13 @@ def test_flush_log(caplog):
     with mock.patch("ddtrace.internal.writer.log") as log:
         writer.write([])
         writer.flush_queue(raise_exc=True)
-        calls = [mock.call(logging.DEBUG, "sent %s in %.5fs", AnyStr(), AnyFloat())]
+        calls = [
+            mock.call(
+                logging.DEBUG,
+                "sent %s in %.5fs to %s",
+                AnyStr(),
+                AnyFloat(),
+                writer.agent_url,
+            )
+        ]
         log.log.assert_has_calls(calls)


### PR DESCRIPTION
When reading the debug logs it wasn't clear where the traces were being sent to.

## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] ~Library documentation is updated.~
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
