### PR TITLE
Skip testing Flask >=2.0.0 and Jinja2 >=3.0.0

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -631,7 +631,7 @@ venv = Venv(
                 Venv(
                     pys=select_pys(),
                     pkgs={
-                        "flask": ["~=1.0.0", "~=1.1.0", latest],
+                        "flask": ["~=1.0.0", "~=1.1.0", "<2.0.0"],
                     },
                 ),
                 Venv(
@@ -642,7 +642,7 @@ venv = Venv(
                         "DATADOG_PATCH_MODULES": "jinja2:false",
                     },
                     pkgs={
-                        "flask": ["~=1.0.0", "~=1.1.0", latest],
+                        "flask": ["~=1.0.0", "~=1.1.0", "<2.0.0"],
                     },
                 ),
             ],

--- a/tox.ini
+++ b/tox.ini
@@ -199,7 +199,7 @@ deps =
     gevent12: gevent>=1.2,<1.3
     gevent13: gevent>=1.3,<1.4
     gevent14: gevent>=1.4,<1.5
-    jinja: jinja2
+    jinja: jinja2<3.0.0
     jinja27: jinja2>=2.7,<2.8
     jinja28: jinja2>=2.8,<2.9
     jinja29: jinja2>=2.9,<2.10


### PR DESCRIPTION
Temporary skip Flask >=2.0.0 and Jinja2 >= 3.0.0 until our integrations are compatible.