### PR TITLE
Refactor: cherrypy distributed tracing helper

### DIFF
--- a/ddtrace/contrib/cherrypy/middleware.py
+++ b/ddtrace/contrib/cherrypy/middleware.py
@@ -16,7 +16,6 @@ from .. import trace_utils
 from ... import compat
 from ...ext import SpanTypes
 from ...ext import errors
-from ...propagation.http import HTTPPropagator
 from ...utils.formats import asbool
 from ...utils.formats import get_env
 
@@ -36,11 +35,12 @@ SPAN_NAME = "cherrypy.request"
 
 
 class TraceTool(cherrypy.Tool):
-    def __init__(self, app, tracer, service, use_distributed_tracing):
+    def __init__(self, app, tracer, service, use_distributed_tracing=None):
         self.app = app
         self._tracer = tracer
         self.service = service
-        self.use_distributed_tracing = use_distributed_tracing
+        if use_distributed_tracing is not None:
+            self.use_distributed_tracing = use_distributed_tracing
 
         # CherryPy uses priority to determine which tools act first on each event. The lower the number, the higher
         # the priority. See: https://docs.cherrypy.org/en/latest/extend.html#tools-ordering
@@ -48,7 +48,7 @@ class TraceTool(cherrypy.Tool):
 
     @property
     def use_distributed_tracing(self):
-        return config.cherrypy.get("distributed_tracing", True)
+        return config.cherrypy.distributed_tracing
 
     @use_distributed_tracing.setter
     def use_distributed_tracing(self, use_distributed_tracing):
@@ -68,11 +68,11 @@ class TraceTool(cherrypy.Tool):
         cherrypy.request.hooks.attach("after_error_response", self._after_error_response, priority=5)
 
     def _on_start_resource(self):
-        if self.use_distributed_tracing:
-            context = HTTPPropagator.extract(cherrypy.request.headers)
-            # Only need to activate the new context if something was propagated
-            if context.trace_id:
-                self._tracer.context_provider.activate(context)
+        trace_utils.activate_distributed_headers(
+            self._tracer,
+            int_config=config.cherrypy,
+            request_headers=cherrypy.request.headers
+        )
 
         cherrypy.request._datadog_span = self._tracer.trace(
             SPAN_NAME,
@@ -140,7 +140,7 @@ class TraceTool(cherrypy.Tool):
 
 
 class TraceMiddleware(object):
-    def __init__(self, app, tracer, service="cherrypy", distributed_tracing=True):
+    def __init__(self, app, tracer, service="cherrypy", distributed_tracing=None):
         self.app = app
 
         self.app.tools.tracer = TraceTool(app, tracer, service, distributed_tracing)


### PR DESCRIPTION
## Description
Cherrypy's `TraceTool.distributed_tracing` property was refactored to reflect the integration config setting on initialization. Additionally, a refactor was made to use the `trace_utils.activate_distributed_headers` helper with the integration config.

