### PR TITLE
tests(rq) support RQ 1.10.1

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -1195,6 +1195,7 @@ venv = Venv(
                             "~=1.7.0",
                             "~=1.8.0",
                             "~=1.9.0",
+                            "~=1.10.0",
                             latest,
                         ],
                         # https://github.com/rq/rq/issues/1469 rq [1.0,1.8] is incompatible with click 8.0+

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job.json
@@ -7,25 +7,21 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 1,
     "meta": {
-      "error.msg": "error",
-      "error.stack": "Traceback (most recent call last):\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/ddtrace/contrib/rq/__init__.py\", line 140, in traced_queue_enqueue_job\n    return func(*args, **kwargs)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/venv_py395_click712_rq~100/lib/python3.9/site-packages/rq/queue.py\", line 356, in enqueue_job\n    job = self.run_job(job)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/venv_py395_click712_rq~100/lib/python3.9/site-packages/rq/queue.py\", line 282, in run_job\n    job.perform()\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/ddtrace/contrib/trace_utils.py\", line 162, in wrapper\n    return func(mod, pin, wrapped, instance, args, kwargs)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/ddtrace/contrib/rq/__init__.py\", line 193, in traced_job_perform\n    return func(*args, **kwargs)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/venv_py395_click712_rq~100/lib/python3.9/site-packages/rq/job.py\", line 588, in perform\n    self._result = self._execute()\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/venv_py395_click712_rq~100/lib/python3.9/site-packages/rq/job.py\", line 594, in _execute\n    return self.func(*self.args, **self.kwargs)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/tests/contrib/rq/jobs.py\", line 10, in job_fail\n    raise MyException(\"error\")\ntests.contrib.rq.jobs.MyException: error\n",
-      "error.type": "tests.contrib.rq.jobs.MyException",
       "job.func_name": "tests.contrib.rq.jobs.job_fail",
-      "job.id": "41b97d3b-3231-4c5a-b317-6c13a6926749",
+      "job.id": "b916a7ab-9289-4c07-a40d-260e96c69f63",
       "queue.name": "sync-q",
-      "runtime-id": "2fae27a28fd644a6bd2fbbd179813bd4"
+      "runtime-id": "5b62413a62ad44468e21e09f3dc941d6"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 67067
+      "system.pid": 4083
     },
-    "duration": 8260000,
-    "start": 1632150770649318000
+    "duration": 9563000,
+    "start": 1638903827586533000
   },
      {
        "name": "rq.job.perform",
@@ -37,10 +33,10 @@
        "error": 1,
        "meta": {
          "error.msg": "error",
-         "error.stack": "Traceback (most recent call last):\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/ddtrace/contrib/rq/__init__.py\", line 193, in traced_job_perform\n    return func(*args, **kwargs)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/venv_py395_click712_rq~100/lib/python3.9/site-packages/rq/job.py\", line 588, in perform\n    self._result = self._execute()\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/.riot/venv_py395_click712_rq~100/lib/python3.9/site-packages/rq/job.py\", line 594, in _execute\n    return self.func(*self.args, **self.kwargs)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/tests/contrib/rq/jobs.py\", line 10, in job_fail\n    raise MyException(\"error\")\ntests.contrib.rq.jobs.MyException: error\n",
+         "error.stack": "Traceback (most recent call last):\n  File \"/Users/brett.langdon/datadog/dd-trace-py/ddtrace/contrib/rq/__init__.py\", line 193, in traced_job_perform\n    return func(*args, **kwargs)\n  File \"/Users/brett.langdon/datadog/dd-trace-py/.riot/venv_py3100_rq_click712/lib/python3.10/site-packages/rq/job.py\", line 821, in perform\n    self._result = self._execute()\n  File \"/Users/brett.langdon/datadog/dd-trace-py/.riot/venv_py3100_rq_click712/lib/python3.10/site-packages/rq/job.py\", line 844, in _execute\n    result = self.func(*self.args, **self.kwargs)\n  File \"/Users/brett.langdon/datadog/dd-trace-py/tests/contrib/rq/jobs.py\", line 10, in job_fail\n    raise MyException(\"error\")\ntests.contrib.rq.jobs.MyException: error\n",
          "error.type": "tests.contrib.rq.jobs.MyException",
-         "job.id": "41b97d3b-3231-4c5a-b317-6c13a6926749"
+         "job.id": "b916a7ab-9289-4c07-a40d-260e96c69f63"
        },
-       "duration": 2357000,
-       "start": 1632150770654147000
+       "duration": 2109000,
+       "start": 1638903827592392000
      }]]

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job_pre_1_10_1.json
@@ -1,0 +1,46 @@
+[[
+  {
+    "name": "rq.queue.enqueue_job",
+    "service": "rq",
+    "resource": "tests.contrib.rq.jobs.job_fail",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 1,
+    "meta": {
+      "error.msg": "error",
+      "error.stack": "Traceback (most recent call last):\n  File \"/Users/brett.langdon/datadog/dd-trace-py/ddtrace/contrib/rq/__init__.py\", line 140, in traced_queue_enqueue_job\n    return func(*args, **kwargs)\n  File \"/Users/brett.langdon/datadog/dd-trace-py/.riot/venv_py3100_rq~190_click712/lib/python3.10/site-packages/rq/queue.py\", line 570, in enqueue_job\n    job = self.run_job(job)\n  File \"/Users/brett.langdon/datadog/dd-trace-py/.riot/venv_py3100_rq~190_click712/lib/python3.10/site-packages/rq/queue.py\", line 448, in run_job\n    job.perform()\n  File \"/root/project/ddtrace/contrib/trace_utils.py\", line 162, in wrapper\n  File \"/Users/brett.langdon/datadog/dd-trace-py/ddtrace/contrib/rq/__init__.py\", line 193, in traced_job_perform\n    return func(*args, **kwargs)\n  File \"/Users/brett.langdon/datadog/dd-trace-py/.riot/venv_py3100_rq~190_click712/lib/python3.10/site-packages/rq/job.py\", line 749, in perform\n    self._result = self._execute()\n  File \"/Users/brett.langdon/datadog/dd-trace-py/.riot/venv_py3100_rq~190_click712/lib/python3.10/site-packages/rq/job.py\", line 772, in _execute\n    result = self.func(*self.args, **self.kwargs)\n  File \"/Users/brett.langdon/datadog/dd-trace-py/tests/contrib/rq/jobs.py\", line 10, in job_fail\n    raise MyException(\"error\")\ntests.contrib.rq.jobs.MyException: error\n",
+      "error.type": "tests.contrib.rq.jobs.MyException",
+      "job.func_name": "tests.contrib.rq.jobs.job_fail",
+      "job.id": "0775ce83-6cb6-454b-aed1-77bed1a66f8f",
+      "queue.name": "sync-q",
+      "runtime-id": "e60df3a2728d440a8398fcbd9566b7f1"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 4490
+    },
+    "duration": 9413000,
+    "start": 1638903903477358000
+  },
+     {
+       "name": "rq.job.perform",
+       "service": "rq",
+       "resource": "tests.contrib.rq.jobs.job_fail",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "error": 1,
+       "meta": {
+         "error.msg": "error",
+         "error.stack": "Traceback (most recent call last):\n  File \"/Users/brett.langdon/datadog/dd-trace-py/ddtrace/contrib/rq/__init__.py\", line 193, in traced_job_perform\n    return func(*args, **kwargs)\n  File \"/Users/brett.langdon/datadog/dd-trace-py/.riot/venv_py3100_rq~190_click712/lib/python3.10/site-packages/rq/job.py\", line 749, in perform\n    self._result = self._execute()\n  File \"/Users/brett.langdon/datadog/dd-trace-py/.riot/venv_py3100_rq~190_click712/lib/python3.10/site-packages/rq/job.py\", line 772, in _execute\n    result = self.func(*self.args, **self.kwargs)\n  File \"/Users/brett.langdon/datadog/dd-trace-py/tests/contrib/rq/jobs.py\", line 10, in job_fail\n    raise MyException(\"error\")\ntests.contrib.rq.jobs.MyException: error\n",
+         "error.type": "tests.contrib.rq.jobs.MyException",
+         "job.id": "0775ce83-6cb6-454b-aed1-77bed1a66f8f"
+       },
+       "duration": 2844000,
+       "start": 1638903903483183000
+     }]]


### PR DESCRIPTION
## Commit Message
<!-- Defaults to the title of the PR. Replace if desired. -->
{{title}}


They changed the behavior for calling sync tasks, they
will now no longer raise an exception.