### PR TITLE
Fix context reentry deadlock

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -50,7 +50,7 @@ class Context(object):
         :param int span_id: span_id of parent span
         """
         self._current_span = None  # type: Optional[Span]
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
         self._parent_trace_id = trace_id
         self._parent_span_id = span_id

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -432,7 +432,7 @@ def test_regression_logging_in_context(tmpdir, logs_injection, debug_mode, patch
     f.write(
         """
 import ddtrace
-ddtrace.patch(logging="%s")
+ddtrace.patch(logging=%s)
 
 s1 = ddtrace.tracer.trace("1")
 s2 = ddtrace.tracer.trace("2")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -452,6 +452,4 @@ s2.finish()
         ),
     )
     p.wait(timeout=2)
-    assert p.stderr.read() == six.b("")
-    assert p.stdout.read() == six.b("")
     assert p.returncode == 0

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -451,5 +451,9 @@ s2.finish()
             DD_TRACE_DEBUG=str(debug_mode).lower(),
         ),
     )
-    p.wait(timeout=2)
+    try:
+        p.wait(timeout=2)
+    except TypeError:
+        # timeout argument added in Python 3.3
+        p.wait()
     assert p.returncode == 0


### PR DESCRIPTION
# Bug fix

## Description
<!-- Please briefly describe the bug. -->
The lock in the context object was not reentrant. There was a regression in #2038
where a debug log line was added to `close_span`. If logs injection was enabled
then it was possible to deadlock when parent spans closed before child spans.

## Fix
<!-- Please provide a succinct overview of the fix. -->
The fix is to make the context lock reentrant.

# Checklist
- [x] Regression test added; or
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [x] Added to the correct milestone.

# Testing
- [x] Tests are run against all relevant library versions (or confirm that the relevant versions are already being tested in `tox.ini`)
