### PR TITLE
Avoid double patching pymongo client._topology

### DIFF
--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -55,7 +55,8 @@ class TracedMongoClient(ObjectProxy):
         # calls in the trace library. This is good because it measures the
         # actual network time. It's bad because it uses a private API which
         # could change. We'll see how this goes.
-        client._topology = TracedTopology(client._topology)
+        if not isinstance(client._topology, TracedTopology):
+            client._topology = TracedTopology(client._topology)
 
         # Default Pin
         ddtrace.Pin(service=mongox.SERVICE, app=mongox.SERVICE).onto(self)

--- a/releasenotes/notes/pymongo-double-patching-topology-dd90eda48daa051c.yaml
+++ b/releasenotes/notes/pymongo-double-patching-topology-dd90eda48daa051c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes double patching of ``pymongo`` client topology.

--- a/tests/contrib/mongoengine/test.py
+++ b/tests/contrib/mongoengine/test.py
@@ -7,6 +7,8 @@ from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.mongoengine.patch import patch
 from ddtrace.contrib.mongoengine.patch import unpatch
+from ddtrace.contrib.pymongo.client import TracedMongoClient
+from ddtrace.contrib.pymongo.client import TracedTopology
 from ddtrace.ext import mongo as mongox
 from tests.opentracer.utils import init_tracer
 from tests.utils import DummyTracer
@@ -311,6 +313,25 @@ class TestMongoEnginePatchClient(TestMongoEnginePatchClientDefault):
         spans = tracer.pop()
         assert spans, spans
         assert len(spans) == 1
+
+    def test_multiple_connect_no_double_patching(self):
+        """Ensure we do not double patch client._topology
+
+        Regression test for https://github.com/DataDog/dd-trace-py/issues/2474
+        """
+        client = mongoengine.connect(port=MONGO_CONFIG["port"])
+        assert isinstance(client, TracedMongoClient)
+        assert not isinstance(client.__wrapped__, TracedMongoClient)
+        assert isinstance(client._topology, TracedTopology)
+        assert not isinstance(client._topology.__wrapped__, TracedTopology)
+        client.close()
+
+        client = mongoengine.connect(port=MONGO_CONFIG["port"])
+        assert isinstance(client, TracedMongoClient)
+        assert not isinstance(client.__wrapped__, TracedMongoClient)
+        assert isinstance(client._topology, TracedTopology)
+        assert not isinstance(client._topology.__wrapped__, TracedTopology)
+        client.close()
 
 
 def _assert_timing(span, start, end):


### PR DESCRIPTION
## Description
Fixes #2474

The `client._topology` is reused between connections. This means that for every new connection created we are re-wrapping the topology again.

This has an increased performance impact on connect for each additional client created. For applications which create a lot of clients this can lead to a very visible performance impact (seconds per connection).


## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- ~[ ] Library documentation is updated.~
- ~[ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
