### PR TITLE
Refactor unnecessary NoneType check in parse_dogstatsd_url

### DIFF
--- a/ddtrace/internal/dogstatsd.py
+++ b/ddtrace/internal/dogstatsd.py
@@ -6,10 +6,7 @@ from ddtrace.vendor.dogstatsd import DogStatsd
 
 
 def parse_dogstatsd_url(url):
-    # type: (Optional[str]) -> Optional[Dict[str, str]]
-    if url is None:
-        return
-
+    # type: (str) -> Dict[str, str]
     # url can be either of the form `udp://<host>:<port>` or `unix://<path>`
     # also support without url scheme included
     if url.startswith("/"):


### PR DESCRIPTION
## Description
In order to make adding mypy type checking/hinting easier for `dogstatsd.py`, this unnecessary NoneType check can be removed in `parse_dogstatsd_url` since the `url` is already processed through a Nonetype/empty string check in `get_dogstatsd_client`, which is the only function calling `parse_dogstatsd_url`.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
