### PR TITLE
fix more_itertools in ci

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -272,7 +272,7 @@ venv = Venv(
         Venv(
             name="celery",
             command="pytest {cmdargs} tests/contrib/celery",
-            pkgs={"pytest": "~=3.10"},
+            pkgs={"pytest": "~=3.10", "more_itertools": "<8.11.0"},
             venvs=[
                 # Non-4.x celery should be able to use the older redis lib, since it locks to an older kombu
                 Venv(
@@ -282,7 +282,6 @@ venv = Venv(
                     pkgs={
                         "celery": "~=3.0",  # most recent 3.x.x release
                         "redis": "~=2.10.6",
-                        "more_itertools": "<8.11.0",
                     },
                 ),
                 # 4.x celery bumps kombu to 4.4+, which requires redis 3.2 or later, this tests against
@@ -356,6 +355,7 @@ venv = Venv(
         Venv(
             name="cherrypy",
             command="python -m pytest {cmdargs} tests/contrib/cherrypy",
+            pkgs={"more_itertools": "<8.11.0"},
             venvs=[
                 Venv(
                     pys=select_pys(),
@@ -369,7 +369,6 @@ venv = Venv(
                             ">=16,<17",
                             ">=17,<18",
                         ],
-                        "more_itertools": "<8.11.0",
                     },
                 ),
                 Venv(

--- a/riotfile.py
+++ b/riotfile.py
@@ -700,6 +700,7 @@ venv = Venv(
                         "Flask-Cache": ["~=0.12.0"],
                         "werkzeug": "<1.0",
                         "pytest": "~=3.0",
+                        "more_itertools": "<8.11.0",
                     },
                 ),
                 Venv(
@@ -710,6 +711,7 @@ venv = Venv(
                         "Flask-Cache": ["~=0.13.0", latest],
                         "werkzeug": "<1.0",
                         "pytest": "~=3.0",
+                        "more_itertools": "<8.11.0",
                     },
                 ),
                 Venv(

--- a/riotfile.py
+++ b/riotfile.py
@@ -282,6 +282,7 @@ venv = Venv(
                     pkgs={
                         "celery": "~=3.0",  # most recent 3.x.x release
                         "redis": "~=2.10.6",
+                        "more_itertools": "<8.11.0",
                     },
                 ),
                 # 4.x celery bumps kombu to 4.4+, which requires redis 3.2 or later, this tests against
@@ -368,6 +369,7 @@ venv = Venv(
                             ">=16,<17",
                             ">=17,<18",
                         ],
+                        "more_itertools": "<8.11.0",
                     },
                 ),
                 Venv(
@@ -607,9 +609,7 @@ venv = Venv(
         Venv(
             name="flask",
             command="pytest {cmdargs} tests/contrib/flask",
-            pkgs={
-                "blinker": latest,
-            },
+            pkgs={"blinker": latest, "more_itertools": "<8.11.0"},
             venvs=[
                 # Flask == 0.12.0
                 Venv(
@@ -1013,7 +1013,7 @@ venv = Venv(
                 Venv(
                     pys=["2.7"],
                     # pytest==4.6 is last to support python 2.7
-                    pkgs={"pytest": ">=4.0,<4.6", "msgpack": latest},
+                    pkgs={"pytest": ">=4.0,<4.6", "msgpack": latest, "more_itertools": "<8.11.0"},
                 ),
                 Venv(
                     pys=select_pys(min_version="3.5"),

--- a/riotfile.py
+++ b/riotfile.py
@@ -1013,7 +1013,7 @@ venv = Venv(
                 Venv(
                     pys=["2.7"],
                     # pytest==4.6 is last to support python 2.7
-                    pkgs={"pytest": ">=4.0,<4.6", "msgpack": latest, "more_itertools": "<8.11.0"},
+                    pkgs={"pytest": ">=4.0,<4.6", "msgpack": latest},
                 ),
                 Venv(
                     pys=select_pys(min_version="3.5"),
@@ -1026,6 +1026,7 @@ venv = Venv(
                             latest,
                         ],
                         "msgpack": latest,
+                        "more_itertools": "<8.11.0",
                     },
                 ),
             ],

--- a/riotfile.py
+++ b/riotfile.py
@@ -608,14 +608,13 @@ venv = Venv(
         Venv(
             name="flask",
             command="pytest {cmdargs} tests/contrib/flask",
-            pkgs={"blinker": latest, "more_itertools": "<8.11.0"},
+            pkgs={"blinker": latest,"pytest": "~=3.0", "more_itertools": "<8.11.0"},
             venvs=[
                 # Flask == 0.12.0
                 Venv(
                     pys=select_pys(),
                     pkgs={
                         "flask": ["~=0.12.0"],
-                        "pytest": "~=3.0",
                     },
                 ),
                 Venv(
@@ -627,7 +626,6 @@ venv = Venv(
                     },
                     pkgs={
                         "flask": ["~=0.12.0"],
-                        "pytest": "~=3.0",
                     },
                 ),
                 # Flask 1.x.x

--- a/riotfile.py
+++ b/riotfile.py
@@ -355,7 +355,6 @@ venv = Venv(
         Venv(
             name="cherrypy",
             command="python -m pytest {cmdargs} tests/contrib/cherrypy",
-            pkgs={"more_itertools": "<8.11.0"},
             venvs=[
                 Venv(
                     pys=select_pys(),
@@ -369,12 +368,14 @@ venv = Venv(
                             ">=16,<17",
                             ">=17,<18",
                         ],
+                        "more_itertools": "<8.11.0",
                     },
                 ),
                 Venv(
                     pys=select_pys(min_version="3.5"),
                     pkgs={
                         "cherrypy": [">=18.0,<19", latest],
+                        "more_itertools": "<8.11.0",
                     },
                 ),
             ],

--- a/riotfile.py
+++ b/riotfile.py
@@ -608,13 +608,15 @@ venv = Venv(
         Venv(
             name="flask",
             command="pytest {cmdargs} tests/contrib/flask",
-            pkgs={"blinker": latest,"pytest": "~=3.0", "more_itertools": "<8.11.0"},
+            pkgs={"blinker": latest},
             venvs=[
                 # Flask == 0.12.0
                 Venv(
                     pys=select_pys(),
                     pkgs={
                         "flask": ["~=0.12.0"],
+                        "pytest": "~=3.0",
+                        "more_itertools": "<8.11.0",
                     },
                 ),
                 Venv(
@@ -624,9 +626,7 @@ venv = Venv(
                         "DATADOG_SERVICE_NAME": "test.flask.service",
                         "DATADOG_PATCH_MODULES": "jinja2:false",
                     },
-                    pkgs={
-                        "flask": ["~=0.12.0"],
-                    },
+                    pkgs={"flask": ["~=0.12.0"], "pytest": "~=3.0", "more_itertools": "<8.11.0"},
                 ),
                 # Flask 1.x.x
                 Venv(


### PR DESCRIPTION
## Commit Message

Tests failing for pytest, flask, cherrypy, and celery.

more_itertools>=8.10.11 is not compatible with python 3.5 

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
