### PR TITLE
New test suite on github actions for the request library

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -247,3 +247,30 @@ jobs:
       #Parameters for keyword expression skip 3 failing tests that are expected due to asserting on headers. The errors are because our context propagation headers are being added
       - name: Run tests
         run: pytest -p no:warnings --ddtrace-patch-all tests -k 'not test_request_headers and not test_subdomain_route and not test_websocket_headers'
+
+  requests-testsuite-2_26_0:
+    runs-on: "ubuntu-latest"
+    env:
+      DD_TESTING_RAISE: true
+      DD_PROFILING_ENABLED: true
+    defaults:
+      run:
+        working-directory: requests
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - uses: actions/checkout@v2
+        with:
+          path: ddtrace
+      - uses: actions/checkout@v2
+        with:
+          repository: psf/requests
+          ref: v2.26.0
+          path: requests
+      - name: Install ddtrace
+        run: pip install ../ddtrace
+      - name: Install dependencies
+        run: "make init"
+      - name: Run tests
+        run: ddtrace-run pytest -p no:warnings tests


### PR DESCRIPTION
## Description
Added a new test suite for the requests library. It currently passes all of the tests they are using for their own library when patching with `ddtrace-run` - https://github.com/psf/requests/tree/main/tests.
![Image 2021-09-24 at 10 33 32 AM](https://user-images.githubusercontent.com/39347269/134717652-a0dad97c-6b78-47d6-a45e-20f34f660c03.jpg)





