### PR TITLE
moved ddtrace.ext.system constant

### DIFF
--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -21,3 +21,5 @@ MANUAL_DROP_KEY = "manual.drop"
 MANUAL_KEEP_KEY = "manual.keep"
 
 LOG_SPAN_KEY = "__datadog_log_span"
+
+PID = "system.pid"

--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -32,4 +32,3 @@ AUTO_REJECT = 0
 AUTO_KEEP = 1
 # Use this to explicitly inform the backend that a trace should be kept and stored.
 USER_KEEP = 2
-

--- a/ddtrace/ext/system.py
+++ b/ddtrace/ext/system.py
@@ -7,7 +7,7 @@ from ddtrace.utils.deprecation import deprecation
 
 deprecation(
     name="ddtrace.ext.system",
-    message="Use `ddtrace.constant` package instead",
+    message="Use `ddtrace.constants` module instead",
     version="1.0.0",
 )
 

--- a/ddtrace/ext/system.py
+++ b/ddtrace/ext/system.py
@@ -1,5 +1,14 @@
 """
 Standard system tags
 """
+from ddtrace.constants import PID
+from ddtrace.utils.deprecation import deprecation
 
-PID = "system.pid"
+
+deprecation(
+    name="ddtrace.ext.system",
+    message="Use `ddtrace.constant` package instead",
+    version="1.0.0",
+)
+
+__all__ = ["PID"]

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -30,9 +30,6 @@ from .constants import PID
 from .constants import SAMPLE_RATE_METRIC_KEY
 from .constants import VERSION_KEY
 from .context import Context
-from .ext import system
-from .ext.priority import AUTO_KEEP
-from .ext.priority import AUTO_REJECT
 from .internal import agent
 from .internal import atexit
 from .internal import compat

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -24,10 +24,10 @@ from . import _hooks
 from .constants import ENV_KEY
 from .constants import FILTERS_KEY
 from .constants import HOSTNAME_KEY
+from .constants import PID
 from .constants import SAMPLE_RATE_METRIC_KEY
 from .constants import VERSION_KEY
 from .context import Context
-from .ext import system
 from .ext.priority import AUTO_KEEP
 from .ext.priority import AUTO_REJECT
 from .internal import agent
@@ -597,7 +597,7 @@ class Tracer(object):
 
         if not span._parent:
             span.meta["runtime-id"] = get_runtime_id()
-            span.metrics[system.PID] = self._pid
+            span.metrics[PID] = self._pid
 
         # Apply default global tags.
         if self.tags:

--- a/releasenotes/notes/moved-system-constants-7894698d5734235a.yaml
+++ b/releasenotes/notes/moved-system-constants-7894698d5734235a.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+     Instead of using system constants from ``ddtrace.ext.system``. Use constants from ``ddtrace.constants`` module. 
+     For Example:: ``ddtrace.ext.system.PID`` -> ``ddtrace.constants.PID``
+      
+deprecations:
+  - |
+    Moved ``ddtrace.ext.system`` constants into ``ddtrace.constants`` module. 

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -20,11 +20,11 @@ from ddtrace.constants import HOSTNAME_KEY
 from ddtrace.constants import MANUAL_DROP_KEY
 from ddtrace.constants import MANUAL_KEEP_KEY
 from ddtrace.constants import ORIGIN_KEY
+from ddtrace.constants import PID
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.constants import VERSION_KEY
 from ddtrace.context import Context
 from ddtrace.ext import priority
-from ddtrace.ext import system
 from ddtrace.internal.writer import AgentWriter
 from ddtrace.internal.writer import LogWriter
 from ddtrace.settings import Config
@@ -116,7 +116,7 @@ class TracerTestCases(TracerTestCase):
                 pass
 
         # Root span should contain the pid of the current process
-        root_span.assert_metrics({system.PID: getpid()}, exact=False)
+        root_span.assert_metrics({PID: getpid()}, exact=False)
 
         # Child span should not contain a pid tag
         child_span.assert_metrics(dict(), exact=True)
@@ -916,7 +916,7 @@ def test_tracer_runtime_tags_cross_execution(tracer):
     with tracer.trace("span") as span:
         pass
     assert span.get_tag("runtime-id") is not None
-    assert span.get_metric(system.PID) is not None
+    assert span.get_metric(PID) is not None
 
 
 def test_start_span_hooks():
@@ -1669,19 +1669,19 @@ def test_fork_manual_span_different_contexts(tracer):
 def test_fork_pid(tracer):
     root = tracer.trace("root_span")
     assert root.get_tag("runtime-id") is not None
-    assert root.get_metric(system.PID) is not None
+    assert root.get_metric(PID) is not None
 
     pid = os.fork()
 
     if pid:
         child1 = tracer.trace("span1")
         assert child1.get_tag("runtime-id") is None
-        assert child1.get_metric(system.PID) is None
+        assert child1.get_metric(PID) is None
         child1.finish()
     else:
         child2 = tracer.trace("span2")
         assert child2.get_tag("runtime-id") is not None
-        assert child2.get_metric(system.PID) is not None
+        assert child2.get_metric(PID) is not None
         child2.finish()
         os._exit(12)
 


### PR DESCRIPTION
## Description
Relocated system constant from `ddtrace.ext.system` to the `ddtrace.constants` module. This is to help restructure the tracer for v1.0
