### PR TITLE
Skip building base for mypy check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,7 +286,7 @@ jobs:
           command: riot run -s flake8
       - run:
           name: "Mypy check"
-          command: riot run mypy
+          command: riot run -s mypy
       - run:
           name: "Codespell check"
           command: riot run -s codespell


### PR DESCRIPTION
The mypy check takes ~1m30s in CI which increases each CI run by about a minute.

<img width="295" alt="image" src="https://user-images.githubusercontent.com/6321485/134271360-dbcc1ef0-dc83-4d56-a512-ea314c67cffe.png">
<img width="559" alt="image" src="https://user-images.githubusercontent.com/6321485/134271426-1db1fb0d-6565-451c-88dc-58b6124d75ad.png">
