### PR TITLE
removing ddtrace.ext.http.normalize_status_code

### DIFF
--- a/ddtrace/contrib/falcon/middleware.py
+++ b/ddtrace/contrib/falcon/middleware.py
@@ -50,7 +50,7 @@ class TraceMiddleware(object):
         if not span:
             return  # unexpected
 
-        status = httpx.normalize_status_code(resp.status)
+        status = resp.status.split(" ")[0]
 
         # FIXME[matt] falcon does not map errors or unmatched routes
         # to proper status codes, so we we have to try to infer them

--- a/ddtrace/contrib/falcon/middleware.py
+++ b/ddtrace/contrib/falcon/middleware.py
@@ -50,7 +50,7 @@ class TraceMiddleware(object):
         if not span:
             return  # unexpected
 
-        status = resp.status.split(" ")[0]
+        status = resp.status.partition(" ")[0]
 
         # FIXME[matt] falcon does not map errors or unmatched routes
         # to proper status codes, so we we have to try to infer them

--- a/ddtrace/ext/http.py
+++ b/ddtrace/ext/http.py
@@ -17,4 +17,3 @@ VERSION = "http.version"
 
 # template render span type
 TEMPLATE = "template"
-

--- a/ddtrace/ext/http.py
+++ b/ddtrace/ext/http.py
@@ -17,3 +17,4 @@ VERSION = "http.version"
 
 # template render span type
 TEMPLATE = "template"
+

--- a/ddtrace/ext/http.py
+++ b/ddtrace/ext/http.py
@@ -18,6 +18,3 @@ VERSION = "http.version"
 # template render span type
 TEMPLATE = "template"
 
-
-def normalize_status_code(code):
-    return code.split(" ")[0]


### PR DESCRIPTION
## Description
<!-- Please briefly describe the change and why it was required. -->
This updates two files. This first file /dd-trace-py/ddtrace/ext/http.py is to remove the function [normalize_status_code]. The second is to update where the function was used, ddtrace/contrib/falcon/middleware.py.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
