### PR TITLE
test: add pytest-mock to default packages for riot

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -76,6 +76,7 @@ venv = Venv(
     pkgs={
         "mock": latest,
         "pytest": latest,
+        "pytest-mock": latest,
         "coverage": latest,
         "pytest-cov": latest,
         "opentracing": latest,


### PR DESCRIPTION
## Description
This is a package we currently install by default in `tox`, would be nice to also make available to `riot` venvs.


`pytest-mock`'s biggest benefit is adding `mocker` fixture for pytest functions which will auto-cleanup/reset any mocking at the end of the test execution.
