### PR TITLE
Update TraceSamplingProcessor log level to be debug

### DIFF
--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -60,10 +60,10 @@ class TraceSamplingProcessor(TraceProcessor):
         # type: (List[Span]) -> Optional[List[Span]]
         sampled_spans = [s for s in trace if s.sampled]
         if len(sampled_spans) == 0:
-            log.info("dropping trace, %d spans unsampled", len(trace))
+            log.debug("dropping trace, %d spans unsampled", len(trace))
             return None
 
-        log.info("trace %d sampled (%d/%d spans sampled)", trace[0].trace_id, len(sampled_spans), len(trace))
+        log.debug("trace %d sampled (%d/%d spans sampled)", trace[0].trace_id, len(sampled_spans), len(trace))
         return trace
 
 


### PR DESCRIPTION
## Description
Updating the log level for the TraceSamplingProcessor from info to debug. Since we call `logging.basicConfig()` logging even as `info` can prove noisy, especially when the log messages are not directly actionable by the users of this library.
