### PR TITLE
[WIP] Implement integration with `aiohttp.ClientSession` 

### DIFF
--- a/ddtrace/contrib/aiohttp/__init__.py
+++ b/ddtrace/contrib/aiohttp/__init__.py
@@ -46,6 +46,18 @@ to the ``request`` object, so that it can be used in the application code::
 
 :ref:`All HTTP tags <http-tagging>` are supported for this integration.
 
+To enable distributed tracing for client calls it is possible to use the standard mechanism
+tracing mechanisms of ``aiohttp.ClientSession`` by passing a ``ddtrace.contrib.aiohttp.DDTraceConfig``
+instance to the `trace_configs` as follows:
+
+    import aiohttp
+    from ddtrace.contrib.aiohttp import DDTraceConfig
+
+    with ClientSession(trace_configs=[DDTraceConfig()]) as session:
+        await session.get('/')
+
+The integration will record a trace from request start to end and propagate the headers for tracing.
+
 """
 from ...utils.importlib import require_modules
 

--- a/ddtrace/contrib/aiohttp/__init__.py
+++ b/ddtrace/contrib/aiohttp/__init__.py
@@ -69,9 +69,6 @@ with require_modules(required_modules) as missing_modules:
         from .middlewares import trace_app
         from .patch import patch
         from .patch import unpatch
+        from .trace_config import DDTraceConfig
 
-        __all__ = [
-            "patch",
-            "unpatch",
-            "trace_app",
-        ]
+        __all__ = ["patch", "unpatch", "trace_app", "DDTraceConfig"]

--- a/ddtrace/contrib/aiohttp/trace_config.py
+++ b/ddtrace/contrib/aiohttp/trace_config.py
@@ -1,4 +1,5 @@
 from aiohttp.tracing import TraceConfig
+
 from ddtrace import tracer
 from ddtrace.propagation.http import HTTPPropagator
 

--- a/ddtrace/contrib/aiohttp/trace_config.py
+++ b/ddtrace/contrib/aiohttp/trace_config.py
@@ -1,0 +1,22 @@
+from aiohttp.tracing import TraceConfig
+from ddtrace import tracer
+from ddtrace.propagation.http import HTTPPropagator
+
+
+async def _on_request_start(session, trace_config_ctx, params):
+    # TODO: other methods
+    span = tracer.trace("ClientSession.{}".format(params.method))
+    trace_config_ctx.span = span
+    HTTPPropagator.inject(span.context, params.headers)
+
+
+async def _on_request_end(session, trace_config_ctx, params):
+    trace_config_ctx.span.finish()
+
+
+class DataDog(TraceConfig):
+    def __init__(self):
+        super().__init__()
+
+        self.on_request_start.append(_on_request_start)
+        self.on_request_end.append(_on_request_end)

--- a/ddtrace/contrib/aiohttp/trace_config.py
+++ b/ddtrace/contrib/aiohttp/trace_config.py
@@ -15,7 +15,7 @@ async def _on_request_end(session, trace_config_ctx, params):
     trace_config_ctx.span.finish()
 
 
-class DataDog(TraceConfig):
+class DDTraceConfig(TraceConfig):
     def __init__(self):
         super().__init__()
 

--- a/tests/contrib/aiohttp/app/web.py
+++ b/tests/contrib/aiohttp/app/web.py
@@ -103,6 +103,14 @@ async def noop_middleware(app, handler):
     return middleware_handler
 
 
+async def echo_request_headers(request):
+    response = web.Response(text="response_headers_test")
+
+    for h, v in request.headers.items():
+        response.headers["request-" + h] = v
+    return response
+
+
 def setup_app(loop=None):
     """
     Use this method to create the app. It must receive
@@ -119,6 +127,7 @@ def setup_app(loop=None):
     app.router.add_get("/", home)
     app.router.add_get("/delayed/", delayed_handler)
     app.router.add_get("/echo/{name}", name)
+    app.router.add_get("/echo_request_headers", echo_request_headers)
     app.router.add_get("/chaining/", coroutine_chaining)
     app.router.add_get("/exception", route_exception)
     app.router.add_get("/async_exception", route_async_exception)

--- a/tests/contrib/aiohttp/test_client_session.py
+++ b/tests/contrib/aiohttp/test_client_session.py
@@ -1,0 +1,21 @@
+from aiohttp import ClientSession
+from aiohttp.test_utils import TestServer
+
+from ddtrace.contrib.aiohttp.trace_config import DataDog
+
+
+async def test_client_session_header_tracing(patched_app_tracer, loop):
+    app, _ = patched_app_tracer
+    server = TestServer(app)
+
+    # TODO: move server fixture to conftest
+
+    async with ClientSession(trace_configs=[DataDog()]) as session:
+        resp = await session.get(server.make_url("/echo_request_headers"))
+        assert resp.status == 200
+
+    # the server would have received the headers in this case
+    assert "request-x-datadog-trace-id" in resp.headers
+    assert "request-x-datadog-parent-id" in resp.headers
+
+    await server.close()

--- a/tests/contrib/aiohttp/test_trace_config.py
+++ b/tests/contrib/aiohttp/test_trace_config.py
@@ -1,7 +1,7 @@
 from aiohttp import ClientSession
 from aiohttp.test_utils import TestServer
 
-from ddtrace.contrib.aiohttp.trace_config import DataDog
+from ddtrace.contrib.aiohttp import DDTraceConfig
 
 
 async def test_client_session_header_tracing(patched_app_tracer, loop):
@@ -10,7 +10,7 @@ async def test_client_session_header_tracing(patched_app_tracer, loop):
 
     # TODO: move server fixture to conftest
 
-    async with ClientSession(trace_configs=[DataDog()]) as session:
+    async with ClientSession(trace_configs=[DDTraceConfig()]) as session:
         resp = await session.get(server.make_url("/echo_request_headers"))
         assert resp.status == 200
 


### PR DESCRIPTION
## Commit Message
<!-- Defaults to the title of the PR. Replace if desired. -->
{{title}}

This change implements a subclass of `TraceConfig` to ease integration with `aiohttp.ClientSession`, this will enable `aiohttp` users to easily instrument and add distributed tracing to their applications by using the standard mechanism for tracing provided by `aiohttp.ClientSession`

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
