### PR TITLE
Enable futures integration by default

### DIFF
--- a/ddtrace/contrib/futures/__init__.py
+++ b/ddtrace/contrib/futures/__init__.py
@@ -1,18 +1,19 @@
 """
-The ``futures`` integration propagates the current active Tracing Context
+The ``futures`` integration propagates the current active tracing context
 between threads. The integration ensures that when operations are executed
 in a new thread, that thread can continue the previously generated trace.
 
-The integration doesn't trace automatically threads execution, so manual
-instrumentation or another integration must be activated. Threads propagation
-is not enabled by default with the `patch_all()` method and must be activated
-as follows::
 
-    from ddtrace import patch, patch_all
+Enabling
+~~~~~~~~
 
+The futures integration is enabled automatically when using
+:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+
+Or use :ref:`patch()<patch>` to manually enable the integration::
+
+    from ddtrace import patch
     patch(futures=True)
-    # or, when instrumenting all libraries
-    patch_all(futures=True)
 """
 from ...utils.importlib import require_modules
 

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -36,7 +36,7 @@ PATCH_MODULES = {
     "django": True,
     "elasticsearch": True,
     "algoliasearch": True,
-    "futures": False,  # experimental propagation
+    "futures": True,
     "grpc": True,
     "mongoengine": True,
     "mysql": True,

--- a/releasenotes/notes/futures-f485da98a50c9d50.yaml
+++ b/releasenotes/notes/futures-f485da98a50c9d50.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The futures integration is now enabled by default.


### PR DESCRIPTION
I don't see a reason for why it should not be enabled by default.

## Checklist
- [ ] Added to the correct milestone.
- [x] ~Tests provided or description of manual testing performed is included in the code or PR.~
- [x] Library documentation is updated.
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
