### PR TITLE
tests: disable hypothesis too_slow health check

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,11 +19,11 @@ pytest_plugins = ("pytester",)
 
 PY_DIR_PATTERN = re.compile(r"^py[23][0-9]$")
 
-
 # Disable the "too slow" health checks. We are ok if data generation is slow
 # https://hypothesis.readthedocs.io/en/latest/healthchecks.html#hypothesis.HealthCheck.too_slow
 hypothesis.settings.register_profile("default", suppress_health_check=(hypothesis.HealthCheck.too_slow,))
 hypothesis.settings.load_profile("default")
+
 
 # Hook for dynamic configuration of pytest in CI
 # https://docs.pytest.org/en/6.2.1/reference.html#pytest.hookspec.pytest_configure

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ import re
 import sys
 from time import time
 
+import hypothesis
 import pytest
 
 
@@ -18,6 +19,11 @@ pytest_plugins = ("pytester",)
 
 PY_DIR_PATTERN = re.compile(r"^py[23][0-9]$")
 
+
+# Disable the "too slow" health checks. We are ok if data generation is slow
+# https://hypothesis.readthedocs.io/en/latest/healthchecks.html#hypothesis.HealthCheck.too_slow
+hypothesis.settings.register_profile("default", suppress_health_check=(hypothesis.HealthCheck.too_slow,))
+hypothesis.settings.load_profile("default")
 
 # Hook for dynamic configuration of pytest in CI
 # https://docs.pytest.org/en/6.2.1/reference.html#pytest.hookspec.pytest_configure

--- a/tox.ini
+++ b/tox.ini
@@ -94,6 +94,7 @@ deps =
     opentracing
 # test dependencies installed in all envs
     mock
+    hypothesis
 # used to test our custom msgpack encoder
     profile: pytest-benchmark
     py{27,35,36,37,38,39}-profile: uwsgi


### PR DESCRIPTION
## Commit Message
{{title}}

We have tests which are flaky because of this health check.
While we do not want tests to be too slow, we don't need to
fail the tests if it is slow.