### PR TITLE
reflect proper default for DD_LOGS_INJECTION

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -89,7 +89,7 @@ below:
        .. _dd-logs-injection:
    * - ``DD_LOGS_INJECTION``
      - Boolean
-     - True
+     - False
      - Enables :ref:`Logs Injection`.
 
        .. _dd-call-basic-config:


### PR DESCRIPTION
DD_LOGS_INJECTION defaults to false here: https://github.com/DataDog/dd-trace-py/blob/master/ddtrace/settings/config.py#L141

update documentation to reflect the default value



## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
