### PR TITLE
feat(writer): add retry logic

### DIFF
--- a/releasenotes/notes/tracer-upload-retry-d60310aa6c91059d.yaml
+++ b/releasenotes/notes/tracer-upload-retry-d60310aa6c91059d.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added retry logic to the tracer to mitigate potential networking issues,
+    like timeouts or dropped connections.

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -66,7 +66,7 @@ class AgentWriterTests(BaseTestCase):
             [
                 mock.call("datadog.tracer.buffer.accepted.traces", 10, tags=[]),
                 mock.call("datadog.tracer.buffer.accepted.spans", 50, tags=[]),
-                mock.call("datadog.tracer.http.requests", 1, tags=[]),
+                mock.call("datadog.tracer.http.requests", writer.RETRY_ATTEMPTS, tags=[]),
                 mock.call("datadog.tracer.http.errors", 1, tags=["type:err"]),
                 mock.call("datadog.tracer.http.dropped.bytes", AnyInt(), tags=[]),
             ],
@@ -92,7 +92,7 @@ class AgentWriterTests(BaseTestCase):
                 mock.call("datadog.tracer.buffer.accepted.spans", 50, tags=[]),
                 mock.call("datadog.tracer.buffer.dropped.traces", 1, tags=["reason:t_too_big"]),
                 mock.call("datadog.tracer.buffer.dropped.bytes", AnyInt(), tags=["reason:t_too_big"]),
-                mock.call("datadog.tracer.http.requests", 1, tags=[]),
+                mock.call("datadog.tracer.http.requests", writer.RETRY_ATTEMPTS, tags=[]),
                 mock.call("datadog.tracer.http.errors", 1, tags=["type:err"]),
                 mock.call("datadog.tracer.http.dropped.bytes", AnyInt(), tags=[]),
             ],
@@ -111,7 +111,7 @@ class AgentWriterTests(BaseTestCase):
             [
                 mock.call("datadog.tracer.buffer.accepted.traces", 10, tags=[]),
                 mock.call("datadog.tracer.buffer.accepted.spans", 50, tags=[]),
-                mock.call("datadog.tracer.http.requests", 1, tags=[]),
+                mock.call("datadog.tracer.http.requests", writer.RETRY_ATTEMPTS, tags=[]),
                 mock.call("datadog.tracer.http.errors", 1, tags=["type:err"]),
                 mock.call("datadog.tracer.http.dropped.bytes", AnyInt(), tags=[]),
             ],
@@ -131,7 +131,7 @@ class AgentWriterTests(BaseTestCase):
             [
                 mock.call("datadog.tracer.buffer.accepted.traces", 10, tags=[]),
                 mock.call("datadog.tracer.buffer.accepted.spans", 50, tags=[]),
-                mock.call("datadog.tracer.http.requests", 1, tags=[]),
+                mock.call("datadog.tracer.http.requests", writer.RETRY_ATTEMPTS, tags=[]),
                 mock.call("datadog.tracer.http.errors", 1, tags=["type:err"]),
                 mock.call("datadog.tracer.http.dropped.bytes", AnyInt(), tags=[]),
             ],
@@ -146,7 +146,7 @@ class AgentWriterTests(BaseTestCase):
             [
                 mock.call("datadog.tracer.buffer.accepted.traces", 1, tags=[]),
                 mock.call("datadog.tracer.buffer.accepted.spans", 5, tags=[]),
-                mock.call("datadog.tracer.http.requests", 1, tags=[]),
+                mock.call("datadog.tracer.http.requests", writer.RETRY_ATTEMPTS, tags=[]),
                 mock.call("datadog.tracer.http.errors", 1, tags=["type:err"]),
                 mock.call("datadog.tracer.http.dropped.bytes", AnyInt(), tags=[]),
             ],


### PR DESCRIPTION
## Description

This change introduces a Fibonacci retry policy (with jitter) to the agent writer to mitigate networking issues (e.g. timeouts, broken pipes, ...), similar to what the profiler does already.

Memory usage might increase up to an extra payload buffer size, meaning that occasionally the tracer would require about 8MB more memory for processing. That is because the buffer will start filling up again while the writer retries flushing the previous payload.

Resolves #1413.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
