### PR TITLE
fix: decode bytes strings when using JSON encoder

### DIFF
--- a/ddtrace/internal/encoding.py
+++ b/ddtrace/internal/encoding.py
@@ -8,6 +8,10 @@ from typing import TYPE_CHECKING
 from ._encoding import ListStringTable
 from ._encoding import MsgpackEncoderV03
 from ._encoding import MsgpackEncoderV05
+from .compat import PY3
+from .compat import binary_type
+from .compat import ensure_text
+from .compat import text_type
 from .logger import get_logger
 
 
@@ -48,17 +52,26 @@ class _EncoderBase(object):
         raise NotImplementedError()
 
 
-class JSONEncoder(_EncoderBase):
+class JSONEncoder(json.JSONEncoder, _EncoderBase):
     content_type = "application/json"
+
+    # In Py2 "backslashreplace" is for encoding only
+    _unicode_errors = "backslashreplace" if PY3 else "replace"
+
+    def __init__(self):
+        # Reduce unnecessary whitespace
+        super(JSONEncoder, self).__init__(separators=(",", ":"), indent=None)
 
     def encode_traces(self, traces):
         normalized_traces = [[span.to_dict() for span in trace] for trace in traces]
         return self.encode(normalized_traces)
 
-    @staticmethod
-    def encode(obj):
-        # type: (Any) -> str
-        return json.dumps(obj)
+    def default(self, obj):
+        # type: (Any) -> Any
+        # Convert any bytes to
+        if isinstance(obj, (binary_type, text_type)):
+            return ensure_text(obj, errors=self._unicode_errors)
+        return super(JSONEncoder, self).default(obj)
 
 
 class JSONEncoderV2(JSONEncoder):

--- a/ddtrace/internal/encoding.py
+++ b/ddtrace/internal/encoding.py
@@ -73,10 +73,9 @@ class JSONEncoder(json.JSONEncoder, _EncoderBase):
 
         if PY3:
             return ensure_text(obj, errors="backslashreplace")
-        else:
-            if isinstance(obj, binary_type):
-                return obj.decode("utf-8", errors="replace")
-            return obj
+        elif isinstance(obj, binary_type):
+            return obj.decode("utf-8", errors="replace")
+        return obj
 
 
 class JSONEncoderV2(JSONEncoder):

--- a/ddtrace/internal/encoding.py
+++ b/ddtrace/internal/encoding.py
@@ -54,10 +54,6 @@ class _EncoderBase(object):
 class JSONEncoder(json.JSONEncoder, _EncoderBase):
     content_type = "application/json"
 
-    def __init__(self):
-        # Reduce unnecessary whitespace
-        super(JSONEncoder, self).__init__(separators=(",", ":"), indent=None)
-
     def encode_traces(self, traces):
         normalized_traces = [[JSONEncoder._normalize_span(span.to_dict()) for span in trace] for trace in traces]
         return self.encode(normalized_traces)

--- a/ddtrace/internal/encoding.py
+++ b/ddtrace/internal/encoding.py
@@ -61,6 +61,8 @@ class JSONEncoder(json.JSONEncoder, _EncoderBase):
     @staticmethod
     def _normalize_span(span):
         # Ensure all string attributes are actually strings and not bytes
+        # DEV: We are deferring meta/metrics to reduce any performance issues.
+        #      Meta/metrics may still contain `bytes` and have encoding issues.
         span["resource"] = JSONEncoder._normalize_str(span["resource"])
         span["name"] = JSONEncoder._normalize_str(span["name"])
         span["service"] = JSONEncoder._normalize_str(span["service"])

--- a/releasenotes/notes/fix-json-encoder-bytes-d35121d00f2b8caf.yaml
+++ b/releasenotes/notes/fix-json-encoder-bytes-d35121d00f2b8caf.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix JSON encoding error when a ``bytes`` string is used for span metadata.


### PR DESCRIPTION
## Commit Message
<!-- Defaults to the title of the PR. Replace if desired. -->
{{title}}

If a `bytes` string is used in span metadata and you are using
the lambda layer/`LogWriter` which uses the `JSONEncoder`
you will get an exception.

This change turns our base `JSONEncoder` class into a subclass
of `json.JSONEncoder` so we can overwrite `JSONEncoder.default`
and properly decode `bytes`.

Subclassing from `json.JSONEncoder` means we don't need to define
an `encode` method on the base class.

Fixes #3115