### PR TITLE
refactor: add metrics to Span pprint method

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -7,6 +7,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import TYPE_CHECKING
+from typing import Tuple
 from typing import Union
 
 from .compat import StringIO
@@ -453,6 +454,13 @@ class Span(object):
     def pprint(self):
         # type: () -> str
         """ Return a human readable version of the span. """
+
+        def _dict_section(name, data):
+            # type: (str, Dict[str, Any]) -> List[Tuple[str, str]]
+            content = [(" ", "%s:%s" % _) for _ in sorted(data.items())]
+            content.insert(0, (name, ""))
+            return content
+
         lines = [
             ("name", self.name),
             ("id", self.span_id),
@@ -465,10 +473,11 @@ class Span(object):
             ("end", "" if not self.duration else self.start + self.duration),
             ("duration", "%fs" % (self.duration or 0)),
             ("error", self.error),
-            ("tags", ""),
         ]
 
-        lines.extend((" ", "%s:%s" % kv) for kv in sorted(self.meta.items()))
+        lines.extend(_dict_section("tags", self.meta))
+        lines.extend(_dict_section("metrics", self.metrics))
+
         return "\n".join("%10s %s" % line for line in lines)
 
     @property

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -561,3 +561,16 @@ def test_on_finish_multi_callback():
     s.finish()
     m1.assert_called_once_with(s)
     m2.assert_called_once_with(s)
+
+
+def test_span_pprint():
+    s = Span(None, "test")
+    s.set_tag("foo", "bar")
+    s.set_metric("asd", 42)
+    sp = s.pprint()
+
+    # TODO: These checks are weak
+    assert "metrics" in sp
+    assert "asd:42" in sp
+    assert "tags" in sp
+    assert "foo:bar" in sp


### PR DESCRIPTION
## Description

Span metrics will now appear in debug logs as a consequence of them being included in the output generated by `Span.pprint`

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
