### PR TITLE
[ci-app] Pytest – Fix Exception Information

### DIFF
--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -193,7 +193,11 @@ def pytest_runtest_makereport(item, call):
                 # XPass (strict=True) are recorded failed by pytest, longrepr contains reason
                 span.set_tag(test.XFAIL_REASON, result.longrepr)
                 span.set_tag(test.RESULT, test.Status.XPASS.value)
-            raise RuntimeWarning(result)
+            if call.excinfo:
+                span.set_exc_info(call.excinfo.type, call.excinfo.value, call.excinfo.tb)
+                span.set_traceback()
+            span.set_tag(test.STATUS, test.Status.FAIL.value)
+
     except Exception:
         span.set_traceback()
         span.set_tag(test.STATUS, test.Status.FAIL.value)

--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -166,38 +166,32 @@ def pytest_runtest_makereport(item, call):
     if not called_without_status and not failed_setup:
         return
 
-    try:
-        result = outcome.get_result()
-        xfail = hasattr(result, "wasxfail") or "xfail" in result.keywords
-        has_skip_keyword = any(x in result.keywords for x in ["skip", "skipif", "skipped"])
+    result = outcome.get_result()
+    xfail = hasattr(result, "wasxfail") or "xfail" in result.keywords
+    has_skip_keyword = any(x in result.keywords for x in ["skip", "skipif", "skipped"])
 
-        if result.skipped:
-            if xfail and not has_skip_keyword:
-                # XFail tests that fail are recorded skipped by pytest, should be passed instead
-                span.set_tag(test.RESULT, test.Status.XFAIL.value)
-                span.set_tag(test.XFAIL_REASON, result.wasxfail)
-                span.set_tag(test.STATUS, test.Status.PASS.value)
-            else:
-                span.set_tag(test.STATUS, test.Status.SKIP.value)
-            reason = _extract_reason(call)
-            if reason is not None:
-                span.set_tag(test.SKIP_REASON, reason)
-        elif result.passed:
+    if result.skipped:
+        if xfail and not has_skip_keyword:
+            # XFail tests that fail are recorded skipped by pytest, should be passed instead
+            span.set_tag(test.RESULT, test.Status.XFAIL.value)
+            span.set_tag(test.XFAIL_REASON, result.wasxfail)
             span.set_tag(test.STATUS, test.Status.PASS.value)
-            if xfail and not has_skip_keyword:
-                # XPass (strict=False) are recorded passed by pytest
-                span.set_tag(test.XFAIL_REASON, getattr(result, "wasxfail", "XFail"))
-                span.set_tag(test.RESULT, test.Status.XPASS.value)
         else:
-            if xfail and not has_skip_keyword:
-                # XPass (strict=True) are recorded failed by pytest, longrepr contains reason
-                span.set_tag(test.XFAIL_REASON, result.longrepr)
-                span.set_tag(test.RESULT, test.Status.XPASS.value)
-            if call.excinfo:
-                span.set_exc_info(call.excinfo.type, call.excinfo.value, call.excinfo.tb)
-                span.set_traceback()
-            span.set_tag(test.STATUS, test.Status.FAIL.value)
-
-    except Exception:
-        span.set_traceback()
+            span.set_tag(test.STATUS, test.Status.SKIP.value)
+        reason = _extract_reason(call)
+        if reason is not None:
+            span.set_tag(test.SKIP_REASON, reason)
+    elif result.passed:
+        span.set_tag(test.STATUS, test.Status.PASS.value)
+        if xfail and not has_skip_keyword:
+            # XPass (strict=False) are recorded passed by pytest
+            span.set_tag(test.XFAIL_REASON, getattr(result, "wasxfail", "XFail"))
+            span.set_tag(test.RESULT, test.Status.XPASS.value)
+    else:
+        if xfail and not has_skip_keyword:
+            # XPass (strict=True) are recorded failed by pytest, longrepr contains reason
+            span.set_tag(test.XFAIL_REASON, result.longrepr)
+            span.set_tag(test.RESULT, test.Status.XPASS.value)
         span.set_tag(test.STATUS, test.Status.FAIL.value)
+        if call.excinfo:
+            span.set_exc_info(call.excinfo.type, call.excinfo.value, call.excinfo.tb)

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -559,7 +559,7 @@ class TestPytest(TracerTestCase):
         )
         file_name = os.path.basename(py_file.strpath)
         rec = self.inline_run("--ddtrace", "--doctest-modules", file_name)
-        rec.assertoutcome(passed=3)
+        rec.assertoutcome(passed=1)
         spans = self.pop_spans()
 
         assert len(spans) == 1

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -558,10 +558,11 @@ class TestPytest(TracerTestCase):
         spans = self.pop_spans()
 
         assert len(spans) == 1
-        assert spans[0].get_tag(test.STATUS) == test.Status.FAIL.value
-        assert spans[0].get_tag("error.type") == "builtins.AssertionError"
-        assert spans[0].get_tag("error.msg") == "assert 2 == 1"
-        assert spans[0].get_tag("error.stack") is not None
+        test_span = spans[0]
+        assert test_span.get_tag(test.STATUS) == test.Status.FAIL.value
+        assert test_span.get_tag("error.type") == "exceptions.AssertionError"
+        assert test_span.get_tag("error.msg") == "assert 2 == 1"
+        assert test_span.get_tag("error.stack") is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -563,8 +563,8 @@ class TestPytest(TracerTestCase):
 
         assert len(spans) == 1
         assert spans[0].get_tag(test.STATUS) == test.Status.FAIL.value
-        assert spans[0].get_tag("error.type") == "AttributeError"
-        assert spans[0].get_tag("error.message") == "AttributeError: 'my_dict' object has no attribute 'value'"
+        assert spans[0].get_tag("error.type") == "builtins.AttributeError"
+        assert spans[0].get_tag("error.msg") == "'dict' object has no attribute 'value'"
         assert spans[0].get_tag("error.stack") is not None
 
 

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -549,11 +549,8 @@ class TestPytest(TracerTestCase):
         """Test that pytest sets exception information correctly."""
         py_file = self.testdir.makepyfile(
             """
-        def will_throw():
-            return 3/0
-
-        def test_will_throw():
-            assert will_throw() == 1
+        def test_will_fail():
+            assert 2 == 1
         """
         )
         file_name = os.path.basename(py_file.strpath)
@@ -562,8 +559,8 @@ class TestPytest(TracerTestCase):
 
         assert len(spans) == 1
         assert spans[0].get_tag(test.STATUS) == test.Status.FAIL.value
-        assert spans[0].get_tag("error.type") == "builtins.ZeroDivisionError"
-        assert spans[0].get_tag("error.msg") == "division by zero"
+        assert spans[0].get_tag("error.type") == "builtins.AssertionError"
+        assert spans[0].get_tag("error.msg") == "assert 2 == 1"
         assert spans[0].get_tag("error.stack") is not None
 
 

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -550,8 +550,7 @@ class TestPytest(TracerTestCase):
         py_file = self.testdir.makepyfile(
             """
         def will_throw():
-            my_dict = dict()
-            return my_dict.value.not_there
+            return 3/0
 
         def test_will_throw():
             assert will_throw() == 1
@@ -563,8 +562,8 @@ class TestPytest(TracerTestCase):
 
         assert len(spans) == 1
         assert spans[0].get_tag(test.STATUS) == test.Status.FAIL.value
-        assert spans[0].get_tag("error.type") == "builtins.AttributeError"
-        assert spans[0].get_tag("error.msg") == "'dict' object has no attribute 'value'"
+        assert spans[0].get_tag("error.type") == "builtins.ZeroDivisionError"
+        assert spans[0].get_tag("error.msg") == "division by zero"
         assert spans[0].get_tag("error.stack") is not None
 
 

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -558,8 +558,7 @@ class TestPytest(TracerTestCase):
         """
         )
         file_name = os.path.basename(py_file.strpath)
-        rec = self.inline_run("--ddtrace", "--doctest-modules", file_name)
-        rec.assertoutcome(passed=1)
+        self.inline_run("--ddtrace", file_name)
         spans = self.pop_spans()
 
         assert len(spans) == 1

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -560,7 +560,7 @@ class TestPytest(TracerTestCase):
         assert len(spans) == 1
         test_span = spans[0]
         assert test_span.get_tag(test.STATUS) == test.Status.FAIL.value
-        assert test_span.get_tag("error.type") == "exceptions.AssertionError"
+        assert test_span.get_tag("error.type").endswith("AssertionError") is True
         assert test_span.get_tag("error.msg") == "assert 2 == 1"
         assert test_span.get_tag("error.stack") is not None
 


### PR DESCRIPTION
## Description
We were setting the pytest error as error tag, which made it hard to debug the actual error: 

Before:

<img width="1170" alt="Screenshot 2021-08-30 at 13 23 19" src="https://user-images.githubusercontent.com/22798219/131331999-623cbc72-32cc-4db9-b016-9707d188266c.png">

After:
<img width="1191" alt="Screenshot 2021-08-30 at 13 23 26" src="https://user-images.githubusercontent.com/22798219/131332014-ef417725-2230-4144-9d0a-95e522b81c93.png">



## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
