### PR TITLE
Fix debug usage of TraceWriters

### DIFF
--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -34,19 +34,11 @@ def tags_to_str(tags):
 def collect(tracer):
     """Collect system and library information into a serializable dict."""
 
-    # The tracer doesn't actually maintain a hostname/port, instead it stores
-    # it on the possibly None writer which actually stores it on an API object.
-    # Note that the tracer DOES have hostname and port attributes that it
-    # sets to the defaults and ignores afterwards.
-    if tracer.writer and isinstance(tracer.writer, LogWriter):
+    if isinstance(tracer.writer, LogWriter):
         agent_url = "AGENTLESS"
         agent_error = None
-    else:
-        if isinstance(tracer.writer, AgentWriter):
-            writer = tracer.writer
-        else:
-            writer = AgentWriter()
-
+    elif isinstance(tracer.writer, AgentWriter):
+        writer = tracer.writer
         agent_url = writer.agent_url
         try:
             writer.write([])
@@ -55,6 +47,9 @@ def collect(tracer):
             agent_error = "Agent not reachable at %s. Exception raised: %s" % (agent_url, str(e))
         else:
             agent_error = None
+    else:
+        agent_url = "CUSTOM"
+        agent_error = None
 
     is_venv = in_venv()
 

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -5,12 +5,16 @@ import os
 import re
 import subprocess
 import sys
+from typing import List
+from typing import Optional
 
 import mock
 import pytest
 
 import ddtrace
+from ddtrace import Span
 from ddtrace.internal import debug
+from ddtrace.internal.writer import TraceWriter
 import ddtrace.sampler
 from tests.subprocesstest import SubprocessTestCase
 from tests.subprocesstest import run_in_subprocess
@@ -269,6 +273,28 @@ def test_agentless(monkeypatch):
     info = debug.collect(tracer)
 
     assert info.get("agent_url", "AGENTLESS")
+
+
+def test_custom_writer():
+    tracer = ddtrace.Tracer()
+
+    class CustomWriter(TraceWriter):
+        def recreate(self):
+            # type: () -> TraceWriter
+            return self
+
+        def stop(self, timeout=None):
+            # type: (Optional[float]) -> None
+            pass
+
+        def write(self, spans=None):
+            # type: (Optional[List[Span]]) -> None
+            pass
+
+    tracer.writer = CustomWriter()
+    info = debug.collect(tracer)
+
+    assert info.get("agent_url", "CUSTOM")
 
 
 def test_different_samplers():

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -272,7 +272,7 @@ def test_agentless(monkeypatch):
     tracer = ddtrace.Tracer()
     info = debug.collect(tracer)
 
-    assert info.get("agent_url", "AGENTLESS")
+    assert info.get("agent_url") == "AGENTLESS"
 
 
 def test_custom_writer():
@@ -294,7 +294,7 @@ def test_custom_writer():
     tracer.writer = CustomWriter()
     info = debug.collect(tracer)
 
-    assert info.get("agent_url", "CUSTOM")
+    assert info.get("agent_url") == "CUSTOM"
 
 
 def test_different_samplers():


### PR DESCRIPTION
Handle the following:
- tracer.writer can no longer be None
- custom trace writers
- the existing usage of AgentWriter was incorrect