### PR TITLE
fix(opentracer): don't override default ddtrace settings

### DIFF
--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -21,11 +21,11 @@ from .utils import get_context_provider_for_scope_manager
 log = get_logger(__name__)
 
 DEFAULT_CONFIG = {
-    keys.AGENT_HOSTNAME: "localhost",
-    keys.AGENT_HTTPS: False,
-    keys.AGENT_PORT: 8126,
+    keys.AGENT_HOSTNAME: None,
+    keys.AGENT_HTTPS: None,
+    keys.AGENT_PORT: None,
     keys.DEBUG: False,
-    keys.ENABLED: True,
+    keys.ENABLED: None,
     keys.GLOBAL_TAGS: {},
     keys.SAMPLER: None,
     keys.PRIORITY_SAMPLING: None,
@@ -63,7 +63,6 @@ class Tracer(opentracing.Tracer):
             self._config.update(config)
         # Pull out commonly used properties for performance
         self._service_name = service_name or get_application_name()
-        self._enabled = self._config.get(keys.ENABLED)
         self._debug = self._config.get(keys.DEBUG)
 
         if self._debug:
@@ -87,7 +86,7 @@ class Tracer(opentracing.Tracer):
         self._dd_tracer = dd_tracer or ddtrace.tracer or DatadogTracer()
         self._dd_tracer.set_tags(self._config.get(keys.GLOBAL_TAGS))
         self._dd_tracer.configure(
-            enabled=self._enabled,
+            enabled=self._config.get(keys.ENABLED),
             hostname=self._config.get(keys.AGENT_HOSTNAME),
             https=self._config.get(keys.AGENT_HTTPS),
             port=self._config.get(keys.AGENT_PORT),

--- a/releasenotes/notes/opentracer-config-4b0422f49f325584.yaml
+++ b/releasenotes/notes/opentracer-config-4b0422f49f325584.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    opentracer: don't override default tracing config for the `ENABLED`,
+      `AGENT_HOSTNAME`, `AGENT_HTTPS` or `AGENT_PORT` settings.

--- a/tests/opentracer/core/test_tracer.py
+++ b/tests/opentracer/core/test_tracer.py
@@ -10,6 +10,7 @@ from opentracing import child_of
 import pytest
 
 import ddtrace
+from ddtrace import Tracer as DDTracer
 from ddtrace.ext.priority import AUTO_KEEP
 from ddtrace.opentracer import Tracer
 from ddtrace.opentracer import set_global_tracer
@@ -70,6 +71,12 @@ class TestTracerConfig(object):
             tracer = Tracer(service_name="mysvc", config=config)
             assert ["enabeld", "setttings"] in str(ce_info)
             assert tracer is not None
+
+    def test_ddtrace_fallback_config(self, monkeypatch):
+        """Ensure datadog configuration is used by default."""
+        monkeypatch.setenv("DD_TRACE_ENABLED", "false")
+        tracer = Tracer(dd_tracer=DDTracer())
+        assert tracer._dd_tracer.enabled == False
 
     def test_global_tags(self):
         """Global tags should be passed from the opentracer to the tracer."""

--- a/tests/opentracer/core/test_tracer.py
+++ b/tests/opentracer/core/test_tracer.py
@@ -26,7 +26,7 @@ class TestTracerConfig(object):
         tracer = Tracer(service_name="myservice", config=config)
 
         assert tracer._service_name == "myservice"
-        assert tracer._enabled is True
+        assert tracer._dd_tracer.enabled is True
 
     def test_no_service_name(self):
         """A service_name should be generated if one is not provided."""
@@ -45,10 +45,7 @@ class TestTracerConfig(object):
 
         # Ensure tracer1's config was not mutated
         assert tracer1._service_name == "serv1"
-        assert tracer1._enabled is True
-
         assert tracer2._service_name == "serv2"
-        assert tracer2._enabled is False
 
     def test_invalid_config_key(self):
         """A config with an invalid key should raise a ConfigException."""

--- a/tests/opentracer/core/test_tracer.py
+++ b/tests/opentracer/core/test_tracer.py
@@ -76,7 +76,7 @@ class TestTracerConfig(object):
         """Ensure datadog configuration is used by default."""
         monkeypatch.setenv("DD_TRACE_ENABLED", "false")
         tracer = Tracer(dd_tracer=DDTracer())
-        assert tracer._dd_tracer.enabled == False
+        assert tracer._dd_tracer.enabled is False
 
     def test_global_tags(self):
         """Global tags should be passed from the opentracer to the tracer."""


### PR DESCRIPTION
# Bug fix

## Description
<!-- Please briefly describe the bug. -->

fix(opentracer): don't override default ddtrace settings

As outlined in #2267, some of the ddtrace default settings were being
overridden as the default opentracer config specified its own overrides.


## Fix
<!-- Please provide a succinct overview of the fix. -->

This patch makes it so that the opentracer doesn't override the ddtrace
defaults.

Fixes #2267

# Checklist
- [x] Regression test added; or
- [x] Description of manual testing performed and explanation is included in the code and/or PR.
- [ ] Added to the correct milestone.
