### PR TITLE
refactor: mypy config blacklist, addressed uncaught mypy errors

### DIFF
--- a/ddtrace/http/headers.py
+++ b/ddtrace/http/headers.py
@@ -78,7 +78,7 @@ def _store_headers(headers, span, integration_config, request_or_response):
 @cached()
 def _normalized_header_name(header_name):
     # type: (str) -> str
-    return NORMALIZE_PATTERN.sub("_", normalize_header_name(header_name))
+    return NORMALIZE_PATTERN.sub("_", normalize_header_name(header_name))  # type: ignore[arg-type]
 
 
 def _normalize_tag_name(request_or_response, header_name):

--- a/ddtrace/internal/runtime/collector.py
+++ b/ddtrace/internal/runtime/collector.py
@@ -1,4 +1,5 @@
 import importlib
+from typing import List
 
 from ..logger import get_logger
 
@@ -20,7 +21,7 @@ class ValueCollector(object):
 
     enabled = True
     periodic = False
-    required_modules = []
+    required_modules = []  # type: List[str]
     value = None
     value_loaded = False
 

--- a/ddtrace/propagation/utils.py
+++ b/ddtrace/propagation/utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from ddtrace.utils.cache import cached
 
 
@@ -13,7 +15,7 @@ def get_wsgi_header(header):
 
 @cached()
 def from_wsgi_header(header):
-    # type: (str) -> str
+    # type: (str) -> Optional[str]
     """Convert a WSGI compliant HTTP header into the original header.
     See https://www.python.org/dev/peps/pep-3333/#environ-variables for
     information from the spec.

--- a/ddtrace/runtime/__init__.py
+++ b/ddtrace/runtime/__init__.py
@@ -18,6 +18,7 @@ class RuntimeMetrics(object):
 
     @staticmethod
     def enable(tracer=None, dogstatsd_url=None, flush_interval=None):
+        # type: (Optional[ddtrace.Tracer], Optional[str], Optional[float]) -> None
         """
         Enable the runtime metrics collection service.
 
@@ -29,7 +30,6 @@ class RuntimeMetrics(object):
         :param dogstatsd_url: The DogStatsD URL.
         :param flush_interval: The flush interval.
         """
-        # type: (Optional[ddtrace.Tracer], Optional[str], Optional[float]) -> None
 
         ddtrace.internal.runtime.runtime_metrics.RuntimeWorker.enable(
             tracer=tracer, dogstatsd_url=dogstatsd_url, flush_interval=flush_interval
@@ -37,13 +37,13 @@ class RuntimeMetrics(object):
 
     @staticmethod
     def disable():
+        # type: () -> None
         """
         Disable the runtime metrics collection service.
 
         Once disabled, runtime metrics can be re-enabled by calling ``enable``
         again.
         """
-        # type: () -> None
         ddtrace.internal.runtime.runtime_metrics.RuntimeWorker.disable()
 
 

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -47,13 +47,14 @@ def get_error_ranges(error_range_str):
     for error_range in error_ranges_str:
         values = error_range.split("-")
         try:
-            values = [int(v) for v in values]
+            # Note: mypy does not like variable type changing
+            values = [int(v) for v in values]  # type: ignore[misc]
         except ValueError:
             log.exception("Error status codes was not a number %s", values)
             continue
-        error_range = (min(values), max(values))
+        error_range = (min(values), max(values))  # type: ignore[assignment]
         error_ranges.append(error_range)
-    return error_ranges
+    return error_ranges  # type: ignore[return-value]
 
 
 class Config(object):
@@ -72,17 +73,18 @@ class Config(object):
             # type: () -> str
             return self._error_statuses
 
-        @property
-        def error_ranges(self):
-            # type: () -> List[Tuple[int, int]]
-            return self._error_ranges
-
         @error_statuses.setter
         def error_statuses(self, value):
             # type: (str) -> None
             self._error_statuses = value
             self._error_ranges = get_error_ranges(value)
-            self.is_error_code.invalidate()
+            # Mypy can't catch cached method's invalidate()
+            self.is_error_code.invalidate()  # type: ignore[attr-defined]
+
+        @property
+        def error_ranges(self):
+            # type: () -> List[Tuple[int, int]]
+            return self._error_ranges
 
         @cachedmethod()
         def is_error_code(self, status_code):

--- a/ddtrace/settings/http.py
+++ b/ddtrace/settings/http.py
@@ -1,3 +1,8 @@
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Union
+
 from ..internal.logger import get_logger
 from ..utils.cache import cachedmethod
 from ..utils.http import normalize_header_name
@@ -13,14 +18,17 @@ class HttpConfig(object):
     """
 
     def __init__(self):
-        self._whitelist_headers = set()
+        # type: () -> None
+        self._whitelist_headers = set()  # type: Set[str]
         self.trace_query_string = None
 
     @property
     def is_header_tracing_configured(self):
+        # type: () -> bool
         return len(self._whitelist_headers) > 0
 
     def trace_headers(self, whitelist):
+        # type: (Union[List[str], str]) -> Optional[HttpConfig]
         """
         Registers a set of headers to be traced at global level or integration level.
         :param whitelist: the case-insensitive list of traced headers
@@ -29,7 +37,7 @@ class HttpConfig(object):
         :rtype: HttpConfig
         """
         if not whitelist:
-            return
+            return None
 
         whitelist = [whitelist] if isinstance(whitelist, str) else whitelist
         for whitelist_entry in whitelist:
@@ -38,12 +46,14 @@ class HttpConfig(object):
                 continue
             self._whitelist_headers.add(normalized_header_name)
 
-        self.header_is_traced.invalidate()
+        # Mypy can't catch cached method's invalidate()
+        self.header_is_traced.invalidate()  # type: ignore[attr-defined]
 
         return self
 
     @cachedmethod()
     def header_is_traced(self, header_name):
+        # type: (str) -> bool
         """
         Returns whether or not the current header should be traced.
         :param header_name: the header name

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,19 @@
 [mypy]
-files = ddtrace/profiling, ddtrace/*.py, ddtrace/utils/*.py, ddtrace/ext/aws.py, ddtrace/internal/*.py
+files = ddtrace
 show_error_codes = true
 warn_unused_ignores = true
 warn_unused_configs = true
 no_implicit_optional = true
+
 # Not supported yet
-# exclude = ddtrace/vendors
+[mypy-ddtrace.contrib.*]
+ignore_errors = true
+
+[mypy-ddtrace.vendor.*]
+ignore_errors = true
+
+[mypy-ddtrace.opentracer.*]
+ignore_errors = true
+
+[mypy-ddtrace.bootstrap.*]
+ignore_errors = true


### PR DESCRIPTION
## Description
It was found that the `mypy.ini` configuration file did not properly exclude certain modules from raising errors including `ddtrace.vendor`, `ddtrace.contrib`, `ddtrace.opentracer`, and `ddtrace.bootstrap`. Instead of using `files = ddtrace/profiling...` as a whitelist, the mypy configuration was changed to read the entire `ddtrace` library but using a blacklist (ignore the above directories).

Additionally, opening the mypy configuration to the entire library raised additional previously uncaught errors. Many of these errors were relating to variable type changing within functions which were not easily fixable without changing code, and while several instances were fixed, the rest were ignored. 