### PR TITLE
Added distributed header context extraction+activation to tracer

### DIFF
--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -13,7 +13,6 @@ from ddtrace import Pin
 from ddtrace import config
 from ddtrace.ext import http
 from ddtrace.internal.logger import get_logger
-from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.utils.cache import cached
 from ddtrace.utils.http import normalize_header_name
 from ddtrace.utils.http import strip_query_string
@@ -273,10 +272,7 @@ def activate_distributed_headers(tracer, int_config=None, request_headers=None, 
         return None
 
     if override or int_config.get("distributed_tracing_enabled", int_config.get("distributed_tracing", False)):
-        context = HTTPPropagator.extract(request_headers)
-        # Only need to activate the new context if something was propagated
-        if context.trace_id:
-            tracer.context_provider.activate(context)
+        tracer.activate_distributed_header(request_headers)
 
 
 def flatten_dict(

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1,6 +1,9 @@
+import abc
 from typing import Dict
 from typing import FrozenSet
 from typing import Optional
+
+import six
 
 from ..context import Context
 from ..internal.logger import get_logger
@@ -27,7 +30,23 @@ POSSIBLE_HTTP_HEADER_SAMPLING_PRIORITIES = frozenset(
 POSSIBLE_HTTP_HEADER_ORIGIN = frozenset([HTTP_HEADER_ORIGIN, get_wsgi_header(HTTP_HEADER_ORIGIN).lower()])
 
 
-class HTTPPropagator(object):
+class Propagator(six.with_metaclass(abc.ABCMeta)):
+    """Base Propagator using request headers as carrier."""
+
+    @staticmethod
+    @abc.abstractmethod
+    def inject(span_context, headers):
+        # type: (Context, Dict[str, str]) -> None
+        pass
+
+    @staticmethod
+    @abc.abstractmethod
+    def extract(headers):
+        # type: (Dict[str, str]) -> Context
+        pass
+
+
+class HTTPPropagator(Propagator):
     """A HTTP Propagator using HTTP headers as carrier."""
 
     @staticmethod

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -77,16 +77,24 @@ required metadata to piece together the trace.
 .. autoclass:: ddtrace.propagation.http.HTTPPropagator
     :members:
 
+Context extraction and activation is also built into the tracer:
+
+.. autoclass:: ddtrace.tracer.Tracer.activate_distributed_headers
+    :members:
+
 Custom
 ^^^^^^
 
-You can manually propagate your tracing context over your RPC protocol. Here is
+You can manually propagate your tracing context over your RPC protocol by creating your
+own Propagator class based on `ddtrace.propagation.http.Propagator`. Here is
 an example assuming that you have `rpc.call` function that call a `method` and
 propagate a `rpc_metadata` dictionary over the wire::
 
 
     # Implement your own context propagator
-    class MyRPCPropagator(object):
+    from ddtrace.propagation.http import Propagator
+
+    class MyRPCPropagator(Propagator):
         def inject(self, span_context, rpc_metadata):
             rpc_metadata.update({
                 'trace_id': span_context.trace_id,

--- a/releasenotes/notes/tracer-propagtor-e04b0f1757727a64.yaml
+++ b/releasenotes/notes/tracer-propagtor-e04b0f1757727a64.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    The tracer now includes a propagator (HTTPPropagator by default but user-configurable) and can extract
+    and activate Contexts from request headers for distributed tracing.


### PR DESCRIPTION
## Description
Currently, users have to create their own Propagator classes and/or use the `HTTPPropagator` along with extra steps of extracting the context from request headers and activating them with the `ContextProvider` class to achieve distributed tracing, described by our documentation as such:

```python
context = HTTPPropagator.extract(headers)
    if context.trace_id:
        tracer.context_provider.activate(context)
```

This is made easier by making it so that the `Tracer` class has access to a `Propagator` property (`HTTPPropagator` by default) and provides a function `activate_distributed_headers()` that accomplishes the aforementioned steps in extracting and activating a distributed request.

Additionally, an abstract `Propagator` class was introduced to base our `HTTPPropagator` and users' custom Propagator classes from, and to provide the base methods of injecting and extracting contexts into/from request headers.


Resolves #1362, #3066