### PR TITLE
fix[flask]: ignore werkzeug.NotFound errors as server errors

### DIFF
--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -463,36 +463,32 @@ def request_tracer(name):
 
         This wrapper will add identifier tags to the current span from `flask.app.Flask.wsgi_app`.
         """
-        current_span = pin.tracer.current_span()
-        if not pin.enabled or not current_span:
+        span = pin.tracer.current_span()
+        if not pin.enabled or not span:
             return wrapped(*args, **kwargs)
 
         try:
             request = flask._request_ctx_stack.top.request
 
             # DEV: This name will include the blueprint name as well (e.g. `bp.index`)
-            if not current_span.get_tag(FLASK_ENDPOINT) and request.endpoint:
-                current_span.resource = u" ".join((request.method, request.endpoint))
-                current_span._set_str_tag(FLASK_ENDPOINT, request.endpoint)
+            if not span.get_tag(FLASK_ENDPOINT) and request.endpoint:
+                span.resource = u" ".join((request.method, request.endpoint))
+                span._set_str_tag(FLASK_ENDPOINT, request.endpoint)
 
-            if not current_span.get_tag(FLASK_URL_RULE) and request.url_rule and request.url_rule.rule:
-                current_span.resource = u" ".join((request.method, request.url_rule.rule))
-                current_span._set_str_tag(FLASK_URL_RULE, request.url_rule.rule)
+            if not span.get_tag(FLASK_URL_RULE) and request.url_rule and request.url_rule.rule:
+                span.resource = u" ".join((request.method, request.url_rule.rule))
+                span._set_str_tag(FLASK_URL_RULE, request.url_rule.rule)
 
-            if (
-                not current_span.get_tag(FLASK_VIEW_ARGS)
-                and request.view_args
-                and config.flask.get("collect_view_args")
-            ):
+            if not span.get_tag(FLASK_VIEW_ARGS) and request.view_args and config.flask.get("collect_view_args"):
                 for k, v in request.view_args.items():
-                    current_span._set_str_tag(u".".join((FLASK_VIEW_ARGS, k)), v)
+                    span._set_str_tag(u".".join((FLASK_VIEW_ARGS, k)), v)
         except Exception:
             log.debug('failed to set tags for "flask.request" span', exc_info=True)
 
         with pin.tracer.trace(
             ".".join(("flask", name)), service=trace_utils.int_service(pin, config.flask, pin)
-        ) as span:
-            span._ignore_exception(werkzeug.exceptions.NotFound)
+        ) as request_span:
+            request_span._ignore_exception(werkzeug.exceptions.NotFound)
             return wrapped(*args, **kwargs)
 
     return _traced_request

--- a/releasenotes/notes/fix-flask-werkzeug-ignore-server-error-5131cbe28afca03a.yaml
+++ b/releasenotes/notes/fix-flask-werkzeug-ignore-server-error-5131cbe28afca03a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ``werkzeug.exceptions.NotFound`` 404 errors are no longer raised and logged as a server error
+    in the Flask integration.

--- a/tests/contrib/flask/test_errorhandler.py
+++ b/tests/contrib/flask/test_errorhandler.py
@@ -30,13 +30,10 @@ class FlaskErrorhandlerTestCase(BaseFlaskTestCase):
         self.assertIsNone(req_span.get_tag("flask.url_rule"))
 
         # flask.dispatch_request span
-        self.assertEqual(dispatch_span.error, 1)
-        error_msg = dispatch_span.get_tag("error.msg")
-        self.assertTrue(error_msg.startswith("404 Not Found"))
-        error_stack = dispatch_span.get_tag("error.stack")
-        self.assertTrue(error_stack.startswith("Traceback (most recent call last):"))
-        error_type = dispatch_span.get_tag("error.type")
-        self.assertEqual(error_type, "werkzeug.exceptions.NotFound")
+        self.assertEqual(dispatch_span.error, 0)
+        self.assertIsNone(dispatch_span.get_tag("error.msg"))
+        self.assertIsNone(dispatch_span.get_tag("error.stack"))
+        self.assertIsNone(dispatch_span.get_tag("error.type"))
 
         # flask.handle_user_exception span
         self.assertEqual(user_ex_span.meta, dict())

--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -463,10 +463,10 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(dispatch_span.service, "flask")
         self.assertEqual(dispatch_span.name, "flask.dispatch_request")
         self.assertEqual(dispatch_span.resource, "flask.dispatch_request")
-        self.assertEqual(dispatch_span.error, 1)
-        self.assertTrue(dispatch_span.get_tag("error.msg").startswith("404 Not Found"))
-        self.assertTrue(dispatch_span.get_tag("error.stack").startswith("Traceback"))
-        self.assertEqual(dispatch_span.get_tag("error.type"), "werkzeug.exceptions.NotFound")
+        self.assertEqual(dispatch_span.error, 0)
+        self.assertIsNone(dispatch_span.get_tag("error.msg"))
+        self.assertIsNone(dispatch_span.get_tag("error.stack"))
+        self.assertIsNone(dispatch_span.get_tag("error.type"))
 
     def test_request_abort_404(self):
         """
@@ -529,10 +529,10 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(dispatch_span.service, "flask")
         self.assertEqual(dispatch_span.name, "flask.dispatch_request")
         self.assertEqual(dispatch_span.resource, "flask.dispatch_request")
-        self.assertEqual(dispatch_span.error, 1)
-        self.assertTrue(dispatch_span.get_tag("error.msg").startswith("404 Not Found"))
-        self.assertTrue(dispatch_span.get_tag("error.stack").startswith("Traceback"))
-        self.assertEqual(dispatch_span.get_tag("error.type"), "werkzeug.exceptions.NotFound")
+        self.assertEqual(dispatch_span.error, 0)
+        self.assertIsNone(dispatch_span.get_tag("error.msg"))
+        self.assertIsNone(dispatch_span.get_tag("error.stack"))
+        self.assertIsNone(dispatch_span.get_tag("error.type"))
 
         # Handler span
         handler_span = spans[4]


### PR DESCRIPTION
## Description
It was found through #2347 that `werkzeug.exceptions.NotFound` 404 errors are currently raised and logged as server errors in `flask.dispatch_request` spans. This 404 error is no longer raised and logged as such.

Resolves #2347.