### PR TITLE
fix(profiling): set back the default timeout to 10 seconds

### DIFF
--- a/ddtrace/profiling/exporter/http.py
+++ b/ddtrace/profiling/exporter/http.py
@@ -39,7 +39,9 @@ class PprofHTTPExporter(pprof.PprofExporter):
 
     endpoint = attr.ib()
     api_key = attr.ib(default=None)
-    timeout = attr.ib(factory=attr_utils.from_env("DD_PROFILING_API_TIMEOUT", agent.DEFAULT_TIMEOUT, float), type=float)
+    # Do not use the default agent timeout: it is too short, the agent is just a unbuffered proxy and the profiling
+    # backend is not as fast as the tracer one.
+    timeout = attr.ib(factory=attr_utils.from_env("DD_PROFILING_API_TIMEOUT", 10.0, float), type=float)
     service = attr.ib(default=None)
     env = attr.ib(default=None)
     version = attr.ib(default=None)

--- a/releasenotes/notes/profiling-timeout-10s-a2468ce1444887b5.yaml
+++ b/releasenotes/notes/profiling-timeout-10s-a2468ce1444887b5.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The default agent timeout for profiling has been restored from 2 to 10
+    seconds to avoid too many profiles from being dropped.


### PR DESCRIPTION
As the agent does no buffering, 2 seconds is too little for the profiling
backend.