### PR TITLE
Catch Cython isort formatting issues in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,8 +274,8 @@ jobs:
       - checkout
       - setup_riot
       - run:
-          name: "Black check"
-          command: riot run -s black --check .
+          name: "Formatting check"
+          command: riot run -s fmt && git diff --exit-code
       - run:
           name: "Flake8 check"
           command: riot run -s flake8

--- a/ddtrace/profiling/collector/_task.pyx
+++ b/ddtrace/profiling/collector/_task.pyx
@@ -5,9 +5,10 @@ from . import _threading
 
 
 try:
-    from greenlet import settrace, getcurrent
-    import gevent.thread
     import gevent.hub
+    import gevent.thread
+    from greenlet import getcurrent
+    from greenlet import settrace
 except ImportError:
     _gevent_tracer = None
 else:


### PR DESCRIPTION
## Commit Message

{{title}}

Our CI relied on flake8-isort to catch isort issues but it doesn't run
on Cython files. Instead, we can run the formatting command and verify
that no changes are made to source files which better ensures that all
formatting has been done.
