### PR TITLE
Use explicit dependency in riotfile

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -826,10 +826,10 @@ venv = Venv(
         Venv(
             name="botocore",
             command="pytest {cmdargs} tests/contrib/botocore",
-            pkgs={"botocore": latest, "moto": [">=1.0,<2.0"]},
+            pkgs={"botocore": latest},
             venvs=[
-                Venv(pys=select_pys(min_version="3.5")),
-                Venv(pys=["2.7"], pkgs={"rsa": ["<4.7.1"]}),
+                Venv(pys=select_pys(min_version="3.5"), pkgs={"moto": [">=1.0,<2.0"]}),
+                Venv(pys=["2.7"], pkgs={"moto": [">=1.0,<2.0"], "rsa": ["<4.7.1"]}),
             ],
         ),
         Venv(


### PR DESCRIPTION
## Description

With the new riot release packages are not propagated down the venv instance parenting relation and therefore no longer provide overrides nor pins for packages at the previous level.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
