### PR TITLE
fix(django): Fix multiple fn middleware sharing the same resource name

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -262,8 +262,12 @@ def traced_load_middleware(django, pin, func, instance, args, kwargs):
                     # r is the middleware handler function returned from the factory
                     r = func(*args, **kwargs)
                     if r:
-                        return wrapt.FunctionWrapper(r, traced_func(django, "django.middleware", resource=resource))
-                    # If r is an empty middleware function (i.e. returns None), don't wrap since NoneType cannot be called
+                        return wrapt.FunctionWrapper(
+                            r,
+                            traced_func(django, "django.middleware", resource=resource),
+                        )
+                    # If r is an empty middleware function (i.e. returns None), don't wrap since
+                    # NoneType cannot be called
                     else:
                         return r
 

--- a/releasenotes/notes/django-multiple-function-middleware-54999c787cf003a0.yaml
+++ b/releasenotes/notes/django-multiple-function-middleware-54999c787cf003a0.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes an issue where all Django function middleware will share the same resource name.

--- a/tests/contrib/django/middleware.py
+++ b/tests/contrib/django/middleware.py
@@ -42,6 +42,16 @@ def fn_middleware(get_response):
     return mw
 
 
+def fn2_middleware(get_response):
+    """Function factory middleware."""
+
+    def mw(request):
+        response = get_response(request)
+        return response
+
+    return mw
+
+
 def empty_middleware(get_response):
     """Empty function middleware for regression testing."""
 

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -449,7 +449,7 @@ def test_empty_middleware_func_is_raised_in_django(client, test_spans):
             client.get("/")
 
 
-@pytest.mark.skipif(django.VERSION < (1, 10, 0), reason="Middleware functions only implemented since 1.10.0")
+@pytest.mark.skipif(django.VERSION < (2, 0, 0), reason="")
 def test_multiple_fn_middleware_resource_names(client, test_spans):
     with modify_settings(MIDDLEWARE={"append": "tests.contrib.django.middleware.fn2_middleware"}):
         client.get("/")

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -449,6 +449,15 @@ def test_empty_middleware_func_is_raised_in_django(client, test_spans):
             client.get("/")
 
 
+@pytest.mark.skipif(django.VERSION < (1, 10, 0), reason="Middleware functions only implemented since 1.10.0")
+def test_multiple_fn_middleware_resource_names(client, test_spans):
+    with modify_settings(MIDDLEWARE={"append": "tests.contrib.django.middleware.fn2_middleware"}):
+        client.get("/")
+
+    assert test_spans.find_span(name="django.middleware", resource="tests.contrib.django.middleware.fn_middleware")
+    assert test_spans.find_span(name="django.middleware", resource="tests.contrib.django.middleware.fn2_middleware")
+
+
 """
 View tests
 """

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -278,7 +278,7 @@ def test_v2XX_middleware(client, test_spans):
         "django.middleware.security.SecurityMiddleware.process_request",
         "django.middleware.security.SecurityMiddleware.process_response",
         "tests.contrib.django.middleware.ClsMiddleware.__call__",
-        "tests.contrib.django.middleware.EverythingMiddleware",
+        "tests.contrib.django.middleware.fn_middleware",
         "tests.contrib.django.middleware.EverythingMiddleware.__call__",
         "tests.contrib.django.middleware.EverythingMiddleware.process_view",
     }

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions.snap
@@ -150,7 +150,7 @@
                                    "duration" 1007000}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_21x.snap
@@ -149,7 +149,7 @@
                                    "duration" 1023000}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_30.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_30.snap
@@ -150,7 +150,7 @@
                                    "duration" 239310}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_31.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_31.snap
@@ -152,7 +152,7 @@
                                    "duration" 1720934}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_3x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_3x.snap
@@ -152,7 +152,7 @@
                                    "duration" 2065900}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_500_30.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_500_30.snap
@@ -150,7 +150,7 @@
                                    "duration" 1747119558}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_500_31.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_500_31.snap
@@ -152,7 +152,7 @@
                                    "duration" 715051343}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_500_3x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_500_3x.snap
@@ -152,7 +152,7 @@
                                    "duration" 392354711}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view.snap
@@ -150,7 +150,7 @@
                                    "duration" 2500000}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_21x.snap
@@ -149,7 +149,7 @@
                                    "duration" 4249000}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view.snap
@@ -150,7 +150,7 @@
                                    "duration" 826000}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_21x.snap
@@ -149,7 +149,7 @@
                                    "duration" 471000}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding.snap
@@ -152,7 +152,7 @@
                                    "duration" 5091000}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_21x.snap
@@ -151,7 +151,7 @@
                                    "duration" 1775000}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.snap
@@ -150,7 +150,7 @@
                                    "duration" 2086000}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include_21x.snap
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include_21x.snap
@@ -149,7 +149,7 @@
                                    "duration" 340000}
                                       {"name" "django.middleware"
                                        "service" "django"
-                                       "resource" "tests.contrib.django.middleware.EverythingMiddleware"
+                                       "resource" "tests.contrib.django.middleware.fn_middleware"
                                        "error" 0
                                        "span_id" 21
                                        "trace_id" 0


### PR DESCRIPTION
Fixes #2873

Just like it was pointed out in #2873 we evaluate the resource name for function middleware after we have looped through all of the middleware and we were using a shared reference to the `mw_path` variable used for the resource name.

This change adds a function wrapper to allow us to close over the proper resource name.