### PR TITLE
test(runtime-metrics): test env variable

### DIFF
--- a/tests/runtime/test_runtime_metrics_api.py
+++ b/tests/runtime/test_runtime_metrics_api.py
@@ -27,7 +27,7 @@ def test_runtime_metrics_api_idempotency():
 def test_manually_start_runtime_metrics(run_python_code_in_subprocess):
     """
     When importing and manually starting runtime metrics
-        There are no errors
+        Runtime metrics worker starts and there are no errors
     """
     out, err, status, pid = run_python_code_in_subprocess(
         """
@@ -42,4 +42,28 @@ assert RuntimeWorker._instance is None
 """,
     )
 
+    assert status == 0
+
+
+def test_start_runtime_metrics_via_env_var(ddtrace_run_python_code_in_subprocess):
+    """
+    When running with ddtrace-run and DD_RUNTIME_METRICS_ENABLED is set
+        Runtime metrics worker starts and there are no errors
+    """
+
+    _, _, status, _ = ddtrace_run_python_code_in_subprocess(
+        """
+from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
+assert RuntimeWorker._instance is None
+"""
+    )
+    assert status == 0
+
+    _, _, status, _ = ddtrace_run_python_code_in_subprocess(
+        """
+from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
+assert RuntimeWorker._instance is not None
+""",
+        env={"DD_RUNTIME_METRICS_ENABLED": "true"},
+    )
     assert status == 0


### PR DESCRIPTION
## Description

Add a test case to ensure that ddtrace-run behaves as expected based on the value of the `DD_RUNTIME_METRICS_ENABLED` environment variable.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
