### PR TITLE
refactor(profiling): simplify task listing with gevent

### DIFF
--- a/ddtrace/profiling/collector/_task.pyx
+++ b/ddtrace/profiling/collector/_task.pyx
@@ -66,7 +66,7 @@ cpdef get_task(thread_id):
     return task_id, task_name, frame
 
 
-cpdef list_tasks():
+cpdef list_tasks(thread_id):
     # type: (...) -> typing.List[typing.Tuple[int, str, types.FrameType]]
     """Return the list of running tasks.
 
@@ -76,7 +76,7 @@ cpdef list_tasks():
     :return: [(task_id, task_name, task_frame), ...]"""
     # We consider all Thread objects to be greenlet
     # This should be true as nobody could use a half-monkey-patched gevent
-    if _gevent_tracer is not None:
+    if thread_id == nogevent.main_thread_id and _gevent_tracer is not None:
         return [
             (greenlet_id,
              _threading.get_thread_name(greenlet_id),

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -296,67 +296,10 @@ cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_tim
         if task_id in thread_id_ignore_list:
             continue
 
+        tasks = _task.list_tasks(thread_id)
+
         # Inject wall time for all running tasks
-        if thread_id == nogevent.main_thread_id:
-            main_thread_is_a_task = False
-
-            for task_id, task_name, task_frame in _task.list_tasks():
-                if task_id == compat.main_thread.ident:
-                    main_thread_is_a_task = True
-
-                    # task_frame is None, so use the thread frames list here
-                    frames, nframes = _traceback.pyframe_to_frames(frame, max_nframes)
-
-                    event = stack_event.StackSampleEvent(
-                        thread_id=thread_id,
-                        thread_native_id=thread_native_id,
-                        thread_name=thread_name,
-                        task_id=task_id,
-                        task_name=task_name,
-                        nframes=nframes, frames=frames,
-                        wall_time_ns=wall_time,
-                        cpu_time_ns=cpu_time,
-                        sampling_period=int(interval * 1e9),
-                    )
-
-                    # FIXME: we only trace spans per thread, so we assign the span to the main thread for now
-                    # we'd need to leverage the greenlet tracer to also store the active span
-                    event.set_trace_info(span, collect_endpoint)
-                else:
-                    frames, nframes = _traceback.pyframe_to_frames(task_frame, max_nframes)
-
-                    event = stack_event.StackSampleEvent(
-                        thread_id=thread_id,
-                        thread_native_id=thread_native_id,
-                        thread_name=thread_name,
-                        task_id=task_id,
-                        task_name=task_name,
-                        nframes=nframes, frames=frames,
-                        wall_time_ns=wall_time,
-                        # we don't have CPU time per task
-                        sampling_period=int(interval * 1e9),
-                    )
-
-                stack_events.append(event)
-
-            if not main_thread_is_a_task:
-                frames, nframes = _traceback.pyframe_to_frames(frame, max_nframes)
-
-                event = stack_event.StackSampleEvent(
-                    thread_id=thread_id,
-                    thread_native_id=thread_native_id,
-                    thread_name=thread_name,
-                    nframes=nframes,
-                    frames=frames,
-                    wall_time_ns=wall_time,
-                    cpu_time_ns=cpu_time,
-                    sampling_period=int(interval * 1e9),
-                )
-
-                event.set_trace_info(span, collect_endpoint)
-
-                stack_events.append(event)
-        else:
+        for task_id, task_name, task_frame in tasks:
             # Inject the task frame and replace the thread frame: this is especially handy for gevent as it allows us to
             # replace the "hub" stack trace by the latest active greenlet, which is more interesting to show and account
             # resources for.
@@ -365,13 +308,47 @@ cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_tim
 
             frames, nframes = _traceback.pyframe_to_frames(frame, max_nframes)
 
+            if task_id == compat.main_thread.ident:
+                event = stack_event.StackSampleEvent(
+                    thread_id=thread_id,
+                    thread_native_id=thread_native_id,
+                    thread_name=thread_name,
+                    task_id=task_id,
+                    task_name=task_name,
+                    nframes=nframes, frames=frames,
+                    wall_time_ns=wall_time,
+                    cpu_time_ns=cpu_time,
+                    sampling_period=int(interval * 1e9),
+                )
+
+                # FIXME: we only trace spans per thread, so we assign the span to the main thread for now
+                # we'd need to leverage the greenlet tracer to also store the active span
+                event.set_trace_info(span, collect_endpoint)
+            else:
+                event = stack_event.StackSampleEvent(
+                    thread_id=thread_id,
+                    thread_native_id=thread_native_id,
+                    thread_name=thread_name,
+                    task_id=task_id,
+                    task_name=task_name,
+                    nframes=nframes, frames=frames,
+                    wall_time_ns=wall_time,
+                    # we don't have CPU time per task
+                    sampling_period=int(interval * 1e9),
+                )
+
+            stack_events.append(event)
+
+        # If a thread has no task, we inject the "regular" thread samples
+        if len(tasks) == 0:
+            frames, nframes = _traceback.pyframe_to_frames(frame, max_nframes)
+
             event = stack_event.StackSampleEvent(
                 thread_id=thread_id,
                 thread_native_id=thread_native_id,
                 thread_name=thread_name,
-                task_id=task_id,
-                task_name=task_name,
-                nframes=nframes, frames=frames,
+                nframes=nframes,
+                frames=frames,
                 wall_time_ns=wall_time,
                 cpu_time_ns=cpu_time,
                 sampling_period=int(interval * 1e9),

--- a/tests/profiling/collector/test_task.py
+++ b/tests/profiling/collector/test_task.py
@@ -21,7 +21,7 @@ def test_get_task_main():
 
 @pytest.mark.skipif(TESTING_GEVENT, reason="only works without gevent")
 def test_list_tasks_nogevent():
-    assert _task.list_tasks() == []
+    assert _task.list_tasks(nogevent.main_thread_id) == []
 
 
 @pytest.mark.skipif(not TESTING_GEVENT, reason="only works with gevent")
@@ -39,7 +39,7 @@ def test_list_tasks_gevent():
     t1 = threading.Thread(target=wait, name="t1")
     t1.start()
 
-    tasks = _task.list_tasks()
+    tasks = _task.list_tasks(nogevent.main_thread_id)
     # can't check == 2 because there are left over from other tests
     assert len(tasks) >= 2
 


### PR DESCRIPTION
This moves the task listing thread check into `list_tasks()` which allows to
simplify a bit the logic of injecting wall time, and prepare the future for
being able to list tasks per thread (hello asyncio).