### PR TITLE
Vendor VCForPython27.msi

### DIFF
--- a/.github/workflows/VCForPython27.sum
+++ b/.github/workflows/VCForPython27.sum
@@ -1,0 +1,1 @@
+4e6342923a8153a94d44ff7307fcdd1f  .github/workflows/VCForPython27.msi

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -28,7 +28,9 @@ jobs:
 
       - name: Install Visual C++ for Python 2.7
         if: runner.os == 'Windows'
-        run: choco install vcpython27 -f -y
+        run: |
+          md5sum -c .github/workflows/VCForPython27.sum
+          msiexec .github/workflows/VCForPython27.msi
 
       - name: Install cibuildwheel
         run: |


### PR DESCRIPTION
Microsoft stopped hosting the file for choco install no longer works


This is a big file to vendor in our repo, might be better to host somewhere else or maybe move to [git lfs](https://git-lfs.github.com/)