### PR TITLE
Add telemetry data classes

### DIFF
--- a/ddtrace/internal/telemetry/data/application.py
+++ b/ddtrace/internal/telemetry/data/application.py
@@ -1,0 +1,39 @@
+import sys
+from typing import TypedDict
+
+from ....settings import _config as config  # noqa: E402
+from ....version import get_version
+
+
+Application = TypedDict(
+    "Application",
+    {
+        "service_name": str,
+        "service_version": str,
+        "env": str,
+        "language_name": str,
+        "language_version": str,
+        "tracer_version": str,
+        "patches": str,
+        "runtime_name": str,
+        "runtime_version": str,
+    },
+)
+
+
+def format_version_info(vi):
+    # type: (sys.version_info) -> str
+    return "%d.%d.%d" % (vi.major, vi.minor, vi.micro)
+
+
+APPLICATION = {
+    "service_name": config.service or "unnamed_python_service",
+    "service_version": config.version or "DD_SERVICE_VERSION NOT SET",
+    "env": config.env or "DD_ENV NOT SET",
+    "language_name": "python",
+    "language_version": format_version_info(sys.version_info),
+    "tracer_version": get_version(),
+    "patches": "",
+    "runtime_name": sys.implementation.name,
+    "runtime_version": format_version_info(sys.implementation.version),
+}  # type: Application

--- a/ddtrace/internal/telemetry/data/dependency.py
+++ b/ddtrace/internal/telemetry/data/dependency.py
@@ -1,0 +1,12 @@
+from typing import TypedDict
+
+
+Dependency = TypedDict("Dependency", {"name": str, "version": str})
+
+
+def create_dependency(name, version):
+    # type: (str, str) -> Dependency
+    return {
+        "name": name,
+        "version": version,
+    }

--- a/ddtrace/internal/telemetry/data/host.py
+++ b/ddtrace/internal/telemetry/data/host.py
@@ -28,11 +28,11 @@ def get_containter_id():
 
 
 HOST = {
-    "os": "",
+    "os": platform.system(),
     "hostname": get_hostname(),
-    "os_version": "",
-    "kernel_name": platform.system(),
-    "kernel_release": platform.release(),
-    "kernel_version": platform.version(),
+    "os_version": platform.version(),
+    "kernel_name": "",
+    "kernel_release": "",
+    "kernel_version": "",
     "container_id": get_containter_id(),
 }  # type: Host

--- a/ddtrace/internal/telemetry/data/host.py
+++ b/ddtrace/internal/telemetry/data/host.py
@@ -1,0 +1,38 @@
+import platform
+from typing import TypedDict
+
+from ...hostname import get_hostname
+from ...runtime.container import get_container_info
+
+
+Host = TypedDict(
+    "Host",
+    {
+        "os": str,
+        "hostname": str,
+        "os_version": str,
+        "kernel_name": str,
+        "kernel_release": str,
+        "kernel_version": str,
+        "container_id": str,
+    },
+)
+
+
+def get_containter_id():
+    # type: () -> str
+    container_info = get_container_info()
+    if container_info and container_info.container_id:
+        return container_info.container_id
+    return ""
+
+
+HOST = {
+    "os": "",
+    "hostname": get_hostname(),
+    "os_version": "",
+    "kernel_name": platform.system(),
+    "kernel_release": platform.release(),
+    "kernel_version": platform.version(),
+    "container_id": get_containter_id(),
+}  # type: Host

--- a/ddtrace/internal/telemetry/data/integration.py
+++ b/ddtrace/internal/telemetry/data/integration.py
@@ -1,0 +1,26 @@
+from typing import TypedDict
+
+
+Integration = TypedDict(
+    "Integration",
+    {"name": str, "version": str, "enabled": bool, "auto_enabled": bool, "compatible": str, "errors": str},
+)
+
+
+def create_integration(name, version="", enabled=True, auto_enabled=True, compatible="", errors=""):
+    # type: (str, str, bool, bool, str, str) -> Integration
+    return {
+        "name": name,
+        "version": version,
+        "enabled": enabled,
+        "auto_enabled": auto_enabled,
+        "compatible": compatible,
+        "errors": errors,
+    }
+
+
+def on_exception(integration, exception, compatible="no"):
+    # type: (Integration, str, str) -> None
+    integration["errors"] = exception
+    integration["compatible"] = compatible
+    integration["enabled"] = False

--- a/ddtrace/internal/telemetry/data/metrics.py
+++ b/ddtrace/internal/telemetry/data/metrics.py
@@ -1,0 +1,65 @@
+import time
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from ...hostname import get_hostname
+
+
+class Series:
+    GAUGE = "gauge"
+    COUNT = "count"
+    RATE = "rate"
+
+    COMMON_TELEMETRY_METRIC = "dd.app_telemetry.tracers.%s"
+    PYTHON_TELEMETRY_METRIC = "dd.app_telemetry.tracers.python.%s"
+
+    def __init__(self, name, metric_type=COUNT, is_common=False, interval=None):
+        # type: (str, str, bool, Optional[int]) -> None
+        self.points = []  # type: List[List[int]]
+        self.tags = {}  # type: Dict[str, str]
+        self.type = metric_type  # type: str
+        self.interval = interval  # type: Optional[int]
+        self.host = get_hostname()  # type: str
+        self.metric = Series.set_metric_name(name, is_common)  # type: str
+
+    @classmethod
+    def set_metric_name(cls, metric_name, is_common=False):
+        # type: (str, bool) -> str
+        if "dd.app_telemetry.tracers." in metric_name:
+            return metric_name
+        elif is_common:
+            return cls.COMMON_TELEMETRY_METRIC % metric_name
+
+        return cls.PYTHON_TELEMETRY_METRIC % metric_name
+
+    def add_point(self, value):
+        # type: (int) -> None
+        timestamp = int(time.time())  # type: int
+        self.points.append([timestamp, value])
+
+    def add_tag(self, name, value):
+        # type: (str, str) -> None
+        self.tags[name] = value
+
+    def combine(self, other_series):
+        # type: (Series) -> None
+        if self.type != other_series.type:
+            raise Exception("Metrics with the same name should have the same type")
+
+        if self.interval != other_series.interval:
+            raise Exception("Metrics with the same name should have the same interval")
+
+        self.tags.update(other_series.tags)
+        self.points.extend(other_series.points)
+
+    def to_dict(self):
+        # type: () -> Dict
+        return {
+            "metric": self.metric,
+            "points": self.points,
+            "tags": self.tags,
+            "type": self.type,
+            "interval": self.interval,
+            "host": self.host,
+        }

--- a/ddtrace/internal/telemetry/data/payload.py
+++ b/ddtrace/internal/telemetry/data/payload.py
@@ -1,0 +1,84 @@
+from typing import Dict
+from typing import List
+
+from ....version import get_version
+from .dependency import Dependency
+from .dependency import create_dependency
+from .integration import Integration
+from .metrics import Series
+
+
+class Payload:
+    REQUEST_TYPE = "not-defined"  # type: str
+
+    def to_dict(self):
+        # type: () -> Dict
+        return {}
+
+
+class AppIntegrationsChangedPayload(Payload):
+    REQUEST_TYPE = "app-integrations-changed"  # type: str
+
+    def __init__(self, integrations):
+        # type: (List[Integration]) -> None
+        super().__init__()
+        self.integrations = integrations  # type: List[Integration]
+
+    def to_dict(self):
+        # type: () -> Dict
+        return {"integrations": self.integrations}
+
+
+class AppStartedPayload(Payload):
+    REQUEST_TYPE = "app-started"  # type: str
+
+    def __init__(self, configurations={}, additional_payload={}):
+        # type: (Dict, Dict) -> None
+        super().__init__()
+        self.configuration = configurations  # type: Dict[str, str]
+        self.additional_payload = additional_payload  # type: Dict[str, str]
+        self.dependencies = self.get_dependencies()
+
+    def get_dependencies(self):
+        # type: () -> List[Dependency]
+        import pkg_resources
+
+        dependencies = []
+        for pkg in pkg_resources.working_set:
+            dependency = create_dependency(pkg.project_name, pkg.version)  # type: Dependency
+            dependencies.append(dependency)
+
+        return dependencies
+
+    def to_dict(self):
+        # type: () -> Dict
+        return {
+            "configuration": self.configuration,
+            "additional_payload": self.additional_payload,
+            "dependencies": self.dependencies,
+        }
+
+
+class AppGenerateMetricsPayload(Payload):
+    REQUEST_TYPE = "app-generate-metrics"  # type: str
+
+    def __init__(self, series):
+        # type: (List[Series]) -> None
+        super().__init__()
+        self.namespace = "tracers"  # type: str
+        self.lib_language = "python"  # type: str
+        self.lib_version = get_version()  # type: str
+        self.series = series  # type: List[Series]
+
+    def to_dict(self):
+        # type: () -> Dict
+        return {
+            "namespace": self.namespace,
+            "lib_language": self.lib_language,
+            "lib_version": self.lib_version,
+            "series": [s.to_dict() for s in self.series],
+        }
+
+
+class AppClosedPayload(Payload):
+    REQUEST_TYPE = "app-closing"  # type: str

--- a/ddtrace/internal/telemetry/data/telemetry_request.py
+++ b/ddtrace/internal/telemetry/data/telemetry_request.py
@@ -1,0 +1,59 @@
+import os
+import time
+from typing import Any
+from typing import Dict
+from typing import TypedDict
+
+from ...runtime import get_runtime_id
+from .application import APPLICATION
+from .application import Application
+from .host import HOST
+from .host import Host
+from .payload import Payload
+
+
+RequestBody = TypedDict(
+    "RequestBody",
+    {
+        "tracer_time": int,
+        "runtime_id": str,
+        "api_version": str,
+        "seq_id": int,
+        "application": Application,
+        "host": Host,
+        "payload": Dict[Any, Any],
+        "request_type": str,
+    },
+)
+
+TelemetryRequest = TypedDict(
+    "TelemetryRequest",
+    {
+        "headers": Dict[str, str],
+        "body": RequestBody,
+    },
+)
+
+
+def create_telemetry_request(payload):
+    # type: (Payload) -> TelemetryRequest
+    return {
+        "headers": {
+            "Content-type": "application/json",
+            "DD-API-KEY": os.environ.get(
+                "DD_API_KEY", default=""
+            ),  # get_api_key() will be removed when agent proxy is live
+            "DD-Telemetry-Request-Type": payload.REQUEST_TYPE,
+            "DD-Telemetry-API-Version": "v1",
+        },
+        "body": {
+            "tracer_time": int(time.time()),
+            "runtime_id": get_runtime_id(),
+            "api_version": "v1",
+            "seq_id": 0,
+            "application": APPLICATION,
+            "host": HOST,
+            "payload": payload.to_dict(),
+            "request_type": payload.REQUEST_TYPE,
+        },
+    }


### PR DESCRIPTION
## Commit Message
<!-- Defaults to the title of the PR. Replace if desired. -->
{{title}}

Breaks up the Python Telemetry Client Proposal across 2 pull requests. This change contains the data classes that will be used to construct a Telemetry Request and send a json payload to the agent.

Original PR: https://github.com/DataDog/dd-trace-py/pull/2940

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
