### PR TITLE
ci: pass DD_TESTING_RAISE correctly for tox-based tests

### DIFF
--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -8,6 +8,7 @@ jobs:
   flask-testsuite-1_1_4:
     runs-on: ubuntu-latest
     env:
+      TOX_TESTENV_PASSENV: DD_TESTING_RAISE
       DD_TESTING_RAISE: true
     defaults:
       run:

--- a/.github/workflows/mako.yml
+++ b/.github/workflows/mako.yml
@@ -8,6 +8,7 @@ jobs:
   mako-testsuite-1_1_4:
     runs-on: ubuntu-latest
     env:
+      TOX_TESTENV_PASSENV: DD_TESTING_RAISE
       DD_TESTING_RAISE: true
     defaults:
       run:


### PR DESCRIPTION
Mako and flask run their tests with tox, but tox clears out the environment
before running the test command. This means DD_TESTING_RAISE is not passed by
default.

This leverages TOX_TESTENV_PASSENV to inform tox we want to pass this down to
the test suite, making sure the tracer raises on important errors.
