### PR TITLE
ci: introduce the internal DD_TESTING_RAISE variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ commands:
             - run:
                 environment:
                   DD_TRACE_AGENT_URL: http://localhost:9126
+                  DD_TESTING_RAISE: true
 
                 command: "echo -p2.7,-p3.5,-p3.6,-p3.7,-p3.8,-p3.9 | tr ',' '\n' | circleci tests split | xargs ./scripts/ddtest riot -v run --exitfirst --pass-env -s '<< parameters.pattern >>'"
       - unless:
@@ -180,6 +181,7 @@ commands:
           name: "Run scripts/run-tox-scenario"
           environment:
             DD_TRACE_AGENT_URL: http://localhost:9126
+            DD_TESTING_RAISE: true
           command: ./scripts/ddtest scripts/run-tox-scenario '<< parameters.pattern >>'
       - save_tox_cache
 

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   bottle-testsuite-0_12_19:
     runs-on: ubuntu-latest
+    env:
+      DD_TESTING_RAISE: true
     defaults:
       run:
         working-directory: bottle

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   django-testsuite-3_1_7:
     runs-on: ubuntu-latest
+    env:
+      DD_TESTING_RAISE: true
     defaults:
       run:
         working-directory: django

--- a/.github/workflows/fastapi.yml
+++ b/.github/workflows/fastapi.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   fastapi-test:
     runs-on: ubuntu-latest
+    env:
+      DD_TESTING_RAISE: true
     defaults:
       run:
         working-directory: fastapi

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   flask-testsuite-1_1_4:
     runs-on: ubuntu-latest
+    env:
+      DD_TESTING_RAISE: true
     defaults:
       run:
         working-directory: flask

--- a/.github/workflows/starlette.yml
+++ b/.github/workflows/starlette.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   starlette-testsuite-0_14_2:
     runs-on: "ubuntu-latest"
+    env:
+      DD_TESTING_RAISE: true
     defaults:
       run:
         working-directory: starlette


### PR DESCRIPTION
## Description

This variable is meant to be used to control exceptional behaviour and whether to let the exception bubble up or handle it and turn it into a warning.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
