### PR TITLE
tests(pymongo) support pymongo 4.0 in tests

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -427,18 +427,16 @@ venv = Venv(
                             ">=3.7,<3.8",
                             ">=3.8,<3.9",
                             ">=3.9,<3.10",
-                            ">=3.10,<3.11",
-                            ">=3.12,<3.13",
-                            latest,
                         ],
                     },
                 ),
                 Venv(
-                    pys=select_pys(min_version="3.10"),
+                    pys=select_pys(min_version="3.6"),
                     pkgs={
                         "pymongo": [
                             ">=3.10,<3.11",
                             ">=3.12,<3.13",
+                            ">=4.0,<4.1",
                             latest,
                         ],
                     },


### PR DESCRIPTION
## Commit Message
{{title}}

Our tests relied on `Collection.count` which has been deprecated in favor of `Collection.count_documents`. Other than the API change the resource name changed from `count ...` to `aggregate ...`.

https://github.com/mongodb/mongo-python-driver/blob/2c28149a301bb33b3347bf38f8dbfe085215ca38/doc/migrate-to-pymongo4.rst