### PR TITLE
fix(ci) for packages that use setuptools `use_2to3`

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -272,7 +272,9 @@ venv = Venv(
             venvs=[
                 # Non-4.x celery should be able to use the older redis lib, since it locks to an older kombu
                 Venv(
-                    pys=select_pys(max_version="3.6"),
+                    # Use <=3.5 to avoid setuptools >=58 which removed `use_2to3` which is needed by celery<4
+                    # https://github.com/pypa/setuptools/issues/2086
+                    pys=select_pys(max_version="3.5"),
                     pkgs={
                         "celery": "~=3.0",  # most recent 3.x.x release
                         "redis": "~=2.10.6",
@@ -892,10 +894,12 @@ venv = Venv(
             },
             venvs=[
                 Venv(
-                    pys=select_pys(),
+                    # Use <=3.5 to avoid setuptools >=58 which dropped `use_2to3` which is needed by mongoengine<0.20
+                    # https://github.com/pypa/setuptools/issues/2086
+                    pys=select_pys(max_version="3.5"),
                     pkgs={
                         # 0.20 dropped support for Python 2.7
-                        "mongoengine": [">=0.15,<0.16", ">=0.16,<0.17", ">=0.17,<0.18", ">=0.18,<0.19"]
+                        "mongoengine": [">=0.15,<0.16", ">=0.16,<0.17", ">=0.17,<0.18", ">=0.18,<0.19"],
                     },
                 ),
                 Venv(

--- a/riotfile.py
+++ b/riotfile.py
@@ -377,15 +377,28 @@ venv = Venv(
         Venv(
             name="pymongo",
             command="pytest {cmdargs} tests/contrib/pymongo",
+            pkgs={
+                "mongoengine": latest,
+            },
             venvs=[
                 Venv(
-                    pys=select_pys(max_version="3.7"),
+                    # Use <=3.5 to avoid setuptools >=58 which dropped `use_2to3` which is needed by mongoengine<0.20
+                    # mongoengine>=0.20 uses pymongo>=3.4
+                    # https://github.com/pypa/setuptools/issues/2086
+                    pys=select_pys(max_version="3.5"),
                     pkgs={
                         "pymongo": [
                             ">=3.0,<3.1",
                             ">=3.1,<3.2",
                             ">=3.2,<3.3",
                             ">=3.3,<3.4",
+                        ],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version="3.6"),
+                    pkgs={
+                        "pymongo": [
                             ">=3.4,<3.5",
                             ">=3.5,<3.6",
                             ">=3.6,<3.7",
@@ -396,27 +409,6 @@ venv = Venv(
                             ">=3.12,<3.13",
                             latest,
                         ],
-                        "mongoengine": latest,
-                    },
-                ),
-                Venv(
-                    pys=select_pys(min_version="3.8"),
-                    pkgs={
-                        "pymongo": [
-                            ">=3.0,<3.1",
-                            ">=3.1,<3.2",
-                            ">=3.2,<3.3",
-                            ">=3.3,<3.4",
-                            ">=3.5,<3.6",
-                            ">=3.6,<3.7",
-                            ">=3.7,<3.8",
-                            ">=3.8,<3.9",
-                            ">=3.9,<3.10",
-                            ">=3.10,<3.11",
-                            ">=3.12,<3.13",
-                            latest,
-                        ],
-                        "mongoengine": latest,
                     },
                 ),
             ],

--- a/riotfile.py
+++ b/riotfile.py
@@ -382,8 +382,7 @@ venv = Venv(
             },
             venvs=[
                 Venv(
-                    # Use <=3.5 to avoid setuptools >=58 which dropped `use_2to3` which is needed by mongoengine<0.20
-                    # mongoengine>=0.20 uses pymongo>=3.4
+                    # Use <=3.5 to avoid setuptools >=58 which dropped `use_2to3` which is needed by pymongo>=3.4
                     # https://github.com/pypa/setuptools/issues/2086
                     pys=select_pys(max_version="3.5"),
                     pkgs={
@@ -396,10 +395,17 @@ venv = Venv(
                     },
                 ),
                 Venv(
+                    # pymongo 3.4 is incompatible with Python>=3.8
+                    # AttributeError: module 'platform' has no attribute 'linux_distribution'
+                    pys=select_pys(max_version="3.7"),
+                    pkgs={
+                        "pymongo": ">=3.4,<3.5",
+                    },
+                ),
+                Venv(
                     pys=select_pys(min_version="3.6"),
                     pkgs={
                         "pymongo": [
-                            ">=3.4,<3.5",
                             ">=3.5,<3.6",
                             ">=3.6,<3.7",
                             ">=3.7,<3.8",


### PR DESCRIPTION
setuptools v58 removed support for `use_2to3`. this version of setuptools can be installed on python>=3.6 and has caused some CI failures for some older libraries that we test with (celery, pymongo, mongoengine).

https://github.com/pypa/setuptools/issues/2086

rather than removing testing for these older versions we will just cap the max version we can test them with to Python 3.5.