### PR TITLE
Ensure ca-certificates is installed for benchmark

### DIFF
--- a/benchmarks/base/Dockerfile
+++ b/benchmarks/base/Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install --no-install-recommends -y \
   curl \
   git \
+  ca-certificates \
   # ddtrace includes c extensions
   build-essential \
   # uuid is used to generate identifier for run if one is not provided


### PR DESCRIPTION
When trying to run benchmarks with a `DDTRACE_INSTALL_V#=git+https://github.com/datadog/dd-trace-py@master` would result in an error because no root certificates were available in the app image.
