### PR TITLE
chore(dbapi2): deprecate analytics

### DIFF
--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -16,6 +16,7 @@ config._add(
     dict(
         _default_service="mysql",
         trace_fetch_methods=asbool(get_env("mysql", "trace_fetch_methods", default=False)),
+        _deprecated_name="dbapi2",
     ),
 )
 

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -19,6 +19,7 @@ config._add(
     dict(
         _default_service="mysql",
         trace_fetch_methods=asbool(get_env("mysqldb", "trace_fetch_methods", default=False)),
+        _deprecated_name="dbapi2",
     ),
 )
 

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -20,6 +20,7 @@ config._add(
     dict(
         _default_service="postgres",
         trace_fetch_methods=asbool(get_env("psycopg", "trace_fetch_methods", default=False)),
+        _deprecated_name="dbapi2",
     ),
 )
 

--- a/ddtrace/contrib/pymysql/patch.py
+++ b/ddtrace/contrib/pymysql/patch.py
@@ -19,6 +19,7 @@ config._add(
         # TODO[v1.0] this should be "mysql"
         _default_service="pymysql",
         trace_fetch_methods=asbool(get_env("pymysql", "trace_fetch_methods", default=False)),
+        _deprecated_name="dbapi2",
     ),
 )
 

--- a/ddtrace/contrib/pyodbc/patch.py
+++ b/ddtrace/contrib/pyodbc/patch.py
@@ -15,6 +15,7 @@ config._add(
     dict(
         _default_service="pyodbc",
         trace_fetch_methods=asbool(get_env("pyodbc", "trace_fetch_methods", default=False)),
+        _deprecated_name="dbapi2",
     ),
 )
 

--- a/ddtrace/contrib/sqlite3/patch.py
+++ b/ddtrace/contrib/sqlite3/patch.py
@@ -23,6 +23,7 @@ config._add(
     dict(
         _default_service="sqlite",
         trace_fetch_methods=asbool(get_env("sqlite", "trace_fetch_methods", default=False)),
+        _deprecated_name="dbapi2",
     ),
 )
 

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -1,4 +1,8 @@
 import os
+from typing import Optional
+from typing import Tuple
+
+from ddtrace.vendor import debtcollector
 
 from .._hooks import Hooks
 from ..utils.attrdict import AttrDict
@@ -39,20 +43,9 @@ class IntegrationConfig(AttrDict):
         object.__setattr__(self, "hooks", Hooks())
         object.__setattr__(self, "http", HttpConfig())
 
-        # Set default analytics configuration, default is disabled
-        # DEV: Default to `None` which means do not set this key
-        # Inject environment variables for integration
-        old_analytics_enabled_env = get_env(name, "analytics_enabled")
-        analytics_enabled_env = os.environ.get(
-            "DD_TRACE_%s_ANALYTICS_ENABLED" % name.upper(), old_analytics_enabled_env
-        )
-        if analytics_enabled_env is not None:
-            analytics_enabled_env = asbool(analytics_enabled_env)
-        self.setdefault("analytics_enabled", analytics_enabled_env)
-        old_analytics_rate = get_env(name, "analytics_sample_rate", default=1.0)
-
-        analytics_rate = os.environ.get("DD_TRACE_%s_ANALYTICS_SAMPLE_RATE" % name.upper(), old_analytics_rate)
-        self.setdefault("analytics_sample_rate", float(analytics_rate))
+        analytics_enabled, analytics_sample_rate = self._get_analytics_settings()
+        self.setdefault("analytics_enabled", analytics_enabled)
+        self.setdefault("analytics_sample_rate", float(analytics_sample_rate))
 
         service = get_env(name, "service", default=get_env(name, "service_name", default=None))
         self.setdefault("service", service)
@@ -60,6 +53,46 @@ class IntegrationConfig(AttrDict):
         # integrations use service_name instead of service. These should be
         # unified.
         self.setdefault("service_name", service)
+
+    def _get_analytics_settings(self):
+        # type: () -> Tuple[Optional[bool], float]
+        # We can have deprecated names for integrations used for analytics settings
+        deprecated_name = deprecated_analytics_enabled = deprecated_analytics_sample_rate = None
+        if hasattr(self, "_deprecated_name"):
+            deprecated_name = self._deprecated_name
+            deprecated_analytics_enabled = get_env(deprecated_name, "analytics_enabled") or os.environ.get(
+                "DD_TRACE_%s_ANALYTICS_ENABLED" % deprecated_name.upper()
+            )
+            deprecated_analytics_sample_rate = get_env(deprecated_name, "analytics_sample_rate") or os.environ.get(
+                "DD_TRACE_%s_ANALYTICS_SAMPLE_RATE" % deprecated_name.upper()
+            )
+            if deprecated_analytics_enabled is not None or deprecated_analytics_sample_rate is not None:
+                debtcollector.deprecate(
+                    (
+                        "*DBAPI2_ANALYTICS* environment variables are now deprecated, "
+                        "use integration-specific configuration."
+                    ),
+                    removal_version="0.50.0",
+                )
+
+        # Set default analytics configuration, default is disabled
+        # DEV: Default to `None` which means do not set this key
+        # Inject environment variables for integration
+        _ = (
+            os.environ.get("DD_TRACE_%s_ANALYTICS_ENABLED" % self.integration_name.upper())
+            or get_env(self.integration_name, "analytics_enabled")
+            or deprecated_analytics_enabled
+        )
+        analytics_enabled = asbool(_) if _ is not None else None
+
+        analytics_sample_rate = float(
+            os.environ.get("DD_TRACE_%s_ANALYTICS_SAMPLE_RATE" % self.integration_name.upper())
+            or get_env(self.integration_name, "analytics_sample_rate")
+            or deprecated_analytics_sample_rate
+            or 1.0
+        )
+
+        return analytics_enabled, analytics_sample_rate
 
     @property
     def trace_query_string(self):

--- a/releasenotes/notes/dbapi2-deprecate-analytics-config-ececae6e9274f852.yaml
+++ b/releasenotes/notes/dbapi2-deprecate-analytics-config-ececae6e9274f852.yaml
@@ -1,0 +1,12 @@
+---
+deprecations:
+  - |
+    Deprecate the configuration of the analytics through the generic dbapi2
+    configuration. This should now be configured via integration configurations,
+    for example::
+
+      # Before
+      export DD_TRACE_DBAPI2_ANALYTICS_ENABLED=1
+
+      # After
+      export DD_TRACE_SQLITE3_ANALYTICS_ENABLED=1

--- a/tests/tracer/test_settings.py
+++ b/tests/tracer/test_settings.py
@@ -268,6 +268,38 @@ class TestIntegrationConfig(BaseTestCase):
         ic = IntegrationConfig(self.config, "foo")
         assert ic.service is None
 
+    def test_get_analytics_sample_rate_deprecated_name(self):
+        """Check method for accessing sample rate based on configuration"""
+        with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED="True")):
+            config = Config()
+            ic = IntegrationConfig(config, "bar", _deprecated_name="foo")
+            self.assertEqual(ic.get_analytics_sample_rate(), 1.0)
+
+        with self.override_env(dict(DD_TRACE_FOO_ANALYTICS_ENABLED="True")):
+            config = Config()
+            ic = IntegrationConfig(config, "bar", _deprecated_name="foo")
+            self.assertEqual(ic.get_analytics_sample_rate(), 1.0)
+
+        with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED="True", DD_FOO_ANALYTICS_SAMPLE_RATE="0.5")):
+            config = Config()
+            ic = IntegrationConfig(config, "bar", _deprecated_name="foo")
+            self.assertEqual(ic.get_analytics_sample_rate(), 0.5)
+
+        with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED="True", DD_TRACE_FOO_ANALYTICS_SAMPLE_RATE="0.5")):
+            config = Config()
+            ic = IntegrationConfig(config, "bar", _deprecated_name="foo")
+            self.assertEqual(ic.get_analytics_sample_rate(), 0.5)
+
+        with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED="False")):
+            config = Config()
+            ic = IntegrationConfig(config, "bar", _deprecated_name="foo")
+            self.assertIsNone(ic.get_analytics_sample_rate())
+
+        with self.override_env(dict(DD_TRACE_FOO_ANALYTICS_ENABLED="False")):
+            config = Config()
+            ic = IntegrationConfig(config, "bar", _deprecated_name="foo")
+            self.assertIsNone(ic.get_analytics_sample_rate())
+
     @BaseTestCase.run_in_subprocess(env_overrides=dict(DD_FOO_SERVICE="foo-svc"))
     def test_service_env_var(self):
         ic = IntegrationConfig(self.config, "foo")


### PR DESCRIPTION
## Description

As part of the effort of deprecating the `dbapi2` configuration, this change deprecates configuring analytics via the `dbapi2` generic configuration.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
