### PR TITLE
Mypy commit hook to read all files, not just staging

### DIFF
--- a/hooks/scripts/run-mypy.sh
+++ b/hooks/scripts/run-mypy.sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.py$')
-riot -v run -s mypy $staged_files
+riot -v run -s mypy


### PR DESCRIPTION
## Description
The mypy pre-commit hook was updated to check all files in `ddtrace/` and `test/`, not just files in staging. This was done because a change to one API can potentially lead to mypy errors (including typing and function signatures) in other parts of the library.