### PR TITLE
Update datadog/dd-trace-py python versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,14 +56,15 @@ RUN git clone git://github.com/yyuu/pyenv.git "${PYENV_ROOT}"
 
 # Install all required python versions
 RUN \
-  pyenv install 2.7.17 \
+  pyenv install 2.7.18 \
   && pyenv install 3.5.10 \
   && pyenv install 3.6.12 \
   && pyenv install 3.7.9 \
-  && pyenv install 3.8.6 \
-  && pyenv install 3.9.0 \
+  && pyenv install 3.8.7 \
+  && pyenv install 3.9.1 \
+  && pyenv install 3.10-dev \
   # Order matters: first version is the global one
-  && pyenv global 3.8.6 2.7.17 3.5.10 3.6.12 3.7.9 3.9.0 \
+  && pyenv global 3.9.1 2.7.18 3.5.10 3.6.12 3.7.9 3.8.7 3.10-dev \
   && pip install --upgrade pip
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Updating all versions to the latest
Making 3.9 the default Python version
Adding 3.10-dev
