### PR TITLE
test(compat): skip maybe_stringify test on PY2

### DIFF
--- a/tests/tracer/test_compat.py
+++ b/tests/tracer/test_compat.py
@@ -8,6 +8,7 @@ import hypothesis.strategies as st
 import pytest
 import six
 
+from ddtrace.internal.compat import PY2
 from ddtrace.internal.compat import PY3
 from ddtrace.internal.compat import get_connection_response
 from ddtrace.internal.compat import is_integer
@@ -137,6 +138,7 @@ def test_pep562():
     assert whatever == "good module attribute"
 
 
+@pytest.mark.skipif(PY2, reason="This hypothesis test hangs occasionally on Python 2")
 @given(
     obj=st.one_of(
         st.none(),


### PR DESCRIPTION
## Description

This test hangs occasionally on Python 2, making the tracer test flaky.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
