### PR TITLE
Fix circleci dd-trace-py image to pre-buster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ default_resource_class: &default_resource_class medium
 cimg_base_image: &cimg_base_image cimg/base:stable
 python38-alpine_image: &python38-alpine_image python:3.8-alpine
 python38_image: &python38_image circleci/python:3.8
-ddtrace_dev_image: &ddtrace_dev_image datadog/dd-trace-py:latest
+ddtrace_dev_image: &ddtrace_dev_image datadog/dd-trace-py@sha256:eeb144838c6077de4ccf8968422ffc5c11dcad976681f7dadc5025d48cbeaebe
 datadog_agent_image: &datadog_agent_image datadog/agent:latest
 redis_image: &redis_image redis:4.0-alpine
 rediscluster_image: &rediscluster_image grokzen/redis-cluster:6.2.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
           - "127.0.0.1:5433:5433"
 
     testrunner:
-        image: datadog/dd-trace-py:latest
+        image: datadog/dd-trace-py@sha256:eeb144838c6077de4ccf8968422ffc5c11dcad976681f7dadc5025d48cbeaebe
         command: bash
         environment:
             - TOX_SKIP_DIST=True


### PR DESCRIPTION
## Description
Updating the `datadog/dd-trace-py:latest` tag to point to the new `:buster` tag broke the CI on 0.49.

This PR uses the last known good image tag for 0.49 CI.