### PR TITLE
chore: move pytest tests from tox to riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -688,8 +688,8 @@ jobs:
   pytest:
     executor: ddtrace_dev
     steps:
-      - run_tox_scenario:
-          pattern: '^pytest_contrib'
+      - run_test:
+          pattern: 'pytest'
 
   pymemcache:
     <<: *contrib_job

--- a/riotfile.py
+++ b/riotfile.py
@@ -884,6 +884,29 @@ venv = Venv(
             ],
         ),
         Venv(
+            name="pytest",
+            command="pytest {cmdargs} tests/contrib/pytest",
+            venvs=[
+                Venv(
+                    pys=["2.7"],
+                    # pytest==4.6 is last to support python 2.7
+                    pkgs={"pytest": ">=4.0,<4.6"},
+                ),
+                Venv(
+                    pys=select_pys(min_version="3.5"),
+                    pkgs={
+                        "pytest": [
+                            ">=3.0,<4.0",
+                            ">=4.0,<5.0",
+                            ">=5.0,<6.0",
+                            ">=6.0,<7.0",
+                            latest,
+                        ],
+                    },
+                ),
+            ],
+        ),
+        Venv(
             name="grpc",
             command="pytest {cmdargs} tests/contrib/grpc",
             pkgs={

--- a/tox.ini
+++ b/tox.ini
@@ -72,8 +72,6 @@ envlist =
     requests_contrib{,_autopatch}-{py27,py35,py36,py37,py38}-requests{208,209,210,211,212,213,219}
     pymysql_contrib-py{27,35,36,37,38,39}-pymysql{07,08,09,}
     pyodbc_contrib-py{27,35,36,37,38,39}-pyodbc{3,4}
-    pytest_contrib-py27-pytest4
-    pytest_contrib-py{35,36,37,38,39}-pytest{4,5,6,}
     pyramid_contrib{,_autopatch}-py{27,35,36,37,38,39}-pyramid{17,18,19,110,}-webtest
     redis_contrib-py{27,35,36,37,38,39}-redis{210,30,32,33,34,35,}
     rediscluster_contrib-py{27,35,36,37,38,39}-rediscluster{135,136,200,}-redis210
@@ -254,9 +252,6 @@ deps =
     pyodbc3: pyodbc>=3.0,<4.0
     pytest: pytest>=3
     pytest3: pytest>=3.0,<4.0
-    pytest4: pytest==4.6  # last 2.7 and 3.4
-    pytest5: pytest>=5.0,<6.0
-    pytest6: pytest>=6.0,<7.0
     redis: redis
     redis210: redis>=2.10,<2.11
     redis30: redis>=3.0,<3.1
@@ -342,7 +337,6 @@ commands =
     pylons_contrib: python -m pytest {posargs} tests/contrib/pylons
     pymysql_contrib: pytest {posargs} tests/contrib/pymysql
     pyodbc_contrib: pytest {posargs} tests/contrib/pyodbc
-    pytest_contrib: pytest {posargs} tests/contrib/pytest
     pyramid_contrib: pytest {posargs} tests/contrib/pyramid/test_pyramid.py
     pyramid_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
     redis_contrib: pytest {posargs} tests/contrib/redis


### PR DESCRIPTION
### Description:
Integration testing for the pytest plugin was moved from tox to riot.
