### PR TITLE
fix(docs): update testing with ddtest and riot

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,24 +62,26 @@ launch them through:
 
 #### Running Tests in docker
 
-Once your docker-compose environment is running, you can run the test runner image:
+Once your docker-compose environment is running, you can use the shell script to
+execute tests within a Docker image. You can start the container with a bash shell: 
 
-    $ docker-compose run --rm testrunner
+    $ scripts/ddtest
 
-Now you are in a bash shell. You can now run tests as you would do in your local environment:
+You can now run tests as you would do in your local environment. We use
+[tox][tox] as well as [riot][riot], a new tool that we developed for addressing
+our specific needs with an ever growing matrix of tests. You can list the tests
+managed by each:
 
-    $ tox -e '{py35,py36}-redis{210}'
+    $ tox -l
+    $ riot list
+    
+You can run multiple tests by using regular expressions:
 
-We also provide a shell script to execute commands in the provided container.
-
-For example to run the tests for `redis-py` 2.10 on Python 3.5 and 3.6:
-
-    $ ./scripts/ddtest tox -e '{py35,py36}-redis{210}'
-
-If you want to run a list of tox environment (as CircleCI does) based on a
-pattern, you can use the following command:
-
-    $ scripts/ddtest scripts/run-tox-scenario '^futures_contrib-'
+    $ scripts/run-tox-scenario '^futures_contrib-'
+    $ riot run psycopg
+    
+[tox]: https://github.com/tox-dev/tox/
+[riot]: https://github.com/DataDog/riot/
 
 ### Continuous Integration
 


### PR DESCRIPTION
## Description

This documentation had fallen out of date. Contributors should use the ddtest script rather than start the testrunner themselves as the script handles installing dependencies. Also, no instructions had been included about running tests managed by riot.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
