### PR TITLE
refactor: kombu, celery, wsgi distributed tracing to use helper

### DIFF
--- a/ddtrace/contrib/celery/signals.py
+++ b/ddtrace/contrib/celery/signals.py
@@ -4,6 +4,7 @@ from ddtrace import Pin
 from ddtrace import config
 
 from . import constants as c
+from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanTypes
@@ -36,10 +37,8 @@ def trace_prerun(*args, **kwargs):
         log.debug("no pin found on task or task.app task_id=%s", task_id)
         return
 
-    if config.celery["distributed_tracing"]:
-        context = propagator.extract(task.request.get("headers", {}))
-        if context.trace_id:
-            pin.tracer.context_provider.activate(context)
+    request_headers = task.request.get("headers", {})
+    trace_utils.activate_distributed_headers(pin.tracer, int_config=config.celery, request_headers=request_headers)
 
     # propagate the `Span` in the current task Context
     service = config.celery["worker_service_name"]

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -5,6 +5,7 @@ from ddtrace import config
 from ddtrace.vendor import wrapt
 
 # project
+from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanTypes
@@ -87,10 +88,9 @@ def traced_receive(func, instance, args, kwargs):
 
     # Signature only takes 2 args: (body, message)
     message = args[1]
-    context = propagator.extract(message.headers)
-    # only need to active the new context if something was propagated
-    if context.trace_id:
-        pin.tracer.context_provider.activate(context)
+
+    trace_utils.activate_distributed_headers(pin.tracer, request_headers=message.headers, override=True)
+
     with pin.tracer.trace(kombux.RECEIVE_NAME, service=pin.service, span_type=SpanTypes.WORKER) as s:
         s.set_tag(SPAN_MEASURED_KEY)
         # run the command

--- a/ddtrace/contrib/wsgi/wsgi.py
+++ b/ddtrace/contrib/wsgi/wsgi.py
@@ -108,10 +108,7 @@ class DDWSGIMiddleware(object):
                 write = start_response(status, response_headers, exc_info)
             return write
 
-        if config.wsgi.distributed_tracing:
-            ctx = propagator.extract(environ)
-            if ctx.trace_id:
-                self.tracer.context_provider.activate(ctx)
+        trace_utils.activate_distributed_headers(self.tracer, int_config=config.wsgi, request_headers=environ)
 
         with self.tracer.trace(
             "wsgi.request",


### PR DESCRIPTION
## Description
Replaced usages of HTTPPropagator in kombu, celery, wsgi with trace_utils helper for distributed tracing.