### PR TITLE
refactor(dogstatsd): remove parse_dogstatsd_url

### DIFF
--- a/ddtrace/internal/dogstatsd.py
+++ b/ddtrace/internal/dogstatsd.py
@@ -1,12 +1,15 @@
-from typing import Dict
 from typing import Optional
 
 from ddtrace.compat import parse
 from ddtrace.vendor.dogstatsd import DogStatsd
+from ddtrace.vendor.dogstatsd import base
 
 
-def parse_dogstatsd_url(url):
-    # type: (str) -> Dict[str, str]
+def get_dogstatsd_client(url):
+    # type: (str) -> Optional[DogStatsd]
+    if not url:
+        return None
+
     # url can be either of the form `udp://<host>:<port>` or `unix://<path>`
     # also support without url scheme included
     if url.startswith("/"):
@@ -17,17 +20,8 @@ def parse_dogstatsd_url(url):
     parsed = parse.urlparse(url)
 
     if parsed.scheme == "unix":
-        return dict(socket_path=parsed.path)
+        return DogStatsd(socket_path=parsed.path)
     elif parsed.scheme == "udp":
-        return dict(host=parsed.hostname, port=parsed.port)
-    else:
-        raise ValueError("Unknown scheme `%s` for DogStatsD URL `{}`".format(parsed.scheme))
+        return DogStatsd(host=parsed.hostname, port=base.DEFAULT_PORT if parsed.port is None else parsed.port)
 
-
-def get_dogstatsd_client(dogstatsd_url):
-    # type: (str) -> Optional[DogStatsd]
-    if not dogstatsd_url:
-        return None
-
-    dogstatsd_kwargs = parse_dogstatsd_url(dogstatsd_url)
-    return DogStatsd(**dogstatsd_kwargs)  # type: ignore[arg-type]
+    raise ValueError("Unknown scheme `%s` for DogStatsD URL `{}`".format(parsed.scheme))


### PR DESCRIPTION
This function actually loses typing information by returning things like port
(int) in Dict[str, str] which does not make sense.
This typing error is not typed because typing information for urlparse does not
work (yet) until we unvendor six.