### PR TITLE
bm(encoder): pre-generate the scenario data

### DIFF
--- a/benchmarks/bm/_scenario.py
+++ b/benchmarks/bm/_scenario.py
@@ -62,11 +62,19 @@ class Scenario(six.with_metaclass(ScenarioMeta)):
         """Returns a context manager that yields a function to be run for performance testing."""
         pass
 
+    @abc.abstractmethod
+    def init(self):
+        """Operations to perform in order to initialize the scenario."""
+        pass
+
     def _pyperf(self, loops):
+        self.init()
         rungen = self.run()
+
         run = next(rungen)
         t0 = time.perf_counter()
-        run(loops)
+        for _ in range(loops):
+            run()
         dt = time.perf_counter() - t0
         try:
             # perform any teardown

--- a/benchmarks/encoder/scenario.py
+++ b/benchmarks/encoder/scenario.py
@@ -10,14 +10,16 @@ class Encoder(bm.Scenario):
     nmetrics = bm.var(type=int)
     dd_origin = bm.var(type=bool)
 
+    def init(self):
+        utils.gen_data()
+
     def run(self):
         encoder = utils.init_encoder()
-        traces = utils.gen_traces(self)
+        traces = utils.load_traces(self.__dict__)
 
-        def _(loops):
-            for _ in range(loops):
-                for trace in traces:
-                    encoder.put(trace)
-                    encoder.encode()
+        def _():
+            for trace in traces:
+                encoder.put(trace)
+                encoder.encode()
 
         yield _

--- a/benchmarks/encoder/utils.py
+++ b/benchmarks/encoder/utils.py
@@ -1,8 +1,22 @@
+import json
+import os
 import random
 import string
 
+import yaml
+
+from ddtrace.internal import _rand
 from ddtrace.internal.encoding import Encoder
 from ddtrace.span import Span
+from ddtrace.utils.attrdict import AttrDict
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def read_config(path):
+    with open(path, "r") as fp:
+        return yaml.load(fp, Loader=yaml.FullLoader)
 
 
 try:
@@ -43,27 +57,90 @@ def gen_traces(config):
         trace = []
         for i in range(0, config.nspans):
             # first span is root so has no parent otherwise parent is root span
-            parent_id = trace[0].span_id if i > 0 else None
+            parent_id = trace[0]["span_id"] if i > 0 else None
             span_name = random.choice(span_names)
             resource = random.choice(resources)
             service = random.choice(services)
-            with Span(None, span_name, resource=resource, service=service, parent_id=parent_id) as span:
-                if i == 0 and config.dd_origin:
-                    # Since we're not using the tracer API, a span's context isn't automatically propagated
-                    # to its children. The encoder only checks the root span's context in a trace for dd_origin, so
-                    # here we need to add dd_origin to the root span's context.
-                    span.context.dd_origin = random.choice(dd_origin_values)
-                if config.ntags > 0:
-                    span.set_tags(dict(zip(tag_keys, [_rands(size=config.ltags) for _ in range(config.ntags)])))
-                if config.nmetrics > 0:
-                    span.set_metrics(
-                        dict(
-                            zip(
-                                metric_keys,
-                                [random.randint(0, 2 ** 16) for _ in range(config.nmetrics)],
-                            )
-                        )
+            span = dict(
+                name=span_name,
+                resource=resource,
+                service=service,
+                parent_id=parent_id,
+                span_id=_rand.rand64bits(),
+                trace_id=_rand.rand64bits(),
+            )
+
+            if i == 0 and config.dd_origin:
+                # Since we're not using the tracer API, a span's context isn't automatically propagated
+                # to its children. The encoder only checks the root span's context in a trace for dd_origin, so
+                # here we need to add dd_origin to the root span's context.
+                span["dd_origin"] = random.choice(dd_origin_values)
+
+            if config.ntags > 0:
+                span["meta"] = dict(zip(tag_keys, [_rands(size=config.ltags) for _ in range(config.ntags)]))
+
+            if config.nmetrics > 0:
+                span["metrics"] = dict(
+                    zip(
+                        metric_keys,
+                        [random.randint(0, 2 ** 16) for _ in range(config.nmetrics)],
                     )
-                trace.append(span)
+                )
+
+            trace.append(span)
+
         traces.append(trace)
+
     return traces
+
+
+def serialize_config(config):
+    return "_".join(sorted(("-".join((k, str(v))) for k, v in config.items())))
+
+
+def load_traces(config):
+    config_file = os.path.join(HERE, serialize_config(config)) + ".json"
+
+    traces = []
+
+    with open(config_file) as f:
+        data = json.load(f)
+        for t in data:
+            trace = []
+            traces.append(trace)
+            for s in t:
+                with Span(
+                    tracer=None,
+                    name=s["name"],
+                    resource=s["resource"],
+                    service=s["service"],
+                    parent_id=s["parent_id"],
+                    span_id=s["span_id"],
+                    trace_id=s["trace_id"],
+                ) as span:
+                    trace.append(span)
+
+                    if "dd_origin" in s:
+                        span.context.dd_origin = s["dd_origin"]
+                    if "meta" in s:
+                        span.set_tags(s["meta"])
+                    if "metrics" in s:
+                        span.set_metrics(s["metrics"])
+
+    return traces
+
+
+def gen_data():
+    config = read_config(os.path.join(HERE, "config.yaml"))
+
+    for name, _ in config.items():
+        _["name"] = name
+        dest = os.path.join(HERE, serialize_config(_)) + ".json"
+        if os.path.isfile(dest):
+            # data was already generated
+            continue
+
+        with open(dest, "w") as f:
+            c = AttrDict(_)
+            t = gen_traces(c)
+            json.dump(t, f)


### PR DESCRIPTION
Data for all the benchmark runs is generated once at start-up to reduce the noise due to running over different test sets.

## Description
<!-- Please briefly describe the change and why it was required. -->


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
