### PR TITLE
ci(mergify): fix config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,6 +13,7 @@ pull_request_rules:
       queue:
         name: default
         method: squash
+        commit_message: default
   # This rule keep the PR updated with its base branch as soon as it has 1
   # approval. This makes it more likely to be ready to be merged once the
   # second approval comes.
@@ -39,6 +40,3 @@ pull_request_rules:
       label:
         remove:
           - conflict
-      merge:
-        commit_message: default
-        method: squash


### PR DESCRIPTION
Last change in d82d52239803b9fffaea296a40adb76080039a51 was actually introduced
in the wrong place and ordered Mergify to merge every non-conflicting PR.

What we want is the queue (merge) action to use the default commit
message, which well, was already the default anyhow.