### PR TITLE
fix(ci): bump Flask test suite to 1.1.4

### DIFF
--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -5,7 +5,7 @@ on:
       - master
   pull_request:
 jobs:
-  flask-testsuite-1_1_2:
+  flask-testsuite-1_1_4:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: pallets/flask
-          ref: 1.1.2
+          ref: 1.1.4
           path: flask
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
## Description
This PR bumps flask to 1.1.4 on the Flask test suite. The CI job was failing because tests are broken upstream for Flask 1.1.2.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
