### PR TITLE
Add env variables to configure Writer behavior

### DIFF
--- a/ddtrace/internal/agent.py
+++ b/ddtrace/internal/agent.py
@@ -14,9 +14,6 @@ DEFAULT_TRACE_PORT = 8126
 DEFAULT_STATS_PORT = 8125
 DEFAULT_TRACE_URL = "http://%s:%s" % (DEFAULT_HOSTNAME, DEFAULT_TRACE_PORT)
 DEFAULT_TIMEOUT = 2.0
-DEFAULT_BUFFER_SIZE = 8 * 1000000  # 8mb
-DEFAULT_MAX_PAYLOAD_SIZE = 8 * 1000000  # 8mb
-DEFAULT_PROCESSING_INTERVAL = 1.0
 
 ConnectionType = Union[HTTPSConnection, HTTPConnection, UDSHTTPConnection]
 
@@ -39,21 +36,6 @@ def get_stats_port():
 def get_trace_agent_timeout():
     # type: () -> float
     return float(get_env("trace", "agent", "timeout", "seconds", default=DEFAULT_TIMEOUT))  # type: ignore[arg-type]
-
-
-def get_trace_writer_buffer_size():
-    # type: () -> int
-    return int(get_env("trace", "writer", "buffer", "size", "bytes", default=DEFAULT_BUFFER_SIZE))  # type: ignore[arg-type]
-
-
-def get_trace_writer_max_payload_size():
-    # type: () -> int
-    return int(get_env("trace", "writer", "max", "payload", "size", "bytes", default=DEFAULT_MAX_PAYLOAD_SIZE))  # type: ignore[arg-type]
-
-
-def get_trace_writer_interval_seconds():
-    # type: () -> float
-    return float(get_env("trace", "writer", "interval", "seconds", default=DEFAULT_PROCESSING_INTERVAL))  # type: ignore[arg-type]
 
 
 def get_trace_url():

--- a/ddtrace/internal/agent.py
+++ b/ddtrace/internal/agent.py
@@ -14,6 +14,9 @@ DEFAULT_TRACE_PORT = 8126
 DEFAULT_STATS_PORT = 8125
 DEFAULT_TRACE_URL = "http://%s:%s" % (DEFAULT_HOSTNAME, DEFAULT_TRACE_PORT)
 DEFAULT_TIMEOUT = 2.0
+DEFAULT_BUFFER_SIZE = 8 * 1000000  # 8mb
+DEFAULT_MAX_PAYLOAD_SIZE = 8 * 1000000  # 8mb
+DEFAULT_PROCESSING_INTERVAL = 1.0
 
 ConnectionType = Union[HTTPSConnection, HTTPConnection, UDSHTTPConnection]
 
@@ -36,6 +39,21 @@ def get_stats_port():
 def get_trace_agent_timeout():
     # type: () -> float
     return float(get_env("trace", "agent", "timeout", "seconds", default=DEFAULT_TIMEOUT))  # type: ignore[arg-type]
+
+
+def get_trace_writer_buffer_size():
+    # type: () -> int
+    return int(get_env("trace", "writer", "buffer", "size", "bytes", default=DEFAULT_BUFFER_SIZE))  # type: ignore[arg-type]
+
+
+def get_trace_writer_max_payload_size():
+    # type: () -> int
+    return int(get_env("trace", "writer", "max", "payload", "size", "bytes", default=DEFAULT_MAX_PAYLOAD_SIZE))  # type: ignore[arg-type]
+
+
+def get_trace_writer_interval_seconds():
+    # type: () -> float
+    return float(get_env("trace", "writer", "interval", "seconds", default=DEFAULT_PROCESSING_INTERVAL))  # type: ignore[arg-type]
 
 
 def get_trace_url():

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -200,11 +200,11 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
         agent_url,  # type: str
         sampler=None,  # type: Optional[BaseSampler]
         priority_sampler=None,  # type: Optional[BasePrioritySampler]
-        processing_interval=1.0,  # type: float
+        processing_interval=agent.get_trace_writer_interval_seconds(),  # type: float
         # Match the payload size since there is no functionality
         # to flush dynamically.
-        buffer_size=8 * 1000000,  # type: int
-        max_payload_size=8 * 1000000,  # type: int
+        buffer_size=agent.get_trace_writer_buffer_size(),  # type: int
+        max_payload_size=agent.get_trace_writer_max_payload_size(),  # type: int
         timeout=agent.get_trace_agent_timeout(),  # type: float
         dogstatsd=None,  # type: Optional[DogStatsd]
         report_metrics=False,  # type: bool

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -60,12 +60,16 @@ def get_writer_buffer_size():
 
 def get_writer_max_payload_size():
     # type: () -> int
-    return int(get_env("trace", "writer_max_payload_size_bytes", default=DEFAULT_MAX_PAYLOAD_SIZE))  # type: ignore[arg-type]
+    return int(
+        get_env("trace", "writer_max_payload_size_bytes", default=DEFAULT_MAX_PAYLOAD_SIZE)  # type: ignore[arg-type]
+    )
 
 
 def get_writer_interval_seconds():
     # type: () -> float
-    return float(get_env("trace", "writer_interval_seconds", default=DEFAULT_PROCESSING_INTERVAL))  # type: ignore[arg-type]
+    return float(
+        get_env("trace", "writer_interval_seconds", default=DEFAULT_PROCESSING_INTERVAL)  # type: ignore[arg-type]
+    )
 
 
 def _human_size(nbytes):

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -21,6 +21,7 @@ from . import service
 from ..constants import KEEP_SPANS_RATE_KEY
 from ..sampler import BasePrioritySampler
 from ..sampler import BaseSampler
+from ..utils.formats import get_env
 from ..utils.time import StopWatch
 from .agent import get_connection
 from .buffer import BufferFull
@@ -46,6 +47,25 @@ LOG_ERR_INTERVAL = 60
 # 2s timeout, the java tracer has a 10s timeout, so we set the window size
 # to 10 buckets of 1s duration.
 DEFAULT_SMA_WINDOW = 10
+
+DEFAULT_BUFFER_SIZE = 8 * 1000000  # 8mb
+DEFAULT_MAX_PAYLOAD_SIZE = 8 * 1000000  # 8mb
+DEFAULT_PROCESSING_INTERVAL = 1.0
+
+
+def get_writer_buffer_size():
+    # type: () -> int
+    return int(get_env("writer", "buffer_size_bytes", default=DEFAULT_BUFFER_SIZE))  # type: ignore[arg-type]
+
+
+def get_writer_max_payload_size():
+    # type: () -> int
+    return int(get_env("writer", "max_payload_size_bytes", default=DEFAULT_MAX_PAYLOAD_SIZE))  # type: ignore[arg-type]
+
+
+def get_writer_interval_seconds():
+    # type: () -> float
+    return float(get_env("writer", "interval_seconds", default=DEFAULT_PROCESSING_INTERVAL))  # type: ignore[arg-type]
 
 
 def _human_size(nbytes):
@@ -200,11 +220,11 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
         agent_url,  # type: str
         sampler=None,  # type: Optional[BaseSampler]
         priority_sampler=None,  # type: Optional[BasePrioritySampler]
-        processing_interval=agent.get_trace_writer_interval_seconds(),  # type: float
+        processing_interval=get_writer_interval_seconds(),  # type: float
         # Match the payload size since there is no functionality
         # to flush dynamically.
-        buffer_size=agent.get_trace_writer_buffer_size(),  # type: int
-        max_payload_size=agent.get_trace_writer_max_payload_size(),  # type: int
+        buffer_size=get_writer_buffer_size(),  # type: int
+        max_payload_size=get_writer_max_payload_size(),  # type: int
         timeout=agent.get_trace_agent_timeout(),  # type: float
         dogstatsd=None,  # type: Optional[DogStatsd]
         report_metrics=False,  # type: bool

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -55,17 +55,17 @@ DEFAULT_PROCESSING_INTERVAL = 1.0
 
 def get_writer_buffer_size():
     # type: () -> int
-    return int(get_env("writer", "buffer_size_bytes", default=DEFAULT_BUFFER_SIZE))  # type: ignore[arg-type]
+    return int(get_env("trace", "writer_buffer_size_bytes", default=DEFAULT_BUFFER_SIZE))  # type: ignore[arg-type]
 
 
 def get_writer_max_payload_size():
     # type: () -> int
-    return int(get_env("writer", "max_payload_size_bytes", default=DEFAULT_MAX_PAYLOAD_SIZE))  # type: ignore[arg-type]
+    return int(get_env("trace", "writer_max_payload_size_bytes", default=DEFAULT_MAX_PAYLOAD_SIZE))  # type: ignore[arg-type]
 
 
 def get_writer_interval_seconds():
     # type: () -> float
-    return float(get_env("writer", "interval_seconds", default=DEFAULT_PROCESSING_INTERVAL))  # type: ignore[arg-type]
+    return float(get_env("trace", "writer_interval_seconds", default=DEFAULT_PROCESSING_INTERVAL))  # type: ignore[arg-type]
 
 
 def _human_size(nbytes):

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -83,6 +83,18 @@ below:
      - Float
      - 2.0
      - The timeout in float to use to connect to the Datadog agent.
+   * - ``DD_TRACE_WRITER_BUFFER_SIZE_BYTES``
+     - Int
+     - 8000000
+     - The max size in bytes of traces to buffer between flushes to the agent.
+   * - ``DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES``
+     - Int
+     - 8000000
+     - The max size in bytes of each payload sent to the trace agent. If max payload size is less than buffer size, multiple payloads will be sent to the trace agent.
+   * - ``DD_TRACE_WRITER_INTERVAL_SECONDS``
+     - Float
+     - 1.0
+     - The time between each flush of traces to the trace agent.
    * - ``DD_TRACE_STARTUP_LOGS``
      - Boolean
      - False

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -83,15 +83,15 @@ below:
      - Float
      - 2.0
      - The timeout in float to use to connect to the Datadog agent.
-   * - ``DD_TRACE_WRITER_BUFFER_SIZE_BYTES``
+   * - ``DD_WRITER_BUFFER_SIZE_BYTES``
      - Int
      - 8000000
      - The max size in bytes of traces to buffer between flushes to the agent.
-   * - ``DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES``
+   * - ``DD_WRITER_MAX_PAYLOAD_SIZE_BYTES``
      - Int
      - 8000000
      - The max size in bytes of each payload sent to the trace agent. If max payload size is less than buffer size, multiple payloads will be sent to the trace agent.
-   * - ``DD_TRACE_WRITER_INTERVAL_SECONDS``
+   * - ``DD_WRITER_INTERVAL_SECONDS``
      - Float
      - 1.0
      - The time between each flush of traces to the trace agent.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -83,15 +83,15 @@ below:
      - Float
      - 2.0
      - The timeout in float to use to connect to the Datadog agent.
-   * - ``DD_WRITER_BUFFER_SIZE_BYTES``
+   * - ``DD_TRACE_WRITER_BUFFER_SIZE_BYTES``
      - Int
      - 8000000
      - The max size in bytes of traces to buffer between flushes to the agent.
-   * - ``DD_WRITER_MAX_PAYLOAD_SIZE_BYTES``
+   * - ``DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES``
      - Int
      - 8000000
      - The max size in bytes of each payload sent to the trace agent. If max payload size is less than buffer size, multiple payloads will be sent to the trace agent.
-   * - ``DD_WRITER_INTERVAL_SECONDS``
+   * - ``DD_TRACE_WRITER_INTERVAL_SECONDS``
      - Float
      - 1.0
      - The time between each flush of traces to the trace agent.

--- a/releasenotes/notes/add-writer-env-config-7c0916dff4f7f80c.yaml
+++ b/releasenotes/notes/add-writer-env-config-7c0916dff4f7f80c.yaml
@@ -3,5 +3,5 @@ features:
   - |
     Add new environment variables to configure the internal trace writer.
 
-    ``DD_TRACE_WRITER_MAX_BUFFER_SIZE``, ``DD_TRACE_WRITER_INTERVAL_SECONDS,
+    ``DD_TRACE_WRITER_MAX_BUFFER_SIZE``, ``DD_TRACE_WRITER_INTERVAL_SECONDS``,
     ``DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES``

--- a/releasenotes/notes/add-writer-env-config-7c0916dff4f7f80c.yaml
+++ b/releasenotes/notes/add-writer-env-config-7c0916dff4f7f80c.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add new environment variables to configure the internal trace writer.
+
+    ``DD_TRACE_WRITER_MAX_BUFFER_SIZE``, ``DD_TRACE_WRITER_INTERVAL_SECONDS,
+    ``DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES``

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -497,3 +497,67 @@ print(len(root.handlers))
         assert out == six.b("1\n")
     else:
         assert out == six.b("0\n")
+
+
+def test_writer_env_configuration(run_python_code_in_subprocess):
+    env = os.environ.copy()
+    env["DD_TRACE_WRITER_BUFFER_SIZE_BYTES"] = "1000"
+    env["DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES"] = "5000"
+    env["DD_TRACE_WRITER_INTERVAL_SECONDS"] = "5.0"
+
+    out, err, status, pid = run_python_code_in_subprocess(
+        """
+import ddtrace
+
+assert ddtrace.tracer.writer._buffer.max_size == 1000
+assert ddtrace.tracer.writer._buffer.max_item_size == 5000
+assert ddtrace.tracer.writer._interval == 5.0
+""",
+        env=env,
+    )
+    assert status == 0, (out, err)
+
+
+def test_writer_env_configuration_defaults(run_python_code_in_subprocess):
+    out, err, status, pid = run_python_code_in_subprocess(
+        """
+import ddtrace
+
+assert ddtrace.tracer.writer._buffer.max_size == 8000000
+assert ddtrace.tracer.writer._buffer.max_item_size == 8000000
+assert ddtrace.tracer.writer._interval == 1.0
+""",
+    )
+    assert status == 0, (out, err)
+
+
+def test_writer_env_configuration_ddtrace_run(ddtrace_run_python_code_in_subprocess):
+    env = os.environ.copy()
+    env["DD_TRACE_WRITER_BUFFER_SIZE_BYTES"] = "1000"
+    env["DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES"] = "5000"
+    env["DD_TRACE_WRITER_INTERVAL_SECONDS"] = "5.0"
+
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(
+        """
+import ddtrace
+
+assert ddtrace.tracer.writer._buffer.max_size == 1000
+assert ddtrace.tracer.writer._buffer.max_item_size == 5000
+assert ddtrace.tracer.writer._interval == 5.0
+""",
+        env=env,
+    )
+    assert status == 0, (out, err)
+
+
+def test_writer_env_configuration_ddtrace_run_defaults(ddtrace_run_python_code_in_subprocess):
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(
+        """
+import ddtrace
+
+assert ddtrace.tracer.writer._buffer.max_size == 8000000
+assert ddtrace.tracer.writer._buffer.max_item_size == 8000000
+assert ddtrace.tracer.writer._interval == 1.0
+""",
+    )
+    assert status == 0, (out, err)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -501,9 +501,9 @@ print(len(root.handlers))
 
 def test_writer_env_configuration(run_python_code_in_subprocess):
     env = os.environ.copy()
-    env["DD_WRITER_BUFFER_SIZE_BYTES"] = "1000"
-    env["DD_WRITER_MAX_PAYLOAD_SIZE_BYTES"] = "5000"
-    env["DD_WRITER_INTERVAL_SECONDS"] = "5.0"
+    env["DD_TRACE_WRITER_BUFFER_SIZE_BYTES"] = "1000"
+    env["DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES"] = "5000"
+    env["DD_TRACE_WRITER_INTERVAL_SECONDS"] = "5.0"
 
     out, err, status, pid = run_python_code_in_subprocess(
         """
@@ -533,9 +533,9 @@ assert ddtrace.tracer.writer._interval == 1.0
 
 def test_writer_env_configuration_ddtrace_run(ddtrace_run_python_code_in_subprocess):
     env = os.environ.copy()
-    env["DD_WRITER_BUFFER_SIZE_BYTES"] = "1000"
-    env["DD_WRITER_MAX_PAYLOAD_SIZE_BYTES"] = "5000"
-    env["DD_WRITER_INTERVAL_SECONDS"] = "5.0"
+    env["DD_TRACE_WRITER_BUFFER_SIZE_BYTES"] = "1000"
+    env["DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES"] = "5000"
+    env["DD_TRACE_WRITER_INTERVAL_SECONDS"] = "5.0"
 
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -501,9 +501,9 @@ print(len(root.handlers))
 
 def test_writer_env_configuration(run_python_code_in_subprocess):
     env = os.environ.copy()
-    env["DD_TRACE_WRITER_BUFFER_SIZE_BYTES"] = "1000"
-    env["DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES"] = "5000"
-    env["DD_TRACE_WRITER_INTERVAL_SECONDS"] = "5.0"
+    env["DD_WRITER_BUFFER_SIZE_BYTES"] = "1000"
+    env["DD_WRITER_MAX_PAYLOAD_SIZE_BYTES"] = "5000"
+    env["DD_WRITER_INTERVAL_SECONDS"] = "5.0"
 
     out, err, status, pid = run_python_code_in_subprocess(
         """
@@ -533,9 +533,9 @@ assert ddtrace.tracer.writer._interval == 1.0
 
 def test_writer_env_configuration_ddtrace_run(ddtrace_run_python_code_in_subprocess):
     env = os.environ.copy()
-    env["DD_TRACE_WRITER_BUFFER_SIZE_BYTES"] = "1000"
-    env["DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES"] = "5000"
-    env["DD_TRACE_WRITER_INTERVAL_SECONDS"] = "5.0"
+    env["DD_WRITER_BUFFER_SIZE_BYTES"] = "1000"
+    env["DD_WRITER_MAX_PAYLOAD_SIZE_BYTES"] = "5000"
+    env["DD_WRITER_INTERVAL_SECONDS"] = "5.0"
 
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """


### PR DESCRIPTION
DD_TRACE_WRITER_BUFFER_SIZE_BYTES - How many bytes of traces to buffer between flushes to the agent
DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES - Max size of any payload to write to the trace agent
DD_TRACE_WRITER_INTERVAL_SECONDS - How many seconds between flushes to the agent


## Checklist
- [x] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Library documentation is updated.
- ~[ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
