### PR TITLE
ci: add skip_existing option

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -98,3 +98,4 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
           # To test: repository_url: https://test.pypi.org/legacy/
+          skip_existing: true

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -98,4 +98,7 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
           # To test: repository_url: https://test.pypi.org/legacy/
+          # Setting skip_existing will prevent the deploy from erring out early
+          # due to a duplicate wheel being present which will ensure that the rest
+          # of the wheels will be uploaded if some are uploaded manually.
           skip_existing: true


### PR DESCRIPTION
When Github actions is unavailable or delayed then we may opt to upload
some wheels manually. When this is the case we probably won't build all
the wheels manually and will still rely on the action.

Setting `skip_existing` will prevent the deploy from erring out early
due to a duplicate wheel being present which will ensure that the rest
of the wheels will be uploaded.
