### PR TITLE
fix(futures) Allow calling ThreadPoolExecutor.submit with fn kwarg

### DIFF
--- a/ddtrace/contrib/futures/threading.py
+++ b/ddtrace/contrib/futures/threading.py
@@ -21,10 +21,12 @@ def _wrap_submit(func, instance, args, kwargs):
     if ddtrace.tracer.context_provider._has_active_context():
         current_ctx = ddtrace.tracer.context_provider.active()
 
-    # extract the target function that must be executed in
-    # a new thread and the `target` arguments
-    fn = args[0]
-    fn_args = args[1:]
+    # The target function can be provided as a kwarg argument "fn" or the first positional argument
+    if "fn" in kwargs:
+        fn = kwargs.pop("fn")
+        fn_args = args
+    else:
+        fn, fn_args = args[0], args[1:]
     return func(_wrap_execution, current_ctx, fn, fn_args, kwargs)
 
 

--- a/releasenotes/notes/fix-futures-args-a206048e19889ad7.yaml
+++ b/releasenotes/notes/fix-futures-args-a206048e19889ad7.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix error when calling ``concurrent.futures.ThreadPoolExecutor.submit`` with ``fn`` keyword argument.


### PR DESCRIPTION
## Commit Message
{{title}}

Calling `ThreadPoolExecutor.submit(fn=target)` would raise an `IndexError: tuple index out of range` exception.

This is because we assumed that `args[0]` would always be the target function and never considered that it could be provided in `kwargs`.

We are not using our helper function because we need to remove `fn` from either `args` or `kwargs` once it is found.

Fixes #3000