### PR TITLE
fix(ci) Use pip install . for CI ccheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install --yes clang-format gcc-10 python3 python3-setuptools python3-pip
       - run: scripts/cformat.sh
-      - run: DD_COMPILE_DEBUG=1 CC=gcc-10 pip install .
+      - run: DD_COMPILE_DEBUG=1 CC=gcc-10 pip -vvv install .
 
   coverage_report:
     executor: python39


### PR DESCRIPTION
Due to https://github.com/pypa/setuptools_scm/issues/605
we are moving the `ccheck` job from `python3 setup.py build_ext` to `pip install .`