### PR TITLE
chore[mypy]: add type hinting to opentracer module

### DIFF
--- a/ddtrace/opentracer/helpers.py
+++ b/ddtrace/opentracer/helpers.py
@@ -1,6 +1,12 @@
+from typing import TYPE_CHECKING
+
 import opentracing
 
 import ddtrace
+
+
+if TYPE_CHECKING:
+    from ddtrace.opentracer import Tracer
 
 
 """
@@ -9,6 +15,7 @@ Helper routines for Datadog OpenTracing.
 
 
 def set_global_tracer(tracer):
+    # type: (Tracer) -> None
     """Sets the global tracers to the given tracer."""
 
     # overwrite the opentracer reference

--- a/ddtrace/opentracer/propagation/http.py
+++ b/ddtrace/opentracer/propagation/http.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from opentracing import InvalidCarrierException
 from opentracing import SpanContextCorruptedException
 
@@ -24,6 +26,7 @@ class HTTPPropagator(Propagator):
 
     @staticmethod
     def inject(span_context, carrier):
+        # type: (SpanContext, Dict[str, str]) -> None
         """Inject a span context into a carrier.
 
         *span_context* is injected into the carrier by first using an
@@ -48,6 +51,7 @@ class HTTPPropagator(Propagator):
 
     @staticmethod
     def extract(carrier):
+        # type: (Dict[str, str]) -> SpanContext
         """Extract a span context from a carrier.
 
         :class:`ddtrace.propagation.http.HTTPPropagator` is used to extract

--- a/ddtrace/opentracer/propagation/propagator.py
+++ b/ddtrace/opentracer/propagation/propagator.py
@@ -1,18 +1,15 @@
-from abc import ABCMeta
-from abc import abstractmethod
+import abc
+
+import six
 
 
-# ref: https://stackoverflow.com/a/38668373
-ABC = ABCMeta("ABC", (object,), {"__slots__": ()})
-
-
-class Propagator(ABC):
+class Propagator(six.with_metaclass(abc.ABCMeta)):
     @staticmethod
-    @abstractmethod
+    @abc.abstractmethod
     def inject(span_context, carrier):
         pass
 
     @staticmethod
-    @abstractmethod
+    @abc.abstractmethod
     def extract(carrier):
         pass

--- a/ddtrace/opentracer/settings.py
+++ b/ddtrace/opentracer/settings.py
@@ -1,4 +1,7 @@
 from collections import namedtuple
+from typing import Any
+from typing import Dict
+from typing import List
 
 
 # Keys used for the configuration dict
@@ -33,5 +36,6 @@ ConfigKeys = ConfigKeyNames(
 
 
 def config_invalid_keys(config):
+    # type: (Dict[str, Any]) -> List[str]
     """Returns a list of keys that exist in *config* and not in KEYS."""
     return [key for key in config.keys() if key not in ConfigKeys]

--- a/ddtrace/opentracer/settings.py
+++ b/ddtrace/opentracer/settings.py
@@ -1,21 +1,22 @@
 from collections import namedtuple
 
 
-CONFIG_KEY_NAMES = [
-    "AGENT_HOSTNAME",
-    "AGENT_HTTPS",
-    "AGENT_PORT",
-    "DEBUG",
-    "ENABLED",
-    "GLOBAL_TAGS",
-    "SAMPLER",
-    "PRIORITY_SAMPLING",
-    "UDS_PATH",
-    "SETTINGS",
-]
-
 # Keys used for the configuration dict
-ConfigKeyNames = namedtuple("ConfigKeyNames", CONFIG_KEY_NAMES)
+ConfigKeyNames = namedtuple(
+    "ConfigKeyNames",
+    [
+        "AGENT_HOSTNAME",
+        "AGENT_HTTPS",
+        "AGENT_PORT",
+        "DEBUG",
+        "ENABLED",
+        "GLOBAL_TAGS",
+        "SAMPLER",
+        "PRIORITY_SAMPLING",
+        "UDS_PATH",
+        "SETTINGS",
+    ],
+)
 
 ConfigKeys = ConfigKeyNames(
     AGENT_HOSTNAME="agent_hostname",

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -1,19 +1,35 @@
 import threading
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import TYPE_CHECKING
+from typing import Text
+from typing import Union
 
 from opentracing import Span as OpenTracingSpan
 from opentracing.ext import tags as OTTags
 
+from ddtrace.context import Context as DatadogContext
 from ddtrace.ext import errors
+from ddtrace.internal.compat import NumericType
 from ddtrace.span import Span as DatadogSpan
 
 from .span_context import SpanContext
 from .tags import Tags
 
 
+if TYPE_CHECKING:
+    from .tracer import Tracer
+
+
+_TagNameType = Union[Text, bytes]
+
+
 class Span(OpenTracingSpan):
     """Datadog implementation of :class:`opentracing.Span`"""
 
     def __init__(self, tracer, context, operation_name):
+        # type: (Tracer, Optional[SpanContext], str) -> None
         if context is not None:
             context = SpanContext(ddcontext=context._dd_context, baggage=context.baggage)
         else:
@@ -27,6 +43,7 @@ class Span(OpenTracingSpan):
         self._dd_span = DatadogSpan(tracer._dd_tracer, operation_name, context=context._dd_context)
 
     def finish(self, finish_time=None):
+        # type: (Optional[float]) -> None
         """Finish the span.
 
         This calls finish on the ddspan.
@@ -43,6 +60,7 @@ class Span(OpenTracingSpan):
         self.finished = True
 
     def set_baggage_item(self, key, value):
+        # type: (str, Any) -> Span
         """Sets a baggage item in the span context of this span.
 
         Baggage is used to propagate state between spans.
@@ -62,6 +80,7 @@ class Span(OpenTracingSpan):
         return self
 
     def get_baggage_item(self, key):
+        # type: (str) -> Optional[str]
         """Gets a baggage item from the span context of this span.
 
         :param key: baggage item key
@@ -73,10 +92,12 @@ class Span(OpenTracingSpan):
         return self.context.get_baggage_item(key)
 
     def set_operation_name(self, operation_name):
+        # type: (str) -> None
         """Set the operation name."""
         self._dd_span.name = operation_name
 
     def log_kv(self, key_values, timestamp=None):
+        # type: (Dict[_TagNameType, Any], Optional[float]) -> Span
         """Add a log record to this span.
 
         Passes on relevant opentracing key values onto the datadog span.
@@ -110,6 +131,7 @@ class Span(OpenTracingSpan):
         return self
 
     def set_tag(self, key, value):
+        # type: (_TagNameType, Any) -> None
         """Set a tag on the span.
 
         This sets the tag on the underlying datadog span.
@@ -130,6 +152,7 @@ class Span(OpenTracingSpan):
             self._dd_span.set_tag(key, value)
 
     def _get_tag(self, key):
+        # type: (_TagNameType) -> Optional[Text]
         """Gets a tag from the span.
 
         This method retrieves the tag from the underlying datadog span.
@@ -137,6 +160,7 @@ class Span(OpenTracingSpan):
         return self._dd_span.get_tag(key)
 
     def _get_metric(self, key):
+        # type: (_TagNameType) -> Optional[NumericType]
         """Gets a metric from the span.
 
         This method retrieves the metric from the underlying datadog span.
@@ -156,6 +180,7 @@ class Span(OpenTracingSpan):
         self.finish()
 
     def _associate_dd_span(self, ddspan):
+        # type: (DatadogSpan) -> None
         """Associates a DD span with this span."""
         # get the datadog span context
         self._dd_span = ddspan
@@ -163,4 +188,5 @@ class Span(OpenTracingSpan):
 
     @property
     def _dd_context(self):
+        # type: () -> DatadogContext
         return self._dd_span.context

--- a/ddtrace/opentracer/span_context.py
+++ b/ddtrace/opentracer/span_context.py
@@ -1,12 +1,24 @@
+from typing import Any
+from typing import Dict
+from typing import Optional
+
 from opentracing import SpanContext as OpenTracingSpanContext
 
 from ddtrace.context import Context as DatadogContext
+from ddtrace.internal.compat import NumericType
 
 
 class SpanContext(OpenTracingSpanContext):
     """Implementation of the OpenTracing span context."""
 
-    def __init__(self, trace_id=None, span_id=None, sampling_priority=None, baggage=None, ddcontext=None):
+    def __init__(
+        self,
+        trace_id=None,  # type: Optional[int]
+        span_id=None,  # type: Optional[int]
+        sampling_priority=None,  # type: Optional[NumericType]
+        baggage=None,  # type: Optional[Dict[str, Any]]
+        ddcontext=None,  # type: Optional[DatadogContext]
+    ):
         # create a new dict for the baggage if it is not provided
         # NOTE: it would be preferable to use opentracing.SpanContext.EMPTY_BAGGAGE
         #       but it is mutable.
@@ -26,9 +38,11 @@ class SpanContext(OpenTracingSpanContext):
 
     @property
     def baggage(self):
+        # type: () -> Dict[str, Any]
         return self._baggage
 
     def set_baggage_item(self, key, value):
+        # type: (str, Any) -> None
         """Sets a baggage item in this span context.
 
         Note that this operation mutates the baggage of this span context
@@ -36,6 +50,7 @@ class SpanContext(OpenTracingSpanContext):
         self.baggage[key] = value
 
     def with_baggage_item(self, key, value):
+        # type: (str, Any) -> SpanContext
         """Returns a copy of this span with a new baggage item.
 
         Useful for instantiating new child span contexts.
@@ -45,5 +60,6 @@ class SpanContext(OpenTracingSpanContext):
         return SpanContext(ddcontext=self._dd_context, baggage=baggage)
 
     def get_baggage_item(self, key):
+        # type: (str) -> Optional[Any]
         """Gets a baggage item in this span context."""
         return self.baggage.get(key, None)

--- a/ddtrace/opentracer/span_context.py
+++ b/ddtrace/opentracer/span_context.py
@@ -19,6 +19,7 @@ class SpanContext(OpenTracingSpanContext):
         baggage=None,  # type: Optional[Dict[str, Any]]
         ddcontext=None,  # type: Optional[DatadogContext]
     ):
+        # type: (...) -> None
         # create a new dict for the baggage if it is not provided
         # NOTE: it would be preferable to use opentracing.SpanContext.EMPTY_BAGGAGE
         #       but it is mutable.

--- a/ddtrace/opentracer/tags.py
+++ b/ddtrace/opentracer/tags.py
@@ -1,16 +1,17 @@
 from collections import namedtuple
 
 
-TAG_NAMES = [
-    "RESOURCE_NAME",
-    "SAMPLING_PRIORITY",
-    "SERVICE_NAME",
-    "SPAN_TYPE",
-    "TARGET_HOST",
-    "TARGET_PORT",
-]
-
-TagNames = namedtuple("TagNames", TAG_NAMES)
+TagNames = namedtuple(
+    "TagNames",
+    [
+        "RESOURCE_NAME",
+        "SAMPLING_PRIORITY",
+        "SERVICE_NAME",
+        "SPAN_TYPE",
+        "TARGET_HOST",
+        "TARGET_PORT",
+    ],
+)
 
 Tags = TagNames(
     RESOURCE_NAME="resource.name",

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -1,16 +1,19 @@
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
 from typing import Union
 
 import opentracing
 from opentracing import Format
+from opentracing import ScopeManager
 from opentracing.scope_managers import ThreadLocalScopeManager
 
 import ddtrace
 from ddtrace import Span as DatadogSpan
 from ddtrace import Tracer as DatadogTracer
 from ddtrace.constants import FILTERS_KEY
+from ddtrace.context import Context as DatadogContext
 from ddtrace.settings import ConfigException
 from ddtrace.utils.config import get_application_name
 
@@ -38,13 +41,20 @@ DEFAULT_CONFIG = {
     keys.SETTINGS: {
         FILTERS_KEY: [],
     },
-}  # type: Dict[str, Optional[Union[str, int, bool, Dict[str, Any]]]]
+}  # type: Dict[str, Any]
 
 
 class Tracer(opentracing.Tracer):
     """A wrapper providing an OpenTracing API for the Datadog tracer."""
 
-    def __init__(self, service_name=None, config=None, scope_manager=None, dd_tracer=None):
+    def __init__(
+        self,
+        service_name=None,  # type: Optional[str]
+        config=None,  # type: Optional[Dict[str, Any]]
+        scope_manager=None,  # type: Optional[ScopeManager]
+        dd_tracer=None,  # type: Optional[DatadogTracer]
+    ):
+        # type: (...) -> None
         """Initialize a new Datadog opentracer.
 
         :param service_name: (optional) the name of the service that this
@@ -89,7 +99,7 @@ class Tracer(opentracing.Tracer):
         dd_context_provider = get_context_provider_for_scope_manager(self._scope_manager)
 
         self._dd_tracer = dd_tracer or ddtrace.tracer or DatadogTracer()
-        self._dd_tracer.set_tags(self._config.get(keys.GLOBAL_TAGS))
+        self._dd_tracer.set_tags(self._config.get(keys.GLOBAL_TAGS))  # type: ignore[arg-type]
         self._dd_tracer.configure(
             enabled=self._config.get(keys.ENABLED),
             hostname=self._config.get(keys.AGENT_HOSTNAME),
@@ -99,7 +109,7 @@ class Tracer(opentracing.Tracer):
             settings=self._config.get(keys.SETTINGS),
             priority_sampling=self._config.get(keys.PRIORITY_SAMPLING),
             uds_path=self._config.get(keys.UDS_PATH),
-            context_provider=dd_context_provider,
+            context_provider=dd_context_provider,  # type: ignore[arg-type]
         )
         self._propagators = {
             Format.HTTP_HEADERS: HTTPPropagator,
@@ -108,18 +118,19 @@ class Tracer(opentracing.Tracer):
 
     @property
     def scope_manager(self):
+        # type: () -> ScopeManager
         """Returns the scope manager being used by this tracer."""
         return self._scope_manager
 
     def start_active_span(
         self,
-        operation_name,
-        child_of=None,
-        references=None,
-        tags=None,
-        start_time=None,
-        ignore_active_span=False,
-        finish_on_close=True,
+        operation_name,  # type: str
+        child_of=None,  # type: Optional[Union[Span, SpanContext]]
+        references=None,  # type: Optional[List[Any]]
+        tags=None,  # type: Optional[Dict[str, str]]
+        start_time=None,  # type: Optional[int]
+        ignore_active_span=False,  # type: bool
+        finish_on_close=True,  # type: bool
     ):
         """Returns a newly started and activated `Scope`.
         The returned `Scope` supports with-statement contexts. For example::
@@ -174,7 +185,13 @@ class Tracer(opentracing.Tracer):
         return scope
 
     def start_span(
-        self, operation_name=None, child_of=None, references=None, tags=None, start_time=None, ignore_active_span=False
+        self,
+        operation_name=None,  # type: Optional[str]
+        child_of=None,  # type: Optional[Union[Span, SpanContext]]
+        references=None,  # type: Optional[List[Any]]
+        tags=None,  # type: Optional[Dict[str, str]]
+        start_time=None,  # type: Optional[int]
+        ignore_active_span=False,  # type: bool
     ):
         """Starts and returns a new Span representing a unit of work.
 
@@ -221,7 +238,8 @@ class Tracer(opentracing.Tracer):
         """
         ot_parent = None  # 'ot_parent' is more readable than 'child_of'
         ot_parent_context = None  # the parent span's context
-        dd_parent = None  # the child_of to pass to the ddtracer
+        # dd_parent: the child_of to pass to the ddtracer
+        dd_parent = None  # type: Optional[Union[DatadogSpan, DatadogContext]]
 
         if child_of is not None:
             ot_parent = child_of  # 'ot_parent' is more readable than 'child_of'
@@ -270,7 +288,7 @@ class Tracer(opentracing.Tracer):
         # create a new otspan and ddspan using the ddtracer and associate it
         # with the new otspan
         ddspan = self._dd_tracer.start_span(
-            name=operation_name,
+            name=operation_name,  # type: ignore[arg-type]
             child_of=dd_parent,
             service=self._service_name,
             activate=False,
@@ -279,7 +297,7 @@ class Tracer(opentracing.Tracer):
         # set the start time if one is specified
         ddspan.start = start_time or ddspan.start
 
-        otspan = Span(self, ot_parent_context, operation_name)
+        otspan = Span(self, ot_parent_context, operation_name)  # type: ignore[arg-type]
         # sync up the OT span with the DD span
         otspan._associate_dd_span(ddspan)
 
@@ -293,6 +311,7 @@ class Tracer(opentracing.Tracer):
 
     @property
     def active_span(self):
+        # type: () -> Optional[Span]
         """Retrieves the active span from the opentracing scope manager
 
         Falls back to using the datadog active span if one is not found. This
@@ -303,14 +322,14 @@ class Tracer(opentracing.Tracer):
             return scope.span
         else:
             dd_span = self._dd_tracer.current_span()
+            ot_span = None  # type: Optional[Span]
             if dd_span:
                 ot_span = Span(self, None, dd_span.name)
                 ot_span._associate_dd_span(dd_span)
-            else:
-                ot_span = None
             return ot_span
 
     def inject(self, span_context, format, carrier):  # noqa: A002
+        # type: (SpanContext, str, Dict[str, str]) -> None
         """Injects a span context into a carrier.
 
         :param span_context: span context to inject.
@@ -325,6 +344,7 @@ class Tracer(opentracing.Tracer):
         propagator.inject(span_context, carrier)
 
     def extract(self, format, carrier):  # noqa: A002
+        # type: (str, Dict[str, str]) -> SpanContext
         """Extracts a span context from a carrier.
 
         :param format: format that the carrier is encoded with.

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -1,3 +1,8 @@
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Union
+
 import opentracing
 from opentracing import Format
 from opentracing.scope_managers import ThreadLocalScopeManager
@@ -33,7 +38,7 @@ DEFAULT_CONFIG = {
     keys.SETTINGS: {
         FILTERS_KEY: [],
     },
-}
+}  # type: Dict[str, Optional[Union[str, int, bool, Dict[str, Any]]]]
 
 
 class Tracer(opentracing.Tracer):

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -6,6 +6,7 @@ from typing import Union
 
 import opentracing
 from opentracing import Format
+from opentracing import Scope
 from opentracing import ScopeManager
 from opentracing.scope_managers import ThreadLocalScopeManager
 
@@ -132,6 +133,7 @@ class Tracer(opentracing.Tracer):
         ignore_active_span=False,  # type: bool
         finish_on_close=True,  # type: bool
     ):
+        # type: (...) -> Scope
         """Returns a newly started and activated `Scope`.
         The returned `Scope` supports with-statement contexts. For example::
 
@@ -193,6 +195,7 @@ class Tracer(opentracing.Tracer):
         start_time=None,  # type: Optional[int]
         ignore_active_span=False,  # type: bool
     ):
+        # type: (...) -> Span
         """Starts and returns a new Span representing a unit of work.
 
         Starting a root Span (a Span with no causal references)::

--- a/ddtrace/opentracer/utils.py
+++ b/ddtrace/opentracer/utils.py
@@ -1,8 +1,14 @@
+from opentracing import ScopeManager
+
+from ddtrace.provider import BaseContextProvider
+
+
 # DEV: If `asyncio` or `gevent` are unavailable we do not throw an error,
 #    `context_provider` will just not be set and we'll get an `AttributeError` instead
 
 
 def get_context_provider_for_scope_manager(scope_manager):
+    # type: (ScopeManager) -> BaseContextProvider
     """Returns the context_provider to use with a given scope_manager."""
 
     scope_manager_type = type(scope_manager).__name__
@@ -12,7 +18,7 @@ def get_context_provider_for_scope_manager(scope_manager):
     if scope_manager_type == "AsyncioScopeManager":
         import ddtrace.contrib.asyncio
 
-        dd_context_provider = ddtrace.contrib.asyncio.context_provider
+        dd_context_provider = ddtrace.contrib.asyncio.context_provider  # type: BaseContextProvider
     elif scope_manager_type == "GeventScopeManager":
         import ddtrace.contrib.gevent
 
@@ -28,6 +34,7 @@ def get_context_provider_for_scope_manager(scope_manager):
 
 
 def _patch_scope_manager(scope_manager, context_provider):
+    # type: (ScopeManager, BaseContextProvider) -> None
     """
     Patches a scope manager so that any time a span is activated
     it'll also activate the underlying ddcontext with the underlying

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,6 +11,3 @@ ignore_errors = true
 
 [mypy-ddtrace.vendor.*]
 ignore_errors = true
-
-[mypy-ddtrace.opentracer.*]
-ignore_errors = true


### PR DESCRIPTION
## Description
The `ddtrace.opentracer` module was removed from the mypy ignores configuration, and type hinting was added.
