### PR TITLE
tests(urllib3): use an actual broken url

### DIFF
--- a/tests/contrib/urllib3/test_urllib3.py
+++ b/tests/contrib/urllib3/test_urllib3.py
@@ -185,7 +185,7 @@ class TestUrllib3(BaseUrllib3TestCase):
         """Tests a connection error results in error spans with proper exc info"""
         retries = 3
         try:
-            self.http.request("GET", "http://fakesubdomain." + SOCKET, retries=retries)
+            self.http.request("GET", "http://localhost:9999", retries=retries)
         except Exception:
             pass
         else:


### PR DESCRIPTION
The previous test attempted to use a subdomain to mimic a broken
resolution but this actually is not broken for later versions of linux +
docker.
