### PR TITLE
feat(span): use `DD_TESTING_RAISE` to control error behaviour when setting string tags

### DIFF
--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -140,6 +140,9 @@ class Config(object):
 
         self.health_metrics_enabled = asbool(get_env("trace", "health_metrics_enabled", default=False))
 
+        # Raise certain errors only if in testing raise mode to prevent crashing in production with non-critical errors
+        self._raise = asbool(os.getenv("DD_TESTING_RAISE", False))
+
     def __getattr__(self, name):
         if name not in self._config:
             self._config[name] = IntegrationConfig(self, name)

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -13,6 +13,7 @@ from typing import Union
 
 import six
 
+from . import config
 from .constants import MANUAL_DROP_KEY
 from .constants import MANUAL_KEEP_KEY
 from .constants import NUMERIC_TAGS
@@ -320,7 +321,12 @@ class Span(object):
         str in Python 3, with decoding errors in conversion being replaced with
         U+FFFD.
         """
-        self.meta[key] = ensure_text(value, errors="replace")
+        try:
+            self.meta[key] = ensure_text(value, errors="replace")
+        except Exception as e:
+            if config._raise:
+                raise e
+            log.warning("Failed to set text tag '%s'", key, exc_info=True)
 
     def _remove_tag(self, key):
         # type: (_TagNameType) -> None

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -19,6 +19,7 @@ from ddtrace.span import Span
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 from tests.utils import assert_is_not_measured
+from tests.utils import override_global_config
 
 
 class SpanTestCase(TracerTestCase):
@@ -513,12 +514,23 @@ def test_span_encoding_set_str_tag(span_log):
     assert span.meta["foo"] == u"/?foo=bar&baz=����ó��"
 
 
-@mock.patch("ddtrace.span.log")
-def test_span_nonstring_set_str_tag(span_log):
+def test_span_nonstring_set_str_tag_exc():
     span = Span(None, None)
     with pytest.raises(TypeError):
         span._set_str_tag("foo", dict(a=1))
     assert "foo" not in span.meta
+
+
+@mock.patch("ddtrace.span.log")
+def test_span_nonstring_set_str_tag_warning(span_log):
+    with override_global_config(dict(_raise=False)):
+        span = Span(None, None)
+        span._set_str_tag("foo", dict(a=1))
+        span_log.warning.assert_called_once_with(
+            "Failed to set text tag '%s'",
+            "foo",
+            exc_info=True,
+        )
 
 
 def test_span_ignored_exceptions():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -87,6 +87,7 @@ def override_global_config(values):
         "env",
         "version",
         "service",
+        "_raise",
     ]
 
     # Grab the current values of all keys


### PR DESCRIPTION
## Description

The new internal variable `DD_TESTING_RAISE` is used to check whether `Span._set_str_tag` should raise or log on error.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
