### PR TITLE
Optimize encoding dd_origin

### DIFF
--- a/benchmarks/encoder/config.yaml
+++ b/benchmarks/encoder/config.yaml
@@ -22,11 +22,17 @@ one-metric:
 many-metrics:
   <<: *base_variant
   nmetrics: 48
-dd-origin:
+one-trace-with-dd-origin:
   <<: *base_variant
   ntags: 10
   ltags: 16
   dd_origin: true
-no-tags-with-dd-origin:
+one-trace-with-dd-origin-no-tags:
   <<: *base_variant
+  dd_origin: true
+many-traces-with-dd-origin:
+  <<: *base_variant
+  ntraces: 100
+  ntags: 10
+  ltags: 16
   dd_origin: true

--- a/benchmarks/encoder/config.yaml
+++ b/benchmarks/encoder/config.yaml
@@ -27,3 +27,6 @@ dd-origin:
   ntags: 10
   ltags: 16
   dd_origin: true
+no-tags-with-dd-origin:
+  <<: *base_variant
+  dd_origin: true

--- a/benchmarks/encoder/config.yaml
+++ b/benchmarks/encoder/config.yaml
@@ -4,6 +4,7 @@ one-trace: &base_variant
   ntags: 0
   ltags: 0
   nmetrics: 0
+  dd_origin: false
 many-traces:
   <<: *base_variant
   ntraces: 100
@@ -21,3 +22,8 @@ one-metric:
 many-metrics:
   <<: *base_variant
   nmetrics: 48
+dd-origin:
+  <<: *base_variant
+  ntags: 10
+  ltags: 16
+  dd_origin: true

--- a/benchmarks/encoder/scenario.py
+++ b/benchmarks/encoder/scenario.py
@@ -9,6 +9,7 @@ class Encoder(bm.Scenario):
     ntags = bm.var(type=int)
     ltags = bm.var(type=int)
     nmetrics = bm.var(type=int)
+    dd_origin = bm.var(type=bool)
 
     def run(self):
         encoder = utils.init_encoder()

--- a/benchmarks/encoder/utils.py
+++ b/benchmarks/encoder/utils.py
@@ -49,6 +49,9 @@ def gen_traces(config):
             service = random.choice(services)
             with Span(None, span_name, resource=resource, service=service, parent_id=parent_id) as span:
                 if i == 0 and config.dd_origin:
+                    # Since we're not using the tracer API, a span's context isn't automatically propagated
+                    # to its children. The encoder only checks the root span's context in a trace for dd_origin, so
+                    # here we need to add dd_origin to the root span's context.
                     span.context.dd_origin = random.choice(dd_origin_values)
                 if config.ntags > 0:
                     span.set_tags(dict(zip(tag_keys, [_rands(size=config.ltags) for _ in range(config.ntags)])))

--- a/benchmarks/encoder/utils.py
+++ b/benchmarks/encoder/utils.py
@@ -37,6 +37,7 @@ def gen_traces(config):
     services = _random_values(16, 16)
     tag_keys = _random_values(config.ntags, 16)
     metric_keys = _random_values(config.nmetrics, 16)
+    dd_origin_values = _random_values(16, 16)
 
     for _ in range(config.ntraces):
         trace = []
@@ -47,6 +48,8 @@ def gen_traces(config):
             resource = random.choice(resources)
             service = random.choice(services)
             with Span(None, span_name, resource=resource, service=service, parent_id=parent_id) as span:
+                if i == 0 and config.dd_origin:
+                    span.context.dd_origin = random.choice(dd_origin_values)
                 if config.ntags > 0:
                     span.set_tags(dict(zip(tag_keys, [_rands(size=config.ltags) for _ in range(config.ntags)])))
                 if config.nmetrics > 0:

--- a/benchmarks/encoder/utils.py
+++ b/benchmarks/encoder/utils.py
@@ -37,7 +37,7 @@ def gen_traces(config):
     services = _random_values(16, 16)
     tag_keys = _random_values(config.ntags, 16)
     metric_keys = _random_values(config.nmetrics, 16)
-    dd_origin_values = _random_values(16, 16)
+    dd_origin_values = ["synthetics", "ciapp-test"]
 
     for _ in range(config.ntraces):
         trace = []

--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -9,7 +9,7 @@ DEF MSGPACK_ARRAY_LENGTH_PREFIX_SIZE = 5
 
 
 cdef extern from "Python.h":
-    char* PyUnicode_AsUTF8AndSize(object obj, Py_ssize_t *l) except NULL
+    const char* PyUnicode_AsUTF8(object o)
 
 cdef extern from "pack.h":
     struct msgpack_packer:
@@ -17,7 +17,6 @@ cdef extern from "pack.h":
         size_t length
         size_t buf_size
 
-    int msgpack_pack_int(msgpack_packer* pk, int d)
     int msgpack_pack_nil(msgpack_packer* pk)
     int msgpack_pack_long(msgpack_packer* pk, long d)
     int msgpack_pack_long_long(msgpack_packer* pk, long long d)
@@ -28,9 +27,6 @@ cdef extern from "pack.h":
     int msgpack_pack_raw(msgpack_packer* pk, size_t l)
     int msgpack_pack_raw_body(msgpack_packer* pk, char* body, size_t l)
     int msgpack_pack_unicode(msgpack_packer* pk, object o, long long limit)
-
-cdef extern from "buff_converter.h":
-    object buff_to_buff(char *, Py_ssize_t)
 
 
 cdef long long ITEM_LIMIT = (2**32)-1
@@ -219,10 +215,7 @@ cdef class MsgpackEncoderBase(BufferedEncoder):
 
         if L > 0 and trace[0].context is not None and trace[0].context.dd_origin is not None:
             IF PY_MAJOR_VERSION >= 3:
-                # To cast as a char array, the unicode string needs to be converted to a bytestring
-                # with the reference to the Python bytestring as long as the char array is in use.
-                dd_origin_bytestring = trace[0].context.dd_origin.encode("UTF-8")
-                dd_origin = dd_origin_bytestring
+                dd_origin = PyUnicode_AsUTF8(trace[0].context.dd_origin)
             ELSE:
                 dd_origin = trace[0].context.dd_origin
 

--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -1,9 +1,8 @@
 from cpython cimport *
 from cpython.bytearray cimport PyByteArray_Check
 from libc cimport stdint
+from libc.string cimport strlen
 import threading
-
-from ..constants import ORIGIN_KEY
 
 
 DEF MSGPACK_ARRAY_LENGTH_PREFIX_SIZE = 5
@@ -209,6 +208,7 @@ cdef class MsgpackEncoderBase(BufferedEncoder):
     cdef inline int _pack_trace(self, list trace):
         cdef int ret
         cdef Py_ssize_t L
+        cdef char *dd_origin = NULL
 
         L = len(trace)
         if L > ITEM_LIMIT:
@@ -217,10 +217,14 @@ cdef class MsgpackEncoderBase(BufferedEncoder):
         ret = msgpack_pack_array(&self.pk, L)
         if ret != 0: raise RuntimeError("Couldn't pack trace")
 
-        if L > 0 and trace[0].context is not None:
-            dd_origin = trace[0].context.dd_origin
-        else:
-            dd_origin = None
+        if L > 0 and trace[0].context is not None and trace[0].context.dd_origin is not None:
+            IF PY_MAJOR_VERSION >= 3:
+                # To cast as a char array, the unicode string needs to be converted to a bytestring
+                # with the reference to the Python bytestring as long as the char array is in use.
+                dd_origin_bytestring = trace[0].context.dd_origin.encode("UTF-8")
+                dd_origin = dd_origin_bytestring
+            ELSE:
+                dd_origin = trace[0].context.dd_origin
 
         with self._lock:
             for span in trace:
@@ -267,7 +271,7 @@ cdef class MsgpackEncoderBase(BufferedEncoder):
     cpdef flush(self):
         raise NotImplementedError()
 
-    cdef pack_span(self, object span, object dd_origin):
+    cdef pack_span(self, object span, char *dd_origin):
         raise NotImplementedError()
 
 
@@ -278,7 +282,7 @@ cdef class MsgpackEncoder(MsgpackEncoderBase):
         finally:
             self._reset_buffer()
 
-    cdef inline int _pack_meta(self, object meta, object dd_origin):
+    cdef inline int _pack_meta(self, object meta, char *dd_origin):
         cdef Py_ssize_t L
         cdef int ret
         cdef dict d
@@ -286,7 +290,7 @@ cdef class MsgpackEncoder(MsgpackEncoderBase):
         if PyDict_CheckExact(meta):
             d = <dict> meta
             L = len(d)
-            if dd_origin is not None:
+            if dd_origin is not NULL:
                 L += 1
             if L > ITEM_LIMIT:
                 raise ValueError("dict is too large")
@@ -298,10 +302,10 @@ cdef class MsgpackEncoder(MsgpackEncoderBase):
                     if ret != 0: break
                     ret = pack_text(&self.pk, v)
                     if ret != 0: break
-                if dd_origin is not None:
-                    ret = pack_text(&self.pk, ORIGIN_KEY)
+                if dd_origin is not NULL:
+                    ret = pack_bytes(&self.pk, <char *> b"_dd.origin", 10)
                     if ret == 0:
-                        ret = pack_text(&self.pk, dd_origin)
+                        ret = pack_bytes(&self.pk, dd_origin, strlen(dd_origin))
             return ret
 
         raise TypeError("Unhandled meta type: %r" % type(meta))
@@ -328,7 +332,7 @@ cdef class MsgpackEncoder(MsgpackEncoderBase):
 
         raise TypeError("Unhandled metrics type: %r" % type(metrics))
 
-    cdef pack_span(self, object span, object dd_origin):
+    cdef pack_span(self, object span, char *dd_origin):
         cdef int ret
         cdef Py_ssize_t L
         cdef int has_span_type
@@ -336,7 +340,7 @@ cdef class MsgpackEncoder(MsgpackEncoderBase):
         cdef int has_metrics
 
         has_span_type = <bint> (span.span_type is not None)
-        has_meta = <bint> (len(span.meta) > 0 or dd_origin is not None)
+        has_meta = <bint> (len(span.meta) > 0 or dd_origin is not NULL)
         has_metrics = <bint> (len(span.metrics) > 0)
 
         L = 9 + has_span_type + has_meta + has_metrics


### PR DESCRIPTION
## Description
Currently, the `dd_origin` key and value is encoded from text to the msgpack buffer PER span in a trace, even though the key and value are constant. This results in an unnecessary conversion and encoding every time a span is encoded.

The proposed solution is to convert the `dd_origin` value once per trace into a constant char array, and then directly encode that into the buffer per span, which is a much less costly operation.

The `_dd.origin` key is now also encoded directly as a constant char array into the msgpack buffer instead of importing and reading from the constants file.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
