### PR TITLE
fix: avoid latest release of mysql-connector-python

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -583,7 +583,7 @@ venv = Venv(
                     pkgs={
                         "sqlalchemy": ["~=1.0.0", "~=1.1.0", "~=1.2.0", "~=1.3.0", latest],
                         "psycopg2": ["~=2.8.0"],
-                        "mysql-connector-python": latest,
+                        "mysql-connector-python": [">=8,<8.0.24"],
                     },
                 ),
             ],

--- a/tox.ini
+++ b/tox.ini
@@ -251,8 +251,8 @@ deps =
     molten07: molten>=0.7,<0.8
     molten10: molten>=1.0,<1.1
     mongoengine: mongoengine
-    mysqlconnector: mysql-connector-python
-    mysqlconnector80: mysql-connector-python>=8.0,<8.1
+    mysqlconnector: mysql-connector-python<8.0.24
+    mysqlconnector80: mysql-connector-python>=8.0,<8.0.24
     mysqldb: mysql-python
     mysqldb12: mysql-python>=1.2,<1.3
     mysqlclient: mysqlclient


### PR DESCRIPTION
## Description

The latest release of mysql-connector-python seems to introduce a
regression on Python 2.7 so we temporarily prevent tox from installing
it.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
