### PR TITLE
fix(six): use first version that has ensure_text

### DIFF
--- a/releasenotes/notes/depends-on-six-e9b79edbf0d169a2.yaml
+++ b/releasenotes/notes/depends-on-six-e9b79edbf0d169a2.yaml
@@ -1,4 +1,5 @@
 ---
 other:
   - |
-    The `six` library has been removed from `vendor` and the system-wide version is being used. It requires version 1.7.0 or later.
+    The `six` library has been removed from `vendor` and the system-wide version
+    is being used. It requires version 1.12.0 or later.

--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ setup(
             "protobuf>=3",
             "tenacity>=5",
             "attrs>=19.2.0",
-            "six>=1.7.0",
+            "six>=1.12.0",
         ],
         extras_require={
             # users can include opentracing by having:


### PR DESCRIPTION
## Description

The `ensure_text` function was added in 1.12.0

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
