### PR TITLE
Do not set django.request resource if it was set by the user manually

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -303,9 +303,11 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
 
     trace_utils.activate_distributed_headers(pin.tracer, int_config=config.django, request_headers=request.META)
 
+    # DEV: Do not set `span.resource` here, leave it as `None`
+    #      until `_set_resolver_tags` so we can know if the user
+    #      has explicitly set it during the request lifetime
     with pin.tracer.trace(
         "django.request",
-        resource=request.method,
         service=trace_utils.int_service(pin, config.django),
         span_type=SpanTypes.WEB,
     ) as span:

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -303,11 +303,9 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
 
     trace_utils.activate_distributed_headers(pin.tracer, int_config=config.django, request_headers=request.META)
 
-    # DEV: Do not set `span.resource` here, leave it as `None`
-    #      until `_set_resolver_tags` so we can know if the user
-    #      has explicitly set it during the request lifetime
     with pin.tracer.trace(
         "django.request",
+        resource=utils.REQUEST_DEFAULT_RESOURCE,
         service=trace_utils.int_service(pin, config.django),
         span_type=SpanTypes.WEB,
     ) as span:

--- a/releasenotes/notes/fix-django-resource-override-135d9ad7a668a51d.yaml
+++ b/releasenotes/notes/fix-django-resource-override-135d9ad7a668a51d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue where a manually set ``django.request`` span resource would get
+    overwritten by the integration.

--- a/tests/contrib/django/django1_app/urls.py
+++ b/tests/contrib/django/django1_app/urls.py
@@ -27,4 +27,5 @@ urlpatterns = [
     url(r"^composed-template-view/$", views.ComposedTemplateView.as_view(), name="composed-template-view"),
     url(r"^composed-get-view/$", views.ComposedGetView.as_view(), name="composed-get-view"),
     url(r"^composed-view/$", views.ComposedView.as_view(), name="composed-view"),
+    url(r"^alter-resource/$", views.alter_resource, name="alter-resource"),
 ]

--- a/tests/contrib/django/django_app/urls.py
+++ b/tests/contrib/django/django_app/urls.py
@@ -68,4 +68,5 @@ urlpatterns = [
     url(r"^composed-view/$", views.ComposedView.as_view(), name="composed-view"),
     url(r"^404-view/$", views.not_found_view, name="404-view"),
     url(r"^shutdown-tracer/$", shutdown, name="shutdown-tracer"),
+    url(r"^alter-resource/$", views.alter_resource),
 ]

--- a/tests/contrib/django/views.py
+++ b/tests/contrib/django/views.py
@@ -15,6 +15,8 @@ from django.views.generic import ListView
 from django.views.generic import TemplateView
 from django.views.generic import View
 
+from ddtrace import tracer
+
 
 class UserList(ListView):
     model = User
@@ -93,6 +95,13 @@ def index(request):
     response = HttpResponse("Hello, test app.")
     response["my-response-header"] = "my_response_value"
     return response
+
+
+def alter_resource(request):
+    root = tracer.current_root_span()
+    root.resource = "custom django.request resource"
+
+    return HttpResponse("")
 
 
 def template_view(request):


### PR DESCRIPTION
Now that we are setting the `django.request` resource name at the end of the request rather than the beginning, if someone was manually setting the resource name we are overwriting it now.

This change makes is to we will check if the value has been overridden manually first before we set it.