### PR TITLE
Pin mypy to <0.900 until we can resolve new modular typeshed issues

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -112,11 +112,11 @@ venv = Venv(
         ),
         Venv(
             pys=["3"],
-            # TODO: https://mypy-lang.blogspot.com/2021/05/the-upcoming-switch-to-modular-typeshed.html
-            name="mypy<0.900",
+            name="mypy",
             command="mypy {cmdargs}",
             pkgs={
-                "mypy": latest,
+                # TODO: https://mypy-lang.blogspot.com/2021/05/the-upcoming-switch-to-modular-typeshed.html
+                "mypy": "<0.900",
             },
         ),
         Venv(

--- a/riotfile.py
+++ b/riotfile.py
@@ -112,7 +112,8 @@ venv = Venv(
         ),
         Venv(
             pys=["3"],
-            name="mypy",
+            # TODO: https://mypy-lang.blogspot.com/2021/05/the-upcoming-switch-to-modular-typeshed.html
+            name="mypy<0.900",
             command="mypy {cmdargs}",
             pkgs={
                 "mypy": latest,


### PR DESCRIPTION
## Description
mypy 0.900 was released today where they moved to a modular typeshed setup, this causes a bunch of errors missing library type hinting in CI.

locally when trying to do `mypy --install-types` as suggested I get segfaults/failures.

we can manually install the missing typing for each library individually, but until then we will just pin to `<0.900`.