### PR TITLE
fix: snowflake ci

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -1394,7 +1394,7 @@ venv = Venv(
             name="snowflake",
             command="pytest {cmdargs} tests/contrib/snowflake",
             pkgs={
-                "responses": latest,
+                "responses": "~=0.16.0",
             },
             venvs=[
                 Venv(


### PR DESCRIPTION
fix snowflake tests by pinning the responses package from latest (0.17.0) to v0.16.0

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
