### PR TITLE
Fix type hint for patch/patch_all **patch_modules

### DIFF
--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -12,7 +12,6 @@ import sys
 import threading
 from typing import Any
 from typing import Callable
-from typing import Dict
 from typing import List
 
 from ddtrace.vendor.wrapt.importer import when_imported

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -136,7 +136,7 @@ def _on_import_factory(module, raise_errors=True):
 
 
 def patch_all(**patch_modules):
-    # type: (Dict[str, bool]) -> None
+    # type: (bool) -> None
     """Automatically patches all available modules.
 
     In addition to ``patch_modules``, an override can be specified via an
@@ -166,7 +166,7 @@ def patch_all(**patch_modules):
 
 
 def patch(raise_errors=True, **patch_modules):
-    # type: (bool, Dict[str, bool]) -> None
+    # type: (bool, bool) -> None
     """Patch only a set of given modules.
 
     :param bool raise_errors: Raise error if one patch fail.

--- a/releasenotes/notes/fix-monkey-patch-typing-ab13fc458c90a260.yaml
+++ b/releasenotes/notes/fix-monkey-patch-typing-ab13fc458c90a260.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes type hinting for ``**patch_modules`` parameter for ``patch``/``patch_all`` functions.


### PR DESCRIPTION
Fixes #2743

As pointed out in #2743 when typing `*args` or `**kwargs` you do not need to type as a `Tuple`/`Dict`, that is implied.

```python
# Correct
def func(*args, **kwargs):
    # type: (int, bool) -> None

# Incorrect
def func(*args, **kwargs):
    # type: (tuple[int], dict[str, bool]) -> None
```