### PR TITLE
refactor(utils): remove merge_dicts

### DIFF
--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -6,7 +6,6 @@ import ddtrace
 from ddtrace import Tracer as DatadogTracer
 from ddtrace.constants import FILTERS_KEY
 from ddtrace.settings import ConfigException
-from ddtrace.utils import merge_dicts
 from ddtrace.utils.config import get_application_name
 
 from ..internal.logger import get_logger
@@ -58,9 +57,9 @@ class Tracer(opentracing.Tracer):
             to the global ``ddtrace.tracer`` tracer.
         """
         # Merge the given config with the default into a new dict
-        config = config or {}
-        self._config = merge_dicts(DEFAULT_CONFIG, config)
-
+        self._config = DEFAULT_CONFIG.copy()
+        if config is not None:
+            self._config.update(config)
         # Pull out commonly used properties for performance
         self._service_name = service_name or get_application_name()
         self._enabled = self._config.get(keys.ENABLED)

--- a/ddtrace/utils/__init__.py
+++ b/ddtrace/utils/__init__.py
@@ -6,14 +6,6 @@ from typing import Optional
 from ..vendor import debtcollector
 
 
-# https://stackoverflow.com/a/26853961
-def merge_dicts(x, y):
-    """Returns a copy of y merged into x."""
-    z = x.copy()  # start with x's keys and values
-    z.update(y)  # modifies z with y's keys and values & returns None
-    return z
-
-
 # Based on: https://stackoverflow.com/a/7864317
 class removed_classproperty(property):
     def __get__(self, cls, owner):

--- a/releasenotes/notes/utils-remove-merge-dicts-9252805c864677f8.yaml
+++ b/releasenotes/notes/utils-remove-merge-dicts-9252805c864677f8.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    The function ``ddtrace.utils.merge_dicts`` has been removed.


### PR DESCRIPTION
This is only used once and is really not needed.