### PR TITLE
perf: use non-forksafe RLock in context

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -56,6 +56,9 @@ class Context(object):
         if lock is not None:
             self._lock = lock
         else:
+            # DEV: A `forksafe.RLock` is not necessary here since Contexts
+            # are recreated by the tracer after fork
+            # https://github.com/DataDog/dd-trace-py/blob/a1932e8ddb704d259ea8a3188d30bf542f59fd8d/ddtrace/tracer.py#L489-L508
             self._lock = threading.RLock()
 
     def _with_span(self, span):

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -6,7 +6,6 @@ from typing import Text
 
 from .constants import ORIGIN_KEY
 from .constants import SAMPLING_PRIORITY_KEY
-from .internal import forksafe
 from .internal.compat import NumericType
 from .internal.logger import get_logger
 from .internal.utils.deprecation import deprecated
@@ -41,7 +40,7 @@ class Context(object):
         sampling_priority=None,  # type: Optional[float]
         meta=None,  # type: Optional[_MetaDictType]
         metrics=None,  # type: Optional[_MetricDictType]
-        lock=None,  # type: Optional[forksafe.ResetObject[threading.RLock]]
+        lock=None,  # type: Optional[threading.RLock]
     ):
         self._meta = meta if meta is not None else {}  # type: _MetaDictType
         self._metrics = metrics if metrics is not None else {}  # type: _MetricDictType
@@ -57,7 +56,7 @@ class Context(object):
         if lock is not None:
             self._lock = lock
         else:
-            self._lock = forksafe.RLock()
+            self._lock = threading.RLock()
 
     def _with_span(self, span):
         # type: (Span) -> Context

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -99,6 +99,10 @@ class Span(object):
         """
         Create a new span. Call `finish` once the traced operation is over.
 
+        **Note:** A ``Span`` should only be accessed or modified in the process
+        that it was created in. Using a ``Span`` from within a child process
+        could result in a deadlock or unexpected behavior.
+
         :param ddtrace.Tracer tracer: the tracer that will submit this span when
             finished.
         :param str name: the name of the traced operation.

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -128,6 +128,14 @@ span has to be propagated as a context::
         time.sleep(1)
         proc.join()
 
+
+.. important::
+
+   A :class:`ddtrace.Span` should only be accessed or modified in the process
+   that it was created in. Using a :class:`ddtrace.Span` from within a child process
+   could result in a deadlock or unexpected behavior.
+
+
 fork
 ****
 If using `fork()`, any open spans from the parent process must be finished by


### PR DESCRIPTION
## Commit Message
{{title}}

Previously in #3036 we made a change to use a forksafe RLock
but did not re-measure the performance overhead of the change.

Creation of a `forksafe.RLock()` is 3 times slower than a
regular `threading.RLock`.

master   - Context(): Mean +- std dev: 3.24 us +- 0.34 us
v0.56.1  - Context(): Mean +- std dev: 754 ns +- 17 ns

Given that we do not _require_ a forksafe lock here we
should use a normal `threading.RLock` for performance reasons.