### PR TITLE
fix(wsgi): handle no root span

### DIFF
--- a/ddtrace/contrib/wsgi/wsgi.py
+++ b/ddtrace/contrib/wsgi/wsgi.py
@@ -97,9 +97,10 @@ class DDWSGIMiddleware(object):
     def __call__(self, environ, start_response):
         def intercept_start_response(status, response_headers, exc_info=None):
             span = self.tracer.current_root_span()
-            status_code, status_msg = status.split(" ", 1)
-            span.set_tag("http.status_msg", status_msg)
-            trace_utils.set_http_meta(span, config.wsgi, status_code=status_code, response_headers=response_headers)
+            if span:
+                status_code, status_msg = status.split(" ", 1)
+                span.set_tag("http.status_msg", status_msg)
+                trace_utils.set_http_meta(span, config.wsgi, status_code=status_code, response_headers=response_headers)
             with self.tracer.trace(
                 "wsgi.start_response",
                 service=trace_utils.int_service(None, config.wsgi),

--- a/ddtrace/contrib/wsgi/wsgi.py
+++ b/ddtrace/contrib/wsgi/wsgi.py
@@ -97,7 +97,7 @@ class DDWSGIMiddleware(object):
     def __call__(self, environ, start_response):
         def intercept_start_response(status, response_headers, exc_info=None):
             span = self.tracer.current_root_span()
-            if span:
+            if span is not None:
                 status_code, status_msg = status.split(" ", 1)
                 span.set_tag("http.status_msg", status_msg)
                 trace_utils.set_http_meta(span, config.wsgi, status_code=status_code, response_headers=response_headers)

--- a/releasenotes/notes/wsgi-73cf1d35043e7fef.yaml
+++ b/releasenotes/notes/wsgi-73cf1d35043e7fef.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a possible NoneType error in the WSGI middleware start_response method.


### PR DESCRIPTION

# Bug fix

## Description
<!-- Please briefly describe the bug. -->

It is possible for `tracer.current_root_span()` to return None which was
not handled here.

## Fix
<!-- Please provide a succinct overview of the fix. -->

Handle the possiblity that the current root span is None.

# Checklist
- [ ] Regression test added; or
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Added to the correct milestone.
