### PR TITLE
ci: stop ci if no scenario is found

### DIFF
--- a/scripts/run-tox-scenario
+++ b/scripts/run-tox-scenario
@@ -6,8 +6,11 @@ shift
 # CircleCI has a bug in its workspace code where it can't handle filenames with some chars
 CLEANED_PATTERN=`echo $PATTERN | tr '^?()$' '_'`
 
+# If no match -> grep returns 1 -> script stops
+ENVLIST=$(tox -l | grep "$PATTERN")
+
 if [[ -z "${CIRCLE_NODE_TOTAL}" && -z "${CIRCLE_NODE_INDEX}" ]]; then
-    exec tox -l | grep "$PATTERN" | tr '\n' ',' | xargs -I ARGS tox -e ARGS -- $@
+    exec echo "$ENVLIST" | tr '\n' ',' | xargs -I ARGS tox -e ARGS -- $@
 else
-    exec tox -l | grep "$PATTERN" | sort | python -c "import os, sys; t, i = int(os.getenv('CIRCLE_NODE_TOTAL')), int(os.getenv('CIRCLE_NODE_INDEX')); inp = sys.stdin.readlines(); s = len(inp)//t; print(''.join(inp[i*s:(i+1)*s] if i+1<t else inp[i*s:]).strip())" | tr '\n' ',' | xargs -I ARGS tox -e ARGS -- $@
+    exec echo "$ENVLIST" | sort | python -c "import os, sys; t, i = int(os.getenv('CIRCLE_NODE_TOTAL')), int(os.getenv('CIRCLE_NODE_INDEX')); inp = sys.stdin.readlines(); s = len(inp)//t; print(''.join(inp[i*s:(i+1)*s] if i+1<t else inp[i*s:]).strip())" | tr '\n' ',' | xargs -I ARGS echo tox -e ARGS -- $@
 fi


### PR DESCRIPTION
The current code does not fail and returns an empty list if no matching test
env is found.

tox -e '' actually runs the whole list of scenarios, which takes hours.

This makes sure the script exits with an error if no env matches.