### PR TITLE
Delay capturing resource name until profile is sent

### DIFF
--- a/ddtrace/profiling/event.py
+++ b/ddtrace/profiling/event.py
@@ -45,28 +45,10 @@ class StackBasedEvent(SampleEvent):
     task_name = attr.ib(default=None)
     frames = attr.ib(default=None)
     nframes = attr.ib(default=None)
-    trace_id = attr.ib(default=None, type=typing.Optional[int])
-    span_id = attr.ib(default=None, type=typing.Optional[int])
-    trace_type = attr.ib(default=None, type=typing.Optional[str])
-    trace_resource = attr.ib(default=None, type=typing.Optional[str])
+    span = attr.ib(default=None, type=typing.Optional[ddspan.Span])
 
     def set_trace_info(
         self,
         span,  # type: typing.Optional[ddspan.Span]
     ):
-        # type: (...) -> None
-        if span is not None:
-            self.trace_id = span.trace_id
-            self.span_id = span.span_id
-            if span._local_root is not None:
-                self.trace_resource = span._local_root.resource
-                self.trace_type = span._local_root.span_type
-            span._on_finish_callbacks.append(self._update_trace_resource)
-
-    def _update_trace_resource(
-        self,
-        span,  # type: ddspan.Span
-    ):
-        # type: (...) -> None
-        if span._local_root is not None:
-            self.trace_resource = span._local_root.resource
+        self.span = span

--- a/releasenotes/notes/profiling-resource-name-fix-5f73526a307e8b40.yaml
+++ b/releasenotes/notes/profiling-resource-name-fix-5f73526a307e8b40.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Make sure that correct endpoint name collected for profiling.

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -354,8 +354,7 @@ def test_exception_collection_trace(tracer):
     assert e.frames == [(__file__, 345, "test_exception_collection_trace")]
     assert e.nframes == 1
     assert e.exc_type == ValueError
-    assert e.span_id == span.span_id
-    assert e.trace_id == span.trace_id
+    assert e.span == span
 
 
 @pytest.fixture
@@ -455,9 +454,7 @@ def test_collect_span_id(tracer_and_collector):
         except IndexError:
             # No event left or no event yet
             continue
-        if span.trace_id == event.trace_id and span.span_id == event.span_id:
-            assert event.trace_resource == resource
-            assert event.trace_type == span_type
+        if event.span == span:
             break
 
 
@@ -473,13 +470,13 @@ def test_collect_span_resource_after_finish(tracer_and_collector):
         except IndexError:
             # No event left or no event yet
             continue
-        if span.trace_id == event.trace_id and span.span_id == event.span_id:
-            assert event.trace_resource == "foobar"
-            assert event.trace_type == span_type
+        if event.span is not None and span.trace_id == event.span.trace_id and span.span_id == event.span.span_id:
+            assert event.span.resource == "foobar"
+            assert event.span.span_type == span_type
             break
     span.resource = resource
     span.finish()
-    assert event.trace_resource == resource
+    assert event.span.resource == resource
 
 
 def test_collect_multiple_span_id(tracer_and_collector):
@@ -495,9 +492,9 @@ def test_collect_multiple_span_id(tracer_and_collector):
         except IndexError:
             # No event left or no event yet
             continue
-        if child.trace_id == event.trace_id and child.span_id == event.span_id:
-            assert event.trace_resource == resource
-            assert event.trace_type == span_type
+        if event.span is not None and child.trace_id == event.span.trace_id and child.span_id == event.span.span_id:
+            assert event.span._local_root.resource == resource
+            assert event.span._local_root.span_type == span_type
             break
 
 

--- a/tests/profiling/exporter/test-pprof-exporter-py2.txt
+++ b/tests/profiling/exporter/test-pprof-exporter-py2.txt
@@ -272,6 +272,12 @@ sample {
     key: 29
   }
   label {
+    key: 30
+  }
+  label {
+    key: 31
+  }
+  label {
     key: 46
     str: 47
   }
@@ -308,6 +314,12 @@ sample {
   }
   label {
     key: 29
+  }
+  label {
+    key: 30
+  }
+  label {
+    key: 31
   }
   label {
     key: 46
@@ -445,6 +457,12 @@ sample {
     key: 29
   }
   label {
+    key: 30
+  }
+  label {
+    key: 31
+  }
+  label {
     key: 46
     str: 48
   }
@@ -575,6 +593,12 @@ sample {
   }
   label {
     key: 29
+  }
+  label {
+    key: 30
+  }
+  label {
+    key: 31
   }
   label {
     key: 46
@@ -710,6 +734,12 @@ sample {
     key: 29
   }
   label {
+    key: 30
+  }
+  label {
+    key: 31
+  }
+  label {
     key: 46
     str: 48
   }
@@ -791,9 +821,11 @@ sample {
   }
   label {
     key: 28
+    str: 36
   }
   label {
     key: 29
+    str: 37
   }
   label {
     key: 30
@@ -888,6 +920,12 @@ sample {
   }
   label {
     key: 29
+  }
+  label {
+    key: 30
+  }
+  label {
+    key: 31
   }
   label {
     key: 46
@@ -1020,6 +1058,12 @@ sample {
   label {
     key: 29
     str: 53
+  }
+  label {
+    key: 30
+  }
+  label {
+    key: 31
   }
   label {
     key: 46

--- a/tests/profiling/exporter/test-pprof-exporter.txt
+++ b/tests/profiling/exporter/test-pprof-exporter.txt
@@ -300,6 +300,12 @@ sample {
     key: 29
   }
   label {
+    key: 30
+  }
+  label {
+    key: 31
+  }
+  label {
     key: 46
     str: 47
   }
@@ -336,6 +342,12 @@ sample {
   }
   label {
     key: 29
+  }
+  label {
+    key: 30
+  }
+  label {
+    key: 31
   }
   label {
     key: 46
@@ -502,6 +514,12 @@ sample {
     key: 29
   }
   label {
+    key: 30
+  }
+  label {
+    key: 31
+  }
+  label {
     key: 46
     str: 48
   }
@@ -660,6 +678,12 @@ sample {
   }
   label {
     key: 29
+  }
+  label {
+    key: 30
+  }
+  label {
+    key: 31
   }
   label {
     key: 46
@@ -824,6 +848,12 @@ sample {
     key: 29
   }
   label {
+    key: 30
+  }
+  label {
+    key: 31
+  }
+  label {
     key: 46
     str: 48
   }
@@ -905,9 +935,11 @@ sample {
   }
   label {
     key: 28
+    str: 36
   }
   label {
     key: 29
+    str: 37
   }
   label {
     key: 30
@@ -1030,6 +1062,12 @@ sample {
   }
   label {
     key: 29
+  }
+  label {
+    key: 30
+  }
+  label {
+    key: 31
   }
   label {
     key: 46
@@ -1190,6 +1228,12 @@ sample {
   label {
     key: 29
     str: 53
+  }
+  label {
+    key: 30
+  }
+  label {
+    key: 31
   }
   label {
     key: 46

--- a/tests/profiling/exporter/test_pprof.py
+++ b/tests/profiling/exporter/test_pprof.py
@@ -4,10 +4,17 @@ import mock
 import six
 
 from ddtrace import ext
+from ddtrace import span as ddspan
 from ddtrace.profiling.collector import memalloc
 from ddtrace.profiling.collector import stack
 from ddtrace.profiling.collector import threading
 from ddtrace.profiling.exporter import pprof
+
+
+def create_span(**kwargs):
+    span = ddspan.Span(None, None, **kwargs)
+    span._local_root = span
+    return span
 
 
 TEST_EVENTS = {
@@ -100,8 +107,10 @@ TEST_EVENTS = {
             timestamp=7,
             thread_id=67892304,
             thread_native_id=123987,
-            trace_id=1322219321,
-            span_id=1322219,
+            span=create_span(
+                trace_id=1322219321,
+                span_id=1322219,
+            ),
             thread_name="MainThread",
             frames=[
                 ("foobar.py", 23, "func1"),
@@ -179,13 +188,15 @@ TEST_EVENTS = {
             thread_id=67892304,
             thread_native_id=123987,
             thread_name="MainThread",
-            trace_id=1322219321,
+            span=create_span(
+                trace_id=1322219321,
+                span_id=49393,
+            ),
             frames=[
                 ("foobar.py", 23, "func1"),
                 ("foobar.py", 44, "func2"),
                 ("foobar2.py", 19, "func5"),
             ],
-            span_id=49393,
             size=68,
             capture_pct=50,
             nframes=3,
@@ -284,7 +295,9 @@ TEST_EVENTS = {
             thread_id=67892304,
             thread_native_id=123987,
             thread_name="MainThread",
-            trace_id=1322219321,
+            span=create_span(
+                trace_id=1322219321,
+            ),
             frames=[
                 ("foobar.py", 23, "func1"),
                 ("foobar.py", 44, "func2"),
@@ -329,9 +342,12 @@ TEST_EVENTS = {
             thread_id=67892304,
             thread_native_id=123987,
             thread_name="MainThread",
-            trace_id=1322219321,
-            trace_resource="myresource",
-            trace_type=ext.SpanTypes.WEB.value,
+            span=create_span(
+                trace_id=1322219321,
+                span_id=49343,
+                resource="myresource",
+                span_type=ext.SpanTypes.WEB.value,
+            ),
             frames=[
                 ("foobar.py", 23, "func1"),
                 ("foobar.py", 44, "func2"),
@@ -339,7 +355,6 @@ TEST_EVENTS = {
             ],
             task_id=123,
             task_name="sometask",
-            span_id=49343,
             wall_time_ns=1324,
             cpu_time_ns=1321,
             sampling_period=1000000,
@@ -350,15 +365,17 @@ TEST_EVENTS = {
             thread_id=67892304,
             thread_native_id=123987,
             thread_name="MainThread",
-            trace_id=1322219321,
-            trace_resource="notme",
-            trace_type="sql",
+            span=create_span(
+                trace_id=1322219321,
+                span_id=24930,
+                resource="notme",
+                span_type="sql",
+            ),
             frames=[
                 ("foobar.py", 23, "func1"),
                 ("foobar.py", 44, "func2"),
                 ("foobar.py", 20, "func5"),
             ],
-            span_id=24930,
             wall_time_ns=13244,
             cpu_time_ns=1312,
             sampling_period=1000000,
@@ -369,13 +386,15 @@ TEST_EVENTS = {
             thread_id=67892304,
             thread_native_id=123987,
             thread_name="MainThread",
-            trace_id=1322219321,
+            span=create_span(
+                trace_id=1322219321,
+                span_id=24930,
+            ),
             frames=[
                 ("foobar.py", 23, "func1"),
                 ("foobar.py", 44, "func2"),
                 ("foobar.py", 19, "func5"),
             ],
-            span_id=24930,
             wall_time_ns=1324,
             cpu_time_ns=29121,
             sampling_period=1000000,
@@ -401,13 +420,15 @@ TEST_EVENTS = {
             thread_id=67892304,
             thread_native_id=123987,
             thread_name="MainThread",
-            trace_id=1322219321,
+            span=create_span(
+                trace_id=1322219321,
+                span_id=249304,
+            ),
             frames=[
                 ("foobar.py", 23, "func1"),
                 ("foobar.py", 44, "func2"),
                 ("foobar2.py", 19, "func5"),
             ],
-            span_id=249304,
             wall_time_ns=132444,
             cpu_time_ns=9042,
             sampling_period=1000000,
@@ -457,10 +478,12 @@ TEST_EVENTS = {
             ],
             task_id=12234,
             task_name="mytask",
-            trace_id=23435,
-            span_id=345432,
-            trace_resource="myresource",
-            trace_type=ext.SpanTypes.WEB.value,
+            span=create_span(
+                trace_id=23435,
+                span_id=345432,
+                resource="myresource",
+                span_type=ext.SpanTypes.WEB.value,
+            ),
             nframes=3,
             wait_time_ns=74839,
             sampling_pct=10,
@@ -470,8 +493,12 @@ TEST_EVENTS = {
             timestamp=2,
             thread_id=67892304,
             thread_name="MainThread",
-            trace_resource="notme",
-            trace_type="sql",
+            span=create_span(
+                trace_id=23435,
+                span_id=345432,
+                resource="notme",
+                span_type="sql",
+            ),
             frames=[
                 ("foobar.py", 23, "func1"),
                 ("foobar.py", 44, "func2"),


### PR DESCRIPTION
## Description
<!-- Please briefly describe the change and why it was required. -->

Make sure that correct endpoint name collected for profiling.
This means that we collect endpoint name when we generate pprof.


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
