### PR TITLE
Fix: container id (with preceding characters) not reporting properly

### DIFF
--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -29,7 +29,7 @@ class CGroupInfo(object):
     LINE_RE = re.compile(r"^(\d+):([^:]*):(.+)$")
     POD_RE = re.compile(r"pod({0})(?:\.slice)?$".format(UUID_SOURCE_PATTERN))
     CONTAINER_RE = re.compile(
-        r"({0}|{1}|{2})(?:\.scope)?$".format(UUID_SOURCE_PATTERN, CONTAINER_SOURCE_PATTERN, TASK_PATTERN)
+        r"(?:.+)?({0}|{1}|{2})(?:\.scope)?$".format(UUID_SOURCE_PATTERN, CONTAINER_SOURCE_PATTERN, TASK_PATTERN)
     )
 
     @classmethod

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -21,7 +21,7 @@ backend
 bikeshedding
 boto
 botocore
-cgroup
+CGroup
 cgroups
 cherrypy
 config

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -21,6 +21,7 @@ backend
 bikeshedding
 boto
 botocore
+cgroup
 cgroups
 cherrypy
 config

--- a/releasenotes/notes/fix-container-id-cgroup-parsing-28790e02a2ac0adc.yaml
+++ b/releasenotes/notes/fix-container-id-cgroup-parsing-28790e02a2ac0adc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CGroup file parsing was fixed to correctly parse container ID with preceding characters.

--- a/tests/tracer/runtime/test_container.py
+++ b/tests/tracer/runtime/test_container.py
@@ -84,18 +84,6 @@ def test_cgroup_info_init():
             ),
         ),
         (
-            # One character too long
-            "13:name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f8698600",
-            CGroupInfo(
-                id="13",
-                groups="name=systemd",
-                controllers=["name=systemd"],
-                path="/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f8698600",
-                container_id=None,
-                pod_id=None,
-            ),
-        ),
-        (
             # Non-hex
             "13:name=systemd:/docker/3726184226f5d3147c25fzyxw5b60097e378e8a720503a5e19ecfdf29f869860",
             CGroupInfo(
@@ -195,6 +183,13 @@ def test_cgroup_info_from_line(line, expected_info):
 1:name=systemd:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
             """,
             "3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1",
+        ),
+        # k8 format with additional characters before task ID
+        (
+            """
+1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/docker-7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199.scope
+            """,
+            "7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199",
         ),
         # ECS file
         (


### PR DESCRIPTION
## Description
From [issue #2314 ](https://github.com/DataDog/dd-trace-py/issues/2314), it was reported that containerIDs with preceding characters with k8 information don't get parsed correctly, i.e. in the following format:
ex: `docker-7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199.scope`
The reason for this was that the previous parsing rule for containerIDs relied on matching the beginning and end of the string, which would inevitably fail if there were preceding characters before the containerID itself.

To fix this, the current container regex parsing rule was changed to add a non-capture 
group for any character preceding a 64 hex-digit character sequence for task/container ID.

Note: this fix ended up breaking a pre-existing test case for invalid containerIDs with one extra character. This test case was determined to be redundant (as in this use case, even if some string is incorrectly tagged as a container somehow, the agent and backend will have no matching actual container instance, so even then it shouldn't cause any issues) and was removed.