### PR TITLE
fix(sanic): fix handling of non-string arguments

### DIFF
--- a/ddtrace/contrib/sanic/patch.py
+++ b/ddtrace/contrib/sanic/patch.py
@@ -83,7 +83,7 @@ def _get_path(request):
         except Exception:
             # Best effort
             continue
-        path = path.replace(str(value), f"<{key}>")
+        path = path.replace(value, f"<{key}>")
     return path
 
 

--- a/ddtrace/contrib/sanic/patch.py
+++ b/ddtrace/contrib/sanic/patch.py
@@ -78,7 +78,12 @@ def _get_path(request):
     except sanic.exceptions.SanicException:
         return path
     for key, value in match_info.items():
-        path = path.replace(value, f"<{key}>")
+        try:
+            value = str(value)
+        except Exception:
+            # Best effort
+            continue
+        path = path.replace(str(value), f"<{key}>")
     return path
 
 

--- a/releasenotes/notes/fix-sanic-non-str-args-4d1b0f506bee3436.yaml
+++ b/releasenotes/notes/fix-sanic-non-str-args-4d1b0f506bee3436.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed the handling of endpoint paths with non-string arguments,


### PR DESCRIPTION
## Description

This change fixes the handling of endpoint paths that take non-string arguments.

Fixes #2678.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
