### PR TITLE
Add msgpack Packer based off msgpack-python 0.6.2

### DIFF
--- a/ddtrace/internal/pack_template.h
+++ b/ddtrace/internal/pack_template.h
@@ -574,6 +574,26 @@ static inline int msgpack_pack_nil(msgpack_packer* x)
 }
 
 
+
+/*
+ * Boolean
+ */
+
+static inline int msgpack_pack_true(msgpack_packer* x)
+{
+    static const unsigned char d = 0xc3;
+    msgpack_pack_append_buffer(x, &d, 1);
+}
+
+
+static inline int msgpack_pack_false(msgpack_packer* x)
+{
+    static const unsigned char d = 0xc2;
+    msgpack_pack_append_buffer(x, &d, 1);
+}
+
+
+
 /*
  * Array
  */

--- a/riotfile.py
+++ b/riotfile.py
@@ -223,6 +223,9 @@ venv = Venv(
             name="vendor",
             command="pytest {cmdargs} tests/vendor/",
             pys=select_pys(),
+            pkgs={
+                "msgpack": ["~=1.0.0", latest],
+            },
         ),
         Venv(
             name="test_logging",

--- a/tests/vendor/msgpack/test_buffer.py
+++ b/tests/vendor/msgpack/test_buffer.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from msgpack import unpackb
+
+from ddtrace.internal._encoding import packb
+
+
+def test_unpack_bytearray():
+    buf = bytearray(packb(["foo", "bar"]))
+    obj = unpackb(buf)
+    assert ["foo", "bar"] == obj
+
+
+def test_unpack_memoryview():
+    buf = bytearray(packb(["foo", "bar"]))
+    view = memoryview(buf)
+    obj = unpackb(view)
+    assert ["foo", "bar"] == obj

--- a/tests/vendor/msgpack/test_case.py
+++ b/tests/vendor/msgpack/test_case.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from msgpack import unpackb
+
+from ddtrace.internal._encoding import packb
+
+
+def check(length, obj):
+    v = packb(obj)
+    assert len(v) == length, "%r length should be %r but get %r" % (obj, length, len(v))
+    assert unpackb(v) == obj
+
+
+def test_1():
+    for o in [None, True, False, 0, 1, (1 << 6), (1 << 7) - 1, -1, -((1 << 5) - 1), -(1 << 5)]:
+        check(1, o)
+
+
+def test_2():
+    for o in [1 << 7, (1 << 8) - 1, -((1 << 5) + 1), -(1 << 7)]:
+        check(2, o)
+
+
+def test_3():
+    for o in [1 << 8, (1 << 16) - 1, -((1 << 7) + 1), -(1 << 15)]:
+        check(3, o)
+
+
+def test_5():
+    for o in [1 << 16, (1 << 32) - 1, -((1 << 15) + 1), -(1 << 31)]:
+        check(5, o)
+
+
+def test_9():
+    for o in [1 << 32, (1 << 64) - 1, -((1 << 31) + 1), -(1 << 63), 1.0, 0.1, -0.1, -1.0]:
+        check(9, o)
+
+
+def check_raw(overhead, num):
+    check(num + overhead, " " * num)
+
+
+def test_fixraw():
+    check_raw(1, 0)
+    check_raw(1, (1 << 5) - 1)
+
+
+def test_raw16():
+    check_raw(3, 1 << 5)
+    check_raw(3, (1 << 16) - 1)
+
+
+def test_raw32():
+    check_raw(5, 1 << 16)
+
+
+def check_array(overhead, num):
+    check(num + overhead, [None] * num)
+
+
+def test_fixarray():
+    check_array(1, 0)
+    check_array(1, (1 << 4) - 1)
+
+
+def test_array16():
+    check_array(3, 1 << 4)
+    check_array(3, (1 << 16) - 1)
+
+
+def test_array32():
+    check_array(5, (1 << 16))
+
+
+def match(obj, buf):
+    assert packb(obj) == buf
+    assert unpackb(buf, strict_map_key=False) == obj
+
+
+def test_match():
+    cases = [
+        (None, b"\xc0"),
+        (False, b"\xc2"),
+        (True, b"\xc3"),
+        (0, b"\x00"),
+        (127, b"\x7f"),
+        (128, b"\xcc\x80"),
+        (256, b"\xcd\x01\x00"),
+        (-1, b"\xff"),
+        (-33, b"\xd0\xdf"),
+        (-129, b"\xd1\xff\x7f"),
+        ({1: 1}, b"\x81\x01\x01"),
+        (1.0, b"\xcb\x3f\xf0\x00\x00\x00\x00\x00\x00"),
+        ([], b"\x90"),
+        ({}, b"\x80"),
+        (
+            dict([(x, x) for x in range(15)]),
+            (
+                b"\x8f\x00\x00\x01\x01\x02\x02\x03\x03\x04"
+                b"\x04\x05\x05\x06\x06\x07\x07\x08\x08\t\t"
+                b"\n\n\x0b\x0b\x0c\x0c\r\r\x0e\x0e"
+            )
+        ),
+        (
+            dict([(x, x) for x in range(16)]),
+            (
+                b"\xde\x00\x10\x00\x00\x01\x01\x02\x02\x03\x03"
+                b"\x04\x04\x05\x05\x06\x06\x07\x07\x08\x08\t\t"
+                b"\n\n\x0b\x0b\x0c\x0c\r\r\x0e\x0e\x0f\x0f"
+            )
+        ),
+    ]
+
+    for v, p in cases:
+        match(v, p)
+
+
+def test_unicode():
+    assert unpackb(packb("foobar"), use_list=1) == "foobar"

--- a/tests/vendor/msgpack/test_except.py
+++ b/tests/vendor/msgpack/test_except.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import datetime
+
+from msgpack import FormatError
+from msgpack import OutOfData
+from msgpack import StackError
+from msgpack import Unpacker
+from msgpack import unpackb
+from pytest import raises
+
+from ddtrace.internal._encoding import packb
+
+
+class DummyException(Exception):
+    pass
+
+
+def test_raise_on_find_unsupported_value():
+    with raises(TypeError):
+        packb(datetime.datetime.now())
+
+
+def test_raise_from_object_hook():
+    def hook(obj):
+        raise DummyException
+
+    raises(DummyException, unpackb, packb({}), object_hook=hook)
+    raises(DummyException, unpackb, packb({"fizz": "buzz"}), object_hook=hook)
+    raises(DummyException, unpackb, packb({"fizz": "buzz"}), object_pairs_hook=hook)
+    raises(DummyException, unpackb, packb({"fizz": {"buzz": "spam"}}), object_hook=hook)
+    raises(
+        DummyException,
+        unpackb,
+        packb({"fizz": {"buzz": "spam"}}),
+        object_pairs_hook=hook,
+    )
+
+
+def test_invalidvalue():
+    incomplete = b"\xd9\x97#DL_"  # raw8 - length=0x97
+    with raises(ValueError):
+        unpackb(incomplete)
+
+    with raises(OutOfData):
+        unpacker = Unpacker()
+        unpacker.feed(incomplete)
+        unpacker.unpack()
+
+    with raises(FormatError):
+        unpackb(b"\xc1")  # (undefined tag)
+
+    with raises(FormatError):
+        unpackb(b"\x91\xc1")  # fixarray(len=1) [ (undefined tag) ]
+
+    with raises(StackError):
+        unpackb(b"\x91" * 3000)  # nested fixarray(len=1)

--- a/tests/vendor/msgpack/test_limits.py
+++ b/tests/vendor/msgpack/test_limits.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# coding: utf-8
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from msgpack import PackOverflowError
+from msgpack import PackValueError
+from msgpack import Packer
+from msgpack import UnpackValueError
+from msgpack import Unpacker
+from msgpack import unpackb
+import pytest
+
+from ddtrace.internal._encoding import packb
+
+
+def test_integer():
+    x = -(2 ** 63)
+    assert unpackb(packb(x)) == x
+    with pytest.raises(PackOverflowError):
+        packb(x - 1)
+
+    x = 2 ** 64 - 1
+    assert unpackb(packb(x)) == x
+    with pytest.raises(PackOverflowError):
+        packb(x + 1)
+
+
+def test_array_header():
+    packer = Packer()
+    packer.pack_array_header(2 ** 32 - 1)
+    with pytest.raises(PackValueError):
+        packer.pack_array_header(2 ** 32)
+
+
+def test_map_header():
+    packer = Packer()
+    packer.pack_map_header(2 ** 32 - 1)
+    with pytest.raises(PackValueError):
+        packer.pack_array_header(2 ** 32)
+
+
+def test_max_str_len():
+    d = "x" * 3
+    packed = packb(d)
+
+    unpacker = Unpacker(max_str_len=3, raw=False)
+    unpacker.feed(packed)
+    assert unpacker.unpack() == d
+
+    unpacker = Unpacker(max_str_len=2, raw=False)
+    with pytest.raises(UnpackValueError):
+        unpacker.feed(packed)
+        unpacker.unpack()
+
+
+def test_max_array_len():
+    d = [1, 2, 3]
+    packed = packb(d)
+
+    unpacker = Unpacker(max_array_len=3)
+    unpacker.feed(packed)
+    assert unpacker.unpack() == d
+
+    unpacker = Unpacker(max_array_len=2)
+    with pytest.raises(UnpackValueError):
+        unpacker.feed(packed)
+        unpacker.unpack()
+
+
+def test_max_map_len():
+    d = {1: 2, 3: 4, 5: 6}
+    packed = packb(d)
+
+    unpacker = Unpacker(max_map_len=3, strict_map_key=False)
+    unpacker.feed(packed)
+    assert unpacker.unpack() == d
+
+    unpacker = Unpacker(max_map_len=2, strict_map_key=False)
+    with pytest.raises(UnpackValueError):
+        unpacker.feed(packed)
+        unpacker.unpack()
+
+
+# auto max len
+
+
+def test_auto_max_array_len():
+    packed = b"\xde\x00\x06zz"
+    with pytest.raises(UnpackValueError):
+        unpackb(packed, raw=False)
+
+    unpacker = Unpacker(max_buffer_size=5, raw=False)
+    unpacker.feed(packed)
+    with pytest.raises(UnpackValueError):
+        unpacker.unpack()
+
+
+def test_auto_max_map_len():
+    # len(packed) == 6 -> max_map_len == 3
+    packed = b"\xde\x00\x04zzz"
+    with pytest.raises(UnpackValueError):
+        unpackb(packed, raw=False)
+
+    unpacker = Unpacker(max_buffer_size=6, raw=False)
+    unpacker.feed(packed)
+    with pytest.raises(UnpackValueError):
+        unpacker.unpack()

--- a/tests/vendor/msgpack/test_pack.py
+++ b/tests/vendor/msgpack/test_pack.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# coding: utf-8
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from io import BytesIO
+import struct
+
+from msgpack import Unpacker
+from msgpack import unpackb
+import pytest
+
+from ddtrace.internal._encoding import Packer
+from ddtrace.internal._encoding import packb
+
+
+def check(data):
+    re = unpackb(packb(data), raw=True)
+    assert re == data
+
+
+def testPack():
+    test_data = [
+        0,
+        1,
+        127,
+        128,
+        255,
+        256,
+        65535,
+        65536,
+        4294967295,
+        4294967296,
+        -1,
+        -32,
+        -33,
+        -128,
+        -129,
+        -32768,
+        -32769,
+        -4294967296,
+        -4294967297,
+        1.0,
+        b"",
+        b"a",
+        b"a" * 31,
+        b"a" * 32,
+        None,
+        True,
+        False,
+        (1 << 23),
+    ]
+    for td in test_data:
+        check(td)
+
+
+def testPackUnicode():
+    test_data = ["", "abcd", ["defgh"], "Русский текст"]
+    for td in test_data:
+        re = unpackb(packb(td), use_list=1, raw=False)
+        assert re == td
+        packer = Packer()
+        data = packer.pack(td)
+        re = Unpacker(BytesIO(data), raw=False, use_list=1).unpack()
+        assert re == td
+
+
+def testPackBytes():
+    test_data = [
+        b"",
+        b"abcd",
+        [b"defgh"],
+    ]
+    for td in test_data:
+        check(td)
+
+
+def testStrictUnicodeUnpack():
+    packed = packb(b"abc\xeddef")
+    with pytest.raises(UnicodeDecodeError):
+        unpackb(packed, raw=False, use_list=1)
+
+
+def testDecodeBinary():
+    re = unpackb(packb(b"abc"), raw=True)
+    assert re == b"abc"
+
+
+def testPackFloat():
+    assert packb(1.0) == b"\xcb" + struct.pack(str(">d"), 1.0)

--- a/tests/vendor/msgpack/test_read_size.py
+++ b/tests/vendor/msgpack/test_read_size.py
@@ -1,0 +1,75 @@
+"""Test Unpacker's read_array_header and read_map_header methods"""
+from msgpack import OutOfData
+from msgpack import Unpacker
+
+from ddtrace.internal._encoding import packb
+
+
+UnexpectedTypeException = ValueError
+
+
+def test_read_array_header():
+    unpacker = Unpacker()
+    unpacker.feed(packb(["a", "b", "c"]))
+    assert unpacker.read_array_header() == 3
+    assert unpacker.unpack() == "a"
+    assert unpacker.unpack() == "b"
+    assert unpacker.unpack() == "c"
+    try:
+        unpacker.unpack()
+        assert 0, "should raise exception"
+    except OutOfData:
+        assert 1, "okay"
+
+
+def test_read_map_header():
+    unpacker = Unpacker()
+    unpacker.feed(packb({"a": "A"}))
+    assert unpacker.read_map_header() == 1
+    assert unpacker.unpack() == "a"
+    assert unpacker.unpack() == "A"
+    try:
+        unpacker.unpack()
+        assert 0, "should raise exception"
+    except OutOfData:
+        assert 1, "okay"
+
+
+def test_incorrect_type_array():
+    unpacker = Unpacker()
+    unpacker.feed(packb(1))
+    try:
+        unpacker.read_array_header()
+        assert 0, "should raise exception"
+    except UnexpectedTypeException:
+        assert 1, "okay"
+
+
+def test_incorrect_type_map():
+    unpacker = Unpacker()
+    unpacker.feed(packb(1))
+    try:
+        unpacker.read_map_header()
+        assert 0, "should raise exception"
+    except UnexpectedTypeException:
+        assert 1, "okay"
+
+
+def test_correct_type_nested_array():
+    unpacker = Unpacker()
+    unpacker.feed(packb({"a": ["b", "c", "d"]}))
+    try:
+        unpacker.read_array_header()
+        assert 0, "should raise exception"
+    except UnexpectedTypeException:
+        assert 1, "okay"
+
+
+def test_incorrect_type_nested_map():
+    unpacker = Unpacker()
+    unpacker.feed(packb([{"a": "b"}]))
+    try:
+        unpacker.read_map_header()
+        assert 0, "should raise exception"
+    except UnexpectedTypeException:
+        assert 1, "okay"

--- a/tests/vendor/msgpack/test_seq.py
+++ b/tests/vendor/msgpack/test_seq.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import io
+
+import msgpack
+
+from ddtrace.internal._encoding import Packer
+
+
+binarydata = bytes(bytearray(range(256)))
+
+
+def gen_binary_data(idx):
+    return binarydata[: idx % 300]
+
+
+def test_exceeding_unpacker_read_size():
+    dumpf = io.BytesIO()
+
+    packer = Packer()
+
+    NUMBER_OF_STRINGS = 6
+    read_size = 16
+    # 5 ok for read_size=16, while 6 glibc detected *** python: double free or corruption (fasttop):
+    # 20 ok for read_size=256, while 25 segfaults / glibc detected *** python: double free or corruption (!prev)
+    # 40 ok for read_size=1024, while 50 introduces errors
+    # 7000 ok for read_size=1024*1024, while 8000 leads to glibc detected *** python: double free or corruption (!prev):
+
+    for idx in range(NUMBER_OF_STRINGS):
+        data = gen_binary_data(idx)
+        dumpf.write(packer.pack(data))
+
+    f = io.BytesIO(dumpf.getvalue())
+    dumpf.close()
+
+    unpacker = msgpack.Unpacker(f, raw=True, read_size=read_size, use_list=1)
+
+    read_count = 0
+    for idx, o in enumerate(unpacker):
+        assert type(o) == bytes
+        assert o == gen_binary_data(idx)
+        read_count += 1
+
+    assert read_count == NUMBER_OF_STRINGS

--- a/tests/vendor/msgpack/test_subtype.py
+++ b/tests/vendor/msgpack/test_subtype.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from collections import namedtuple
+
+import pytest
+
+from ddtrace.internal._encoding import packb
+
+
+class MyList(list):
+    pass
+
+
+class MyDict(dict):
+    pass
+
+
+class MyTuple(tuple):
+    pass
+
+
+MyNamedTuple = namedtuple("MyNamedTuple", "x y")
+
+
+def test_types():
+    with pytest.raises(TypeError):
+        assert packb(MyDict()) == packb(dict())
+    with pytest.raises(TypeError):
+        assert packb(MyList()) == packb(list())
+    with pytest.raises(TypeError):
+        assert packb(MyNamedTuple(1, 2)) == packb((1, 2))

--- a/tests/vendor/msgpack/test_unpack.py
+++ b/tests/vendor/msgpack/test_unpack.py
@@ -1,0 +1,51 @@
+from io import BytesIO
+import sys
+
+from msgpack import OutOfData
+from msgpack import Unpacker
+from pytest import mark
+from pytest import raises
+
+from ddtrace.internal._encoding import packb
+
+
+def test_unpack_array_header_from_file():
+    f = BytesIO(packb([1, 2, 3, 4]))
+    unpacker = Unpacker(f)
+    assert unpacker.read_array_header() == 4
+    assert unpacker.unpack() == 1
+    assert unpacker.unpack() == 2
+    assert unpacker.unpack() == 3
+    assert unpacker.unpack() == 4
+    with raises(OutOfData):
+        unpacker.unpack()
+
+
+@mark.skipif("not hasattr(sys, 'getrefcount') == True", reason="sys.getrefcount() is needed to pass this test")
+def test_unpacker_hook_refcnt():
+    result = []
+
+    def hook(x):
+        result.append(x)
+        return x
+
+    basecnt = sys.getrefcount(hook)
+
+    up = Unpacker(object_hook=hook, list_hook=hook)
+
+    assert sys.getrefcount(hook) >= basecnt + 2
+
+    up.feed(packb([{}]))
+    up.feed(packb([{}]))
+    assert up.unpack() == [{}]
+    assert up.unpack() == [{}]
+    assert result == [{}, [{}], {}, [{}]]
+
+    del up
+
+    assert sys.getrefcount(hook) == basecnt
+
+
+if __name__ == "__main__":
+    test_unpack_array_header_from_file()
+    test_unpacker_hook_refcnt()


### PR DESCRIPTION
## Commit Message
{{title}}

It's handy to have a general msgpack encoder that can be used for
encoding arbitrary payloads of primitive Python types (see #2915).

The encoder added here is based off the one added in #1491.

It might be useful to use as a fallback for encoding traces as well if
an issue with the custom msgpack encoder is suspected.

The relevant tests from the msgpack-python implementation are included
as well to ensure that the implementation is correct.


## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
