### PR TITLE
fix: enable `DD_TESTING_RAISE` via riot and tox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,6 @@ commands:
             - run:
                 environment:
                   DD_TRACE_AGENT_URL: http://localhost:9126
-                  DD_TESTING_RAISE: true
 
                 command: "echo -p2.7,-p3.5,-p3.6,-p3.7,-p3.8,-p3.9 | tr ',' '\n' | circleci tests split | xargs ./scripts/ddtest riot -v run --exitfirst --pass-env -s '<< parameters.pattern >>'"
       - unless:
@@ -181,7 +180,6 @@ commands:
           name: "Run scripts/run-tox-scenario"
           environment:
             DD_TRACE_AGENT_URL: http://localhost:9126
-            DD_TESTING_RAISE: true
           command: ./scripts/ddtest scripts/run-tox-scenario '<< parameters.pattern >>'
       - save_tox_cache
 

--- a/riotfile.py
+++ b/riotfile.py
@@ -80,6 +80,9 @@ venv = Venv(
         "opentracing": latest,
         "hypothesis": latest,
     },
+    env={
+        "DD_TESTING_RAISE": "1",
+    },
     venvs=[
         Venv(
             pys=["3"],

--- a/tox.ini
+++ b/tox.ini
@@ -99,6 +99,7 @@ install_command=python -m pip install --no-binary gevent {opts} {packages}
 usedevelop = true
 
 setenv =
+    DD_TESTING_RAISE=1
     profile-gevent: DD_PROFILE_TEST_GEVENT=1
     integration-v5: AGENT_VERSION=v5
     integration-latest: AGENT_VERSION=latest


### PR DESCRIPTION
## Description

This change sets the `DD_TESTING_RAISE` variable via riot and tox to ensure consistent behaviour between CI and local test runs.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
