### PR TITLE
ci(pylons,dogpile): limit to decorator<5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -207,6 +207,8 @@ deps =
     consul07: python-consul>=0.7,<1.0
     consul10: python-consul>=1.0,<1.1
     consul11: python-consul>=1.1,<1.2
+# decorator 5 dropped support for Python 2
+    dogpile_contrib-py27: decorator<5
     dogpilecache: dogpile.cache
     dogpilecache06: dogpile.cache==0.6.*
     dogpilecache07: dogpile.cache==0.7.*
@@ -262,6 +264,8 @@ deps =
     pylibmc160: pylibmc>=1.6,<1.7
 # webob is required for Pylons < 1.0
     pylons: pylons
+# decorator 5 dropped support for Python 2
+    pylons_contrib: decorator<5
     pylons096: pylons>=0.9.6,<0.9.7
     pylons096: webob<1.1
     pylons097: pylons>=0.9.7,<0.9.8


### PR DESCRIPTION
Version 5 dropped support for Python 2.