### PR TITLE
Fix requests service naming

### DIFF
--- a/ddtrace/contrib/requests/__init__.py
+++ b/ddtrace/contrib/requests/__init__.py
@@ -1,35 +1,75 @@
 """
-The ``requests`` integration traces all HTTP calls to internal or external services.
-Auto instrumentation is available using the ``patch`` function that **must be called
-before** importing the ``requests`` library. The following is an example::
+The ``requests`` integration traces all HTTP requests made with the ``requests``
+library.
+
+The default service name used is `requests` but it can be configured to match
+the services that the specific requests are made to.
+
+Enabling
+~~~~~~~~
+
+The requests integration is enabled automatically when using
+:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+
+Or use :ref:`patch()<patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(requests=True)
 
-    import requests
-    requests.get("https://www.datadoghq.com")
+    # use requests like usual
 
-If you would prefer finer grained control, use a ``TracedSession`` object as you would a
-``requests.Session``::
 
-    from ddtrace.contrib.requests import TracedSession
+Global Configuration
+~~~~~~~~~~~~~~~~~~~~
 
-    session = TracedSession()
-    session.get("https://www.datadoghq.com")
+.. py:data:: ddtrace.config.requests['service']
 
-The library can be configured globally and per instance, using the Configuration API::
+   The service name reported by default for requests queries. This value will
+   be overridden by an instance override or if the split_by_domain setting is
+   enabled.
+
+   This option can also be set with the ``DD_REQUESTS_SERVICE`` environment
+   variable.
+
+   Default: ``"requests"``
+
+
+.. py:data:: ddtrace.config.requests['distributed_tracing']
+
+   Whether or not to parse distributed tracing headers.
+
+   Default: ``True``
+
+
+.. py:data:: ddtrace.config.requests['trace_query_string']
+
+   Whether or not to include the query string as a tag.
+
+   Default: ``False``
+
+
+.. py:data:: ddtrace.config.requests['split_by_domain']
+
+   Whether or not to use the domain name of requests as the service name. This
+   setting can be overridden with session overrides (described in the Instance
+   Configuration section).
+
+   Default: ``False``
+
+
+Instance Configuration
+~~~~~~~~~~~~~~~~~~~~~~
+
+To set configuration options for all requests made with a ``requests.Session`` object
+use the config API::
 
     from ddtrace import config
+    from requests import Session
 
-    # disable distributed tracing globally
-    config.requests['distributed_tracing'] = False
-
-    # change the service name/distributed tracing only for this session
     session = Session()
     cfg = config.get_from(session)
     cfg['service_name'] = 'auth-api'
-
-:ref:`Headers tracing <http-headers-tracing>` is supported for this integration.
+    cfg['distributed_tracing'] = False
 """
 from ...utils.importlib import require_modules
 

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -18,6 +18,7 @@ config._add(
     {
         "distributed_tracing": asbool(get_env("requests", "distributed_tracing", default=True)),
         "split_by_domain": asbool(get_env("requests", "split_by_domain", default=False)),
+        "_default_service": "requests",
     },
 )
 

--- a/releasenotes/notes/requests-b06e324e36e03ae5.yaml
+++ b/releasenotes/notes/requests-b06e324e36e03ae5.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    requests: add global config support. This enables the requests service name to be
+    configured with ``ddtrace.config.requests['service']`` or the ``DD_REQUESTS_SERVICE``
+    environment variable.
+upgrade:
+  - |
+    requests: spans will no longer inherit the service name from the parent.


### PR DESCRIPTION
## Description
The service naming for the requests integration used the wrong type of
service configuration. requests spans should not inherit from parent
spans as requests are made to external services.

In addition to the above fix support is added to the integration for the
global configuration using the config API or environment variables.

The docs are also rewritten to be consistent with our newer
integrations.

## Checklist
- [x] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Library documentation is updated.
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
