### PR TITLE
[ci-app] Pytest – Fix Potentially Missing `test.status`

### DIFF
--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -165,15 +165,15 @@ def pytest_runtest_makereport(item, call):
     if span is None:
         return
 
-    result = outcome.get_result()
-    xfail = hasattr(result, "wasxfail") or "xfail" in result.keywords
-    has_skip_keyword = any(x in result.keywords for x in ["skip", "skipif", "skipped"])
-
     is_setup_or_teardown = call.when == "setup" or call.when == "teardown"
     has_exception = call.excinfo is not None
 
     if is_setup_or_teardown and not has_exception:
         return
+
+    result = outcome.get_result()
+    xfail = hasattr(result, "wasxfail") or "xfail" in result.keywords
+    has_skip_keyword = any(x in result.keywords for x in ["skip", "skipif", "skipped"])
 
     if result.skipped:
         if xfail and not has_skip_keyword:

--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -169,6 +169,12 @@ def pytest_runtest_makereport(item, call):
     xfail = hasattr(result, "wasxfail") or "xfail" in result.keywords
     has_skip_keyword = any(x in result.keywords for x in ["skip", "skipif", "skipped"])
 
+    is_setup_or_teardown = call.when == "setup" or call.when == "teardown"
+    has_exception = call.excinfo is not None
+
+    if is_setup_or_teardown and not has_exception:
+        return
+
     if result.skipped:
         if xfail and not has_skip_keyword:
             # XFail tests that fail are recorded skipped by pytest, should be passed instead

--- a/releasenotes/notes/fix-pytest-test-status-dcdef93ac5b988d7.yaml
+++ b/releasenotes/notes/fix-pytest-test-status-dcdef93ac5b988d7.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fixes cases in which the test status tag of a test span in `pytest` would be missing
-    because `pytest_runtest_makereport` hook is not run, like when `pytest` has an internal error.
+    Fixes cases in which the ``test.status`` tag of a test span from ``pytest`` would be missing
+    because ``pytest_runtest_makereport`` hook is not run, like when ``pytest`` has an internal error.

--- a/releasenotes/notes/fix-pytest-test-status-dcdef93ac5b988d7.yaml
+++ b/releasenotes/notes/fix-pytest-test-status-dcdef93ac5b988d7.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes cases in which the test status tag of a test span in `pytest` would be missing
+    because `pytest_runtest_makereport` hook is not run, like when `pytest` has an internal error.

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -564,6 +564,80 @@ class TestPytest(TracerTestCase):
         assert test_span.get_tag("error.msg") == "assert 2 == 1"
         assert test_span.get_tag("error.stack") is not None
 
+    def test_pytest_tests_with_internal_exceptions_get_test_status(self):
+        """Test that pytest sets a fail test status if it has an internal exception."""
+        py_file = self.testdir.makepyfile(
+            """
+        import pytest
+
+        # This is bad usage and results in a pytest internal exception
+        @pytest.mark.filterwarnings("ignore::pytest.ExceptionThatDoesNotExist")
+        def test_will_fail_internally():
+            assert 2 == 2
+        """
+        )
+        file_name = os.path.basename(py_file.strpath)
+        self.inline_run("--ddtrace", file_name)
+        spans = self.pop_spans()
+
+        assert len(spans) == 1
+        test_span = spans[0]
+        assert test_span.get_tag(test.STATUS) == test.Status.FAIL.value
+
+    def test_pytest_broken_setup_will_be_reported_as_error(self):
+        """Test that pytest sets a fail test status if the setup fails."""
+        py_file = self.testdir.makepyfile(
+            """
+        import pytest
+
+        @pytest.fixture
+        def my_fixture():
+            raise Exception('will fail in setup')
+            yield
+
+        def test_will_fail_in_setup(my_fixture):
+            assert 1 == 1
+        """
+        )
+        file_name = os.path.basename(py_file.strpath)
+        self.inline_run("--ddtrace", file_name)
+        spans = self.pop_spans()
+
+        assert len(spans) == 1
+        test_span = spans[0]
+
+        assert test_span.get_tag(test.STATUS) == test.Status.FAIL.value
+        assert test_span.get_tag("error.type").endswith("Exception") is True
+        assert test_span.get_tag("error.msg") == "will fail in setup"
+        assert test_span.get_tag("error.stack") is not None
+
+    def test_pytest_broken_teardown_will_be_reported_as_error(self):
+        """Test that pytest sets a fail test status if the teardown fails."""
+        py_file = self.testdir.makepyfile(
+            """
+        import pytest
+
+        @pytest.fixture
+        def my_fixture():
+            yield
+            raise Exception('will fail in teardown')
+
+        def test_will_fail_in_teardown(my_fixture):
+            assert 1 == 1
+        """
+        )
+        file_name = os.path.basename(py_file.strpath)
+        self.inline_run("--ddtrace", file_name)
+        spans = self.pop_spans()
+
+        assert len(spans) == 1
+        test_span = spans[0]
+
+        assert test_span.get_tag(test.STATUS) == test.Status.FAIL.value
+        assert test_span.get_tag("error.type").endswith("Exception") is True
+        assert test_span.get_tag("error.msg") == "will fail in teardown"
+        assert test_span.get_tag("error.stack") is not None
+
 
 @pytest.mark.parametrize(
     "repository_url,repository_name",

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -583,6 +583,7 @@ class TestPytest(TracerTestCase):
         assert len(spans) == 1
         test_span = spans[0]
         assert test_span.get_tag(test.STATUS) == test.Status.FAIL.value
+        assert test_span.get_tag("error.type") is None
 
     def test_pytest_broken_setup_will_be_reported_as_error(self):
         """Test that pytest sets a fail test status if the setup fails."""


### PR DESCRIPTION
## Description
When there's a `pytest` internal error, `pytest_runtest_makereport` is not called, so we never set the `test.status`. By preemptively setting a failed test status we make sure that if a test fails because of an internal error, we do set `test.status`. 

## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
