### PR TITLE
Fix how bool values from config.yml are parsed for perf benchmarks

### DIFF
--- a/benchmarks/bm/__init__.py
+++ b/benchmarks/bm/__init__.py
@@ -1,10 +1,10 @@
 from ._scenario import Scenario
 from ._scenario import var
-from ._scenario import var_bool as bool
+from ._scenario import var_bool
 
 
 __all__ = [
     "var",
-    "bool",
+    "var_bool",
     "Scenario",
 ]

--- a/benchmarks/bm/__init__.py
+++ b/benchmarks/bm/__init__.py
@@ -1,8 +1,10 @@
 from ._scenario import Scenario
 from ._scenario import var
+from ._scenario import var_bool as bool
 
 
 __all__ = [
     "var",
+    "bool",
     "Scenario",
 ]

--- a/benchmarks/bm/_scenario.py
+++ b/benchmarks/bm/_scenario.py
@@ -5,8 +5,14 @@ import attr
 import pyperf
 import six
 
+from ._to_bool import to_bool
+
 
 var = attr.ib
+
+
+def var_bool(*args, **kwargs):
+    return attr.ib(*args, **kwargs, converter=to_bool)
 
 
 def _register(scenario_cls):

--- a/benchmarks/bm/_to_bool.py
+++ b/benchmarks/bm/_to_bool.py
@@ -1,0 +1,38 @@
+def to_bool(val):
+    """
+    Copied from
+    https://github.com/python-attrs/attrs/blob/e84b57ea687942e5344badfe41a2728e24037431/src/attr/converters.py#L114
+
+    Please remove after updating attrs to 21.3.0.
+
+    Convert "boolean" strings (e.g., from env. vars.) to real booleans.
+    Values mapping to :code:`True`:
+    - :code:`True`
+    - :code:`"true"` / :code:`"t"`
+    - :code:`"yes"` / :code:`"y"`
+    - :code:`"on"`
+    - :code:`"1"`
+    - :code:`1`
+    Values mapping to :code:`False`:
+    - :code:`False`
+    - :code:`"false"` / :code:`"f"`
+    - :code:`"no"` / :code:`"n"`
+    - :code:`"off"`
+    - :code:`"0"`
+    - :code:`0`
+    :raises ValueError: for any other value.
+    .. versionadded:: 21.3.0
+    """
+    if isinstance(val, str):
+        val = val.lower()
+    truthy = {True, "true", "t", "yes", "y", "on", "1", 1}
+    falsy = {False, "false", "f", "no", "n", "off", "0", 0}
+    try:
+        if val in truthy:
+            return True
+        if val in falsy:
+            return False
+    except TypeError:
+        # Raised when "val" is not hashable (e.g., lists)
+        pass
+    raise ValueError("Cannot convert value to bool: {}".format(val))

--- a/benchmarks/django_simple/scenario.py
+++ b/benchmarks/django_simple/scenario.py
@@ -3,8 +3,8 @@ import utils
 
 
 class DjangoSimple(bm.Scenario):
-    tracer_enabled = bm.var(type=bool)
-    profiler_enabled = bm.var(type=bool)
+    tracer_enabled = bm.bool()
+    profiler_enabled = bm.bool()
 
     def run(self):
         with utils.server(self) as get_response:

--- a/benchmarks/django_simple/scenario.py
+++ b/benchmarks/django_simple/scenario.py
@@ -3,8 +3,8 @@ import utils
 
 
 class DjangoSimple(bm.Scenario):
-    tracer_enabled = bm.bool()
-    profiler_enabled = bm.bool()
+    tracer_enabled = bm.var_bool()
+    profiler_enabled = bm.var_bool()
 
     def run(self):
         with utils.server(self) as get_response:

--- a/benchmarks/encoder/scenario.py
+++ b/benchmarks/encoder/scenario.py
@@ -8,7 +8,7 @@ class Encoder(bm.Scenario):
     ntags = bm.var(type=int)
     ltags = bm.var(type=int)
     nmetrics = bm.var(type=int)
-    dd_origin = bm.var(type=bool)
+    dd_origin = bm.bool()
     encoding = bm.var(type=str)
 
     def run(self):

--- a/benchmarks/encoder/scenario.py
+++ b/benchmarks/encoder/scenario.py
@@ -8,7 +8,7 @@ class Encoder(bm.Scenario):
     ntags = bm.var(type=int)
     ltags = bm.var(type=int)
     nmetrics = bm.var(type=int)
-    dd_origin = bm.bool()
+    dd_origin = bm.var_bool()
     encoding = bm.var(type=str)
 
     def run(self):

--- a/benchmarks/flask_simple/scenario.py
+++ b/benchmarks/flask_simple/scenario.py
@@ -3,8 +3,8 @@ import utils
 
 
 class FlaskSimple(bm.Scenario):
-    tracer_enabled = bm.var(type=bool)
-    profiler_enabled = bm.var(type=bool)
+    tracer_enabled = bm.bool()
+    profiler_enabled = bm.bool()
 
     def run(self):
         with utils.server(self) as get_response:

--- a/benchmarks/flask_simple/scenario.py
+++ b/benchmarks/flask_simple/scenario.py
@@ -3,8 +3,8 @@ import utils
 
 
 class FlaskSimple(bm.Scenario):
-    tracer_enabled = bm.bool()
-    profiler_enabled = bm.bool()
+    tracer_enabled = bm.var_bool()
+    profiler_enabled = bm.var_bool()
 
     def run(self):
         with utils.server(self) as get_response:

--- a/benchmarks/span/scenario.py
+++ b/benchmarks/span/scenario.py
@@ -9,7 +9,7 @@ class Span(bm.Scenario):
     ntags = bm.var(type=int)
     ltags = bm.var(type=int)
     nmetrics = bm.var(type=int)
-    finishspan = bm.bool()
+    finishspan = bm.var_bool()
 
     def run(self):
         # run scenario to also set tags on spans

--- a/benchmarks/span/scenario.py
+++ b/benchmarks/span/scenario.py
@@ -9,7 +9,7 @@ class Span(bm.Scenario):
     ntags = bm.var(type=int)
     ltags = bm.var(type=int)
     nmetrics = bm.var(type=int)
-    finishspan = bm.var(type=bool)
+    finishspan = bm.bool()
 
     def run(self):
         # run scenario to also set tags on spans


### PR DESCRIPTION
## Commit Message

Boolean values are incorrectly parsed and are always set to True. This bugfix uses code from [not yet released attrs 21.3.0](https://www.attrs.org/en/latest/api.html#attr.converters.to_bool) to fix the issue.

## Before change

![Screenshot 2021-11-08 at 14 35 53](https://user-images.githubusercontent.com/88330911/140751921-e70b71d4-574b-4358-b5ef-8a3dc613a6d4.png)

## After change

![Screenshot 2021-11-08 at 14 35 08](https://user-images.githubusercontent.com/88330911/140751959-f391e2f3-be5e-4919-97f9-3f41ab7b3df8.png)
