### PR TITLE
chore(settings): remove unused copy methods

### DIFF
--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import os
 
 from .._hooks import Hooks
@@ -61,18 +60,6 @@ class IntegrationConfig(AttrDict):
         # integrations use service_name instead of service. These should be
         # unified.
         self.setdefault("service_name", service)
-
-    def __deepcopy__(self, memodict=None):
-        new = IntegrationConfig(self.global_config, self.integration_name, deepcopy(dict(self), memodict))
-        new.hooks = deepcopy(self.hooks, memodict)
-        new.http = deepcopy(self.http, memodict)
-        return new
-
-    def copy(self):
-        new = IntegrationConfig(self.global_config, self.integration_name, dict(self))
-        new.hooks = self.hooks
-        new.http = self.http
-        return new
 
     @property
     def trace_query_string(self):

--- a/tests/tracer/test_settings.py
+++ b/tests/tracer/test_settings.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 from ddtrace.settings import Config
 from ddtrace.settings import HttpConfig
 from ddtrace.settings import IntegrationConfig
@@ -265,30 +263,6 @@ class TestIntegrationConfig(BaseTestCase):
             config = Config()
             ic = IntegrationConfig(config, "foo")
             self.assertIsNone(ic.get_analytics_sample_rate(use_global_config=True))
-
-    def test_deepcopy(self):
-        ic = IntegrationConfig(
-            self.config, "foo", analytics_enabled=True, analytics_sample_rate=0.5, deep={"field": "sodeep"}
-        )
-        cpy = deepcopy(ic)
-        assert isinstance(cpy, IntegrationConfig)
-        assert cpy == ic
-        assert cpy.deep["field"] == ic.deep["field"]
-        ic.deep["field"] = ""
-        assert cpy.deep["field"] != ic.deep["field"]
-
-    def test_copy(self):
-        ic = IntegrationConfig(self.config, "foo", analytics_enabled=True, analytics_sample_rate=0.5)
-        copy = ic.copy()
-        assert isinstance(copy, IntegrationConfig)
-
-        for key in ic:
-            assert key in copy
-
-        for key in copy:
-            assert key in ic
-
-        assert ic == copy
 
     def test_service(self):
         ic = IntegrationConfig(self.config, "foo")


### PR DESCRIPTION
## Description

With #2358 there is no longer the need to copy integration configurations and therefore this code can be removed. This PR also supersedes #2085.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
