### PR TITLE
Add config to bottle, cherrypy, falcon, pylons

### DIFF
--- a/ddtrace/contrib/bottle/patch.py
+++ b/ddtrace/contrib/bottle/patch.py
@@ -3,7 +3,17 @@ import bottle
 from ddtrace import config
 from ddtrace.vendor import wrapt
 
+from ...utils.formats import asbool
+from ...utils.formats import get_env
 from .trace import TracePlugin
+
+
+config._add(
+    "bottle",
+    dict(
+        distributed_tracing=asbool(get_env("bottle", "distributed_tracing", default=True)),
+    ),
+)
 
 
 def patch():

--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -11,16 +11,26 @@ from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanTypes
 from ...propagation.http import HTTPPropagator
+from ...utils.formats import asbool
 
 
 class TracePlugin(object):
     name = "trace"
     api = 2
 
-    def __init__(self, service="bottle", tracer=None, distributed_tracing=True):
+    def __init__(self, service="bottle", tracer=None, distributed_tracing=None):
         self.service = ddtrace.config.service or service
         self.tracer = tracer or ddtrace.tracer
-        self.distributed_tracing = distributed_tracing
+        if distributed_tracing is not None:
+            self.distributed_tracing = distributed_tracing
+
+    @property
+    def distributed_tracing(self):
+        return config.bottle.get("distributed_tracing", True)
+
+    @distributed_tracing.setter
+    def distributed_tracing(self, distributed_tracing):
+        config.bottle["distributed_tracing"] = asbool(distributed_tracing)
 
     def apply(self, callback, route):
         def wrapped(*args, **kwargs):

--- a/ddtrace/contrib/cherrypy/middleware.py
+++ b/ddtrace/contrib/cherrypy/middleware.py
@@ -36,11 +36,12 @@ SPAN_NAME = "cherrypy.request"
 
 
 class TraceTool(cherrypy.Tool):
-    def __init__(self, app, tracer, service, use_distributed_tracing):
+    def __init__(self, app, tracer, service, use_distributed_tracing=None):
         self.app = app
         self._tracer = tracer
         self.service = service
-        self.use_distributed_tracing = use_distributed_tracing
+        if use_distributed_tracing is not None:
+            self.use_distributed_tracing = use_distributed_tracing
 
         # CherryPy uses priority to determine which tools act first on each event. The lower the number, the higher
         # the priority. See: https://docs.cherrypy.org/en/latest/extend.html#tools-ordering
@@ -140,7 +141,7 @@ class TraceTool(cherrypy.Tool):
 
 
 class TraceMiddleware(object):
-    def __init__(self, app, tracer, service="cherrypy", distributed_tracing=True):
+    def __init__(self, app, tracer, service="cherrypy", distributed_tracing=None):
         self.app = app
 
         self.app.tools.tracer = TraceTool(app, tracer, service, distributed_tracing)

--- a/ddtrace/contrib/falcon/patch.py
+++ b/ddtrace/contrib/falcon/patch.py
@@ -9,6 +9,14 @@ from ...utils.formats import get_env
 from .middleware import TraceMiddleware
 
 
+config._add(
+    "flask",
+    dict(
+        distributed_tracing=asbool(get_env("falcon", "distributed_tracing", default=True)),
+    ),
+)
+
+
 def patch():
     """
     Patch falcon.API to include contrib.falcon.TraceMiddleware

--- a/ddtrace/contrib/pylons/patch.py
+++ b/ddtrace/contrib/pylons/patch.py
@@ -11,6 +11,14 @@ from ...utils.wrappers import unwrap as _u
 from .middleware import PylonsTraceMiddleware
 
 
+config._add(
+    "pylons",
+    dict(
+        distributed_tracing=asbool(get_env("pylons", "distributed_tracing", default=True)),
+    ),
+)
+
+
 def patch():
     """Instrument Pylons applications"""
     if getattr(pylons.wsgiapp, "_datadog_patch", False):
@@ -34,9 +42,10 @@ def traced_init(wrapped, instance, args, kwargs):
 
     # set tracing options and create the TraceMiddleware
     service = config._get_service(default="pylons")
-    distributed_tracing = asbool(get_env("pylons", "distributed_tracing", default=True))
     Pin(service=service, tracer=tracer).onto(instance)
-    traced_app = PylonsTraceMiddleware(instance, tracer, service=service, distributed_tracing=distributed_tracing)
+    traced_app = PylonsTraceMiddleware(
+        instance, tracer, service=service, distributed_tracing=config.pylons.get(["distributed_tracing"], True)
+    )
 
     # re-order the middleware stack so that the first middleware is ours
     traced_app.app = instance.app


### PR DESCRIPTION
## Description
From #2216, it was found that several integrations (including flask.middlewares, cherrypy.middleware, falcon.middleware, tornado.handler, pyramid.trace, bottle.trace, pylons.middleware) have unique setting objects to check for the distributed_tracing setting instead of using their respective integration config objects. To make integrations consistent, their integration configs were added explicitly.

