### PR TITLE
Update pre-commit hooks to only read files in staging

### DIFF
--- a/hooks/scripts/run-black.sh
+++ b/hooks/scripts/run-black.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-riot -v run -s black .
+staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.py$')
+riot -v run -s black $staged_files

--- a/hooks/scripts/run-flake8.sh
+++ b/hooks/scripts/run-flake8.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-riot -v run -s flake8
+staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.py$')
+riot -v run -s flake8-hook $staged_files

--- a/hooks/scripts/run-flake8.sh
+++ b/hooks/scripts/run-flake8.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.py$')
-riot -v run -s flake8-hook $staged_files
+riot -v run -s hook-flake8 $staged_files

--- a/hooks/scripts/run-mypy.sh
+++ b/hooks/scripts/run-mypy.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-riot -v run -s mypy
+staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.py$')
+riot -v run -s mypy  $staged_files

--- a/hooks/scripts/run-mypy.sh
+++ b/hooks/scripts/run-mypy.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.py$')
-riot -v run -s mypy  $staged_files
+riot -v run -s mypy $staged_files

--- a/riotfile.py
+++ b/riotfile.py
@@ -1,3 +1,4 @@
+# type: ignore
 from typing import List
 from typing import Tuple
 
@@ -100,8 +101,6 @@ venv = Venv(
         ),
         Venv(
             pys=["3"],
-            name="flake8",
-            command="flake8 {cmdargs} ddtrace/ tests/",
             pkgs={
                 "flake8": ">=3.8,<3.9",
                 "flake8-blind-except": latest,
@@ -112,6 +111,16 @@ venv = Venv(
                 "flake8-isort": latest,
                 "pygments": latest,
             },
+            venvs=[
+                Venv(
+                    name="flake8",
+                    command="flake8 {cmdargs} ddtrace/ tests/",
+                ),
+                Venv(
+                    name="flake8-hook",
+                    command="flake8 {cmdargs}",
+                ),
+            ],
         ),
         Venv(
             pys=["3"],

--- a/riotfile.py
+++ b/riotfile.py
@@ -117,7 +117,7 @@ venv = Venv(
                     command="flake8 {cmdargs} ddtrace/ tests/",
                 ),
                 Venv(
-                    name="flake8-hook",
+                    name="hook-flake8",
                     command="flake8 {cmdargs}",
                 ),
             ],


### PR DESCRIPTION
## Description
Our current pre-commit hooks `run-black.sh`, `run-mypy.sh`, and `run-flake8.sh` use riot commands respectively to check black, mypy, and flake8. However, our current configuration for calling those commands implicitly calls every file in the tracer library (`ddtrace/` and `tests/`) to be checked, which considerably slows down the pre-commit checks (approximately 1 minute for the checks to succeed at the moment).

To fix this issue, this PR updates the pre-commit hooks to only read files in staging to be committed, including added, copied, modified, and renamed `.py` files. This results in our pre-commit hooks taking approximately less than 10 seconds to succeed.

Note: `riotfile.py` has been marked with `# type: ignore` temporarily, will be addressed in a future PR.