### PR TITLE
internal: Define return type on pack_span method

### DIFF
--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -261,7 +261,7 @@ cdef class MsgpackEncoderBase(BufferedEncoder):
     cpdef flush(self):
         raise NotImplementedError()
 
-    cdef pack_span(self, object span, char *dd_origin):
+    cdef int pack_span(self, object span, char *dd_origin):
         raise NotImplementedError()
 
 
@@ -322,7 +322,7 @@ cdef class MsgpackEncoder(MsgpackEncoderBase):
 
         raise TypeError("Unhandled metrics type: %r" % type(metrics))
 
-    cdef pack_span(self, object span, char *dd_origin):
+    cdef int pack_span(self, object span, char *dd_origin):
         cdef int ret
         cdef Py_ssize_t L
         cdef int has_span_type


### PR DESCRIPTION
Define the return type of `cdef pack_span` to avoid converting `cdef int ret` to and from `PyObject*`.

This didn't have as big of a performance change as I expected, but the change to the CPython calls in `pack_span` is improved.

<details>
<summary><b>Before</b></summary>
<img width="545" alt="image" src="https://user-images.githubusercontent.com/1320353/132040655-956a5fa3-4ca1-4137-bcb8-bdac2c471e74.png">
</details>

<details>
<summary><b>After</b></summary>
<img width="635" alt="image" src="https://user-images.githubusercontent.com/1320353/132040768-6f64af66-db28-42b0-a2fd-1e6e3dbc11df.png">
</details>