### PR TITLE
perf(trace): loop over trace once when aggregating

### DIFF
--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -127,8 +127,19 @@ class SpanAggregator(SpanProcessor):
             if trace.num_finished == len(trace.spans) or (
                 self._partial_flush_enabled and trace.num_finished >= self._partial_flush_min_spans
             ):
-                finished = [s for s in trace.spans if s.finished]
-                trace.spans = [s for s in trace.spans if not s.finished]
+                trace_spans = trace.spans
+                trace.spans = []
+                if trace.num_finished < len(trace_spans):
+                    finished = []
+                    for s in trace_spans:
+                        if s.finished:
+                            finished.append(s)
+                        else:
+                            trace.spans.append(s)
+
+                else:
+                    finished = trace_spans
+
                 trace.num_finished -= len(finished)
 
                 if len(trace.spans) == 0:


### PR DESCRIPTION
## Description

The trace can be walked once to separate finished/unfinished spans in one pass. This also halves the number of calls to the `finished` property.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
