### PR TITLE
refactor(context): use a mixin

### DIFF
--- a/ddtrace/contrib/asyncio/provider.py
+++ b/ddtrace/contrib/asyncio/provider.py
@@ -1,10 +1,11 @@
 import asyncio
 
 from ...provider import BaseContextProvider
+from ...provider import DatadogContextMixin
 from ...span import Span
 
 
-class AsyncioContextProvider(BaseContextProvider):
+class AsyncioContextProvider(BaseContextProvider, DatadogContextMixin):
     """Manages the active context for asyncio execution. Framework
     instrumentation that is built on top of the ``asyncio`` library, should
     use this provider when contextvars are not available (Python versions

--- a/ddtrace/contrib/gevent/provider.py
+++ b/ddtrace/contrib/gevent/provider.py
@@ -1,10 +1,11 @@
 import gevent
 
 from ...provider import BaseContextProvider
+from ...provider import DatadogContextMixin
 from ...span import Span
 
 
-class GeventContextProvider(BaseContextProvider):
+class GeventContextProvider(BaseContextProvider, DatadogContextMixin):
     """Manages the active context for gevent execution.
 
     This provider depends on corresponding monkey patches to copy the active


### PR DESCRIPTION
Having `_update_active` on the abstract base class was a bit awkward
because it's an actual implementation.

Will also help make #2590 cleaner.