### PR TITLE
docs: Fix code blocks

### DIFF
--- a/docs/installation_quickstart.rst
+++ b/docs/installation_quickstart.rst
@@ -13,7 +13,7 @@ your environment is ready to receive traces.
 Installation
 ------------
 
-Install with :code:`bash`::
+Install with :code:`pip`::
 
     pip install ddtrace
 
@@ -29,7 +29,7 @@ Installation on Alpine
 
 Binary distributions are not available for Alpine so build dependencies must be installed first.
 
-:code:`bash`::
+.. code-block:: bash
 
     apk add gcc musl-dev linux-headers
     pip install ddtrace


### PR DESCRIPTION
## Description
I am apparently bad at RST code blocks.

I never noticed how this was rendered locally to see that it was wrong.

The current rendering before this change: https://ddtrace.readthedocs.io/en/latest/installation_quickstart.html


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
