### PR TITLE
feat(aiobotocore): add context propagation in Lambda calls

### DIFF
--- a/ddtrace/contrib/aiobotocore/__init__.py
+++ b/ddtrace/contrib/aiobotocore/__init__.py
@@ -17,6 +17,26 @@ To enable it, you must run ``patch_all(aiobotocore=True)``
 
     # This query generates a trace
     lambda_client.list_functions()
+
+Configuration
+~~~~~~~~~~~~~
+
+.. py:data:: ddtrace.config.aiobotocore['distributed_tracing']
+
+   Whether to inject distributed tracing data to requests in Lambda.
+
+   Can also be enabled with the ``DD_AIOBOTOCORE_DISTRIBUTED_TRACING`` environment variable.
+
+   Default: ``True``
+
+
+Example::
+
+    from ddtrace import config
+
+    # Enable distributed tracing
+    config.aiobotocore['distributed_tracing'] = True
+
 """
 from ...utils.importlib import require_modules
 

--- a/releasenotes/notes/aiobotocore-integration-add-tracing-context-propagation-to-AWS-Lambda-calls-2814ac55086fbb91.yaml
+++ b/releasenotes/notes/aiobotocore-integration-add-tracing-context-propagation-to-AWS-Lambda-calls-2814ac55086fbb91.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    aiobotocore integration: propagate tracing context through Lambda Invoke API calls.

--- a/releasenotes/notes/aiobotocore-integration:-add-tracing-context-propagation-to-AWS-Lambda-calls-2814ac55086fbb91.yaml
+++ b/releasenotes/notes/aiobotocore-integration:-add-tracing-context-propagation-to-AWS-Lambda-calls-2814ac55086fbb91.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    aiobocotore integration: propagate tracing context through Lambda Invoke API calls.

--- a/releasenotes/notes/aiobotocore-integration:-add-tracing-context-propagation-to-AWS-Lambda-calls-2814ac55086fbb91.yaml
+++ b/releasenotes/notes/aiobotocore-integration:-add-tracing-context-propagation-to-AWS-Lambda-calls-2814ac55086fbb91.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    aiobocotore integration: propagate tracing context through Lambda Invoke API calls.

--- a/tests/contrib/aiobotocore/test.py
+++ b/tests/contrib/aiobotocore/test.py
@@ -235,16 +235,13 @@ class AIOBotocoreTest(AsyncioTestCase):
                 },
                 Publish=True,
                 Timeout=30,
-                MemorySize=128
+                MemorySize=128,
             )
 
             # we are not interested in the traces of the previous call
             self.reset()
 
-            yield from lambda_client.invoke(
-                FunctionName="ironmaiden",
-                Payload=json.dumps({})
-            )
+            yield from lambda_client.invoke(FunctionName="ironmaiden", Payload=json.dumps({}))
 
         spans = self.get_spans()
         assert spans
@@ -281,16 +278,13 @@ class AIOBotocoreTest(AsyncioTestCase):
                     },
                     Publish=True,
                     Timeout=30,
-                    MemorySize=128
+                    MemorySize=128,
                 )
 
                 # we are not interested in the traces of the previous call
                 self.reset()
 
-                yield from lambda_client.invoke(
-                    FunctionName="ironmaiden",
-                    Payload=json.dumps({})
-                )
+                yield from lambda_client.invoke(FunctionName="ironmaiden", Payload=json.dumps({}))
 
             spans = self.get_spans()
             assert spans
@@ -329,9 +323,7 @@ class AIOBotocoreTest(AsyncioTestCase):
             self.reset()
 
             yield from lambda_client.invoke(
-                FunctionName="megadeth",
-                ClientContext=client_context,
-                Payload=json.dumps({})
+                FunctionName="megadeth", ClientContext=client_context, Payload=json.dumps({})
             )
 
         spans = self.get_spans()

--- a/tests/contrib/aiobotocore/utils.py
+++ b/tests/contrib/aiobotocore/utils.py
@@ -1,4 +1,6 @@
 from contextlib import contextmanager
+import io
+import zipfile
 
 import aiobotocore.session
 
@@ -35,3 +37,17 @@ def aiobotocore_client(service, tracer):
         yield client
     finally:
         client.close()
+
+
+def get_zip_lambda():
+    """Helper function that returns a valid lambda package."""
+    code = """
+def lambda_handler(event, context):
+    return event
+"""
+    zip_output = io.BytesIO()
+    zip_file = zipfile.ZipFile(zip_output, "w", zipfile.ZIP_DEFLATED)
+    zip_file.writestr("lambda_function.py", code)
+    zip_file.close()
+    zip_output.seek(0)
+    return zip_output.read()


### PR DESCRIPTION
## Description

Unlike the botocore integration, the aiobotocore integration does not propagate the tracing context when a Lambda function is called. As I need this feature, I'm opening this PR, hoping that I can get this upstreamed :slightly_smiling_face: 

The botocore integration also supports context propagation in SNS and SQS, but since I don't have a need for them yet, I didn't include them in this PR.

I implemented this by adapting the code in the botocore integration (https://github.com/DataDog/dd-trace-py/blob/master/ddtrace/contrib/botocore/patch.py) and the corresponding tests (https://github.com/DataDog/dd-trace-py/blob/master/tests/contrib/botocore/test.py). I kept the "musical" function names too :smile: 

There is one noteworthy difference: for some reason, during the aiobotocore tests, the lambda API returns HTTP 202 (instead of HTTP 200) in API calls. That's the expected return code for an 'Event' invocation (rather than 'RequestResponse'). I changed the tests accordingly; if there is a chance that this PR might be merged and you give me some pointers as to where to look, I'm OK with spending some more time investigating this.

There is some duplicated code between the botocore and aiobotocore integrations. I don't know if you'd rather keep the implementations for these two libraries completely decoupled, or if you'd rather extract the helper methods in a common module. Here again, I'm OK with spending some more time on this if it means that this PR will be merged :slightly_smiling_face: 

Fixes https://github.com/DataDog/dd-trace-py/issues/2039.

## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
