### PR TITLE
Add pytest fixture for snapshot_context with preconfigured test token

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import contextlib
 import sys
 
 import pytest
@@ -5,7 +6,7 @@ import pytest
 from tests.utils import DummyTracer
 from tests.utils import TracerSpanContainer
 from tests.utils import call_program
-from tests.utils import snapshot_context
+from tests.utils import snapshot_context as _snapshot_context
 
 
 def pytest_configure(config):
@@ -46,17 +47,44 @@ def ddtrace_run_python_code_in_subprocess(tmpdir):
     yield _run
 
 
+def _request_token(request):
+    token = ""
+    token += request.module.__name__
+    token += ".%s" % request.cls.__name__ if request.cls else ""
+    token += ".%s" % request.node.name
+    return token
+
+
 @pytest.fixture(autouse=True)
 def snapshot(request):
     marks = [m for m in request.node.iter_markers(name="snapshot")]
     assert len(marks) < 2, "Multiple snapshot marks detected"
     if marks:
         snap = marks[0]
-        token = ""
-        token += request.module.__name__
-        token += ".%s" % request.cls.__name__ if request.cls else ""
-        token += ".%s" % request.node.name
-        with snapshot_context(token, *snap.args, **snap.kwargs) as snapshot:
+        token = _request_token(request)
+        with _snapshot_context(token, *snap.args, **snap.kwargs) as snapshot:
             yield snapshot
     else:
         yield
+
+
+@pytest.fixture
+def snapshot_context(request):
+    """
+    Fixture to provide a context manager for executing code within a ``tests.utils.snapshot_context``
+    with a default ``token`` based on the test function/``pytest`` request.
+
+    def test_case(snapshot_context):
+        with snapshot_context():
+            # my code
+    """
+    token = _request_token(request)
+
+    @contextlib.contextmanager
+    def _snapshot(**kwargs):
+        if "token" not in kwargs:
+            kwargs["token"] = token
+        with _snapshot_context(**kwargs) as snapshot:
+            yield snapshot
+
+    return _snapshot


### PR DESCRIPTION
Adding in a new pytest fixture to provide a `snapshot_context` context manager with a preconfigured token based on the `pytest` `request` data.

We are using this in #2420 to test both sync and async clients in the same test case and the same snapshot files.

```python
async def test(snapshot_context):
    with snapshot_context():
        httpx.get(url)

    with snapshot_context():
        async with httpx.AsyncClient() as client:
            await client.get(url)
```