### PR TITLE
perf: support statistical analysis

### DIFF
--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -52,6 +52,8 @@ COPY ./bm/ /app/bm/
 # Add scenario code, overriding anything from base
 COPY ./${SCENARIO}/ /app/
 
+RUN pip install -r requirements.txt
+
 ENV SCENARIO=${SCENARIO}
 
 ENTRYPOINT ["/app/entrypoint"]

--- a/benchmarks/base/benchmark
+++ b/benchmarks/base/benchmark
@@ -7,16 +7,8 @@ fi
 
 ARTIFACTS=/artifacts/${RUN_ID}/${SCENARIO}
 
-OUTPUT_V1=${ARTIFACTS}/${DDTRACE_V1}/
-mkdir -p ${OUTPUT_V1}
-source ${VENV_DDTRACE_V1}/bin/activate
-python run.py ${OUTPUT_V1}
-deactivate
-
-OUTPUT_V2=${ARTIFACTS}/${DDTRACE_V2}/
-mkdir -p ${OUTPUT_V2}
-source ${VENV_DDTRACE_V2}/bin/activate
-python run.py ${OUTPUT_V2}
-# use pyperf to compare results from both runs
-pyperf compare_to --table ${OUTPUT_V1}/results.json ${OUTPUT_V2}/results.json
-deactivate
+OUTPUT=${ARTIFACTS}/${DDTRACE_VERSION}/
+mkdir -p ${OUTPUT}
+python run.py ${OUTPUT}
+pyperf stats ${OUTPUT}/results.json
+pyperf hist ${OUTPUT}/results.json

--- a/benchmarks/base/entrypoint
+++ b/benchmarks/base/entrypoint
@@ -6,22 +6,7 @@ if [[ -f "/app/install.sh" ]]; then
     /app/install.sh
 fi
 
-# Use separate venvs for the two versions of the library being compared
-export VENV_DDTRACE_V1=/app/.venv_ddtrace_v1/
-export VENV_DDTRACE_V2=/app/.venv_ddtrace_v2/
-
-python3 -m venv ${VENV_DDTRACE_V1}
-source ${VENV_DDTRACE_V1}/bin/activate
-pip install ${DDTRACE_INSTALL_V1}
-pip install -r requirements.txt
-export DDTRACE_V1=$(python -c "import ddtrace; print(ddtrace.__version__)")
-deactivate
-
-python3 -m venv ${VENV_DDTRACE_V2}
-source ${VENV_DDTRACE_V2}/bin/activate
-pip install ${DDTRACE_INSTALL_V2}
-pip install -r requirements.txt
-export DDTRACE_V2=$(python -c "import ddtrace; print(ddtrace.__version__)")
-deactivate
+pip install ${DDTRACE_INSTALL}
+export DDTRACE_VERSION=$(python -c "import ddtrace; print(ddtrace.__version__)")
 
 exec "$@"

--- a/benchmarks/base/run.py
+++ b/benchmarks/base/run.py
@@ -18,6 +18,8 @@ def run(scenario_py, cname, cvars, output_dir):
         scenario_py,
         # necessary to copy PYTHONPATH for venvs
         "--copy-env",
+        "--values=5",
+        "--rigorous",
         "--append",
         os.path.join(output_dir, "results.json"),
         "--name",

--- a/benchmarks/bm/_scenario.py
+++ b/benchmarks/bm/_scenario.py
@@ -1,4 +1,5 @@
 import abc
+import os
 import time
 
 import attr
@@ -17,7 +18,17 @@ def _register(scenario_cls):
             if hasattr(args, field.name):
                 cmd.extend(("--{}".format(field.name), str(getattr(args, field.name))))
 
-    runner = pyperf.Runner(add_cmdline_args=add_cmdline_args)
+    metadata = {}
+
+    ddtrace_version = os.environ.get("DDTRACE_VERSION")
+    if ddtrace_version:
+        metadata["ddtrace_version"] = ddtrace_version
+
+    ddtrace_install = os.environ.get("DDTRACE_INSTALL")
+    if ddtrace_install:
+        metadata["ddtrace_install"] = ddtrace_install
+
+    runner = pyperf.Runner(add_cmdline_args=add_cmdline_args, metadata=metadata)
     cmd = runner.argparser
 
     for field in attr.fields(scenario_cls):

--- a/benchmarks/encoder/config.yaml
+++ b/benchmarks/encoder/config.yaml
@@ -7,7 +7,7 @@ one-trace: &base_variant
   dd_origin: false
 many-traces:
   <<: *base_variant
-  ntraces: 100
+  ntraces: 10
 one-tag:
   <<: *base_variant
   ntags: 1
@@ -22,17 +22,21 @@ one-metric:
 many-metrics:
   <<: *base_variant
   nmetrics: 48
-one-trace-with-dd-origin:
+dd-origin:
+  <<: *base_variant
+  dd_origin: true
+dd-origin-many-tags:
   <<: *base_variant
   ntags: 10
   ltags: 16
   dd_origin: true
-one-trace-with-dd-origin-no-tags:
+dd-origin-many-traces:
   <<: *base_variant
+  ntraces: 10
   dd_origin: true
-many-traces-with-dd-origin:
+dd-origin-many-traces-many-tags:
   <<: *base_variant
-  ntraces: 100
+  ntraces: 10
   ntags: 10
   ltags: 16
   dd_origin: true

--- a/benchmarks/encoder/scenario.py
+++ b/benchmarks/encoder/scenario.py
@@ -11,13 +11,12 @@ class Encoder(bm.Scenario):
     dd_origin = bm.var(type=bool)
 
     def run(self):
-        encoder = utils.init_encoder()
+        encode = utils.init_encoder()
         traces = utils.gen_traces(self)
 
         def _(loops):
             for _ in range(loops):
                 for trace in traces:
-                    encoder.put(trace)
-                    encoder.encode()
+                    encode(trace)
 
         yield _

--- a/benchmarks/encoder/utils.py
+++ b/benchmarks/encoder/utils.py
@@ -60,6 +60,7 @@ def gen_traces(config):
             span_name = random.choice(span_names)
             resource = random.choice(resources)
             service = random.choice(services)
+            # Need to instantiate a context as this is needed for dd_origin but was not initialized in span <0.49
             with Span(None, span_name, resource=resource, service=service, parent_id=parent_id, context=Context()) as span:
                 if i == 0 and config.dd_origin:
                     # Since we're not using the tracer API, a span's context isn't automatically propagated

--- a/benchmarks/threading/scenario.py
+++ b/benchmarks/threading/scenario.py
@@ -26,7 +26,6 @@ class NoopWriter(TraceWriter):
         pass
 
 
-@bm.register
 class Threading(bm.Scenario):
     nthreads = bm.var(type=int)
     ntraces = bm.var(type=int)

--- a/scripts/perf-run-all-scenarios
+++ b/scripts/perf-run-all-scenarios
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+for SCENARIO in "encoder" "span" "tracer" "django_simple" "flask_simple" "threading"; do
+    scripts/perf-run-scenario "${SCENARIO}" "$@"
+done

--- a/scripts/perf-run-scenario
+++ b/scripts/perf-run-scenario
@@ -43,18 +43,34 @@ fi
 TAG="dd-trace-py/perf-${SCENARIO}"
 scripts/perf-build-scenario "${SCENARIO}" "${TAG}"
 
+# Same run id for all benchmark runs
+if [[ -z ${RUN_ID} ]]; then
+  RUN_ID=$(uuidgen)
+fi
+
 if [[ -n ${ARTIFACTS} ]]; then
    # Resolve artifacts to an absolute path
-   ARTIFACTS="$(echo $ARTIFACTS | python -c 'import os,sys; print(os.path.abspath(sys.stdin.read()))')"
+   ARTIFACTS="$(realpath $ARTIFACTS)"
    mkdir -p ${ARTIFACTS}
-   docker run -it --rm \
+   docker run --rm \
+          ${DOCKER_RUN_OPTS} \
           -v ${ARTIFACTS}:/artifacts/ \
-          -e DDTRACE_INSTALL_V1="$(expand_git_version $DDTRACE_V1)" \
-          -e DDTRACE_INSTALL_V2="$(expand_git_version $DDTRACE_V2)" \
+          -e DDTRACE_INSTALL="$(expand_git_version $DDTRACE_V1)" \
+          -e RUN_ID="${RUN_ID}" \
+          $TAG
+   docker run --rm \
+          ${DOCKER_RUN_OPTS} \
+          -v ${ARTIFACTS}:/artifacts/ \
+          -e DDTRACE_INSTALL="$(expand_git_version $DDTRACE_V2)" \
+          -e RUN_ID="${RUN_ID}" \
           $TAG
 else
-   docker run -it --rm \
-          -e DDTRACE_INSTALL_V1="$(expand_git_version $DDTRACE_V1)" \
-          -e DDTRACE_INSTALL_V2="$(expand_git_version $DDTRACE_V2)" \
+   docker run --rm \
+          -e DDTRACE_INSTALL="$(expand_git_version $DDTRACE_V1)" \
+          -e RUN_ID="${RUN_ID}" \
+          $TAG
+   docker run --rm \
+          -e DDTRACE_INSTALL="$(expand_git_version $DDTRACE_V2)" \
+          -e RUN_ID="${RUN_ID}" \
           $TAG
 fi


### PR DESCRIPTION
## Description

This PR is an effort to help with statistical tests on the benchmark results. We no longer use the built-in `compare_to` command from `pyperf` but instead print stats from each scenario along with histograms.

Changes:
* increase number of processes from 20 to 40
* increase number of values for each process from 3 to 5
* add `ddtrace_version` and `ddtrace_install` as metadata to run
* reduce `encoder-many-traces*` scenarios from 100 traces to 50 traces given time budget constraints
* add `scripts/perf-run-all-scenarios`