### PR TITLE
chore(setup): remove Cython build_ext usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ setup(
         },
         # plugin tox
         tests_require=["tox", "flake8"],
-        cmdclass={"test": Tox, "build_ext": Cython.Distutils.build_ext},
+        cmdclass={"test": Tox},
         entry_points={
             "console_scripts": [
                 "ddtrace-run = ddtrace.commands.ddtrace_run:main",


### PR DESCRIPTION
Since cythonize is called explicitly where we want, there's no need to do it
magically with Cython `build_ext` function.
The latter might break other extension types.