### PR TITLE
perf: optimize meta/metrics dict iteration

### DIFF
--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -276,10 +276,11 @@ cdef class MsgpackEncoder(MsgpackEncoderBase):
         cdef Py_ssize_t L
         cdef int ret
         cdef dict d
+        cdef object k
 
         if PyDict_CheckExact(meta):
             d = <dict> meta
-            L = len(d)
+            L = PyDict_Size(d)
             if dd_origin is not NULL:
                 L += 1
             if L > ITEM_LIMIT:
@@ -287,10 +288,10 @@ cdef class MsgpackEncoder(MsgpackEncoderBase):
 
             ret = msgpack_pack_map(&self.pk, L)
             if ret == 0:
-                for k, v in d.items():
+                for k in d:
                     ret = pack_text(&self.pk, k)
                     if ret != 0: break
-                    ret = pack_text(&self.pk, v)
+                    ret = pack_text(&self.pk, d[k])
                     if ret != 0: break
                 if dd_origin is not NULL:
                     ret = pack_bytes(&self.pk, <char *> b"_dd.origin", 10)
@@ -304,19 +305,20 @@ cdef class MsgpackEncoder(MsgpackEncoderBase):
         cdef Py_ssize_t L
         cdef int ret
         cdef dict d
+        cdef object k
 
         if PyDict_CheckExact(metrics):
             d = <dict> metrics
-            L = len(d)
+            L = PyDict_Size(d)
             if L > ITEM_LIMIT:
                 raise ValueError("dict is too large")
 
             ret = msgpack_pack_map(&self.pk, L)
             if ret == 0:
-                for k, v in d.items():
+                for k in d:
                     ret = pack_text(&self.pk, k)
                     if ret != 0: break
-                    ret = pack_number(&self.pk, v)
+                    ret = pack_number(&self.pk, d[k])
                     if ret != 0: break
             return ret
 


### PR DESCRIPTION
- Directly call `PyDict_Size(d)` to avoid a Cython None check on `d`
- Use `for k in d: v = d[k]` for more consistent/optimized dictionary iteration

Since the default language level used by Cython is Python 2, Python 2 compatible code transformations are used. One of such is how `dict().items()` is handled.

With Python 3 `PyDict_Next` iterator us used, compared with Python 2 where `dict().items()` is converted to a List and then iterated over with tuple unpacking, etc.

However, the code generated is the same for `for k in d; v = d[k]` which will use `PyDict_Next`. We do need to use an additional `PyDict_GetItem` to get the value, but definitely better than previously generated code.

You can see the results of the code being generated in this notebook: https://gist.github.com/brettlangdon/dee46d4421f55f2c79dad3383d498aaa


These are the performance results from running locally.

| Benchmark          | ddtrace@master | ddtrace@brettlangdon/encoding.dict |
|--------------------|------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
| encoder-one-trace  | 69.7 us                                                                                        | 64.5 us: 1.08x faster                                                                          |
| encoder-one-tag    | 74.7 us                                                                                        | 69.4 us: 1.08x faster                                                                          |
| encoder-many-tags  | 558 us                                                                                         | 663 us: 1.19x slower                                                                           |
| encoder-one-metric | 89.6 us                                                                                        | 78.5 us: 1.14x faster                                                                          |
| Geometric mean     | (ref)                                                                                          | 1.01x faster                                                                                   |
