### PR TITLE
fix(http): do not make mixin inherit from HTTPConnection

### DIFF
--- a/ddtrace/internal/http.py
+++ b/ddtrace/internal/http.py
@@ -2,19 +2,12 @@ from ddtrace.internal.compat import httplib
 from ddtrace.internal.compat import parse
 
 
-class BasePathMixin(httplib.HTTPConnection, object):
+class BasePathMixin(object):
     """
     Mixin for HTTPConnection to insert a base path to requested URLs
     """
 
     _base_path = "/"  # type: str
-
-    def putrequest(self, method, url, skip_host=False, skip_accept_encoding=False):
-        # type: (str, str, bool, bool) -> None
-        url = parse.urljoin(self._base_path, url)
-        return super(BasePathMixin, self).putrequest(
-            method, url, skip_host=skip_host, skip_accept_encoding=skip_accept_encoding
-        )
 
     @classmethod
     def with_base_path(cls, *args, **kwargs):
@@ -29,8 +22,22 @@ class HTTPConnection(BasePathMixin, httplib.HTTPConnection):
     httplib.HTTPConnection wrapper to add a base path to requested URLs
     """
 
+    def putrequest(self, method, url, skip_host=False, skip_accept_encoding=False):
+        # type: (str, str, bool, bool) -> None
+        url = parse.urljoin(self._base_path, url)
+        return super(HTTPConnection, self).putrequest(
+            method, url, skip_host=skip_host, skip_accept_encoding=skip_accept_encoding
+        )
+
 
 class HTTPSConnection(BasePathMixin, httplib.HTTPSConnection):
     """
     httplib.HTTPSConnection wrapper to add a base path to requested URLs
     """
+
+    def putrequest(self, method, url, skip_host=False, skip_accept_encoding=False):
+        # type: (str, str, bool, bool) -> None
+        url = parse.urljoin(self._base_path, url)
+        return super(HTTPSConnection, self).putrequest(
+            method, url, skip_host=skip_host, skip_accept_encoding=skip_accept_encoding
+        )

--- a/releasenotes/notes/profiling-fix-http-upload-61917c778d63a494.yaml
+++ b/releasenotes/notes/profiling-fix-http-upload-61917c778d63a494.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix broken HTTPS upload due to wrong class inheritance.


### PR DESCRIPTION
This can also be used by HTTPSConnection and it currently fails with:

  File ".tox/py39/lib/python3.9/site-packages/ddtrace/internal/http.py", line 22, in with_base_path
    obj = cls(*args, **kwargs)
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/http/client.py", line 1412, in __init__
    super(HTTPSConnection, self).__init__(host, port, timeout,
TypeError: super(type, obj): obj must be an instance or subtype of type