### PR TITLE
internal: add tool.pyright excludes to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,14 @@ exclude = '''
   | dist/
 )
 '''
+
+[tool.pyright]
+exclude = [
+  "**/__pycache__",
+  ".git",
+  ".ddriot",
+  ".ddtox",
+  ".riot",
+  ".tox",
+  ".venv",
+]


### PR DESCRIPTION
I have been using [lsp-pyright](https://emacs-lsp.github.io/lsp-pyright/) for development, found that I need a minimal config of ignores for it to work properly (not be very very slow since it'll look in all of these folders).

I can also configure this in a `pyrightconfig.json` and just not commit it if we don't want to add this to the repo. I don't have strong opinions / won't be hurt if someone rejects this.

## Commit Message
{{title}}
