### PR TITLE
ci: test latest supported versions

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -358,9 +358,7 @@ venv = Venv(
                     },
                     pkgs={
                         "celery": [
-                            # Pin until https://github.com/celery/celery/issues/6829 is resolved.
-                            # "~=5.0.5",
-                            "==5.0.5",
+                            "~=5.0.5",
                             "~=5.0",  # most recent 5.x
                             latest,
                         ],

--- a/tox.ini
+++ b/tox.ini
@@ -32,17 +32,17 @@ envlist =
     aiohttp_contrib-{py35,py36}-aiohttp{20,21,22}-aiohttp_jinja{012,013}-yarl-pytest3
     aiohttp_contrib-{py35,py36,py37,py38}-aiohttp23-aiohttp_jinja015-yarl10-pytest3
     aiohttp_contrib-{py35,py36,py37}-aiohttp{30,31,32,33,35,36}-aiohttp_jinja{015}-yarl10-pytest3
-    aiohttp_contrib-py{38,39}-aiohttp{30,31,32,33,36}-aiohttp_jinja015-yarl10-pytest3
+    aiohttp_contrib-py{38,39}-aiohttp{30,31,32,33,36,37}-aiohttp_jinja015-yarl10-pytest3
     aiopg_contrib-{py35,py36}-aiopg{012,015}
-    aiopg_contrib-py{37,38,39}-aiopg015
+    aiopg_contrib-py{37,38,39}-aiopg{015,016}
     algoliasearch_contrib-py{27,35,36,37,38,39}-algoliasearch{1,2,}
     asyncio_contrib-py{35,36,37,38,39}
     bottle_contrib{,_autopatch}-py{27,35,36,37,38,39}-bottle{11,12,}-webtest
-    cassandra_contrib-py{27,35,36,37,38,39}-cassandra{35,36,37,38,315}
+    cassandra_contrib-py{27,35,36,37,38,39}-cassandra{35,36,37,38,315,325}
     consul_contrib-py{27,35,36,37,38,39}-consul{07,10,11,}
     dbapi_contrib-py{27,35,36,37,38,39}
     dogpile_contrib-py{27,35}-dogpilecache{06,07,08,09}
-    dogpile_contrib-py{36,37,38,39}-dogpilecache{06,07,08,09,10,}
+    dogpile_contrib-py{36,37,38,39}-dogpilecache{06,07,08,09,10,11}
     futures_contrib-py27-futures{30,31,32,}
     futures_contrib-py{35,36,37,38,39}
     gevent_contrib-py27-gevent{11,12,13}-sslmodules
@@ -50,12 +50,12 @@ envlist =
     gevent_contrib-py{37,38}-gevent{13,14}-sslmodules3-sslmodules
     gevent_contrib-py39-gevent{209,2012,211}-sslmodules3-sslmodules
     httplib_contrib-py{27,35,36,37,38,39}
-    jinja2_contrib-py{27,35,36,37,38,39}-jinja{27,28,29,210,211,}
+    jinja2_contrib-py{27,35,36,37,38,39}-jinja{27,28,29,210,211,30}
     kombu_contrib-py{27,35,36}-kombu{40,41,42,43,44,45,46,}
 # Kombu >= 4.2 only supports Python 3.7+
-    kombu_contrib-py{37,38,39}-kombu{42,43,44,45,46,}
+    kombu_contrib-py{37,38,39}-kombu{42,43,44,45,46,51}
     molten_contrib-py{36,37,38,39}-molten{06,07,10,}
-    mysqldb_contrib-py{27,35,36,37,38,39}-mysqlclient{13,14,}
+    mysqldb_contrib-py{27,35,36,37,38,39}-mysqlclient{13,14,20}
     pylibmc_contrib-py{27,35,36,37,38,39}-pylibmc{140,150,}
     pylons_contrib-py27-pylons{096,097,010,10,}
     pymongo_contrib-py{27,35,36,37}-pymongo{30,31,32,33,34,35,36,37,38,39,310,}-mongoengine
@@ -63,7 +63,7 @@ envlist =
 # but these tests still work.
     pymongo_contrib-py38-pymongo{30,31,32,33,35,36,37,38,39,310,}-mongoengine
     pymysql_contrib-py{27,35,36,37,38}-pymysql{07,08,09,}
-    pynamodb_contrib-{py27,py35,py36,py37,py38}-pynamodb{40,41,42,43,}-moto1
+    pynamodb_contrib-{py27,py35,py36,py37,py38}-pynamodb{40,41,42,43,}-moto{1,2}
     pyodbc_contrib-py{27,35,36,37,38}-pyodbc{3,4}
 
     pyramid_contrib{,_autopatch}-py{27,35,36,37,38}-pyramid{17,18,19,110,}-webtest
@@ -72,15 +72,15 @@ envlist =
     requests_contrib{,_autopatch}-{py27,py35,py36,py37,py38}-requests{208,209,210,211,212,213,219}
     pymysql_contrib-py{27,35,36,37,38,39}-pymysql{07,08,09,}
     pyodbc_contrib-py{27,35,36,37,38,39}-pyodbc{3,4}
-    pyramid_contrib{,_autopatch}-py{27,35,36,37,38,39}-pyramid{17,18,19,110,}-webtest
+    pyramid_contrib{,_autopatch}-py{27,35,36,37,38,39}-pyramid{17,18,19,110,20}-webtest
     redis_contrib-py{27,35,36,37,38,39}-redis{210,30,32,33,34,35,}
     rediscluster_contrib-py{27,35,36,37,38,39}-rediscluster{135,136,200,}-redis210
     sanic_contrib-py{37,38,39}-sanic{1906,1909,1912,2003,2006,2103,}
     sqlite3_contrib-py{27,35,36,37,38,39}-sqlite3
     tornado_contrib-py{27,35,36,37,38,39}-tornado{44,45}
-    tornado_contrib-py{37,38,39}-tornado{50,51,60,}
+    tornado_contrib-py{37,38,39}-tornado{50,51,60,61}
     tornado_contrib-py27-tornado{44,45}-futures{30,31,32,}
-    vertica_contrib-py{27,35,36,37,38,39}-vertica{060,070}
+    vertica_contrib-py{27,35,36,37,38,39}-vertica{060,070,10}
 # Opentracer
     py{27,35,36,37,38,39}-opentracer
     py{35,36,37,38}-opentracer_asyncio
@@ -150,6 +150,7 @@ deps =
     aiobotocore02: multidict==4.5.2
     aiopg012: aiopg>=0.12,<0.13
     aiopg015: aiopg>=0.15,<0.16
+    aiopg016: aiopg>=0.16,<0.17
     aiopg: sqlalchemy
     aiohttp_contrib: pytest-aiohttp
     aiohttp20: aiohttp>=2.0,<2.1
@@ -163,6 +164,7 @@ deps =
     aiohttp34: aiohttp>=3.4,<3.5
     aiohttp35: aiohttp>=3.5,<3.6
     aiohttp36: aiohttp>=3.6,<3.7
+    aiohttp37: aiohttp>=3.7,<3.8
     aiohttp_jinja012: aiohttp_jinja2>=0.12,<0.13
     aiohttp_jinja013: aiohttp_jinja2>=0.13,<0.14
     aiohttp_jinja015: aiohttp_jinja2>=0.15,<0.16
@@ -178,6 +180,7 @@ deps =
     cassandra37: cassandra-driver>=3.7,<3.8
     cassandra38: cassandra-driver>=3.8,<3.9
     cassandra315: cassandra-driver>=3.15,<3.16
+    cassandra325: cassandra-driver>=3.25,<3.26
     consul: python-consul
     consul07: python-consul>=0.7,<1.0
     consul10: python-consul>=1.0,<1.1
@@ -190,6 +193,7 @@ deps =
     dogpilecache08: dogpile.cache==0.8.*
     dogpilecache09: dogpile.cache==0.9.*
     dogpilecache10: dogpile.cache==1.0.*
+    dogpilecache10: dogpile.cache==1.1.*
     futures: futures
     futures30: futures>=3.0,<3.1
     futures31: futures>=3.1,<3.2
@@ -207,6 +211,7 @@ deps =
     jinja29: jinja2>=2.9,<2.10
     jinja210: jinja2>=2.10,<2.11
     jinja211: jinja2>=2.11,<2.12
+    jinja30: jinja2>=3.0,<3.1
     kombu: kombu
     kombu40: kombu>=4.0,<4.1
     kombu41: kombu>=4.1,<4.2
@@ -215,9 +220,11 @@ deps =
     kombu44: kombu>=4.4,<4.5
     kombu45: kombu>=4.5,<4.6
     kombu46: kombu>=4.6,<4.7
+    kombu51: kombu>=5.1,<5.2
     memcached: python-memcached
     moto: moto
     moto1: moto>=1,<2
+    moto2: moto>=2,<3
     molten: molten
     molten06: molten>=0.6,<0.7
     molten07: molten>=0.7,<0.8
@@ -226,6 +233,7 @@ deps =
     mysqlclient: mysqlclient
     mysqlclient13: mysqlclient>=1.3,<1.4
     mysqlclient14: mysqlclient>=1.4,<1.5
+    mysqlclient20: mysqlclient>=2.0,<2.1
     pylibmc: pylibmc
     pylibmc140: pylibmc>=1.4,<1.5
     pylibmc150: pylibmc>=1.5,<1.6
@@ -250,6 +258,7 @@ deps =
     pyramid18: pyramid>=1.8,<1.9
     pyramid19: pyramid>=1.9,<1.10
     pyramid110: pyramid>=1.10,<1.11
+    pyramid20: pyramid>=2.0,<2.1
     pyodbc: pyodbc
     pyodbc4: pyodbc>=4.0,<5.0
     pyodbc3: pyodbc>=3.0,<4.0
@@ -302,8 +311,10 @@ deps =
     tornado50: tornado>=5.0,<5.1
     tornado51: tornado>=5.1,<5.2
     tornado60: tornado>=6.0,<6.1
+    tornado61: tornado>=6.1,<6.2
     vertica060: vertica-python>=0.6.0,<0.7.0
     vertica070: vertica-python>=0.7.0,<0.8.0
+    vertica10: vertica-python>=1.0,<1.1
     webtest: WebTest
     asyncio_contrib: pytest-asyncio
     opentracer_asyncio: pytest-asyncio


### PR DESCRIPTION
## Description
<!-- Please briefly describe the change and why it was required. -->

This is a draft PR to track progress on supporting latest versions of all integrations, and additionally migrating to riot

## Progress

- aiohttp: migrate to riot
- aiopg: requires work
- cassandra: #2634 
- dogpile_cache: 
- jinja2: #2615 
- kombu: migrate to riot
- mysqlpython
- pyramid
- tornado: migrate to riot
- vertica
