### PR TITLE
internal: add _dd.py.partial_flush tag when we partially flush a chunk

### DIFF
--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -180,6 +180,7 @@ class SpanAggregator(SpanProcessor):
 
                 if should_partial_flush:
                     log.debug("Partially flushing %d spans for trace %d", num_finished, span.trace_id)
+                    finished[0].set_metric("_dd.py.partial_flush", num_finished)
 
                 trace.num_finished -= num_finished
 

--- a/tests/tracer/test_processors.py
+++ b/tests/tracer/test_processors.py
@@ -163,8 +163,10 @@ def test_aggregator_partial_flush_0_spans():
     assert writer.pop() == []
     parent.finish()
     assert writer.pop() == [parent]
+    assert parent.get_metric("_dd.py.partial_flush") == 1
     child.finish()
     assert writer.pop() == [child]
+    assert child.get_metric("_dd.py.partial_flush") == 1
 
 
 def test_aggregator_partial_flush_2_spans():
@@ -216,8 +218,11 @@ def test_aggregator_partial_flush_2_spans():
     assert writer.pop() == []
     child2.finish()
     assert writer.pop() == [child1, child2]
+    assert child1.get_metric("_dd.py.partial_flush") == 2
+    assert child2.get_metric("_dd.py.partial_flush") is None
     parent.finish()
     assert writer.pop() == [parent]
+    assert parent.get_metric("_dd.py.partial_flush") is None
 
 
 def test_trace_top_level_span_processor_partial_flushing():


### PR DESCRIPTION
## Commit Message
{{title}}

Add a new metric to the chunk root span of a partially flushed chunk
that indicates the total number of spans that were partially flushed.

The goal for this new metric is to be able to easily identify from
a trace whether partial flushing is enabled and working without
the need of debug logs or metrics to identify.

This should greatly help support and verifying customer configurations
with minimal back and forth.