### PR TITLE
perf(django): reduce overheads in instrumentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,14 +56,15 @@ RUN git clone git://github.com/yyuu/pyenv.git "${PYENV_ROOT}"
 
 # Install all required python versions
 RUN \
-  pyenv install 2.7.17 \
+  pyenv install 2.7.18 \
   && pyenv install 3.5.10 \
   && pyenv install 3.6.12 \
   && pyenv install 3.7.9 \
-  && pyenv install 3.8.6 \
-  && pyenv install 3.9.0 \
+  && pyenv install 3.8.7 \
+  && pyenv install 3.9.1 \
+  && pyenv install 3.10-dev \
   # Order matters: first version is the global one
-  && pyenv global 3.8.6 2.7.17 3.5.10 3.6.12 3.7.9 3.9.0 \
+  && pyenv global 3.9.1 2.7.18 3.5.10 3.6.12 3.7.9 3.8.7 3.10-dev \
   && pip install --upgrade pip
 
 CMD ["/bin/bash"]

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -99,7 +99,7 @@ def get_request_uri(request):
 
     # Build request url from the information available
     # DEV: We are explicitly omitting query strings since they may contain sensitive information
-    urlparts = dict(scheme=request.scheme, netloc=host, path=request.path, params=None, query=None, fragment=None)
+    urlparts = dict(scheme=request.scheme, netloc=host, path=request.path)
 
     # If any url part is a SimpleLazyObject, use its __class__ property to cast
     # str/bytes and allow for _setup() to execute

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -14,6 +14,7 @@ from ddtrace.ext import http
 import ddtrace.http
 from ddtrace.internal.logger import get_logger
 from ddtrace.propagation.http import HTTPPropagator
+from ddtrace.utils.cache import cached
 from ddtrace.utils.http import strip_query_string
 import ddtrace.utils.wrappers
 from ddtrace.vendor import wrapt
@@ -137,6 +138,7 @@ def get_error_ranges(error_range_str):
     return error_ranges
 
 
+@cached()
 def is_error_code(status_code):
     # type: (int) -> bool
     """Returns a boolean representing whether or not a status code is an error code.
@@ -212,7 +214,7 @@ def activate_distributed_headers(tracer, int_config=None, request_headers=None, 
         return None
 
     if override or int_config.get("distributed_tracing_enabled", int_config.get("distributed_tracing", False)):
-        context = HTTPPropagator.extract(request_headers)
+        context = HTTPPropagator.extract(request_headers, trace_required=True)
         # Only need to activate the new context if something was propagated
         if context.trace_id:
             tracer.context_provider.activate(context)

--- a/ddtrace/http/headers.py
+++ b/ddtrace/http/headers.py
@@ -1,6 +1,7 @@
 import re
 
 from ..internal.logger import get_logger
+from ..utils.cache import cached
 from ..utils.http import normalize_header_name
 
 
@@ -67,6 +68,11 @@ def _store_headers(headers, span, integration_config, request_or_response):
         span.set_tag(tag_name, header_value)
 
 
+@cached()
+def _normalized_header_name(header_name):
+    return NORMALIZE_PATTERN.sub("_", normalize_header_name(header_name))
+
+
 def _normalize_tag_name(request_or_response, header_name):
     """
     Given a tag name, e.g. 'Content-Type', returns a corresponding normalized tag name, i.e
@@ -87,5 +93,5 @@ def _normalize_tag_name(request_or_response, header_name):
     #   - any letter is converted to lowercase
     #   - any digit is left unchanged
     #   - any block of any length of different ASCII chars is converted to a single underscore '_'
-    normalized_name = NORMALIZE_PATTERN.sub("_", normalize_header_name(header_name))
+    normalized_name = _normalized_header_name(header_name)
     return "http.{}.headers.{}".format(request_or_response, normalized_name)

--- a/ddtrace/propagation/utils.py
+++ b/ddtrace/propagation/utils.py
@@ -1,3 +1,6 @@
+from ddtrace.utils.cache import cached
+
+
 def get_wsgi_header(header):
     """Returns a WSGI compliant HTTP header.
     See https://www.python.org/dev/peps/pep-3333/#environ-variables for
@@ -6,6 +9,7 @@ def get_wsgi_header(header):
     return "HTTP_{}".format(header.upper().replace("-", "_"))
 
 
+@cached()
 def from_wsgi_header(header):
     """Convert a WSGI compliant HTTP header into the original header.
     See https://www.python.org/dev/peps/pep-3333/#environ-variables for

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
 import os
 
+from ddtrace.utils.cache import cachedmethod
+
 from .._hooks import Hooks
 from ..utils.attrdict import AttrDict
 from ..utils.formats import asbool
@@ -80,6 +82,7 @@ class IntegrationConfig(AttrDict):
             return self.http.trace_query_string
         return self.global_config.http.trace_query_string
 
+    @cachedmethod()
     def header_is_traced(self, header_name):
         """
         Returns whether or not the current header should be traced.

--- a/ddtrace/utils/cache.py
+++ b/ddtrace/utils/cache.py
@@ -1,0 +1,71 @@
+from threading import RLock
+
+
+def cached(maxsize=256):
+    def cached_wrapper(f):
+        cache = {}
+        lock = RLock()
+        miss = object()
+
+        def cached_f(key):
+            if len(cache) >= maxsize:
+                for _, h in zip(range(maxsize >> 1), sorted(cache, key=lambda h: cache[h][1])):
+                    del cache[h]
+
+            _ = cache.get(key, miss)
+            if _ is not miss:
+                value, count = _
+                cache[key] = (value, count + 1)
+                return value
+
+            with lock:
+                _ = cache.get(key, miss)
+                if _ is not miss:
+                    value, count = _
+                    cache[key] = (value, count + 1)
+                    return value
+
+                result = f(key)
+
+                cache[key] = (result, 1)
+
+                return result
+
+        return cached_f
+
+    return cached_wrapper
+
+
+def cachedmethod(maxsize=256):
+    def cached_wrapper(f):
+        cache = {}
+        lock = RLock()
+        miss = object()
+
+        def cached_f(self, key):
+            if len(cache) >= maxsize:
+                for _, h in zip(range(maxsize >> 1), sorted(cache, key=lambda h: cache[h][1])):
+                    del cache[h]
+
+            _ = cache.get(key, miss)
+            if _ is not miss:
+                value, count = _
+                cache[key] = (value, count + 1)
+                return value
+
+            with lock:
+                _ = cache.get(key, miss)
+                if _ is not miss:
+                    value, count = _
+                    cache[key] = (value, count + 1)
+                    return value
+
+                result = f(self, key)
+
+                cache[key] = (result, 1)
+
+                return result
+
+        return cached_f
+
+    return cached_wrapper

--- a/ddtrace/utils/importlib.py
+++ b/ddtrace/utils/importlib.py
@@ -23,9 +23,10 @@ class require_modules(object):
 
 def func_name(f):
     """Return a human readable version of the function's name."""
-    if hasattr(f, "__module__"):
+    try:
         return "%s.%s" % (f.__module__, getattr(f, "__name__", f.__class__.__name__))
-    return getattr(f, "__name__", f.__class__.__name__)
+    except AttributeError:
+        return getattr(f, "__name__", f.__class__.__name__)
 
 
 def module_name(instance):


### PR DESCRIPTION
## Description

After CPU profiling, a few areas were discovered in the Django
instrumentation that could account for about 40% CPU overheads. This
change tries to mitigate some of these overheads as much as possible by
avoiding repeating work or optimising some of the tracing steps.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
