### PR TITLE
fix(aioredis): function is coroutine instead of future when pool is empty in aioredis 1.3

### DIFF
--- a/ddtrace/contrib/aioredis/patch.py
+++ b/ddtrace/contrib/aioredis/patch.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 
 import aioredis
@@ -144,8 +145,10 @@ def traced_13_execute_command(func, instance, args, kwargs):
             span.finish()
 
     task = func(*args, **kwargs)
-    # if not asyncio.isfuture(task):
-    #     task = asyncio.ensure_future(task)
+    if not asyncio.isfuture(task):
+        # Execute command returns a coroutine when no free connections are available
+        # https://github.com/aio-libs/aioredis-py/blob/v1.3.1/aioredis/pool.py#L191
+        task = asyncio.ensure_future(task)
     task.add_done_callback(_finish_span)
     return task
 

--- a/ddtrace/contrib/aioredis/patch.py
+++ b/ddtrace/contrib/aioredis/patch.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 
 import aioredis
@@ -144,6 +145,8 @@ def traced_13_execute_command(func, instance, args, kwargs):
             span.finish()
 
     task = func(*args, **kwargs)
+    if not callable(getattr(task, "add_done_callback", None)):
+        task = asyncio.ensure_future(task)
     task.add_done_callback(_finish_span)
     return task
 

--- a/ddtrace/contrib/aioredis/patch.py
+++ b/ddtrace/contrib/aioredis/patch.py
@@ -145,10 +145,9 @@ def traced_13_execute_command(func, instance, args, kwargs):
             span.finish()
 
     task = func(*args, **kwargs)
-    if not asyncio.isfuture(task):
-        # Execute command returns a coroutine when no free connections are available
-        # https://github.com/aio-libs/aioredis-py/blob/v1.3.1/aioredis/pool.py#L191
-        task = asyncio.ensure_future(task)
+    # Execute command returns a coroutine when no free connections are available
+    # https://github.com/aio-libs/aioredis-py/blob/v1.3.1/aioredis/pool.py#L191
+    task = asyncio.ensure_future(task)
     task.add_done_callback(_finish_span)
     return task
 

--- a/ddtrace/contrib/aioredis/patch.py
+++ b/ddtrace/contrib/aioredis/patch.py
@@ -1,4 +1,3 @@
-import asyncio
 import sys
 
 import aioredis
@@ -145,8 +144,8 @@ def traced_13_execute_command(func, instance, args, kwargs):
             span.finish()
 
     task = func(*args, **kwargs)
-    if not callable(getattr(task, "add_done_callback", None)):
-        task = asyncio.ensure_future(task)
+    # if not asyncio.isfuture(task):
+    #     task = asyncio.ensure_future(task)
     task.add_done_callback(_finish_span)
     return task
 

--- a/releasenotes/notes/fix-aioredis-coroutine-execute-10fc849a7123b456.yaml
+++ b/releasenotes/notes/fix-aioredis-coroutine-execute-10fc849a7123b456.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes issue with aioredis when empty pool is not available and execute
+    returns a coroutine instead of a future. When patch tries to add callback
+    for the span using add_done_callback function it crashes because this
+    function is only for futures.

--- a/tests/contrib/aioredis/test_aioredis.py
+++ b/tests/contrib/aioredis/test_aioredis.py
@@ -121,7 +121,7 @@ async def test_closed_connection_pool(single_pool_redis_client):
 
     # start running the task after blocking the pool
     with (await single_pool_redis_client):
-        task = [asyncio.create_task(execute_task())]
+        task = [asyncio.ensure_future(execute_task())]
     # Pool is released, make sure we wait for the task to finish
     await asyncio.gather(*task, return_exceptions=True)
 

--- a/tests/contrib/aioredis/test_aioredis.py
+++ b/tests/contrib/aioredis/test_aioredis.py
@@ -112,7 +112,7 @@ async def test_closed_connection_pool(single_pool_redis_client):
     """Make sure it doesn't raise error when no free connections are available."""
     with (await single_pool_redis_client):
         with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(single_pool_redis_client.get("cheese"), timeout=0.2)
+            await asyncio.wait_for(single_pool_redis_client.get("cheese"), timeout=0.5)
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/aioredis/test_aioredis.py
+++ b/tests/contrib/aioredis/test_aioredis.py
@@ -106,13 +106,17 @@ async def test_decoding_non_utf8_pipeline_args(redis_client):
     assert response_list[3] == b"\x80abc"
 
 
+@pytest.mark.skipif(aioredis_version > (2, 0), reason="only affects aioredis < 2.0")
 @pytest.mark.asyncio
 @pytest.mark.snapshot
 async def test_closed_connection_pool(single_pool_redis_client):
-    """Make sure it doesn't raise error when no free connections are available."""
+    """
+    Make sure it doesn't raise error when no free connections are available.
+    After aioredis 2.0 it raises Too many connections error when it happens.
+    """
     with (await single_pool_redis_client):
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(single_pool_redis_client.get("cheese"), timeout=0.5)
+        task = asyncio.gather(single_pool_redis_client.get("cheese"))
+    await task
 
 
 @pytest.mark.asyncio

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_closed_connection_pool.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_closed_connection_pool.json
@@ -1,0 +1,28 @@
+[[
+  {
+    "name": "redis.command",
+    "service": "redis",
+    "resource": "GET cheese",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "redis",
+    "meta": {
+      "out.host": "127.0.0.1",
+      "redis.raw_command": "GET cheese",
+      "runtime-id": "11462765c64e4024a06bfffd4f6d8538"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "out.port": 6379,
+      "out.redis_db": 0,
+      "redis.args_length": 2,
+      "system.pid": 62908
+    },
+    "duration": 1973000,
+    "start": 1638885382734225000
+  }]]

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_closed_connection_pool.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_closed_connection_pool.json
@@ -7,14 +7,10 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 1,
     "meta": {
       "out.host": "127.0.0.1",
-      "error.msg": "",
-      "error.stack": "",
       "redis.raw_command": "GET cheese",
       "runtime-id": "a76e23453dc9417bb8e4e691e0d9a567",
-      "error.type": "concurrent.futures._base.CancelledError",
     },
     "metrics": {
       "_dd.agent_psr": 1.0,

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_closed_connection_pool.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_closed_connection_pool.json
@@ -10,7 +10,7 @@
     "meta": {
       "out.host": "127.0.0.1",
       "redis.raw_command": "GET cheese",
-      "runtime-id": "a76e23453dc9417bb8e4e691e0d9a567",
+      "runtime-id": "a76e23453dc9417bb8e4e691e0d9a567"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_closed_connection_pool.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_closed_connection_pool.json
@@ -7,10 +7,14 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 1,
     "meta": {
       "out.host": "127.0.0.1",
+      "error.msg": "",
+      "error.stack": "",
       "redis.raw_command": "GET cheese",
-      "runtime-id": "11462765c64e4024a06bfffd4f6d8538"
+      "runtime-id": "a76e23453dc9417bb8e4e691e0d9a567",
+      "error.type": "concurrent.futures._base.CancelledError",
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
@@ -21,7 +25,7 @@
       "out.port": 6379,
       "out.redis_db": 0,
       "redis.args_length": 2,
-      "system.pid": 62908
+      "system.pid": 179
     },
     "duration": 1973000,
     "start": 1638885382734225000


### PR DESCRIPTION
Fixes #3133

Problem reproduced: 
[_Example of the error in CI_](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/13278/workflows/d03dd931-9619-4a9d-8626-ec2fb10aa55c/jobs/948017)

## Commit Message
* aioredis 1.3 execute can be a coroutine

The execute command might be `coroutine` instead of `future` ([source](https://github.com/aio-libs/aioredis-py/blob/v1.3.1/aioredis/pool.py#L191)), that is why it is producing this error:
`AttributeError: 'coroutine' object has no attribute 'add_done_callback'`

This PR creates another future from the coroutine and assigns the callback function to that future.

Build is failing for Python 3.10, but couldn't find out why exactly, might be due to creating the pool in aioredis 1.3 (default behavior of aioredis 2). Might be related to [this](https://github.com/django/channels_redis/issues/278).

## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).

PS. Had to do testing in the PR (CI) due to issues with the docker-compose where riot testing (following the documentation) provided `404 page not found` error for all aioredis test cases except `test_patching`.