### PR TITLE
update partial flush config keys

### DIFF
--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -391,8 +391,8 @@ def test_partial_flush_log(run_python_code_in_subprocess):
 
     partial_flush_min_spans = "2"
     env = os.environ.copy()
-    env["DD_TRACER_PARTIAL_FLUSH_ENABLED"] = "true"
-    env["DD_TRACER_PARTIAL_FLUSH_MIN_SPANS"] = partial_flush_min_spans
+    env["DD_TRACE_PARTIAL_FLUSH_ENABLED"] = "true"
+    env["DD_TRACE_PARTIAL_FLUSH_MIN_SPANS"] = partial_flush_min_spans
 
     out, err, status, pid = run_python_code_in_subprocess(
         """

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1140,7 +1140,7 @@ def test_early_exit(tracer, test_spans):
 
 class TestPartialFlush(TracerTestCase):
     @TracerTestCase.run_in_subprocess(
-        env_overrides=dict(DD_TRACER_PARTIAL_FLUSH_ENABLED="true", DD_TRACER_PARTIAL_FLUSH_MIN_SPANS="5")
+        env_overrides=dict(DD_TRACE_PARTIAL_FLUSH_ENABLED="true", DD_TRACE_PARTIAL_FLUSH_MIN_SPANS="5")
     )
     def test_partial_flush(self):
         root = self.tracer.trace("root")
@@ -1159,7 +1159,7 @@ class TestPartialFlush(TracerTestCase):
         assert traces[0][0].name == "root"
 
     @TracerTestCase.run_in_subprocess(
-        env_overrides=dict(DD_TRACER_PARTIAL_FLUSH_ENABLED="true", DD_TRACER_PARTIAL_FLUSH_MIN_SPANS="1")
+        env_overrides=dict(DD_TRACE_PARTIAL_FLUSH_ENABLED="true", DD_TRACE_PARTIAL_FLUSH_MIN_SPANS="1")
     )
     def test_partial_flush_too_many(self):
         root = self.tracer.trace("root")
@@ -1180,7 +1180,7 @@ class TestPartialFlush(TracerTestCase):
         assert traces[0][0].name == "root"
 
     @TracerTestCase.run_in_subprocess(
-        env_overrides=dict(DD_TRACER_PARTIAL_FLUSH_ENABLED="true", DD_TRACER_PARTIAL_FLUSH_MIN_SPANS="6")
+        env_overrides=dict(DD_TRACE_PARTIAL_FLUSH_ENABLED="true", DD_TRACE_PARTIAL_FLUSH_MIN_SPANS="6")
     )
     def test_partial_flush_too_few(self):
         root = self.tracer.trace("root")
@@ -1207,7 +1207,7 @@ class TestPartialFlush(TracerTestCase):
         self.test_partial_flush_too_few()
 
     @TracerTestCase.run_in_subprocess(
-        env_overrides=dict(DD_TRACER_PARTIAL_FLUSH_ENABLED="false", DD_TRACER_PARTIAL_FLUSH_MIN_SPANS="6")
+        env_overrides=dict(DD_TRACE_PARTIAL_FLUSH_ENABLED="false", DD_TRACE_PARTIAL_FLUSH_MIN_SPANS="6")
     )
     def test_partial_flush_configure_precedence(self):
         self.tracer.configure(partial_flush_enabled=True, partial_flush_min_spans=5)


### PR DESCRIPTION
## Description

Currently some configs have keys starting with DD_TRACER_… whereas the rest of the environment variables we use are DD_TRACE_…. This change will replace DD_TRACER with DD_TRACE. 

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (No corp documentation found for DD_TRACER_PARTIAL_FLUSH_ENABLED and DD_TRACE_PARTIAL_FLUSH_MIN_SPANS)
