### PR TITLE
Keep contexts active

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -147,7 +147,7 @@ class Span(object):
         self.sampled = True  # type: bool
 
         self._context = context  # type: Optional[Context]
-        self._parent = None  # type: Optional[Span]
+        self._parent = None  # type: Optional[Union[Context, Span]]
         self._ignored_exceptions = None  # type: Optional[List[Exception]]
         self._local_root = None  # type: Optional[Span]
 


### PR DESCRIPTION
Previously contexts would be "consumed" by a trace if the trace was
completed:

```python
tracer.context_provider.activate(ctx)
with tracer.trace("trace1") as span:
  assert span.parent_id == ctx.span_id

with tracer.trace("trace2") as span:
  assert span.parent_id is None
```

With this change a context will remain active after the trace has been
finished.

After this change:

```python
tracer.context_provider.activate(ctx)
with tracer.trace("trace1") as span:
  assert span.parent_id == ctx.span_id

with tracer.trace("trace2") as span:
  assert span.parent_id == ctx.span_id
```

This isn't a great solution at the moment as it can result in large
traces which aren't very usable in the UI but it does correlate work
better especially in the case of threads and tasks.

## Description
<!-- Please briefly describe the change and why it was required. -->


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
