### PR TITLE
ci(sqlalchemy): re-enable latest mysqlconnector on Python 3

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -598,11 +598,19 @@ venv = Venv(
             command="pytest {cmdargs} tests/contrib/sqlalchemy",
             venvs=[
                 Venv(
-                    pys=select_pys(),
+                    pys=select_pys(max_version="3"),
                     pkgs={
                         "sqlalchemy": ["~=1.0.0", "~=1.1.0", "~=1.2.0", "~=1.3.0", latest],
                         "psycopg2": ["~=2.8.0"],
-                        "mysql-connector-python": [">=8,<8.0.24"],
+                        "mysql-connector-python": ["<8.0.24"],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version="3"),
+                    pkgs={
+                        "sqlalchemy": ["~=1.0.0", "~=1.1.0", "~=1.2.0", "~=1.3.0", latest],
+                        "psycopg2": ["~=2.8.0"],
+                        "mysql-connector-python": latest,
                     },
                 ),
             ],


### PR DESCRIPTION
## Description

mysql-connector-python has dropped support for Python 2 since 8.0.24. As
an initial measure, the dependency on this package for SQLAlchemy was
restricted for all Python versions. This change re-enables testing against
the latest release on Python 3.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
