### PR TITLE
Remove superfluous function _get_tags from aredis and redis integrations

### DIFF
--- a/ddtrace/contrib/aredis/patch.py
+++ b/ddtrace/contrib/aredis/patch.py
@@ -65,7 +65,7 @@ async def traced_execute_command(func, instance, args, kwargs):
         s.set_tag(redisx.RAWCMD, query)
         if pin.tags:
             s.set_tags(pin.tags)
-        s.set_tags(_get_tags(instance))
+        s.set_tags(_extract_conn_tags(instance.connection_pool.connection_kwargs))
         s.set_metric(redisx.ARGS_LEN, len(args))
         # set analytics sample rate if enabled
         s.set_tag(ANALYTICS_SAMPLE_RATE_KEY, config.aredis.get_analytics_sample_rate())
@@ -98,7 +98,7 @@ async def traced_execute_pipeline(func, instance, args, kwargs):
     ) as s:
         s.set_tag(SPAN_MEASURED_KEY)
         s.set_tag(redisx.RAWCMD, resource)
-        s.set_tags(_get_tags(instance))
+        s.set_tags(_extract_conn_tags(instance.connection_pool.connection_kwargs))
         s.set_metric(redisx.PIPELINE_LEN, len(instance.command_stack))
 
         # set analytics sample rate if enabled
@@ -147,7 +147,3 @@ def format_command_args(args):
             break
 
     return " ".join(out)
-
-
-def _get_tags(conn):
-    return _extract_conn_tags(conn.connection_pool.connection_kwargs)

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -77,7 +77,7 @@ def traced_execute_command(func, instance, args, kwargs):
         s.set_tag(redisx.RAWCMD, query)
         if pin.tags:
             s.set_tags(pin.tags)
-        s.set_tags(_get_tags(instance))
+        s.set_tags(_extract_conn_tags(instance.connection_pool.connection_kwargs))
         s.set_metric(redisx.ARGS_LEN, len(args))
         # set analytics sample rate if enabled
         s.set_tag(ANALYTICS_SAMPLE_RATE_KEY, config.redis.get_analytics_sample_rate())
@@ -110,14 +110,10 @@ def traced_execute_pipeline(func, instance, args, kwargs):
     ) as s:
         s.set_tag(SPAN_MEASURED_KEY)
         s.set_tag(redisx.RAWCMD, resource)
-        s.set_tags(_get_tags(instance))
+        s.set_tags(_extract_conn_tags(instance.connection_pool.connection_kwargs))
         s.set_metric(redisx.PIPELINE_LEN, len(instance.command_stack))
 
         # set analytics sample rate if enabled
         s.set_tag(ANALYTICS_SAMPLE_RATE_KEY, config.redis.get_analytics_sample_rate())
 
         return func(*args, **kwargs)
-
-
-def _get_tags(conn):
-    return _extract_conn_tags(conn.connection_pool.connection_kwargs)


### PR DESCRIPTION

# Commit Message
redis & aredis integrations had a _get_tags method, which just called the _extract_conn_tags method (and nothing else). Remove the _get_tags method and call extract_conn_tags directly.