### PR TITLE
ci: pin riot to 0.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ commands:
     description: "Install riot"
     steps:
       # Make sure we install and run riot on Python 3
-      - run: pip3 install -U riot
+      - run: pip3 install riot==0.6
 
   restore_tox_cache:
     description: "Restore .tox directory from previous runs for faster installs"

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -10,4 +10,4 @@ then
 fi
 
 # install and upgrade tox and riot in case testrunner image has not been updated
-docker-compose run -e CIRCLE_NODE_TOTAL -e CIRCLE_NODE_INDEX -e DD_TRACE_AGENT_URL --rm testrunner bash -c "pip install -q --disable-pip-version-check -U riot tox && $CMD"
+docker-compose run -e CIRCLE_NODE_TOTAL -e CIRCLE_NODE_INDEX -e DD_TRACE_AGENT_URL --rm testrunner bash -c "pip install -q --disable-pip-version-check riot==0.6 tox && $CMD"


### PR DESCRIPTION
We broke some things in 0.7 so lets pin until we can get them fixed up.
