### PR TITLE
mysql-connector-python 8.0.24 requires Python 3.6

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -682,7 +682,7 @@ venv = Venv(
                     pkgs={"mysql-connector-python": ["==8.0.5", "<8.0.24"]},
                 ),
                 Venv(
-                    pys=select_pys(min_version="3"),
+                    pys=select_pys(min_version="3.6"),
                     pkgs={"mysql-connector-python": ["==8.0.5", ">=8.0", latest]},
                 ),
             ],
@@ -775,7 +775,7 @@ venv = Venv(
                     },
                 ),
                 Venv(
-                    pys=select_pys(min_version="3"),
+                    pys=select_pys(min_version="3.6"),
                     pkgs={
                         "sqlalchemy": ["~=1.0.0", "~=1.1.0", "~=1.2.0", "~=1.3.0", latest],
                         "psycopg2": ["~=2.8.0"],


### PR DESCRIPTION
## Description
Should fix the following CI error: https://github.com/DataDog/dd-trace-py/pull/2667/files#diff-c2bbf2d05171ce6e867e127133d651ae7217320d295ab9ead7f28b04930f1a3fR41-R49