### PR TITLE
Chore(aiopg): format with black

### DIFF
--- a/ddtrace/contrib/aiopg/__init__.py
+++ b/ddtrace/contrib/aiopg/__init__.py
@@ -18,10 +18,10 @@ Instrument aiopg to report a span for each executed Postgres queries::
 from ...utils.importlib import require_modules
 
 
-required_modules = ['aiopg']
+required_modules = ["aiopg"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
         from .patch import patch
 
-        __all__ = ['patch']
+        __all__ = ["patch"]

--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -14,13 +14,13 @@ from ...pin import Pin
 
 
 class AIOTracedCursor(wrapt.ObjectProxy):
-    """ TracedCursor wraps a psql cursor and traces its queries. """
+    """TracedCursor wraps a psql cursor and traces its queries."""
 
     def __init__(self, cursor, pin):
         super(AIOTracedCursor, self).__init__(cursor)
         pin.onto(self)
-        name = pin.app or 'sql'
-        self._datadog_name = '%s.query' % name
+        name = pin.app or "sql"
+        self._datadog_name = "%s.query" % name
 
     @asyncio.coroutine
     def _trace_method(self, method, resource, extra_tags, *args, **kwargs):
@@ -30,44 +30,38 @@ class AIOTracedCursor(wrapt.ObjectProxy):
             return result
         service = pin.service
 
-        with pin.tracer.trace(self._datadog_name, service=service,
-                              resource=resource, span_type=SpanTypes.SQL) as s:
+        with pin.tracer.trace(self._datadog_name, service=service, resource=resource, span_type=SpanTypes.SQL) as s:
             s.set_tag(SPAN_MEASURED_KEY)
             s.set_tag(sql.QUERY, resource)
             s.set_tags(pin.tags)
             s.set_tags(extra_tags)
 
             # set analytics sample rate
-            s.set_tag(
-                ANALYTICS_SAMPLE_RATE_KEY,
-                config.aiopg.get_analytics_sample_rate()
-            )
+            s.set_tag(ANALYTICS_SAMPLE_RATE_KEY, config.aiopg.get_analytics_sample_rate())
 
             try:
                 result = yield from method(*args, **kwargs)
                 return result
             finally:
-                s.set_metric('db.rowcount', self.rowcount)
+                s.set_metric("db.rowcount", self.rowcount)
 
     @asyncio.coroutine
     def executemany(self, query, *args, **kwargs):
         # FIXME[matt] properly handle kwargs here. arg names can be different
         # with different libs.
         result = yield from self._trace_method(
-            self.__wrapped__.executemany, query, {'sql.executemany': 'true'},
-            query, *args, **kwargs)
+            self.__wrapped__.executemany, query, {"sql.executemany": "true"}, query, *args, **kwargs
+        )
         return result
 
     @asyncio.coroutine
     def execute(self, query, *args, **kwargs):
-        result = yield from self._trace_method(
-            self.__wrapped__.execute, query, {}, query, *args, **kwargs)
+        result = yield from self._trace_method(self.__wrapped__.execute, query, {}, query, *args, **kwargs)
         return result
 
     @asyncio.coroutine
     def callproc(self, proc, args):
-        result = yield from self._trace_method(
-            self.__wrapped__.callproc, proc, {}, proc, args)
+        result = yield from self._trace_method(self.__wrapped__.callproc, proc, {}, proc, args)
         return result
 
     def __aiter__(self):
@@ -75,7 +69,7 @@ class AIOTracedCursor(wrapt.ObjectProxy):
 
 
 class AIOTracedConnection(wrapt.ObjectProxy):
-    """ TracedConnection wraps a Connection with tracing code. """
+    """TracedConnection wraps a Connection with tracing code."""
 
     def __init__(self, conn, pin=None, cursor_cls=AIOTracedCursor):
         super(AIOTracedConnection, self).__init__(conn)

--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -3,14 +3,13 @@ import asyncio
 from aiopg.utils import _ContextManager
 
 from ddtrace import config
+from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import SPAN_MEASURED_KEY
+from ddtrace.contrib import dbapi
+from ddtrace.ext import SpanTypes
+from ddtrace.ext import sql
+from ddtrace.pin import Pin
 from ddtrace.vendor import wrapt
-
-from .. import dbapi
-from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...constants import SPAN_MEASURED_KEY
-from ...ext import SpanTypes
-from ...ext import sql
-from ...pin import Pin
 
 
 class AIOTracedCursor(wrapt.ObjectProxy):

--- a/ddtrace/contrib/aiopg/patch.py
+++ b/ddtrace/contrib/aiopg/patch.py
@@ -14,21 +14,21 @@ from .connection import AIOTracedConnection
 
 
 def patch():
-    """ Patch monkey patches psycopg's connection function
-        so that the connection's functions are traced.
+    """Patch monkey patches psycopg's connection function
+    so that the connection's functions are traced.
     """
-    if getattr(aiopg, '_datadog_patch', False):
+    if getattr(aiopg, "_datadog_patch", False):
         return
-    setattr(aiopg, '_datadog_patch', True)
+    setattr(aiopg, "_datadog_patch", True)
 
-    wrapt.wrap_function_wrapper(aiopg.connection, '_connect', patched_connect)
+    wrapt.wrap_function_wrapper(aiopg.connection, "_connect", patched_connect)
     _patch_extensions(_aiopg_extensions)  # do this early just in case
 
 
 def unpatch():
-    if getattr(aiopg, '_datadog_patch', False):
-        setattr(aiopg, '_datadog_patch', False)
-        _u(aiopg.connection, '_connect')
+    if getattr(aiopg, "_datadog_patch", False):
+        setattr(aiopg, "_datadog_patch", False)
+        _u(aiopg.connection, "_connect")
         _unpatch_extensions(_aiopg_extensions)
 
 
@@ -41,6 +41,7 @@ def patched_connect(connect_func, _, args, kwargs):
 def _extensions_register_type(func, _, args, kwargs):
     def _unroll_args(obj, scope=None):
         return obj, scope
+
     obj, scope = _unroll_args(*args, **kwargs)
 
     # register_type performs a c-level check of the object
@@ -53,7 +54,5 @@ def _extensions_register_type(func, _, args, kwargs):
 
 # extension hooks
 _aiopg_extensions = [
-    (psycopg2.extensions.register_type,
-     psycopg2.extensions, 'register_type',
-     _extensions_register_type),
+    (psycopg2.extensions.register_type, psycopg2.extensions, "register_type", _extensions_register_type),
 ]

--- a/ddtrace/contrib/aiopg/patch.py
+++ b/ddtrace/contrib/aiopg/patch.py
@@ -4,13 +4,12 @@ import asyncio
 import aiopg.connection
 import psycopg2.extensions
 
+from ddtrace.contrib.aiopg.connection import AIOTracedConnection
+from ddtrace.contrib.psycopg.patch import _patch_extensions
+from ddtrace.contrib.psycopg.patch import _unpatch_extensions
+from ddtrace.contrib.psycopg.patch import patch_conn as psycopg_patch_conn
+from ddtrace.utils.wrappers import unwrap as _u
 from ddtrace.vendor import wrapt
-
-from ...utils.wrappers import unwrap as _u
-from ..psycopg.patch import _patch_extensions
-from ..psycopg.patch import _unpatch_extensions
-from ..psycopg.patch import patch_conn as psycopg_patch_conn
-from .connection import AIOTracedConnection
 
 
 def patch():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,7 @@ exclude = '''
   | ddtrace/(
     contrib/
     (
-      aiopg
-      | boto
+      boto
       | jinja2
       | pylibmc
       | rediscluster
@@ -54,8 +53,7 @@ exclude = '''
   (
     contrib/
     (
-      aiopg
-      | config.py
+      config.py
       | jinja2
       | pylibmc
       | rediscluster

--- a/tests/contrib/aiopg/py35/test.py
+++ b/tests/contrib/aiopg/py35/test.py
@@ -4,22 +4,21 @@ import asyncio
 # 3p
 import aiopg
 
-from ddtrace import Pin
 # project
+from ddtrace import Pin
 from ddtrace.contrib.aiopg.patch import patch
 from ddtrace.contrib.aiopg.patch import unpatch
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio
-# testing
 from tests.contrib.config import POSTGRES_CONFIG
 
 
-TEST_PORT = str(POSTGRES_CONFIG['port'])
+TEST_PORT = str(POSTGRES_CONFIG["port"])
 
 
 class TestPsycopgPatch(AsyncioTestCase):
     # default service
-    TEST_SERVICE = 'postgres'
+    TEST_SERVICE = "postgres"
 
     def setUp(self):
         super().setUp()
@@ -46,16 +45,16 @@ class TestPsycopgPatch(AsyncioTestCase):
         t = type(cur)
 
         async with conn.cursor() as cur:
-            assert t == type(cur), '%s != %s' % (t, type(cur))
-            await cur.execute(query='select \'blah\'')
+            assert t == type(cur), "%s != %s" % (t, type(cur))
+            await cur.execute(query="select 'blah'")
             rows = await cur.fetchall()
             assert len(rows) == 1
-            assert rows[0][0] == 'blah'
+            assert rows[0][0] == "blah"
 
         spans = self.pop_spans()
         assert len(spans) == 1
         span = spans[0]
-        assert span.name == 'postgres.query'
+        assert span.name == "postgres.query"
 
     @mark_asyncio
     def test_cursor_ctx_manager(self):

--- a/tests/contrib/aiopg/py37/test.py
+++ b/tests/contrib/aiopg/py37/test.py
@@ -1,22 +1,21 @@
 # 3p
 import aiopg
 
-from ddtrace import Pin
 # project
+from ddtrace import Pin
 from ddtrace.contrib.aiopg.patch import patch
 from ddtrace.contrib.aiopg.patch import unpatch
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio
-# testing
 from tests.contrib.config import POSTGRES_CONFIG
 
 
-TEST_PORT = str(POSTGRES_CONFIG['port'])
+TEST_PORT = str(POSTGRES_CONFIG["port"])
 
 
 class AiopgTestCase(AsyncioTestCase):
     # default service
-    TEST_SERVICE = 'postgres'
+    TEST_SERVICE = "postgres"
 
     def setUp(self):
         super().setUp()
@@ -40,14 +39,14 @@ class AiopgTestCase(AsyncioTestCase):
     async def test_async_generator(self):
         conn, tracer = await self._get_conn_and_tracer()
         cursor = await conn.cursor()
-        q = 'select \'foobarblah\''
+        q = "select 'foobarblah'"
         await cursor.execute(q)
         rows = []
         async for row in cursor:
             rows.append(row)
 
-        assert rows == [('foobarblah',)]
+        assert rows == [("foobarblah",)]
         spans = self.pop_spans()
         assert len(spans) == 1
         span = spans[0]
-        assert span.name == 'postgres.query'
+        assert span.name == "postgres.query"

--- a/tests/contrib/aiopg/test.py
+++ b/tests/contrib/aiopg/test.py
@@ -15,9 +15,8 @@ from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.opentracer.utils import init_tracer
+from tests.subprocesstest import run_in_subprocess
 from tests.utils import assert_is_measured
-
-from ...subprocesstest import run_in_subprocess
 
 
 TEST_PORT = POSTGRES_CONFIG["port"]

--- a/tests/contrib/aiopg/test.py
+++ b/tests/contrib/aiopg/test.py
@@ -6,27 +6,26 @@ import time
 import aiopg
 from psycopg2 import extras
 
-from ddtrace import Pin
 # project
+from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.aiopg.patch import patch
 from ddtrace.contrib.aiopg.patch import unpatch
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio
 from tests.contrib.config import POSTGRES_CONFIG
-# testing
 from tests.opentracer.utils import init_tracer
 from tests.utils import assert_is_measured
 
 from ...subprocesstest import run_in_subprocess
 
 
-TEST_PORT = POSTGRES_CONFIG['port']
+TEST_PORT = POSTGRES_CONFIG["port"]
 
 
 class AiopgTestCase(AsyncioTestCase):
     # default service
-    TEST_SERVICE = 'postgres'
+    TEST_SERVICE = "postgres"
 
     def setUp(self):
         super().setUp()
@@ -53,84 +52,84 @@ class AiopgTestCase(AsyncioTestCase):
         # ensure the trace aiopg client doesn't add non-standard
         # methods
         try:
-            yield from db.execute('select \'foobar\'')
+            yield from db.execute("select 'foobar'")
         except AttributeError:
             pass
 
         # Ensure we can run a query and it's correctly traced
-        q = 'select \'foobarblah\''
+        q = "select 'foobarblah'"
         start = time.time()
         cursor = yield from db.cursor()
         yield from cursor.execute(q)
         rows = yield from cursor.fetchall()
         end = time.time()
-        assert rows == [('foobarblah',)]
+        assert rows == [("foobarblah",)]
         assert rows
         spans = self.pop_spans()
         assert spans
         assert len(spans) == 1
         span = spans[0]
         assert_is_measured(span)
-        assert span.name == 'postgres.query'
+        assert span.name == "postgres.query"
         assert span.resource == q
         assert span.service == service
-        assert span.meta['sql.query'] == q
+        assert span.meta["sql.query"] == q
         assert span.error == 0
-        assert span.span_type == 'sql'
+        assert span.span_type == "sql"
         assert start <= span.start <= end
         assert span.duration <= end - start
 
         # Ensure OpenTracing compatibility
-        ot_tracer = init_tracer('aiopg_svc', tracer)
-        with ot_tracer.start_active_span('aiopg_op'):
+        ot_tracer = init_tracer("aiopg_svc", tracer)
+        with ot_tracer.start_active_span("aiopg_op"):
             cursor = yield from db.cursor()
             yield from cursor.execute(q)
             rows = yield from cursor.fetchall()
-            assert rows == [('foobarblah',)]
+            assert rows == [("foobarblah",)]
         spans = self.pop_spans()
         assert len(spans) == 2
         ot_span, dd_span = spans
         # confirm the parenting
         assert ot_span.parent_id is None
         assert dd_span.parent_id == ot_span.span_id
-        assert ot_span.name == 'aiopg_op'
-        assert ot_span.service == 'aiopg_svc'
-        assert dd_span.name == 'postgres.query'
+        assert ot_span.name == "aiopg_op"
+        assert ot_span.service == "aiopg_svc"
+        assert dd_span.name == "postgres.query"
         assert dd_span.resource == q
         assert dd_span.service == service
-        assert dd_span.meta['sql.query'] == q
+        assert dd_span.meta["sql.query"] == q
         assert dd_span.error == 0
-        assert dd_span.span_type == 'sql'
+        assert dd_span.span_type == "sql"
 
         # run a query with an error and ensure all is well
-        q = 'select * from some_non_existant_table'
+        q = "select * from some_non_existant_table"
         cur = yield from db.cursor()
         try:
             yield from cur.execute(q)
         except Exception:
             pass
         else:
-            assert 0, 'should have an error'
+            assert 0, "should have an error"
         spans = self.pop_spans()
         assert spans, spans
         assert len(spans) == 1
         span = spans[0]
-        assert span.name == 'postgres.query'
+        assert span.name == "postgres.query"
         assert span.resource == q
         assert span.service == service
-        assert span.meta['sql.query'] == q
+        assert span.meta["sql.query"] == q
         assert span.error == 1
         # assert span.meta['out.host'] == 'localhost'
-        assert span.metrics['out.port'] == TEST_PORT
-        assert span.span_type == 'sql'
+        assert span.metrics["out.port"] == TEST_PORT
+        assert span.span_type == "sql"
 
     @mark_asyncio
     def test_disabled_execute(self):
         conn, tracer = yield from self._get_conn_and_tracer()
         tracer.enabled = False
         # these calls were crashing with a previous version of the code.
-        yield from (yield from conn.cursor()).execute(query='select \'blah\'')
-        yield from (yield from conn.cursor()).execute('select \'blah\'')
+        yield from (yield from conn.cursor()).execute(query="select 'blah'")
+        yield from (yield from conn.cursor()).execute("select 'blah'")
         assert not self.pop_spans()
 
     @mark_asyncio
@@ -143,7 +142,7 @@ class AiopgTestCase(AsyncioTestCase):
 
     @mark_asyncio
     def test_connect_factory(self):
-        services = ['db', 'another']
+        services = ["db", "another"]
         for service in services:
             conn, _ = yield from self._get_conn_and_tracer()
             Pin.get_from(conn).clone(service=service, tracer=self.tracer).onto(conn)
@@ -156,11 +155,11 @@ class AiopgTestCase(AsyncioTestCase):
         patch()
         patch()
 
-        service = 'fo'
+        service = "fo"
 
         conn = yield from aiopg.connect(**POSTGRES_CONFIG)
         Pin.get_from(conn).clone(service=service, tracer=self.tracer).onto(conn)
-        yield from (yield from conn.cursor()).execute('select \'blah\'')
+        yield from (yield from conn.cursor()).execute("select 'blah'")
         conn.close()
 
         spans = self.pop_spans()
@@ -171,7 +170,7 @@ class AiopgTestCase(AsyncioTestCase):
         unpatch()
 
         conn = yield from aiopg.connect(**POSTGRES_CONFIG)
-        yield from (yield from conn.cursor()).execute('select \'blah\'')
+        yield from (yield from conn.cursor()).execute("select 'blah'")
         conn.close()
 
         spans = self.pop_spans()
@@ -182,7 +181,7 @@ class AiopgTestCase(AsyncioTestCase):
 
         conn = yield from aiopg.connect(**POSTGRES_CONFIG)
         Pin.get_from(conn).clone(service=service, tracer=self.tracer).onto(conn)
-        yield from (yield from conn.cursor()).execute('select \'blah\'')
+        yield from (yield from conn.cursor()).execute("select 'blah'")
         conn.close()
 
         spans = self.pop_spans()
@@ -197,11 +196,12 @@ class AiopgTestCase(AsyncioTestCase):
         """
         # Ensure that the service name was configured
         from ddtrace import config
+
         assert config.service == "mysvc"
 
         conn = yield from aiopg.connect(**POSTGRES_CONFIG)
         Pin.get_from(conn).clone(tracer=self.tracer).onto(conn)
-        yield from (yield from conn.cursor()).execute('select \'blah\'')
+        yield from (yield from conn.cursor()).execute("select 'blah'")
         conn.close()
 
         spans = self.get_spans()
@@ -215,10 +215,10 @@ class AiopgAnalyticsTestCase(AiopgTestCase):
     def trace_spans(self):
         conn, _ = yield from self._get_conn_and_tracer()
 
-        Pin.get_from(conn).clone(service='db', tracer=self.tracer).onto(conn)
+        Pin.get_from(conn).clone(service="db", tracer=self.tracer).onto(conn)
 
         cursor = yield from conn.cursor()
-        yield from cursor.execute('select \'foobar\'')
+        yield from cursor.execute("select 'foobar'")
         rows = yield from cursor.fetchall()
         assert rows
 
@@ -232,20 +232,14 @@ class AiopgAnalyticsTestCase(AiopgTestCase):
 
     @mark_asyncio
     def test_analytics_with_rate(self):
-        with self.override_config(
-            'aiopg',
-            dict(analytics_enabled=True, analytics_sample_rate=0.5)
-        ):
+        with self.override_config("aiopg", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
             spans = yield from self.trace_spans()
             self.assertEqual(len(spans), 1)
             self.assertEqual(spans[0].get_metric(ANALYTICS_SAMPLE_RATE_KEY), 0.5)
 
     @mark_asyncio
     def test_analytics_without_rate(self):
-        with self.override_config(
-            'aiopg',
-            dict(analytics_enabled=True)
-        ):
+        with self.override_config("aiopg", dict(analytics_enabled=True)):
             spans = yield from self.trace_spans()
             self.assertEqual(len(spans), 1)
             self.assertEqual(spans[0].get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)


### PR DESCRIPTION
## Description
The `ddtrace.contrib.aiopg` and `tests.contrib.aiopg` directories were formatted with black and subsequently removed from the black exclude configuration.