### PR TITLE
Fix memory leak when the tracer is disabled

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -630,8 +630,10 @@ class Tracer(object):
         if service and service not in self._services and self._is_span_internal(span):
             self._services.add(service)
 
-        for p in self._span_processors:
-            p.on_span_start(span)
+        # Only call span processors if the tracer is enabled
+        if self.enabled:
+            for p in self._span_processors:
+                p.on_span_start(span)
 
         self._hooks.emit(self.__class__.start_span, span)
         return span
@@ -648,11 +650,10 @@ class Tracer(object):
                 "span %r closing after its parent %r, this is an error when not using async", span, span._parent
             )
 
-        if not self.enabled:
-            return  # nothing to do
-
-        for p in self._span_processors:
-            p.on_span_finish(span)
+        # Only call span processors if the tracer is enabled
+        if self.enabled:
+            for p in self._span_processors:
+                p.on_span_finish(span)
 
         if self.log.isEnabledFor(logging.DEBUG):
             self.log.debug("finishing span %s (enabled:%s)", span.pprint(), self.enabled)

--- a/releasenotes/notes/fix-disabled-memory-leak-c793801e11c45bfe.yaml
+++ b/releasenotes/notes/fix-disabled-memory-leak-c793801e11c45bfe.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix memory leak caused when the tracer is disabled.


### PR DESCRIPTION
## Commit Message
{{title}}

The SpanAggregator will store spans in a list when on_span_start
is called. When a span is finished on_span_finish is called and
if the trace is complete the SpanAggregator will remove all of
the traces spans from the list and give them to the writer.

However, when the tracer is disabled it never calls on_span_finish
so we never get an opportunity to remove a finished span from
memory when it is finished because on_span_finish is never called.

The fix here is to update the logic for on_span_start to only be
called if the tracer is enabled.