### PR TITLE
Add span debug logging to _on_span_finish

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -536,7 +536,7 @@ class Tracer(object):
             return  # nothing to do
 
         if self.log.isEnabledFor(logging.DEBUG):
-            self.log.debug("finishing span %r", span)
+            self.log.debug("finishing span %s (enabled:%s)", span.pprint(), self.enabled)
 
         for p in self._span_processors:
             p.on_span_finish(span)

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -359,3 +359,15 @@ def test_error_output_ddtracerun():
     stderr = p.stderr.read()
     assert b"DATADOG TRACER CONFIGURATION" not in stderr
     assert b"DATADOG TRACER DIAGNOSTIC - Agent not reachable" not in stderr
+
+
+def test_debug_span_log():
+    p = subprocess.Popen(
+        ["python", "-c", 'import os; print(os.environ);import ddtrace; ddtrace.tracer.trace("span").finish()'],
+        env=dict(DD_TRACE_AGENT_URL="http://localhost:8126", DD_TRACE_DEBUG="true", **os.environ),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    p.wait()
+    stderr = p.stderr.read()
+    assert b"finishing span name='span'" in stderr

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -3,7 +3,6 @@
 tests for Tracer and utilities.
 """
 import contextlib
-import logging
 import multiprocessing
 import os
 from os import getpid

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -3,6 +3,7 @@
 tests for Tracer and utilities.
 """
 import contextlib
+import logging
 import multiprocessing
 import os
 from os import getpid
@@ -1514,3 +1515,16 @@ def test_spans_sampled_all(tracer, test_spans):
 
     spans = test_spans.pop()
     assert len(spans) == 3
+
+
+def test_span_debug_log(tracer):
+    tracer.log.setLevel(logging.DEBUG)
+    tracer.log = mock.MagicMock(wraps=tracer.log)
+    with tracer.trace("test") as span:
+        pass
+
+    tracer.log.debug.assert_has_calls(
+        [
+            mock.call("finishing span %s (enabled:%s)", span.pprint(), True),
+        ]
+    )

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1515,16 +1515,3 @@ def test_spans_sampled_all(tracer, test_spans):
 
     spans = test_spans.pop()
     assert len(spans) == 3
-
-
-def test_span_debug_log(tracer):
-    tracer.log.setLevel(logging.DEBUG)
-    tracer.log = mock.MagicMock(wraps=tracer.log)
-    with tracer.trace("test") as span:
-        pass
-
-    tracer.log.debug.assert_has_calls(
-        [
-            mock.call("finishing span %s (enabled:%s)", span.pprint(), True),
-        ]
-    )


### PR DESCRIPTION
This is done in `tracer.write()` but we should also do it here since `tracer.write()` is going to be deprecated and removed soon.
