### PR TITLE
Disable known failing Django tests

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set Pythonpath
         run: echo "PYTHONPATH=." >> $GITHUB_ENV
       - name: Disable unsupported tests
-        run: >
+        run: |
           # Note: test_supports_json_field_operational_error will fail with the tracer
           # DEV: Insert @skipUnless before the test definition
           # DEV: We need to escape the space indenting

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -33,9 +33,14 @@ jobs:
         run: pip install ../django
       - name: Set Pythonpath
         run: echo "PYTHONPATH=." >> $GITHUB_ENV
+      - name: Disable unsupported tests
+        run: >
+          # Note: test_supports_json_field_operational_error will fail with the tracer
+          # DEV: Insert @skipUnless before the test definition
+          # DEV: We need to escape the space indenting
+          sed -i'' '/def test_supports_json_field_operational_error/i \ \ \ \ @skipUnless(False, "test not supported by dd-trace-py")' tests/backends/sqlite/test_features.py
       - name: Run tests
         # django.tests.requests module interferes with requests library patching in the tracer -> disable requests patch
-        # Note: test_supports_json_field_operational_error will fail with the tracer
         run: DD_TRACE_REQUESTS_ENABLED=0 ddtrace-run tests/runtests.py
 
 


### PR DESCRIPTION
## Description
Django's test runner doesn't offer a way to skip a specific test case. We can exclude tags, but there isn't a way to use that to disable only that one known test case.

This isn't a lovely approach, but it works. Using `sed` to add a `@skipUnless(False, "")` before the test case (We are using `skipUnless` because it is already imported in the test file).


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
