### PR TITLE
Add SPAN_MEASURED_KEY tag to grpc client

### DIFF
--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -11,7 +11,7 @@ from ddtrace.vendor import wrapt
 
 from . import constants
 from .. import trace_utils
-from ...constants import ANALYTICS_SAMPLE_RATE_KEY
+from ...constants import ANALYTICS_SAMPLE_RATE_KEY, SPAN_MEASURED_KEY
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
 from .utils import parse_method_path
@@ -174,6 +174,7 @@ class _ClientInterceptor(
             service=trace_utils.ext_service(self._pin, config.grpc),
             resource=client_call_details.method,
         )
+        span.set_tag(SPAN_MEASURED_KEY)
 
         # tags for method details
         method_path = client_call_details.method

--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -11,7 +11,8 @@ from ddtrace.vendor import wrapt
 
 from . import constants
 from .. import trace_utils
-from ...constants import ANALYTICS_SAMPLE_RATE_KEY, SPAN_MEASURED_KEY
+from ...constants import ANALYTICS_SAMPLE_RATE_KEY
+from ...constants import SPAN_MEASURED_KEY
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
 from .utils import parse_method_path

--- a/releasenotes/notes/grpc-client-measured-span-aa043d35bfe71238.yaml
+++ b/releasenotes/notes/grpc-client-measured-span-aa043d35bfe71238.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    gRPC client spans are now marked as measured by default.

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -71,7 +71,7 @@ class GrpcTestCase(TracerTestCase):
         self._server_pool.shutdown(wait=True)
 
     def _check_client_span(self, span, service, method_name, method_kind):
-        self.assert_is_not_measured(span)
+        self.assert_is_measured(span)
         assert span.name == "grpc"
         assert span.resource == "/helloworld.Hello/{}".format(method_name)
         assert span.service == service


### PR DESCRIPTION
## Description

Add `SPAN_MEASURED_KEY` tag to gRPC client spans.
It was present on the server span but missing on the client.
