### PR TITLE
perf: Add flask_simple benchmark scenario

### DIFF
--- a/benchmarks/flask_simple/app.py
+++ b/benchmarks/flask_simple/app.py
@@ -1,0 +1,42 @@
+import random
+
+from flask import Flask
+from flask import render_template_string
+
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def index():
+    rand_numbers = [random.random() for _ in range(20)]
+    return render_template_string(
+        """
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Hello World!</title>
+  </head>
+  <body>
+  <section class="section">
+    <div class="container">
+      <h1 class="title">
+        Hello World
+      </h1>
+      <p class="subtitle">
+        My first website
+      </p>
+      <ul>
+        {% for i in rand_numbers %}
+          <li>{{ i }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </section>
+  </body>
+</html>
+    """,
+        rand_numbers=rand_numbers,
+    )

--- a/benchmarks/flask_simple/config.yaml
+++ b/benchmarks/flask_simple/config.yaml
@@ -1,0 +1,13 @@
+baseline: &baseline
+  tracer_enabled: false
+  profiler_enabled: false
+tracer:
+  <<: *baseline
+  tracer_enabled: true
+profiler:
+  <<: *baseline
+  profiler_enabled: true
+tracer-and-profiler:
+  <<: *baseline
+  tracer_enabled: true
+  profiler_enabled: true

--- a/benchmarks/flask_simple/gunicorn.conf.py
+++ b/benchmarks/flask_simple/gunicorn.conf.py
@@ -1,0 +1,26 @@
+import os
+
+
+def post_fork(server, worker):
+    # Set lower defaults for ensuring profiler collect is run
+    if os.environ.get("PERF_PROFILER_ENABLED") == "1":
+        os.environ.update(
+            {"DD_PROFILING_ENABLED": "1", "DD_PROFILING_API_TIMEOUT": "0.1", "DD_PROFILING_UPLOAD_INTERVAL": "10"}
+        )
+    # This will not work with gevent workers as the gevent hub has not been
+    # initialized when this hook is called.
+    if os.environ.get("PERF_TRACER_ENABLED") == "1":
+        import ddtrace.bootstrap.sitecustomize  # noqa
+
+
+def post_worker_init(worker):
+    # If profiling enabled but not tracer than only run auto script for profiler
+    if os.environ.get("PERF_PROFILER_ENABLED") == "1" and os.environ.get("PERF_TRACER_ENABLED") == "0":
+        import ddtrace.profiling.auto  # noqa
+
+
+bind = "0.0.0.0:8000"
+worker_class = "sync"
+workers = 1
+wsgi_app = "app:app"
+pidfile = "gunicorn.pid"

--- a/benchmarks/flask_simple/requirements_scenario.txt
+++ b/benchmarks/flask_simple/requirements_scenario.txt
@@ -1,0 +1,3 @@
+flask==2.0.1
+gunicorn==20.1.0
+requests==2.25.1

--- a/benchmarks/flask_simple/scenario.py
+++ b/benchmarks/flask_simple/scenario.py
@@ -1,0 +1,17 @@
+import bm
+import utils
+
+
+@bm.register
+class FlaskSimple(bm.Scenario):
+    tracer_enabled = bm.var(type=bool)
+    profiler_enabled = bm.var(type=bool)
+
+    def run(self):
+        with utils.server(self) as get_response:
+
+            def _(loops):
+                for _ in range(loops):
+                    get_response()
+
+            yield _

--- a/benchmarks/flask_simple/utils.py
+++ b/benchmarks/flask_simple/utils.py
@@ -1,0 +1,48 @@
+from contextlib import contextmanager
+import os
+import subprocess
+
+import requests
+import tenacity
+
+
+SERVER_URL = "http://0.0.0.0:8000/"
+
+
+def _get_response():
+    r = requests.get(SERVER_URL)
+    r.raise_for_status()
+
+
+@tenacity.retry(
+    wait=tenacity.wait_fixed(1),
+    stop=tenacity.stop_after_attempt(30),
+)
+def _wait():
+    _get_response()
+
+
+@contextmanager
+def server(scenario):
+    env = {
+        "PERF_TRACER_ENABLED": str(scenario.tracer_enabled),
+        "PERF_PROFILER_ENABLED": str(scenario.profiler_enabled),
+    }
+    # copy over current environ
+    env.update(os.environ)
+    cmd = ["gunicorn", "-c", "gunicorn.conf.py"]
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True,
+        env=env,
+    )
+    # make sure process has been started
+    assert proc.poll() is None
+    try:
+        _wait()
+        yield _get_response
+    finally:
+        proc.terminate()
+        proc.wait()

--- a/scripts/perf-build-push
+++ b/scripts/perf-build-push
@@ -11,7 +11,7 @@ shift
 
 IMAGES=()
 
-for SCENARIO in "encoder" "span" "tracer" "django_simple"; do
+for SCENARIO in "encoder" "span" "tracer" "django_simple" "flask_simple"; do
     TAG="${REPOSITORY}/perf-${SCENARIO}"
     scripts/perf-build-scenario "${SCENARIO}" "${TAG}"
     IMAGE="${TAG}:latest"


### PR DESCRIPTION
Similar to the `django_simple` scenario, but with Flask. We are not hitting any databases, but just generating some random numbers and rendering a template to simulate work load.

Adding some middleware tracing could be good.

A lot of the gunicorn/scenario/utils are copy/pasta from Django. We should consider in the future how we can refactor/DRY this up.