### PR TITLE
tests: move redis tests to riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -803,8 +803,10 @@ jobs:
     <<: *machine_executor
     parallelism: 4
     steps:
-      - run_tox_scenario_with_testagent:
-          pattern: '^redis_contrib-'
+      - run_test:
+          docker_services: 'redis'
+          pattern: 'redis$'
+          snapshot: true
 
   rediscluster:
     <<: *contrib_job

--- a/riotfile.py
+++ b/riotfile.py
@@ -1130,5 +1130,22 @@ venv = Venv(
             ],
             command="pytest {cmdargs} tests/contrib/jinja2",
         ),
+        Venv(
+            name="redis",
+            pys=select_pys(),
+            command="pytest {cmdargs} tests/contrib/redis",
+            pkgs={
+                "redis": [
+                    ">=2.10,<2.11",
+                    ">=3.0,<3.1",
+                    ">=3.1,<3.2",
+                    ">=3.2,<3.3",
+                    ">=3.3,<3.4",
+                    ">=3.4,<3.5",
+                    ">=3.5,<3.6",
+                    latest,
+                ]
+            },
+        ),
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -63,13 +63,11 @@ envlist =
     pyodbc_contrib-py{27,35,36,37,38}-pyodbc{3,4}
 
     pyramid_contrib{,_autopatch}-py{27,35,36,37,38}-pyramid{17,18,19,110,}-webtest
-    redis_contrib-py{27,35,36,37,38}-redis{210,30,32,33,34,35,}
     rediscluster_contrib-py{27,35,36,37,38}-rediscluster{135,136,200,}-redis210
     requests_contrib{,_autopatch}-{py27,py35,py36,py37,py38}-requests{208,209,210,211,212,213,219}
     pymysql_contrib-py{27,35,36,37,38,39}-pymysql{07,08,09,}
     pyodbc_contrib-py{27,35,36,37,38,39}-pyodbc{3,4}
     pyramid_contrib{,_autopatch}-py{27,35,36,37,38,39}-pyramid{17,18,19,110,}-webtest
-    redis_contrib-py{27,35,36,37,38,39}-redis{210,30,32,33,34,35,}
     rediscluster_contrib-py{27,35,36,37,38,39}-rediscluster{135,136,200,}-redis210
     sanic_contrib-py{37,38,39}-sanic{1906,1909,1912,2003,2006,2103,}
     sqlite3_contrib-py{27,35,36,37,38,39}-sqlite3
@@ -240,11 +238,6 @@ deps =
     pytest3: pytest>=3.0,<4.0
     redis: redis
     redis210: redis>=2.10,<2.11
-    redis30: redis>=3.0,<3.1
-    redis32: redis>=3.2,<3.3
-    redis33: redis>=3.3,<3.4
-    redis34: redis>=3.4,<3.5
-    redis35: redis>=3.5,<3.6
     rediscluster: redis-py-cluster
     rediscluster135: redis-py-cluster>=1.3.5,<1.3.6
     rediscluster136: redis-py-cluster>=1.3.6,<1.3.7
@@ -335,7 +328,6 @@ commands =
     pyodbc_contrib: pytest {posargs} tests/contrib/pyodbc
     pyramid_contrib: pytest {posargs} tests/contrib/pyramid/test_pyramid.py
     pyramid_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/pyramid/test_pyramid_autopatch.py
-    redis_contrib: pytest {posargs} tests/contrib/redis
     rediscluster_contrib: pytest {posargs} tests/contrib/rediscluster
     kombu_contrib: pytest {posargs} tests/contrib/kombu
     sanic_contrib: pytest {posargs} tests/contrib/sanic/test_sanic.py


### PR DESCRIPTION
This is an easy enough review that I've omitted the `riot list`/`tox -l` results

The redis suite run time is now down from ~14 minutes to about 5 minutes