### PR TITLE
Update Falcon doc to not suggest a DATADOG_ envar

### DIFF
--- a/ddtrace/contrib/falcon/__init__.py
+++ b/ddtrace/contrib/falcon/__init__.py
@@ -18,7 +18,7 @@ You can also use the autopatching functionality::
     app = falcon.API()
 
 To disable distributed tracing when using autopatching, set the
-``DATADOG_FALCON_DISTRIBUTED_TRACING`` environment variable to ``False``.
+``DD_FALCON_DISTRIBUTED_TRACING`` environment variable to ``False``.
 
 **Supported span hooks**
 


### PR DESCRIPTION
We previously recommended the use of `DATADOG_FALCON_DISTRIBUTED_TRACING` when it should be `DD_FALCON_DISTRIBUTED_TRACING` since we've deprecated DATADOG_ envars.
