### PR TITLE
Add additional tests for distributed tracing enabled

### DIFF
--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -168,11 +168,7 @@ def with_traced_module(func):
 def distributed_tracing_enabled(int_config, default=False):
     # type: (IntegrationConfig, bool) -> bool
     """Returns whether distributed tracing is enabled for this integration config"""
-    if "distributed_tracing_enabled" in int_config and int_config.distributed_tracing_enabled is not None:
-        return int_config.distributed_tracing_enabled
-    elif "distributed_tracing" in int_config and int_config.distributed_tracing is not None:
-        return int_config.distributed_tracing
-    return default
+    return int_config.get("distributed_tracing_enabled", int_config.get("distributed_tracing", default))
 
 
 def int_service(pin, int_config, default=None):

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -168,7 +168,11 @@ def with_traced_module(func):
 def distributed_tracing_enabled(int_config, default=False):
     # type: (IntegrationConfig, bool) -> bool
     """Returns whether distributed tracing is enabled for this integration config"""
-    return int_config.get("distributed_tracing_enabled", int_config.get("distributed_tracing", default))
+    if "distributed_tracing_enabled" in int_config and int_config.distributed_tracing_enabled is not None:
+        return int_config.distributed_tracing_enabled
+    elif "distributed_tracing" in int_config and int_config.distributed_tracing is not None:
+        return int_config.distributed_tracing
+    return default
 
 
 def int_service(pin, int_config, default=None):


### PR DESCRIPTION
Pull out how we check if distributed tracing is enabled for an integration config into a helper that can be used by integrations and will match the logic we have in `activate_distributed_headers`