### PR TITLE
Use multiproject pipeline to deploy to reliability env

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,27 +1,18 @@
 stages:
   - deploy
 
-variables:
-  INDEX_FILE: index.txt
-
 .common: &common
   tags: [ "runner:main", "size:large" ]
 
-copy_to_s3:
-  <<: *common
+deploy_to_reliability_env:
   stage: deploy
-  image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
-  rules:
-    - if: '$CI_COMMIT_BRANCH == "master"'
-      when: on_success
-    - if: '$CI_COMMIT_BRANCH == "staging"'
-      when: on_success
-  script:
-    - export ACCESS_KEY_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-py.secret_key_id --with-decryption --query "Parameter.Value" --out text)
-    - export SECRET_ACCESS_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-py.secret_sec_key_id --with-decryption --query "Parameter.Value" --out text)
-    - export AWS_ACCESS_KEY_ID=$ACCESS_KEY_ID
-    - export AWS_SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY
-    - echo $CI_COMMIT_REF_NAME >> $INDEX_FILE
-    - echo $CI_COMMIT_SHA >> $INDEX_FILE
-    - echo $GITLAB_USER_NAME >> $INDEX_FILE
-    - aws s3 cp $INDEX_FILE s3://datadog-reliability-env/python/$INDEX_FILE
+  when: on_success
+  trigger:
+    project: DataDog/datadog-reliability-env
+    branch: landerson/python-downstream
+  variables:
+    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
+    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
+    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
+    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
+    FORCE_TRIGGER: $FORCE_TRIGGER

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,6 @@ deploy_to_reliability_env:
   when: on_success
   trigger:
     project: DataDog/datadog-reliability-env
-    branch: landerson/python-downstream
   variables:
     UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID


### PR DESCRIPTION
## Description
Instead of S3, this PR makes use of a multiproject pipeline to deploy to the reliability env. This should provide faster and more stable deploys.

Manually tested through gitlab

## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
