### PR TITLE
Add build wheels for python 3.10

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '2.7'
+          python-version: '3.8'
 
       - name: Set up QEMU
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Commit Message

ci: build wheels for python 3.10

cibuildwheel v1.x.x supports python versions 2.7, 3.5, 3.6, 3.7, 3.8, 3.9,  x 
cibuildwheel v2.x.x supports python versions   x,   x ,  3.6, 3.7, 3.8, 3.9, 3.10

This change introduces two ci build wheels:
  -  joerick/cibuildwheel@v1.12.0 to run py2.7 and py3.5
  -  pypa/cibuildwheel@v2.1.3     to run py3.6-py3.10