### PR TITLE
Added `ci.workspace_path` from git executable, not just CI env vars

### DIFF
--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -5,18 +5,17 @@ from typing import Dict
 import pytest
 
 import ddtrace
-
-from ...constants import SPAN_KIND
-from ...ext import SpanTypes
-from ...ext import ci
-from ...ext import test
-from ...internal import compat
-from ...internal.logger import get_logger
-from ...pin import Pin
-from ..trace_utils import int_service
-from .constants import FRAMEWORK
-from .constants import HELP_MSG
-from .constants import KIND
+from ddtrace.constants import SPAN_KIND
+from ddtrace.contrib.pytest.constants import FRAMEWORK
+from ddtrace.contrib.pytest.constants import HELP_MSG
+from ddtrace.contrib.pytest.constants import KIND
+from ddtrace.contrib.trace_utils import int_service
+from ddtrace.ext import SpanTypes
+from ddtrace.ext import ci
+from ddtrace.ext import test
+from ddtrace.internal import compat
+from ddtrace.internal.logger import get_logger
+from ddtrace.pin import Pin
 
 
 PATCH_ALL_HELP_MSG = "Call ddtrace.patch_all before running tests."

--- a/ddtrace/ext/git.py
+++ b/ddtrace/ext/git.py
@@ -56,20 +56,20 @@ log = get_logger(__name__)
 def _git_subprocess_cmd(cmd, cwd=None):
     # type: (str, Optional[str]) -> str
     """Helper for invoking the git CLI binary."""
-    git_cmd = subprocess.Popen(cmd.split(" "), stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd)
-    stdout, stderr = git_cmd.communicate()
-    if git_cmd.returncode == 0:
+    git_cmd = cmd.split(" ")
+    git_cmd.insert(0, "git")
+    process = subprocess.Popen(git_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd)
+    stdout, stderr = process.communicate()
+    if process.returncode == 0:
         return compat.ensure_text(stdout).strip()
     raise ValueError(stderr)
 
 
 def extract_user_info(cwd=None):
     # type: (Optional[str]) -> Dict[str, Tuple[str, str, str]]
-    """Extract git commit author/committer info."""
+    """Extract commit author info from the git repository in the current directory or one specified by ``cwd``."""
     # Note: `git show -s --format... --date...` is supported since git 2.1.4 onwards
-    stdout = _git_subprocess_cmd(
-        "git show -s --format=%an,%ae,%ad,%cn,%ce,%cd --date=format:%Y-%m-%dT%H:%M:%S%z", cwd=cwd
-    )
+    stdout = _git_subprocess_cmd("show -s --format=%an,%ae,%ad,%cn,%ce,%cd --date=format:%Y-%m-%dT%H:%M:%S%z", cwd=cwd)
     author_name, author_email, author_date, committer_name, committer_email, committer_date = stdout.split(",")
     return {
         "author": (author_name, author_email, author_date),
@@ -79,24 +79,24 @@ def extract_user_info(cwd=None):
 
 def extract_repository_url(cwd=None):
     # type: (Optional[str]) -> str
-    """Extract git repository url."""
+    """Extract the repository url from the git repository in the current directory or one specified by ``cwd``."""
     # Note: `git show ls-remote --get-url` is supported since git 2.6.7 onwards
-    repository_url = _git_subprocess_cmd("git ls-remote --get-url", cwd=cwd)
+    repository_url = _git_subprocess_cmd("ls-remote --get-url", cwd=cwd)
     return repository_url
 
 
 def extract_commit_message(cwd=None):
     # type: (Optional[str]) -> str
-    """Extract git commit message."""
+    """Extract git commit message from the git repository in the current directory or one specified by ``cwd``."""
     # Note: `git show -s --format... --date...` is supported since git 2.1.4 onwards
-    commit_message = _git_subprocess_cmd("git show -s --format=%s", cwd=cwd)
+    commit_message = _git_subprocess_cmd("show -s --format=%s", cwd=cwd)
     return commit_message
 
 
 def extract_workspace_path(cwd=None):
     # type: (Optional[str]) -> str
-    """Extract workspace path of git repository."""
-    workspace_path = _git_subprocess_cmd("git rev-parse --show-toplevel", cwd=cwd)
+    """Extract the root directory path from the git repository in the current directory or one specified by ``cwd``."""
+    workspace_path = _git_subprocess_cmd("rev-parse --show-toplevel", cwd=cwd)
     return workspace_path
 
 

--- a/ddtrace/ext/git.py
+++ b/ddtrace/ext/git.py
@@ -53,62 +53,51 @@ COMMIT_MESSAGE = "git.commit.message"
 log = get_logger(__name__)
 
 
+def _git_subprocess_cmd(cmd, cwd=None):
+    # type: (str, Optional[str]) -> str
+    """Helper for invoking the git CLI binary."""
+    git_cmd = subprocess.Popen(cmd.split(" "), stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd)
+    stdout, stderr = git_cmd.communicate()
+    if git_cmd.returncode == 0:
+        return compat.ensure_text(stdout).strip()
+    raise ValueError(stderr)
+
+
 def extract_user_info(cwd=None):
     # type: (Optional[str]) -> Dict[str, Tuple[str, str, str]]
     """Extract git commit author/committer info."""
     # Note: `git show -s --format... --date...` is supported since git 2.1.4 onwards
-    cmd = subprocess.Popen(
-        ["git", "show", "-s", "--format=%an,%ae,%ad,%cn,%ce,%cd", "--date=format:%Y-%m-%dT%H:%M:%S%z"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        cwd=cwd,
+    stdout = _git_subprocess_cmd(
+        "git show -s --format=%an,%ae,%ad,%cn,%ce,%cd --date=format:%Y-%m-%dT%H:%M:%S%z", cwd=cwd
     )
-    stdout, stderr = cmd.communicate()
-    if cmd.returncode == 0:
-        author_name, author_email, author_date, committer_name, committer_email, committer_date = (
-            compat.ensure_text(stdout).strip().split(",")
-        )
-        return {
-            "author": (author_name, author_email, author_date),
-            "committer": (committer_name, committer_email, committer_date),
-        }
-    raise ValueError(stderr)
+    author_name, author_email, author_date, committer_name, committer_email, committer_date = stdout.split(",")
+    return {
+        "author": (author_name, author_email, author_date),
+        "committer": (committer_name, committer_email, committer_date),
+    }
 
 
 def extract_repository_url(cwd=None):
     # type: (Optional[str]) -> str
+    """Extract git repository url."""
     # Note: `git show ls-remote --get-url` is supported since git 2.6.7 onwards
-    cmd = subprocess.Popen(["git", "ls-remote", "--get-url"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd)
-    stdout, stderr = cmd.communicate()
-    if cmd.returncode == 0:
-        repository_url = compat.ensure_text(stdout).strip()
-        return repository_url
-    raise ValueError(stderr)
+    repository_url = _git_subprocess_cmd("git ls-remote --get-url", cwd=cwd)
+    return repository_url
 
 
 def extract_commit_message(cwd=None):
     # type: (Optional[str]) -> str
+    """Extract git commit message."""
     # Note: `git show -s --format... --date...` is supported since git 2.1.4 onwards
-    cmd = subprocess.Popen(
-        ["git", "show", "-s", "--format=%s"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd
-    )
-    stdout, stderr = cmd.communicate()
-    if cmd.returncode == 0:
-        commit_message = compat.ensure_text(stdout).strip()
-        return commit_message
-    raise ValueError(stderr)
+    commit_message = _git_subprocess_cmd("git show -s --format=%s", cwd=cwd)
+    return commit_message
 
 
 def extract_workspace_path(cwd=None):
     # type: (Optional[str]) -> str
-    cmd = subprocess.Popen(
-        ["git", "rev-parse", "--show-toplevel"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd
-    )
-    stdout, stderr = cmd.communicate()
-    if cmd.returncode == 0:
-        workspace_path = compat.ensure_text(stdout).strip()
-        return workspace_path
-    raise ValueError(stderr)
+    """Extract workspace path of git repository."""
+    workspace_path = _git_subprocess_cmd("git rev-parse --show-toplevel", cwd=cwd)
+    return workspace_path
 
 
 def extract_git_metadata(cwd=None):

--- a/ddtrace/ext/git.py
+++ b/ddtrace/ext/git.py
@@ -8,7 +8,6 @@ from typing import Tuple
 
 import six
 
-from ddtrace.ext import ci
 from ddtrace.internal import compat
 from ddtrace.internal.logger import get_logger
 
@@ -126,7 +125,6 @@ def extract_git_metadata(cwd=None):
         tags[COMMIT_COMMITTER_NAME] = users["committer"][0]
         tags[COMMIT_COMMITTER_EMAIL] = users["committer"][1]
         tags[COMMIT_COMMITTER_DATE] = users["committer"][2]
-        tags[ci.WORKSPACE_PATH] = extract_workspace_path(cwd=cwd)
     except GitNotFoundError:
         log.error("Git executable not found, cannot extract git metadata.")
     except ValueError:

--- a/tests/tracer/test_ext.py
+++ b/tests/tracer/test_ext.py
@@ -76,7 +76,7 @@ def test_git_extract_user_info(git_repo):
 
 
 def test_git_extract_user_info_error(git_repo_empty):
-    """On error, the author/committer tags should not be extracted, and should internally raise and log the error."""
+    """On error, the author/committer tags should not be extracted, and should internally raise an error."""
     with pytest.raises(ValueError):
         git.extract_user_info(cwd=git_repo_empty)
 
@@ -88,7 +88,7 @@ def test_git_extract_repository_url(git_repo):
 
 
 def test_git_extract_repository_url_error(git_repo_empty):
-    """On error, the repository url tag should not be extracted, and should internally raise the error."""
+    """On error, the repository url tag should not be extracted, and should internally raise an error."""
     with pytest.raises(ValueError):
         git.extract_repository_url(cwd=git_repo_empty)
 
@@ -100,9 +100,20 @@ def test_git_extract_commit_message(git_repo):
 
 
 def test_git_extract_commit_message_error(git_repo_empty):
-    """On error, the commit message tag should not be extracted, and should internally raise and log the error."""
+    """On error, the commit message tag should not be extracted, and should internally raise an error."""
     with pytest.raises(ValueError):
         git.extract_commit_message(cwd=git_repo_empty)
+
+
+def test_git_extract_workspace_path(git_repo):
+    """Make sure that workspace path is correctly extracted."""
+    assert git.extract_workspace_path(cwd=git_repo) == git_repo
+
+
+def test_git_extract_workspace_path_error(tmpdir):
+    """On error, workspace path should not be extracted, and should internally raise an error."""
+    with pytest.raises(ValueError):
+        git.extract_workspace_path(cwd=tmpdir)
 
 
 def test_extract_git_metadata(git_repo):
@@ -116,6 +127,7 @@ def test_extract_git_metadata(git_repo):
         git.COMMIT_COMMITTER_NAME: "Jane Doe",
         git.COMMIT_COMMITTER_EMAIL: "jane@doe.com",
         git.COMMIT_COMMITTER_DATE: "2021-01-20T04:37:21-0400",
+        ci.WORKSPACE_PATH: git_repo,
     }
     assert git.extract_git_metadata(cwd=git_repo) == expected_tags
 
@@ -162,7 +174,7 @@ def test_falsey_ci_provider_values_overwritten_by_git_executable(git_repo):
     """If no or None or empty string values from CI provider env, should be overwritten by extracted git metadata."""
     ci_provider_env = {
         "APPVEYOR": "true",
-        "APPVEYOR_BUILD_FOLDER": "/foo/bar",
+        "APPVEYOR_BUILD_FOLDER": "",
         "APPVEYOR_BUILD_ID": "appveyor-build-id",
         "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
         "APPVEYOR_REPO_BRANCH": "master",
@@ -179,6 +191,7 @@ def test_falsey_ci_provider_values_overwritten_by_git_executable(git_repo):
     assert extracted_tags["git.commit.message"] == "this is a commit msg"
     assert extracted_tags["git.commit.author.name"] == "John Doe"
     assert extracted_tags["git.commit.author.email"] == "john@doe.com"
+    assert extracted_tags["ci.workspace_path"] == git_repo
 
 
 def test_os_runtime_metadata_tagging():

--- a/tests/tracer/test_ext.py
+++ b/tests/tracer/test_ext.py
@@ -113,7 +113,7 @@ def test_git_extract_workspace_path(git_repo):
 def test_git_extract_workspace_path_error(tmpdir):
     """On error, workspace path should not be extracted, and should internally raise an error."""
     with pytest.raises(ValueError):
-        git.extract_workspace_path(cwd=tmpdir)
+        git.extract_workspace_path(cwd=str(tmpdir))
 
 
 def test_extract_git_metadata(git_repo):
@@ -127,7 +127,6 @@ def test_extract_git_metadata(git_repo):
         git.COMMIT_COMMITTER_NAME: "Jane Doe",
         git.COMMIT_COMMITTER_EMAIL: "jane@doe.com",
         git.COMMIT_COMMITTER_DATE: "2021-01-20T04:37:21-0400",
-        ci.WORKSPACE_PATH: git_repo,
     }
     assert git.extract_git_metadata(cwd=git_repo) == expected_tags
 


### PR DESCRIPTION
## Description
We currently read `ci.WORKSPACE_PATH` from CI Env vars for the CIApp, but we can also extract this information from the local git executable on top of the git author/committer/repository_url/commit_message as a fallback in case this information is not provided via the CI env vars.