### PR TITLE
Improve determinism of encoder benchmarks

### DIFF
--- a/benchmarks/encoder/utils.py
+++ b/benchmarks/encoder/utils.py
@@ -25,10 +25,12 @@ def _rands(size=6, chars=string.ascii_uppercase + string.digits):
 
 
 def _random_values(k, size):
-    return list(set([_rands(size=size) for _ in range(k)]))
+    return list(dict.fromkeys([_rands(size=size) for _ in range(k)]))
 
 
 def gen_traces(config):
+    random.seed(1)
+
     traces = []
 
     # choose from a set of randomly generated span attributes


### PR DESCRIPTION
## Commit Message

1. Set fixed random seed to ensure that generated input is the same between runs.
2. Use dict.fromkeys instead of set to guarantee the same order in generated input. (https://stackoverflow.com/a/53657523/2678487)

## Prephase

I assume that the goal of benchmark for **Encoder** is to measure latency of encoding. The only factor that must be different between runs is a version of tracer. Thus I propose a fix for variability in randomly generated input data.

_Long version:_

I encountered the issue - the results from **Encoder** family of benchmarks deviate a lot when running multiple times (not only quantitatively, but qualitatively as well). I believe we can improve this by introducing 2 simple fixes in benchmark script.

There are several methods to design experiments. One of the simplest and most common is [One factor-at-a-time](https://en.wikipedia.org/wiki/One-factor-at-a-time_method). It is useful when there is just one independent variable, as in our case, only version of tracer. In this case, to see only the impact of tracer's version on performance, we need to keep all other variables constant, including input data.

If we want to see the impact of tracer's version AND variation in input data on performance (2 factors at once), then benchmark must be designed in a different way (using factorial experiment methods), and at very least output latency measurements along with input data.

## Before change

Right now the benchmarking process is inconsistent, because of random input data. I obtained the following data by comparing v0.55.1 and v0.51.2 of tracers.

1. Generate 1000 traces, then encode. Repeat same process 50 times. Below are statistics for the size of encoded MessagePack payload (~16 MB).

![image](https://user-images.githubusercontent.com/88330911/140072613-b68cf04a-c117-41ce-af7c-35469bfe0315.png)

As you see, there is some non-determinism in the size of resulting MessagePack payload. The difference between max and min size is only 588 bytes (not too significant), but there is something in the structure of data that differ from time to time and lead to significant issue (see later).

2. See how random service names look like between runs.

`services = _random_values(16, 16)`

![Screenshot 2021-11-03 at 15 14 06](https://user-images.githubusercontent.com/88330911/140076877-f5f8a730-c99b-4f5b-994a-6ac16b359a82.png)

3. See how mean latency values are distributed (20 runs, each had 200 subruns where 1000 traces were encoded).

**v0.55.1**

![Screenshot 2021-11-03 at 14 37 42](https://user-images.githubusercontent.com/88330911/140077331-a6e37b97-3a3e-4977-b836-b71a825e423e.png)

**v0.51.2**

![Screenshot 2021-11-03 at 14 37 57](https://user-images.githubusercontent.com/88330911/140077351-176ca435-605e-461c-a53a-ab1971a86975.png)


## After change

1. Generate 1000 traces, then encode. Repeat same process 50 times. Below are statistics for the size of encoded MessagePack payload.

![image](https://user-images.githubusercontent.com/88330911/140077774-31f332b7-41c8-4691-b6d2-c8a8e7a83aa4.png)

**3x smaller MAD, 2x smaller standard deviation = less variability.** 

Setting `random.seed()` didn't fix non-determinism. I investigated further and found that though random values from benchmark script are deterministic after setting seed, the *span ids are random*. Unfortunately, I don't see right now an easy way to fix seed from https://github.com/DataDog/dd-trace-py/blob/master/ddtrace/internal/_rand.pyx#L79, so there is still some variability in generated input present.

2. See how random service names look like between runs.
2.1. With `list(set(...))`

![Screenshot 2021-11-03 at 15 24 12](https://user-images.githubusercontent.com/88330911/140078699-29bb8800-ea46-4fae-8530-0c97f0424c71.png)

Order is not guaranteed. One more source of non-determinism in input.

2.2. With `list(dict.fromkeys(...))`

![Screenshot 2021-11-03 at 15 25 12](https://user-images.githubusercontent.com/88330911/140078888-a55ec1da-a98d-40bf-8f79-321da6adfe21.png)

Now order is guaranteed.

3. See how mean latency values are distributed (20 runs, each had 200 subruns where 1000 traces were encoded).

**Standard deviation and MAD for latency measurements of v0.55.1 are 20x less**, leading to better precision.

**v0.55.1**

![Screenshot 2021-11-03 at 14 38 36](https://user-images.githubusercontent.com/88330911/140084373-e964208c-cc81-4a53-8498-c32be6fbac44.png)

**v0.51.2**

![Screenshot 2021-11-03 at 14 38 25](https://user-images.githubusercontent.com/88330911/140084409-a4ac07c3-2e9a-48db-ad37-8e84973d8bd3.png)
