### PR TITLE
fix(ci): pass environment through riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ commands:
             - run:
                 environment:
                   DD_TRACE_AGENT_URL: http://localhost:9126
-                command: "echo -p2.7,-p3.5,-p3.6,-p3.7,-p3.8,-p3.9 | tr ',' '\n' | circleci tests split | xargs ./scripts/ddtest riot -v run -s '<< parameters.pattern >>'"
+                command: "echo -p2.7,-p3.5,-p3.6,-p3.7,-p3.8,-p3.9 | tr ',' '\n' | circleci tests split | xargs ./scripts/ddtest riot -v run --pass-env -s '<< parameters.pattern >>'"
       - unless:
           condition:
               << parameters.snapshot >>

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -434,10 +434,10 @@ class DummyTracer(Tracer):
 
     def __init__(self):
         super(DummyTracer, self).__init__()
-        self._update_writer()
+        self._update_writer(getattr(self.writer, "agent_url", None))
 
-    def _update_writer(self):
-        self.writer = DummyWriter()
+    def _update_writer(self, agent_url):
+        self.writer = DummyWriter(agent_url)
 
     def pop(self):
         # type: () -> List[Span]
@@ -450,7 +450,7 @@ class DummyTracer(Tracer):
     def configure(self, *args, **kwargs):
         super(DummyTracer, self).configure(*args, **kwargs)
         # `.configure()` may reset the writer
-        self._update_writer()
+        self._update_writer(self.writer.agent_url)
 
 
 class TestSpan(Span):


### PR DESCRIPTION
riot 0.5 fixed environment variables which actually exposed a
misconfiguration we had.

The `DD_TRACE_AGENT_URL` env var needs to be passed through for tests to use the test agent