### PR TITLE
ci: use Debian Buster image to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ default_resource_class: &default_resource_class medium
 cimg_base_image: &cimg_base_image cimg/base:stable
 python39-alpine_image: &python39-alpine_image python:3.9-alpine
 python39_image: &python39_image cimg/python:3.9
-ddtrace_dev_image: &ddtrace_dev_image datadog/dd-trace-py:latest
+ddtrace_dev_image: &ddtrace_dev_image datadog/dd-trace-py:buster
 datadog_agent_image: &datadog_agent_image datadog/agent:latest
 redis_image: &redis_image redis:4.0-alpine
 rediscluster_image: &rediscluster_image grokzen/redis-cluster:6.2.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
           - "127.0.0.1:5433:5433"
 
     testrunner:
-        image: datadog/dd-trace-py:latest
+        image: datadog/dd-trace-py:buster
         command: bash
         environment:
             - TOX_SKIP_DIST=True


### PR DESCRIPTION
This is needed to deploy Python 3.10 which requires newer libssl version.