### PR TITLE
Add double fork test cases

### DIFF
--- a/ddtrace/internal/forksafe.py
+++ b/ddtrace/internal/forksafe.py
@@ -32,7 +32,11 @@ def ddtrace_after_in_child():
 
 def register(after_in_child):
     # type: (typing.Callable[[], None]) -> typing.Callable[[], None]
-    """Register a function to be called after fork in the child process."""
+    """Register a function to be called after fork in the child process.
+
+    Note that ``after_in_child`` will be called in all child processes across
+    multiple forks unless it is unregistered.
+    """
     _registry.append(after_in_child)
     return after_in_child
 

--- a/tests/tracer/runtime/test_runtime_id.py
+++ b/tests/tracer/runtime/test_runtime_id.py
@@ -32,3 +32,31 @@ def test_get_runtime_id_fork():
     exit_code = os.WEXITSTATUS(status)
 
     assert exit_code == 42
+
+
+def test_get_runtime_id_double_fork():
+    runtime_id = runtime.get_runtime_id()
+
+    child = os.fork()
+
+    if child == 0:
+        runtime_id_child = runtime.get_runtime_id()
+        assert runtime_id != runtime_id_child
+
+        child2 = os.fork()
+
+        if child2 == 0:
+            runtime_id_child2 = runtime.get_runtime_id()
+            assert runtime_id != runtime_id_child
+            assert runtime_id_child != runtime_id_child2
+            os._exit(42)
+
+        pid, status = os.waitpid(child2, 0)
+        exit_code = os.WEXITSTATUS(status)
+        assert exit_code == 42
+
+        os._exit(42)
+
+    pid, status = os.waitpid(child, 0)
+    exit_code = os.WEXITSTATUS(status)
+    assert exit_code == 42


### PR DESCRIPTION
There weren't any before. Also documents the existing behaviour of `forksafe.register`.
