### PR TITLE
[ci-app] Add `AUTO_KEEP` to All `pytest` Test Spans

### DIFF
--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -115,6 +115,7 @@ def pytest_runtest_protocol(item, nextitem):
         span_type=SpanTypes.TEST.value,
     ) as span:
         span.context.dd_origin = ci.CI_APP_TEST_ORIGIN
+        span.context.sampling_priority = AUTO_KEEP
         span.set_tags(pin.tags)
         span.set_tag(SPAN_KIND, KIND)
         span.set_tag(test.FRAMEWORK, FRAMEWORK)

--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -13,6 +13,7 @@ from ddtrace.contrib.trace_utils import int_service
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import ci
 from ddtrace.ext import test
+from ddtrace.ext.priority import AUTO_KEEP
 from ddtrace.internal import compat
 from ddtrace.internal.logger import get_logger
 from ddtrace.pin import Pin

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -527,6 +527,22 @@ class TestPytest(TracerTestCase):
         assert len(spans) == 3
         for span in spans:
             assert span.get_tag(test.SUITE) == file_name.partition(".py")[0]
+    
+    def test_pytest_sets_sample_priority(self):
+        """Test sample priority tags."""
+        py_file = self.testdir.makepyfile(
+            """
+            def test_sample_priority():
+                assert True == True
+        """
+        )
+        file_name = os.path.basename(py_file.strpath)
+        rec = self.inline_run("--ddtrace", file_name)
+        rec.assertoutcome(passed=1)
+        spans = self.pop_spans()
+
+        assert len(spans) == 1
+        assert spans[0][b"meta"][b"sampling_priority"] == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -534,7 +534,7 @@ class TestPytest(TracerTestCase):
         py_file = self.testdir.makepyfile(
             """
             def test_sample_priority():
-                assert True == True
+                assert True is True
         """
         )
         file_name = os.path.basename(py_file.strpath)

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -6,6 +6,7 @@ import mock
 import pytest
 
 from ddtrace import Pin
+from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.contrib.pytest.plugin import _extract_repository_name
 from ddtrace.ext import ci
 from ddtrace.ext import test
@@ -542,7 +543,7 @@ class TestPytest(TracerTestCase):
         spans = self.pop_spans()
 
         assert len(spans) == 1
-        assert spans[0][b"meta"][b"sampling_priority"] == 1
+        assert spans[0].get_metric(SAMPLING_PRIORITY_KEY) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -527,7 +527,7 @@ class TestPytest(TracerTestCase):
         assert len(spans) == 3
         for span in spans:
             assert span.get_tag(test.SUITE) == file_name.partition(".py")[0]
-    
+
     def test_pytest_sets_sample_priority(self):
         """Test sample priority tags."""
         py_file = self.testdir.makepyfile(


### PR DESCRIPTION
## Description
* Set `AUTO_KEEP` to span priority for `pytest` test spans. 

This way we make sure that the agent does not drop *any* test span, which is the intended behavior.

## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
