### PR TITLE
fix(span): ensure ID args have the correct type

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -102,6 +102,14 @@ class Span(object):
         :param object context: the Context of the span.
         :param on_finish: list of functions called when the span finishes.
         """
+        # pre-conditions
+        if not (span_id is None or isinstance(span_id, six.integer_types)):
+            raise TypeError("span_id must be an integer")
+        if not (trace_id is None or isinstance(trace_id, six.integer_types)):
+            raise TypeError("trace_id must be an integer")
+        if not (parent_id is None or isinstance(parent_id, six.integer_types)):
+            raise TypeError("parent_id must be an integer")
+
         # required span info
         self.name = name
         self.service = service

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -561,3 +561,10 @@ def test_on_finish_multi_callback():
     s.finish()
     m1.assert_called_once_with(s)
     m2.assert_called_once_with(s)
+
+
+@pytest.mark.parametrize("arg", ["span_id", "trace_id", "parent_id"])
+def test_span_preconditions(arg):
+    Span(None, "test", **{arg: None})
+    with pytest.raises(TypeError):
+        Span(None, "test", **{arg: "foo"})


### PR DESCRIPTION
## Description

Among all the arguments of the Span constructor, the ones bearing IDs are the most important type-wise. This change adds checks to ensure that `span_id`, `trace_id` and `parent_id` all have the expected type.

The rationale for adding the check at construction time is so that this error could be caught as soon as possible, rather than defer it to later processing stages, thus avoiding invalid entries in the processing queue.

## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
