### PR TITLE
Use type variable to fix tracer.wrap decorator

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -11,6 +11,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Set
+from typing import TypeVar
 from typing import Union
 
 from ddtrace import config
@@ -75,6 +76,9 @@ if debug_mode and not hasHandlers(log) and call_basic_config:
 
 
 _INTERNAL_APPLICATION_SPAN_TYPES = {"custom", "template", "web", "worker"}
+
+
+AnyCallable = TypeVar("AnyCallable", bound=Callable)
 
 
 class Tracer(object):
@@ -781,7 +785,7 @@ class Tracer(object):
         resource=None,  # type: Optional[str]
         span_type=None,  # type: Optional[str]
     ):
-        # type: (...) -> Callable[[Callable[..., Any]], Callable[..., Any]]
+        # type: (...) -> Callable[[AnyCallable], AnyCallable]
         """
         A decorator used to trace an entire function. If the traced function
         is a coroutine, it traces the coroutine execution when is awaited.
@@ -825,6 +829,7 @@ class Tracer(object):
         """
 
         def wrap_decorator(f):
+            # type: (AnyCallable) -> AnyCallable
             # FIXME[matt] include the class name for methods.
             span_name = name if name else "%s.%s" % (f.__module__, f.__name__)
 


### PR DESCRIPTION
## Description
<!-- Please briefly describe the change and why it was required. -->

This fixes an issue that has been bugging me on Visual Studio Code for some time. The `tracer.wrap` decorator breaks the hover help for decorated functions. By using a type variable, we enforce that the signature of the function passed to the decorator is the same as the signature of the function returned by it.

Before the change:

![image](https://user-images.githubusercontent.com/8453072/121571756-b1c3d700-ca23-11eb-84e1-206b9d66dec1.png)

After the change:

![image](https://user-images.githubusercontent.com/8453072/121571842-cb651e80-ca23-11eb-878c-3fd1e0f379b9.png)

Full snippet:

```py
from ddtrace import tracer

@tracer.wrap()
def do_something(a, b):
    # type: (int, float) -> None
    """
    Do something with an int and a float.

    Args:
        a (int): An integer.
        b (float): A float.
    """
    print(a, b)


def call_do_something():
    a = 1
    b = 2.0
    do_something(a, b)
```

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
