### PR TITLE
Allow raising of more exceptions

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -531,7 +531,10 @@ class Span(object):
                 self.set_exc_info(exc_type, exc_val, exc_tb)
             self.finish()
         except Exception:
-            log.exception("error closing trace")
+            if config._raise:
+                raise
+            else:
+                log.exception("error closing trace")
 
     def __repr__(self):
         return "<Span(id=%s,trace_id=%s,parent_id=%s,name=%s)>" % (

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -797,3 +797,14 @@ def test_no_warnings():
             )
             * 75
         ), err
+
+
+def test_raise_mode_encoding_error():
+    with override_global_config(dict(_raise=True)):
+        t = Tracer()
+        t.configure(writer=AgentWriter(agent.get_trace_url(), raise_exc=True))
+
+        s = t.trace("operation")
+        s.meta["dsaf"] = object()  # type: ignore
+        with pytest.raises(TypeError):
+            s.finish()


### PR DESCRIPTION
## Commit Message
{{title}}

Enables the raising of exceptions raised during span finish (including
encoding) and in the writer by using the global `ddtrace.config._raise` setting
or a new argument `raise_exc` to the writer.
