### PR TITLE
fix(ci) Use austin devel branch instead of austinp

### DIFF
--- a/scripts/profiles/encoders/setup.sh
+++ b/scripts/profiles/encoders/setup.sh
@@ -21,7 +21,7 @@ pip install pip --upgrade
 # Install austin
 pushd ${PREFIX}
     sudo apt-get -y install libunwind-dev
-    git clone --depth=1 https://github.com/p403n1x87/austin.git -b austinp
+    git clone --depth=1 https://github.com/p403n1x87/austin.git -b devel
     pushd austin
         gcc -O3 -Os -s -Wall -pthread src/*.c -DAUSTINP -lunwind-ptrace -lunwind-generic -o src/austinp
         mv src/austinp ${PREFIX}/austinp


### PR DESCRIPTION
https://github.com/P403n1x87/austin/pull/85 was merged and the base branch was finally deleted.

It doesn't look like these `austinp` changes have been released yet, so just updating CI to use the `devel` branch instead.