### PR TITLE
fix(grpc): support future-like responses

### DIFF
--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -69,7 +69,10 @@ def _future_done_callback(span):
 
 
 def _handle_response(span, response):
-    if isinstance(response, grpc.Future):
+    # use duck-typing to support future-like response as in the case of
+    # google-api-core which has its own future base class
+    # https://github.com/googleapis/python-api-core/blob/49c6755a21215bbb457b60db91bab098185b77da/google/api_core/future/base.py#L23
+    if hasattr(response, "add_done_callback"):
         response.add_done_callback(_future_done_callback(span))
 
 

--- a/releasenotes/notes/grpc-future-callback-a3cc27b11df34eef.yaml
+++ b/releasenotes/notes/grpc-future-callback-a3cc27b11df34eef.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes issue of unfinished spans when response is not a `grpc.Future` but has the same interface, as is the case with the base future class in `google-api-core`.


### PR DESCRIPTION
## Description

Fixes issue of unfinished spans when response is not a `grpc.Future` but has the same interface, as is the case with the base future class in google-api-core.

We should use duck-typing to support the case of `google.api_core.operation.Operation` which inherits from an internal [base class](https://github.com/googleapis/python-api-core/blob/49c6755a21215bbb457b60db91bab098185b77da/google/api_core/future/base.py#L23) rather `grpc.Future`. 


## Checklist
- [x] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
