### PR TITLE
ci(coverage): disable coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ commands:
         default: ""
       store_coverage:
         type: boolean
-        default: true
+        default: false
     steps:
       - attach_workspace:
           at: .
@@ -193,7 +193,7 @@ commands:
         default: ""
       store_coverage:
         type: boolean
-        default: true
+        default: false
     steps:
       - checkout
       - setup_tox
@@ -1096,4 +1096,4 @@ workflows:
       - wsgi: *requires_base_venvs
 
       # Final reports
-      - coverage_report: *requires_tests
+      # - coverage_report: *requires_tests

--- a/riotfile.py
+++ b/riotfile.py
@@ -75,8 +75,8 @@ venv = Venv(
     pkgs={
         "mock": latest,
         "pytest": latest,
-        "coverage": latest,
-        "pytest-cov": latest,
+        # "coverage": latest,
+        # "pytest-cov": latest,
         "opentracing": latest,
         "hypothesis": latest,
     },
@@ -141,7 +141,7 @@ venv = Venv(
             name="benchmarks",
             pys=select_pys(),
             pkgs={"pytest-benchmark": latest, "msgpack": latest},
-            command="pytest --no-cov {cmdargs} tests/benchmarks",
+            command="pytest {cmdargs} tests/benchmarks",
         ),
         Venv(
             name="tracer",
@@ -163,7 +163,7 @@ venv = Venv(
         ),
         Venv(
             name="ddtracerun",
-            command="pytest {cmdargs} --no-cov tests/commands/test_runner.py",
+            command="pytest {cmdargs} tests/commands/test_runner.py",
             pys=select_pys(),
             pkgs={
                 "redis": latest,

--- a/tests/profiling/conftest.py
+++ b/tests/profiling/conftest.py
@@ -5,4 +5,7 @@ import pytest
 
 @pytest.fixture(scope="session", autouse=True)
 def disable_coverage_for_subprocess():
-    del os.environ["COV_CORE_SOURCE"]
+    try:
+        del os.environ["COV_CORE_SOURCE"]
+    except KeyError:
+        pass

--- a/tox.ini
+++ b/tox.ini
@@ -128,7 +128,6 @@ extras =
 
 deps =
     cython
-    pytest-cov
     pytest-mock
     opentracing
 # test dependencies installed in all envs
@@ -347,7 +346,7 @@ commands =
     opentracer_asyncio: pytest {posargs} tests/opentracer/test_tracer_asyncio.py
     opentracer_tornado-tornado{40,41,42,43,44}: pytest {posargs} tests/opentracer/test_tracer_tornado.py
     opentracer_gevent: pytest {posargs} tests/opentracer/test_tracer_gevent.py
-    integration-{v5,latest,snapshot}: pytest --no-cov {posargs} tests/integration/
+    integration-{v5,latest,snapshot}: pytest {posargs} tests/integration/
 # Contribs
     aiobotocore_contrib: pytest {posargs} tests/contrib/aiobotocore
     aiopg_contrib: pytest {posargs} tests/contrib/aiopg
@@ -404,7 +403,9 @@ ignore_outcome=true
 # DEV: We use `conftest.py` as a local pytest plugin to configure hooks for collection
 [pytest]
 # --cov-report is intentionally empty else pytest-cov will default to generating a report
-addopts = -p tests.cache.conftest --cov=ddtrace/ --cov=tests/ --cov-append --cov-report= --durations=10 --junitxml=test-results/junit.xml
+# DEV: cov report is being disabled as it tries to analyze .so objects in CI runs
+# addopts = -p tests.cache.conftest --cov=ddtrace/ --cov=tests/ --cov-append --cov-report= --durations=10 --junitxml=test-results/junit.xml
+addopts = -p tests.cache.conftest --durations=10 --junitxml=test-results/junit.xml
 # DEV: The default is `test_*\.py` which will miss `test.py` files
 python_files = test*\.py
 filterwarnings =


### PR DESCRIPTION
## Description

Coverage is being disabled to allow the CI to finish test runs. At the moment of making this change, the coverage tool tries to analyse .so files from the library and fails with an encoding error.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
