### PR TITLE
fix[pytest]: extract module name from DoctestItem

### DIFF
--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -118,7 +118,10 @@ def pytest_runtest_protocol(item, nextitem):
         span.set_tag(SPAN_KIND, KIND)
         span.set_tag(test.FRAMEWORK, FRAMEWORK)
         span.set_tag(test.NAME, item.name)
-        span.set_tag(test.SUITE, item.module.__name__)
+        if hasattr(item, "module"):
+            span.set_tag(test.SUITE, item.module.__name__)
+        elif hasattr(item, "dtest"):
+            span.set_tag(test.SUITE, item.dtest.globs["__name__"])
         span.set_tag(test.TYPE, SpanTypes.TEST.value)
 
         # Parameterized test cases will have a `callspec` attribute attached to the pytest Item object.

--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -1,3 +1,4 @@
+from doctest import DocTest
 import json
 from typing import Dict
 
@@ -120,7 +121,7 @@ def pytest_runtest_protocol(item, nextitem):
         span.set_tag(test.NAME, item.name)
         if hasattr(item, "module"):
             span.set_tag(test.SUITE, item.module.__name__)
-        elif hasattr(item, "dtest"):
+        elif hasattr(item, "dtest") and isinstance(item.dtest, DocTest):
             span.set_tag(test.SUITE, item.dtest.globs["__name__"])
         span.set_tag(test.TYPE, SpanTypes.TEST.value)
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -45,6 +45,7 @@ dbapi
 ddtrace
 deprecations
 django
+doctest
 dogpile
 dogpile.cache
 dogstatsd

--- a/releasenotes/notes/fix-pytest-doctest-4918b724f736ef88.yaml
+++ b/releasenotes/notes/fix-pytest-doctest-4918b724f736ef88.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue when using the pytest plugin with doctest, where ``DoctestItem`` does not contain the
+    test module name.

--- a/releasenotes/notes/fix-pytest-doctest-4918b724f736ef88.yaml
+++ b/releasenotes/notes/fix-pytest-doctest-4918b724f736ef88.yaml
@@ -1,5 +1,4 @@
 ---
 fixes:
   - |
-    Fixes an issue when using the pytest plugin with doctest, where ``DoctestItem`` does not contain the
-    test module name.
+    Fixes an issue when using the pytest plugin with doctest which raises an ``AttributeError`` on ``DoctestItem``.


### PR DESCRIPTION
## Description
From #2792, the pytest plugin caused errors when attempting to use with doctest. The bug was caused by the fact that the pytest hooks used by the plugin takes in pytest `Item` objects as arguments, which contain references to the test module. When used with doctest however, the hooks are provided `DoctestItem` objects which are subclasses of the pytest `Item` class, but do not contain references to the test module in the same manner as `item.module`. Instead, the `DoctestItem` objects store the test module name in its `globs` dictionary.

This fix adds a special case to check if the pytest item contains a `module`, and if not checks for the corresponding `dtest` (Doctest) item which will contain the module name.

Resolves #2792 