### PR TITLE
moved ddtrace.ext.error constant

### DIFF
--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -39,4 +39,3 @@ AUTO_REJECT = 0
 AUTO_KEEP = 1
 # Use this to explicitly inform the backend that a trace should be kept and stored.
 USER_KEEP = 2
-

--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -21,3 +21,12 @@ MANUAL_DROP_KEY = "manual.drop"
 MANUAL_KEEP_KEY = "manual.keep"
 
 LOG_SPAN_KEY = "__datadog_log_span"
+
+ERROR_MSG = "error.msg"  # a string representing the error message
+ERROR_TYPE = "error.type"  # a string representing the type of the error
+ERROR_STACK = "error.stack"  # a human readable version of the stack. beta.
+
+# shorthand for -----^
+MSG = ERROR_MSG
+TYPE = ERROR_TYPE
+STACK = ERROR_STACK

--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -24,12 +24,7 @@ LOG_SPAN_KEY = "__datadog_log_span"
 
 ERROR_MSG = "error.msg"  # a string representing the error message
 ERROR_TYPE = "error.type"  # a string representing the type of the error
-ERROR_STACK = "error.stack"  # a human readable version of the stack. beta.
-
-# shorthand for -----^
-MSG = ERROR_MSG
-TYPE = ERROR_TYPE
-STACK = ERROR_STACK
+ERROR_STACK = "error.stack"  # a human readable version of the stack.
 
 # Use this to explicitly inform the backend that a trace should be rejected and not stored.
 USER_REJECT = -1

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -10,10 +10,11 @@ import cassandra.cluster
 from ddtrace import config
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
+from ...constants import ERROR_MSG
+from ...constants import ERROR_TYPE
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanTypes
 from ...ext import cassandra as cassx
-from ...ext import errors
 from ...ext import net
 from ...internal.compat import maybe_stringify
 from ...internal.compat import stringify
@@ -83,8 +84,8 @@ def _close_span_on_error(exc, future):
         # handling the exception manually because we
         # don't have an ongoing exception here
         span.error = 1
-        span.set_tag(errors.ERROR_MSG, exc.args[0])
-        span.set_tag(errors.ERROR_TYPE, exc.__class__.__name__)
+        span.set_tag(ERROR_MSG, exc.args[0])
+        span.set_tag(ERROR_TYPE, exc.__class__.__name__)
     except Exception:
         log.debug("traced_set_final_exception was not able to set the error, failed with error", exc_info=True)
     finally:

--- a/ddtrace/contrib/cherrypy/middleware.py
+++ b/ddtrace/contrib/cherrypy/middleware.py
@@ -12,6 +12,7 @@ from cherrypy.lib.httputil import valid_status
 # project
 from ddtrace import config
 from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
 
 from .. import trace_utils
@@ -89,7 +90,7 @@ class TraceTool(cherrypy.Tool):
         span.error = 1
         span.set_tag(ERROR_TYPE, cherrypy._cperror._exc_info()[0])
         span.set_tag(ERROR_MSG, str(cherrypy._cperror._exc_info()[1]))
-        span.set_tag(ERROR_MSG, cherrypy._cperror.format_exc())
+        span.set_tag(ERROR_STACK, cherrypy._cperror.format_exc())
 
         self._close_span(span)
 

--- a/ddtrace/contrib/cherrypy/middleware.py
+++ b/ddtrace/contrib/cherrypy/middleware.py
@@ -11,10 +11,11 @@ from cherrypy.lib.httputil import valid_status
 
 # project
 from ddtrace import config
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_TYPE
 
 from .. import trace_utils
 from ...ext import SpanTypes
-from ...ext import errors
 from ...internal import compat
 from ...utils.formats import asbool
 from ...utils.formats import get_env
@@ -86,9 +87,9 @@ class TraceTool(cherrypy.Tool):
             return
 
         span.error = 1
-        span.set_tag(errors.ERROR_TYPE, cherrypy._cperror._exc_info()[0])
-        span.set_tag(errors.ERROR_MSG, str(cherrypy._cperror._exc_info()[1]))
-        span.set_tag(errors.STACK, cherrypy._cperror.format_exc())
+        span.set_tag(ERROR_TYPE, cherrypy._cperror._exc_info()[0])
+        span.set_tag(ERROR_MSG, str(cherrypy._cperror._exc_info()[1]))
+        span.set_tag(ERROR_MSG, cherrypy._cperror.format_exc())
 
         self._close_span(span)
 

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -4,10 +4,11 @@ from flask import signals
 import flask.templating
 
 from ddtrace import config
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_TYPE
 
 from .. import trace_utils
 from ...ext import SpanTypes
-from ...ext import errors
 from ...ext import http
 from ...internal import compat
 from ...internal.logger import get_logger
@@ -198,8 +199,8 @@ def _set_error_on_span(span, exception):
     # also get the exception from the sys.exc_info (and fill the error meta).
     # Since we aren't sure it always work/for insuring no BC break, keep
     # these lines which get overridden anyway.
-    span.set_tag(errors.ERROR_TYPE, type(exception))
-    span.set_tag(errors.ERROR_MSG, exception)
+    span.set_tag(ERROR_TYPE, type(exception))
+    span.set_tag(ERROR_MSG, exception)
     # The provided `exception` object doesn't have a stack trace attached,
     # so attach the stack trace with `set_traceback`.
     span.set_traceback()

--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -4,7 +4,6 @@ import grpc
 
 from ddtrace import config
 from ddtrace.ext import SpanTypes
-from ddtrace.ext import errors
 from ddtrace.internal.compat import stringify
 from ddtrace.internal.compat import to_unicode
 from ddtrace.vendor import wrapt
@@ -13,6 +12,9 @@ from . import constants
 from . import utils
 from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
+from ...constants import ERROR_MSG
+from ...constants import ERROR_STACK
+from ...constants import ERROR_TYPE
 from ...constants import SPAN_MEASURED_KEY
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
@@ -92,8 +94,8 @@ def _handle_error(span, response_error, status_code):
         # handle cancelled futures separately to avoid raising grpc.FutureCancelledError
         span.error = 1
         exc_val = to_unicode(response_error.details())
-        span._set_str_tag(errors.ERROR_MSG, exc_val)
-        span._set_str_tag(errors.ERROR_TYPE, status_code)
+        span._set_str_tag(ERROR_MSG, exc_val)
+        span._set_str_tag(ERROR_TYPE, status_code)
         return
 
     exception = response_error.exception()
@@ -105,9 +107,9 @@ def _handle_error(span, response_error, status_code):
             # handle internal gRPC exceptions separately to get status code and
             # details as tags properly
             exc_val = to_unicode(response_error.details())
-            span._set_str_tag(errors.ERROR_MSG, exc_val)
-            span._set_str_tag(errors.ERROR_TYPE, status_code)
-            span._set_str_tag(errors.ERROR_STACK, stringify(traceback))
+            span._set_str_tag(ERROR_MSG, exc_val)
+            span._set_str_tag(ERROR_TYPE, status_code)
+            span._set_str_tag(ERROR_STACK, stringify(traceback))
         else:
             exc_type = type(exception)
             span.set_exc_info(exc_type, exception, traceback)

--- a/ddtrace/contrib/grpc/server_interceptor.py
+++ b/ddtrace/contrib/grpc/server_interceptor.py
@@ -1,13 +1,14 @@
 import grpc
 
 from ddtrace import config
-from ddtrace.ext import errors
 from ddtrace.internal.compat import to_unicode
 from ddtrace.vendor import wrapt
 
 from . import constants
 from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
+from ...constants import ERROR_MSG
+from ...constants import ERROR_TYPE
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanTypes
 from .utils import set_grpc_method_meta
@@ -37,8 +38,8 @@ def _handle_server_exception(server_context, span):
         code = to_unicode(server_context._state.code)
         details = to_unicode(server_context._state.details)
         span.error = 1
-        span._set_str_tag(errors.ERROR_MSG, details)
-        span._set_str_tag(errors.ERROR_TYPE, code)
+        span._set_str_tag(ERROR_MSG, details)
+        span._set_str_tag(ERROR_TYPE, code)
 
 
 def _wrap_response_iterator(response_iterator, server_context, span):

--- a/ddtrace/ext/errors.py
+++ b/ddtrace/ext/errors.py
@@ -18,7 +18,7 @@ __all__ = [ERROR_MSG, ERROR_TYPE, ERROR_STACK, MSG, TYPE, STACK]
 
 deprecation(
     name="ddtrace.ext.errors",
-    message="Use `ddtrace.constant` package instead",
+    message="Use `ddtrace.constants` module instead",
     version="1.0.0",
 )
 

--- a/ddtrace/ext/errors.py
+++ b/ddtrace/ext/errors.py
@@ -4,17 +4,26 @@ tags for common error attributes
 
 import traceback
 
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
+from ddtrace.constants import ERROR_TYPE
+from ddtrace.constants import MSG
+from ddtrace.constants import STACK
+from ddtrace.constants import TYPE
+from ddtrace.utils.deprecation import deprecated
+from ddtrace.utils.deprecation import deprecation
 
-ERROR_MSG = "error.msg"  # a string representing the error message
-ERROR_TYPE = "error.type"  # a string representing the type of the error
-ERROR_STACK = "error.stack"  # a human readable version of the stack. beta.
 
-# shorthand for -----^
-MSG = ERROR_MSG
-TYPE = ERROR_TYPE
-STACK = ERROR_STACK
+__all__ = [ERROR_MSG, ERROR_TYPE, ERROR_STACK, MSG, TYPE, STACK]
+
+deprecation(
+    name="ddtrace.ext.errors",
+    message="Use `ddtrace.constant` package instead",
+    version="1.0.0",
+)
 
 
+@deprecated("This method and module will be removed altogether", "1.0.0")
 def get_traceback(tb=None, error=None):
     t = None
     if error:

--- a/ddtrace/ext/errors.py
+++ b/ddtrace/ext/errors.py
@@ -7,20 +7,22 @@ import traceback
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
-from ddtrace.constants import MSG
-from ddtrace.constants import STACK
-from ddtrace.constants import TYPE
 from ddtrace.utils.deprecation import deprecated
 from ddtrace.utils.deprecation import deprecation
 
 
-__all__ = [ERROR_MSG, ERROR_TYPE, ERROR_STACK, MSG, TYPE, STACK]
+__all__ = [ERROR_MSG, ERROR_TYPE, ERROR_STACK]
 
 deprecation(
     name="ddtrace.ext.errors",
     message="Use `ddtrace.constants` module instead",
     version="1.0.0",
 )
+
+# shorthand for ERROR constants to be removed in v1.0-----^
+MSG = ERROR_MSG
+TYPE = ERROR_TYPE
+STACK = ERROR_STACK
 
 
 @deprecated("This method and module will be removed altogether", "1.0.0")

--- a/ddtrace/ext/errors.py
+++ b/ddtrace/ext/errors.py
@@ -15,7 +15,10 @@ __all__ = [ERROR_MSG, ERROR_TYPE, ERROR_STACK]
 
 deprecation(
     name="ddtrace.ext.errors",
-    message="Use `ddtrace.constants` module instead",
+    message=(
+        "Use `ddtrace.constants` module instead. "
+        "Shorthand error constants will be removed. Use ERROR_MSG, ERROR_TYPE, and ERROR_STACK instead."
+    ),
     version="1.0.0",
 )
 

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -9,8 +9,10 @@ from typing import Union
 from opentracing import Span as OpenTracingSpan
 from opentracing.ext import tags as OTTags
 
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
+from ddtrace.constants import ERROR_TYPE
 from ddtrace.context import Context as DatadogContext
-from ddtrace.ext import errors
 from ddtrace.internal.compat import NumericType
 from ddtrace.span import Span as DatadogSpan
 
@@ -120,11 +122,11 @@ class Span(OpenTracingSpan):
                 self._dd_span.error = 1
                 self.set_tag("error", 1)
             elif key == "error" or key == "error.object":
-                self.set_tag(errors.ERROR_TYPE, val)
+                self.set_tag(ERROR_TYPE, val)
             elif key == "message":
-                self.set_tag(errors.ERROR_MSG, val)
+                self.set_tag(ERROR_MSG, val)
             elif key == "stack":
-                self.set_tag(errors.ERROR_STACK, val)
+                self.set_tag(ERROR_STACK, val)
             else:
                 pass
 

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -14,6 +14,9 @@ from typing import Union
 import six
 
 from . import config
+from .constants import ERROR_MSG
+from .constants import ERROR_STACK
+from .constants import ERROR_TYPE
 from .constants import MANUAL_DROP_KEY
 from .constants import MANUAL_KEEP_KEY
 from .constants import NUMERIC_TAGS
@@ -23,7 +26,6 @@ from .constants import SPAN_MEASURED_KEY
 from .constants import VERSION_KEY
 from .context import Context
 from .ext import SpanTypes
-from .ext import errors
 from .ext import http
 from .ext import net
 from .ext import priority
@@ -450,7 +452,7 @@ class Span(object):
             self.set_exc_info(exc_type, exc_val, exc_tb)
         else:
             tb = "".join(traceback.format_stack(limit=limit + 1)[:-1])
-            self.meta[errors.ERROR_STACK] = tb
+            self.meta[ERROR_STACK] = tb
 
     def set_exc_info(self, exc_type, exc_val, exc_tb):
         # type: (Any, Any, Any) -> None
@@ -471,17 +473,17 @@ class Span(object):
         # readable version of type (e.g. exceptions.ZeroDivisionError)
         exc_type_str = "%s.%s" % (exc_type.__module__, exc_type.__name__)
 
-        self.meta[errors.ERROR_MSG] = str(exc_val)
-        self.meta[errors.ERROR_TYPE] = exc_type_str
-        self.meta[errors.ERROR_STACK] = tb
+        self.meta[ERROR_MSG] = str(exc_val)
+        self.meta[ERROR_TYPE] = exc_type_str
+        self.meta[ERROR_STACK] = tb
 
     def _remove_exc_info(self):
         # type: () -> None
         """Remove all exception related information from the span."""
         self.error = 0
-        self._remove_tag(errors.ERROR_MSG)
-        self._remove_tag(errors.ERROR_TYPE)
-        self._remove_tag(errors.ERROR_STACK)
+        self._remove_tag(ERROR_MSG)
+        self._remove_tag(ERROR_TYPE)
+        self._remove_tag(ERROR_STACK)
 
     def pprint(self):
         # type: () -> str

--- a/releasenotes/notes/moved-error-constants-97c7278a381b56d0.yaml
+++ b/releasenotes/notes/moved-error-constants-97c7278a381b56d0.yaml
@@ -2,7 +2,7 @@
 upgrade:
   - |
      Instead of using error constants from ``ddtrace.ext.errors``. Use constants from ``ddtrace.constants`` module. 
-     For Example:: ``ddtrace.ext.errors.ERROR_MSG`` -> ``ddtrace.constants.ERROR_MSG``
+     For example: ``ddtrace.ext.errors.ERROR_MSG`` -> ``ddtrace.constants.ERROR_MSG``
       
 deprecations:
   - |

--- a/releasenotes/notes/moved-error-constants-97c7278a381b56d0.yaml
+++ b/releasenotes/notes/moved-error-constants-97c7278a381b56d0.yaml
@@ -6,6 +6,7 @@ upgrade:
       
 deprecations:
   - |
-    Moved ``ddtrace.ext.errors`` constants into ``ddtrace.constants`` module. 
-    Function ``get_traceback()`` in ddtrace.ext.errors is now deprecated and will be removed.
+    Moved ``ddtrace.ext.errors`` constants into ``ddtrace.constants`` module & will be removed in v1.0. 
+    Shorthand error constants in ``ddtrace.ext.errors`` will be removed in v1.0.
+    Function ``get_traceback()`` in ddtrace.ext.errors is now deprecated and will be removed v1.0.
 

--- a/releasenotes/notes/moved-error-constants-97c7278a381b56d0.yaml
+++ b/releasenotes/notes/moved-error-constants-97c7278a381b56d0.yaml
@@ -7,5 +7,5 @@ upgrade:
 deprecations:
   - |
     Moved ``ddtrace.ext.errors`` constants into ``ddtrace.constants`` module. 
-    Function ``get_traceback()`` in ddtrace.ext.errors is now deprecated.
+    Function ``get_traceback()`` in ddtrace.ext.errors is now deprecated and will be removed.
 

--- a/releasenotes/notes/moved-error-constants-97c7278a381b56d0.yaml
+++ b/releasenotes/notes/moved-error-constants-97c7278a381b56d0.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+     Instead of using error constants from ``ddtrace.ext.errors``. Use constants from ``ddtrace.constants`` module. 
+     For Example:: ``ddtrace.ext.errors.ERROR_MSG`` -> ``ddtrace.constants.ERROR_MSG``
+      
+deprecations:
+  - |
+    Moved ``ddtrace.ext.errors`` constants into ``ddtrace.constants`` module. 
+

--- a/releasenotes/notes/moved-error-constants-97c7278a381b56d0.yaml
+++ b/releasenotes/notes/moved-error-constants-97c7278a381b56d0.yaml
@@ -7,4 +7,5 @@ upgrade:
 deprecations:
   - |
     Moved ``ddtrace.ext.errors`` constants into ``ddtrace.constants`` module. 
+    Function ``get_traceback()`` in ddtrace.ext.errors is now deprecated.
 

--- a/releasenotes/notes/moved-error-constants-97c7278a381b56d0.yaml
+++ b/releasenotes/notes/moved-error-constants-97c7278a381b56d0.yaml
@@ -6,7 +6,7 @@ upgrade:
       
 deprecations:
   - |
-    Moved ``ddtrace.ext.errors`` constants into ``ddtrace.constants`` module & will be removed in v1.0. 
-    Shorthand error constants in ``ddtrace.ext.errors`` will be removed in v1.0.
+    Moved ``ddtrace.ext.errors`` constants into the ``ddtrace.constants`` module. ``ddtrace.ext.errors`` will be removed in v1.0. 
+    Shorthand error constant (MSG,TYPE,STACK) in ``ddtrace.ext.errors`` will be removed in v1.0.
     Function ``get_traceback()`` in ddtrace.ext.errors is now deprecated and will be removed v1.0.
 

--- a/tests/contrib/cassandra/test.py
+++ b/tests/contrib/cassandra/test.py
@@ -11,12 +11,13 @@ from cassandra.query import SimpleStatement
 from ddtrace import Pin
 from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.cassandra.patch import patch
 from ddtrace.contrib.cassandra.patch import unpatch
 from ddtrace.contrib.cassandra.session import SERVICE
 from ddtrace.contrib.cassandra.session import get_traced_cassandra
 from ddtrace.ext import cassandra as cassx
-from ddtrace.ext import errors
 from ddtrace.ext import net
 from tests.contrib.config import CASSANDRA_CONFIG
 from tests.opentracer.utils import init_tracer
@@ -295,7 +296,7 @@ class CassandraBase(object):
         assert spans
         query = spans[0]
         assert query.error == 1
-        for k in (errors.ERROR_MSG, errors.ERROR_TYPE):
+        for k in (ERROR_MSG, ERROR_TYPE):
             assert query.get_tag(k)
 
     def test_bound_statement(self):

--- a/tests/contrib/cherrypy/test_middleware.py
+++ b/tests/contrib/cherrypy/test_middleware.py
@@ -9,9 +9,11 @@ from six.moves.urllib.parse import quote as url_quote
 
 import ddtrace
 from ddtrace import config
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
+from ddtrace.constants import ERROR_TYPE
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.contrib.cherrypy import TraceMiddleware
-from ddtrace.ext import errors
 from ddtrace.ext import http
 from tests.utils import TracerTestCase
 from tests.utils import assert_span_http_status_code
@@ -193,9 +195,9 @@ class TestCherrypy(TracerTestCase, helper.CPWebCase):
         assert_span_http_status_code(s, 500)
         assert s.error == 1
         assert s.meta.get(http.METHOD) == "GET"
-        assert "ZeroDivisionError" in s.meta.get(errors.ERROR_TYPE), s.meta
-        assert "by zero" in s.meta.get(errors.ERROR_MSG)
-        assert re.search('File ".*/contrib/cherrypy/web.py", line [0-9]+, in fatal', s.meta.get(errors.ERROR_STACK))
+        assert "ZeroDivisionError" in s.meta.get(ERROR_TYPE), s.meta
+        assert "by zero" in s.meta.get(ERROR_MSG)
+        assert re.search('File ".*/contrib/cherrypy/web.py", line [0-9]+, in fatal', s.meta.get(ERROR_STACK))
 
     def test_unicode(self):
         # Encoded utf8 query strings MUST be parsed correctly.

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -16,10 +16,12 @@ from six import ensure_text
 
 from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
+from ddtrace.constants import ERROR_TYPE
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.contrib.django.patch import instrument_view
 from ddtrace.contrib.django.utils import get_request_uri
-from ddtrace.ext import errors
 from ddtrace.ext import http
 from ddtrace.ext.priority import USER_KEEP
 from ddtrace.internal.compat import PY2
@@ -383,9 +385,9 @@ def test_middleware_trace_error_500(client, test_spans):
         assert span.resource == "GET ^error-500/$"
     else:
         assert span.resource == "GET tests.contrib.django.views.error_500"
-    assert span.get_tag(errors.ERROR_MSG) is None
-    assert span.get_tag(errors.ERROR_TYPE) is None
-    assert span.get_tag(errors.ERROR_STACK) is None
+    assert span.get_tag(ERROR_MSG) is None
+    assert span.get_tag(ERROR_TYPE) is None
+    assert span.get_tag(ERROR_STACK) is None
 
     # Test the view span (where the exception is generated)
     view_span = list(test_spans.filter_spans(name="django.view"))
@@ -393,17 +395,17 @@ def test_middleware_trace_error_500(client, test_spans):
     view_span = view_span[0]
     assert view_span.error == 1
     # Make sure the message is somewhere in the stack trace
-    assert "Error 500" in view_span.get_tag(errors.ERROR_STACK)
+    assert "Error 500" in view_span.get_tag(ERROR_STACK)
 
     # Test the catch exception middleware
     res = "tests.contrib.django.middleware.CatchExceptionMiddleware.process_exception"
     mw_span = list(test_spans.filter_spans(resource=res))[0]
     assert mw_span.error == 1
     # Make sure the message is somewhere in the stack trace
-    assert "Error 500" in view_span.get_tag(errors.ERROR_STACK)
-    assert mw_span.get_tag(errors.ERROR_MSG) is not None
-    assert mw_span.get_tag(errors.ERROR_TYPE) is not None
-    assert mw_span.get_tag(errors.ERROR_STACK) is not None
+    assert "Error 500" in view_span.get_tag(ERROR_STACK)
+    assert mw_span.get_tag(ERROR_MSG) is not None
+    assert mw_span.get_tag(ERROR_TYPE) is not None
+    assert mw_span.get_tag(ERROR_STACK) is not None
 
 
 def test_middleware_handled_view_exception_success(client, test_spans):
@@ -428,9 +430,9 @@ def test_middleware_handled_view_exception_success(client, test_spans):
     # Test the root span
     root_span = test_spans.get_root_span()
     assert root_span.error == 0
-    assert root_span.get_tag(errors.ERROR_STACK) is None
-    assert root_span.get_tag(errors.ERROR_MSG) is None
-    assert root_span.get_tag(errors.ERROR_TYPE) is None
+    assert root_span.get_tag(ERROR_STACK) is None
+    assert root_span.get_tag(ERROR_MSG) is None
+    assert root_span.get_tag(ERROR_TYPE) is None
 
     # Test the view span (where the exception is generated)
     view_span = list(test_spans.filter_spans(name="django.view"))

--- a/tests/contrib/flask/test_middleware.py
+++ b/tests/contrib/flask/test_middleware.py
@@ -5,9 +5,11 @@ import time
 from flask import make_response
 
 from ddtrace import config
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
+from ddtrace.constants import ERROR_TYPE
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.contrib.flask import TraceMiddleware
-from ddtrace.ext import errors
 from ddtrace.ext import http
 from tests.opentracer.utils import init_tracer
 from tests.utils import DummyTracer
@@ -268,9 +270,9 @@ class TestFlask(TracerTestCase):
         assert_span_http_status_code(s, 500)
         assert s.error == 1
         assert s.meta.get(http.METHOD) == "GET"
-        assert "ZeroDivisionError" in s.meta.get(errors.ERROR_TYPE), s.meta
-        assert "by zero" in s.meta.get(errors.ERROR_MSG)
-        assert re.search('File ".*/contrib/flask/web.py", line [0-9]+, in fatal', s.meta.get(errors.ERROR_STACK))
+        assert "ZeroDivisionError" in s.meta.get(ERROR_TYPE), s.meta
+        assert "by zero" in s.meta.get(ERROR_MSG)
+        assert re.search('File ".*/contrib/flask/web.py", line [0-9]+, in fatal', s.meta.get(ERROR_STACK))
 
     def test_unicode(self):
         start = time.time()

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -4,10 +4,10 @@ from molten.testing import TestClient
 from ddtrace import Pin
 from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import ERROR_MSG
 from ddtrace.contrib.molten import patch
 from ddtrace.contrib.molten import unpatch
 from ddtrace.contrib.molten.patch import MOLTEN_VERSION
-from ddtrace.ext import errors
 from ddtrace.ext import http
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
@@ -198,8 +198,8 @@ class TestMolten(TracerTestCase):
         self.assertEqual(span.resource, "GET /error")
         self.assertEqual(span.error, 1)
         # error tags only set for route function span and not root span
-        self.assertIsNone(span.get_tag(errors.ERROR_MSG))
-        self.assertEqual(route_error_span.get_tag(errors.ERROR_MSG), "Error message")
+        self.assertIsNone(span.get_tag(ERROR_MSG))
+        self.assertEqual(route_error_span.get_tag(ERROR_MSG), "Error message")
 
     def test_resources(self):
         """Tests request has expected span resources"""

--- a/tests/contrib/pylons/test_pylons.py
+++ b/tests/contrib/pylons/test_pylons.py
@@ -8,9 +8,11 @@ from routes import url_for
 
 from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
+from ddtrace.constants import ERROR_TYPE
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.contrib.pylons import PylonsTraceMiddleware
-from ddtrace.ext import errors
 from ddtrace.ext import http
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
@@ -60,9 +62,9 @@ class PylonsTestCase(TracerTestCase):
         assert span.get_tag(http.URL) == "http://localhost:80/raise_exception"
         assert_span_http_status_code(span, 200)
         assert http.QUERY_STRING not in span.meta
-        assert span.get_tag(errors.ERROR_MSG) is None
-        assert span.get_tag(errors.ERROR_TYPE) is None
-        assert span.get_tag(errors.ERROR_STACK) is None
+        assert span.get_tag(ERROR_MSG) is None
+        assert span.get_tag(ERROR_TYPE) is None
+        assert span.get_tag(ERROR_STACK) is None
         assert span.span_type == "web"
 
     def test_mw_exc_success(self):
@@ -92,9 +94,9 @@ class PylonsTestCase(TracerTestCase):
         assert span.error == 0
         assert span.get_tag(http.URL) == "http://localhost:80/"
         assert_span_http_status_code(span, 200)
-        assert span.get_tag(errors.ERROR_MSG) is None
-        assert span.get_tag(errors.ERROR_TYPE) is None
-        assert span.get_tag(errors.ERROR_STACK) is None
+        assert span.get_tag(ERROR_MSG) is None
+        assert span.get_tag(ERROR_TYPE) is None
+        assert span.get_tag(ERROR_STACK) is None
 
     def test_middleware_exception(self):
         """Ensure exceptions raised in middleware are properly handled.
@@ -122,9 +124,9 @@ class PylonsTestCase(TracerTestCase):
         assert span.error == 1
         assert span.get_tag(http.URL) == "http://localhost:80/"
         assert_span_http_status_code(span, 500)
-        assert span.get_tag(errors.ERROR_MSG) == "Middleware exception"
-        assert span.get_tag(errors.ERROR_TYPE) == "exceptions.Exception"
-        assert span.get_tag(errors.ERROR_STACK)
+        assert span.get_tag(ERROR_MSG) == "Middleware exception"
+        assert span.get_tag(ERROR_TYPE) == "exceptions.Exception"
+        assert span.get_tag(ERROR_STACK)
 
     def test_exc_success(self):
         from .app.middleware import ExceptionToSuccessMiddleware
@@ -146,9 +148,9 @@ class PylonsTestCase(TracerTestCase):
         assert span.error == 0
         assert span.get_tag(http.URL) == "http://localhost:80/raise_exception"
         assert_span_http_status_code(span, 200)
-        assert span.get_tag(errors.ERROR_MSG) is None
-        assert span.get_tag(errors.ERROR_TYPE) is None
-        assert span.get_tag(errors.ERROR_STACK) is None
+        assert span.get_tag(ERROR_MSG) is None
+        assert span.get_tag(ERROR_TYPE) is None
+        assert span.get_tag(ERROR_STACK) is None
 
     def test_exc_client_failure(self):
         from .app.middleware import ExceptionToClientErrorMiddleware
@@ -170,9 +172,9 @@ class PylonsTestCase(TracerTestCase):
         assert span.error == 0
         assert span.get_tag(http.URL) == "http://localhost:80/raise_exception"
         assert_span_http_status_code(span, 404)
-        assert span.get_tag(errors.ERROR_MSG) is None
-        assert span.get_tag(errors.ERROR_TYPE) is None
-        assert span.get_tag(errors.ERROR_STACK) is None
+        assert span.get_tag(ERROR_MSG) is None
+        assert span.get_tag(ERROR_TYPE) is None
+        assert span.get_tag(ERROR_STACK) is None
 
     def test_success_200(self, query_string=""):
         if query_string:

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -11,11 +11,12 @@ import six
 from ddtrace import Pin
 from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
 from ddtrace.contrib.requests import patch
 from ddtrace.contrib.requests import unpatch
 from ddtrace.contrib.requests.connection import _extract_hostname
 from ddtrace.contrib.requests.connection import _extract_query_string
-from ddtrace.ext import errors
 from ddtrace.ext import http
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
@@ -205,10 +206,10 @@ class TestRequests(BaseRequestTestCase, TracerTestCase):
         assert_is_measured(s)
         assert s.get_tag(http.METHOD) == "GET"
         assert s.error == 1
-        assert "Failed to establish a new connection" in s.get_tag(errors.MSG)
-        assert "Failed to establish a new connection" in s.get_tag(errors.STACK)
-        assert "Traceback (most recent call last)" in s.get_tag(errors.STACK)
-        assert "requests.exception" in s.get_tag(errors.TYPE)
+        assert "Failed to establish a new connection" in s.get_tag(ERROR_MSG)
+        assert "Failed to establish a new connection" in s.get_tag(ERROR_STACK)
+        assert "Traceback (most recent call last)" in s.get_tag(ERROR_STACK)
+        assert "requests.exception" in s.get_tag(ERROR_MSG)
 
     def test_500(self):
         out = self.session.get(URL_500)

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -13,6 +13,7 @@ from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
+from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.requests import patch
 from ddtrace.contrib.requests import unpatch
 from ddtrace.contrib.requests.connection import _extract_hostname
@@ -209,7 +210,7 @@ class TestRequests(BaseRequestTestCase, TracerTestCase):
         assert "Failed to establish a new connection" in s.get_tag(ERROR_MSG)
         assert "Failed to establish a new connection" in s.get_tag(ERROR_STACK)
         assert "Traceback (most recent call last)" in s.get_tag(ERROR_STACK)
-        assert "requests.exception" in s.get_tag(ERROR_MSG)
+        assert "requests.exception" in s.get_tag(ERROR_TYPE)
 
     def test_500(self):
         out = self.session.get(URL_500)

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -6,11 +6,13 @@ import pytest
 import ddtrace
 from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
+from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.sqlite3 import connection_factory
 from ddtrace.contrib.sqlite3.patch import TracedSQLiteCursor
 from ddtrace.contrib.sqlite3.patch import patch
 from ddtrace.contrib.sqlite3.patch import unpatch
-from ddtrace.ext import errors
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
@@ -83,9 +85,9 @@ class TestSQLite(TracerTestCase):
             root = self.get_root_span()
             assert_is_measured(root)
             self.assertIsNone(root.get_tag("sql.query"))
-            self.assertIsNotNone(root.get_tag(errors.ERROR_STACK))
-            self.assertIn("OperationalError", root.get_tag(errors.ERROR_TYPE))
-            self.assertIn("no such table", root.get_tag(errors.ERROR_MSG))
+            self.assertIsNotNone(root.get_tag(ERROR_STACK))
+            self.assertIn("OperationalError", root.get_tag(ERROR_TYPE))
+            self.assertIn("no such table", root.get_tag(ERROR_MSG))
             self.reset()
 
     def test_sqlite_fetchall_is_traced(self):

--- a/tests/contrib/urllib3/test_urllib3.py
+++ b/tests/contrib/urllib3/test_urllib3.py
@@ -4,9 +4,11 @@ import urllib3
 
 from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
+from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.urllib3 import patch
 from ddtrace.contrib.urllib3 import unpatch
-from ddtrace.ext import errors
 from ddtrace.ext import http
 from ddtrace.pin import Pin
 from tests.opentracer.utils import init_tracer
@@ -196,10 +198,10 @@ class TestUrllib3(BaseUrllib3TestCase):
             if i > 0:
                 assert s.get_tag(http.RETRIES_REMAIN) == str(retries - i)
             assert s.error == 1
-            assert "Failed to establish a new connection" in s.get_tag(errors.MSG)
-            assert "Failed to establish a new connection" in s.get_tag(errors.STACK)
-            assert "Traceback (most recent call last)" in s.get_tag(errors.STACK)
-            assert "urllib3.exceptions.MaxRetryError" in s.get_tag(errors.TYPE)
+            assert "Failed to establish a new connection" in s.get_tag(ERROR_MSG)
+            assert "Failed to establish a new connection" in s.get_tag(ERROR_STACK)
+            assert "Traceback (most recent call last)" in s.get_tag(ERROR_STACK)
+            assert "urllib3.exceptions.MaxRetryError" in s.get_tag(ERROR_TYPE)
 
     def test_default_service_name(self):
         """Test the default service name is set"""

--- a/tests/contrib/vertica/test_vertica.py
+++ b/tests/contrib/vertica/test_vertica.py
@@ -4,9 +4,11 @@ import ddtrace
 from ddtrace import Pin
 from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
+from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.vertica.patch import patch
 from ddtrace.contrib.vertica.patch import unpatch
-from ddtrace.ext import errors
 from ddtrace.settings.config import _deepmerge
 from ddtrace.vendor import wrapt
 from tests.contrib.config import VERTICA_CONFIG
@@ -243,10 +245,10 @@ class TestVertica(TracerTestCase):
         # check all the metadata
         assert spans[0].service == "vertica"
         assert spans[0].error == 1
-        assert "INVALID QUERY" in spans[0].get_tag(errors.ERROR_MSG)
+        assert "INVALID QUERY" in spans[0].get_tag(ERROR_MSG)
         error_type = "vertica_python.errors.VerticaSyntaxError"
-        assert spans[0].get_tag(errors.ERROR_TYPE) == error_type
-        assert spans[0].get_tag(errors.ERROR_STACK)
+        assert spans[0].get_tag(ERROR_TYPE) == error_type
+        assert spans[0].get_tag(ERROR_STACK)
 
         assert spans[1].resource == "COMMIT;"
 

--- a/tests/opentracer/core/test_span.py
+++ b/tests/opentracer/core/test_span.py
@@ -72,7 +72,9 @@ class TestSpan(object):
         """Ensure keys that can be handled by our impl. are indeed handled."""
         import traceback
 
-        from ddtrace.ext import errors
+        from ddtrace.constants import ERROR_MSG
+        from ddtrace.constants import ERROR_STACK
+        from ddtrace.constants import ERROR_TYPE
 
         stack_trace = str(traceback.format_stack())
         nop_span.log_kv(
@@ -87,9 +89,9 @@ class TestSpan(object):
         # Ensure error flag is set...
         assert nop_span._dd_span.error
         # ...and that error tags are set with the correct key
-        assert nop_span._get_tag(errors.ERROR_STACK) == stack_trace
-        assert nop_span._get_tag(errors.ERROR_MSG) == "my error message"
-        assert nop_span._get_metric(errors.ERROR_TYPE) == 3
+        assert nop_span._get_tag(ERROR_STACK) == stack_trace
+        assert nop_span._get_tag(ERROR_MSG) == "my error message"
+        assert nop_span._get_metric(ERROR_TYPE) == 3
 
     def test_operation_name(self, nop_span):
         """Sanity check for setting the operation name."""

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -10,11 +10,13 @@ import six
 
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.constants import ENV_KEY
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
+from ddtrace.constants import ERROR_TYPE
 from ddtrace.constants import SERVICE_VERSION_KEY
 from ddtrace.constants import SPAN_MEASURED_KEY
 from ddtrace.constants import VERSION_KEY
 from ddtrace.ext import SpanTypes
-from ddtrace.ext import errors
 from ddtrace.span import Span
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
@@ -189,16 +191,16 @@ class SpanTestCase(TracerTestCase):
             assert 0, "should have failed"
 
         assert s.error
-        assert "by zero" in s.get_tag(errors.ERROR_MSG)
-        assert "ZeroDivisionError" in s.get_tag(errors.ERROR_TYPE)
+        assert "by zero" in s.get_tag(ERROR_MSG)
+        assert "ZeroDivisionError" in s.get_tag(ERROR_TYPE)
 
     def test_traceback_without_error(self):
         s = Span(None, "test.span")
         s.set_traceback()
         assert not s.error
-        assert not s.get_tag(errors.ERROR_MSG)
-        assert not s.get_tag(errors.ERROR_TYPE)
-        assert "in test_traceback_without_error" in s.get_tag(errors.ERROR_STACK)
+        assert not s.get_tag(ERROR_MSG)
+        assert not s.get_tag(ERROR_TYPE)
+        assert "in test_traceback_without_error" in s.get_tag(ERROR_STACK)
 
     def test_ctx_mgr(self):
         s = Span(self.tracer, "bar")
@@ -214,9 +216,9 @@ class SpanTestCase(TracerTestCase):
             assert out == e
             assert s.duration > 0, s.duration
             assert s.error
-            assert s.get_tag(errors.ERROR_MSG) == "boo"
-            assert "Exception" in s.get_tag(errors.ERROR_TYPE)
-            assert s.get_tag(errors.ERROR_STACK)
+            assert s.get_tag(ERROR_MSG) == "boo"
+            assert "Exception" in s.get_tag(ERROR_TYPE)
+            assert s.get_tag(ERROR_STACK)
 
         else:
             assert 0, "should have failed"
@@ -542,9 +544,9 @@ def test_span_ignored_exceptions():
             raise ValueError()
 
     assert s.error == 0
-    assert s.get_tag(errors.ERROR_MSG) is None
-    assert s.get_tag(errors.ERROR_TYPE) is None
-    assert s.get_tag(errors.ERROR_STACK) is None
+    assert s.get_tag(ERROR_MSG) is None
+    assert s.get_tag(ERROR_TYPE) is None
+    assert s.get_tag(ERROR_STACK) is None
 
     s = Span(None, None)
     s._ignore_exception(ValueError)
@@ -558,9 +560,9 @@ def test_span_ignored_exceptions():
             raise RuntimeError()
 
     assert s.error == 1
-    assert s.get_tag(errors.ERROR_MSG) is not None
-    assert "RuntimeError" in s.get_tag(errors.ERROR_TYPE)
-    assert s.get_tag(errors.ERROR_STACK) is not None
+    assert s.get_tag(ERROR_MSG) is not None
+    assert "RuntimeError" in s.get_tag(ERROR_TYPE)
+    assert s.get_tag(ERROR_STACK) is not None
 
 
 def test_span_ignored_exception_multi():
@@ -577,9 +579,9 @@ def test_span_ignored_exception_multi():
             raise RuntimeError()
 
     assert s.error == 0
-    assert s.get_tag(errors.ERROR_MSG) is None
-    assert s.get_tag(errors.ERROR_TYPE) is None
-    assert s.get_tag(errors.ERROR_STACK) is None
+    assert s.get_tag(ERROR_MSG) is None
+    assert s.get_tag(ERROR_TYPE) is None
+    assert s.get_tag(ERROR_STACK) is None
 
 
 def test_span_ignored_exception_subclass():
@@ -595,9 +597,9 @@ def test_span_ignored_exception_subclass():
             raise RuntimeError()
 
     assert s.error == 0
-    assert s.get_tag(errors.ERROR_MSG) is None
-    assert s.get_tag(errors.ERROR_TYPE) is None
-    assert s.get_tag(errors.ERROR_STACK) is None
+    assert s.get_tag(ERROR_MSG) is None
+    assert s.get_tag(ERROR_TYPE) is None
+    assert s.get_tag(ERROR_STACK) is None
 
 
 def test_on_finish_single_callback():


### PR DESCRIPTION
## Description
Relocated error constant from `ddtrace.ext.error` to the `ddtrace.constants` module and deprecated the `get_traceback()` method. This is to help restructure the tracer for v1.0


