### PR TITLE
Update tracer get hostname unit test

### DIFF
--- a/ddtrace/internal/hostname.py
+++ b/ddtrace/internal/hostname.py
@@ -11,3 +11,8 @@ def get_hostname():
     if not _hostname:
         _hostname = socket.gethostname()
     return _hostname
+
+
+def _reset():
+    global _hostname
+    _hostname = None

--- a/tests/tracer/test_hostname.py
+++ b/tests/tracer/test_hostname.py
@@ -9,8 +9,10 @@ from ddtrace.internal.hostname import get_hostname
 def reset_hostname():
     # Ensure _hostname is not set
     _reset()
-    yield
-    _reset()
+    try:
+        yield
+    finally:
+        _reset()
 
 
 @mock.patch("socket.gethostname")

--- a/tests/tracer/test_hostname.py
+++ b/tests/tracer/test_hostname.py
@@ -1,6 +1,16 @@
 import mock
+import pytest
 
+from ddtrace.internal.hostname import _reset
 from ddtrace.internal.hostname import get_hostname
+
+
+@pytest.fixture(autouse=True)
+def reset_hostname():
+    # Ensure _hostname is not set
+    _reset()
+    yield
+    _reset()
 
 
 @mock.patch("socket.gethostname")


### PR DESCRIPTION
Currently the test `test_get_hostname` depends on hostname._hostname not being set before the test is run. This won't always be the case (telemetry client may set this global variable in the future). 

This change ensures that this test does not depend on the state of a global variable.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
