### PR TITLE
perf(span): make `span_type` a slot attribute

### DIFF
--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -126,7 +126,7 @@ def pytest_runtest_protocol(item, nextitem):
         ddtrace.config.pytest.operation_name,
         service=int_service(pin, ddtrace.config.pytest),
         resource=item.nodeid,
-        span_type=SpanTypes.TEST.value,
+        span_type=SpanTypes.TEST,
     ) as span:
         span.context.dd_origin = ci.CI_APP_TEST_ORIGIN
         span.set_tags(pin.tags)
@@ -134,7 +134,7 @@ def pytest_runtest_protocol(item, nextitem):
         span.set_tag(test.FRAMEWORK, FRAMEWORK)
         span.set_tag(test.NAME, item.name)
         span.set_tag(test.SUITE, item.module.__name__)
-        span.set_tag(test.TYPE, SpanTypes.TEST.value)
+        span.set_tag(test.TYPE, SpanTypes.TEST)
 
         # Parameterized test cases will have a `callspec` attribute attached to the pytest Item object.
         # Pytest docs: https://docs.pytest.org/en/6.2.x/reference.html#pytest.Function

--- a/ddtrace/ext/__init__.py
+++ b/ddtrace/ext/__init__.py
@@ -1,7 +1,4 @@
-from enum import Enum
-
-
-class SpanTypes(Enum):
+class SpanTypes(object):
     CACHE = "cache"
     CASSANDRA = "cassandra"
     ELASTICSEARCH = "elasticsearch"

--- a/ddtrace/profiling/exporter/pprof.pyx
+++ b/ddtrace/profiling/exporter/pprof.pyx
@@ -359,7 +359,7 @@ class PprofExporter(exporter.Exporter):
     ):
         # type: (...) -> _stack_event_group_key_T
 
-        if event.trace_type == ext.SpanTypes.WEB.value:
+        if event.trace_type == ext.SpanTypes.WEB:
             trace_resource = self._none_to_str(event.trace_resource)
         else:
             # Do not export trace_resource for privacy concerns.
@@ -390,7 +390,7 @@ class PprofExporter(exporter.Exporter):
     def _lock_event_group_key(
         self, event  # type: lock.LockEventBase
     ):
-        if event.trace_type == ext.SpanTypes.WEB.value:
+        if event.trace_type == ext.SpanTypes.WEB:
             trace_resource = self._none_to_str(event.trace_resource)
         else:
             # Do not export trace_resource for privacy concerns.

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -22,7 +22,6 @@ from .constants import SERVICE_VERSION_KEY
 from .constants import SPAN_MEASURED_KEY
 from .constants import VERSION_KEY
 from .context import Context
-from .ext import SpanTypes
 from .ext import errors
 from .ext import http
 from .ext import net
@@ -63,7 +62,7 @@ class Span(object):
         "meta",
         "error",
         "metrics",
-        "_span_type",
+        "span_type",
         "start_ns",
         "duration_ns",
         "tracer",
@@ -124,7 +123,6 @@ class Span(object):
         self.name = name
         self.service = service
         self.resource = resource or name
-        self._span_type = None
         self.span_type = span_type
 
         # tags / metadata
@@ -168,14 +166,6 @@ class Span(object):
     def start(self, value):
         # type: (Union[int, float]) -> None
         self.start_ns = int(value * 1e9)
-
-    @property
-    def span_type(self):
-        return self._span_type
-
-    @span_type.setter
-    def span_type(self, value):
-        self._span_type = value.value if isinstance(value, SpanTypes) else value
 
     @property
     def finished(self):

--- a/releasenotes/notes/span-types-enum-5ca7cb35031a199e.yaml
+++ b/releasenotes/notes/span-types-enum-5ca7cb35031a199e.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    ``SpanTypes`` is no longer an ``Enum``.

--- a/tests/contrib/pymongo/test.py
+++ b/tests/contrib/pymongo/test.py
@@ -496,7 +496,7 @@ class TestPymongoSocketTracing(TracerTestCase):
     def check_socket_metadata(span):
         assert span.name == "pymongo.get_socket"
         assert span.service == mongox.SERVICE
-        assert span.span_type == SpanTypes.MONGODB.value
+        assert span.span_type == SpanTypes.MONGODB
         assert span.meta.get("out.host") == "localhost"
         assert span.metrics.get("out.port") == MONGO_CONFIG["port"]
 

--- a/tests/profiling/exporter/test_pprof.py
+++ b/tests/profiling/exporter/test_pprof.py
@@ -331,7 +331,7 @@ TEST_EVENTS = {
             thread_name="MainThread",
             trace_id=1322219321,
             trace_resource="myresource",
-            trace_type=ext.SpanTypes.WEB.value,
+            trace_type=ext.SpanTypes.WEB,
             frames=[
                 ("foobar.py", 23, "func1"),
                 ("foobar.py", 44, "func2"),
@@ -456,7 +456,7 @@ TEST_EVENTS = {
             trace_id=23435,
             span_id=345432,
             trace_resource="myresource",
-            trace_type=ext.SpanTypes.WEB.value,
+            trace_type=ext.SpanTypes.WEB,
             nframes=3,
             wait_time_ns=74839,
             sampling_pct=10,

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -13,6 +13,7 @@ from hypothesis.strategies import text
 import msgpack
 import pytest
 
+from ddtrace.ext import SpanTypes
 from ddtrace.ext.ci import CI_APP_TEST_ORIGIN
 from ddtrace.internal._encoding import BufferFull
 from ddtrace.internal._encoding import BufferItemTooLarge
@@ -23,7 +24,6 @@ from ddtrace.internal.encoding import JSONEncoderV2
 from ddtrace.internal.encoding import MsgpackEncoder
 from ddtrace.internal.encoding import _EncoderBase
 from ddtrace.span import Span
-from ddtrace.span import SpanTypes
 from ddtrace.tracer import Tracer
 from tests.utils import DummyTracer
 


### PR DESCRIPTION
## Description

The getter and setter for `Span.span_type` had unrelated types (`str` and subclass of `Enum` respectively), which is a sign that something is not quite right. By making `ddtrace.ext.SpanTypes` a "namespace" object one can avoid making `span_type` a property, thus benefitting from the `__slots__` optimisation.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
