### PR TITLE
Add docker-compose, testagent pytest fixtures

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -79,6 +79,7 @@ venv = Venv(
         "pytest-cov": latest,
         "opentracing": latest,
         "hypothesis": latest,
+        "docker-compose": latest,
     },
     venvs=[
         Venv(

--- a/tests/contrib/config.py
+++ b/tests/contrib/config.py
@@ -40,10 +40,6 @@ MYSQL_CONFIG = {
     'database': os.getenv('TEST_MYSQL_DATABASE', 'test'),
 }
 
-REDIS_CONFIG = {
-    'port': int(os.getenv('TEST_REDIS_PORT', 6379)),
-}
-
 REDISCLUSTER_CONFIG = {
     'host': '127.0.0.1',
     'ports': os.getenv('TEST_REDISCLUSTER_PORTS', '7000,7001,7002,7003,7004,7005'),

--- a/tox.ini
+++ b/tox.ini
@@ -133,6 +133,7 @@ deps =
     pytest-cov
     pytest-mock
     opentracing
+    docker-compose
 # test dependencies installed in all envs
     mock
 # used to test our custom msgpack encoder


### PR DESCRIPTION
Moving the docker-compose usage to the test code has several advantages:

- Related code is grouped together - helps with discoverability
- Can programmatically start stop and wait for containers
- Makes running tests locally easier
- Removes dependence on CI provider (eg. can more easily move from
circleci to github)
