### PR TITLE
Add DD_CALL_BASIC_CONFIG={true,false} environment variable

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -38,7 +38,6 @@ if config.logs_injection:
 # upon initializing it the first time.
 # See https://github.com/python/cpython/blob/112e4afd582515fcdcc0cde5012a4866e5cfda12/Lib/logging/__init__.py#L1550
 # Debug mode from the tracer will do a basicConfig so only need to do this otherwise
-# DD_CALL_BASIC_CONFIG=false can be used to skip calling `logging.basicConfig()`
 call_basic_config = asbool(os.environ.get("DD_CALL_BASIC_CONFIG", "true"))
 if not debug_mode and call_basic_config:
     if config.logs_injection:

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -38,7 +38,9 @@ if config.logs_injection:
 # upon initializing it the first time.
 # See https://github.com/python/cpython/blob/112e4afd582515fcdcc0cde5012a4866e5cfda12/Lib/logging/__init__.py#L1550
 # Debug mode from the tracer will do a basicConfig so only need to do this otherwise
-if not debug_mode:
+# DD_CALL_BASIC_CONFIG=false can be used to skip calling `logging.basicConfig()`
+call_basic_config = asbool(os.environ.get("DD_CALL_BASIC_CONFIG", "true"))
+if not debug_mode and call_basic_config:
     if config.logs_injection:
         logging.basicConfig(format=DD_LOG_FORMAT)
     else:

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -60,12 +60,13 @@ from .utils.formats import get_env
 log = get_logger(__name__)
 
 debug_mode = asbool(get_env("trace", "debug", default=False))
+call_basic_config = asbool(os.environ.get("DD_CALL_BASIC_CONFIG", "true"))
 
 DD_LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] {}- %(message)s".format(
     "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s"
     " dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] "
 )
-if debug_mode and not hasHandlers(log):
+if debug_mode and not hasHandlers(log) and call_basic_config:
     if config.logs_injection:
         logging.basicConfig(level=logging.DEBUG, format=DD_LOG_FORMAT)
     else:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -72,7 +72,7 @@ below:
    * - ``DD_CALL_BASIC_CONFIG``
      - Boolean
      - True
-     - Controls whether ``ddtrace-run`` calls ``logging.basicConfig``, or when running in debug mode.
+     - Controls whether ``logging.basicConfig`` is called in ``ddtrace-run`` or when debug mode is enabled.
    * - ``DD_TRACE_AGENT_URL``
      - URL
      - ``http://localhost:8126``

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,6 +69,10 @@ below:
      - Boolean
      - True
      - Enables :ref:`Logs Injection`.
+   * - ``DD_CALL_BASIC_CONFIG``
+     - Boolean
+     - True
+     - Controls whether ``ddtrace-run`` calls ``logging.basicConfig``, or when running in debug mode.
    * - ``DD_TRACE_AGENT_URL``
      - URL
      - ``http://localhost:8126``

--- a/releasenotes/notes/add-dd_call_basic_config-env-15570281d176f438.yaml
+++ b/releasenotes/notes/add-dd_call_basic_config-env-15570281d176f438.yaml
@@ -3,6 +3,5 @@ features:
   - |
     Add ``DD_CALL_BASIC_CONFIG={true,false}`` environment variable to control whether ``ddtrace`` calls ``logging.basicConfig``.
     By default when using ``ddtrace-run`` or running in debug mode ``logging.basicConfig`` is called to ensure there is always a
-    root handler. This has compatibility issues for some logging configurations. With this new environment variable you can use
-    ``DD_CALL_BASIC_CONFIG=false`` to skip calling ``logging.basicConfig``. The default value is ``true`` to maintain existing
-    behaviour.
+    root handler. This has compatibility issues for some logging configurations. ``DD_CALL_BASIC_CONFIG=false`` can be used to
+    skip calling ``logging.basicConfig``. The default value is ``true`` to maintain existing behaviour.

--- a/releasenotes/notes/add-dd_call_basic_config-env-15570281d176f438.yaml
+++ b/releasenotes/notes/add-dd_call_basic_config-env-15570281d176f438.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Add ``DD_CALL_BASIC_CONFIG={true,false}`` environment variable to control whether ``ddtrace`` calls ``logging.basicConfig``.
+    By default when using ``ddtrace-run`` or running in debug mode, we always call ``logging.basicConfig`` to ensure there is always a
+    root handler. This has compatibility issues for some logging configurations. With this new environment variable you can use
+    ``DD_CALL_BASIC_CONFIG=false`` to skip calling ``logging.basicConfig``. The default value is ``true`` to maintain existing
+    behaviors.

--- a/releasenotes/notes/add-dd_call_basic_config-env-15570281d176f438.yaml
+++ b/releasenotes/notes/add-dd_call_basic_config-env-15570281d176f438.yaml
@@ -5,4 +5,4 @@ features:
     By default when using ``ddtrace-run`` or running in debug mode ``logging.basicConfig`` is called to ensure there is always a
     root handler. This has compatibility issues for some logging configurations. With this new environment variable you can use
     ``DD_CALL_BASIC_CONFIG=false`` to skip calling ``logging.basicConfig``. The default value is ``true`` to maintain existing
-    behaviors.
+    behaviour.

--- a/releasenotes/notes/add-dd_call_basic_config-env-15570281d176f438.yaml
+++ b/releasenotes/notes/add-dd_call_basic_config-env-15570281d176f438.yaml
@@ -4,4 +4,4 @@ features:
     Add ``DD_CALL_BASIC_CONFIG={true,false}`` environment variable to control whether ``ddtrace`` calls ``logging.basicConfig``.
     By default when using ``ddtrace-run`` or running in debug mode ``logging.basicConfig`` is called to ensure there is always a
     root handler. This has compatibility issues for some logging configurations. ``DD_CALL_BASIC_CONFIG=false`` can be used to
-    skip calling ``logging.basicConfig``. The default value is ``true`` to maintain existing behaviour.
+    skip calling ``logging.basicConfig``. The default value is ``true`` to maintain existing behavior.

--- a/releasenotes/notes/add-dd_call_basic_config-env-15570281d176f438.yaml
+++ b/releasenotes/notes/add-dd_call_basic_config-env-15570281d176f438.yaml
@@ -2,7 +2,7 @@
 features:
   - |
     Add ``DD_CALL_BASIC_CONFIG={true,false}`` environment variable to control whether ``ddtrace`` calls ``logging.basicConfig``.
-    By default when using ``ddtrace-run`` or running in debug mode, we always call ``logging.basicConfig`` to ensure there is always a
+    By default when using ``ddtrace-run`` or running in debug mode ``logging.basicConfig`` is called to ensure there is always a
     root handler. This has compatibility issues for some logging configurations. With this new environment variable you can use
     ``DD_CALL_BASIC_CONFIG=false`` to skip calling ``logging.basicConfig``. The default value is ``true`` to maintain existing
     behaviors.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,19 @@ def test_spans(tracer):
 
 @pytest.fixture
 def run_python_code_in_subprocess(tmpdir):
-    def _run(code):
+    def _run(code, **kwargs):
         pyfile = tmpdir.join("test.py")
         pyfile.write(code)
-        return call_program(sys.executable, str(pyfile))
+        return call_program(sys.executable, str(pyfile), **kwargs)
+
+    yield _run
+
+
+@pytest.fixture
+def ddtrace_run_python_code_in_subprocess(tmpdir):
+    def _run(code, **kwargs):
+        pyfile = tmpdir.join("test.py")
+        pyfile.write(code)
+        return call_program("ddtrace-run", sys.executable, str(pyfile), **kwargs)
 
     yield _run

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -463,7 +463,7 @@ s2.finish()
     "call_basic_config,debug_mode",
     itertools.permutations((True, False, None), 2),
 )
-def test_call_basic_config(tmpdir, call_basic_config, debug_mode):
+def test_call_basic_config(ddtrace_run_python_code_in_subprocess, call_basic_config, debug_mode):
     """
     When setting DD_CALL_BASIC_CONFIG env variable
         When true
@@ -473,14 +473,6 @@ def test_call_basic_config(tmpdir, call_basic_config, debug_mode):
         When not set
             We call logging.basicConfig()
     """
-    f = tmpdir.join("test.py")
-    f.write(
-        """
-import logging
-root = logging.getLogger()
-print(len(root.handlers))
-""".lstrip()
-    )
     env = os.environ.copy()
 
     if debug_mode is not None:
@@ -491,21 +483,17 @@ print(len(root.handlers))
     else:
         has_root_handlers = True
 
-    p = subprocess.Popen(
-        ["ddtrace-run", sys.executable, "test.py"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        cwd=str(tmpdir),
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(
+        """
+import logging
+root = logging.getLogger()
+print(len(root.handlers))
+""",
         env=env,
     )
-    try:
-        p.wait(timeout=2)
-    except TypeError:
-        # timeout argument added in Python 3.3
-        p.wait()
-    assert p.returncode == 0
 
+    assert status == 0
     if has_root_handlers:
-        assert p.stdout.read() == six.b("1\n")
+        assert out == six.b("1\n")
     else:
-        assert p.stdout.read() == six.b("0\n")
+        assert out == six.b("0\n")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -481,7 +481,8 @@ root = logging.getLogger()
 print(len(root.handlers))
 """.lstrip()
     )
-    env = {}
+    env = os.environ.copy()
+
     if debug_mode is not None:
         env["DD_TRACE_DEBUG"] = str(debug_mode).lower()
     if call_basic_config is not None:
@@ -505,6 +506,6 @@ print(len(root.handlers))
     assert p.returncode == 0
 
     if has_root_handlers:
-        assert p.stdout.read() == six.b("1")
+        assert p.stdout.read() == six.b("1\n")
     else:
-        assert p.stdout.read() == six.b("0")
+        assert p.stdout.read() == six.b("0\n")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -943,12 +943,13 @@ class AnyFloat(object):
         return isinstance(other, float)
 
 
-def call_program(*args):
+def call_program(*args, **kwargs):
     subp = subprocess.Popen(
         args,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         close_fds=True,
+        **kwargs,
     )
     stdout, stderr = subp.communicate()
     return stdout, stderr, subp.wait(), subp.pid

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -944,12 +944,6 @@ class AnyFloat(object):
 
 
 def call_program(*args, **kwargs):
-    subp = subprocess.Popen(
-        args,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        close_fds=True,
-        **kwargs,
-    )
+    subp = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True, **kwargs)
     stdout, stderr = subp.communicate()
     return stdout, stderr, subp.wait(), subp.pid


### PR DESCRIPTION
## Description

Short term fix for #2482.

With the addition of `DD_CALL_BASIC_CONFIG` env variable, customers can control whether we call `logging.basicConfig()` or not.

## Checklist
- [x] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Library documentation is updated.
- ~[ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
