### PR TITLE
fix(grpc): ensure streaming response finish spans

### DIFF
--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -118,6 +118,9 @@ class _WrappedResponseCallFuture(wrapt.ObjectProxy):
     def __init__(self, wrapped, span):
         super(_WrappedResponseCallFuture, self).__init__(wrapped)
         self._span = span
+        # Registers callback on the _MultiThreadedRendezvous future to finish
+        # span in case StopIteration is never raised but RPC is terminated
+        _handle_response(self._span, self.__wrapped__)
 
     def __iter__(self):
         return self
@@ -133,8 +136,7 @@ class _WrappedResponseCallFuture(wrapt.ObjectProxy):
         try:
             return next(self.__wrapped__)
         except StopIteration:
-            # at end of iteration handle response status from wrapped future
-            _handle_response(self._span, self.__wrapped__)
+            # Callback will handle span finishing
             raise
         except grpc.RpcError as rpc_error:
             # DEV: grpcio<1.18.0 grpc.RpcError is raised rather than returned as response

--- a/releasenotes/notes/fix-grpc-streaming-prefetch-95e816bd0fd85723.yaml
+++ b/releasenotes/notes/fix-grpc-streaming-prefetch-95e816bd0fd85723.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    grpc: Add done callback in streaming response to avoid unfinished spans if a `StopIteration` is never raised, as is found in the Google Cloud libraries.


### PR DESCRIPTION
## Description

Use a done callback to finish span with server streaming responses. This addresses a problem that shows up in Google Cloud libraries that include a method wrapper that prefetches results. In the case that an RPC call only has one result this can lead to no `StopIteration` being raised but the RPC being terminated properly.

Using the Firestore tests in https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/firestore/cloud-client/, we can see how `grpc_helpers._StreamingResponseIterator` from the Google Core API library will be terminated after the prefetch but will not be called with another next in cases such as you find with the `/google.firestore.v1.Firestore/BatchGetDocuments` RPC:

```
> /Users/tahir.butt/.virtualenvs/APMS-5058-python-docs-samples/lib/python3.8/site-packages/google/api_core/grpc_helpers.py(114)next()
-> return result
(Pdb) l
109             try:
110                 if hasattr(self, "_stored_first_result"):
111                     result = self._stored_first_result
112                     del self._stored_first_result
113                     import pdb; pdb.set_trace()
114  ->                 return result
115                 return six.next(self._wrapped)
116             except grpc.RpcError as exc:
117                 # If the stream has already returned data, we cannot recover here.
118                 six.raise_from(exceptions.from_grpc_error(exc), exc)
119
(Pdb) result
found {
  name: "projects/buoyant-road-310215/databases/(default)/documents/dc_samples-e82d302c-e82d302c/distributed_counter/shards/0"
  fields {
    key: "count"
    value {
      integer_value: 1
    }
  }
  create_time {
    seconds: 1620055131
    nanos: 105013000
  }
  update_time {
    seconds: 1620055131
    nanos: 276290000
  }
}
read_time {
  seconds: 1620055131
  nanos: 424906000
}

(Pdb) self._wrapped
<_WrappedResponseCallFuture at 0x10481c100 for _MultiThreadedRendezvous at 0x1037ee040>
(Pdb) self._wrapped.__wrapped__
<_MultiThreadedRendezvous of RPC that terminated with:
        status = StatusCode.OK
        details = ""
>
```

## Checklist
- [ ] Added to the correct milestone.
- [X] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
