### PR TITLE
chore(pylibmc): format with black

### DIFF
--- a/ddtrace/contrib/pylibmc/__init__.py
+++ b/ddtrace/contrib/pylibmc/__init__.py
@@ -22,11 +22,11 @@
 from ...utils.importlib import require_modules
 
 
-required_modules = ['pylibmc']
+required_modules = ["pylibmc"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
         from .client import TracedClient
         from .patch import patch
 
-        __all__ = ['TracedClient', 'patch']
+        __all__ = ["TracedClient", "patch"]

--- a/ddtrace/contrib/pylibmc/client.py
+++ b/ddtrace/contrib/pylibmc/client.py
@@ -6,16 +6,14 @@ import pylibmc
 # project
 import ddtrace
 from ddtrace import config
-# 3p
+from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import SPAN_MEASURED_KEY
+from ddtrace.contrib.pylibmc.addrs import parse_addresses
+from ddtrace.ext import SpanTypes
+from ddtrace.ext import memcached
+from ddtrace.ext import net
+from ddtrace.internal.logger import get_logger
 from ddtrace.vendor.wrapt import ObjectProxy
-
-from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...constants import SPAN_MEASURED_KEY
-from ...ext import SpanTypes
-from ...ext import memcached
-from ...ext import net
-from ...internal.logger import get_logger
-from .addrs import parse_addresses
 
 
 # Original Client class
@@ -26,12 +24,10 @@ log = get_logger(__name__)
 
 
 class TracedClient(ObjectProxy):
-    """ TracedClient is a proxy for a pylibmc.Client that times it's network operations. """
+    """TracedClient is a proxy for a pylibmc.Client that times it's network operations."""
 
     def __init__(self, client=None, service=memcached.SERVICE, tracer=None, *args, **kwargs):
-        """ Create a traced client that wraps the given memcached client.
-
-        """
+        """Create a traced client that wraps the given memcached client."""
         # The client instance/service/tracer attributes are kept for compatibility
         # with the old interface: TracedClient(client=pylibmc.Client(['localhost:11211']))
         # TODO(Benjamin): Remove these in favor of patching.
@@ -40,8 +36,10 @@ class TracedClient(ObjectProxy):
             # Note that, in that case, client isn't a real client (just the first argument)
             client = _Client(client, *args, **kwargs)
         else:
-            log.warning('TracedClient instantiation is deprecated and will be remove '
-                        'in future versions (0.6.0). Use patching instead (see the docs).')
+            log.warning(
+                "TracedClient instantiation is deprecated and will be remove "
+                "in future versions (0.6.0). Use patching instead (see the docs)."
+            )
 
         super(TracedClient, self).__init__(client)
 
@@ -52,7 +50,7 @@ class TracedClient(ObjectProxy):
         try:
             self._addresses = parse_addresses(client.addresses)
         except Exception:
-            log.debug('error setting addresses', exc_info=True)
+            log.debug("error setting addresses", exc_info=True)
 
     def clone(self, *args, **kwargs):
         # rewrap new connections.
@@ -64,64 +62,64 @@ class TracedClient(ObjectProxy):
         return traced_client
 
     def get(self, *args, **kwargs):
-        return self._trace_cmd('get', *args, **kwargs)
+        return self._trace_cmd("get", *args, **kwargs)
 
     def set(self, *args, **kwargs):
-        return self._trace_cmd('set', *args, **kwargs)
+        return self._trace_cmd("set", *args, **kwargs)
 
     def delete(self, *args, **kwargs):
-        return self._trace_cmd('delete', *args, **kwargs)
+        return self._trace_cmd("delete", *args, **kwargs)
 
     def gets(self, *args, **kwargs):
-        return self._trace_cmd('gets', *args, **kwargs)
+        return self._trace_cmd("gets", *args, **kwargs)
 
     def touch(self, *args, **kwargs):
-        return self._trace_cmd('touch', *args, **kwargs)
+        return self._trace_cmd("touch", *args, **kwargs)
 
     def cas(self, *args, **kwargs):
-        return self._trace_cmd('cas', *args, **kwargs)
+        return self._trace_cmd("cas", *args, **kwargs)
 
     def incr(self, *args, **kwargs):
-        return self._trace_cmd('incr', *args, **kwargs)
+        return self._trace_cmd("incr", *args, **kwargs)
 
     def decr(self, *args, **kwargs):
-        return self._trace_cmd('decr', *args, **kwargs)
+        return self._trace_cmd("decr", *args, **kwargs)
 
     def append(self, *args, **kwargs):
-        return self._trace_cmd('append', *args, **kwargs)
+        return self._trace_cmd("append", *args, **kwargs)
 
     def prepend(self, *args, **kwargs):
-        return self._trace_cmd('prepend', *args, **kwargs)
+        return self._trace_cmd("prepend", *args, **kwargs)
 
     def get_multi(self, *args, **kwargs):
-        return self._trace_multi_cmd('get_multi', *args, **kwargs)
+        return self._trace_multi_cmd("get_multi", *args, **kwargs)
 
     def set_multi(self, *args, **kwargs):
-        return self._trace_multi_cmd('set_multi', *args, **kwargs)
+        return self._trace_multi_cmd("set_multi", *args, **kwargs)
 
     def delete_multi(self, *args, **kwargs):
-        return self._trace_multi_cmd('delete_multi', *args, **kwargs)
+        return self._trace_multi_cmd("delete_multi", *args, **kwargs)
 
     def _trace_cmd(self, method_name, *args, **kwargs):
-        """ trace the execution of the method with the given name and will
-            patch the first arg.
+        """trace the execution of the method with the given name and will
+        patch the first arg.
         """
         method = getattr(self.__wrapped__, method_name)
         with self._span(method_name) as span:
 
             if span and args:
-                span.set_tag(memcached.QUERY, '%s %s' % (method_name, args[0]))
+                span.set_tag(memcached.QUERY, "%s %s" % (method_name, args[0]))
 
             return method(*args, **kwargs)
 
     def _trace_multi_cmd(self, method_name, *args, **kwargs):
-        """ trace the execution of the multi command with the given name. """
+        """trace the execution of the multi command with the given name."""
         method = getattr(self.__wrapped__, method_name)
         with self._span(method_name) as span:
 
-            pre = kwargs.get('key_prefix')
+            pre = kwargs.get("key_prefix")
             if span and pre:
-                span.set_tag(memcached.QUERY, '%s %s' % (method_name, pre))
+                span.set_tag(memcached.QUERY, "%s %s" % (method_name, pre))
 
             return method(*args, **kwargs)
 
@@ -130,13 +128,13 @@ class TracedClient(ObjectProxy):
         yield None
 
     def _span(self, cmd_name):
-        """ Return a span timing the given command. """
+        """Return a span timing the given command."""
         pin = ddtrace.Pin.get_from(self)
         if not pin or not pin.enabled():
             return self._no_span()
 
         span = pin.tracer.trace(
-            'memcached.cmd',
+            "memcached.cmd",
             service=pin.service,
             resource=cmd_name,
             span_type=SpanTypes.CACHE,
@@ -146,7 +144,7 @@ class TracedClient(ObjectProxy):
         try:
             self._tag_span(span)
         except Exception:
-            log.debug('error tagging span', exc_info=True)
+            log.debug("error tagging span", exc_info=True)
         return span
 
     def _tag_span(self, span):
@@ -158,7 +156,4 @@ class TracedClient(ObjectProxy):
             span.set_meta(net.TARGET_PORT, port)
 
         # set analytics sample rate
-        span.set_tag(
-            ANALYTICS_SAMPLE_RATE_KEY,
-            config.pylibmc.get_analytics_sample_rate()
-        )
+        span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, config.pylibmc.get_analytics_sample_rate())

--- a/ddtrace/contrib/pylibmc/patch.py
+++ b/ddtrace/contrib/pylibmc/patch.py
@@ -8,8 +8,8 @@ _Client = pylibmc.Client
 
 
 def patch():
-    setattr(pylibmc, 'Client', TracedClient)
+    setattr(pylibmc, "Client", TracedClient)
 
 
 def unpatch():
-    setattr(pylibmc, 'Client', _Client)
+    setattr(pylibmc, "Client", _Client)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ exclude = '''
       aiopg
       | boto
       | jinja2
-      | pylibmc
       | rediscluster
     )
     | profiling/exporter/pprof_.*pb2.py$
@@ -57,7 +56,6 @@ exclude = '''
       aiopg
       | config.py
       | jinja2
-      | pylibmc
       | rediscluster
     )
   )

--- a/tests/contrib/pylibmc/test.py
+++ b/tests/contrib/pylibmc/test.py
@@ -12,12 +12,10 @@ from ddtrace.contrib.pylibmc import TracedClient
 from ddtrace.contrib.pylibmc.patch import patch
 from ddtrace.contrib.pylibmc.patch import unpatch
 from ddtrace.ext import memcached
+from tests.contrib.config import MEMCACHED_CONFIG as cfg
+from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
-
-from ...contrib.config import MEMCACHED_CONFIG as cfg
-# testing
-from ...opentracer.utils import init_tracer
 
 
 class PylibmcCore(object):
@@ -34,23 +32,23 @@ class PylibmcCore(object):
         pass
 
     def test_upgrade(self):
-        raise SkipTest('upgrade memcached')
+        raise SkipTest("upgrade memcached")
         # add tests for touch, cas, gets etc
 
     def test_append_prepend(self):
         client, tracer = self.get_client()
         # test
         start = time.time()
-        client.set('a', 'crow')
-        client.prepend('a', 'holy ')
-        client.append('a', '!')
+        client.set("a", "crow")
+        client.prepend("a", "holy ")
+        client.append("a", "!")
 
         # FIXME[matt] there is a bug in pylibmc & python 3 (perhaps with just
         # some versions of the libmemcache?) where append/prepend are replaced
         # with get. our traced versions do the right thing, so skipping this
         # test.
         try:
-            assert client.get('a') == 'holy crow!'
+            assert client.get("a") == "holy crow!"
         except AssertionError:
             pass
 
@@ -59,7 +57,7 @@ class PylibmcCore(object):
         spans = tracer.pop()
         for s in spans:
             self._verify_cache_span(s, start, end)
-        expected_resources = sorted(['append', 'prepend', 'get', 'set'])
+        expected_resources = sorted(["append", "prepend", "get", "set"])
         resources = sorted(s.resource for s in spans)
         assert expected_resources == resources
 
@@ -67,31 +65,31 @@ class PylibmcCore(object):
         client, tracer = self.get_client()
         # test
         start = time.time()
-        client.set('a', 1)
-        client.incr('a', 2)
-        client.decr('a', 1)
-        v = client.get('a')
+        client.set("a", 1)
+        client.incr("a", 2)
+        client.decr("a", 1)
+        v = client.get("a")
         assert v == 2
         end = time.time()
         # verify spans
         spans = tracer.pop()
         for s in spans:
             self._verify_cache_span(s, start, end)
-        expected_resources = sorted(['get', 'set', 'incr', 'decr'])
+        expected_resources = sorted(["get", "set", "incr", "decr"])
         resources = sorted(s.resource for s in spans)
         assert expected_resources == resources
 
     def test_incr_decr_ot(self):
         """OpenTracing version of test_incr_decr."""
         client, tracer = self.get_client()
-        ot_tracer = init_tracer('memcached', tracer)
+        ot_tracer = init_tracer("memcached", tracer)
 
         start = time.time()
-        with ot_tracer.start_active_span('mc_ops'):
-            client.set('a', 1)
-            client.incr('a', 2)
-            client.decr('a', 1)
-            v = client.get('a')
+        with ot_tracer.start_active_span("mc_ops"):
+            client.set("a", 1)
+            client.incr("a", 2)
+            client.decr("a", 1)
+            v = client.get("a")
             assert v == 2
         end = time.time()
 
@@ -99,12 +97,12 @@ class PylibmcCore(object):
         spans = tracer.pop()
         ot_span = spans[0]
 
-        assert ot_span.name == 'mc_ops'
+        assert ot_span.name == "mc_ops"
 
         for s in spans[1:]:
             assert s.parent_id == ot_span.span_id
             self._verify_cache_span(s, start, end)
-        expected_resources = sorted(['get', 'set', 'incr', 'decr'])
+        expected_resources = sorted(["get", "set", "incr", "decr"])
         resources = sorted(s.resource for s in spans[1:])
         assert expected_resources == resources
 
@@ -113,12 +111,12 @@ class PylibmcCore(object):
         client, tracer = self.get_client()
         cloned = client.clone()
         start = time.time()
-        cloned.get('a')
+        cloned.get("a")
         end = time.time()
         spans = tracer.pop()
         for s in spans:
             self._verify_cache_span(s, start, end)
-        expected_resources = ['get']
+        expected_resources = ["get"]
         resources = sorted(s.resource for s in spans)
         assert expected_resources == resources
 
@@ -126,16 +124,16 @@ class PylibmcCore(object):
         client, tracer = self.get_client()
         # test
         start = time.time()
-        client.set_multi({'a': 1, 'b': 2})
-        out = client.get_multi(['a', 'c'])
-        assert out == {'a': 1}
-        client.delete_multi(['a', 'c'])
+        client.set_multi({"a": 1, "b": 2})
+        out = client.get_multi(["a", "c"])
+        assert out == {"a": 1}
+        client.delete_multi(["a", "c"])
         end = time.time()
         # verify
         spans = tracer.pop()
         for s in spans:
             self._verify_cache_span(s, start, end)
-        expected_resources = sorted(['get_multi', 'set_multi', 'delete_multi'])
+        expected_resources = sorted(["get_multi", "set_multi", "delete_multi"])
         resources = sorted(s.resource for s in spans)
         assert expected_resources == resources
 
@@ -143,25 +141,25 @@ class PylibmcCore(object):
         client, tracer = self.get_client()
         # test
         start = time.time()
-        client.set_multi({'a': 1, 'b': 2}, key_prefix='foo')
-        out = client.get_multi(['a', 'c'], key_prefix='foo')
-        assert out == {'a': 1}
-        client.delete_multi(['a', 'c'], key_prefix='foo')
+        client.set_multi({"a": 1, "b": 2}, key_prefix="foo")
+        out = client.get_multi(["a", "c"], key_prefix="foo")
+        assert out == {"a": 1}
+        client.delete_multi(["a", "c"], key_prefix="foo")
         end = time.time()
         # verify
         spans = tracer.pop()
         for s in spans:
             self._verify_cache_span(s, start, end)
-            assert s.get_tag('memcached.query') == '%s foo' % s.resource
-        expected_resources = sorted(['get_multi', 'set_multi', 'delete_multi'])
+            assert s.get_tag("memcached.query") == "%s foo" % s.resource
+        expected_resources = sorted(["get_multi", "set_multi", "delete_multi"])
         resources = sorted(s.resource for s in spans)
         assert expected_resources == resources
 
     def test_get_set_delete(self):
         client, tracer = self.get_client()
         # test
-        k = u'cafe'
-        v = 'val-foo'
+        k = u"cafe"
+        v = "val-foo"
         start = time.time()
         client.delete(k)  # just in case
         out = client.get(k)
@@ -174,8 +172,8 @@ class PylibmcCore(object):
         spans = tracer.pop()
         for s in spans:
             self._verify_cache_span(s, start, end)
-            assert s.get_tag('memcached.query') == '%s %s' % (s.resource, k)
-        expected_resources = sorted(['get', 'get', 'delete', 'set'])
+            assert s.get_tag("memcached.query") == "%s %s" % (s.resource, k)
+        expected_resources = sorted(["get", "get", "delete", "set"])
         resources = sorted(s.resource for s in spans)
         assert expected_resources == resources
 
@@ -184,38 +182,32 @@ class PylibmcCore(object):
         assert s.start > start
         assert s.start + s.duration < end
         assert s.service == self.TEST_SERVICE
-        assert s.span_type == 'cache'
-        assert s.name == 'memcached.cmd'
-        assert s.get_tag('out.host') == cfg['host']
-        assert s.get_metric('out.port') == cfg['port']
+        assert s.span_type == "cache"
+        assert s.name == "memcached.cmd"
+        assert s.get_tag("out.host") == cfg["host"]
+        assert s.get_metric("out.port") == cfg["port"]
 
     def test_analytics_default(self):
         client, tracer = self.get_client()
-        client.set('a', 'crow')
+        client.set("a", "crow")
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
         self.assertIsNone(spans[0].get_metric(ANALYTICS_SAMPLE_RATE_KEY))
 
     def test_analytics_with_rate(self):
-        with self.override_config(
-            'pylibmc',
-            dict(analytics_enabled=True, analytics_sample_rate=0.5)
-        ):
+        with self.override_config("pylibmc", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
             client, tracer = self.get_client()
-            client.set('a', 'crow')
+            client.set("a", "crow")
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
         self.assertEqual(spans[0].get_metric(ANALYTICS_SAMPLE_RATE_KEY), 0.5)
 
     def test_analytics_without_rate(self):
-        with self.override_config(
-            'pylibmc',
-            dict(analytics_enabled=True)
-        ):
+        with self.override_config("pylibmc", dict(analytics_enabled=True)):
             client, tracer = self.get_client()
-            client.set('a', 'crow')
+            client.set("a", "crow")
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
@@ -229,7 +221,7 @@ class PylibmcCore(object):
         try:
             tracer.enabled = False
 
-            client.set('a', 'crow')
+            client.set("a", "crow")
 
             spans = self.get_spans()
             assert len(spans) == 0
@@ -244,10 +236,11 @@ class PylibmcCore(object):
         """
         # Ensure that the service name was configured
         from ddtrace import config
+
         assert config.service == "mysvc"
 
         client, tracer = self.get_client()
-        client.set('a', 'crow')
+        client.set("a", "crow")
         spans = self.get_spans()
         assert len(spans) == 1
         assert spans[0].service != "mysvc"
@@ -256,10 +249,10 @@ class PylibmcCore(object):
 class TestPylibmcLegacy(TracerTestCase, PylibmcCore):
     """Test suite for the tracing of pylibmc with the legacy TracedClient interface"""
 
-    TEST_SERVICE = 'mc-legacy'
+    TEST_SERVICE = "mc-legacy"
 
     def get_client(self):
-        url = '%s:%s' % (cfg['host'], cfg['port'])
+        url = "%s:%s" % (cfg["host"], cfg["port"])
         raw_client = pylibmc.Client([url])
         raw_client.flush_all()
 
@@ -279,7 +272,7 @@ class TestPylibmcPatchDefault(TracerTestCase, PylibmcCore):
         super(TestPylibmcPatchDefault, self).tearDown()
 
     def get_client(self):
-        url = '%s:%s' % (cfg['host'], cfg['port'])
+        url = "%s:%s" % (cfg["host"], cfg["port"])
         client = pylibmc.Client([url])
         client.flush_all()
 
@@ -291,7 +284,7 @@ class TestPylibmcPatchDefault(TracerTestCase, PylibmcCore):
 class TestPylibmcPatch(TestPylibmcPatchDefault):
     """Test suite for the tracing of pylibmc with a configured lib patching"""
 
-    TEST_SERVICE = 'mc-custom-patch'
+    TEST_SERVICE = "mc-custom-patch"
 
     def get_client(self):
         client, tracer = TestPylibmcPatchDefault.get_client(self)
@@ -301,18 +294,16 @@ class TestPylibmcPatch(TestPylibmcPatchDefault):
         return client, tracer
 
     def test_patch_unpatch(self):
-        url = '%s:%s' % (cfg['host'], cfg['port'])
+        url = "%s:%s" % (cfg["host"], cfg["port"])
 
         # Test patch idempotence
         patch()
         patch()
 
         client = pylibmc.Client([url])
-        Pin.get_from(client).clone(
-            service=self.TEST_SERVICE,
-            tracer=self.tracer).onto(client)
+        Pin.get_from(client).clone(service=self.TEST_SERVICE, tracer=self.tracer).onto(client)
 
-        client.set('a', 1)
+        client.set("a", 1)
 
         spans = self.pop_spans()
         assert spans, spans
@@ -322,7 +313,7 @@ class TestPylibmcPatch(TestPylibmcPatchDefault):
         unpatch()
 
         client = pylibmc.Client([url])
-        client.set('a', 1)
+        client.set("a", 1)
 
         spans = self.pop_spans()
         assert not spans, spans
@@ -332,7 +323,7 @@ class TestPylibmcPatch(TestPylibmcPatchDefault):
 
         client = pylibmc.Client([url])
         Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(client)
-        client.set('a', 1)
+        client.set("a", 1)
 
         spans = self.pop_spans()
         assert spans, spans


### PR DESCRIPTION
## Description
The `ddtrace.contrib.pylibmc` and `tests.contrib.pylibmc` directories were formatted with black and subsequently removed from the black excludes configuration.