### PR TITLE
Pin latest sanic tests

### DIFF
--- a/tests/contrib/sanic/conftest.py
+++ b/tests/contrib/sanic/conftest.py
@@ -3,6 +3,8 @@ import sys
 import pytest
 
 import ddtrace
+from ddtrace.contrib.sanic import patch
+from ddtrace.contrib.sanic import unpatch
 from tests.utils import DummyTracer
 
 
@@ -16,5 +18,7 @@ def tracer():
 
         tracer.configure(context_provider=AsyncioContextProvider())
     setattr(ddtrace, "tracer", tracer)
+    patch()
     yield tracer
     setattr(ddtrace, "tracer", original_tracer)
+    unpatch()

--- a/tests/contrib/sanic/conftest.py
+++ b/tests/contrib/sanic/conftest.py
@@ -3,8 +3,6 @@ import sys
 import pytest
 
 import ddtrace
-from ddtrace.contrib.sanic import patch
-from ddtrace.contrib.sanic import unpatch
 from tests.utils import DummyTracer
 
 
@@ -18,7 +16,5 @@ def tracer():
 
         tracer.configure(context_provider=AsyncioContextProvider())
     setattr(ddtrace, "tracer", tracer)
-    patch()
     yield tracer
     setattr(ddtrace, "tracer", original_tracer)
-    unpatch()

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,8 @@ envlist =
     pymysql_contrib-py{27,35,36,37,38,39}-pymysql{07,08,09,}
     pyodbc_contrib-py{27,35,36,37,38,39}-pyodbc{3,4}
     pyramid_contrib{,_autopatch}-py{27,35,36,37,38,39}-pyramid{17,18,19,110,}-webtest
-    sanic_contrib-py{37,38,39}-sanic{1906,1909,1912,2003,2006,2103,}
+    sanic_contrib-py{37}-sanic{1906,1909,1912,2003,2006,2103}
+    sanic_contrib-py{38,39}-sanic{1906,1909,1912,2003,2006,2103,}
     sqlite3_contrib-py{27,35,36,37,38,39}-sqlite3
     tornado_contrib-py{27,35,36,37,38,39}-tornado{44,45}
     tornado_contrib-py{37,38,39}-tornado{50,51,60,}
@@ -240,7 +241,7 @@ deps =
     sanic2103: pytest-sanic==1.7.1
     sanic2103: httpx==0.15.4
     sanic: sanic
-    sanic: pytest-sanic==1.7.1
+    sanic: pytest-sanic==1.8.1
     sanic: httpx==0.15.4
     sqlalchemy: sqlalchemy
     sslmodules3: aiohttp

--- a/tox.ini
+++ b/tox.ini
@@ -61,8 +61,7 @@ envlist =
     pymysql_contrib-py{27,35,36,37,38,39}-pymysql{07,08,09,}
     pyodbc_contrib-py{27,35,36,37,38,39}-pyodbc{3,4}
     pyramid_contrib{,_autopatch}-py{27,35,36,37,38,39}-pyramid{17,18,19,110,}-webtest
-    sanic_contrib-py{37}-sanic{1906,1909,1912,2003,2006,2103}
-    sanic_contrib-py{38,39}-sanic{1906,1909,1912,2003,2006,2103,}
+    sanic_contrib-py{37,38,39}-sanic{1906,1909,1912,2003,2006,2103}
     sqlite3_contrib-py{27,35,36,37,38,39}-sqlite3
     tornado_contrib-py{27,35,36,37,38,39}-tornado{44,45}
     tornado_contrib-py{37,38,39}-tornado{50,51,60,}


### PR DESCRIPTION
The sanic latest tests are failing due to the pytest-sanic plugin not updating in response to the `21.9.0` sanic release.