### PR TITLE
fix(ci): pin celery

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -358,9 +358,11 @@ venv = Venv(
                     },
                     pkgs={
                         "celery": [
-                            "~=5.0.5",
-                            # "~=5.0",  # most recent 5.x
-                            # latest, # Pin until https://github.com/celery/celery/issues/6829 is resolved.
+                            # Pin until https://github.com/celery/celery/issues/6829 is resolved.
+                            # "~=5.0.5",
+                            "==5.0.5",
+                            "~=5.0",  # most recent 5.x
+                            latest,
                         ],
                         "redis": "~=3.5",
                     },

--- a/riotfile.py
+++ b/riotfile.py
@@ -360,7 +360,7 @@ venv = Venv(
                         "celery": [
                             "~=5.0.5",
                             "~=5.0",  # most recent 5.x
-                            latest,
+                            # latest, # Pin until https://github.com/celery/celery/issues/6829 is resolved.
                         ],
                         "redis": "~=3.5",
                     },

--- a/riotfile.py
+++ b/riotfile.py
@@ -359,7 +359,7 @@ venv = Venv(
                     pkgs={
                         "celery": [
                             "~=5.0.5",
-                            "~=5.0",  # most recent 5.x
+                            # "~=5.0",  # most recent 5.x
                             # latest, # Pin until https://github.com/celery/celery/issues/6829 is resolved.
                         ],
                         "redis": "~=3.5",


### PR DESCRIPTION
Latest celery appears to be broken until
https://github.com/celery/celery/issues/6829 is resolved.
