### PR TITLE
chore(rediscluster): format with black

### DIFF
--- a/ddtrace/contrib/rediscluster/__init__.py
+++ b/ddtrace/contrib/rediscluster/__init__.py
@@ -20,10 +20,10 @@
 from ...utils.importlib import require_modules
 
 
-required_modules = ['rediscluster', 'rediscluster.client']
+required_modules = ["rediscluster", "rediscluster.client"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
         from .patch import patch
 
-        __all__ = ['patch']
+        __all__ = ["patch"]

--- a/ddtrace/contrib/rediscluster/patch.py
+++ b/ddtrace/contrib/rediscluster/patch.py
@@ -3,61 +3,60 @@ import rediscluster
 
 # project
 from ddtrace import config
+from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import SPAN_MEASURED_KEY
+from ddtrace.contrib.redis.patch import traced_execute_command
+from ddtrace.contrib.redis.patch import traced_pipeline
+from ddtrace.contrib.redis.util import format_command_args
+from ddtrace.ext import SpanTypes
+from ddtrace.ext import redis as redisx
+from ddtrace.pin import Pin
+from ddtrace.utils.wrappers import unwrap
 from ddtrace.vendor import wrapt
-
-from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...constants import SPAN_MEASURED_KEY
-from ...ext import SpanTypes
-from ...ext import redis as redisx
-from ...pin import Pin
-from ...utils.wrappers import unwrap
-from ..redis.patch import traced_execute_command
-from ..redis.patch import traced_pipeline
-from ..redis.util import format_command_args
 
 
 # DEV: In `2.0.0` `__version__` is a string and `VERSION` is a tuple,
 #      but in `1.x.x` `__version__` is a tuple annd `VERSION` does not exist
-REDISCLUSTER_VERSION = getattr(rediscluster, 'VERSION', rediscluster.__version__)
+REDISCLUSTER_VERSION = getattr(rediscluster, "VERSION", rediscluster.__version__)
 
 
 def patch():
-    """Patch the instrumented methods
-    """
-    if getattr(rediscluster, '_datadog_patch', False):
+    """Patch the instrumented methods"""
+    if getattr(rediscluster, "_datadog_patch", False):
         return
-    setattr(rediscluster, '_datadog_patch', True)
+    setattr(rediscluster, "_datadog_patch", True)
 
     _w = wrapt.wrap_function_wrapper
     if REDISCLUSTER_VERSION >= (2, 0, 0):
-        _w('rediscluster', 'client.RedisCluster.execute_command', traced_execute_command)
-        _w('rediscluster', 'client.RedisCluster.pipeline', traced_pipeline)
-        _w('rediscluster', 'pipeline.ClusterPipeline.execute', traced_execute_pipeline)
+        _w("rediscluster", "client.RedisCluster.execute_command", traced_execute_command)
+        _w("rediscluster", "client.RedisCluster.pipeline", traced_pipeline)
+        _w("rediscluster", "pipeline.ClusterPipeline.execute", traced_execute_pipeline)
         Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP).onto(rediscluster.RedisCluster)
     else:
-        _w('rediscluster', 'StrictRedisCluster.execute_command', traced_execute_command)
-        _w('rediscluster', 'StrictRedisCluster.pipeline', traced_pipeline)
-        _w('rediscluster', 'StrictClusterPipeline.execute', traced_execute_pipeline)
+        _w("rediscluster", "StrictRedisCluster.execute_command", traced_execute_command)
+        _w("rediscluster", "StrictRedisCluster.pipeline", traced_pipeline)
+        _w("rediscluster", "StrictClusterPipeline.execute", traced_execute_pipeline)
         Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP).onto(rediscluster.StrictRedisCluster)
 
 
 def unpatch():
-    if getattr(rediscluster, '_datadog_patch', False):
-        setattr(rediscluster, '_datadog_patch', False)
+    if getattr(rediscluster, "_datadog_patch", False):
+        setattr(rediscluster, "_datadog_patch", False)
 
         if REDISCLUSTER_VERSION >= (2, 0, 0):
-            unwrap(rediscluster.client.RedisCluster, 'execute_command')
-            unwrap(rediscluster.client.RedisCluster, 'pipeline')
-            unwrap(rediscluster.pipeline.ClusterPipeline, 'execute')
+            unwrap(rediscluster.client.RedisCluster, "execute_command")
+            unwrap(rediscluster.client.RedisCluster, "pipeline")
+            unwrap(rediscluster.pipeline.ClusterPipeline, "execute")
         else:
-            unwrap(rediscluster.StrictRedisCluster, 'execute_command')
-            unwrap(rediscluster.StrictRedisCluster, 'pipeline')
-            unwrap(rediscluster.StrictClusterPipeline, 'execute')
+            unwrap(rediscluster.StrictRedisCluster, "execute_command")
+            unwrap(rediscluster.StrictRedisCluster, "pipeline")
+            unwrap(rediscluster.StrictClusterPipeline, "execute")
 
 
 #
 # tracing functions
 #
+
 
 def traced_execute_pipeline(func, instance, args, kwargs):
     pin = Pin.get_from(instance)
@@ -65,7 +64,7 @@ def traced_execute_pipeline(func, instance, args, kwargs):
         return func(*args, **kwargs)
 
     cmds = [format_command_args(c.args) for c in instance.command_stack]
-    resource = '\n'.join(cmds)
+    resource = "\n".join(cmds)
     tracer = pin.tracer
     with tracer.trace(redisx.CMD, resource=resource, service=pin.service, span_type=SpanTypes.REDIS) as s:
         s.set_tag(SPAN_MEASURED_KEY)
@@ -73,9 +72,6 @@ def traced_execute_pipeline(func, instance, args, kwargs):
         s.set_metric(redisx.PIPELINE_LEN, len(instance.command_stack))
 
         # set analytics sample rate if enabled
-        s.set_tag(
-            ANALYTICS_SAMPLE_RATE_KEY,
-            config.rediscluster.get_analytics_sample_rate()
-        )
+        s.set_tag(ANALYTICS_SAMPLE_RATE_KEY, config.rediscluster.get_analytics_sample_rate())
 
         return func(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ exclude = '''
       | boto
       | jinja2
       | pylibmc
-      | rediscluster
     )
     | profiling/exporter/pprof_.*pb2.py$
     | vendor/
@@ -58,7 +57,6 @@ exclude = '''
       | config.py
       | jinja2
       | pylibmc
-      | rediscluster
     )
   )
 )

--- a/tests/contrib/rediscluster/test.py
+++ b/tests/contrib/rediscluster/test.py
@@ -5,24 +5,20 @@ from ddtrace import Pin
 from ddtrace.contrib.rediscluster.patch import REDISCLUSTER_VERSION
 from ddtrace.contrib.rediscluster.patch import patch
 from ddtrace.contrib.rediscluster.patch import unpatch
+from tests.contrib.config import REDISCLUSTER_CONFIG
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 
-from ..config import REDISCLUSTER_CONFIG
-
 
 class TestRedisPatch(TracerTestCase):
 
-    TEST_SERVICE = 'rediscluster-patch'
-    TEST_HOST = REDISCLUSTER_CONFIG['host']
-    TEST_PORTS = REDISCLUSTER_CONFIG['ports']
+    TEST_SERVICE = "rediscluster-patch"
+    TEST_HOST = REDISCLUSTER_CONFIG["host"]
+    TEST_PORTS = REDISCLUSTER_CONFIG["ports"]
 
     def _get_test_client(self):
-        startup_nodes = [
-            {'host': self.TEST_HOST, 'port': int(port)}
-            for port in self.TEST_PORTS.split(',')
-        ]
+        startup_nodes = [{"host": self.TEST_HOST, "port": int(port)} for port in self.TEST_PORTS.split(",")]
         if REDISCLUSTER_VERSION >= (2, 0, 0):
             return rediscluster.RedisCluster(startup_nodes=startup_nodes)
         else:
@@ -41,25 +37,25 @@ class TestRedisPatch(TracerTestCase):
         super(TestRedisPatch, self).tearDown()
 
     def test_basics(self):
-        us = self.r.get('cheese')
+        us = self.r.get("cheese")
         assert us is None
         spans = self.get_spans()
         assert len(spans) == 1
         span = spans[0]
         assert_is_measured(span)
         assert span.service == self.TEST_SERVICE
-        assert span.name == 'redis.command'
-        assert span.span_type == 'redis'
+        assert span.name == "redis.command"
+        assert span.span_type == "redis"
         assert span.error == 0
-        assert span.get_tag('redis.raw_command') == u'GET cheese'
-        assert span.get_metric('redis.args_length') == 2
-        assert span.resource == 'GET cheese'
+        assert span.get_tag("redis.raw_command") == u"GET cheese"
+        assert span.get_metric("redis.args_length") == 2
+        assert span.resource == "GET cheese"
 
     def test_pipeline(self):
         with self.r.pipeline(transaction=False) as p:
-            p.set('blah', 32)
-            p.rpush('foo', u'éé')
-            p.hgetall('xxx')
+            p.set("blah", 32)
+            p.rpush("foo", u"éé")
+            p.hgetall("xxx")
             p.execute()
 
         spans = self.get_spans()
@@ -67,12 +63,12 @@ class TestRedisPatch(TracerTestCase):
         span = spans[0]
         assert_is_measured(span)
         assert span.service == self.TEST_SERVICE
-        assert span.name == 'redis.command'
-        assert span.resource == u'SET blah 32\nRPUSH foo éé\nHGETALL xxx'
-        assert span.span_type == 'redis'
+        assert span.name == "redis.command"
+        assert span.resource == u"SET blah 32\nRPUSH foo éé\nHGETALL xxx"
+        assert span.span_type == "redis"
         assert span.error == 0
-        assert span.get_tag('redis.raw_command') == u'SET blah 32\nRPUSH foo éé\nHGETALL xxx'
-        assert span.get_metric('redis.pipeline_length') == 3
+        assert span.get_tag("redis.raw_command") == u"SET blah 32\nRPUSH foo éé\nHGETALL xxx"
+        assert span.get_metric("redis.pipeline_length") == 3
 
     def test_patch_unpatch(self):
         tracer = DummyTracer()
@@ -83,7 +79,7 @@ class TestRedisPatch(TracerTestCase):
 
         r = self._get_test_client()
         Pin.get_from(r).clone(tracer=tracer).onto(r)
-        r.get('key')
+        r.get("key")
 
         spans = tracer.pop()
         assert spans, spans
@@ -93,7 +89,7 @@ class TestRedisPatch(TracerTestCase):
         unpatch()
 
         r = self._get_test_client()
-        r.get('key')
+        r.get("key")
 
         spans = tracer.pop()
         assert not spans, spans
@@ -103,7 +99,7 @@ class TestRedisPatch(TracerTestCase):
 
         r = self._get_test_client()
         Pin.get_from(r).clone(tracer=tracer).onto(r)
-        r.get('key')
+        r.get("key")
 
         spans = tracer.pop()
         assert spans, spans
@@ -117,6 +113,7 @@ class TestRedisPatch(TracerTestCase):
         """
         # Ensure that the service name was configured
         from ddtrace import config
+
         assert config.service == "mysvc"
 
         r = self._get_test_client()


### PR DESCRIPTION
## Description
The `ddtrace.contrib.rediscluster` and `tests.contrib.rediscluster` directories were formatted with black and subsequently removed from the black excludes configuration.