### PR TITLE
moved ddtrace.ext.priority to ddtrace.constants

### DIFF
--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -21,3 +21,12 @@ MANUAL_DROP_KEY = "manual.drop"
 MANUAL_KEEP_KEY = "manual.keep"
 
 LOG_SPAN_KEY = "__datadog_log_span"
+
+# Use this to explicitly inform the backend that a trace should be rejected and not stored.
+USER_REJECT = -1
+# Used by the builtin sampler to inform the backend that a trace should be rejected and not stored.
+AUTO_REJECT = 0
+# Used by the builtin sampler to inform the backend that a trace should be kept and stored.
+AUTO_KEEP = 1
+# Use this to explicitly inform the backend that a trace should be kept and stored.
+USER_KEEP = 2

--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -5,6 +5,7 @@ from typing import Dict
 import pytest
 
 import ddtrace
+from ddtrace.constants import AUTO_KEEP
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.pytest.constants import FRAMEWORK
 from ddtrace.contrib.pytest.constants import HELP_MSG
@@ -13,7 +14,6 @@ from ddtrace.contrib.trace_utils import int_service
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import ci
 from ddtrace.ext import test
-from ddtrace.ext.priority import AUTO_KEEP
 from ddtrace.internal import compat
 from ddtrace.internal.logger import get_logger
 from ddtrace.pin import Pin

--- a/ddtrace/ext/priority.py
+++ b/ddtrace/ext/priority.py
@@ -17,9 +17,13 @@ from ddtrace.constants import AUTO_KEEP
 from ddtrace.constants import AUTO_REJECT
 from ddtrace.constants import USER_KEEP
 from ddtrace.constants import USER_REJECT
+from ddtrace.utils.deprecation import deprecation
 
 
-USER_REJECT = USER_REJECT
-AUTO_REJECT = AUTO_REJECT
-AUTO_KEEP = AUTO_KEEP
-USER_KEEP = USER_KEEP
+deprecation(
+    name="ddtrace.ext.priority",
+    message="Use `ddtrace.constant` package instead",
+    version="1.0.0",
+)
+
+__all__ = ["USER_REJECT", "AUTO_REJECT", "AUTO_KEEP", "USER_KEEP"]

--- a/ddtrace/ext/priority.py
+++ b/ddtrace/ext/priority.py
@@ -22,7 +22,7 @@ from ddtrace.utils.deprecation import deprecation
 
 deprecation(
     name="ddtrace.ext.priority",
-    message="Use `ddtrace.constant` package instead",
+    message="Use `ddtrace.constants` module instead",
     version="1.0.0",
 )
 

--- a/ddtrace/ext/priority.py
+++ b/ddtrace/ext/priority.py
@@ -13,12 +13,13 @@ context.sampling_priority = USER_REJECT
 # Indicate to keep the trace
 span.context.sampling_priority = USER_KEEP
 """
+from ddtrace.constants import AUTO_KEEP
+from ddtrace.constants import AUTO_REJECT
+from ddtrace.constants import USER_KEEP
+from ddtrace.constants import USER_REJECT
 
-# Use this to explicitly inform the backend that a trace should be rejected and not stored.
-USER_REJECT = -1
-# Used by the builtin sampler to inform the backend that a trace should be rejected and not stored.
-AUTO_REJECT = 0
-# Used by the builtin sampler to inform the backend that a trace should be kept and stored.
-AUTO_KEEP = 1
-# Use this to explicitly inform the backend that a trace should be kept and stored.
-USER_KEEP = 2
+
+USER_REJECT = USER_REJECT
+AUTO_REJECT = AUTO_REJECT
+AUTO_KEEP = AUTO_KEEP
+USER_KEEP = USER_KEEP

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -11,12 +11,12 @@ from typing import TYPE_CHECKING
 
 import six
 
+from .constants import AUTO_KEEP
+from .constants import AUTO_REJECT
 from .constants import ENV_KEY
 from .constants import SAMPLING_AGENT_DECISION
 from .constants import SAMPLING_LIMIT_DECISION
 from .constants import SAMPLING_RULE_DECISION
-from .ext.priority import AUTO_KEEP
-from .ext.priority import AUTO_REJECT
 from .internal.compat import iteritems
 from .internal.compat import pattern_type
 from .internal.logger import get_logger

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -20,13 +20,14 @@ from .constants import NUMERIC_TAGS
 from .constants import SERVICE_KEY
 from .constants import SERVICE_VERSION_KEY
 from .constants import SPAN_MEASURED_KEY
+from .constants import USER_KEEP
+from .constants import USER_REJECT
 from .constants import VERSION_KEY
 from .context import Context
 from .ext import SpanTypes
 from .ext import errors
 from .ext import http
 from .ext import net
-from .ext import priority
 from .internal import _rand
 from .internal.compat import NumericType
 from .internal.compat import StringIO
@@ -294,10 +295,10 @@ class Span(object):
             return
 
         elif key == MANUAL_KEEP_KEY:
-            self.context.sampling_priority = priority.USER_KEEP
+            self.context.sampling_priority = USER_KEEP
             return
         elif key == MANUAL_DROP_KEY:
-            self.context.sampling_priority = priority.USER_REJECT
+            self.context.sampling_priority = USER_REJECT
             return
         elif key == SERVICE_KEY:
             self.service = value

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -21,6 +21,8 @@ from ddtrace.utils.deprecation import deprecation
 from ddtrace.vendor import debtcollector
 
 from . import _hooks
+from .constants import AUTO_KEEP
+from .constants import AUTO_REJECT
 from .constants import ENV_KEY
 from .constants import FILTERS_KEY
 from .constants import HOSTNAME_KEY
@@ -28,8 +30,6 @@ from .constants import SAMPLE_RATE_METRIC_KEY
 from .constants import VERSION_KEY
 from .context import Context
 from .ext import system
-from .ext.priority import AUTO_KEEP
-from .ext.priority import AUTO_REJECT
 from .internal import agent
 from .internal import atexit
 from .internal import compat

--- a/releasenotes/notes/moved-priority-constants-316d6b3b791d6b3e.yaml
+++ b/releasenotes/notes/moved-priority-constants-316d6b3b791d6b3e.yaml
@@ -1,7 +1,7 @@
 ---
 upgrade:
   - |
-     Instead of using priority constants from the ``ddtrace.ext.priority``. Use constants from ``ddtrace.constants`` module. 
+     Instead of using priority constants from ``ddtrace.ext.priority``. Use constants from ``ddtrace.constants`` module. 
      For Example:: ``ddtrace.ext.priority.AUTO_KEEP`` -> ``ddtrace.constants.AUTO_KEEP``
       
 deprecations:

--- a/releasenotes/notes/moved-priority-constants-316d6b3b791d6b3e.yaml
+++ b/releasenotes/notes/moved-priority-constants-316d6b3b791d6b3e.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    Moved `ddtrace.ext.priority` constants into `ddtrace.constants` module.

--- a/releasenotes/notes/moved-priority-constants-316d6b3b791d6b3e.yaml
+++ b/releasenotes/notes/moved-priority-constants-316d6b3b791d6b3e.yaml
@@ -1,4 +1,9 @@
 ---
+upgrade:
+  - |
+     Instead of using priority constants from the ``ddtrace.ext.priority``. Use constants from ``ddtrace.constants`` module. 
+     For Example:: ``ddtrace.ext.priority.AUTO_KEEP`` -> ``ddtrace.constants.AUTO_KEEP``
+      
 deprecations:
   - |
-    Moved `ddtrace.ext.priority` constants into `ddtrace.constants` module.
+    Moved ``ddtrace.ext.priority`` constants into ``ddtrace.constants`` module.

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -17,11 +17,11 @@ from six import ensure_text
 from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
+from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.django.patch import instrument_view
 from ddtrace.contrib.django.utils import get_request_uri
 from ddtrace.ext import errors
 from ddtrace.ext import http
-from ddtrace.ext.priority import USER_KEEP
 from ddtrace.internal.compat import PY2
 from ddtrace.internal.compat import binary_type
 from ddtrace.internal.compat import string_type

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -6,10 +6,10 @@ from opentracing.scope_managers.gevent import GeventScopeManager
 
 import ddtrace
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
+from ddtrace.constants import USER_KEEP
 from ddtrace.context import Context
 from ddtrace.contrib.gevent import patch
 from ddtrace.contrib.gevent import unpatch
-from ddtrace.ext.priority import USER_KEEP
 from ddtrace.internal.compat import PY3
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase

--- a/tests/opentracer/core/test_span.py
+++ b/tests/opentracer/core/test_span.py
@@ -16,7 +16,7 @@ def nop_tracer():
 
 @pytest.fixture
 def nop_span_ctx():
-    from ddtrace.ext.priority import AUTO_KEEP
+    from ddtrace.constants import AUTO_KEEP
     from ddtrace.opentracer.span_context import SpanContext
 
     return SpanContext(sampling_priority=AUTO_KEEP)

--- a/tests/opentracer/core/test_tracer.py
+++ b/tests/opentracer/core/test_tracer.py
@@ -11,7 +11,7 @@ import pytest
 
 import ddtrace
 from ddtrace import Tracer as DDTracer
-from ddtrace.ext.priority import AUTO_KEEP
+from ddtrace.constants import AUTO_KEEP
 from ddtrace.opentracer import Tracer
 from ddtrace.opentracer import set_global_tracer
 from ddtrace.opentracer.span_context import SpanContext

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -6,13 +6,13 @@ import unittest
 import mock
 import pytest
 
+from ddtrace.constants import AUTO_KEEP
+from ddtrace.constants import AUTO_REJECT
 from ddtrace.constants import SAMPLE_RATE_METRIC_KEY
 from ddtrace.constants import SAMPLING_AGENT_DECISION
 from ddtrace.constants import SAMPLING_LIMIT_DECISION
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.constants import SAMPLING_RULE_DECISION
-from ddtrace.ext.priority import AUTO_KEEP
-from ddtrace.ext.priority import AUTO_REJECT
 from ddtrace.internal.compat import iteritems
 from ddtrace.internal.rate_limiter import RateLimiter
 from ddtrace.sampler import AllSampler

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -15,12 +15,16 @@ import pytest
 import six
 
 import ddtrace
+from ddtrace.constants import AUTO_KEEP
+from ddtrace.constants import AUTO_REJECT
 from ddtrace.constants import ENV_KEY
 from ddtrace.constants import HOSTNAME_KEY
 from ddtrace.constants import MANUAL_DROP_KEY
 from ddtrace.constants import MANUAL_KEEP_KEY
 from ddtrace.constants import ORIGIN_KEY
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
+from ddtrace.constants import USER_KEEP
+from ddtrace.constants import USER_REJECT
 from ddtrace.constants import VERSION_KEY
 from ddtrace.context import Context
 from ddtrace.ext import priority
@@ -1356,14 +1360,14 @@ def test_manual_keep(tracer, test_spans):
     with tracer.trace("asdf") as s:
         s.set_tag(MANUAL_KEEP_KEY)
     spans = test_spans.pop()
-    assert spans[0].metrics[SAMPLING_PRIORITY_KEY] is priority.USER_KEEP
+    assert spans[0].metrics[SAMPLING_PRIORITY_KEY] is USER_KEEP
 
     # On a child span
     with tracer.trace("asdf"):
         with tracer.trace("child") as s:
             s.set_tag(MANUAL_KEEP_KEY)
     spans = test_spans.pop()
-    assert spans[0].metrics[SAMPLING_PRIORITY_KEY] is priority.USER_KEEP
+    assert spans[0].metrics[SAMPLING_PRIORITY_KEY] is USER_KEEP
 
 
 def test_manual_keep_then_drop(tracer, test_spans):
@@ -1373,7 +1377,7 @@ def test_manual_keep_then_drop(tracer, test_spans):
             child.set_tag(MANUAL_KEEP_KEY)
         root.set_tag(MANUAL_DROP_KEY)
     spans = test_spans.pop()
-    assert spans[0].metrics[SAMPLING_PRIORITY_KEY] is priority.USER_REJECT
+    assert spans[0].metrics[SAMPLING_PRIORITY_KEY] is USER_REJECT
 
 
 def test_manual_drop(tracer, test_spans):
@@ -1535,7 +1539,7 @@ def test_bad_agent_url(monkeypatch):
 
 def test_context_priority(tracer, test_spans):
     """Assigning a sampling_priority should not affect if the trace is sent to the agent"""
-    for p in [priority.USER_REJECT, priority.AUTO_REJECT, priority.AUTO_KEEP, priority.USER_KEEP, None, 999]:
+    for p in [USER_REJECT, AUTO_REJECT, AUTO_KEEP, USER_KEEP, None, 999]:
         with tracer.trace("span_%s" % p) as span:
             span.context.sampling_priority = p
 
@@ -1543,7 +1547,7 @@ def test_context_priority(tracer, test_spans):
         # the agent needs to know the sampling decision.
         spans = test_spans.pop()
         assert len(spans) == 1, "trace should be sampled"
-        if p in [priority.USER_REJECT, priority.AUTO_REJECT, priority.AUTO_KEEP, priority.USER_KEEP]:
+        if p in [USER_REJECT, AUTO_REJECT, AUTO_KEEP, USER_KEEP]:
             assert spans[0].metrics[SAMPLING_PRIORITY_KEY] == p
 
 


### PR DESCRIPTION
## Description
The constants from `ddtrace.ext.priority` have been deprecated and been relocated to the `ddtrace.constants`. This is to  help restructure the tracer for v1.0


