### PR TITLE
Adds DD_TRACE_AGENT_TIMEOUT_SECONDS

### DIFF
--- a/ddtrace/internal/agent.py
+++ b/ddtrace/internal/agent.py
@@ -33,6 +33,11 @@ def get_stats_port():
     return int(get_env("dogstatsd", "port", default=DEFAULT_STATS_PORT))  # type: ignore[arg-type]
 
 
+def get_trace_url_timeout():
+    # type: () -> float
+    return float(os.environ.get("DD_TRACE_URL_TIMEOUT", default=DEFAULT_TIMEOUT))
+
+
 def get_trace_url():
     # type: () -> str
     """Return the Agent URL computed from the environment.

--- a/ddtrace/internal/agent.py
+++ b/ddtrace/internal/agent.py
@@ -35,7 +35,7 @@ def get_stats_port():
 
 def get_trace_url_timeout():
     # type: () -> float
-    return float(os.environ.get("DD_TRACE_URL_TIMEOUT", default=DEFAULT_TIMEOUT))
+    return float(get_env("trace", "url", "timeout", default=DEFAULT_TIMEOUT))
 
 
 def get_trace_url():

--- a/ddtrace/internal/agent.py
+++ b/ddtrace/internal/agent.py
@@ -33,9 +33,9 @@ def get_stats_port():
     return int(get_env("dogstatsd", "port", default=DEFAULT_STATS_PORT))  # type: ignore[arg-type]
 
 
-def get_trace_url_timeout():
+def get_trace_agent_timeout():
     # type: () -> float
-    return float(get_env("trace", "url", "timeout", default=DEFAULT_TIMEOUT))
+    return float(get_env("trace", "agent", "timeout", "seconds", default=DEFAULT_TIMEOUT))  # type: ignore[arg-type]
 
 
 def get_trace_url():

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -205,7 +205,7 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
         # to flush dynamically.
         buffer_size=8 * 1000000,  # type: int
         max_payload_size=8 * 1000000,  # type: int
-        timeout=agent.DEFAULT_TIMEOUT,  # type: float
+        timeout=agent.get_trace_url_timeout(),  # type: float
         dogstatsd=None,  # type: Optional[DogStatsd]
         report_metrics=False,  # type: bool
         sync_mode=False,  # type: bool

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -205,7 +205,7 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
         # to flush dynamically.
         buffer_size=8 * 1000000,  # type: int
         max_payload_size=8 * 1000000,  # type: int
-        timeout=agent.get_trace_url_timeout(),  # type: float
+        timeout=agent.get_trace_agent_timeout(),  # type: float
         dogstatsd=None,  # type: Optional[DogStatsd]
         report_metrics=False,  # type: bool
         sync_mode=False,  # type: bool

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -79,7 +79,7 @@ below:
      - The URL to use to connect the Datadog agent. The url can starts with
        ``http://`` to connect using HTTP or with ``unix://`` to use a Unix
        Domain Socket.
-   * - ``DD_TRACE_URL_TIMEOUT``
+   * - ``DD_TRACE_AGENT_TIMEOUT_SECONDS``
      - Float
      - 2.0
      - The timeout in float to use to connect to the Datadog agent.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -79,6 +79,10 @@ below:
      - The URL to use to connect the Datadog agent. The url can starts with
        ``http://`` to connect using HTTP or with ``unix://`` to use a Unix
        Domain Socket.
+   * - ``DD_TRACE_URL_TIMEOUT``
+     - Float
+     - 2.0
+     - The timeout in float to use to connect to the Datadog agent.
    * - ``DD_TRACE_STARTUP_LOGS``
      - Boolean
      - False

--- a/releasenotes/notes/add-dd-trace-agent-timeout-seconds-env-844b53ff0ccc7c9f.yaml
+++ b/releasenotes/notes/add-dd-trace-agent-timeout-seconds-env-844b53ff0ccc7c9f.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add new ``DD_TRACE_AGENT_TIMEOUT_SECONDS`` to override the default
+    connection timeout used when sending data to the trace agent.
+    The default is ``2.0`` seconds.


### PR DESCRIPTION
## Description
For sending apm metrics to localhost, the defaults of `2.0` is enough. However, for setup where datadog agents are exposed over `https`, the timeout of 2.0 is not sufficient. Such kind of setup is used for non-prod environment for devs to test their apm/stats configuration without having to install ddagent on every non-prod machines or generate multiple ddagent key for each dev to test themselves.


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
