### PR TITLE
fix(pin): `get_from` type hint

### DIFF
--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -98,7 +98,7 @@ class Pin(object):
 
     @staticmethod
     def get_from(obj):
-        # type: (Any) -> Pin
+        # type: (Any) -> Optional[Pin]
         """Return the pin associated with the given object. If a pin is attached to
         `obj` but the instance is not the owner of the pin, a new pin is cloned and
         attached. This ensures that a pin inherited from a class is a copy for the new
@@ -147,7 +147,7 @@ class Pin(object):
             return
 
         pin = cls.get_from(obj)
-        if not pin:
+        if pin is None:
             pin = Pin(service)
 
         pin.clone(


### PR DESCRIPTION
## Description

Fixed the type hint of the `get_from` method, which could return `None`.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
