### PR TITLE
internal: Add _DD_CYTHON_ANNOTATE=1 to configure Cython annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ ddtrace/internal/_encoding.c
 ddtrace/internal/_rand.c
 *.so
 
+# Cython annotate HTML files
+ddtrace/**/*.html
+
 # Distribution / packaging
 .Python
 env/

--- a/setup.py
+++ b/setup.py
@@ -216,13 +216,6 @@ setup(
                 include_dirs=["."],
                 libraries=encoding_libraries,
                 define_macros=encoding_macros,
-                language="c++",
-            ),
-            Cython.Distutils.Extension(
-                "ddtrace.internal._span",
-                ["ddtrace/internal/_span.pyx"],
-                include_dirs=["."],
-                language="c++",
             ),
             Cython.Distutils.Extension(
                 "ddtrace.profiling.collector.stack",

--- a/setup.py
+++ b/setup.py
@@ -216,6 +216,13 @@ setup(
                 include_dirs=["."],
                 libraries=encoding_libraries,
                 define_macros=encoding_macros,
+                language="c++",
+            ),
+            Cython.Distutils.Extension(
+                "ddtrace.internal._span",
+                ["ddtrace/internal/_span.pyx"],
+                include_dirs=["."],
+                language="c++",
             ),
             Cython.Distutils.Extension(
                 "ddtrace.profiling.collector.stack",
@@ -255,6 +262,7 @@ setup(
             "PY_MICRO_VERSION": sys.version_info.micro,
         },
         force=True,
+        annotate=os.getenv("CYTHON_ANNOTATE") == "1",
     )
     + get_exts_for("wrapt")
     + get_exts_for("psutil"),

--- a/setup.py
+++ b/setup.py
@@ -255,7 +255,7 @@ setup(
             "PY_MICRO_VERSION": sys.version_info.micro,
         },
         force=True,
-        annotate=os.getenv("CYTHON_ANNOTATE") == "1",
+        annotate=os.getenv("_DD_CYTHON_ANNOTATE") == "1",
     )
     + get_exts_for("wrapt")
     + get_exts_for("psutil"),


### PR DESCRIPTION
Adds an environment variable to enable Cython annotations.

https://docs.cython.org/en/stable/src/userguide/source_files_and_compilation.html?highlight=annotate#Cython.Compiler.Options.annotate
https://docs.cython.org/en/stable/src/userguide/source_files_and_compilation.html#cythonize-arguments

```
_DD_CYTHON_ANNOTATE=1 pip install -e .
```