### PR TITLE
Update mypy, codespell configurations

### DIFF
--- a/benchmarks/django_simple.Dockerfile
+++ b/benchmarks/django_simple.Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION=3.9-slim-buster
 
-# define an alias for the specfic python version used in this file.
+# define an alias for the specific python version used in this file.
 FROM python:${PYTHON_VERSION} as python
 
 # Python build stage

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -21,7 +21,7 @@ def normalize_vendor(vendor):
 
 
 try:
-    from psycopg2.extensions import parse_dsn as parse_pg_dsn  # type: ignore[import]
+    from psycopg2.extensions import parse_dsn as parse_pg_dsn
 except ImportError:
 
     def parse_pg_dsn(dsn):

--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -231,7 +231,7 @@ else:
 
 
 try:
-    from pep562 import Pep562  # type: ignore[import]  # noqa
+    from pep562 import Pep562  # noqa
 
     def ensure_pep562(module_name):
         # type: (str) -> None

--- a/ddtrace/internal/nogevent.py
+++ b/ddtrace/internal/nogevent.py
@@ -10,7 +10,7 @@ from ddtrace.internal import forksafe
 
 
 try:
-    import gevent.monkey  # type: ignore[import]
+    import gevent.monkey
 except ImportError:
 
     def get_original(module, func):

--- a/ddtrace/internal/uwsgi.py
+++ b/ddtrace/internal/uwsgi.py
@@ -22,7 +22,7 @@ def check_uwsgi(worker_callback=None, atexit=None):
     :param worker_callback: Callback function to call in uWSGI worker processes.
     """
     try:
-        import uwsgi  # type: ignore[import]
+        import uwsgi
     except ImportError:
         return
 
@@ -47,7 +47,7 @@ def check_uwsgi(worker_callback=None, atexit=None):
         # Register the function to be called in child process at startup
         if worker_callback is not None:
             try:
-                import uwsgidecorators  # type: ignore[import]
+                import uwsgidecorators
             except ImportError:
                 raise uWSGIConfigError("Running under uwsgi but uwsgidecorators cannot be imported")
             uwsgidecorators.postfork(worker_callback)

--- a/ddtrace/profiling/collector/threading.py
+++ b/ddtrace/profiling/collector/threading.py
@@ -58,7 +58,7 @@ if os.environ.get("WRAPT_DISABLE_EXTENSIONS"):
     WRAPT_C_EXT = False
 else:
     try:
-        import ddtrace.vendor.wrapt._wrappers as _w  # type: ignore[import] # noqa: F401
+        import ddtrace.vendor.wrapt._wrappers as _w  # noqa: F401
     except ImportError:
         WRAPT_C_EXT = False
     else:

--- a/ddtrace/utils/config.py
+++ b/ddtrace/utils/config.py
@@ -7,7 +7,7 @@ def get_application_name():
     # type: () -> typing.Optional[str]
     """Attempts to find the application name using system arguments."""
     try:
-        import __main__  # type: ignore[import]
+        import __main__
 
         name = __main__.__file__
     except (ImportError, AttributeError):

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,7 @@ show_error_codes = true
 warn_unused_ignores = true
 warn_unused_configs = true
 no_implicit_optional = true
+ignore_missing_imports = true
 
 [mypy-ddtrace.contrib.*]
 ignore_errors = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 universal=1
 
 [codespell]
-skip = *.c,.riot,.tox,.mypy_cache,ddtrace/vendor
+skip = *.c,.riot,.tox,.mypy_cache,.git,*ddtrace/vendor
 ignore-words-list = dne,fo,medias,ment,nin,ot,setttings,statics


### PR DESCRIPTION
## Description
There are several third party library imports in the ddtrace library that result in `Cannot find implementation or library stub for module named ...`, which have up until now been suppressed with individual `# type: ignore[import]` ignores. These individual warnings have been replaced with a global configuration setting `ignore_missing_imports = true`.

Secondly, the codespell configuration has been changed to exclude the `ddtrace/vendor` and `.git/` directories, which were being unintentionally checked during pre-commit hooks if no python files were present in a commit (as the riot codespell command defaults to checking all files in the library).


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
