### PR TITLE
Disable building Windows 2.7 wheels

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -26,10 +26,6 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Install Visual C++ for Python 2.7
-        if: runner.os == 'Windows'
-        run: choco install vcpython27 -f -y
-
       - name: Install cibuildwheel
         run: |
           python -m pip install cibuildwheel~=1.8.0
@@ -39,7 +35,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
-          CIBW_SKIP: pp*
+          CIBW_SKIP: pp* cp27-win*
 
       - uses: actions/upload-artifact@v2
         with:
@@ -62,10 +58,6 @@ jobs:
         name: Install Python
         with:
           python-version: '3.8'
-
-      - name: Install Visual C++ for Python 2.7
-        if: runner.os == 'Windows'
-        run: choco install vcpython27 -f -y
 
       - name: Install cibuildwheel
         run: |


### PR DESCRIPTION
The remote file either doesn't exist, is unauthorized, or is forbidden
for url
'https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi'.
Exception calling "Read" with "3" argument(s): "Unable to read data from
the transport connection: An existing connection was forcibly closed by
the remote host.
