### PR TITLE
Start writer thread on instantiation

### DIFF
--- a/ddtrace/contrib/gevent/__init__.py
+++ b/ddtrace/contrib/gevent/__init__.py
@@ -1,13 +1,15 @@
 """
 The gevent integration adds support for tracing across greenlets.
 
-
 The integration patches the gevent internals to add context management logic.
 
 .. note::
-    If you are using :ref:`ddtrace-run<ddtracerun>` you must set ``DD_GEVENT_PATCH_ALL=true`` and ``ddtrace-run`` will
-    call ``gevent.monkey.patch_all()`` as early as possible in your application to avoid patching conflicts.
-    If you are doing manual instrumentation, you must call ``gevent.monkey.patch_all`` before importing ``ddtrace``.
+    If :ref:`ddtrace-run<ddtracerun>` is being used set ``DD_GEVENT_PATCH_ALL=true`` and
+    ``gevent.monkey.patch_all()`` will be called as early as possible in the application
+    to avoid patching conflicts.
+
+    If ``ddtrace-run`` is not being used then be sure to call ``gevent.monkey.patch_all``
+    before importing ``ddtrace``.
 
 
 The integration also configures the global tracer instance to use a gevent

--- a/docs/installation_quickstart.rst
+++ b/docs/installation_quickstart.rst
@@ -41,6 +41,12 @@ Quickstart
 Tracing
 ~~~~~~~
 
+.. important::
+
+    If ``gevent`` is used in the application then read the documentation
+    :ref:`here<gevent>`.
+
+
 Getting started for tracing is as easy as prefixing your python entry-point
 command with ``ddtrace-run``.
 


### PR DESCRIPTION
In #1193 thread starting was deferred to `writer.write` to avoid
having the thread be created before gevent patches. However we now
require gevent patching to be applied before ddtrace is imported (and a
tracer/writer are created) so the writer can be started on
instantiation.

#2532 was an attempt to improve the performance of the check but now
the check isn't required.