### PR TITLE
Add notice for gevent in docs

### DIFF
--- a/ddtrace/contrib/gevent/__init__.py
+++ b/ddtrace/contrib/gevent/__init__.py
@@ -9,7 +9,7 @@ The integration patches the gevent internals to add context management logic.
     ``gevent.monkey.patch_all()`` will be called as early as possible in the application
     to avoid patching conflicts.
     If ``ddtrace-run`` is not being used then be sure to call ``gevent.monkey.patch_all``
-    before importing ``ddtrace``.
+    before importing ``ddtrace`` and calling ``ddtrace.patch`` or `ddtrace.patch_all``.
 
 
 The integration also configures the global tracer instance to use a gevent

--- a/ddtrace/contrib/gevent/__init__.py
+++ b/ddtrace/contrib/gevent/__init__.py
@@ -5,9 +5,11 @@ The gevent integration adds support for tracing across greenlets.
 The integration patches the gevent internals to add context management logic.
 
 .. note::
-    If you are using :ref:`ddtrace-run<ddtracerun>` you must set ``DD_GEVENT_PATCH_ALL=true`` and ``ddtrace-run`` will
-    call ``gevent.monkey.patch_all()`` as early as possible in your application to avoid patching conflicts.
-    If you are doing manual instrumentation, you must call ``gevent.monkey.patch_all`` before importing ``ddtrace``.
+    If :ref:`ddtrace-run<ddtracerun>` is being used set ``DD_GEVENT_PATCH_ALL=true`` and
+    ``gevent.monkey.patch_all()`` will be called as early as possible in the application
+    to avoid patching conflicts.
+    If ``ddtrace-run`` is not being used then be sure to call ``gevent.monkey.patch_all``
+    before importing ``ddtrace``.
 
 
 The integration also configures the global tracer instance to use a gevent

--- a/docs/installation_quickstart.rst
+++ b/docs/installation_quickstart.rst
@@ -41,6 +41,12 @@ Quickstart
 Tracing
 ~~~~~~~
 
+.. important::
+
+    If ``gevent`` is used in the application then read the documentation
+    :ref:`here<gevent>`.
+
+
 Getting started for tracing is as easy as prefixing your python entry-point
 command with ``ddtrace-run``.
 


### PR DESCRIPTION
Make it clear in our docs for gevent users that they must perform
gevent's monkeypatching before ddtrace's.
