### PR TITLE
fix(django): fix instrumentation for multiple db backends

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,7 +583,7 @@ jobs:
       - run_test:
           pattern: 'django$'
           snapshot: true
-          docker_services: "memcached redis"
+          docker_services: "memcached redis postgres"
 
   djangorestframework:
     <<: *machine_executor

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -20,6 +20,7 @@ attrs
 autodetected
 autopatching
 backend
+backends
 bikeshedding
 boto
 botocore

--- a/releasenotes/notes/fix-django-db-connections-b9b98a7b49f27c5f.yaml
+++ b/releasenotes/notes/fix-django-db-connections-b9b98a7b49f27c5f.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    django: fix instrumentation for multiple db backends
+    django: fix a bug where multiple database backends would not be instrumented.

--- a/releasenotes/notes/fix-django-db-connections-b9b98a7b49f27c5f.yaml
+++ b/releasenotes/notes/fix-django-db-connections-b9b98a7b49f27c5f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    django: fix instrumentation for multiple db backends

--- a/riotfile.py
+++ b/riotfile.py
@@ -427,6 +427,7 @@ venv = Venv(
                         "pytest-django": "==3.10.0",
                         "python-memcached": latest,
                         "redis": ">=2.10,<2.11",
+                        "psycopg2": ["~=2.8.0"],
                     },
                 ),
                 Venv(
@@ -439,6 +440,7 @@ venv = Venv(
                         "pytest-django": "==3.10.0",
                         "python-memcached": latest,
                         "redis": ">=2.10,<2.11",
+                        "psycopg2": ["~=2.8.0"],
                     },
                 ),
                 Venv(
@@ -451,6 +453,7 @@ venv = Venv(
                         "pytest-django": "==3.10.0",
                         "python-memcached": latest,
                         "redis": ">=2.10,<2.11",
+                        "psycopg2": ["~=2.8.0"],
                     },
                 ),
                 Venv(

--- a/tests/contrib/django/django1_app/settings.py
+++ b/tests/contrib/django/django1_app/settings.py
@@ -7,7 +7,17 @@ ALLOWED_HOSTS = [
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+DATABASES = {
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"},
+    "postgres": {
+        "ENGINE": "django.db.backends.postgresql_psycopg2",
+        "NAME": "postgres",
+        "USER": "postgres",
+        "PASSWORD": "postgres",
+        "HOST": "127.0.0.1",
+        "PORT": 5432,
+    },
+}
 
 CACHES = {
     "default": {

--- a/tests/contrib/django/django_app/settings.py
+++ b/tests/contrib/django/django_app/settings.py
@@ -7,7 +7,17 @@ ALLOWED_HOSTS = [
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+DATABASES = {
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"},
+    "postgres": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "postgres",
+        "USER": "postgres",
+        "PASSWORD": "postgres",
+        "HOST": "127.0.0.1",
+        "PORT": 5432,
+    },
+}
 
 CACHES = {
     "default": {

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -1694,8 +1694,11 @@ class TestWSGI:
 
 @pytest.mark.django_db
 def test_connections_patched():
+    from django.db import connection
     from django.db import connections
 
     assert len(connections.all())
     for conn in connections.all():
         assert isinstance(conn.cursor, wrapt.ObjectProxy)
+
+    assert isinstance(connection.cursor, wrapt.ObjectProxy)


### PR DESCRIPTION
## Description

If multiple database backends are used, the Django db instrumentation fails to patch all of their cursor functions as expected. This problem was discovered in #2463.

While #2084 was intended as a performance change, there were no tests for the case of multiple db backends so a regression was missed. Previous to this, the `django.db.connections.all()` was wrapped. The reason that had worked was because this happened to be called during initialization time: https://github.com/django/django/blob/main/django/db/__init__.py#L27.

The solution here is preferable as it does not depend on a side effect of initialization in the supported library.

https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/8703/workflows/d9ec6881-10f7-46c9-b8cb-d5d22c554cff/jobs/708236

```
        assert len(connections.all())
        for conn in connections.all():
>           assert isinstance(conn.cursor, wrapt.ObjectProxy)
E           AssertionError: assert False
E            +  where False = isinstance(<bound method DatabaseWrapper.cursor of <django.db.backends.postgresql_psycopg2.base.DatabaseWrapper object at 0x7fb7229b7550>>, <type 'ObjectProxy'>)
E            +    where <bound method DatabaseWrapper.cursor of <django.db.backends.postgresql_psycopg2.base.DatabaseWrapper object at 0x7fb7229b7550>> = <django.db.backends.postgresql_psycopg2.base.DatabaseWrapper object at 0x7fb7229b7550>.cursor
E            +    and   <type 'ObjectProxy'> = wrapt.ObjectProxy
```

Backport to 0.49


## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
