### PR TITLE
chore(docs): add anchors to environment variables

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -130,51 +130,51 @@ below:
      - 1.0
      - The time between each flush of traces to the trace agent.
 
-       .. _dd_trace_startup_logs:
+       .. _dd-trace-startup-logs:
    * - ``DD_TRACE_STARTUP_LOGS``
      - Boolean
      - False
      - Enable or disable start up diagnostic logging.
 
-       .. _dd_trace_sample_rate:
+       .. _dd-trace-sample-rate:
    * - ``DD_TRACE_SAMPLE_RATE``
      - Float
      - 1.0
      - A float, f, 0.0 <= f <= 1.0. f*100% of traces will be sampled.
 
-       .. _dd_profiling_enabled:
+       .. _dd-profiling-enabled:
    * - ``DD_PROFILING_ENABLED``
      - Boolean
      - False
      - Enable Datadog profiling when using ``ddtrace-run``.
 
-       .. _dd_profiling_api_timeout:
+       .. _dd-profiling-api-timeout:
    * - ``DD_PROFILING_API_TIMEOUT``
      - Float
      - 10
      - The timeout in seconds before dropping events if the HTTP API does not
        reply.
 
-       .. _dd_profiling_max_time_usage_pct:
+       .. _dd-profiling-max-time-usage-pct:
    * - ``DD_PROFILING_MAX_TIME_USAGE_PCT``
      - Float
      - 1
      - The percentage of maximum time the stack profiler can use when computing
        statistics. Must be greater than 0 and lesser or equal to 100.
 
-       .. _dd_profiling_max_frames:
+       .. _dd-profiling-max-frames:
    * - ``DD_PROFILING_MAX_FRAMES``
      - Integer
      - 64
      - The maximum number of frames to capture in stack execution tracing.
 
-       .. _dd_profiling_heap_enabled:
+       .. _dd-profiling-heap-enabled:
    * - ``DD_PROFILING_HEAP_ENABLED``
      - Boolean
      - False
      - Whether to enable the heap memory profiler.
 
-       .. _dd_profiling_capture_pct:
+       .. _dd-profiling-capture-pct:
    * - ``DD_PROFILING_CAPTURE_PCT``
      - Float
      - 2
@@ -182,19 +182,19 @@ below:
        allocation). Greater values reduce the program execution speed. Must be
        greater than 0 lesser or equal to 100.
 
-       .. _dd_profiling_upload_interval:
+       .. _dd-profiling-upload-interval:
    * - ``DD_PROFILING_UPLOAD_INTERVAL``
      - Float
      - 60
      - The interval in seconds to wait before flushing out recorded events.
 
-       .. _dd_profiling_ignore_profiler:
+       .. _dd-profiling-ignore-profiler:
    * - ``DD_PROFILING_IGNORE_PROFILER``
      - Boolean
      - False
      - **Deprecated**: whether to ignore the profiler in the generated data.
 
-       .. _dd_profiling_tags:
+       .. _dd-profiling-tags:
    * - ``DD_PROFILING_TAGS``
      - String
      -

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,10 +15,14 @@ below:
      - Type
      - Default value
      - Description
+
+       .. _dd-env:
    * - ``DD_ENV``
      - String
      -
      - Set an application's environment e.g. ``prod``, ``pre-prod``, ``staging``. Added in ``v0.36.0``. See `Unified Service Tagging`_ for more information.
+
+       .. _dd-service:
    * - ``DD_SERVICE``
      - String
      - (autodetected)
@@ -26,119 +30,171 @@ below:
        provided for these integrations: :ref:`bottle`, :ref:`flask`, :ref:`grpc`,
        :ref:`pyramid`, :ref:`pylons`, :ref:`tornado`, :ref:`celery`, :ref:`django` and
        :ref:`falcon`. Added in ``v0.36.0``. See `Unified Service Tagging`_ for more information.
+
+       .. _dd-service-mapping:
    * - ``DD_SERVICE_MAPPING``
      - String
      -
      - Define service name mappings to allow renaming services in traces, e.g. ``postgres:postgresql,defaultdb:postgresql``.
+
+       .. _dd-tags:
    * - ``DD_TAGS``
      - String
      -
      - Set global tags to be attached to every span. Value must be either comma or space separated. e.g. ``key1:value1,key2,value2`` or ``key1:value key2:value2``. Comma separated support added in ``v0.38.0`` and space separated support added in ``v0.48.0``.
+
+       .. _dd-version:
    * - ``DD_VERSION``
      - String
      -
      - Set an application's version in traces and logs e.g. ``1.2.3``,
        ``6c44da20``, ``2020.02.13``. Generally set along with ``DD_SERVICE``. Added in ``v0.36.0``. See `Unified Service Tagging`_ for more information.
+
+       .. _dd-site:
    * - ``DD_SITE``
      - String
      - datadoghq.com
      - Specify which site to use for uploading profiles. Set to
        ``datadoghq.eu`` to use EU site.
+
+       .. _dd-trace-enabled:
    * - ``DD_TRACE_ENABLED``
      - Boolean
      - True
      - Enable sending of spans to the Agent. Note that instrumentation will still be installed and spans will be
        generated. Added in ``v0.41.0`` (formerly named ``DATADOG_TRACE_ENABLED``).
+
+       .. _dd-trace-debug:
    * - ``DD_TRACE_DEBUG``
      - Boolean
      - False
      - Enables debug logging in the tracer. Setting this flag will cause the library to create a root logging handler if
        one does not already exist. Added in ``v0.41.0`` (formerly named ``DATADOG_TRACE_DEBUG``).
+
+       .. _dd-trace-integration-enabled:
    * - ``DD_TRACE_<INTEGRATION>_ENABLED``
      - Boolean
      - True
      - Enables <INTEGRATION> to be patched. For example, ``DD_TRACE_DJANGO_ENABLED=false`` will disable the Django
        integration from being installed. Added in ``v0.41.0``.
+
+       .. _datadog-patch-modules:
    * - ``DATADOG_PATCH_MODULES``
      - String
      -
      - Override the modules patched for this execution of the program. Must be
        a list in the ``module1:boolean,module2:boolean`` format. For example,
        ``boto:true,redis:false``.
+
+       .. _dd-logs-injection:
    * - ``DD_LOGS_INJECTION``
      - Boolean
      - True
      - Enables :ref:`Logs Injection`.
+
+       .. _dd-call-basic-config:
    * - ``DD_CALL_BASIC_CONFIG``
      - Boolean
      - True
      - Controls whether ``logging.basicConfig`` is called in ``ddtrace-run`` or when debug mode is enabled.
+
+       .. _dd-trace-agent-url:
    * - ``DD_TRACE_AGENT_URL``
      - URL
      - ``http://localhost:8126``
      - The URL to use to connect the Datadog agent. The url can starts with
        ``http://`` to connect using HTTP or with ``unix://`` to use a Unix
        Domain Socket.
+
+       .. _dd-trace-agent-timeout-seconds:
    * - ``DD_TRACE_AGENT_TIMEOUT_SECONDS``
      - Float
      - 2.0
      - The timeout in float to use to connect to the Datadog agent.
+
+       .. _dd-trace-writer-buffer-size-bytes:
    * - ``DD_TRACE_WRITER_BUFFER_SIZE_BYTES``
      - Int
      - 8000000
      - The max size in bytes of traces to buffer between flushes to the agent.
+
+       .. _dd-trace-writer-max-payload-size-bytes:
    * - ``DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES``
      - Int
      - 8000000
      - The max size in bytes of each payload sent to the trace agent. If max payload size is less than buffer size, multiple payloads will be sent to the trace agent.
+
+       .. _dd-trace-writer-interval-seconds:
    * - ``DD_TRACE_WRITER_INTERVAL_SECONDS``
      - Float
      - 1.0
      - The time between each flush of traces to the trace agent.
+
+       .. _dd_trace_startup_logs:
    * - ``DD_TRACE_STARTUP_LOGS``
      - Boolean
      - False
      - Enable or disable start up diagnostic logging.
+
+       .. _dd_trace_sample_rate:
    * - ``DD_TRACE_SAMPLE_RATE``
      - Float
      - 1.0
      - A float, f, 0.0 <= f <= 1.0. f*100% of traces will be sampled.
+
+       .. _dd_profiling_enabled:
    * - ``DD_PROFILING_ENABLED``
      - Boolean
      - False
      - Enable Datadog profiling when using ``ddtrace-run``.
+
+       .. _dd_profiling_api_timeout:
    * - ``DD_PROFILING_API_TIMEOUT``
      - Float
      - 10
      - The timeout in seconds before dropping events if the HTTP API does not
        reply.
+
+       .. _dd_profiling_max_time_usage_pct:
    * - ``DD_PROFILING_MAX_TIME_USAGE_PCT``
      - Float
      - 1
      - The percentage of maximum time the stack profiler can use when computing
        statistics. Must be greater than 0 and lesser or equal to 100.
+
+       .. _dd_profiling_max_frames:
    * - ``DD_PROFILING_MAX_FRAMES``
      - Integer
      - 64
      - The maximum number of frames to capture in stack execution tracing.
+
+       .. _dd_profiling_heap_enabled:
    * - ``DD_PROFILING_HEAP_ENABLED``
      - Boolean
      - False
      - Whether to enable the heap memory profiler.
+
+       .. _dd_profiling_capture_pct:
    * - ``DD_PROFILING_CAPTURE_PCT``
      - Float
      - 2
      - The percentage of events that should be captured (e.g. memory
        allocation). Greater values reduce the program execution speed. Must be
        greater than 0 lesser or equal to 100.
+
+       .. _dd_profiling_upload_interval:
    * - ``DD_PROFILING_UPLOAD_INTERVAL``
      - Float
      - 60
      - The interval in seconds to wait before flushing out recorded events.
+
+       .. _dd_profiling_ignore_profiler:
    * - ``DD_PROFILING_IGNORE_PROFILER``
      - Boolean
      - False
      - **Deprecated**: whether to ignore the profiler in the generated data.
+
+       .. _dd_profiling_tags:
    * - ``DD_PROFILING_TAGS``
      - String
      -


### PR DESCRIPTION
## Description

Add `id` to table rows that can be used to refer to environment variables in the configuration.

E.g., https://788960-61572326-gh.circle-artifacts.com/0/tmp/docs/configuration.html#dd-profiling-capture-pct

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
