### PR TITLE
perf(encoder) add small encoder optimizations

### DIFF
--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -66,7 +66,7 @@ cdef class Packer(object):
         self.pk.buf_size = buf_size
         self.pk.length = 0
 
-    def __init__(self, buf_size, buf_start_size=1024*1024):
+    def __init__(self, buf_size):
         self._default = None
 
         if PY_MAJOR_VERSION < 3:

--- a/ddtrace/internal/pack.h
+++ b/ddtrace/internal/pack.h
@@ -41,13 +41,10 @@ static inline int msgpack_pack_write(msgpack_packer* pk, const char *data, size_
     size_t bs = pk->buf_size;
     size_t len = pk->length;
 
+    // return an error if we are going to overflow the buffer, no resizing
+    // this generally means a single trace is larger than the buffer size
     if (len + l > bs) {
-        bs = (len + l) * 2;
-        buf = (char*)PyMem_Realloc(buf, bs);
-        if (!buf) {
-            PyErr_NoMemory();
-            return -1;
-        }
+      return -1;
     }
     memcpy(buf + len, data, l);
     len += l;

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -239,7 +239,7 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
                 }
             )
 
-        self._encoder = Encoder()
+        self._encoder = Encoder(buf_size=self._max_payload_size)
         self._headers.update({"Content-Type": self._encoder.content_type})
 
         self.dogstatsd = dogstatsd

--- a/tests/benchmarks/test_encoding.py
+++ b/tests/benchmarks/test_encoding.py
@@ -1,3 +1,5 @@
+import struct
+
 import msgpack
 from msgpack.fallback import Packer
 import pytest
@@ -6,10 +8,6 @@ from ddtrace.internal.encoding import MsgpackEncoder
 from ddtrace.internal.encoding import _EncoderBase
 from tests.tracer.test_encoders import RefMsgpackEncoder
 from tests.tracer.test_encoders import gen_trace
-
-
-msgpack_encoder = RefMsgpackEncoder()
-trace_encoder = MsgpackEncoder()
 
 
 class PPMsgpackEncoder(_EncoderBase):
@@ -23,57 +21,117 @@ class PPMsgpackEncoder(_EncoderBase):
     def decode(data):
         return msgpack.unpackb(data, raw=True)
 
+    def join_encoded(self, objs):
+        """Join a list of encoded objects together as a msgpack array"""
+        buf = b"".join(objs)
+
+        count = len(objs)
+        if count <= 0xF:
+            return struct.pack("B", 0x90 + count) + buf
+        elif count <= 0xFFFF:
+            return struct.pack(">BH", 0xDC, count) + buf
+        else:
+            return struct.pack(">BI", 0xDD, count) + buf
+
+
+msgpack_encoder = RefMsgpackEncoder()
+trace_encoder = MsgpackEncoder()
+fallback_encoder = PPMsgpackEncoder()
 
 trace_large = gen_trace(nspans=1000)
 trace_small = gen_trace(nspans=50, key_size=10, ntags=5, nmetrics=4)
 
 
 @pytest.mark.benchmark(group="encoding.join_encoded", min_time=0.005)
-def test_join_encoded(benchmark):
-    benchmark(
-        msgpack_encoder.join_encoded,
-        [msgpack_encoder.encode_trace(trace_large), msgpack_encoder.encode_trace(trace_small)],
-    )
+@pytest.mark.parametrize(
+    "encoder_name,encoder",
+    [
+        ("reference", msgpack_encoder),
+        ("custom", trace_encoder),
+        ("fallback", fallback_encoder),
+    ],
+)
+def test_join_encoded(benchmark, encoder_name, encoder):
+    traces = [encoder.encode_trace(trace_large), encoder.encode_trace(trace_small)]
+    benchmark(encoder.join_encoded, traces)
 
 
-@pytest.mark.benchmark(group="encoding", min_time=0.005)
-def test_encode_1000_span_trace(benchmark):
-    benchmark(msgpack_encoder.encode_trace, trace_large)
-
-
-@pytest.mark.benchmark(group="encoding.small", min_time=0.005)
-def test_encode_trace_small(benchmark):
-    benchmark(msgpack_encoder.encode_trace, trace_small)
-
-
-@pytest.mark.benchmark(group="encoding.small.multi", min_time=0.005)
-def test_encode_trace_small_multi(benchmark):
-    benchmark(msgpack_encoder.encode_traces, [trace_small for _ in range(50)])
-
-
-@pytest.mark.benchmark(group="encoding", min_time=0.005)
-def test_encode_1000_span_trace_fallback(benchmark):
-    encoder = PPMsgpackEncoder()
+@pytest.mark.benchmark(group="encoding.1000_spans", min_time=0.005)
+@pytest.mark.parametrize(
+    "encoder_name,encoder",
+    [
+        ("reference", msgpack_encoder),
+        ("custom", trace_encoder),
+        ("fallback", fallback_encoder),
+    ],
+)
+def test_encode_1000_span_trace(benchmark, encoder_name, encoder):
     benchmark(encoder.encode_trace, trace_large)
 
 
-@pytest.mark.benchmark(group="encoding", min_time=0.005)
-def test_encode_1000_span_trace_custom(benchmark):
-    benchmark(trace_encoder.encode_trace, trace_large)
-
-
 @pytest.mark.benchmark(group="encoding.small", min_time=0.005)
-def test_encode_trace_small_custom(benchmark):
-    benchmark(trace_encoder.encode_trace, trace_small)
+@pytest.mark.parametrize(
+    "encoder_name,encoder",
+    [
+        ("reference", msgpack_encoder),
+        ("custom", trace_encoder),
+        ("fallback", fallback_encoder),
+    ],
+)
+def test_encode_trace_small(benchmark, encoder_name, encoder):
+    benchmark(encoder.encode_trace, trace_small)
 
 
 @pytest.mark.benchmark(group="encoding.small.multi", min_time=0.005)
-def test_encode_trace_small_multi_custom(benchmark):
-    benchmark(trace_encoder.encode_traces, [trace_small for _ in range(50)])
+@pytest.mark.parametrize(
+    "encoder_name,encoder",
+    [
+        ("reference", msgpack_encoder),
+        ("custom", trace_encoder),
+        ("fallback", fallback_encoder),
+    ],
+)
+def test_encode_trace_small_multi(benchmark, encoder_name, encoder):
+    benchmark(encoder.encode_traces, [trace_small for _ in range(50)])
 
 
-@pytest.mark.benchmark(group="encoding.join_encoded", min_time=0.005)
-def test_join_encoded_custom(benchmark):
-    benchmark(
-        trace_encoder.join_encoded, [trace_encoder.encode_trace(trace_large), trace_encoder.encode_trace(trace_small)]
-    )
+@pytest.mark.benchmark(group="encoding.small.dd_origin", min_time=0.005)
+@pytest.mark.parametrize(
+    "encoder_name,encoder,dd_origin",
+    [
+        ("reference", msgpack_encoder, "synthetics"),
+        ("custom", trace_encoder, "synthetics"),
+        ("fallback", fallback_encoder, "synthetics"),
+    ],
+)
+def test_encode_trace_small_dd_origin(benchmark, encoder_name, encoder, dd_origin):
+    trace = gen_trace(nspans=50, key_size=10, ntags=5, nmetrics=4, dd_origin=dd_origin)
+    benchmark(encoder.encode_trace, trace)
+
+
+@pytest.mark.benchmark(group="encoding.small.multi.dd_origin", min_time=0.005)
+@pytest.mark.parametrize(
+    "encoder_name,encoder,dd_origin",
+    [
+        ("reference", msgpack_encoder, "synthetics"),
+        ("custom", trace_encoder, "synthetics"),
+        ("fallback", fallback_encoder, "synthetics"),
+    ],
+)
+def test_encode_trace_small_multi_dd_origin(benchmark, encoder_name, encoder, dd_origin):
+    trace = gen_trace(nspans=50, key_size=10, ntags=5, nmetrics=4, dd_origin=dd_origin)
+    benchmark(encoder.encode_traces, [trace for _ in range(50)])
+
+
+@pytest.mark.benchmark(group="encoding.1000_spans.dd_origin", min_time=0.005)
+@pytest.mark.parametrize(
+    "encoder_name,encoder,dd_origin",
+    [
+        ("reference", msgpack_encoder, "synthetics"),
+        ("custom", trace_encoder, "synthetics"),
+        ("fallback", fallback_encoder, "synthetics"),
+    ],
+)
+def test_encode_1000_span_trace_dd_origin(benchmark, encoder_name, encoder, dd_origin):
+    trace = gen_trace(nspans=1000, dd_origin=dd_origin)
+    benchmark(encoder.encode_trace, trace)

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -23,7 +23,7 @@ def rands(size=6, chars=string.ascii_uppercase + string.digits):
     return "".join(random.choice(chars) for _ in range(size))
 
 
-def gen_trace(nspans=1000, ntags=50, key_size=15, value_size=20, nmetrics=10):
+def gen_trace(nspans=1000, ntags=50, key_size=15, value_size=20, nmetrics=10, dd_origin=None):
     t = Tracer()
 
     root = None
@@ -51,6 +51,7 @@ def gen_trace(nspans=1000, ntags=50, key_size=15, value_size=20, nmetrics=10):
 
             if not root:
                 root = span
+                root.set_tag("_dd.origin", dd_origin)
 
     return trace
 


### PR DESCRIPTION
This is a POC PR just to see what improvements we can squeeze out of the encoder with minimal changes.

- Directly write raw bytes to buffer for primary span attributes.
- Initialize a single Packer per encoder instance rather than per encode call.
- Initialize Packer with max buffer size, and remove buffer realloc/growth.
  - This reduces number of calls to PyMem_Realloc and PyMem_Malloc.
  - This also means that any single trace that is larger than our max payload size will fail to encode.


## Before
```
---------------------------------------------------------------------------------------- benchmark 'encoding.1000_spans': 3 tests ----------------------------------------------------------------------------------------
Name (time in ms)                                        Min                 Max                Mean             StdDev              Median                IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_encode_1000_span_trace[custom-encoder1]          3.8027 (1.0)        9.8967 (1.0)        5.2567 (1.0)       0.9589 (1.0)        5.0220 (1.0)       1.1095 (1.0)          48;9  190.2331 (1.0)         187           1
test_encode_1000_span_trace[reference-encoder0]       5.9753 (1.57)      25.2855 (2.55)       8.4187 (1.60)      2.0768 (2.17)       8.2054 (1.63)      1.6923 (1.53)          9;2  118.7838 (0.62)        102           1
test_encode_1000_span_trace[fallback-encoder2]      156.2464 (41.09)    193.1020 (19.51)    165.3263 (31.45)    14.1801 (14.79)    159.1548 (31.69)    10.3511 (9.33)          1;1    6.0486 (0.03)          6           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------------------- benchmark 'encoding.1000_spans.dd_origin': 3 tests --------------------------------------------------------------------------------------------
Name (time in ms)                                                             Min                 Max                Mean            StdDev              Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_encode_1000_span_trace_dd_origin[custom-encoder1-synthetics]          3.5194 (1.0)        7.3096 (1.0)        4.6737 (1.0)      0.8606 (1.0)        4.3639 (1.0)      0.7557 (1.0)         23;10  213.9613 (1.0)         120           2
test_encode_1000_span_trace_dd_origin[reference-encoder0-synthetics]       5.3735 (1.53)      11.6883 (1.60)       7.0145 (1.50)     1.2005 (1.40)       6.6884 (1.53)     1.6231 (2.15)         43;1  142.5628 (0.67)        130           1
test_encode_1000_span_trace_dd_origin[fallback-encoder2-synthetics]      156.3256 (44.42)    165.6842 (22.67)    160.4756 (34.34)    3.3210 (3.86)     160.6980 (36.82)    5.0306 (6.66)          2;0    6.2315 (0.03)          7           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

-------------------------------------------------------------------------------------- benchmark 'encoding.join_encoded': 3 tests --------------------------------------------------------------------------------------
Name (time in us)                              Min                   Max                Mean              StdDev              Median                 IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_join_encoded[fallback-encoder2]      178.3524 (1.0)      1,361.4237 (1.15)     746.9803 (1.0)      266.3174 (2.28)     795.2602 (1.0)      412.5402 (2.82)         32;0        1.3387 (1.0)         115          10
test_join_encoded[custom-encoder1]        619.9262 (3.48)     1,187.5950 (1.0)      897.1723 (1.20)     116.8230 (1.0)      896.4302 (1.13)     146.3911 (1.0)          33;0        1.1146 (0.83)        116          10
test_join_encoded[reference-encoder0]     649.5601 (3.64)     1,244.9076 (1.05)     921.3767 (1.23)     194.2807 (1.66)     857.8991 (1.08)     324.8614 (2.22)         13;0        1.0853 (0.81)         34          20
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------------------------- benchmark 'encoding.small': 3 tests -----------------------------------------------------------------------------------------------
Name (time in us)                                      Min                   Max                  Mean              StdDev                Median                 IQR            Outliers          OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_encode_trace_small[custom-encoder1]           50.0761 (1.0)         75.8011 (1.0)         55.4345 (1.0)        3.2631 (1.0)         54.7001 (1.0)        1.9036 (1.0)         24;21  18,039.3197 (1.0)         169         100
test_encode_trace_small[reference-encoder0]        91.9830 (1.84)       130.8370 (1.73)       104.0596 (1.88)       5.2867 (1.62)       103.9562 (1.90)       2.9889 (1.57)        21;18   9,609.8751 (0.53)         93         100
test_encode_trace_small[fallback-encoder2]      2,092.5205 (41.79)    2,920.3277 (38.53)    2,293.3001 (41.37)    135.2267 (41.44)    2,272.3459 (41.54)    101.5795 (53.36)         6;3     436.0528 (0.02)         42          10
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------------------------- benchmark 'encoding.small.dd_origin': 3 tests ----------------------------------------------------------------------------------------------------
Name (time in us)                                                           Min                   Max                  Mean             StdDev                Median                IQR            Outliers          OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_encode_trace_small_dd_origin[custom-encoder1-synthetics]           47.1001 (1.0)         87.6994 (1.0)         55.8105 (1.0)       4.9793 (1.41)        54.7929 (1.0)       3.6052 (1.27)        31;10  17,917.7798 (1.0)         170         100
test_encode_trace_small_dd_origin[reference-encoder0-synthetics]        99.7615 (2.12)       123.0314 (1.40)       110.1782 (1.97)      3.5361 (1.0)        109.9489 (2.01)      2.8309 (1.0)          14;8   9,076.2060 (0.51)         71         100
test_encode_trace_small_dd_origin[fallback-encoder2-synthetics]      2,074.0736 (44.04)    2,523.0724 (28.77)    2,265.3686 (40.59)    79.3174 (22.43)    2,267.2602 (41.38)    67.4792 (23.84)        12;3     441.4293 (0.02)         43          10
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------------- benchmark 'encoding.small.multi': 3 tests ----------------------------------------------------------------------------------------
Name (time in ms)                                          Min                 Max                Mean            StdDev              Median               IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_encode_trace_small_multi[custom-encoder1]          2.3590 (1.0)        3.4379 (1.0)        2.6924 (1.0)      0.1305 (1.0)        2.6774 (1.0)      0.0759 (1.0)         36;31  371.4155 (1.0)         179           2
test_encode_trace_small_multi[reference-encoder0]       4.8731 (2.07)      18.1728 (5.29)       5.7138 (2.12)     1.7607 (13.49)      5.3406 (1.99)     0.3696 (4.87)         3;11  175.0155 (0.47)        147           1
test_encode_trace_small_multi[fallback-encoder2]      111.4484 (47.24)    119.8367 (34.86)    116.9793 (43.45)    2.5915 (19.85)    117.3917 (43.85)    2.5484 (33.58)         2;1    8.5485 (0.02)          9           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------------------- benchmark 'encoding.small.multi.dd_origin': 3 tests ---------------------------------------------------------------------------------------------
Name (time in ms)                                                               Min                 Max                Mean            StdDev              Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_encode_trace_small_multi_dd_origin[custom-encoder1-synthetics]          2.3750 (1.0)        4.1332 (1.0)        2.7546 (1.0)      0.2382 (1.0)        2.6823 (1.0)      0.0960 (1.0)         20;24  363.0268 (1.0)         180           2
test_encode_trace_small_multi_dd_origin[reference-encoder0-synthetics]       4.6420 (1.95)      18.4238 (4.46)       5.7639 (2.09)     1.6836 (7.07)       5.4431 (2.03)     0.4939 (5.14)          4;9  173.4928 (0.48)        169           1
test_encode_trace_small_multi_dd_origin[fallback-encoder2-synthetics]      112.4253 (47.34)    132.5304 (32.06)    117.4399 (42.63)    6.0943 (25.59)    114.9581 (42.86)    3.6613 (38.13)         1;1    8.5150 (0.02)          9           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

## After
```
--------------------------------------------------------------------------------------- benchmark 'encoding.1000_spans': 3 tests ---------------------------------------------------------------------------------------
Name (time in ms)                                        Min                 Max                Mean            StdDev              Median               IQR            Outliers       OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_encode_1000_span_trace[custom-encoder1]          2.7814 (1.0)        4.4123 (1.0)        3.3889 (1.0)      0.2949 (1.0)        3.3641 (1.0)      0.3406 (1.0)          37;6  295.0775 (1.0)         146           2
test_encode_1000_span_trace[reference-encoder0]       4.6720 (1.68)      20.0605 (4.55)       6.6905 (1.97)     1.6168 (5.48)       6.4693 (1.92)     2.0015 (5.88)         20;1  149.4650 (0.51)        148           1
test_encode_1000_span_trace[fallback-encoder2]      146.8287 (52.79)    168.6062 (38.21)    153.5157 (45.30)    7.2109 (24.45)    151.3105 (44.98)    5.3667 (15.76)         1;1    6.5140 (0.02)          7           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------------------- benchmark 'encoding.1000_spans.dd_origin': 3 tests --------------------------------------------------------------------------------------------
Name (time in ms)                                                             Min                 Max                Mean            StdDev              Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_encode_1000_span_trace_dd_origin[custom-encoder1-synthetics]          2.8811 (1.0)        4.5657 (1.0)        3.3381 (1.0)      0.2609 (1.0)        3.2727 (1.0)      0.3106 (1.0)          32;3  299.5727 (1.0)         146           2
test_encode_1000_span_trace_dd_origin[reference-encoder0-synthetics]       5.2189 (1.81)      19.6322 (4.30)       6.7509 (2.02)     1.4844 (5.69)       6.2710 (1.92)     1.4916 (4.80)         24;1  148.1278 (0.49)        170           1
test_encode_1000_span_trace_dd_origin[fallback-encoder2-synthetics]      152.9647 (53.09)    162.5263 (35.60)    156.8816 (47.00)    3.4457 (13.21)    155.8598 (47.62)    5.0936 (16.40)         2;0    6.3742 (0.02)          7           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

-------------------------------------------------------------------------------------- benchmark 'encoding.join_encoded': 3 tests --------------------------------------------------------------------------------------
Name (time in us)                              Min                   Max                Mean              StdDev              Median                 IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_join_encoded[custom-encoder1]        545.1826 (1.0)      1,025.5244 (1.0)      702.4479 (1.12)      96.9571 (1.27)     694.6468 (1.14)     142.8469 (2.14)         47;2        1.4236 (0.89)        147          10
test_join_encoded[fallback-encoder2]      546.5928 (1.00)     1,076.4206 (1.05)     711.7780 (1.14)     101.5075 (1.33)     701.4609 (1.15)     144.9635 (2.17)         39;1        1.4049 (0.88)        133          10
test_join_encoded[reference-encoder0]     546.6019 (1.00)     1,091.0684 (1.06)     624.6547 (1.0)       76.0967 (1.0)      610.5281 (1.0)       66.7206 (1.0)           4;2        1.6009 (1.0)          68          20
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------------------------- benchmark 'encoding.small': 3 tests -----------------------------------------------------------------------------------------------
Name (time in us)                                      Min                   Max                  Mean             StdDev                Median                 IQR            Outliers          OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_encode_trace_small[custom-encoder1]           43.7934 (1.0)         65.1043 (1.0)         50.4088 (1.0)       2.8000 (1.0)         50.6091 (1.0)        2.3264 (1.0)         47;16  19,837.8151 (1.0)         185         100
test_encode_trace_small[reference-encoder0]        90.5800 (2.07)       139.6548 (2.15)       107.8199 (2.14)      8.9136 (3.18)       105.2761 (2.08)       6.9971 (3.01)        25;11   9,274.7215 (0.47)         95         100
test_encode_trace_small[fallback-encoder2]      2,032.1243 (46.40)    2,436.7874 (37.43)    2,237.3629 (44.38)    94.9536 (33.91)    2,251.4438 (44.49)    142.1959 (61.12)        13;0     446.9548 (0.02)         42          10
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------------------------- benchmark 'encoding.small.dd_origin': 3 tests ----------------------------------------------------------------------------------------------------
Name (time in us)                                                           Min                   Max                  Mean             StdDev                Median                IQR            Outliers          OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_encode_trace_small_dd_origin[custom-encoder1-synthetics]           43.8231 (1.0)         67.6003 (1.0)         50.6212 (1.0)       3.1118 (1.0)         50.4635 (1.0)       1.4504 (1.0)         39;41  19,754.5766 (1.0)         198         105
test_encode_trace_small_dd_origin[reference-encoder0-synthetics]        92.1181 (2.10)       133.7178 (1.98)       104.3483 (2.06)      5.2767 (1.70)       104.1641 (2.06)      4.2937 (2.96)         20;8   9,583.2878 (0.49)         95         100
test_encode_trace_small_dd_origin[fallback-encoder2-synthetics]      2,106.0269 (48.06)    2,635.5617 (38.99)    2,269.5854 (44.83)    97.3045 (31.27)    2,265.1064 (44.89)    69.8428 (48.15)        11;3     440.6091 (0.02)         44          10
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------------- benchmark 'encoding.small.multi': 3 tests ----------------------------------------------------------------------------------------
Name (time in ms)                                          Min                 Max                Mean            StdDev              Median               IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_encode_trace_small_multi[custom-encoder1]          2.2070 (1.0)        4.3921 (1.0)        2.5610 (1.0)      0.2044 (1.0)        2.5273 (1.0)      0.0936 (1.0)         32;36  390.4722 (1.0)         193           2
test_encode_trace_small_multi[reference-encoder0]       4.8985 (2.22)      19.1986 (4.37)       5.9166 (2.31)     1.8366 (8.99)       5.5391 (2.19)     0.4541 (4.85)         4;12  169.0151 (0.43)        147           1
test_encode_trace_small_multi[fallback-encoder2]      110.6539 (50.14)    118.4990 (26.98)    113.8466 (44.45)    2.2644 (11.08)    114.1555 (45.17)    2.4858 (26.55)         2;0    8.7838 (0.02)          9           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------------------- benchmark 'encoding.small.multi.dd_origin': 3 tests ---------------------------------------------------------------------------------------------
Name (time in ms)                                                               Min                 Max                Mean            StdDev              Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_encode_trace_small_multi_dd_origin[custom-encoder1-synthetics]          2.2741 (1.0)        2.8221 (1.0)        2.5145 (1.0)      0.1148 (1.0)        2.5198 (1.0)      0.1142 (1.0)          10;3  397.6927 (1.0)          39          10
test_encode_trace_small_multi_dd_origin[reference-encoder0-synthetics]       4.6641 (2.05)      18.4690 (6.54)       5.6625 (2.25)     1.9651 (17.12)      5.3161 (2.11)     0.3140 (2.75)         5;13  176.6003 (0.44)        172           1
test_encode_trace_small_multi_dd_origin[fallback-encoder2-synthetics]      107.7696 (47.39)    117.6976 (41.70)    112.3685 (44.69)    3.2418 (28.24)    112.6308 (44.70)    4.6418 (40.65)         4;0    8.8993 (0.02)          9           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```