### PR TITLE
fix(botocore) ensure env vars are parsed as booleans

### DIFF
--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -20,6 +20,7 @@ from ...internal.logger import get_logger
 from ...pin import Pin
 from ...propagation.http import HTTPPropagator
 from ...utils import get_argument_value
+from ...utils.formats import asbool
 from ...utils.formats import deep_getattr
 from ...utils.formats import get_env
 from ...utils.wrappers import unwrap
@@ -37,8 +38,8 @@ log = get_logger(__name__)
 config._add(
     "botocore",
     {
-        "distributed_tracing": get_env("botocore", "distributed_tracing", default=True),
-        "invoke_with_legacy_context": get_env("botocore", "invoke_with_legacy_context", default=False),
+        "distributed_tracing": asbool(get_env("botocore", "distributed_tracing", default=True)),
+        "invoke_with_legacy_context": asbool(get_env("botocore", "invoke_with_legacy_context", default=False)),
     },
 )
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -25,6 +25,7 @@ autopatching
 backend
 backends
 bikeshedding
+booleans
 boto
 botocore
 CGroup

--- a/releasenotes/notes/fix-botocore-env-vars-89b106aadf2bba1d.yaml
+++ b/releasenotes/notes/fix-botocore-env-vars-89b106aadf2bba1d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes parsing of ``botocore`` env variables to ensure they are parsed as booleans.

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -1,4 +1,3 @@
-# 3p
 import base64
 import datetime
 import io
@@ -15,6 +14,7 @@ from moto import mock_s3
 from moto import mock_sqs
 
 from ddtrace import Pin
+from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.botocore.patch import patch
 from ddtrace.contrib.botocore.patch import unpatch
@@ -805,3 +805,15 @@ class BotocoreTest(TracerTestCase):
         assert delivery_stream_span.get_tag("aws.operation") == "CreateDeliveryStream"
         assert put_record_batch_span.get_tag("aws.operation") == "PutRecordBatch"
         assert put_record_batch_span.get_tag("params.Records") is None
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_BOTOCORE_DISTRIBUTED_TRACING="true"))
+    def test_distributed_tracing_env_override(self):
+        assert config.botocore.distributed_tracing is True
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_BOTOCORE_DISTRIBUTED_TRACING="false"))
+    def test_distributed_tracing_env_override_false(self):
+        assert config.botocore.distributed_tracing is False
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_BOTOCORE_INVOKE_WITH_LEGACY_CONTEXT="true"))
+    def test_invoke_legacy_context_env_override(self):
+        assert config.botocore.invoke_with_legacy_context is True


### PR DESCRIPTION
## Commit Message
{{title}}

fixes #2978

We were not calling `asbool` when parsing the values