### PR TITLE
Add Opentracing Baggage support to DD tracer

### DIFF
--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -123,6 +123,25 @@ class TraceTagsProcessor(TraceProcessor):
 
 
 @attr.s
+class TraceBaggageProcessor(TraceProcessor):
+    """Processor that applies trace-level tags to the trace."""
+
+    def process_trace(self, trace):
+        # type: (List[Span]) -> Optional[List[Span]]
+        if not trace:
+            return trace
+
+        for span in trace:
+            ctx = span._context
+            if not ctx:
+                continue
+
+            ctx._update_baggage_items(span)
+
+        return trace
+
+
+@attr.s
 class SpanAggregator(SpanProcessor):
     """Processor that aggregates spans together by trace_id and writes the
     spans to the provided writer when:

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -9,13 +9,14 @@ from .utils import get_wsgi_header
 
 log = get_logger(__name__)
 
+HTTP_BAGGAGE_PREFIX = "ot-baggage-"
+
 # HTTP headers one should set for distributed tracing.
 # These are cross-language (eg: Python, Go and other implementations should honor these)
 HTTP_HEADER_TRACE_ID = "x-datadog-trace-id"
 HTTP_HEADER_PARENT_ID = "x-datadog-parent-id"
 HTTP_HEADER_SAMPLING_PRIORITY = "x-datadog-sampling-priority"
 HTTP_HEADER_ORIGIN = "x-datadog-origin"
-
 
 # Note that due to WSGI spec we have to also check for uppercased and prefixed
 # versions of these headers
@@ -59,6 +60,11 @@ class HTTPPropagator(object):
         # Propagate origin only if defined
         if span_context.dd_origin is not None:
             headers[HTTP_HEADER_ORIGIN] = str(span_context.dd_origin)
+
+        # Add the baggage item
+        if span_context.baggage is not None:
+            for key in span_context.baggage:
+                headers[HTTP_BAGGAGE_PREFIX + key] = span_context.baggage[key]
 
     @staticmethod
     def _extract_header_value(possible_header_names, headers, default=None):

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -406,6 +406,36 @@ class Span(object):
         # type: (_TagNameType) -> Optional[NumericType]
         return self.metrics.get(key)
 
+    def set_baggage_item(self, key, value):
+        # type: (str, Any) -> Span
+        """Sets a baggage item in the span context of this span.
+
+        Baggage is used to propagate state between spans.
+
+        :param key: baggage item key
+        :type key: str
+
+        :param value: baggage item value
+        :type value: a type that can be compat.stringify()'d
+
+        :rtype: Span
+        :return: itself for chaining calls
+        """
+        self._context = self.context.with_baggage_item(key, value)
+        return self
+
+    def get_baggage_item(self, key):
+        # type: (str) -> Optional[str]
+        """Gets a baggage item from the span context of this span.
+
+        :param key: baggage item key
+        :type key: str
+
+        :rtype: str
+        :return: the baggage value for the given key or ``None``.
+        """
+        return self.context.get_baggage_item(key)
+
     def to_dict(self):
         # type: () -> Dict[str, Any]
         d = {

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -43,6 +43,7 @@ from .internal.logger import get_logger
 from .internal.logger import hasHandlers
 from .internal.processor import SpanProcessor
 from .internal.processor.trace import SpanAggregator
+from .internal.processor.trace import TraceBaggageProcessor
 from .internal.processor.trace import TraceProcessor
 from .internal.processor.trace import TraceSamplingProcessor
 from .internal.processor.trace import TraceTagsProcessor
@@ -662,6 +663,7 @@ class Tracer(object):
         # type: () -> None
         trace_processors = []  # type: List[TraceProcessor]
         trace_processors += [TraceTagsProcessor()]
+        trace_processors += [TraceBaggageProcessor()]
         trace_processors += [TraceSamplingProcessor()]
         trace_processors += [TraceTopLevelSpanProcessor()]
         trace_processors += self._filters

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -5,6 +5,7 @@ import pytest
 
 from ddtrace.context import Context
 from ddtrace.propagation.http import HTTPPropagator
+from ddtrace.propagation.http import HTTP_BAGGAGE_PREFIX
 from ddtrace.propagation.http import HTTP_HEADER_ORIGIN
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_SAMPLING_PRIORITY
@@ -26,6 +27,8 @@ class TestHttpPropagation(TestCase):
         tracer = DummyTracer()
 
         ctx = Context(trace_id=1234, sampling_priority=2, dd_origin="synthetics")
+        ctx.set_baggage_item("key1", "val1")
+
         tracer.context_provider.activate(ctx)
         with tracer.trace("global_root_span") as span:
             headers = {}
@@ -35,6 +38,7 @@ class TestHttpPropagation(TestCase):
             assert int(headers[HTTP_HEADER_PARENT_ID]) == span.span_id
             assert int(headers[HTTP_HEADER_SAMPLING_PRIORITY]) == span.context.sampling_priority
             assert headers[HTTP_HEADER_ORIGIN] == span.context.dd_origin
+            assert headers[HTTP_BAGGAGE_PREFIX + "key1"] == "val1"
 
     def test_extract(self):
         tracer = DummyTracer()

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -391,6 +391,22 @@ class SpanTestCase(TracerTestCase):
         s.set_tag(ENV_KEY, "prod")
         assert s.get_tag(ENV_KEY) == "prod"
 
+    def test_set_baggage_item(self):
+        s = Span(tracer=None, name="test.span")
+        s.set_baggage_item("custom.key", "123")
+        assert s.get_baggage_item("custom.key") == "123"
+
+    def test_baggage_propagation(self):
+        span1 = Span(tracer=None, name="test.span1")
+        span1.set_baggage_item("item1", "123")
+
+        span2 = Span(tracer=None, name="test.span2", context=span1.context)
+        span2.set_baggage_item("item2", "456")
+
+        assert span2.get_baggage_item("item1") == "123"
+        assert span2.get_baggage_item("item2") == "456"
+        assert span1.get_baggage_item("item2") is None
+
 
 @pytest.mark.parametrize(
     "value,assertion",


### PR DESCRIPTION
## Commit Message
Similar to the Opentracing baggage items, any item that is set via
span.set_baggage_item will be carried across spans and services
boundaries.

Signed-off-by: Tian Lan <tian@twosigma.com>
<!-- Briefly describe the change and why it was required. -->

## Description
Currently, there is no option to set baggage item in the Span unless the global tracer is configured to be Opentracer.Tracer. Since most of our applications are using DD Tracer by default, it makes switching the tracer implementation less trivial due to API incompatibilities. This PR would simply implement the Baggage feature that is currently available under Opentracer.Tracer to the DD Tracer. And it also makes DD Tracer behaves similarly to the Java DD Tracer.

Happy to discuss any alternatives if you think there are better options.

Thanks.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
