### PR TITLE
fix(profiling): make sure lineno is always an int and funcname is never None

### DIFF
--- a/ddtrace/profiling/collector/_traceback.pyx
+++ b/ddtrace/profiling/collector/_traceback.pyx
@@ -12,7 +12,8 @@ cpdef traceback_to_frames(traceback, max_nframes):
         if nframes < max_nframes:
             frame = tb.tb_frame
             code = frame.f_code
-            frames.insert(0, (code.co_filename, frame.f_lineno, code.co_name))
+            lineno = 0 if frame.f_lineno is None else frame.f_lineno
+            frames.insert(0, (code.co_filename, lineno, code.co_name))
         nframes += 1
         tb = tb.tb_next
     return frames, nframes
@@ -30,6 +31,7 @@ cpdef pyframe_to_frames(frame, max_nframes):
         nframes += 1
         if len(frames) < max_nframes:
             code = frame.f_code
-            frames.append((code.co_filename, frame.f_lineno, code.co_name))
+            lineno = 0 if frame.f_lineno is None else frame.f_lineno
+            frames.append((code.co_filename, lineno, code.co_name))
         frame = frame.f_back
     return frames, nframes

--- a/ddtrace/profiling/event.py
+++ b/ddtrace/profiling/event.py
@@ -9,7 +9,7 @@ from ddtrace.internal import compat
 _T = typing.TypeVar("_T")
 
 # (filename, line number, function name)
-FrameType = typing.Tuple[str, int, typing.Optional[str]]
+FrameType = typing.Tuple[str, int, str]
 StackTraceType = typing.List[FrameType]
 
 

--- a/ddtrace/profiling/exporter/pprof.pyx
+++ b/ddtrace/profiling/exporter/pprof.pyx
@@ -151,20 +151,16 @@ class _PprofConverter(object):
         self,
         filename: str,
         lineno: int,
-        funcname: typing.Optional[str] = None,
+        funcname: str,
     ) -> pprof_LocationType:
         try:
             return self._locations[(filename, lineno, funcname)]
         except KeyError:
-            if funcname is None:
-                real_funcname = "<unknown function>"
-            else:
-                real_funcname = funcname
             location = pprof_pb2.Location(  # type: ignore[attr-defined]
                 id=self._last_location_id.generate(),
                 line=[
                     pprof_pb2.Line(  # type: ignore[attr-defined]
-                        function_id=self._to_Function(filename, real_funcname).id,
+                        function_id=self._to_Function(filename, funcname).id,
                         line=lineno,
                     ),
                 ],


### PR DESCRIPTION
In some cases, f_lineno can be `None` which would trigger an error in the pprof
output. This is not even caught by mypy, and I've proposed a fix here:

  https://github.com/python/typeshed/pull/6769

This patch makes sure we always use 0 if the line number is `None`.

It also makes sure a funcname is always passed — in practice it's now the case,
but make sure typing reflects that.

Fixes #3046
