### PR TITLE
Updated bitrise CI environment var for ci.pipeline.name

### DIFF
--- a/ddtrace/ext/ci.py
+++ b/ddtrace/ext/ci.py
@@ -398,7 +398,7 @@ def extract_bitrise(env):
     return {
         PROVIDER_NAME: "bitrise",
         PIPELINE_ID: env.get("BITRISE_BUILD_SLUG"),
-        PIPELINE_NAME: env.get("BITRISE_APP_TITLE"),
+        PIPELINE_NAME: env.get("BITRISE_TRIGGERED_WORKFLOW_ID"),
         PIPELINE_NUMBER: env.get("BITRISE_BUILD_NUMBER"),
         PIPELINE_URL: env.get("BITRISE_BUILD_URL"),
         WORKSPACE_PATH: env.get("BITRISE_SOURCE_DIR"),

--- a/tests/tracer/fixtures/ci/bitrise.json
+++ b/tests/tracer/fixtures/ci/bitrise.json
@@ -1,7 +1,7 @@
 [
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -25,7 +25,7 @@
   ],
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -50,7 +50,7 @@
   ],
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -75,7 +75,7 @@
   ],
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -100,7 +100,7 @@
   ],
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -125,7 +125,7 @@
   ],
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -152,7 +152,7 @@
   ],
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -179,7 +179,7 @@
   ],
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -206,7 +206,7 @@
   ],
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -231,7 +231,7 @@
   ],
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -256,7 +256,7 @@
   ],
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -282,7 +282,7 @@
   ],
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -308,7 +308,7 @@
   ],
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -333,7 +333,7 @@
   ],
   [
     {
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -359,7 +359,7 @@
   [
     {
       "BITRISEIO_GIT_BRANCH_DEST": "origin/master",
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",
@@ -384,7 +384,7 @@
   [
     {
       "BITRISEIO_GIT_BRANCH_DEST": "origin/notmaster",
-      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "bitrise-build-url",


### PR DESCRIPTION
## Description
Updating ci extraction and the bitrise ci spec test fixture file after `datadog-ci-spec` changed Bitrise's environment variable for `ci.pipeline.name` from `BITRISE_APP_TITLE` to `BITRISE_TRIGGERED_WORKFLOW_ID`.