### PR TITLE
chore[mypy]: removed bootstrap from mypy ignores

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -5,6 +5,8 @@ Add all monkey-patching that needs to run by default here
 import logging
 import os
 import sys
+from typing import Any
+from typing import Dict
 
 
 # Perform gevent patching as early as possible in the application before
@@ -84,12 +86,12 @@ try:
     if asbool(get_env("runtime_metrics", "enabled")):
         RuntimeWorker.enable()
 
-    opts = {}
+    opts = {}  # type: Dict[str, Any]
 
     if asbool(os.environ.get("DATADOG_TRACE_ENABLED", True)):
-        patch = True
+        trace_enabled = True
     else:
-        patch = False
+        trace_enabled = False
         opts["enabled"] = False
 
     if hostname:
@@ -101,7 +103,7 @@ try:
 
     tracer.configure(**opts)
 
-    if patch:
+    if trace_enabled:
         update_patched_modules()
         from ddtrace import patch_all
 

--- a/ddtrace/utils/formats.py
+++ b/ddtrace/utils/formats.py
@@ -99,7 +99,7 @@ def asbool(value):
 
 
 def parse_tags_str(tags_str):
-    # type: (str) -> Dict[str, str]
+    # type: (Optional[str]) -> Dict[str, str]
     """Parse a string of tags typically provided via environment variables.
 
     The expected string is of the form::

--- a/mypy.ini
+++ b/mypy.ini
@@ -14,6 +14,3 @@ ignore_errors = true
 
 [mypy-ddtrace.opentracer.*]
 ignore_errors = true
-
-[mypy-ddtrace.bootstrap.*]
-ignore_errors = true


### PR DESCRIPTION
## Description
The `ddtrace.bootstrap` module was removed from the mypy ignores configuration, and type hinting was added.
