### PR TITLE
Move tox -e docs to riot run docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,11 +265,11 @@ commands:
 
   build_docs:
     steps:
-      - setup_tox
+      - setup_riot
       - run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libenchant-dev
-      - run: tox -e docs
+      - run: riot run docs
 
 executors:
   cimg_base:

--- a/riotfile.py
+++ b/riotfile.py
@@ -126,6 +126,18 @@ venv = Venv(
             pkgs={"riot": latest},
         ),
         Venv(
+            name="docs",
+            pys=["3"],
+            pkgs={
+                "cython": latest,
+                "reno[sphinx]": latest,
+                "sphinx": latest,
+                "sphinxcontrib-spelling": latest,
+                "PyEnchant": latest,
+            },
+            command="scripts/build-docs",
+        ),
+        Venv(
             name="benchmarks",
             pys=select_pys(),
             pkgs={"pytest-benchmark": latest, "msgpack": latest},

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+reno lint
+sphinx-build -W -b spelling docs docs/_build/html
+sphinx-build -W -b html docs docs/_build/html

--- a/tox.ini
+++ b/tox.ini
@@ -406,20 +406,6 @@ deps=
 # this is somewhat flaky (can fail and still be up) so try the tests anyway
 ignore_outcome=true
 
-[testenv:docs]
-extras=
-  opentracing
-deps=
-  cython
-  reno[sphinx]
-  sphinx
-  sphinxcontrib-spelling
-  PyEnchant
-commands=reno lint
-         sphinx-build -W -b spelling docs docs/_build/html
-         sphinx-build -W -b html docs docs/_build/html
-basepython=python
-
 # DEV: We use `conftest.py` as a local pytest plugin to configure hooks for collection
 [pytest]
 # --cov-report is intentionally empty else pytest-cov will default to generating a report


### PR DESCRIPTION
Migrate `tox -e docs` to `riot run docs`.

~Blocker for now is being able to do extra installs with `riot`. https://github.com/DataDog/riot/issues/104~

This isn't actually blocked because we globally install `opentracing` for all envs.