### PR TITLE
Context copy improvements

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -52,12 +52,11 @@ class Context(object):
     def _with_span(self, span):
         # type: (Span) -> Context
         """Return a shallow copy of the context with the given span."""
-        with self._lock:
-            ctx = self.__class__(trace_id=span.trace_id, span_id=span.span_id)
-            ctx._lock = self._lock
-            ctx._meta = self._meta
-            ctx._metrics = self._metrics
-            return ctx
+        ctx = self.__class__(trace_id=span.trace_id, span_id=span.span_id)
+        ctx._lock = self._lock
+        ctx._meta = self._meta
+        ctx._metrics = self._metrics
+        return ctx
 
     def _update_tags(self, span):
         # type: (Span) -> None

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -35,8 +35,10 @@ class Context(object):
     _metrics = attr.ib(factory=dict)  # type: _MetricDictType
 
     def __attrs_post_init__(self):
-        self.dd_origin = self._dd_origin
-        self.sampling_priority = self._sampling_priority
+        if self._dd_origin is not None:
+            self.dd_origin = self._dd_origin
+        if self._sampling_priority is not None:
+            self.sampling_priority = self._sampling_priority
         del self._dd_origin
         del self._sampling_priority
 

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -146,7 +146,7 @@ class Span(object):
         # sampling
         self.sampled = True  # type: bool
 
-        self._context = context  # type: Optional[Context]
+        self._context = context._with_span(self) if context else None  # type: Optional[Context]
         self._parent = None  # type: Optional[Span]
         self._ignored_exceptions = None  # type: Optional[List[Exception]]
         self._local_root = None  # type: Optional[Span]
@@ -504,11 +504,8 @@ class Span(object):
         # type: () -> Context
         """Return the trace context for this span."""
         if self._context is None:
-            ctx = Context(trace_id=self.trace_id, span_id=self.span_id)
-            self._context = ctx
-        else:
-            ctx = self._context._with_span(self)
-        return ctx
+            self._context = Context(trace_id=self.trace_id, span_id=self.span_id)
+        return self._context
 
     def __enter__(self):
         return self

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -490,7 +490,7 @@ class Tracer(object):
             if isinstance(child_of, Context):
                 context = child_of
             else:
-                context = child_of._context
+                context = child_of._context or Context()
                 parent = child_of
         else:
             context = Context()

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -490,7 +490,7 @@ class Tracer(object):
             if isinstance(child_of, Context):
                 context = child_of
             else:
-                context = child_of.context
+                context = child_of._context
                 parent = child_of
         else:
             context = Context()

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -490,7 +490,7 @@ class Tracer(object):
             if isinstance(child_of, Context):
                 context = child_of
             else:
-                context = child_of._context or Context()
+                context = child_of.context
                 parent = child_of
         else:
             context = Context()


### PR DESCRIPTION
Each span needs its own context copy as the `span.context` property
returns the trace context specialized with the span's id.

The lock is removed from `context._with_span` as the copied references
are not volatile.