### PR TITLE
ci(encoders): add missing austinp build dependency

### DIFF
--- a/scripts/profiles/encoders/setup.sh
+++ b/scripts/profiles/encoders/setup.sh
@@ -20,10 +20,10 @@ pip install pip --upgrade
 
 # Install austin
 pushd ${PREFIX}
-    sudo apt-get -y install libunwind-dev
+    sudo apt-get -y install libunwind-dev binutils-dev libiberty-dev
     git clone --depth=1 https://github.com/p403n1x87/austin.git -b devel
     pushd austin
-        gcc -O3 -Os -s -Wall -pthread src/*.c -DAUSTINP -lunwind-ptrace -lunwind-generic -o src/austinp
+        gcc -O3 -Os -s -Wall -pthread src/*.c -DAUSTINP -lunwind-ptrace -lunwind-generic -lbfd -o src/austinp
         mv src/austinp ${PREFIX}/austinp
         chmod +x ${PREFIX}/austinp
     popd


### PR DESCRIPTION
The latest development version of austinp requires the bfd headers to build, which on Debian-like distros are provided by binutils-dev.

## Commit Message
<!-- Defaults to the title of the PR. Replace if desired. -->
{{title}}

<!-- Briefly describe the change and why it was required. -->

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
