### PR TITLE
fix(profiling): restart the profiler on uwsgi fork

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -74,7 +74,7 @@ class Profiler(object):
 
         if profile_children:
             try:
-                uwsgi.check_uwsgi(self.start, atexit=self.stop if stop_on_exit else None)
+                uwsgi.check_uwsgi(self._restart_on_fork, atexit=self.stop if stop_on_exit else None)
             except uwsgi.uWSGIMasterProcess:
                 # Do nothing, the start() method will be called in each worker subprocess
                 return

--- a/releasenotes/notes/profiling-fix-uwsgi-empty-profiles-7dbd5fdd93dea47f.yaml
+++ b/releasenotes/notes/profiling-fix-uwsgi-empty-profiles-7dbd5fdd93dea47f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    In certain circumstances, the profiles generated in a uWSGI application
+    could have been empty. This is now fixed and the profiler records correctly
+    the generated events.

--- a/tests/profiling/exporter/test_file.py
+++ b/tests/profiling/exporter/test_file.py
@@ -2,7 +2,7 @@ import os
 
 from ddtrace.profiling.exporter import file
 
-from .. import test_main
+from .. import utils
 from ..exporter import test_pprof
 
 
@@ -10,4 +10,4 @@ def test_export(tmp_path):
     filename = str(tmp_path / "pprof")
     exp = file.PprofFileExporter(filename)
     exp.export(test_pprof.TEST_EVENTS, 0, 1)
-    test_main.check_pprof_file(filename + "." + str(os.getpid()) + ".1")
+    utils.check_pprof_file(filename + "." + str(os.getpid()) + ".1")

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -1,10 +1,9 @@
-import gzip
 import os
 import subprocess
 
 import pytest
 
-from ddtrace.profiling.exporter import pprof_pb2
+from . import utils
 
 
 def call_program(*args):
@@ -38,15 +37,6 @@ def test_call_script_gevent(monkeypatch):
     assert exitcode == 0
 
 
-def check_pprof_file(filename):
-    with gzip.open(filename, "rb") as f:
-        content = f.read()
-    p = pprof_pb2.Profile()
-    p.ParseFromString(content)
-    assert len(p.sample_type) == 11
-    assert p.string_table[p.sample_type[0].type] == "cpu-samples"
-
-
 def test_call_script_pprof_output(tmp_path, monkeypatch):
     """This checks if the pprof output and atexit register work correctly.
 
@@ -58,15 +48,8 @@ def test_call_script_pprof_output(tmp_path, monkeypatch):
     monkeypatch.setenv("DD_PROFILING_ENABLED", "1")
     _, _, exitcode, pid = call_program("ddtrace-run", os.path.join(os.path.dirname(__file__), "simple_program.py"))
     assert exitcode == 42
-    check_pprof_file(filename + "." + str(pid) + ".1")
+    utils.check_pprof_file(filename + "." + str(pid) + ".1")
     return filename, pid
-
-
-def test_call_script_pprof_output_interval(tmp_path, monkeypatch):
-    monkeypatch.setenv("DD_PROFILING_UPLOAD_INTERVAL", "0.1")
-    filename, pid = test_call_script_pprof_output(tmp_path, monkeypatch)
-    for i in (2, 3):
-        check_pprof_file(filename + "." + str(pid) + (".%d" % i))
 
 
 def test_fork(tmp_path, monkeypatch):
@@ -79,8 +62,8 @@ def test_fork(tmp_path, monkeypatch):
     )
     assert exitcode == 0
     child_pid = stdout.decode().strip()
-    check_pprof_file(filename + "." + str(pid) + ".1")
-    check_pprof_file(filename + "." + str(child_pid) + ".1")
+    utils.check_pprof_file(filename + "." + str(pid) + ".1")
+    utils.check_pprof_file(filename + "." + str(child_pid) + ".1")
 
 
 @pytest.mark.skipif(not os.getenv("DD_PROFILE_TEST_GEVENT", False), reason="Not testing gevent")

--- a/tests/profiling/utils.py
+++ b/tests/profiling/utils.py
@@ -1,0 +1,16 @@
+import gzip
+
+from ddtrace.profiling.exporter import pprof_pb2
+
+
+def check_pprof_file(
+    filename,  # type: str
+):
+    # type: (...) -> None
+    with gzip.open(filename, "rb") as f:
+        content = f.read()
+    p = pprof_pb2.Profile()
+    p.ParseFromString(content)
+    assert len(p.sample_type) == 11
+    assert p.string_table[p.sample_type[0].type] == "cpu-samples"
+    assert len(p.sample) >= 1


### PR DESCRIPTION
In uWSGI, the current code starts in the forked process the ProfilerInstance
that has been created in the master process. That actually works fine, except
all Events are discarded by the Recorder because its `pid` attribute is not
updated: it is still the pid of the master process.

Using the `_restart_on_fork` method makes sure that the `ProfilerInstance` gets
a new `Recorder` object with the correct PID.

The test is updated to not test only for file presence, but making sure that
there is at least one sample included.