### PR TITLE
fix(asgi): handle invalid headers

### DIFF
--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -85,11 +85,15 @@ class TraceMiddleware:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        headers = _extract_headers(scope)
-
-        trace_utils.activate_distributed_headers(
-            self.tracer, int_config=self.integration_config, request_headers=headers
-        )
+        try:
+            headers = _extract_headers(scope)
+        except Exception:
+            log.warning("failed to decode headers", exc_info=True)
+            headers = {}
+        else:
+            trace_utils.activate_distributed_headers(
+                self.tracer, int_config=self.integration_config, request_headers=headers
+            )
 
         resource = "{} {}".format(scope["method"], scope["path"])
 

--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -88,7 +88,7 @@ class TraceMiddleware:
         try:
             headers = _extract_headers(scope)
         except Exception:
-            log.warning("failed to decode headers", exc_info=True)
+            log.warning("failed to decode headers for distributed tracing", exc_info=True)
             headers = {}
         else:
             trace_utils.activate_distributed_headers(

--- a/releasenotes/notes/asgi-bc983a8dfffe823e.yaml
+++ b/releasenotes/notes/asgi-bc983a8dfffe823e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASGI: handle decoding errors when extracting headers for trace propagation.

--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -339,17 +339,26 @@ async def test_multiple_requests(tracer, test_spans):
 
 
 @pytest.mark.asyncio
-async def test_bad_headers(tracer, test_spans):
-    class BadMiddleware(object):
-        def __init__(self, app):
-            self.app = app
+async def test_bad_headers(scope, tracer, test_spans):
+    """
+    When headers can't be decoded
+        The middleware should not raise
+    """
 
-        async def __call__(self, scope, receive, send):
-            scope["headers"] += [(bytes.fromhex("c0"), "test")]
-            return await self.app(scope, receive, send)
+    app = TraceMiddleware(basic_app, tracer=tracer)
+    headers = [(bytes.fromhex("c0"), "test")]
+    scope["headers"] = headers
 
-    app = BadMiddleware(TraceMiddleware(basic_app, tracer=tracer))
-    async with httpx.AsyncClient(app=app) as client:
-        response = await client.get("http://testserver/")
-
-    assert response.status_code == 200
+    instance = ApplicationCommunicator(app, scope)
+    await instance.send_input({"type": "http.request", "body": b""})
+    response_start = await instance.receive_output(1)
+    assert response_start == {
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [[b"Content-Type", b"text/plain"]],
+    }
+    response_body = await instance.receive_output(1)
+    assert response_body == {
+        "type": "http.response.body",
+        "body": b"*",
+    }


### PR DESCRIPTION
# Bug fix

## Description
<!-- Please briefly describe the bug. -->

Reported in #2103.

The ASGI specification on headers:

> headers: These are byte strings of the exact byte sequences sent by the client/to be sent by the server. While modern HTTP standards say that headers should be ASCII, older ones did not and allowed a wider range of characters. Frameworks/applications should decode headers as they deem appropriate.


## Fix
<!-- Please provide a succinct overview of the fix. -->

This patch adds error handling for when headers cannot be decoded.

Fixes #2103

# Checklist
- [x] Regression test added; or
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [x] Added to the correct milestone.
