### PR TITLE
feature: extend @cached to support multiple args

### DIFF
--- a/tests/tracer/test_utils.py
+++ b/tests/tracer/test_utils.py
@@ -354,33 +354,33 @@ def test_infer_arg_value_miss(args, kwargs, pos, kw):
 
 
 def cached_test_recipe(expensive, cheap, witness, cache_size):
-    assert cheap("Foo") == expensive("Foo")
-    assert cheap("Foo") == expensive("Foo")
+    assert cheap("F", "o", "o") == expensive("F", "o", "o")
+    assert cheap("F", "o", "o") == expensive("F", "o", "o")
 
-    witness.assert_called_with("Foo")
+    witness.assert_called_with("F")
     assert witness.call_count == 1
 
     cheap.invalidate()
 
     for i in range(cache_size >> 1):
-        cheap("Foo%d" % i)
+        cheap("F", "o", str(i))
 
     assert witness.call_count == 1 + (cache_size >> 1)
 
     for i in range(cache_size):
-        cheap("Foo%d" % i)
+        cheap("F", "o", str(i))
 
     assert witness.call_count == 1 + cache_size
 
-    MAX_FOO = "Foo%d" % (cache_size - 1)
+    MAX_FOO = ("F", "o", str(cache_size - 1))
 
-    cheap("last drop")  # Forces least frequent elements out of the cache
+    cheap("last", " ", "drop")  # Forces least frequent elements out of the cache
     assert witness.call_count == 2 + cache_size
 
-    cheap(MAX_FOO)  # Check MAX_FOO was dropped
+    cheap(*MAX_FOO)  # Check MAX_FOO was dropped
     assert witness.call_count == 3 + cache_size
 
-    cheap("last drop")  # Check last drop was retained
+    cheap("last", " ", "drop")  # Check last drop was retained
     assert witness.call_count == 3 + cache_size
 
 
@@ -388,13 +388,14 @@ def test_cached():
     witness = mock.Mock()
     cache_size = 128
 
-    def expensive(key):
+    def expensive(key1, key2, key3):
+        key = key1 + key2 + key3
         return key[::-1].lower()
 
     @cached(cache_size)
-    def cheap(key):
-        witness(key)
-        return expensive(key)
+    def cheap(key1, key2, key3):
+        witness(key1)
+        return expensive(key1, key2, key3)
 
     cached_test_recipe(expensive, cheap, witness, cache_size)
 
@@ -403,14 +404,15 @@ def test_cachedmethod():
     witness = mock.Mock()
     cache_size = 128
 
-    def expensive(key):
+    def expensive(key1, key2, key3):
+        key = key1 + key2 + key3
         return key[::-1].lower()
 
     class Foo(object):
         @cachedmethod(cache_size)
-        def cheap(self, key):
-            witness(key)
-            return expensive(key)
+        def cheap(self, key1, key2, key3):
+            witness(key1)
+            return expensive(key1, key2, key3)
 
     cached_test_recipe(expensive, Foo().cheap, witness, cache_size)
 


### PR DESCRIPTION
Updates `@cached` to support caching functions with more than one parameter and/or keyword args

 *** tests are a work in progress

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
