### PR TITLE
chore(profiling): do not ignore the profiler by default

### DIFF
--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -94,7 +94,7 @@ class MemoryCollector(collector.PeriodicCollector):
     _max_events = attr.ib(factory=attr_utils.from_env("_DD_PROFILING_MEMORY_EVENTS_BUFFER", _DEFAULT_MAX_EVENTS, int))
     max_nframe = attr.ib(factory=attr_utils.from_env("DD_PROFILING_MAX_FRAMES", 64, int))
     heap_sample_size = attr.ib(type=int, factory=_get_default_heap_sample_size)
-    ignore_profiler = attr.ib(factory=attr_utils.from_env("DD_PROFILING_IGNORE_PROFILER", True, formats.asbool))
+    ignore_profiler = attr.ib(factory=attr_utils.from_env("DD_PROFILING_IGNORE_PROFILER", False, formats.asbool))
 
     def _start_service(self):  # type: ignore[override]
         # type: (...) -> None

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -463,7 +463,7 @@ class StackCollector(collector.PeriodicCollector):
 
     max_time_usage_pct = attr.ib(factory=attr_utils.from_env("DD_PROFILING_MAX_TIME_USAGE_PCT", 1, float))
     nframes = attr.ib(factory=attr_utils.from_env("DD_PROFILING_MAX_FRAMES", 64, int))
-    ignore_profiler = attr.ib(factory=attr_utils.from_env("DD_PROFILING_IGNORE_PROFILER", True, formats.asbool))
+    ignore_profiler = attr.ib(factory=attr_utils.from_env("DD_PROFILING_IGNORE_PROFILER", False, formats.asbool))
     tracer = attr.ib(default=None)
     _thread_time = attr.ib(init=False, repr=False, eq=False)
     _last_wall_time = attr.ib(init=False, repr=False, eq=False)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -121,8 +121,8 @@ below:
      - The interval in seconds to wait before flushing out recorded events.
    * - ``DD_PROFILING_IGNORE_PROFILER``
      - Boolean
-     - True
-     - Whether to ignore the profiler in the generated data.
+     - False
+     - **Deprecated**: whether to ignore the profiler in the generated data.
    * - ``DD_PROFILING_TAGS``
      - String
      -

--- a/releasenotes/notes/profiling-ignore-profiler-daa056f8384008dc.yaml
+++ b/releasenotes/notes/profiling-ignore-profiler-daa056f8384008dc.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    The profiler won't be ignoring its own resource usage anymore and will
+    report it in the profiles.

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -137,7 +137,9 @@ def test_max_time_usage_over():
 
 
 def test_ignore_profiler_single():
-    r, c, thread_id = test_collector._test_collector_collect(stack.StackCollector, stack.StackSampleEvent)
+    r, c, thread_id = test_collector._test_collector_collect(
+        stack.StackCollector, stack.StackSampleEvent, ignore_profiler=True
+    )
     events = r.events[stack.StackSampleEvent]
     assert thread_id not in {e.thread_id for e in events}
 
@@ -210,7 +212,7 @@ def test_repr():
         stack.StackCollector,
         "StackCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
         "recorder=Recorder(default_max_events=32768, max_events={}), min_interval_time=0.01, max_time_usage_pct=1.0, "
-        "nframes=64, ignore_profiler=True, tracer=None)",
+        "nframes=64, ignore_profiler=False, tracer=None)",
     )
 
 
@@ -340,7 +342,7 @@ def test_exception_collection():
     assert e.sampling_period > 0
     assert e.thread_id == nogevent.thread_get_ident()
     assert e.thread_name == "MainThread"
-    assert e.frames == [(__file__, 334, "test_exception_collection")]
+    assert e.frames == [(__file__, 336, "test_exception_collection")]
     assert e.nframes == 1
     assert e.exc_type == ValueError
 


### PR DESCRIPTION
In order to gather more (internal) stats about the profiler resource usage, we
shouldn't try to remove the profiler from the profiles.

This deprecates the option in case anyone wanted to use it and until we remove
the code completely.

The changelog keeps things simple as it's supposedly not a user-controlled
change, but it could still be visible.