### PR TITLE
Lazy load pkg_resources in debug

### DIFF
--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -8,8 +8,6 @@ from typing import Dict
 from typing import TYPE_CHECKING
 from typing import Union
 
-import pkg_resources
-
 import ddtrace
 from ddtrace.internal.writer import AgentWriter
 from ddtrace.internal.writer import LogWriter
@@ -44,6 +42,8 @@ def tags_to_str(tags):
 def collect(tracer):
     # type: (Tracer) -> Dict[str, Any]
     """Collect system and library information into a serializable dict."""
+
+    import pkg_resources
 
     if isinstance(tracer.writer, LogWriter):
         agent_url = "AGENTLESS"


### PR DESCRIPTION
## Description

`pkg_resources` is quite heavy and slows down cold start in a AWS Lambda environment. This PR lazy load this package.


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
