### PR TITLE
Fix: Sanic Integration for Pre-21

### DIFF
--- a/ddtrace/contrib/sanic/patch.py
+++ b/ddtrace/contrib/sanic/patch.py
@@ -171,7 +171,12 @@ async def patch_handle_request(wrapped, instance, args, kwargs):
 
         if write_callback is not None:
             new_kwargs["write_callback"] = _wrap_response_callback(span, write_callback)
+        elif SANIC_PRE_21:
+            new_kwargs["write_callback"] = None
+
         if stream_callback is not None:
             new_kwargs["stream_callback"] = _wrap_response_callback(span, stream_callback)
+        elif SANIC_PRE_21:
+            new_kwargs["stream_callback"] = None
 
         return await wrapped(request, **new_kwargs)


### PR DESCRIPTION
## What this does
Current integration for sanic pre-21 break as `Sanic.handle_request` has non-conditional parameters and the integration conditionally adds kwargs `write_callback` & `stream_callback`. This PR adds the kwargs with `None` value if sanic is pre-21.

Link to 20.12 LTS method declaration: https://github.com/sanic-org/sanic/blob/89d942451f1582bf63725c4f4d0255ecf2321c72/sanic/app.py#L881