### PR TITLE
refactor(service): make Service class thread-safe

### DIFF
--- a/ddtrace/internal/periodic.py
+++ b/ddtrace/internal/periodic.py
@@ -168,7 +168,7 @@ def PeriodicRealThreadClass():
 class PeriodicService(service.Service):
     """A service that runs periodically."""
 
-    _interval = attr.ib()
+    _interval = attr.ib(type=float)
     _worker = attr.ib(default=None, init=False, repr=False)
 
     _real_thread = False
@@ -176,17 +176,25 @@ class PeriodicService(service.Service):
 
     @property
     def interval(self):
+        # type: (...) -> float
         return self._interval
 
     @interval.setter
-    def interval(self, value):
+    def interval(
+        self, value  # type: float
+    ):
+        # type: (...) -> None
         self._interval = value
         # Update the interval of the PeriodicThread based on ours
         if self._worker:
             self._worker.interval = value
 
-    def _start(self):
-        # type: () -> None
+    def _start_service(
+        self,
+        *args,  # type: typing.Any
+        **kwargs  # type: typing.Any
+    ):
+        # type: (...) -> None
         """Start the periodic service."""
         periodic_thread_class = PeriodicRealThreadClass() if self._real_thread else PeriodicThread
         self._worker = periodic_thread_class(
@@ -197,15 +205,22 @@ class PeriodicService(service.Service):
         )
         self._worker.start()
 
-    def join(self, timeout=None):
+    def _stop_service(
+        self,
+        *args,  # type: typing.Any
+        **kwargs  # type: typing.Any
+    ):
+        # type: (...) -> None
+        """Stop the periodic collector."""
+        self._worker.stop()
+        super(PeriodicService, self)._stop_service(*args, **kwargs)
+
+    def join(
+        self, timeout=None  # type: typing.Optional[float]
+    ):
+        # type: (...) -> None
         if self._worker:
             self._worker.join(timeout)
-
-    def stop(self):
-        """Stop the periodic collector."""
-        if self._worker:
-            self._worker.stop()
-        super(PeriodicService, self).stop()
 
     @staticmethod
     def on_shutdown():

--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -142,10 +142,11 @@ class RuntimeWorker(periodic.PeriodicService):
                 log.debug("Writing metric %s:%s", key, value)
                 self._dogstatsd_client.gauge(key, value)
 
-    def stop(self):
+    def _stop_service(self):  # type: ignore[override]
+        # type: (...) -> None
         # De-register span hook
+        super(RuntimeWorker, self)._stop_service()
         self.tracer.deregister_on_start_span(self._set_language_on_span)
-        super(RuntimeWorker, self).stop()
 
     def update_runtime_tags(self):
         # type: () -> None

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -361,16 +361,14 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
 
     def write(self, spans=None):
         # type: (Optional[List[Span]]) -> None
-        # Start the AgentWriter on first write.
-        # Starting it earlier might be an issue with gevent, see:
-        # https://github.com/DataDog/dd-trace-py/issues/1192
         if spans is None:
             return
 
         if self._sync_mode is False:
+            # Start the AgentWriter on first write.
             try:
                 self.start()
-            except service.ServiceAlreadyRunning:
+            except service.ServiceStatusError:
                 pass
 
         self._metrics_dist("writer.accepted.traces")
@@ -443,10 +441,13 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
     def periodic(self):
         self.flush_queue(raise_exc=False)
 
-    def stop(self, timeout=None):
-        # type: (Optional[float]) -> None
+    def _stop_service(  # type: ignore[override]
+        self,
+        timeout=None,  # type: Optional[float]
+    ):
+        # type: (...) -> None
         # FIXME: don't join() on stop(), let the caller handle this
-        super(AgentWriter, self).stop()
+        super(AgentWriter, self)._stop_service()
         self.join(timeout=timeout)
 
     on_shutdown = periodic

--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -96,21 +96,25 @@ class MemoryCollector(collector.PeriodicCollector):
     heap_sample_size = attr.ib(type=int, factory=_get_default_heap_sample_size)
     ignore_profiler = attr.ib(factory=attr_utils.from_env("DD_PROFILING_IGNORE_PROFILER", True, formats.asbool))
 
-    def _start(self):
+    def _start_service(self):  # type: ignore[override]
+        # type: (...) -> None
         """Start collecting memory profiles."""
         if _memalloc is None:
             raise collector.CollectorUnavailable
 
         _memalloc.start(self.max_nframe, self._max_events, self.heap_sample_size)
-        super(MemoryCollector, self)._start()
 
-    def stop(self):
+        super(MemoryCollector, self)._start_service()
+
+    def _stop_service(self):  # type: ignore[override]
+        # type: (...) -> None
+        super(MemoryCollector, self)._stop_service()
+
         if _memalloc is not None:
             try:
                 _memalloc.stop()
             except RuntimeError:
                 pass
-            super(MemoryCollector, self).stop()
 
     def _get_thread_id_ignore_set(self):
         # type: () -> typing.Set[int]

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -481,13 +481,13 @@ class StackCollector(collector.PeriodicCollector):
             self._thread_span_links = _ThreadSpanLinks()
             self.tracer.on_start_span(self._thread_span_links.link_span)
 
-    def _start(self):
+    def _start_service(self):
         # This is split in its own function to ease testing
         self._init()
-        super(StackCollector, self)._start()
+        super(StackCollector, self)._start_service()
 
-    def stop(self):
-        super(StackCollector, self).stop()
+    def _stop_service(self):
+        super(StackCollector, self)._stop_service()
         if self.tracer is not None:
             self.tracer.deregister_on_start_span(self._thread_span_links.link_span)
 

--- a/ddtrace/profiling/collector/threading.py
+++ b/ddtrace/profiling/collector/threading.py
@@ -162,17 +162,20 @@ class LockCollector(collector.CaptureSamplerCollector):
     nframes = attr.ib(factory=attr_utils.from_env("DD_PROFILING_MAX_FRAMES", 64, int))
     tracer = attr.ib(default=None)
 
-    def start(self):
+    def _start_service(self):  # type: ignore[override]
+        # type: (...) -> None
         """Start collecting `threading.Lock` usage."""
-        super(LockCollector, self).start()
         self.patch()
+        super(LockCollector, self)._start_service()
 
-    def stop(self):
+    def _stop_service(self):  # type: ignore[override]
+        # type: (...) -> None
         """Stop collecting `threading.Lock` usage."""
+        super(LockCollector, self)._stop_service()
         self.unpatch()
-        super(LockCollector, self).stop()
 
     def patch(self):
+        # type: (...) -> None
         """Patch the threading module for tracking lock allocation."""
         # We only patch the lock from the `threading` module.
         # Nobody should use locks from `_thread`; if they do so, then it's deliberate and we don't profile.
@@ -182,8 +185,9 @@ class LockCollector(collector.CaptureSamplerCollector):
             lock = wrapped(*args, **kwargs)
             return _ProfiledLock(lock, self.recorder, self.tracer, self.nframes, self._capture_sampler)
 
-        threading.Lock = FunctionWrapper(self.original, _allocate_lock)
+        threading.Lock = FunctionWrapper(self.original, _allocate_lock)  # type: ignore[misc]
 
     def unpatch(self):
+        # type: (...) -> None
         """Unpatch the threading module for tracking lock allocation."""
-        threading.Lock = self.original
+        threading.Lock = self.original  # type: ignore[misc]

--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -28,10 +28,11 @@ class Scheduler(periodic.PeriodicService):
         # Copy the value to use it later since we're going to adjust the real interval
         self._configured_interval = self.interval
 
-    def start(self):
+    def _start_service(self):  # type: ignore[override]
+        # type: (...) -> None
         """Start the scheduler."""
         LOG.debug("Starting scheduler")
-        super(Scheduler, self).start()
+        super(Scheduler, self)._start_service()
         self._last_export = compat.time_ns()
         LOG.debug("Scheduler started")
 

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -33,6 +33,7 @@ from .internal import atexit
 from .internal import compat
 from .internal import debug
 from .internal import hostname
+from .internal import service
 from .internal.dogstatsd import get_dogstatsd_client
 from .internal.logger import get_logger
 from .internal.logger import hasHandlers
@@ -312,7 +313,11 @@ class Tracer(object):
             # get the URL from.
             url = None  # type: ignore
 
-        self.writer.stop()
+        try:
+            self.writer.stop()
+        except service.ServiceStatusError:
+            # It's possible the writer never got started in the first place :(
+            pass
 
         if writer is not None:
             self.writer = writer
@@ -828,7 +833,11 @@ class Tracer(object):
             before exiting or :obj:`None` to block until flushing has successfully completed (default: :obj:`None`)
         :type timeout: :obj:`int` | :obj:`float` | :obj:`None`
         """
-        self.writer.stop(timeout=timeout)
+        try:
+            self.writer.stop(timeout=timeout)
+        except service.ServiceStatusError:
+            # It's possible the writer never got started in the first place :(
+            pass
         atexit.unregister(self._atexit)
 
     @staticmethod

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -31,11 +31,7 @@ def test_restart():
 
 
 def test_multiple_stop():
-    """Check that the profiler can be stopped twice.
-
-    This is useful since the atexit.unregister call might not exist on Python 2,
-    therefore the profiler can be stopped twice (once per the user, once at exit).
-    """
+    """Check that the profiler can be stopped twice."""
     p = profiler.Profiler()
     p.start()
     p.stop(flush=False)
@@ -252,6 +248,12 @@ def test_snapshot(monkeypatch):
         def snapshot():
             return [[event.Event()]]
 
+        def _start_service(self):
+            pass
+
+        def _stop_service(self):
+            pass
+
     all_events = {}
 
     class Exporter(exporter.Exporter):
@@ -273,8 +275,11 @@ def test_snapshot(monkeypatch):
 
 def test_failed_start_collector(caplog, monkeypatch):
     class ErrCollect(collector.Collector):
-        def start(self):
+        def _start_service(self):
             raise RuntimeError("could not import required module")
+
+        def _stop_service(self):
+            pass
 
         @staticmethod
         def collect():

--- a/tests/tracer/test_periodic.py
+++ b/tests/tracer/test_periodic.py
@@ -107,12 +107,14 @@ def test_gevent_class():
 def test_periodic_service_start_stop():
     t = periodic.PeriodicService(1)
     t.start()
-    with pytest.raises(service.ServiceAlreadyRunning):
+    with pytest.raises(service.ServiceStatusError):
         t.start()
     t.stop()
     t.join()
-    t.stop()
-    t.stop()
+    with pytest.raises(service.ServiceStatusError):
+        t.stop()
+    with pytest.raises(service.ServiceStatusError):
+        t.stop()
     t.join()
     t.join()
 
@@ -120,12 +122,15 @@ def test_periodic_service_start_stop():
 def test_periodic_join_stop_no_start():
     t = periodic.PeriodicService(1)
     t.join()
-    t.stop()
+    with pytest.raises(service.ServiceStatusError):
+        t.stop()
     t.join()
     t = periodic.PeriodicService(1)
-    t.stop()
+    with pytest.raises(service.ServiceStatusError):
+        t.stop()
     t.join()
-    t.stop()
+    with pytest.raises(service.ServiceStatusError):
+        t.stop()
 
 
 def test_is_alive_before_start():

--- a/tests/tracer/test_service.py
+++ b/tests/tracer/test_service.py
@@ -3,8 +3,16 @@ import pytest
 from ddtrace.internal import service
 
 
+class MyService(service.Service):
+    def _start_service(self):
+        pass
+
+    def _stop_service(self):
+        pass
+
+
 def test_service_status():
-    s = service.Service()
+    s = MyService()
     assert s.status == service.ServiceStatus.STOPPED
     s.start()
     assert s.status == service.ServiceStatus.RUNNING
@@ -13,15 +21,44 @@ def test_service_status():
     s.start()
     assert s.status == service.ServiceStatus.RUNNING
     s.stop()
+    assert s.status == service.ServiceStatus.STOPPED
+
+
+def test_service_status_multi_start():
+    s = MyService()
+    assert s.status == service.ServiceStatus.STOPPED
+    s.start()
+    with pytest.raises(service.ServiceStatusError) as e:
+        s.start()
+    assert e.value.current_status == service.ServiceStatus.RUNNING
+    assert str(e.value) == "MyService is already in status running"
+    assert s.status == service.ServiceStatus.RUNNING
+    s.stop()
+    with pytest.raises(service.ServiceStatusError) as e:
+        s.stop()
+    assert e.value.current_status == service.ServiceStatus.STOPPED
+    assert str(e.value) == "MyService is already in status stopped"
     assert s.status == service.ServiceStatus.STOPPED
 
 
 def test_service_status_on_fail():
-    class ServiceFail(service.Service):
-        def _start(self):
+    class ServiceFail(MyService):
+        def _start_service(self):
             raise RuntimeError
 
     s = ServiceFail()
     with pytest.raises(RuntimeError):
         s.start()
     assert s.status == service.ServiceStatus.STOPPED
+
+
+def test_service_status_on_fail_stop():
+    class ServiceFail(MyService):
+        def _stop_service(self):
+            raise RuntimeError
+
+    s = ServiceFail()
+    s.start()
+    with pytest.raises(RuntimeError):
+        s.stop()
+    assert s.status == service.ServiceStatus.RUNNING

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -11,7 +11,6 @@ from six.moves import BaseHTTPServer
 from six.moves import socketserver
 
 from ddtrace.constants import KEEP_SPANS_RATE_KEY
-from ddtrace.internal import service
 from ddtrace.internal.compat import PY3
 from ddtrace.internal.compat import get_connection_response
 from ddtrace.internal.compat import httplib
@@ -488,14 +487,3 @@ def test_racing_start():
         t.join()
 
     assert len(writer._buffer) == 100
-
-
-def test_double_stop():
-    # Ensure double stopping doesn't result in an exception.
-    writer = AgentWriter(agent_url="http://dne:1234")
-    writer.write([])
-    assert writer.status == service.ServiceStatus.RUNNING
-    writer.stop()
-    assert writer.status == service.ServiceStatus.STOPPED
-    writer.stop()
-    assert writer.status == service.ServiceStatus.STOPPED


### PR DESCRIPTION
This makes the base Service class entirely thread safe for starting and
stopping services.

Service must now implement a _{start,stop}_service method which does the heavy
work and is guaranteed to run only once in a thread-safe manner.