### PR TITLE
ci: allow to use latest cryptography on Alpine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,7 +379,8 @@ jobs:
   test_build_alpine:
     executor: python38-alpine
     steps:
-      - run: apk add git gcc musl-dev libffi-dev openssl-dev bash
+      # Rust + Cargo are needed for Cryptography
+      - run: apk add git gcc musl-dev libffi-dev openssl-dev bash rust cargo
       - test_build
 
   tracer:

--- a/.circleci/scripts/test_build.sh
+++ b/.circleci/scripts/test_build.sh
@@ -14,10 +14,7 @@ fi
 
 # Install required dependencies
 # DEV: `wheel` is needed to run `bdist_wheel`
-# DEV: `cryoptography==3.4` dropped support for Python 2.7 and now requires Rust to build from source
-#      This version constraint only applies to Alpine builds where wheels are not available
-#      https://cryptography.io/en/3.4/changelog.html#v3-4
-pip install twine readme_renderer[md] wheel cython "cryptography<3.4"
+pip install twine readme_renderer[md] wheel cython
 # Ensure we didn't cache from previous runs
 rm -rf build/ dist/
 # Manually build any extensions to ensure they succeed


### PR DESCRIPTION
This just pulls Rust and Cargo to allow building Cryptography latest version
which embeds some Rust code.
Alpine does not have wheels so it needs to compile everything.