### PR TITLE
[WIP] Tracing for `grpc.aio` server

### DIFF
--- a/ddtrace/contrib/grpc/constants.py
+++ b/ddtrace/contrib/grpc/constants.py
@@ -1,6 +1,14 @@
 import grpc
 
 
+try:
+    from grpc import aio
+
+    GRPC_AIO_PIN_MODULE_SERVER = aio.Server
+except ImportError:
+    pass
+
+
 GRPC_PIN_MODULE_SERVER = grpc.Server
 GRPC_PIN_MODULE_CLIENT = grpc.Channel
 GRPC_METHOD_PATH_KEY = "grpc.method.path"
@@ -21,4 +29,5 @@ GRPC_METHOD_KIND_CLIENT_STREAMING = "client_streaming"
 GRPC_METHOD_KIND_SERVER_STREAMING = "server_streaming"
 GRPC_METHOD_KIND_BIDI_STREAMING = "bidi_streaming"
 GRPC_SERVICE_SERVER = "grpc-server"
+GRPC_AIO_SERVICE_SERVER = "grpc-aio-server"
 GRPC_SERVICE_CLIENT = "grpc-client"

--- a/ddtrace/contrib/grpc_aio/__init__.py
+++ b/ddtrace/contrib/grpc_aio/__init__.py
@@ -1,0 +1,11 @@
+from ...utils.importlib import require_modules
+
+
+required_modules = ["grpc.aio"]
+
+with require_modules(required_modules) as missing_modules:
+    if not missing_modules:
+        from .patch import patch
+        from .patch import unpatch
+
+        __all__ = ["patch", "unpatch"]

--- a/ddtrace/contrib/grpc_aio/__init__.py
+++ b/ddtrace/contrib/grpc_aio/__init__.py
@@ -1,3 +1,17 @@
+"""
+The gRPC integration traces aio.grpc server using the interceptor pattern.
+
+
+Enabling
+~~~~~~~~To manually enable the integration::
+
+    from ddtrace import patch
+    patch(grpc_aio=True)
+
+    # use grpc like usual
+"""
+
+
 from ...utils.importlib import require_modules
 
 

--- a/ddtrace/contrib/grpc_aio/aio_server_interceptor.py
+++ b/ddtrace/contrib/grpc_aio/aio_server_interceptor.py
@@ -1,0 +1,88 @@
+from grpc import aio
+
+from ddtrace import config
+from ddtrace.vendor import wrapt
+
+from .. import trace_utils
+from ...constants import ANALYTICS_SAMPLE_RATE_KEY
+from ...constants import SPAN_MEASURED_KEY
+from ...ext import SpanTypes
+from ..grpc import constants
+from ..grpc.utils import set_grpc_method_meta
+
+
+def create_aio_server_interceptor(pin):
+    async def interceptor_function(continuation, handler_call_details):
+
+        rpc_method_handler = await continuation(handler_call_details)
+
+        # continuation returns an RpcMethodHandler instance if the RPC is
+        # considered serviced, or None otherwise
+        # https://grpc.github.io/grpc/python/grpc.html#grpc.ServerInterceptor.intercept_service
+
+        if rpc_method_handler:
+            return _TracedRpcMethodHandler(pin, handler_call_details, rpc_method_handler)
+
+        return rpc_method_handler
+
+    return _ServerInterceptor(interceptor_function)
+
+
+class _TracedRpcMethodHandler(wrapt.ObjectProxy):
+    def __init__(self, pin, handler_call_details, wrapped):
+        super(_TracedRpcMethodHandler, self).__init__(wrapped)
+        self._pin = pin
+        self._handler_call_details = handler_call_details
+
+    async def _fn(self, method_kind, behavior, args, kwargs):
+        tracer = self._pin.tracer
+        headers = dict(self._handler_call_details.invocation_metadata)
+
+        trace_utils.activate_distributed_headers(tracer, int_config=config.grpc_aio_server, request_headers=headers)
+
+        span = tracer.trace(
+            "grpc",
+            span_type=SpanTypes.GRPC,
+            service=trace_utils.int_service(self._pin, config.grpc_aio_server),
+            resource=self._handler_call_details.method,
+        )
+        span.set_tag(SPAN_MEASURED_KEY)
+
+        set_grpc_method_meta(span, self._handler_call_details.method, method_kind)
+        span._set_str_tag(constants.GRPC_SPAN_KIND_KEY, constants.GRPC_SPAN_KIND_VALUE_SERVER)
+
+        sample_rate = config.grpc_aio_server.get_analytics_sample_rate()
+        if sample_rate is not None:
+            span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, sample_rate)
+
+        if self._pin.tags:
+            span.set_tags(self._pin.tags)
+        try:
+            response_or_iterator = await behavior(*args, **kwargs)
+        except Exception:
+            # TODO: properly catch exception
+            pass
+        finally:
+            span.finish()
+
+        return response_or_iterator
+
+    async def unary_unary(self, *args, **kwargs):
+        return await self._fn(constants.GRPC_METHOD_KIND_UNARY, self.__wrapped__.unary_unary, args, kwargs)
+
+    async def unary_stream(self, *args, **kwargs):
+        return await self._fn(constants.GRPC_METHOD_KIND_SERVER_STREAMING, self.__wrapped__.unary_stream, args, kwargs)
+
+    async def stream_unary(self, *args, **kwargs):
+        return await self._fn(constants.GRPC_METHOD_KIND_CLIENT_STREAMING, self.__wrapped__.stream_unary, args, kwargs)
+
+    async def stream_stream(self, *args, **kwargs):
+        return await self._fn(constants.GRPC_METHOD_KIND_BIDI_STREAMING, self.__wrapped__.stream_stream, args, kwargs)
+
+
+class _ServerInterceptor(aio.ServerInterceptor):
+    def __init__(self, interceptor_function):
+        self._fn = interceptor_function
+
+    async def intercept_service(self, continuation, handler_call_details):
+        return await self._fn(continuation, handler_call_details)

--- a/ddtrace/contrib/grpc_aio/aio_server_interceptor.py
+++ b/ddtrace/contrib/grpc_aio/aio_server_interceptor.py
@@ -27,6 +27,7 @@ def create_aio_server_interceptor(pin):
 
     return _ServerInterceptor(interceptor_function)
 
+
 class _TracedRpcMethodHandler(wrapt.ObjectProxy):
     def __init__(self, pin, handler_call_details, wrapped):
         super(_TracedRpcMethodHandler, self).__init__(wrapped)
@@ -60,7 +61,7 @@ class _TracedRpcMethodHandler(wrapt.ObjectProxy):
             response_or_iterator = await behavior(*args, **kwargs)
         except Exception:
             span.set_traceback()
-            # https://github.com/grpc/grpc/issues/27409 there seems to be a bug with 
+            # https://github.com/grpc/grpc/issues/27409 there seems to be a bug with
             # accessing code and details from server side context
             span.error = 1
             raise

--- a/ddtrace/contrib/grpc_aio/aio_server_interceptor.py
+++ b/ddtrace/contrib/grpc_aio/aio_server_interceptor.py
@@ -27,7 +27,6 @@ def create_aio_server_interceptor(pin):
 
     return _ServerInterceptor(interceptor_function)
 
-
 class _TracedRpcMethodHandler(wrapt.ObjectProxy):
     def __init__(self, pin, handler_call_details, wrapped):
         super(_TracedRpcMethodHandler, self).__init__(wrapped)
@@ -60,8 +59,11 @@ class _TracedRpcMethodHandler(wrapt.ObjectProxy):
         try:
             response_or_iterator = await behavior(*args, **kwargs)
         except Exception:
-            # TODO: properly catch exception
-            pass
+            span.set_traceback()
+            # https://github.com/grpc/grpc/issues/27409 there seems to be a bug with 
+            # accessing code and details from server side context
+            span.error = 1
+            raise
         finally:
             span.finish()
 

--- a/ddtrace/contrib/grpc_aio/patch.py
+++ b/ddtrace/contrib/grpc_aio/patch.py
@@ -1,0 +1,54 @@
+from ddtrace import Pin
+from ddtrace import config
+from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
+
+from ..grpc import constants
+from .aio_server_interceptor import create_aio_server_interceptor
+
+
+config._add(
+    "grpc_aio_server",
+    dict(
+        _default_service=constants.GRPC_AIO_SERVICE_SERVER,
+        distributed_tracing_enabled=True,
+    ),
+)
+
+
+def patch():
+    _patch_aio_server()
+
+
+def unpatch():
+    _unpatch_aio_server()
+
+
+def _patch_aio_server():
+
+    if getattr(constants.GRPC_AIO_PIN_MODULE_SERVER, "__datadog_patch", False):
+        return
+    setattr(constants.GRPC_AIO_PIN_MODULE_SERVER, "__datadog_patch", True)
+
+    Pin().onto(constants.GRPC_AIO_PIN_MODULE_SERVER)
+
+    _w("grpc.aio", "server", _aio_server_constructor_interceptor)
+
+
+def _aio_server_constructor_interceptor(wrapped, instance, args, kwargs):
+    pin = Pin.get_from(constants.GRPC_AIO_PIN_MODULE_SERVER)
+
+    if not pin or not pin.enabled():
+        return wrapped(*args, **kwargs)
+
+    interceptor = create_aio_server_interceptor(pin)
+    # DEV: Inject our tracing interceptor first in the list of interceptors
+    if "interceptors" in kwargs:
+        kwargs["interceptors"] = (interceptor,) + tuple(kwargs["interceptors"])
+    else:
+        kwargs["interceptors"] = (interceptor,)
+
+    return wrapped(*args, **kwargs)
+
+
+def _unpatch_aio_server():
+    pass

--- a/riotfile.py
+++ b/riotfile.py
@@ -1089,7 +1089,7 @@ venv = Venv(
             },
             venvs=[
                 Venv(
-                    pys=select_pys(min_version="3.5"),
+                    pys=select_pys(min_version="3.6"),
                     pkgs={
                         "grpcio": [
                             "~=1.32.0",

--- a/riotfile.py
+++ b/riotfile.py
@@ -1081,6 +1081,32 @@ venv = Venv(
             ],
         ),
         Venv(
+            name="grpc_aio",
+            command="python -m pytest {cmdargs} tests/contrib/grpc_aio",
+            pkgs={
+                "googleapis-common-protos": latest,
+                "pytest-asyncio": latest,
+            },
+            venvs=[
+                Venv(
+                    pys=select_pys(min_version="3.5"),
+                    pkgs={
+                        "grpcio": [
+                            "~=1.32.0",
+                            "~=1.33.0",
+                            "~=1.34.0",
+                            "~=1.35.0",
+                            "~=1.36.0",
+                            "~=1.37.0",
+                            "~=1.38.0",
+                            "~=1.39.0",
+                            latest,
+                        ],
+                    },
+                ),
+            ],
+        ),
+        Venv(
             name="rq",
             command="pytest tests/contrib/rq",
             venvs=[

--- a/tests/contrib/grpc_aio/test_grpc_aio.py
+++ b/tests/contrib/grpc_aio/test_grpc_aio.py
@@ -1,0 +1,127 @@
+import grpc
+from grpc import aio
+import pytest
+
+from ddtrace import Pin
+from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import ERROR_STACK
+from ddtrace.contrib.grpc import constants
+from ddtrace.contrib.grpc_aio import patch
+from ddtrace.contrib.grpc_aio import unpatch
+from tests.contrib.grpc.hello_pb2 import HelloReply
+from tests.contrib.grpc.hello_pb2 import HelloRequest
+from tests.contrib.grpc.hello_pb2_grpc import HelloServicer
+from tests.contrib.grpc.hello_pb2_grpc import HelloStub
+from tests.contrib.grpc.hello_pb2_grpc import add_HelloServicer_to_server
+from tests.utils import DummyTracer
+from tests.utils import assert_is_measured
+from tests.utils import override_config
+
+
+_GRPC_PORT = 50531
+
+
+class _HelloServicer(HelloServicer):
+    async def SayHello(self, request, context):
+        if request.name == "propogator":
+            metadata = context.invocation_metadata()
+            context.set_code(grpc.StatusCode.OK)
+            message = ";".join(w.key + "=" + w.value for w in metadata if w.key.startswith("x-datadog"))
+            return HelloReply(message=message)
+
+        if request.name == "abort":
+            await context.abort(grpc.StatusCode.ABORTED, "aborted")
+
+        if request.name == "exception":
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "exception")
+
+        return HelloReply(message="Hello {}".format(request.name))
+
+
+@pytest.fixture
+def tracer():
+    tracer = DummyTracer()
+    return tracer
+
+
+@pytest.fixture
+def grpc_server(event_loop, tracer):
+    """Configures grpc server and starts it in pytest-asyncio event loop"""
+    patch()
+    Pin.override(constants.GRPC_AIO_PIN_MODULE_SERVER, tracer=tracer)
+    _server = aio.server()
+    _server.add_insecure_port("[::]:%d" % (_GRPC_PORT))
+    add_HelloServicer_to_server(_HelloServicer(), _server)
+    event_loop.create_task(_server.start())
+
+    yield
+
+    event_loop.run_until_complete(_server.stop(grace=None))
+    tracer.pop()
+    unpatch()
+
+
+def _check_server_span(span, service, method_name, method_kind):
+    assert_is_measured(span)
+    assert span.name == "grpc"
+    assert span.resource == "/helloworld.Hello/{}".format(method_name)
+    assert span.service == service
+    assert span.error == 0
+    assert span.span_type == "grpc"
+    assert span.get_tag("grpc.method.path") == "/helloworld.Hello/{}".format(method_name)
+    assert span.get_tag("grpc.method.package") == "helloworld"
+    assert span.get_tag("grpc.method.service") == "Hello"
+    assert span.get_tag("grpc.method.name") == method_name
+    assert span.get_tag("grpc.method.kind") == method_kind
+
+
+@pytest.mark.asyncio
+async def test_grpc_server(grpc_server, tracer):
+    target = "localhost:%d" % (_GRPC_PORT)
+    async with aio.insecure_channel(target) as channel:
+        stub = HelloStub(channel)
+        await stub.SayHello(HelloRequest(name="test"))
+
+    spans = tracer.writer.spans
+    assert len(spans) == 1
+
+    _check_server_span(spans[0], "grpc-aio-server", "SayHello", "unary")
+
+
+@pytest.mark.asyncio
+async def test_pin_not_activated(grpc_server, tracer):
+    tracer.configure(enabled=False)
+    async with aio.insecure_channel("localhost:%d" % (_GRPC_PORT)) as channel:
+        stub = HelloStub(channel)
+        await stub.SayHello(HelloRequest(name="test"))
+
+    spans = tracer.writer.spans
+    assert len(spans) == 0
+
+
+@pytest.mark.asyncio
+async def test_analytics_with_rate(grpc_server, tracer):
+    with override_config("grpc_aio_server", dict(analytics_enabled=True, analytics_sample_rate=0.75)):
+        async with aio.insecure_channel("localhost:%d" % (_GRPC_PORT)) as channel:
+            stub = HelloStub(channel)
+            await stub.SayHello(HelloRequest(name="test"))
+
+    spans = tracer.writer.spans
+    assert spans[0].get_metric(ANALYTICS_SAMPLE_RATE_KEY) == 0.75
+
+
+@pytest.mark.asyncio
+async def test_unary_exception(grpc_server, tracer):
+    async with aio.insecure_channel("localhost:%d" % (_GRPC_PORT)) as channel:
+        stub = HelloStub(channel)
+
+        with pytest.raises(grpc.RpcError):
+            await stub.SayHello(HelloRequest(name="exception"))
+
+    spans = tracer.writer.spans
+    server_span = spans[0]
+
+    assert server_span.resource == "/helloworld.Hello/SayHello"
+    assert server_span.error == 1
+    assert "Traceback" in server_span.get_tag(ERROR_STACK)
+    assert "grpc.StatusCode.INVALID_ARGUMENT" in server_span.get_tag(ERROR_STACK)


### PR DESCRIPTION
## Commit Message
<!-- Defaults to the title of the PR. Replace if desired. -->
{{title}}

<!-- Briefly describe the change and why it was required. -->

Partly addresses https://github.com/DataDog/dd-trace-py/issues/1889. The implementation is mainly a copy-paste from original `grpc` implementation with async/await and different interceptor base class (`aio.ServerInterceptor`).

Exceptions are not currently fully covered due to the issue in `grpc.aio.ServicerContext`. (https://github.com/grpc/grpc/issues/27409)

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
