### PR TITLE
Pytest: Enable CI App feature tracking

### DIFF
--- a/.dd-ci/README.md
+++ b/.dd-ci/README.md
@@ -1,0 +1,8 @@
+# CI App Python Tracer Feature Tracking 
+
+## Description:
+
+The `ci-app-spec.json` file tracks the CI App features supported by 
+the tracer, currently for pytest spans. This file is then
+used in the [datadog-ci-spec](https://github.com/DataDog/datadog-ci-spec/blob/main/.github/workflows/feature-track.yml) 
+repository. 

--- a/.dd-ci/ci-app-spec.json
+++ b/.dd-ci/ci-app-spec.json
@@ -1,0 +1,19 @@
+[
+  "ci.job.name",
+  "ci.job.url",
+  "ci.pipeline.id",
+  "ci.pipeline.name",
+  "ci.pipeline.number",
+  "ci.pipeline.url",
+  "ci.provider.name",
+  "ci.stage.name",
+  "ci.workspace_path",
+  "git.branch",
+  "git.commit.sha",
+  "git.repository.url",
+  "git.tag",
+  "test.framework",
+  "test.name",
+  "test.suite",
+  "test.type"
+]

--- a/.dd-ci/ci-app-spec.json
+++ b/.dd-ci/ci-app-spec.json
@@ -12,8 +12,12 @@
   "git.commit.sha",
   "git.repository.url",
   "git.tag",
+  "pytest.result",
+  "pytest.xfail.reason",
   "test.framework",
   "test.name",
+  "test.skip_reason",
+  "test.status",
   "test.suite",
   "test.type"
 ]


### PR DESCRIPTION
## Description
The CI App uses the `ci-app-spec.json` file to generate a dynamic HTML page with tags supported by each tracer in the context of the CI App. As the Python tracer is currently updating the pytest plugin to add more tags in an ongoing effort to reach feature parity with the other tracers, this will help visualize the progress of the ongoing work.