### PR TITLE
perf: don't create unnecessary lock with Context._with_span usage

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -40,6 +40,7 @@ class Context(object):
         sampling_priority=None,  # type: Optional[float]
         meta=None,  # type: Optional[_MetaDictType]
         metrics=None,  # type: Optional[_MetricDictType]
+        lock=None,  # type: Optional[threading.RLock]
     ):
         self._meta = meta if meta is not None else {}  # type: _MetaDictType
         self._metrics = metrics if metrics is not None else {}  # type: _MetricDictType
@@ -52,16 +53,17 @@ class Context(object):
         if sampling_priority is not None:
             self._metrics[SAMPLING_PRIORITY_KEY] = sampling_priority
 
-        self._lock = threading.RLock()
+        if lock is not None:
+            self._lock = lock
+        else:
+            self._lock = threading.RLock()
 
     def _with_span(self, span):
         # type: (Span) -> Context
         """Return a shallow copy of the context with the given span."""
-        ctx = self.__class__(trace_id=span.trace_id, span_id=span.span_id)
-        ctx._lock = self._lock
-        ctx._meta = self._meta
-        ctx._metrics = self._metrics
-        return ctx
+        return self.__class__(
+            trace_id=span.trace_id, span_id=span.span_id, meta=self._meta, metrics=self._metrics, lock=self._lock
+        )
 
     def _update_tags(self, span):
         # type: (Span) -> None

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -1,3 +1,4 @@
+import threading
 from typing import Any
 from typing import Optional
 from typing import TYPE_CHECKING
@@ -40,7 +41,7 @@ class Context(object):
         sampling_priority=None,  # type: Optional[float]
         meta=None,  # type: Optional[_MetaDictType]
         metrics=None,  # type: Optional[_MetricDictType]
-        lock=None,  # type: Optional[forksafe.RLock]
+        lock=None,  # type: Optional[forksafe.ResetObject[threading.RLock]]
     ):
         self._meta = meta if meta is not None else {}  # type: _MetaDictType
         self._metrics = metrics if metrics is not None else {}  # type: _MetricDictType

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Any
 from typing import Optional
 from typing import TYPE_CHECKING
@@ -6,6 +5,7 @@ from typing import Text
 
 from .constants import ORIGIN_KEY
 from .constants import SAMPLING_PRIORITY_KEY
+from .internal import forksafe
 from .internal.compat import NumericType
 from .internal.logger import get_logger
 from .internal.utils.deprecation import deprecated
@@ -40,7 +40,7 @@ class Context(object):
         sampling_priority=None,  # type: Optional[float]
         meta=None,  # type: Optional[_MetaDictType]
         metrics=None,  # type: Optional[_MetricDictType]
-        lock=None,  # type: Optional[threading.RLock]
+        lock=None,  # type: Optional[forksafe.RLock]
     ):
         self._meta = meta if meta is not None else {}  # type: _MetaDictType
         self._metrics = metrics if metrics is not None else {}  # type: _MetricDictType
@@ -56,7 +56,7 @@ class Context(object):
         if lock is not None:
             self._lock = lock
         else:
-            self._lock = threading.RLock()
+            self._lock = forksafe.RLock()
 
     def _with_span(self, span):
         # type: (Span) -> Context


### PR DESCRIPTION
## Commit Message
<!-- Defaults to the title of the PR. Replace if desired. -->
{{title}}

Small optimization to avoid creating a `threading.RLock` or two dicts if we are just going to overwrite them anyways.

This gives us a very tiny performance optimization, but mostly helps us avoid creating an additional RLock/two dicts which will save us on object creation + GC.


**Benchmark: tracer**
| Benchmark      | _master_ | _this branch_ |
| -- | -- | -- |
| tracer-small | 506 us | 500 us: 1.01x faster | 
| tracer-medium  | 4.90 ms | 4.79 ms: 1.02x faster |
| tracer-large   | 50.6 ms | 47.2 ms: 1.07x faster |
| Geometric mean | (ref) | 1.03x faster |

**Benchmark: flask_simple**
| Benchmark      | _master_ | _this branch_ |
| -- | -- | -- |
| flasksimple-baseline | 4.66 ms | 3.72 ms: 1.25x faster | 
| flasksimple-tracer   | 4.31 ms | 3.78 ms: 1.14x faster |
| flasksimple-profiler | 4.06 ms | 3.74 ms: 1.09x faster |
| Geometric mean | (ref) | 1.11x faster |

**Benchmark: django_simple**
No significant change.

Given the results from Flask I was expecting Django to also show an improvement.
