### PR TITLE
perf: add threading benchmark scenario

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -70,3 +70,9 @@ Example::
 
   scripts/perf-run-scenario span ddtrace==0.50.0 ddtrace==0.51.0 ./artifacts/
   scripts/perf-run-scenario span Datadog/dd-trace-py@master Datadog/dd-trace-py@my-feature ./artifacts/
+
+
+Scenarios
+^^^^^^^^^
+
+.. include:: ../benchmarks/threading/README.rst

--- a/benchmarks/threading/README.rst
+++ b/benchmarks/threading/README.rst
@@ -5,6 +5,6 @@ This benchmark test is used to simulate the creation, encoding, and flushing of 
 
 It uses a ``concurrent.futures.ThreadPool`` to manage the total number of workers.
 
-The only modification to the tracing workflow that has been modified is using a ``NoopWriter`` which does not start a
+The only modification to the tracing workflow that has been made is using a ``NoopWriter`` which does not start a
 background thread and drops traces on ``writer.write``. This means we skip encoding, queuing, and flushing payloads
 to the agent, but we will still use the span processors.

--- a/benchmarks/threading/README.rst
+++ b/benchmarks/threading/README.rst
@@ -1,0 +1,10 @@
+Benchmark: threading
+====================
+
+This benchmark test is used to simulate the creation, encoding, and flushing of traces in threaded environments.
+
+It uses a ``concurrent.futures.ThreadPool`` to manage the total number of workers.
+
+The only modification to the tracing workflow that has been modified is the ``AgentWriter``'s ``_send_payload`` has been overridden to do nothing.
+This means we will still start the background worker for the agent, put traces into the queue, and encode them into payloads to send. We will just
+not try to make the HTTP call to the agent to reduce any impact from an external process on this test.

--- a/benchmarks/threading/README.rst
+++ b/benchmarks/threading/README.rst
@@ -1,10 +1,10 @@
-Benchmark: threading
-====================
+threading
+~~~~~~~~~
 
 This benchmark test is used to simulate the creation, encoding, and flushing of traces in threaded environments.
 
 It uses a ``concurrent.futures.ThreadPool`` to manage the total number of workers.
 
 The only modification to the tracing workflow that has been modified is using a ``NoopWriter`` which does not start a
-background thread and drops traces on ``writer.write``. This means we skip encoding, queueing, and flushing payloads
+background thread and drops traces on ``writer.write``. This means we skip encoding, queuing, and flushing payloads
 to the agent, but we will still use the span processors.

--- a/benchmarks/threading/README.rst
+++ b/benchmarks/threading/README.rst
@@ -5,6 +5,6 @@ This benchmark test is used to simulate the creation, encoding, and flushing of 
 
 It uses a ``concurrent.futures.ThreadPool`` to manage the total number of workers.
 
-The only modification to the tracing workflow that has been modified is the ``AgentWriter``'s ``_send_payload`` has been overridden to do nothing.
-This means we will still start the background worker for the agent, put traces into the queue, and encode them into payloads to send. We will just
-not try to make the HTTP call to the agent to reduce any impact from an external process on this test.
+The only modification to the tracing workflow that has been modified is using a ``NoopWriter`` which does not start a
+background thread and drops traces on ``writer.write``. This means we skip encoding, queueing, and flushing payloads
+to the agent, but we will still use the span processors.

--- a/benchmarks/threading/config.yaml
+++ b/benchmarks/threading/config.yaml
@@ -1,0 +1,13 @@
+1-thread: &baseline
+  nthreads: 1
+  ntraces: 1000
+  nspans: 10
+10-threads:
+  <<: *baseline
+  nthreads: 10
+50-threads:
+  <<: *baseline
+  nthreads: 50
+100-threads:
+  <<: *baseline
+  nthreads: 100

--- a/benchmarks/threading/scenario.py
+++ b/benchmarks/threading/scenario.py
@@ -1,0 +1,39 @@
+import concurrent.futures
+
+import bm
+
+from ddtrace.internal.writer import AgentWriter
+
+
+class DummyWriter(AgentWriter):
+    def _send_payload(self, payload, count):
+        # Do nothing
+        pass
+
+
+@bm.register
+class Threading(bm.Scenario):
+    nthreads = bm.var(type=int)
+    ntraces = bm.var(type=int)
+    nspans = bm.var(type=int)
+
+    def create_trace(self, tracer):
+        with tracer.trace("root") as root:
+            for _ in range(self.nspans - 1):
+                with tracer.trace("child"):
+                    pass
+
+    def run(self):
+        # use DummyWriter to prevent network calls to the agent
+        from ddtrace import tracer
+
+        tracer.configure(writer=DummyWriter("http://localhost:8126/"))
+
+        def _(loops):
+            for _ in range(loops):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=self.nthreads) as executor:
+                    tasks = {executor.submit(self.create_trace, tracer) for i in range(self.ntraces)}
+                    for task in concurrent.futures.as_completed(tasks):
+                        task.result()
+
+        yield _

--- a/benchmarks/threading/scenario.py
+++ b/benchmarks/threading/scenario.py
@@ -8,6 +8,7 @@ from typing import Optional
 import bm
 
 from ddtrace.internal.writer import TraceWriter
+from ddtrace.span import Span
 from ddtrace.tracer import Tracer
 
 

--- a/benchmarks/threading/scenario.py
+++ b/benchmarks/threading/scenario.py
@@ -18,7 +18,7 @@ class Threading(bm.Scenario):
     nspans = bm.var(type=int)
 
     def create_trace(self, tracer):
-        with tracer.trace("root") as root:
+        with tracer.trace("root"):
             for _ in range(self.nspans - 1):
                 with tracer.trace("child"):
                     pass

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -144,5 +144,6 @@ uvicorn
 versioned
 vertica
 whitelist
+workflow
 wsgi
 xfail

--- a/scripts/perf-build-push
+++ b/scripts/perf-build-push
@@ -11,7 +11,7 @@ shift
 
 IMAGES=()
 
-for SCENARIO in "encoder" "span" "tracer" "django_simple" "flask_simple"; do
+for SCENARIO in "encoder" "span" "tracer" "django_simple" "flask_simple" "threading"; do
     TAG="${REPOSITORY}/perf-${SCENARIO}"
     scripts/perf-build-scenario "${SCENARIO}" "${TAG}"
     IMAGE="${TAG}:latest"


### PR DESCRIPTION
This benchmark test is used to simulate the creation, encoding, and flushing of traces in threaded environments.

It uses a ``concurrent.futures.ThreadPool`` to manage the total number of workers.

The only modification to the tracing workflow that has been modified is the ``AgentWriter``'s ``_send_payload`` has been overridden to do nothing.
This means we will still start the background worker for the agent, put traces into the queue, and encode them into payloads to send. We will just
not try to make the HTTP call to the agent to reduce any impact from an external process on this test.
