### PR TITLE
fix(ci) Skip running cibuildwheel for Python 3.10 on macos

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -105,7 +105,7 @@ jobs:
           CIBW_BUILD: cp3*
           # Skip 3.10 on macos until this is resolved
           #   https://github.com/pypa/cibuildwheel/issues/902
-          CIBW_SKIP: cp310-macosx_universal2
+          CIBW_SKIP: cp310-macosx_*
           # Run a smoke test on every supported platform
           CIBW_TEST_COMMAND: python {project}/tests/smoke_test.py
           # Testing arm on MacOS is currently not supported by Github

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -103,6 +103,9 @@ jobs:
           # emulated ones
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD: cp3*
+          # Skip 3.10 on macos until this is resolved
+          #   https://github.com/pypa/cibuildwheel/issues/902
+          CIBW_SKIP: cp310-macosx_universal2
           # Run a smoke test on every supported platform
           CIBW_TEST_COMMAND: python {project}/tests/smoke_test.py
           # Testing arm on MacOS is currently not supported by Github


### PR DESCRIPTION
## Commit Message
{{title}}

The 3.10 package that cibuildwheel is trying to download no longer exists
on python.org.

Skip this version of Python on macos until this PR is resolved:
https://github.com/pypa/cibuildwheel/issues/902