### PR TITLE
fix(docs): use gunicorn post_worker_init hook

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -675,8 +675,8 @@ There are different options to make that happen:
 - Replace ``ddtrace-run`` by using ``import ddtrace.bootstrap.sitecustomize``
   as the first import of your application.
 
-- Use a `post_fork hook <https://docs.gunicorn.org/en/stable/settings.html#post-fork>`_
-  to import ``ddtrace.bootstrap.sitecustomize``.
+- Use a `post_worker_init <https://docs.gunicorn.org/en/stable/settings.html#post-worker-init>`_
+  hook to import ``ddtrace.bootstrap.sitecustomize``.
 
 API
 ---


### PR DESCRIPTION
## Description

In gunicorn, the `post_fork` hook is called before the worker's `init_process`. The gevent worker calls gevent's `patch_all` during the worker's `init_process`. This means that the current documentation would result in ddtrace's patching occurring before gevent's. Instead gunicorn users should use the `post_worker_init` hook which is called after the gevent patching has been applied and the gevent hub has been reinitialized following the fork.

https://github.com/benoitc/gunicorn/blob/1299ea9e967a61ae2edebe191082fd169b864c64/gunicorn/arbiter.py#L588-L589
https://github.com/benoitc/gunicorn/blob/1299ea9e967a61ae2edebe191082fd169b864c64/gunicorn/workers/ggevent.py#L143-L146
https://github.com/benoitc/gunicorn/blob/1299ea9e967a61ae2edebe191082fd169b864c64/gunicorn/workers/base.py#L138

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [X] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
