### PR TITLE
Disable, mark snowflake integration as beta

### DIFF
--- a/ddtrace/contrib/snowflake/__init__.py
+++ b/ddtrace/contrib/snowflake/__init__.py
@@ -1,16 +1,21 @@
 """
 The snowflake integration instruments the ``snowflake-connector-python`` library to trace Snowflake queries.
 
+Note that this integration is in beta.
+
 Enabling
 ~~~~~~~~
 
-The integration is enabled automatically when using
+The integration is not enabled automatically when using
 :ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Use :ref:`patch()<patch>` to manually enable the integration::
 
-    from ddtrace import patch
+    from ddtrace import patch, patch_all
     patch(snowflake=True)
+    patch_all(snowflake=True)
+
+or the ``DD_TRACE_SNOWFLAKE_ENABLED=true`` to enable it with ``ddtrace-run``.
 
 
 Global Configuration

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -53,7 +53,7 @@ PATCH_MODULES = {
     "requests": True,
     "rq": True,
     "sanic": True,
-    "snowflake": True,
+    "snowflake": False,
     "sqlalchemy": False,  # Prefer DB client instrumentation
     "sqlite3": True,
     "aiohttp": True,  # requires asyncio (Python 3.4+)

--- a/releasenotes/notes/add-snowflake-9fdedcd5058de2f7.yaml
+++ b/releasenotes/notes/add-snowflake-9fdedcd5058de2f7.yaml
@@ -1,4 +1,7 @@
 ---
 features:
   - |
-    Add support for `snowflake-connector-python <https://pypi.org/project/snowflake-connector-python/>`_ >= 2.0.0.
+    Add support for `snowflake-connector-python
+    <https://pypi.org/project/snowflake-connector-python/>`_ >= 2.0.0. Note
+    that this integration is in beta and is not enabled by default. See the
+    snowflake integration documentation for how to enable.


### PR DESCRIPTION

## Commit Message
<!-- Defaults to the title of the PR. Replace if desired. -->
{{title}}

<!-- Briefly describe the change and why it was required. -->
We haven't yet been able to verify snowflake with a real snowflake
instance. Until a time in which we can, the integration should be
disabled by default.
