### PR TITLE
chore(tests): fix silent errors

### DIFF
--- a/tests/tracer/test_ext.py
+++ b/tests/tracer/test_ext.py
@@ -31,7 +31,7 @@ def git_repo_empty(tmpdir):
     cwd = str(tmpdir)
     version = subprocess.check_output("git version", shell=True)
     # decode "git version 2.28.0" to (2, 28, 0)
-    decoded_version = tuple(int(n) for n in version.decode().strip().split(' ')[-1].split(".") if n.isdigit())
+    decoded_version = tuple(int(n) for n in version.decode().strip().split(" ")[-1].split(".") if n.isdigit())
     if decoded_version >= (2, 28):
         # versions starting from 2.28 can have a different initial branch name
         # configured in ~/.gitconfig

--- a/tests/tracer/test_ext.py
+++ b/tests/tracer/test_ext.py
@@ -29,7 +29,7 @@ def _updateenv(monkeypatch, env):
 def git_repo(tmpdir):
     """Create temporary git directory, with one added file commit with a unique author and committer."""
     cwd = str(tmpdir)
-    subprocess.check_output("git init", cwd=cwd, shell=True)
+    subprocess.check_output("git init --initial-branch=master", cwd=cwd, shell=True)
     subprocess.check_output('git remote add origin "git@github.com:test-repo-url.git"', cwd=cwd, shell=True)
     # Set temporary git directory to not require gpg commit signing
     subprocess.check_output("git config --local commit.gpgsign false", cwd=cwd, shell=True)
@@ -52,7 +52,7 @@ def git_repo(tmpdir):
 def git_repo_empty(tmpdir):
     """Create temporary empty git directory, meaning no commits/users/repository-url to extract (error)"""
     cwd = str(tmpdir)
-    subprocess.check_output("git init", cwd=cwd, shell=True)
+    subprocess.check_output("git init --initial-branch=master", cwd=cwd, shell=True)
     yield cwd
 
 

--- a/tests/tracer/test_ext.py
+++ b/tests/tracer/test_ext.py
@@ -32,7 +32,7 @@ def git_repo_empty(tmpdir):
     version = subprocess.check_output("git version", shell=True)
     # decode "git version 2.28.0" to (2, 28, 0)
     decoded_version = tuple(int(n) for n in version.decode().strip().split(' ')[-1].split(".") if n.isdigit())
-    if decoded_version > (2, 28):
+    if decoded_version >= (2, 28):
         # versions starting from 2.28 can have a different initial branch name
         # configured in ~/.gitconfig
         subprocess.check_output("git init --initial-branch=master", cwd=cwd, shell=True)

--- a/tests/tracer/test_ext.py
+++ b/tests/tracer/test_ext.py
@@ -26,9 +26,26 @@ def _updateenv(monkeypatch, env):
 
 
 @pytest.fixture
-def git_repo(tmpdir):
-    """Create temporary git directory, with one added file commit with a unique author and committer."""
+def git_repo_empty(tmpdir):
+    """Create temporary empty git directory, meaning no commits/users/repository-url to extract (error)"""
     cwd = str(tmpdir)
+    version = subprocess.check_output("git version", shell=True)
+    # decode "git version 2.28.0" to (2, 28, 0)
+    decoded_version = tuple(int(n) for n in version.decode().strip().split(' ')[-1].split(".") if n.isdigit())
+    if decoded_version > (2, 28):
+        # versions starting from 2.28 can have a different initial branch name
+        # configured in ~/.gitconfig
+        subprocess.check_output("git init --initial-branch=master", cwd=cwd, shell=True)
+    else:
+        # versions prior to 2.28 will create a master branch by default
+        subprocess.check_output("git init", cwd=cwd, shell=True)
+    yield cwd
+
+
+@pytest.fixture
+def git_repo(git_repo_empty):
+    """Create temporary git directory, with one added file commit with a unique author and committer."""
+    cwd = git_repo_empty
     subprocess.check_output("git init --initial-branch=master", cwd=cwd, shell=True)
     subprocess.check_output('git remote add origin "git@github.com:test-repo-url.git"', cwd=cwd, shell=True)
     # Set temporary git directory to not require gpg commit signing
@@ -45,14 +62,6 @@ def git_repo(tmpdir):
         cwd=cwd,
         shell=True,
     )
-    yield cwd
-
-
-@pytest.fixture
-def git_repo_empty(tmpdir):
-    """Create temporary empty git directory, meaning no commits/users/repository-url to extract (error)"""
-    cwd = str(tmpdir)
-    subprocess.check_output("git init --initial-branch=master", cwd=cwd, shell=True)
     yield cwd
 
 

--- a/tests/tracer/test_ext.py
+++ b/tests/tracer/test_ext.py
@@ -46,7 +46,6 @@ def git_repo_empty(tmpdir):
 def git_repo(git_repo_empty):
     """Create temporary git directory, with one added file commit with a unique author and committer."""
     cwd = git_repo_empty
-    subprocess.check_output("git init --initial-branch=master", cwd=cwd, shell=True)
     subprocess.check_output('git remote add origin "git@github.com:test-repo-url.git"', cwd=cwd, shell=True)
     # Set temporary git directory to not require gpg commit signing
     subprocess.check_output("git config --local commit.gpgsign false", cwd=cwd, shell=True)

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -70,7 +70,7 @@ class RateSamplerTest(unittest.TestCase):
             iterations = int(1e4 / sample_rate)
 
             for i in range(iterations):
-                span = tracer.trace(i)
+                span = tracer.trace(str(i))
                 span.finish()
 
             samples = tracer.pop()
@@ -89,14 +89,14 @@ class RateSamplerTest(unittest.TestCase):
         tracer.sampler = RateSampler(0.5)
 
         for i in range(10):
-            span = tracer.trace(i)
+            span = tracer.trace(str(i))
             span.finish()
 
             samples = tracer.pop()
             assert len(samples) <= 1, "there should be 0 or 1 spans"
             sampled = 1 == len(samples)
             for j in range(10):
-                other_span = Span(tracer, i, trace_id=span.trace_id)
+                other_span = Span(tracer, str(i), trace_id=span.trace_id)
                 assert sampled == tracer.sampler.sample(
                     other_span
                 ), "sampling should give the same result for a given trace_id"
@@ -141,7 +141,7 @@ class RateByServiceSamplerTest(unittest.TestCase):
             iterations = int(1e4 / sample_rate)
 
             for i in range(iterations):
-                span = tracer.trace(i)
+                span = tracer.trace(str(i))
                 span.finish()
 
             samples = tracer.writer.pop()
@@ -407,7 +407,7 @@ def test_sampling_rule_sample(sample_rate):
     rule = SamplingRule(sample_rate=sample_rate)
 
     iterations = int(1e4 / sample_rate)
-    sampled = sum(rule.sample(Span(tracer=tracer, name=i)) for i in range(iterations))
+    sampled = sum(rule.sample(Span(tracer=tracer, name=str(i))) for i in range(iterations))
 
     # Less than 5% deviation when 'enough' iterations (arbitrary, just check if it converges)
     deviation = abs(sampled - (iterations * sample_rate)) / (iterations * sample_rate)
@@ -421,7 +421,7 @@ def test_sampling_rule_sample_rate_1():
     rule = SamplingRule(sample_rate=1)
 
     iterations = int(1e4)
-    assert all(rule.sample(Span(tracer=tracer, name=i)) for i in range(iterations))
+    assert all(rule.sample(Span(tracer=tracer, name=str(i))) for i in range(iterations))
 
 
 def test_sampling_rule_sample_rate_0():
@@ -429,7 +429,7 @@ def test_sampling_rule_sample_rate_0():
     rule = SamplingRule(sample_rate=0)
 
     iterations = int(1e4)
-    assert sum(rule.sample(Span(tracer=tracer, name=i)) for i in range(iterations)) == 0
+    assert sum(rule.sample(Span(tracer=tracer, name=str(i))) for i in range(iterations)) == 0
 
 
 def test_datadog_sampler_init():


### PR DESCRIPTION
## Description
The PR fixes some silent errors from the tests.

The first patch fixes the default git branch and silents this message:

```
tests/tracer/test_ext.py::test_git_extract_user_info hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint:   git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint:   git branch -m <name>
```

The second patch fixes a silent exceptions on the `DummyWriter`:
```
tests/tracer/test_sampler.py::RateSamplerTest::test_deterministic_behavior TypeError: Unhandled text type: <class 'int'>
Exception ignored in: 'ddtrace.internal._encoding.Packer._pack_text'
Traceback (most recent call last):
  File "/home/nicolas/Workspaces/Datadog/dd-trace-py/tests/utils.py", line 436, in write
    self.msgpack_encoder.encode_traces(trace)
TypeError: Unhandled text type: <class 'int'>
TypeError: Unhandled text type: <class 'int'>
```

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
