### PR TITLE
Add option to log payloads on error response from the trace agent

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -420,7 +420,7 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
             if self._log_error_payloads:
                 msg += ", payload %s"
                 # If the payload is bytes then hex encode the value before logging
-                if isinstance(payload, bytes):
+                if isinstance(payload, six.binary_type):
                     log_args += (binascii.hexlify(payload).decode(),)
                 else:
                     log_args += (payload,)

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -389,13 +389,16 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
         self._metrics_dist("http.requests")
 
         if self._log_payloads:
-            data = {
-                "hex_payload": binascii.hexlify(payload).decode(),
-                "agent_url": self.agent_url,
-                "timeout": self._timeout,
-                "headers": headers,
-            }
-            log.debug("sending payload: %s", json.dumps(data))
+            try:
+                data = {
+                    "hex_payload": binascii.hexlify(payload).decode(),
+                    "agent_url": self.agent_url,
+                    "timeout": self._timeout,
+                    "headers": headers,
+                }
+                log.debug("sending payload: %s", json.dumps(data))
+            except Exception as e:
+                log.debug("failed to log payload: %s, %r", e, payload)
         response = self._put(payload, headers)
 
         if response.status >= 400:

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -302,7 +302,7 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
             stop=tenacity.stop_after_attempt(self.RETRY_ATTEMPTS),
             retry=tenacity.retry_if_exception_type((compat.httplib.HTTPException, OSError, IOError)),
         )
-        self._log_payloads = asbool(os.environ.get("_DD_TRACE_WRITER_LOG_PAYLOADS", False))
+        self._log_payloads = asbool(os.environ.get("_DD_TRACE_WRITER_LOG_ERROR_PAYLOADS", False))
 
     def _metrics_dist(self, name, count=1, tags=None):
         self._metrics[name]["count"] += count

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -440,10 +440,20 @@ def test_bad_payload_log_payload_non_bytes(monkeypatch):
             pass
 
         def encode(self):
-            return "bad_payload"
+            # Python 2.7
+            # >>> isinstance("", bytes)
+            # True
+            # >>> isinstance(u"", bytes)
+            # False
+            # Python 3
+            # >>> isinstance("", bytes)
+            # False
+            # >>> isinstance(u"", bytes)
+            # False
+            return u"bad_payload"
 
         def encode_traces(self, traces):
-            return "bad_payload"
+            return u"bad_payload"
 
     t.writer._encoder = BadEncoder()
     with mock.patch("ddtrace.internal.writer.log") as log:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -395,7 +395,7 @@ def test_bad_payload():
 
 @pytest.mark.skipif(AGENT_VERSION == "testagent", reason="FIXME: Test agent response is different.")
 def test_bad_payload_log_payload(monkeypatch):
-    monkeypatch.setenv("_DD_TRACE_WRITER_LOG_PAYLOADS", "true")
+    monkeypatch.setenv("_DD_TRACE_WRITER_LOG_ERROR_PAYLOADS", "true")
     t = Tracer()
 
     class BadEncoder:
@@ -429,7 +429,7 @@ def test_bad_payload_log_payload(monkeypatch):
 
 @pytest.mark.skipif(AGENT_VERSION == "testagent", reason="FIXME: Test agent response is different.")
 def test_bad_payload_log_payload_non_bytes(monkeypatch):
-    monkeypatch.setenv("_DD_TRACE_WRITER_LOG_PAYLOADS", "true")
+    monkeypatch.setenv("_DD_TRACE_WRITER_LOG_ERROR_PAYLOADS", "true")
     t = Tracer()
 
     class BadEncoder:


### PR DESCRIPTION
Adding new environment variable `_DD_TRACE_WRITER_LOG_ERROR_PAYLOADS`
which when enabled will update the existing "failed to send traces to Datadog agent" log message
to include the payload.

The purpose of this is to debug any trace agent decoding issues.
With this we will be able to validate that the payloads
generated are valid and complete messages as expected.

The resulting log will look like:

```
ERROR:ddtrace.internal.writer:failed to send traces to Datadog Agent at http://localhost:8126: HTTP error status 400, reason Bad Request, payload <hex_encoded_mspack_binary_data>
```

You can then decode via:

```python
import binascii
import msgpack

payload = msgpack.unpackb(binascii.unhexlify("<hex_encoded_mspack_binary_data>"))
```

## Commit Message
{{title}}

Adding new environment variable `_DD_TRACE_WRITER_LOG_ERROR_PAYLOADS`
which when enabled will update the existing "failed to send traces to Datadog agent" log message
to include the payload.