### PR TITLE
internal: Move common helper to _utils.h

### DIFF
--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -3,6 +3,7 @@ from cpython.bytearray cimport PyByteArray_Check
 from libc cimport stdint
 from libc.string cimport strlen
 import threading
+from ._utils cimport PyBytesLike_Check
 
 
 DEF MSGPACK_ARRAY_LENGTH_PREFIX_SIZE = 5
@@ -38,10 +39,6 @@ class BufferFull(Exception):
 
 class BufferItemTooLarge(Exception):
     pass
-
-
-cdef inline int PyBytesLike_Check(object o):
-    return PyBytes_Check(o) or PyByteArray_Check(o)
 
 
 cdef inline int array_prefix_size(int l):

--- a/ddtrace/internal/_utils.h
+++ b/ddtrace/internal/_utils.h
@@ -1,0 +1,6 @@
+#include <string.h>
+
+// Determine if the provided object can be treated as a `bytes`
+static inline int PyBytesLike_Check(PyObject* o) {
+  return PyBytes_Check(o) || PyByteArray_Check(o);
+}

--- a/ddtrace/internal/_utils.pxd
+++ b/ddtrace/internal/_utils.pxd
@@ -1,0 +1,2 @@
+cdef extern from "_utils.h":
+    cdef inline int PyBytesLike_Check(object o)


### PR DESCRIPTION
## Description
Start to collect some common C helpers into `ddtrace/internal/_utils.h` to be shared by all Cython/C modules.