### PR TITLE
fix(span): correct `Span.finish` signature

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -210,20 +210,18 @@ class Span(object):
         self.duration_ns = int(value * 1e9)
 
     def finish(self, finish_time=None):
-        # type: (Optional[int]) -> None
+        # type: (Optional[float]) -> None
         """Mark the end time of the span and submit it to the tracer.
-        If the span has already been finished don't do anything
+        If the span has already been finished don't do anything.
 
-        :param int finish_time: The end time of the span in seconds.
-                                Defaults to now.
+        :param finish_time: The end time of the span, in seconds. Defaults to ``now``.
         """
-        if self.finished:
+        if self.duration_ns is not None:
             return
 
-        if self.duration_ns is None:
-            ft = time_ns() if finish_time is None else int(finish_time * 1e9)
-            # be defensive so we don't die if start isn't set
-            self.duration_ns = ft - (self.start_ns or ft)
+        ft = time_ns() if finish_time is None else int(finish_time * 1e9)
+        # be defensive so we don't die if start isn't set
+        self.duration_ns = ft - (self.start_ns or ft)
 
         for cb in self._on_finish_callbacks:
             cb(self)

--- a/releasenotes/notes/fix-span-finish-signature-b0c1073b56c3b559.yaml
+++ b/releasenotes/notes/fix-span-finish-signature-b0c1073b56c3b559.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed the optional argument of ``Span.finish`` to ``Optional[float]``
+    instead of ``Optional[int]``.


### PR DESCRIPTION
## Description

The argument to `Span.finish` should accept a `float` rather than an `int`. Also removed a redundant branching.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
