### PR TITLE
fix(rand): do not over-register forksafe hooks

### DIFF
--- a/ddtrace/internal/_rand.pyx
+++ b/ddtrace/internal/_rand.pyx
@@ -75,9 +75,7 @@ cpdef seed():
 
 # We have to reseed the RNG or we will get collisions between the processes as
 # they will share the seed and generate the same random numbers.
-cpdef _reseed_on_fork():
-    seed()
-    forksafe.register(_reseed_on_fork)
+forksafe.register(seed)
 
 
 cpdef rand64bits():
@@ -88,4 +86,4 @@ cpdef rand64bits():
     return <uint64_t>(state * <uint64_t>2685821657736338717)
 
 
-_reseed_on_fork()
+seed()

--- a/tests/tracer/test_rand.py
+++ b/tests/tracer/test_rand.py
@@ -13,6 +13,7 @@ import threading
 from ddtrace import Span
 from ddtrace import tracer
 from ddtrace.internal import _rand
+from ddtrace.internal import forksafe
 from ddtrace.internal.compat import Queue
 
 
@@ -81,6 +82,7 @@ def test_multiprocess():
     q = MPQueue()
 
     def target(q):
+        assert sum((_ is _rand.seed for _ in forksafe._registry)) == 1
         q.put([_rand.rand64bits() for _ in range(100)])
 
     ps = [mp.Process(target=target, args=(q,)) for _ in range(30)]
@@ -89,6 +91,7 @@ def test_multiprocess():
 
     for p in ps:
         p.join()
+        assert p.exitcode == 0
 
     ids_list = [_rand.rand64bits() for _ in range(1000)]
     ids = set(ids_list)


### PR DESCRIPTION
## Description

Registered forksafe hooks are not discarded once executed so the current implementation of _rand would cause over-registration of hooks.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
