### PR TITLE
Change AppTypes removal releasenote type to upgrade

### DIFF
--- a/releasenotes/notes/remove-apptypes-76c78d46c1792863.yaml
+++ b/releasenotes/notes/remove-apptypes-76c78d46c1792863.yaml
@@ -1,4 +1,4 @@
 ---
-other:
+upgrade:
   - |
     Removed `ddtrace.ext.AppTypes` and its usages in the tracer library.


### PR DESCRIPTION
Having it be `other` makes it less visible and could go unnoticed since
it should be an upgrade note.
