### PR TITLE
perf(tracer): make span.context lazy

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -53,10 +53,10 @@ class Context(object):
                 )
         return False
 
-    def _with_span(self, span):
-        # type: (Span) -> Context
+    def _copy(self):
+        # type: () -> Context
         """Return a shallow copy of the context with the given span."""
-        ctx = self.__class__(trace_id=span.trace_id, span_id=span.span_id)
+        ctx = self.__class__(trace_id=self.trace_id, span_id=self.span_id)
         ctx._lock = self._lock
         ctx._meta = self._meta
         ctx._metrics = self._metrics

--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -78,7 +78,7 @@ class TraceTagsProcessor(TraceProcessor):
             return trace
 
         chunk_root = trace[0]
-        ctx = chunk_root._context
+        ctx = chunk_root._trace_context
         if not ctx:
             return trace
 

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -239,7 +239,7 @@ class DatadogSampler(BasePrioritySampler):
 
     def _set_priority(self, span, priority):
         # type: (Span, int) -> None
-        span.context.sampling_priority = priority
+        span._trace_context.sampling_priority = priority
         span.sampled = priority is AUTO_KEEP
 
     def sample(self, span):


### PR DESCRIPTION
span.context does not always get accessed. It should only be accessed
when distributing a trace across execution boundaries which is not
always the case. So we can save having to copy the base context until it
is really necessary.

Benchmarks to come

## Description
<!-- Please briefly describe the change and why it was required. -->


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
