### PR TITLE
Revert "fix(ci) Skip running cibuildwheel for Python 3.10 on macos"

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -103,9 +103,6 @@ jobs:
           # emulated ones
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD: cp3*
-          # Skip 3.10 on macos until this is resolved
-          #   https://github.com/pypa/cibuildwheel/issues/902
-          CIBW_SKIP: cp310-macosx_*
           # Run a smoke test on every supported platform
           CIBW_TEST_COMMAND: python {project}/tests/smoke_test.py
           # Testing arm on MacOS is currently not supported by Github


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#2976

The issue has been resolved, this work around is no longer needed.