### PR TITLE
Add support for DD_PROFILING_ENDPOINT_COLLECTION_ENABLED

### DIFF
--- a/ddtrace/profiling/event.py
+++ b/ddtrace/profiling/event.py
@@ -53,7 +53,7 @@ class StackBasedEvent(SampleEvent):
     def set_trace_info(
         self,
         span,  # type: typing.Optional[ddspan.Span]
-        endpoint_collection_enabled,
+        endpoint_collection_enabled,  # type: bool
     ):
         if span:
             self.span_id = span.span_id

--- a/ddtrace/profiling/event.py
+++ b/ddtrace/profiling/event.py
@@ -53,10 +53,12 @@ class StackBasedEvent(SampleEvent):
     def set_trace_info(
         self,
         span,  # type: typing.Optional[ddspan.Span]
+        endpoint_collection_enabled,
     ):
         if span:
             self.span_id = span.span_id
             if span._local_root is not None:
                 self.local_root_span_id = span._local_root.span_id
                 self.trace_type = span._local_root._span_type
-                self.trace_resource_container = span._local_root._resource
+                if endpoint_collection_enabled:
+                    self.trace_resource_container = span._local_root._resource

--- a/releasenotes/notes/profiling-option-to-disable-endpoint-collection-48ab251acb0d9b4e.yaml
+++ b/releasenotes/notes/profiling-option-to-disable-endpoint-collection-48ab251acb0d9b4e.yaml
@@ -1,5 +1,5 @@
 ---
 features:
   - |
-    Add support for `DD_PROFILING_ENDPOINT_COLLECTION_ENABLED` env vaireble
+    Add support for ``DD_PROFILING_ENDPOINT_COLLECTION_ENABLED`` env variable
     to disable endpoint name collection in profiler.

--- a/releasenotes/notes/profiling-option-to-disable-endpoint-collection-48ab251acb0d9b4e.yaml
+++ b/releasenotes/notes/profiling-option-to-disable-endpoint-collection-48ab251acb0d9b4e.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add support for `DD_PROFILING_ENDPOINT_COLLECTION_ENABLED` env vaireble
+    to disable endpoint name collection in profiler.

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -198,7 +198,7 @@ def test_repr():
         stack.StackCollector,
         "StackCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
         "recorder=Recorder(default_max_events=32768, max_events={}), min_interval_time=0.01, max_time_usage_pct=1.0, "
-        "nframes=64, ignore_profiler=False, tracer=None)",
+        "nframes=64, ignore_profiler=False, endpoint_collection_enabled=True, tracer=None)",
     )
 
 
@@ -481,6 +481,30 @@ def test_collect_span_resource_after_finish(tracer_and_collector):
     span.resource = resource
     span.finish()
     assert event.trace_resource_container[0] == resource
+
+
+def test_resource_not_collected(monkeypatch, tracer):
+    monkeypatch.setenv("DD_PROFILING_ENDPOINT_COLLECTION_ENABLED", "false")
+    r = recorder.Recorder()
+    collector = stack.StackCollector(r, tracer=tracer)
+    collector.start()
+    try:
+        resource = str(uuid.uuid4())
+        span_type = str(uuid.uuid4())
+        span = tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type)
+        # This test will run forever if it fails. Don't make it fail.
+        while True:
+            try:
+                event = collector.recorder.events[stack.StackSampleEvent].pop()
+            except IndexError:
+                # No event left or no event yet
+                continue
+            if span.span_id == event.span_id:
+                assert event.trace_resource_container is None
+                assert event.trace_type == span_type
+                break
+    finally:
+        collector.stop()
 
 
 def test_collect_multiple_span_id(tracer_and_collector):

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -15,7 +15,8 @@ def test_repr():
     test_collector._test_repr(
         collector_threading.LockCollector,
         "LockCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
-        "recorder=Recorder(default_max_events=32768, max_events={}), capture_pct=2.0, nframes=64, endpoint_collection_enabled=True, tracer=None)",
+        "recorder=Recorder(default_max_events=32768, max_events={}), capture_pct=2.0, nframes=64, "
+        "endpoint_collection_enabled=True, tracer=None)",
     )
 
 
@@ -62,7 +63,7 @@ def test_lock_acquire_events():
     assert len(r.events[collector_threading.LockAcquireEvent]) == 1
     assert len(r.events[collector_threading.LockReleaseEvent]) == 0
     event = r.events[collector_threading.LockAcquireEvent][0]
-    assert event.lock_name == "test_threading.py:60"
+    assert event.lock_name == "test_threading.py:61"
     assert event.thread_id == nogevent.thread_get_ident()
     assert event.wait_time_ns > 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
@@ -89,14 +90,14 @@ def test_lock_events_tracer(tracer):
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
     for event_type in (collector_threading.LockAcquireEvent, collector_threading.LockReleaseEvent):
-        assert {"test_threading.py:80", "test_threading.py:83"}.issubset({e.lock_name for e in events[event_type]})
+        assert {"test_threading.py:81", "test_threading.py:84"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
-            if event.name == "test_threading.py:80":
+            if event.name == "test_threading.py:81":
                 assert event.trace_id is None
                 assert event.span_id is None
                 assert event.trace_resource_container is None
                 assert event.trace_type is None
-            elif event.name == "test_threading.py:83":
+            elif event.name == "test_threading.py:84":
                 assert event.trace_id == trace_id
                 assert event.span_id == span_id
                 assert event.trace_resource_container[0] == t.resource
@@ -122,14 +123,14 @@ def test_lock_events_tracer_late_finish(tracer):
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
     for event_type in (collector_threading.LockAcquireEvent, collector_threading.LockReleaseEvent):
-        assert {"test_threading.py:111", "test_threading.py:114"}.issubset({e.lock_name for e in events[event_type]})
+        assert {"test_threading.py:112", "test_threading.py:115"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
-            if event.name == "test_threading.py:111":
+            if event.name == "test_threading.py:112":
                 assert event.trace_id is None
                 assert event.span_id is None
                 assert event.trace_resource_container is None
                 assert event.trace_type is None
-            elif event.name == "test_threading.py:114":
+            elif event.name == "test_threading.py:115":
                 assert event.trace_id == trace_id
                 assert event.span_id == span_id
                 assert event.trace_resource_container[0] == span.resource
@@ -154,14 +155,14 @@ def test_resource_not_collected(monkeypatch, tracer):
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
     for event_type in (collector_threading.LockAcquireEvent, collector_threading.LockReleaseEvent):
-        assert {"test_threading.py:145", "test_threading.py:148"}.issubset({e.lock_name for e in events[event_type]})
+        assert {"test_threading.py:146", "test_threading.py:149"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
-            if event.name == "test_threading.py:145":
+            if event.name == "test_threading.py:146":
                 assert event.trace_id is None
                 assert event.span_id is None
                 assert event.trace_resource_container is None
                 assert event.trace_type is None
-            elif event.name == "test_threading.py:148":
+            elif event.name == "test_threading.py:149":
                 assert event.trace_id == trace_id
                 assert event.span_id == span_id
                 assert event.trace_resource_container is None
@@ -177,13 +178,13 @@ def test_lock_release_events():
     assert len(r.events[collector_threading.LockAcquireEvent]) == 1
     assert len(r.events[collector_threading.LockReleaseEvent]) == 1
     event = r.events[collector_threading.LockReleaseEvent][0]
-    assert event.lock_name == "test_threading.py:174"
+    assert event.lock_name == "test_threading.py:175"
     assert event.thread_id == nogevent.thread_get_ident()
     assert event.locked_for_ns >= 0.1
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[0] == (__file__, 176, "test_lock_release_events")
+    assert event.frames[0] == (__file__, 177, "test_lock_release_events")
     assert event.sampling_pct == 100
 
 

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -69,7 +69,7 @@ def test_lock_acquire_events():
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[0] == (__file__, 61, "test_lock_acquire_events")
+    assert event.frames[0] == (__file__, 62, "test_lock_acquire_events")
     assert event.sampling_pct == 100
 
 
@@ -206,7 +206,7 @@ def test_lock_gevent_tasks():
     assert len(r.events[collector_threading.LockReleaseEvent]) >= 1
 
     event = r.events[collector_threading.LockAcquireEvent][0]
-    assert event.lock_name == "test_threading.py:163"
+    assert event.lock_name == "test_threading.py:196"
     assert event.thread_id == nogevent.main_thread_id
     assert event.wait_time_ns >= 0
     assert event.task_id == t.ident
@@ -214,13 +214,13 @@ def test_lock_gevent_tasks():
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[0] == (__file__, 164, "play_with_lock")
+    assert event.frames[0] == (__file__, 197, "play_with_lock")
     assert event.sampling_pct == 100
     assert event.task_id == t.ident
     assert event.task_name == "foobar"
 
     event = r.events[collector_threading.LockReleaseEvent][0]
-    assert event.lock_name == "test_threading.py:163"
+    assert event.lock_name == "test_threading.py:196"
     assert event.thread_id == nogevent.main_thread_id
     assert event.locked_for_ns >= 0.1
     assert event.task_id == t.ident
@@ -228,7 +228,7 @@ def test_lock_gevent_tasks():
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[0] == (__file__, 165, "play_with_lock")
+    assert event.frames[0] == (__file__, 198, "play_with_lock")
     assert event.sampling_pct == 100
     assert event.task_id == t.ident
     assert event.task_name == "foobar"


### PR DESCRIPTION
To disable endpoint collection. Enabled by default.

## Description
<!-- Please briefly describe the change and why it was required. -->


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
