### PR TITLE
django: remove duplicate tracing header extraction

### DIFF
--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -139,8 +139,6 @@ def get_request_uri(request):
 
 
 def _before_request_tags(pin, span, request):
-    trace_utils.activate_distributed_headers(pin.tracer, int_config=config.django, request_headers=request.META)
-    span.name = "django.request"
     span.resource = request.method
     span.service = trace_utils.int_service(pin, config.django)
     span.span_type = SpanTypes.WEB

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -1167,6 +1167,9 @@ def test_django_request_distributed(client, test_spans):
         },
     )
 
+    first_child_span = test_spans.find_span(parent_id=root.span_id)
+    assert first_child_span
+
 
 def test_django_request_distributed_disabled(client, test_spans):
     """


### PR DESCRIPTION
## Description
<!-- Please briefly describe the change and why it was required. -->

This line was duplicated when factoring out the request/response tagging
done in 84a48a6.

Surprisingly this wasn't caught by the test suite so a regression test
is added as well. It should have resulted in a failure at some point
as reactivating the headers after a span is created should change the
parenting.


## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] ~Library documentation is updated.~
- [x] ~[Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).~
