### PR TITLE
refactor(nogevent): make sure is_module_patched is called at runtime

### DIFF
--- a/ddtrace/profiling/collector/_threading.pyx
+++ b/ddtrace/profiling/collector/_threading.pyx
@@ -12,7 +12,7 @@ cpdef get_thread_name(thread_id):
     # Therefore we special case the MainThread that way.
     # If native threads are started using gevent.threading, they will be inserted in threading._active
     # so we will find them normally.
-    if thread_id == nogevent.main_thread_id:
+    if thread_id == nogevent.main_thread_id():
         return "MainThread"
 
     # We don't want to bother to lock anything here, especially with eventlet involved 😓. We make a best effort to

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -235,7 +235,7 @@ cdef get_task(thread_id):
     """Return the task id and name for a thread."""
     # gevent greenlet support:
     # we only support tracing tasks in the greenlets are run in the MainThread.
-    if thread_id == nogevent.main_thread_id and _gevent_tracer is not None:
+    if thread_id == nogevent.main_thread_id() and _gevent_tracer is not None:
         if _gevent_tracer.active_greenlet is None:
             # That means gevent never switch to another greenlet, we're still in the main one
             task_id = compat.main_thread.ident

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -80,7 +80,7 @@ def test_iter_events():
         last_call = stack[0]
         assert size >= 1  # size depends on the object size
         if last_call[2] == "<listcomp>" and last_call[1] == _ALLOC_LINE_NUMBER:
-            assert thread_id == nogevent.main_thread_id
+            assert thread_id == nogevent.main_thread_id()
             assert last_call[0] == __file__
             assert stack[1][0] == __file__
             assert stack[1][1] == _ALLOC_LINE_NUMBER
@@ -130,7 +130,7 @@ def test_iter_events_multi_thread():
         assert size >= 1  # size depends on the object size
         if last_call[2] == "<listcomp>" and last_call[1] == _ALLOC_LINE_NUMBER:
             assert last_call[0] == __file__
-            if thread_id == nogevent.main_thread_id:
+            if thread_id == nogevent.main_thread_id():
                 count_object += 1
                 assert stack[1][0] == __file__
                 assert stack[1][1] == _ALLOC_LINE_NUMBER
@@ -161,7 +161,7 @@ def test_memory_collector():
         last_call = event.frames[0]
         assert event.size > 0
         if last_call[2] == "<listcomp>" and last_call[1] == _ALLOC_LINE_NUMBER:
-            assert event.thread_id == nogevent.main_thread_id
+            assert event.thread_id == nogevent.main_thread_id()
             assert event.thread_name == "MainThread"
             count_object += 1
             assert event.frames[2][0] == __file__
@@ -206,7 +206,7 @@ def test_heap():
     for (stack, nframe, thread_id), size in _memalloc.heap():
         assert 0 < len(stack) <= max_nframe
         assert size > 0
-        if thread_id == nogevent.main_thread_id:
+        if thread_id == nogevent.main_thread_id():
             thread_found = True
         assert isinstance(thread_id, int)
         if (


### PR DESCRIPTION
It's possible somebody would load the nogevent module before monkey patching
gevent. That currently breaks some assumption by this module and break the code
relying on it.

This fixes the current code by making sure the patch check is done at runtime,
not at load time.