### PR TITLE
Move contrib/aiohttp tests to riot

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -1078,6 +1078,42 @@ venv = Venv(
             command="pytest {cmdargs} tests/contrib/aiopg",
         ),
         Venv(
+            name="aiohttp_contrib",
+            # Python 3.7 needs at least aiohttp 2.3
+            #aiohttp_contrib-{py35,py36}-aiohttp{20,21,22}-aiohttp_jinja{012,013}-yarl-pytest3
+            #aiohttp_contrib-{py35,py36,py37,py38}-aiohttp23-aiohttp_jinja015-yarl10-pytest3
+
+            #aiohttp_contrib-{py35,py36,py37}-aiohttp{30,31,32,33,35,36}-aiohttp_jinja{015}-yarl10-pytest3
+            #aiohttp_contrib-py{38,39}       -aiohttp{30,31,32,33,36}-aiohttp_jinja015-yarl10-pytest3
+            venvs=[
+                Venv(
+                    pys=["3.5","3.6"],
+                    pkgs={
+                        "aiohttp": ["~=2.0", "~=2.1", "~=2.2"],
+                        "aiohttp_jinja": ["~=0.1.2", "~=0.1.3"],
+                        "yarl": "latest",
+                    },
+                ),
+                Venv(
+                    pys=["3.5","3.6", "3.7", "3.8"],
+                    pkgs={
+                        "aiohttp": "~=2.3",
+                        "aiohttp_jinja":"~=0.1.5",
+                        "yarl": "~=1.0",
+                    },
+                ),
+                Venv(
+                    pys=["3.5","3.6", "3.7", "3.8", "3.9"],
+                    pkgs={
+                        "aiohttp": ["~=3.0", "~=3.1", "~=3.2","~=3.3", "~=3.4", "~=3.5", "~=3.6"],
+                        "aiohttp_jinja": "0.1.5",
+                        "yarl": "~=1.0",
+                    },
+                ),
+            ],
+            command="pytest3 {cmdargs} tests/contrib/aiohttp",
+        ),
+        Venv(
             name="jinja2",
             venvs=[
                 Venv(

--- a/tox.ini
+++ b/tox.ini
@@ -28,11 +28,6 @@ envlist =
     # aiobotocore 0.2 and 0.4 do not work because they use async as a reserved keyword
     aiobotocore_contrib-py{37,38}-aiobotocore{03,05,07,08,09,010,011,012}
     aiobotocore_contrib-py39-aiobotocore{010,011,012}
-    # Python 3.7 needs at least aiohttp 2.3
-    aiohttp_contrib-{py35,py36}-aiohttp{20,21,22}-aiohttp_jinja{012,013}-yarl-pytest3
-    aiohttp_contrib-{py35,py36,py37,py38}-aiohttp23-aiohttp_jinja015-yarl10-pytest3
-    aiohttp_contrib-{py35,py36,py37}-aiohttp{30,31,32,33,35,36}-aiohttp_jinja{015}-yarl10-pytest3
-    aiohttp_contrib-py{38,39}-aiohttp{30,31,32,33,36}-aiohttp_jinja015-yarl10-pytest3
     algoliasearch_contrib-py{27,35,36,37,38,39}-algoliasearch{1,2,}
     asyncio_contrib-py{35,36,37,38,39}
     bottle_contrib{,_autopatch}-py{27,35,36,37,38,39}-bottle{11,12,}-webtest


### PR DESCRIPTION
## Description

Migrate aiohttp from tox to riot

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
