### PR TITLE
fix(monkey): use correct integration name when patching-on-import a module that is already loaded

### DIFF
--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -178,7 +178,8 @@ def patch(raise_errors=True, **patch_modules):
             for m in modules_to_poi:
                 # If the module has already been imported then patch immediately
                 if m in sys.modules:
-                    patch_module(m, raise_errors=raise_errors)
+                    patch_module(module, raise_errors=raise_errors)
+                    break
                 # Otherwise, add a hook to patch when it is imported for the first time
                 else:
                     # Use factory to create handler to close over `module` and `raise_errors` values from this loop

--- a/releasenotes/notes/fix-monkey-patch-on-import-7bbf81bcd2a86f11.yaml
+++ b/releasenotes/notes/fix-monkey-patch-on-import-7bbf81bcd2a86f11.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug that prevented the right integration name to be used when
+    trying to patch a module on import that is already loaded.


### PR DESCRIPTION
## Description

The fix affects elasticsearch in particular. The wrong integration name was being used when patching-on-import a module that was already loaded. Fixes #2272.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
