### PR TITLE
fix(perf): fix many-tags encoder scenario

### DIFF
--- a/benchmarks/encoder/config.yaml
+++ b/benchmarks/encoder/config.yaml
@@ -13,7 +13,7 @@ one-tag:
   ltags: 16
 many-tags:
   <<: *base_variant
-  ntags: 1
+  ntags: 100
   ltags: 16
 one-metric:
   <<: *base_variant


### PR DESCRIPTION
## Description

Incorrect `ntags` for `many-tags` scenario run.
