### PR TITLE
Add pytest snapshot fixture

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -2,6 +2,7 @@ import abc
 from collections import defaultdict
 from json import loads
 import logging
+import os
 import sys
 from typing import List
 from typing import Optional
@@ -22,6 +23,7 @@ from ..constants import KEEP_SPANS_RATE_KEY
 from ..sampler import BasePrioritySampler
 from ..sampler import BaseSampler
 from ..utils.formats import get_env
+from ..utils.formats import parse_tags_str
 from ..utils.time import StopWatch
 from ._encoding import BufferFull
 from ._encoding import BufferItemTooLarge
@@ -266,6 +268,9 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
             max_item_size=self._max_payload_size,
         )
         self._headers.update({"Content-Type": self._encoder.content_type})
+        additional_header_str = os.environ.get("_DD_TRACE_WRITER_ADDITIONAL_HEADERS")
+        if additional_header_str is not None:
+            self._headers.update(parse_tags_str(additional_header_str))
         self.dogstatsd = dogstatsd
         self._report_metrics = report_metrics
         self._metrics_reset()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,13 @@ import pytest
 from tests.utils import DummyTracer
 from tests.utils import TracerSpanContainer
 from tests.utils import call_program
+from tests.utils import snapshot_context
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "snapshot(*args, **kwargs): mark test to run as a snapshot test which sends traces to the test agent"
+    )
 
 
 @pytest.fixture
@@ -37,3 +44,19 @@ def ddtrace_run_python_code_in_subprocess(tmpdir):
         return call_program("ddtrace-run", sys.executable, str(pyfile), **kwargs)
 
     yield _run
+
+
+@pytest.fixture(autouse=True)
+def snapshot(request):
+    marks = [m for m in request.node.iter_markers(name="snapshot")]
+    assert len(marks) < 2, "Multiple snapshot marks detected"
+    if marks:
+        snap = marks[0]
+        token = ""
+        token += request.module.__name__
+        token += ".%s" % request.cls.__name__ if request.cls else ""
+        token += ".%s" % request.node.name
+        with snapshot_context(token, *snap.args, **snap.kwargs) as snapshot:
+            yield snapshot
+    else:
+        yield


### PR DESCRIPTION
The snapshot decorator worked ok for basic integration tests but isn't
compatible for more advanced pytest usage like parametrization.

By creating a fixture we can `pytest.mark.snapshot` test cases which
will make use of a `snapshot` pytest fixture which supports more
advanced pytest usage.

~(Draft until #2689 is decided upon)~