### PR TITLE
B3 + configurable HTTP injectors/extractors support

### DIFF
--- a/ddtrace/propagation/b3.py
+++ b/ddtrace/propagation/b3.py
@@ -1,0 +1,156 @@
+from typing import Dict
+
+from ..context import Context
+from ..ext import priority
+from ..internal.logger import get_logger
+from .base_http_propagator import BaseHTTPPropagator
+from .utils import extract_header_value
+from .utils import get_wsgi_header
+
+
+log = get_logger(__name__)
+
+HTTP_HEADER_SINGLE = "b3"
+HTTP_HEADER_TRACE_ID = "x-b3-traceid"
+HTTP_HEADER_SPAN_ID = "x-b3-spanid"
+HTTP_HEADER_SAMPLED = "x-b3-sampled"
+HTTP_HEADER_DEBUG = "x-b3-flags"
+
+# Note that due to WSGI spec we have to also check for uppercased and prefixed
+# versions of these headers
+POSSIBLE_HTTP_HEADER_SINGLE = frozenset([HTTP_HEADER_SINGLE, get_wsgi_header(HTTP_HEADER_SINGLE).lower()])
+POSSIBLE_HTTP_HEADER_TRACE_IDS = frozenset([HTTP_HEADER_TRACE_ID, get_wsgi_header(HTTP_HEADER_TRACE_ID).lower()])
+POSSIBLE_HTTP_HEADER_SPAN_IDS = frozenset([HTTP_HEADER_SPAN_ID, get_wsgi_header(HTTP_HEADER_SPAN_ID).lower()])
+POSSIBLE_HTTP_HEADER_SAMPLED = frozenset([HTTP_HEADER_SAMPLED, get_wsgi_header(HTTP_HEADER_SAMPLED).lower()])
+POSSIBLE_HTTP_HEADER_DEBUG = frozenset([HTTP_HEADER_DEBUG, get_wsgi_header(HTTP_HEADER_DEBUG).lower()])
+
+# x-b3-sampled accepted truthy values for pre-specification tracers
+_SAMPLED_TRUTHY_VALUES = {"1", "True", "true", "d"}
+
+_SAMPLING_PRIORITY_MAP = {
+    priority.USER_REJECT: "0",
+    priority.AUTO_REJECT: "0",
+    priority.AUTO_KEEP: "1",
+    priority.USER_KEEP: "1",
+}
+
+
+class B3HTTPPropagator(BaseHTTPPropagator):
+    """
+    An HTTP Propagator using B3 headers as carrier.
+
+    It is recommended to use HTTPPropagator rather than this class directly
+    """
+
+    @staticmethod
+    def inject(span_context, headers):
+        # type: (Context, Dict[str, str]) -> None
+        """
+        Inject Context attributes to be propagated as B3 HTTP headers.
+
+        :param Context span_context: Span context to propagate.
+        :param dict headers: HTTP headers to extend with tracing attributes.
+        """
+        sampled = "0"
+        if span_context.sampling_priority is not None:
+            sampled = _SAMPLING_PRIORITY_MAP[int(span_context.sampling_priority)]
+
+        if span_context.trace_id is not None:
+            headers[HTTP_HEADER_TRACE_ID] = format_trace_id(span_context.trace_id)
+
+        if span_context.span_id is not None:
+            headers[HTTP_HEADER_SPAN_ID] = format_span_id(span_context.span_id)
+
+        headers[HTTP_HEADER_SAMPLED] = sampled
+
+    @staticmethod
+    def extract(headers):
+        # type: (Dict[str,str]) -> Context
+        """
+        Extract a Context from B3 HTTP headers into a new Context.
+
+        :param dict headers: HTTP headers to extract tracing attributes.
+        :return: New `Context` with propagated attributes.
+        """
+        if not headers:
+            return Context()
+
+        normalized_headers = {name.lower(): v for name, v in headers.items()}
+
+        single_header = extract_header_value(
+            POSSIBLE_HTTP_HEADER_SINGLE,
+            normalized_headers,
+        )
+
+        if single_header:
+            # The b3 spec calls for the sampling state to be
+            # "deferred", which is unspecified. This concept does not
+            # translate to SpanContext, so we set it as recorded
+            sampled = "1"
+            fields = single_header.split("-")
+            if len(fields) == 1:
+                sampled = fields[0]
+            elif len(fields) == 2:
+                trace_id, span_id = fields
+            elif len(fields) == 3:
+                trace_id, span_id, sampled = fields
+            elif len(fields) == 4:
+                trace_id, span_id, sampled, _ = fields
+            else:
+                return Context()
+        else:
+            trace_id = extract_header_value(
+                POSSIBLE_HTTP_HEADER_TRACE_IDS,
+                normalized_headers,
+            )  # type: ignore[assignment]
+            span_id = extract_header_value(
+                POSSIBLE_HTTP_HEADER_SPAN_IDS,
+                normalized_headers,
+            )  # type: ignore[assignment]
+            sampled = extract_header_value(
+                POSSIBLE_HTTP_HEADER_SAMPLED,
+                normalized_headers,
+            )  # type: ignore[assignment]
+
+            if not (trace_id and span_id):
+                return Context()
+
+        debug = extract_header_value(
+            POSSIBLE_HTTP_HEADER_DEBUG,
+            normalized_headers,
+        )
+
+        if sampled in _SAMPLED_TRUTHY_VALUES or debug == "1":
+            sampling_priority = priority.AUTO_KEEP
+        else:
+            sampling_priority = priority.AUTO_REJECT
+
+        try:
+            return Context(
+                trace_id=int(trace_id, 16),
+                span_id=int(span_id, 16),
+                sampling_priority=sampling_priority,
+            )
+        except (TypeError, ValueError):
+            log.debug(
+                "received invalid x-b3-* headers, trace-id: %r, span-id: %r, sampled: %r",
+                trace_id,
+                span_id,
+                sampled,
+            )
+            return Context()
+        except Exception:
+            log.debug("error while extracting b3 headers", exc_info=True)
+            return Context()
+
+
+def format_trace_id(trace_id):
+    # type: (int) -> str
+    """Format the trace id according to b3 specification (128 bit, 32 hex)"""
+    return format(trace_id, "032x")
+
+
+def format_span_id(span_id):
+    # type: (int) -> str
+    """Format the span id according to b3 specification (64 bit, 16 hex)"""
+    return format(span_id, "016x")

--- a/ddtrace/propagation/base_http_propagator.py
+++ b/ddtrace/propagation/base_http_propagator.py
@@ -1,0 +1,20 @@
+import abc
+from typing import Dict
+
+import six
+
+from ..context import Context
+
+
+class BaseHTTPPropagator(six.with_metaclass(abc.ABCMeta)):
+    @staticmethod
+    @abc.abstractmethod
+    def inject(span_context, headers):
+        # type: (Context, Dict[str, str]) -> None
+        pass
+
+    @staticmethod
+    @abc.abstractmethod
+    def extract(headers):
+        # type: (Dict[str,str]) -> Context
+        pass

--- a/ddtrace/propagation/datadog.py
+++ b/ddtrace/propagation/datadog.py
@@ -1,0 +1,118 @@
+from typing import Dict
+
+from ..context import Context
+from ..internal.logger import get_logger
+from .base_http_propagator import BaseHTTPPropagator
+from .utils import extract_header_value
+from .utils import get_wsgi_header
+
+
+log = get_logger(__name__)
+
+# HTTP headers one should set for distributed tracing.
+# These are cross-language (eg: Python, Go and other implementations should honor these)
+HTTP_HEADER_TRACE_ID = "x-datadog-trace-id"
+HTTP_HEADER_PARENT_ID = "x-datadog-parent-id"
+HTTP_HEADER_SAMPLING_PRIORITY = "x-datadog-sampling-priority"
+HTTP_HEADER_ORIGIN = "x-datadog-origin"
+
+
+# Note that due to WSGI spec we have to also check for uppercased and prefixed
+# versions of these headers
+POSSIBLE_HTTP_HEADER_TRACE_IDS = frozenset([HTTP_HEADER_TRACE_ID, get_wsgi_header(HTTP_HEADER_TRACE_ID).lower()])
+POSSIBLE_HTTP_HEADER_PARENT_IDS = frozenset([HTTP_HEADER_PARENT_ID, get_wsgi_header(HTTP_HEADER_PARENT_ID).lower()])
+POSSIBLE_HTTP_HEADER_SAMPLING_PRIORITIES = frozenset(
+    [HTTP_HEADER_SAMPLING_PRIORITY, get_wsgi_header(HTTP_HEADER_SAMPLING_PRIORITY).lower()]
+)
+POSSIBLE_HTTP_HEADER_ORIGIN = frozenset([HTTP_HEADER_ORIGIN, get_wsgi_header(HTTP_HEADER_ORIGIN).lower()])
+
+
+class DatadogHTTPPropagator(BaseHTTPPropagator):
+    """
+    An HTTP Propagator using Datadog headers as carrier.
+
+    It is recommended to use HTTPPropagator rather than this class directly
+    """
+
+    @staticmethod
+    def inject(span_context, headers):
+        # type: (Context, Dict[str, str]) -> None
+        """
+        Inject Context attributes to be propagated as Datadog HTTP headers.
+
+        :param Context span_context: Span context to propagate.
+        :param dict headers: HTTP headers to extend with tracing attributes.
+        """
+        headers[HTTP_HEADER_TRACE_ID] = str(span_context.trace_id)
+        headers[HTTP_HEADER_PARENT_ID] = str(span_context.span_id)
+        sampling_priority = span_context.sampling_priority
+        # Propagate priority only if defined
+        if sampling_priority is not None:
+            headers[HTTP_HEADER_SAMPLING_PRIORITY] = str(span_context.sampling_priority)
+        # Propagate origin only if defined
+        if span_context.dd_origin is not None:
+            headers[HTTP_HEADER_ORIGIN] = str(span_context.dd_origin)
+
+    @staticmethod
+    def extract(headers):
+        # type: (Dict[str,str]) -> Context
+        """
+        Extract a Context from Datadog HTTP headers into a new Context.
+
+        :param dict headers: HTTP headers to extract tracing attributes.
+        :return: New `Context` with propagated attributes.
+        """
+        if not headers:
+            return Context()
+
+        try:
+            normalized_headers = {name.lower(): v for name, v in headers.items()}
+            # TODO: Fix variable type changing (mypy)
+            trace_id = extract_header_value(
+                POSSIBLE_HTTP_HEADER_TRACE_IDS,
+                normalized_headers,
+            )
+            if trace_id is None:
+                return Context()
+
+            parent_span_id = extract_header_value(
+                POSSIBLE_HTTP_HEADER_PARENT_IDS,
+                normalized_headers,
+                default="0",
+            )
+            sampling_priority = extract_header_value(
+                POSSIBLE_HTTP_HEADER_SAMPLING_PRIORITIES,
+                normalized_headers,
+            )
+            origin = extract_header_value(
+                POSSIBLE_HTTP_HEADER_ORIGIN,
+                normalized_headers,
+            )
+
+            # Try to parse values into their expected types
+            try:
+                if sampling_priority is not None:
+                    sampling_priority = int(sampling_priority)  # type: ignore[assignment]
+                else:
+                    sampling_priority = sampling_priority
+
+                return Context(
+                    # DEV: Do not allow `0` for trace id or span id, use None instead
+                    trace_id=int(trace_id) or None,
+                    span_id=int(parent_span_id) or None,  # type: ignore[arg-type]
+                    sampling_priority=sampling_priority,  # type: ignore[arg-type]
+                    dd_origin=origin,
+                )
+            # If headers are invalid and cannot be parsed, return a new context and log the issue.
+            except (TypeError, ValueError):
+                log.debug(
+                    "received invalid x-datadog-* headers, trace-id: %r, parent-id: %r, priority: %r, origin: %r",
+                    trace_id,
+                    parent_span_id,
+                    sampling_priority,
+                    origin,
+                )
+                return Context()
+        except Exception:
+            log.debug("error while extracting x-datadog-* headers", exc_info=True)
+            return Context()

--- a/ddtrace/propagation/utils.py
+++ b/ddtrace/propagation/utils.py
@@ -1,3 +1,5 @@
+from typing import Dict
+from typing import FrozenSet
 from typing import Optional
 
 from ddtrace.utils.cache import cached
@@ -29,3 +31,15 @@ def from_wsgi_header(header):
     elif header not in UNPREFIXED_HEADERS:
         return None
     return header.replace("_", "-").title()
+
+
+def extract_header_value(possible_header_names, headers, default=None):
+    # type: (FrozenSet[str], Dict[str, str], Optional[str]) -> Optional[str]
+    """Search through a list of possible header names, return the value of the first match"""
+    for header in possible_header_names:
+        try:
+            return headers[header]
+        except KeyError:
+            pass
+
+    return default

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -140,6 +140,12 @@ class Config(object):
 
         self.logs_injection = asbool(get_env("logs", "injection", default=False))
 
+        self.propagation_style_inject = os.getenv("DD_PROPAGATION_STYLE_INJECT", "Datadog").lower().split(",")
+
+        self.propagation_style_extract = (
+            os.getenv("DD_PROPAGATION_STYLE_EXTRACT", str.join(",", self.propagation_style_inject)).lower().split(",")
+        )
+
         self.report_hostname = asbool(get_env("trace", "report_hostname", default=False))
 
         self.health_metrics_enabled = asbool(get_env("trace", "health_metrics_enabled", default=False))

--- a/tests/benchmarks/test_propagation.py
+++ b/tests/benchmarks/test_propagation.py
@@ -1,6 +1,10 @@
 import pytest
 
+from ddtrace.propagation import b3
+from ddtrace.propagation import datadog
 from ddtrace.propagation import http
+
+from ..utils import override_env
 
 
 @pytest.mark.benchmark(group="HTTPPropagator.extract")
@@ -19,25 +23,66 @@ def test_extract_no_headers(benchmark):
 
 
 @pytest.mark.benchmark(group="HTTPPropagator.extract")
-def test_extract_ideal_scenario(benchmark):
+def test_http_propagator_ideal_scenario_all_propagators(benchmark):
+    with override_env(dict(DD_PROPAGATION_STYLE_EXTRACT="B3,Datadog")):
+        benchmark(
+            http.HTTPPropagator.extract,
+            {
+                datadog.HTTP_HEADER_TRACE_ID: 1,
+                datadog.HTTP_HEADER_PARENT_ID: 2,
+                datadog.HTTP_HEADER_SAMPLING_PRIORITY: 1,
+                datadog.HTTP_HEADER_ORIGIN: "benchmarks",
+                b3.HTTP_HEADER_TRACE_ID: "00000000000000000000000000000001",
+                b3.HTTP_HEADER_SPAN_ID: "0000000000000002",
+                b3.HTTP_HEADER_SAMPLED: 1,
+            },
+        )
+
+
+@pytest.mark.benchmark(group="HTTPPropagator.extract")
+def test_extract_ideal_scenario_datadog(benchmark):
     benchmark(
-        http.HTTPPropagator.extract,
+        datadog.DatadogHTTPPropagator.extract,
         {
-            http.HTTP_HEADER_TRACE_ID: 1,
-            http.HTTP_HEADER_PARENT_ID: 2,
-            http.HTTP_HEADER_SAMPLING_PRIORITY: 1,
-            http.HTTP_HEADER_ORIGIN: "benchmarks",
+            datadog.HTTP_HEADER_TRACE_ID: 1,
+            datadog.HTTP_HEADER_PARENT_ID: 2,
+            datadog.HTTP_HEADER_SAMPLING_PRIORITY: 1,
+            datadog.HTTP_HEADER_ORIGIN: "benchmarks",
         },
     )
 
 
 @pytest.mark.benchmark(group="HTTPPropagator.extract")
-def test_extract_invalid_values(benchmark):
+def test_extract_ideal_scenario_b3(benchmark):
     benchmark(
-        http.HTTPPropagator.extract,
+        b3.B3HTTPPropagator.extract,
         {
-            http.HTTP_HEADER_TRACE_ID: "one",
-            http.HTTP_HEADER_PARENT_ID: "two",
-            http.HTTP_HEADER_SAMPLING_PRIORITY: "one",
+            b3.HTTP_HEADER_TRACE_ID: "00000000000000000000000000000001",
+            b3.HTTP_HEADER_SPAN_ID: "0000000000000002",
+            b3.HTTP_HEADER_SAMPLED: 1,
+        },
+    )
+
+
+@pytest.mark.benchmark(group="HTTPPropagator.extract")
+def test_extract_invalid_values_datadog(benchmark):
+    benchmark(
+        datadog.DatadogHTTPPropagator.extract,
+        {
+            datadog.HTTP_HEADER_TRACE_ID: "one",
+            datadog.HTTP_HEADER_PARENT_ID: "two",
+            datadog.HTTP_HEADER_SAMPLING_PRIORITY: "one",
+        },
+    )
+
+
+@pytest.mark.benchmark(group="HTTPPropagator.extract")
+def test_extract_invalid_values_b3(benchmark):
+    benchmark(
+        b3.B3HTTPPropagator.extract,
+        {
+            b3.HTTP_HEADER_TRACE_ID: "one",
+            b3.HTTP_HEADER_SPAN_ID: "two",
+            b3.HTTP_HEADER_SAMPLED: "one",
         },
     )

--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -9,7 +9,8 @@ import pytest
 
 from ddtrace.contrib.asgi import TraceMiddleware
 from ddtrace.contrib.asgi import span_from_scope
-from ddtrace.propagation import http as http_propagation
+from ddtrace.propagation.datadog import HTTP_HEADER_PARENT_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_TRACE_ID
 from tests.utils import DummyTracer
 from tests.utils import override_http_config
 
@@ -274,8 +275,8 @@ async def test_asgi_error_custom(scope, tracer, test_spans):
 async def test_distributed_tracing(scope, tracer, test_spans):
     app = TraceMiddleware(basic_app, tracer=tracer)
     headers = [
-        (http_propagation.HTTP_HEADER_PARENT_ID.encode(), "1234".encode()),
-        (http_propagation.HTTP_HEADER_TRACE_ID.encode(), "5678".encode()),
+        (HTTP_HEADER_PARENT_ID.encode(), "1234".encode()),
+        (HTTP_HEADER_TRACE_ID.encode(), "5678".encode()),
     ]
     scope["headers"] = headers
     instance = ApplicationCommunicator(app, scope)

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -19,8 +19,8 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.botocore.patch import patch
 from ddtrace.contrib.botocore.patch import unpatch
 from ddtrace.internal.compat import stringify
-from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
-from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_PARENT_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_TRACE_ID
 from ddtrace.utils.version import parse_version
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -27,9 +27,9 @@ from ddtrace.ext import http
 from ddtrace.internal.compat import PY2
 from ddtrace.internal.compat import binary_type
 from ddtrace.internal.compat import string_type
-from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
-from ddtrace.propagation.http import HTTP_HEADER_SAMPLING_PRIORITY
-from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_PARENT_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_SAMPLING_PRIORITY
+from ddtrace.propagation.datadog import HTTP_HEADER_TRACE_ID
 from ddtrace.propagation.utils import get_wsgi_header
 from ddtrace.vendor import wrapt
 from tests.opentracer.utils import init_tracer

--- a/tests/contrib/fastapi/test_fastapi.py
+++ b/tests/contrib/fastapi/test_fastapi.py
@@ -8,7 +8,8 @@ import pytest
 import ddtrace
 from ddtrace.contrib.fastapi import patch as fastapi_patch
 from ddtrace.contrib.fastapi import unpatch as fastapi_unpatch
-from ddtrace.propagation import http as http_propagation
+from ddtrace.propagation.datadog import HTTP_HEADER_PARENT_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_TRACE_ID
 from tests.utils import DummyTracer
 from tests.utils import TracerSpanContainer
 from tests.utils import override_config
@@ -389,8 +390,8 @@ def test_multi_path_param_aggregate(client, tracer, test_spans):
 
 def test_distributed_tracing(client, tracer, test_spans):
     headers = [
-        (http_propagation.HTTP_HEADER_PARENT_ID, "5555"),
-        (http_propagation.HTTP_HEADER_TRACE_ID, "9999"),
+        (HTTP_HEADER_PARENT_ID, "5555"),
+        (HTTP_HEADER_TRACE_ID, "9999"),
         ("sleep", "False"),
     ]
     response = client.get("http://testserver/", headers=dict(headers))

--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -10,8 +10,8 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.flask.patch import flask_version
 from ddtrace.ext import http
 from ddtrace.internal.compat import PY2
-from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
-from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_PARENT_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_TRACE_ID
 from tests.utils import assert_is_measured
 from tests.utils import assert_span_http_status_code
 

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -9,8 +9,8 @@ from ddtrace.contrib.molten import patch
 from ddtrace.contrib.molten import unpatch
 from ddtrace.contrib.molten.patch import MOLTEN_VERSION
 from ddtrace.ext import http
-from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
-from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_PARENT_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_TRACE_ID
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 from tests.utils import assert_span_http_status_code

--- a/tests/contrib/sanic/test_sanic.py
+++ b/tests/contrib/sanic/test_sanic.py
@@ -14,7 +14,8 @@ from sanic.server import HttpProtocol
 
 from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
-from ddtrace.propagation import http as http_propagation
+from ddtrace.propagation.datadog import HTTP_HEADER_PARENT_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_TRACE_ID
 from tests.utils import override_config
 from tests.utils import override_http_config
 
@@ -154,8 +155,8 @@ async def test_basic_app(tracer, client, integration_config, integration_http_co
     with override_http_config("sanic", integration_http_config):
         with override_config("sanic", integration_config):
             headers = [
-                (http_propagation.HTTP_HEADER_PARENT_ID, "1234"),
-                (http_propagation.HTTP_HEADER_TRACE_ID, "5678"),
+                (HTTP_HEADER_PARENT_ID, "1234"),
+                (HTTP_HEADER_TRACE_ID, "5678"),
             ]
             response = await client.get("/hello", params=[("foo", "bar")], headers=headers)
             assert _response_status(response) == 200

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -13,7 +13,8 @@ from ddtrace.contrib.sqlalchemy import patch as sql_patch
 from ddtrace.contrib.sqlalchemy import unpatch as sql_unpatch
 from ddtrace.contrib.starlette import patch as starlette_patch
 from ddtrace.contrib.starlette import unpatch as starlette_unpatch
-from ddtrace.propagation import http as http_propagation
+from ddtrace.propagation.datadog import HTTP_HEADER_PARENT_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_TRACE_ID
 from tests.contrib.starlette.app import get_app
 from tests.utils import DummyTracer
 from tests.utils import TracerSpanContainer
@@ -185,8 +186,8 @@ def test_500error(client, tracer, test_spans):
 
 def test_distributed_tracing(client, tracer, test_spans):
     headers = [
-        (http_propagation.HTTP_HEADER_PARENT_ID, "1234"),
-        (http_propagation.HTTP_HEADER_TRACE_ID, "5678"),
+        (HTTP_HEADER_PARENT_ID, "1234"),
+        (HTTP_HEADER_TRACE_ID, "5678"),
     ]
     r = client.get("http://testserver/", headers=dict(headers))
 

--- a/tests/opentracer/core/test_tracer.py
+++ b/tests/opentracer/core/test_tracer.py
@@ -15,7 +15,7 @@ from ddtrace.constants import AUTO_KEEP
 from ddtrace.opentracer import Tracer
 from ddtrace.opentracer import set_global_tracer
 from ddtrace.opentracer.span_context import SpanContext
-from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_TRACE_ID
 from ddtrace.settings import ConfigException
 
 

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -3,12 +3,12 @@ from unittest import TestCase
 
 import pytest
 
+from ddtrace import config as global_config
 from ddtrace.context import Context
-from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.propagation.http import HTTP_HEADER_ORIGIN
-from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
-from ddtrace.propagation.http import HTTP_HEADER_SAMPLING_PRIORITY
-from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
+from ddtrace.propagation import b3
+from ddtrace.propagation import datadog
+from ddtrace.propagation import http
+from ddtrace.propagation.utils import extract_header_value
 from ddtrace.propagation.utils import get_wsgi_header
 from tests.utils import DummyTracer
 
@@ -17,39 +17,93 @@ NOT_SET = object()
 
 
 class TestHttpPropagation(TestCase):
-    """
-    Tests related to the ``Context`` class that hosts the trace for the
-    current execution flow.
-    """
+    def setUp(self):
+        global_config.propagation_style_extract = ["datadog"]
+        global_config.propagation_style_inject = ["datadog"]
+        self.tracer = DummyTracer()
+
+    def test_inject_all_propagators(self):
+        ctx = Context(trace_id=1234, sampling_priority=1, dd_origin="synthetics")
+        self.tracer.context_provider.activate(ctx)
+        global_config.propagation_style_inject = ["b3", "datadog"]
+
+        with self.tracer.trace("global_root_span") as span:
+            headers = {}
+            http.HTTPPropagator.inject(span.context, headers)
+
+            assert int(headers[datadog.HTTP_HEADER_TRACE_ID]) == span.trace_id
+            assert int(headers[datadog.HTTP_HEADER_PARENT_ID]) == span.span_id
+            assert int(headers[datadog.HTTP_HEADER_SAMPLING_PRIORITY]) == span.context.sampling_priority
+            assert headers[datadog.HTTP_HEADER_ORIGIN] == span.context.dd_origin
+            assert int(headers[b3.HTTP_HEADER_TRACE_ID], 16) == span.trace_id
+            assert int(headers[b3.HTTP_HEADER_SPAN_ID], 16) == span.span_id
+            assert int(headers[b3.HTTP_HEADER_SAMPLED]) == span.context.sampling_priority
+
+    def test_extract_propagator_order(self):
+        """Datadog extractor should take precedence when multiple extractors + headers are present"""
+        global_config.propagation_style_extract = ["b3", "datadog"]
+        headers = {
+            "x-b3-traceid": "000000000000000000000000000004d2",
+            "x-b3-spanid": "000000000000162e",
+            "x-b3-sampled": "1",
+            "x-datadog-trace-id": "9999",
+            "x-datadog-parent-id": "5555",
+            "x-datadog-sampling-priority": "1",
+            "x-datadog-origin": "synthetics",
+        }
+
+        context = http.HTTPPropagator.extract(headers)
+        self.tracer.context_provider.activate(context)
+
+        with self.tracer.trace("local_root_span") as span:
+            assert span.trace_id == 9999
+            assert span.parent_id == 5555
+            assert span.context.sampling_priority == 1
+
+    def test_extract_b3(self):
+        global_config.propagation_style_extract = ["b3"]
+        headers = {
+            "x-b3-traceid": "000000000000000000000000000004d2",
+            "x-b3-spanid": "000000000000162e",
+            "x-b3-sampled": "1",
+        }
+
+        context = http.HTTPPropagator.extract(headers)
+        self.tracer.context_provider.activate(context)
+
+        with self.tracer.trace("local_root_span") as span:
+            assert span.trace_id == 1234
+            assert span.parent_id == 5678
+            assert span.context.sampling_priority == 1
+
+
+class TestDatadogHttpPropagation(TestCase):
+    def setUp(self):
+        self.tracer = DummyTracer()
 
     def test_inject(self):
-        tracer = DummyTracer()
-
         ctx = Context(trace_id=1234, sampling_priority=2, dd_origin="synthetics")
-        tracer.context_provider.activate(ctx)
-        with tracer.trace("global_root_span") as span:
+        self.tracer.context_provider.activate(ctx)
+        with self.tracer.trace("global_root_span") as span:
             headers = {}
-            HTTPPropagator.inject(span.context, headers)
+            datadog.DatadogHTTPPropagator.inject(span.context, headers)
 
-            assert int(headers[HTTP_HEADER_TRACE_ID]) == span.trace_id
-            assert int(headers[HTTP_HEADER_PARENT_ID]) == span.span_id
-            assert int(headers[HTTP_HEADER_SAMPLING_PRIORITY]) == span.context.sampling_priority
-            assert headers[HTTP_HEADER_ORIGIN] == span.context.dd_origin
+            assert int(headers[datadog.HTTP_HEADER_TRACE_ID]) == span.trace_id
+            assert int(headers[datadog.HTTP_HEADER_PARENT_ID]) == span.span_id
+            assert int(headers[datadog.HTTP_HEADER_SAMPLING_PRIORITY]) == span.context.sampling_priority
+            assert headers[datadog.HTTP_HEADER_ORIGIN] == span.context.dd_origin
 
     def test_extract(self):
-        tracer = DummyTracer()
-
         headers = {
             "x-datadog-trace-id": "1234",
             "x-datadog-parent-id": "5678",
             "x-datadog-sampling-priority": "1",
             "x-datadog-origin": "synthetics",
         }
+        context = datadog.DatadogHTTPPropagator.extract(headers)
+        self.tracer.context_provider.activate(context)
 
-        context = HTTPPropagator.extract(headers)
-        tracer.context_provider.activate(context)
-
-        with tracer.trace("local_root_span") as span:
+        with self.tracer.trace("local_root_span") as span:
             assert span.trace_id == 1234
             assert span.parent_id == 5678
             assert span.context.sampling_priority == 1
@@ -57,23 +111,81 @@ class TestHttpPropagation(TestCase):
 
     def test_WSGI_extract(self):
         """Ensure we support the WSGI formatted headers as well."""
-        tracer = DummyTracer()
-
         headers = {
             "HTTP_X_DATADOG_TRACE_ID": "1234",
             "HTTP_X_DATADOG_PARENT_ID": "5678",
             "HTTP_X_DATADOG_SAMPLING_PRIORITY": "1",
             "HTTP_X_DATADOG_ORIGIN": "synthetics",
         }
+        context = datadog.DatadogHTTPPropagator.extract(headers)
+        self.tracer.context_provider.activate(context)
 
-        context = HTTPPropagator.extract(headers)
-        tracer.context_provider.activate(context)
-
-        with tracer.trace("local_root_span") as span:
+        with self.tracer.trace("local_root_span") as span:
             assert span.trace_id == 1234
             assert span.parent_id == 5678
             assert span.context.sampling_priority == 1
             assert span.context.dd_origin == "synthetics"
+
+
+class TestB3HttpPropagation(TestCase):
+    def setUp(self):
+        self.tracer = DummyTracer()
+
+    def test_inject(self):
+        ctx = Context(trace_id=1234, sampling_priority=1)
+        self.tracer.context_provider.activate(ctx)
+        with self.tracer.trace("global_root_span") as span:
+            headers = {}
+            b3.B3HTTPPropagator.inject(span.context, headers)
+
+            assert int(headers[b3.HTTP_HEADER_TRACE_ID], 16) == span.trace_id
+            assert int(headers[b3.HTTP_HEADER_SPAN_ID], 16) == span.span_id
+            assert int(headers[b3.HTTP_HEADER_SAMPLED]) == span.context.sampling_priority
+
+    def test_extract(self):
+        headers = {
+            "x-b3-traceid": "000000000000000000000000000004d2",
+            "x-b3-spanid": "000000000000162e",
+            "x-b3-sampled": "1",
+        }
+
+        context = b3.B3HTTPPropagator.extract(headers)
+        self.tracer.context_provider.activate(context)
+
+        with self.tracer.trace("local_root_span") as span:
+            assert span.trace_id == 1234
+            assert span.context.sampling_priority == 1
+
+    def test_extract_64_bit_trace(self):
+        headers = {
+            "x-b3-traceid": "00000000000004d2",
+            "x-b3-spanid": "000000000000162e",
+            "x-b3-sampled": "1",
+        }
+
+        context = b3.B3HTTPPropagator.extract(headers)
+        self.tracer.context_provider.activate(context)
+
+        with self.tracer.trace("local_root_span") as span:
+            assert span.trace_id == 1234
+            assert span.context.sampling_priority == 1
+
+    def test_WSGI_extract(self):
+        """Ensure we support the WSGI formatted headers as well."""
+        tracer = DummyTracer()
+
+        headers = {
+            "HTTP_X_B3_TRACEID": "000000000000000000000000000004d2",
+            "HTTP_X_B3_SPANID": "000000000000162e",
+            "HTTP_X_B3_SAMPLED": "1",
+        }
+
+        context = b3.B3HTTPPropagator.extract(headers)
+        tracer.context_provider.activate(context)
+
+        with tracer.trace("local_root_span") as span:
+            assert span.trace_id == 1234
+            assert span.context.sampling_priority == 1
 
 
 @pytest.mark.parametrize(
@@ -90,38 +202,129 @@ class TestHttpPropagation(TestCase):
         [None, NOT_SET],
     ),
 )
-def test_extract_bad_values(trace_id, parent_span_id, sampling_priority, dd_origin):
+def test_extract_bad_values_datadog(trace_id, parent_span_id, sampling_priority, dd_origin):
     headers = dict()
     wsgi_headers = dict()
 
     if trace_id is not NOT_SET:
-        headers[HTTP_HEADER_TRACE_ID] = trace_id
-        wsgi_headers[get_wsgi_header(HTTP_HEADER_TRACE_ID)] = trace_id
+        headers[datadog.HTTP_HEADER_TRACE_ID] = trace_id
+        wsgi_headers[get_wsgi_header(datadog.HTTP_HEADER_TRACE_ID)] = trace_id
     if parent_span_id is not NOT_SET:
-        headers[HTTP_HEADER_PARENT_ID] = parent_span_id
-        wsgi_headers[get_wsgi_header(HTTP_HEADER_PARENT_ID)] = parent_span_id
+        headers[datadog.HTTP_HEADER_PARENT_ID] = parent_span_id
+        wsgi_headers[get_wsgi_header(datadog.HTTP_HEADER_PARENT_ID)] = parent_span_id
     if sampling_priority is not NOT_SET:
-        headers[HTTP_HEADER_SAMPLING_PRIORITY] = sampling_priority
-        wsgi_headers[get_wsgi_header(HTTP_HEADER_SAMPLING_PRIORITY)] = sampling_priority
+        headers[datadog.HTTP_HEADER_SAMPLING_PRIORITY] = sampling_priority
+        wsgi_headers[get_wsgi_header(datadog.HTTP_HEADER_SAMPLING_PRIORITY)] = sampling_priority
     if dd_origin is not NOT_SET:
-        headers[HTTP_HEADER_ORIGIN] = dd_origin
-        wsgi_headers[get_wsgi_header(HTTP_HEADER_ORIGIN)] = dd_origin
+        headers[datadog.HTTP_HEADER_ORIGIN] = dd_origin
+        wsgi_headers[get_wsgi_header(datadog.HTTP_HEADER_ORIGIN)] = dd_origin
 
     # x-datadog-*headers
-    context = HTTPPropagator.extract(headers)
+    context = datadog.DatadogHTTPPropagator.extract(headers)
     assert context.trace_id is None
     assert context.span_id is None
     assert context.sampling_priority is None
     assert context.dd_origin is None
 
     # HTTP_X_DATADOG_* headers
-    context = HTTPPropagator.extract(wsgi_headers)
+    context = datadog.DatadogHTTPPropagator.extract(wsgi_headers)
     assert context.trace_id is None
     assert context.span_id is None
     assert context.sampling_priority is None
     assert context.dd_origin is None
 
 
+@pytest.mark.parametrize(
+    "trace_id,span_id,sampled",
+    itertools.product(
+        # Trace id
+        ["one", None, "123.4", "", NOT_SET],
+        # Parent id
+        # DEV: 10 is valid for parent id but is ignored if trace id is ever invalid
+        ["one", None, "123.4", "", NOT_SET, "10"],
+        # Sampling priority
+        ["one", None, "123.4", "", NOT_SET],
+    ),
+)
+def test_extract_bad_values_b3_multi(trace_id, span_id, sampled):
+    headers = dict()
+    wsgi_headers = dict()
+
+    if sampled is not NOT_SET:
+        headers[b3.HTTP_HEADER_SAMPLED] = sampled
+        wsgi_headers[get_wsgi_header(b3.HTTP_HEADER_SAMPLED)] = sampled
+    if trace_id is not NOT_SET:
+        headers[b3.HTTP_HEADER_TRACE_ID] = trace_id
+        wsgi_headers[get_wsgi_header(b3.HTTP_HEADER_TRACE_ID)] = trace_id
+    if span_id is not NOT_SET:
+        headers[b3.HTTP_HEADER_SPAN_ID] = span_id
+        wsgi_headers[get_wsgi_header(b3.HTTP_HEADER_SPAN_ID)] = span_id
+
+    # x-b3-*headers
+    context = b3.B3HTTPPropagator.extract(headers)
+    assert context.trace_id is None
+    assert context.span_id is None
+    assert context.sampling_priority is None
+
+    # HTTP_X_B3_* headers
+    context = b3.B3HTTPPropagator.extract(wsgi_headers)
+    assert context.trace_id is None
+    assert context.span_id is None
+    assert context.sampling_priority is None
+
+
+@pytest.mark.parametrize(
+    "trace_id,span_id,sampled",
+    itertools.product(
+        # Trace id
+        ["one", None, "123.4", "", NOT_SET],
+        # Parent id
+        # DEV: 10 is valid for parent id but is ignored if trace id is ever invalid
+        ["one", None, "123.4", "", NOT_SET, "10"],
+        # Sampling priority
+        ["one", None, "123.4", "", NOT_SET],
+    ),
+)
+def test_extract_bad_values_b3_single(trace_id, span_id, sampled):
+    headers = dict()
+    wsgi_headers = dict()
+
+    if sampled is not NOT_SET:
+        if (trace_id and span_id) is not NOT_SET:
+            headers[b3.HTTP_HEADER_SINGLE] = "{},{},{}".format(trace_id, span_id, sampled)
+            wsgi_headers[get_wsgi_header(b3.HTTP_HEADER_SINGLE)] = "{},{},{}".format(trace_id, span_id, sampled)
+        else:
+            headers[b3.HTTP_HEADER_SINGLE] = "{}".format(sampled)
+            wsgi_headers[get_wsgi_header(b3.HTTP_HEADER_SINGLE)] = "{}".format(sampled)
+    else:
+        if (trace_id and span_id) is not NOT_SET:
+            headers[b3.HTTP_HEADER_SINGLE] = "{},{}".format(trace_id, span_id)
+            wsgi_headers[get_wsgi_header(b3.HTTP_HEADER_SINGLE)] = "{},{}".format(trace_id, span_id)
+
+    # b3 header
+    context = b3.B3HTTPPropagator.extract(headers)
+    assert context.trace_id is None
+    assert context.span_id is None
+    assert context.sampling_priority is None
+
+    # HTTP_B3 header
+    context = b3.B3HTTPPropagator.extract(wsgi_headers)
+    assert context.trace_id is None
+    assert context.span_id is None
+    assert context.sampling_priority is None
+
+
 class TestPropagationUtils(object):
     def test_get_wsgi_header(self):
         assert get_wsgi_header("x-datadog-trace-id") == "HTTP_X_DATADOG_TRACE_ID"
+
+    def test_extract_header_value(self):
+        headers = {"foo": "1", "bar": "2", "baz": "3"}
+        assert extract_header_value(possible_header_names=frozenset(["tom", "dick", "harry"]), headers=headers) is None
+        assert extract_header_value(possible_header_names=frozenset(["bob", "alice", "foo"]), headers=headers) == "1"
+        assert (
+            extract_header_value(
+                possible_header_names=frozenset(["bob", "alice", "carol"]), headers=headers, default="default"
+            )
+            == "default"
+        )

--- a/tests/tracer/test_settings.py
+++ b/tests/tracer/test_settings.py
@@ -51,6 +51,33 @@ class TestConfig(BaseTestCase):
             config = Config()
             self.assertFalse(config.logs_injection)
 
+    def test_propagation_style_inject(self):
+        config = Config()
+        self.assertEqual(config.propagation_style_inject, ["datadog"])
+        with self.override_env(dict(DD_PROPAGATION_STYLE_INJECT="B3")):
+            config = Config()
+            self.assertEqual(config.propagation_style_inject, ["b3"])
+        with self.override_env(dict(DD_PROPAGATION_STYLE_INJECT="B3,Datadog")):
+            config = Config()
+            self.assertEqual(config.propagation_style_inject, ["b3", "datadog"])
+
+    def test_propagation_style_extract(self):
+        config = Config()
+        self.assertEqual(config.propagation_style_extract, ["datadog"])
+        with self.override_env(dict(DD_PROPAGATION_STYLE_EXTRACT="B3")):
+            config = Config()
+            self.assertEqual(config.propagation_style_extract, ["b3"])
+        with self.override_env(dict(DD_PROPAGATION_STYLE_EXTRACT="B3,Datadog")):
+            config = Config()
+            self.assertEqual(config.propagation_style_extract, ["b3", "datadog"])
+        # extract defaults to whatever inject is configured as
+        with self.override_env(dict(DD_PROPAGATION_STYLE_INJECT="B3,Datadog")):
+            config = Config()
+            self.assertEqual(config.propagation_style_extract, ["b3", "datadog"])
+        with self.override_env(dict(DD_PROPAGATION_STYLE_INJECT="B3", DD_PROPAGATION_STYLE_EXTRACT="Datadog")):
+            config = Config()
+            self.assertEqual(config.propagation_style_extract, ["datadog"])
+
     def test_service(self):
         # If none is provided the default should be ``None``
         with self.override_env(dict()):

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -18,8 +18,8 @@ from ddtrace import tracer
 from ddtrace.contrib import trace_utils
 from ddtrace.ext import http
 from ddtrace.internal.compat import stringify
-from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
-from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_PARENT_ID
+from ddtrace.propagation.datadog import HTTP_HEADER_TRACE_ID
 from ddtrace.settings import Config
 from ddtrace.settings import IntegrationConfig
 from tests.utils import override_global_config


### PR DESCRIPTION
## Description
This PR adds support for B3 format headers from the OpenZipkin project that we desperately need, as our python services are huge black holes in our trace map.

I've tried to implement the functionality in a similar way to other dd trace libs that already have support for this (cpp, golang, java etc).

* Add support for DD_PROPAGATION_STYLE_INJECT
* Add support for DD_PROPAGATION_STYLE_EXTRACT
* Move datadog HTTP propagator into it's own class, keeping existing class as a facade/iterator over other implementations
* Add b3 HTTP propagator


## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [x] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
