### PR TITLE
fix failing botocore test suite

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
         # container that executes mocked AWS services; this is a custom
         # build that runs all of them in a single container. It is built
         # using this fork: https://github.com/palazzem/moto/tree/palazzem/docker-service
-        image: datadog/docker-library:moto_1_0_1
+        image: motoserver/moto:2.2.19
         ports:
             - "127.0.0.1:5000:5000"
             - "127.0.0.1:5001:5001"
@@ -132,7 +132,7 @@ services:
           - ./.ddriot:/root/project/.riot
 
     localstack:
-        image: localstack/localstack:0.12.1
+        image: localstack/localstack:0.13.1
         network_mode: bridge
         ports:
           - "127.0.0.1:4566:4566"

--- a/riotfile.py
+++ b/riotfile.py
@@ -980,14 +980,14 @@ venv = Venv(
         Venv(
             name="boto",
             command="pytest {cmdargs} tests/contrib/boto",
-            venvs=[Venv(pys=select_pys(max_version="3.6"), pkgs={"boto": latest, "moto": ["<1.0"]})],
+            venvs=[Venv(pys=select_pys(max_version="3.6"), pkgs={"boto": latest, "moto[all]": latest})],
         ),
         Venv(
             name="botocore",
             command="pytest {cmdargs} tests/contrib/botocore",
-            pkgs={"botocore": latest},
+            pkgs={"botocore": "<1.22.0"},
             venvs=[
-                Venv(pys=select_pys(min_version="3.5"), pkgs={"moto": [">=1.0,<2.0"]}),
+                Venv(pys=select_pys(min_version="3.5"), pkgs={"moto[all]": latest}),
                 Venv(pys=["2.7"], pkgs={"moto": [">=1.0,<2.0"], "rsa": ["<4.7.1"]}),
             ],
         ),

--- a/riotfile.py
+++ b/riotfile.py
@@ -985,7 +985,7 @@ venv = Venv(
         Venv(
             name="botocore",
             command="pytest {cmdargs} tests/contrib/botocore",
-            pkgs={"botocore": "<1.22.0"},
+            pkgs={"botocore": latest},
             venvs=[
                 Venv(pys=select_pys(min_version="3.5"), pkgs={"moto[all]": latest}),
                 Venv(pys=["2.7"], pkgs={"moto": [">=1.0,<2.0"], "rsa": ["<4.7.1"]}),

--- a/riotfile.py
+++ b/riotfile.py
@@ -980,7 +980,7 @@ venv = Venv(
         Venv(
             name="boto",
             command="pytest {cmdargs} tests/contrib/boto",
-            venvs=[Venv(pys=select_pys(max_version="3.6"), pkgs={"boto": latest, "moto[all]": latest})],
+            venvs=[Venv(pys=select_pys(max_version="3.6"), pkgs={"boto": latest, "moto": "<1.0.0"})],
         ),
         Venv(
             name="botocore",
@@ -988,7 +988,7 @@ venv = Venv(
             pkgs={"botocore": latest},
             venvs=[
                 Venv(pys=select_pys(min_version="3.5"), pkgs={"moto[all]": latest}),
-                Venv(pys=["2.7"], pkgs={"moto": [">=1.0,<2.0"], "rsa": ["<4.7.1"]}),
+                Venv(pys=["2.7"], pkgs={"moto": ["~=1.0"], "rsa": ["<4.7.1"]}),
             ],
         ),
         Venv(

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -7,12 +7,18 @@ import zipfile
 
 import botocore.session
 from moto import mock_ec2
-from moto import mock_firehose
 from moto import mock_kinesis
 from moto import mock_kms
 from moto import mock_lambda
 from moto import mock_s3
 from moto import mock_sqs
+
+
+# Older version of moto used kinesis to mock firehose
+try:
+    from moto import mock_firehose
+except ImportError:
+    from moto import mock_kinesis as mock_firehose
 
 from ddtrace import Pin
 from ddtrace import config

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -7,6 +7,7 @@ import zipfile
 
 import botocore.session
 from moto import mock_ec2
+from moto import mock_firehose
 from moto import mock_kinesis
 from moto import mock_kms
 from moto import mock_lambda
@@ -761,7 +762,7 @@ class BotocoreTest(TracerTestCase):
             service_response = s3.list_buckets()
             assert service_response == response
 
-    @mock_kinesis
+    @mock_firehose
     def test_firehose_no_records_arg(self):
         firehose = self.session.create_client("firehose", region_name="us-west-2")
         Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(firehose)


### PR DESCRIPTION
## Commit Message
<!-- Defaults to the title of the PR. Replace if desired. -->
{{title}}

New version of `botocore` added a new region that was not recognized by `moto` causing a startup error.

This PR:
- upgrades `localstack`/`moto` server containers to latest.
- update `moto` test library to latest for `botocore`
- Fix `mock_kinesis`/`mock_firehose` usage

