### PR TITLE
refactor(service): add ForksafeService class

### DIFF
--- a/ddtrace/internal/service.py
+++ b/ddtrace/internal/service.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 import abc
 import enum
 import threading
@@ -5,6 +6,15 @@ import typing
 
 import attr
 import six
+
+from ddtrace.internal import atexit
+from ddtrace.internal import forksafe
+from ddtrace.internal import uwsgi
+
+from .logger import get_logger
+
+
+log = get_logger(__name__)
 
 
 class ServiceStatus(enum.Enum):
@@ -32,9 +42,10 @@ class Service(six.with_metaclass(abc.ABCMeta)):
     """A service that can be started or stopped."""
 
     status = attr.ib(default=ServiceStatus.STOPPED, type=ServiceStatus, init=False, eq=False)
-    _service_lock = attr.ib(factory=threading.Lock, repr=False, init=False, eq=False)
+    _service_lock = attr.ib(factory=threading.Lock, repr=False, init=False, eq=False, type=threading.Lock)
 
     def __enter__(self):
+        # type: (...) -> Service
         self.start()
         return self
 
@@ -103,3 +114,85 @@ class Service(six.with_metaclass(abc.ABCMeta)):
     ):
         # type: (...) -> None
         """Join the service once stopped."""
+
+    def copy(self):
+        # type: (...) -> Service
+        return attr.evolve(self)
+
+
+class ForksafeService(object):
+    """A manager that can handle the lifecycle of a Service in a process.
+
+    This allows to handle a service that should keep running when, e.g., the Python process forks.
+
+    This class is not thread-safe.
+    """
+
+    SERVICE_CLASS = None  # type: typing.ClassVar[typing.Type[Service]]
+
+    def __init__(
+        self,
+        *args,  # type: typing.Any
+        **kwargs  # type: typing.Any
+    ):
+        # type: (...) -> None
+        super(ForksafeService, self).__init__()
+        self._service = self.SERVICE_CLASS(*args, **kwargs)  # type: ignore[call-arg]
+
+    def start(self, *args, **kwargs):
+        # type: (...) -> None
+        """Start the service."""
+        log.debug("Starting service %r", self._service)
+        stop_on_exit = kwargs.pop("stop_on_exit", True)
+        self.start_in_children = kwargs.pop("start_in_children", True)
+        try:
+            uwsgi.check_uwsgi(self._start_in_child, atexit=self.stop if stop_on_exit else None)
+        except uwsgi.uWSGIMasterProcess:
+            # Do nothing in the uWSGI master process, the start() method will be called in each worker subprocess if
+            # asked for it via `start_in_children`.
+            return
+
+        self._service.start(*args, **kwargs)
+
+        if stop_on_exit:
+            atexit.register(self.stop)
+
+        forksafe.register(self._restart_on_fork)
+
+    def stop(self):
+        # type: (...) -> None
+        """Stop the service."""
+        log.debug("Stopping service %r", self._service)
+        atexit.unregister(self.stop)
+
+        try:
+            forksafe.unregister(self._restart_on_fork)
+        except ValueError:
+            pass
+
+        self._service.stop()
+
+    def __getattr__(
+        self,
+        k,  # type: typing.Any
+    ):
+        # type: (...) -> typing.Any
+        return getattr(self._service, k)
+
+    def _start_in_child(self):
+        # type: (...) -> None
+        if self.start_in_children:
+            log.debug("Starting %r in child process", self._service)
+            self._service = self._service.copy()
+            self.start()
+
+    def _restart_on_fork(self):
+        # type: (...) -> None
+        # Be sure to stop the parent first:
+        # Parent might have to "undo" some work before the child can start.
+        atexit.unregister(self.stop)
+        try:
+            self._service.stop()
+        except ServiceStatusError:
+            log.error("Unable to stop service %r", self._service, exc_info=True)
+        self._start_in_child()

--- a/tests/tracer/test_service.py
+++ b/tests/tracer/test_service.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import pytest
 
 from ddtrace.internal import service
@@ -62,3 +65,327 @@ def test_service_status_on_fail_stop():
     with pytest.raises(RuntimeError):
         s.stop()
     assert s.status == service.ServiceStatus.RUNNING
+
+
+def test_service_copy():
+    s = MyService()
+    # Comparison is done by identity because attr.s(eq=False)
+    assert s.copy() != s.copy()
+    assert s.copy() is not s.copy()
+    s.start()
+    s2 = s.copy()
+    assert s is not s2
+    assert s != s2
+    assert s.status == service.ServiceStatus.RUNNING
+    assert s2.status == service.ServiceStatus.STOPPED
+    s.stop()
+    assert s is not s2
+    assert s != s2
+    assert s.status == service.ServiceStatus.STOPPED
+    assert s2.status == service.ServiceStatus.STOPPED
+
+
+def test_forksafe_service():
+    class MyForksafeService(service.ForksafeService):
+        SERVICE_CLASS = MyService
+
+    sm = MyForksafeService()
+    sm.start()
+    assert sm.status == sm._service.status == service.ServiceStatus.RUNNING
+    with pytest.raises(RuntimeError):
+        sm.start()
+
+    sm.stop()
+    assert sm.status == sm._service.status == service.ServiceStatus.STOPPED
+    with pytest.raises(RuntimeError):
+        sm.stop()
+
+
+def call_program(*args):
+    subp = subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True,
+    )
+    stdout, stderr = subp.communicate()
+    return stdout, stderr, subp.wait(), subp.pid
+
+
+def test_forksafe_service_pass_args(tmpdir):
+    pyfile = tmpdir.join("test.py")
+    pyfile.write(
+        """
+from ddtrace.internal import service
+
+class MyService(service.Service):
+    def _start_service(self, foobar):
+        assert foobar == 42
+        print("Started")
+
+    def _stop_service(self):
+        print("I was stopped, thank you")
+
+class MyForksafeService(service.ForksafeService):
+    SERVICE_CLASS = MyService
+
+sm = MyForksafeService()
+sm.start(foobar=42)
+assert sm.status == service.ServiceStatus.RUNNING
+"""
+    )
+    out, err, status, pid = call_program(sys.executable, str(pyfile))
+    assert status == 0
+    assert out == b"Started\nI was stopped, thank you\n"
+    assert err == b""
+
+
+def test_forksafe_service_stop_on_exit(tmpdir):
+    pyfile = tmpdir.join("test.py")
+    pyfile.write(
+        """
+from ddtrace.internal import service
+
+class MyService(service.Service):
+    def _start_service(self):
+        pass
+
+    def _stop_service(self):
+        print("I was stopped, thank you")
+
+class MyForksafeService(service.ForksafeService):
+    SERVICE_CLASS = MyService
+
+sm = MyForksafeService()
+sm.start()
+"""
+    )
+    out, err, status, pid = call_program(sys.executable, str(pyfile))
+    assert status == 0
+    assert out == b"I was stopped, thank you\n"
+    assert err == b""
+
+
+def test_forksafe_service_stop_on_exit_false(tmpdir):
+    pyfile = tmpdir.join("test.py")
+    pyfile.write(
+        """
+from ddtrace.internal import service
+
+class MyService(service.Service):
+    def _start_service(self):
+        pass
+
+    def _stop_service(self):
+        print("I was stopped, thank you")
+
+class MyForksafeService(service.ForksafeService):
+    SERVICE_CLASS = MyService
+
+sm = MyForksafeService()
+sm.start(stop_on_exit=False)
+"""
+    )
+    out, err, status, pid = call_program(sys.executable, str(pyfile))
+    assert status == 0
+    assert out == b""
+    assert err == b""
+
+
+def test_forksafe_service_start_in_children_false(tmpdir):
+    pyfile = tmpdir.join("test.py")
+    pyfile.write(
+        """
+import os
+import sys
+
+from ddtrace.internal import service
+
+class MyService(service.Service):
+    def _start_service(self):
+        pass
+
+    def _stop_service(self):
+        print("I was stopped, thank you")
+
+class MyForksafeService(service.ForksafeService):
+    SERVICE_CLASS = MyService
+
+sm = MyForksafeService()
+sm.start(start_in_children=False)
+
+parent_service_instance = sm._service
+
+child_pid = os.fork()
+if child_pid == 0:
+    assert parent_service_instance.status == service.ServiceStatus.STOPPED
+    assert sm._service == parent_service_instance
+    assert sm._service is parent_service_instance
+    assert sm.status == service.ServiceStatus.STOPPED
+else:
+    assert sm._service is parent_service_instance
+    assert sm.status == service.ServiceStatus.RUNNING
+    pid, status = os.waitpid(child_pid, 0)
+    sys.exit(os.WEXITSTATUS(status))
+"""
+    )
+    out, err, status, pid = call_program(sys.executable, str(pyfile))
+    assert status == 0
+    # Stopped 2 times:
+    # parent stopped in child (at exit())
+    # parent stopped in parent (at exit())
+    assert out == b"I was stopped, thank you\nI was stopped, thank you\n"
+    assert err == b""
+
+
+def test_forksafe_service_start_in_children_but_stopped(tmpdir):
+    pyfile = tmpdir.join("test.py")
+    pyfile.write(
+        """
+import os
+import sys
+
+from ddtrace.internal import service
+
+class MyService(service.Service):
+    def _start_service(self):
+        pass
+
+    def _stop_service(self):
+        print("I was stopped, thank you")
+
+class MyForksafeService(service.ForksafeService):
+    SERVICE_CLASS = MyService
+
+sm = MyForksafeService()
+sm.start(start_in_children=True)
+
+sm.stop()
+
+parent_service_instance = sm._service
+
+child_pid = os.fork()
+if child_pid == 0:
+    assert parent_service_instance.status == service.ServiceStatus.STOPPED
+    assert sm._service == parent_service_instance
+    assert sm._service is parent_service_instance
+    assert sm.status == service.ServiceStatus.STOPPED
+else:
+    assert sm._service is parent_service_instance
+    assert sm.status == service.ServiceStatus.STOPPED
+    pid, status = os.waitpid(child_pid, 0)
+    sys.exit(os.WEXITSTATUS(status))
+"""
+    )
+    out, err, status, pid = call_program(sys.executable, str(pyfile))
+    assert status == 0, (out, err)
+    # Stopped 2 times:
+    # parent stopped in child (at exit())
+    # parent stopped in parent (at exit())
+    assert out == b"I was stopped, thank you\nI was stopped, thank you\n"
+    assert err == b""
+
+
+def test_forksafe_service_start_in_children(tmpdir):
+    pyfile = tmpdir.join("test.py")
+    pyfile.write(
+        """
+import os
+import sys
+
+from ddtrace.internal import service
+
+class MyService(service.Service):
+    def _start_service(self):
+        pass
+
+    def _stop_service(self):
+        print("I was stopped, thank you")
+
+class MyForksafeService(service.ForksafeService):
+    SERVICE_CLASS = MyService
+
+sm = MyForksafeService()
+sm.start()
+
+parent_service_instance = sm._service
+
+child_pid = os.fork()
+if child_pid == 0:
+    assert parent_service_instance.status == service.ServiceStatus.STOPPED
+    assert sm._service is not parent_service_instance
+    assert sm.status == service.ServiceStatus.RUNNING
+else:
+    assert sm._service is parent_service_instance
+    assert sm.status == service.ServiceStatus.RUNNING
+    pid, status = os.waitpid(child_pid, 0)
+    sys.exit(os.WEXITSTATUS(status))
+"""
+    )
+    out, err, status, pid = call_program(sys.executable, str(pyfile))
+    assert status == 0
+    # Stopped 3 times:
+    # parent stopped in the child (at fork())
+    # child stopped in child (at exit())
+    # parent stopped in parent (at exit())
+    assert out == b"I was stopped, thank you\nI was stopped, thank you\nI was stopped, thank you\n"
+    assert err == b""
+
+
+def test_forksafe_service_start_in_children_unique_attr(tmpdir):
+    pyfile = tmpdir.join("test.py")
+    pyfile.write(
+        """
+import os
+import sys
+import uuid
+
+import attr
+
+from ddtrace.internal import service
+
+@attr.s
+class MyService(service.Service):
+    unique = attr.ib(factory=uuid.uuid4)
+
+    def copy(self):
+        c = super(MyService, self).copy()
+        c.unique = uuid.uuid4()
+        return c
+
+    def _start_service(self):
+        pass
+
+    def _stop_service(self):
+        print("I was stopped, thank you")
+
+class MyForksafeService(service.ForksafeService):
+    SERVICE_CLASS = MyService
+
+sm = MyForksafeService()
+sm.start()
+
+parent_service_instance = sm._service
+
+child_pid = os.fork()
+if child_pid == 0:
+    assert parent_service_instance.status == service.ServiceStatus.STOPPED
+    assert parent_service_instance.unique != sm._service.unique
+    assert sm._service != parent_service_instance
+    assert sm._service is not parent_service_instance
+    assert sm.status == service.ServiceStatus.RUNNING
+else:
+    assert sm._service is parent_service_instance
+    assert sm.status == service.ServiceStatus.RUNNING
+    pid, status = os.waitpid(child_pid, 0)
+    sys.exit(os.WEXITSTATUS(status))
+"""
+    )
+    out, err, status, pid = call_program(sys.executable, str(pyfile))
+    assert status == 0
+    # Stopped 3 times:
+    # parent stopped in the child (at fork())
+    # child stopped in child (at exit())
+    # parent stopped in parent (at exit())
+    assert out == b"I was stopped, thank you\nI was stopped, thank you\nI was stopped, thank you\n"
+    assert err == b""


### PR DESCRIPTION
This adds a new class `ForksafeService` which is able to handle the lifecycle of
Service with respect to its processes (fork, exit, etc).