### PR TITLE
Handle configure when using LogWriter

### DIFF
--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -915,6 +915,8 @@ class EnvTracerTestCase(TracerTestCase):
     def test_detect_agentless_env(self):
         tracer = Tracer()
         assert isinstance(tracer.writer, LogWriter)
+        tracer.configure(enabled=True)
+        assert isinstance(tracer.writer, LogWriter)
 
     @run_in_subprocess(env_overrides=dict(AWS_LAMBDA_FUNCTION_NAME="my-func", DD_AGENT_HOST="localhost"))
     def test_detect_agent_config(self):


### PR DESCRIPTION
## Description
<!-- Please briefly describe the change and why it was required. -->
Re-`configure`-ing the tracer when using the `LogWriter` would result in an `AgentWriter` being instantiated.


## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] ~Library documentation is updated.~
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
