### PR TITLE
ci: fix run-tox-scenario on CircleCI

### DIFF
--- a/scripts/run-tox-scenario
+++ b/scripts/run-tox-scenario
@@ -12,5 +12,5 @@ ENVLIST=$(tox -l | grep "$PATTERN")
 if [[ -z "${CIRCLE_NODE_TOTAL}" && -z "${CIRCLE_NODE_INDEX}" ]]; then
     exec echo "$ENVLIST" | tr '\n' ',' | xargs -I ARGS tox -e ARGS -- $@
 else
-    exec echo "$ENVLIST" | sort | python -c "import os, sys; t, i = int(os.getenv('CIRCLE_NODE_TOTAL')), int(os.getenv('CIRCLE_NODE_INDEX')); inp = sys.stdin.readlines(); s = len(inp)//t; print(''.join(inp[i*s:(i+1)*s] if i+1<t else inp[i*s:]).strip())" | tr '\n' ',' | xargs -I ARGS echo tox -e ARGS -- $@
+    exec echo "$ENVLIST" | sort | python -c "import os, sys; t, i = int(os.getenv('CIRCLE_NODE_TOTAL')), int(os.getenv('CIRCLE_NODE_INDEX')); inp = sys.stdin.readlines(); s = len(inp)//t; print(''.join(inp[i*s:(i+1)*s] if i+1<t else inp[i*s:]).strip())" | tr '\n' ',' | xargs -I ARGS tox -e ARGS -- $@
 fi


### PR DESCRIPTION
There was a left over from debugging with an echo command that has been almost
missed in https://github.com/DataDog/dd-trace-py/pull/2480