### PR TITLE
feat(sanic): add support for Sanic>=21.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -751,10 +751,11 @@ jobs:
           pattern: '^requests_gevent_contrib-'
 
   sanic:
-    <<: *contrib_job
+    <<: *machine_executor
     steps:
-      - run_tox_scenario:
-          pattern: '^sanic_contrib-'
+      - run_test:
+          pattern: "sanic"
+          snapshot: true
 
   snowflake:
     <<: *machine_executor

--- a/ddtrace/contrib/sanic/patch.py
+++ b/ddtrace/contrib/sanic/patch.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import sanic
+from sanic.exceptions import NotFound
 
 import ddtrace
 from ddtrace import config
@@ -19,17 +20,24 @@ log = get_logger(__name__)
 
 config._add("sanic", dict(_default_service="sanic", distributed_tracing=True))
 
-SANIC_PRE_21 = None
+SANIC_VERSION = (0, 0, 0)
+
+
+def _get_current_span(request):
+    pin = Pin._find(request.ctx)
+    if not pin or not pin.enabled():
+        return None
+
+    return pin.tracer.current_span()
 
 
 def update_span(span, response):
-    if isinstance(response, sanic.response.BaseHTTPResponse):
-        status_code = response.status
-        response_headers = response.headers
-    else:
-        # invalid response causes ServerError exception which must be handled
-        status_code = 500
-        response_headers = None
+    # Check for response status or headers on the response object
+    # DEV: This object can either be a form of BaseResponse or an Exception
+    #      if we do not have a status code, we can assume this is an exception
+    #      and so use 500
+    status_code = getattr(response, "status", 500)
+    response_headers = getattr(response, "headers", None)
     trace_utils.set_http_meta(span, config.sanic, status_code=status_code, response_headers=response_headers)
 
 
@@ -62,11 +70,16 @@ async def patch_request_respond(wrapped, instance, args, kwargs):
     # Only for sanic 21 and newer
     # Wrap the framework response to set HTTP response span tags
     response = await wrapped(*args, **kwargs)
-    pin = Pin._find(instance.ctx)
-    if pin is not None and pin.enabled():
-        span = pin.tracer.current_span()
-        if span is not None:
-            update_span(span, response)
+    span = _get_current_span(instance)
+    if not span:
+        return response
+
+    update_span(span, response)
+
+    # Sanic 21.9.x does not dispatch `http.lifecycle.response` in `handle_exception`
+    #  so we have to handle finishing the span here instead
+    if (21, 9, 0) <= SANIC_VERSION < (21, 12, 0) and getattr(instance.ctx, "__dd_span_call_finish", False):
+        span.finish()
     return response
 
 
@@ -90,39 +103,57 @@ def _get_path(request):
 async def patch_run_request_middleware(wrapped, instance, args, kwargs):
     # Set span resource from the framework request
     request = args[0]
-    pin = Pin._find(request.ctx)
-    if pin is not None and pin.enabled():
-        span = pin.tracer.current_span()
-        if span is not None:
-            span.resource = "{} {}".format(request.method, _get_path(request))
+    span = _get_current_span(request)
+    if span is not None:
+        span.resource = "{} {}".format(request.method, _get_path(request))
     return await wrapped(*args, **kwargs)
 
 
 def patch():
     """Patch the instrumented methods."""
-    global SANIC_PRE_21
+    global SANIC_VERSION
 
     if getattr(sanic, "__datadog_patch", False):
         return
     setattr(sanic, "__datadog_patch", True)
 
-    SANIC_PRE_21 = sanic.__version__[:2] < "21"
+    SANIC_VERSION = tuple(map(int, sanic.__version__.split(".")))
 
-    _w("sanic", "Sanic.handle_request", patch_handle_request)
-    if not SANIC_PRE_21:
-        _w("sanic", "Sanic._run_request_middleware", patch_run_request_middleware)
+    if SANIC_VERSION >= (21, 9, 0):
+        _w("sanic", "Sanic.__init__", patch_sanic_init)
         _w(sanic.request, "Request.respond", patch_request_respond)
+    else:
+        _w("sanic", "Sanic.handle_request", patch_handle_request)
+        if SANIC_VERSION >= (21, 0, 0):
+            _w("sanic", "Sanic._run_request_middleware", patch_run_request_middleware)
+            _w(sanic.request, "Request.respond", patch_request_respond)
 
 
 def unpatch():
     """Unpatch the instrumented methods."""
-    _u(sanic.Sanic, "handle_request")
-    if not SANIC_PRE_21:
-        _u(sanic.Sanic, "_run_request_middleware")
-        _u(sanic.request.Request, "respond")
     if not getattr(sanic, "__datadog_patch", False):
         return
+
+    if SANIC_VERSION >= (21, 9, 0):
+        _u(sanic.Sanic, "__init__")
+        _u(sanic.request.Request, "respond")
+    else:
+        _u(sanic.Sanic, "handle_request")
+        if SANIC_VERSION >= (21, 0, 0):
+            _u(sanic.Sanic, "_run_request_middleware")
+            _u(sanic.request.Request, "respond")
+
     setattr(sanic, "__datadog_patch", False)
+
+
+def patch_sanic_init(wrapped, instance, args, kwargs):
+    """Wrapper for creating sanic apps to automatically add our signal handlers"""
+    wrapped(*args, **kwargs)
+
+    instance.add_signal(sanic_http_lifecycle_handle, "http.lifecycle.handle")
+    instance.add_signal(sanic_http_routing_after, "http.routing.after")
+    instance.add_signal(sanic_http_lifecycle_exception, "http.lifecycle.exception")
+    instance.add_signal(sanic_http_lifecycle_response, "http.lifecycle.response")
 
 
 async def patch_handle_request(wrapped, instance, args, kwargs):
@@ -136,42 +167,103 @@ async def patch_handle_request(wrapped, instance, args, kwargs):
     if request.scheme not in ("http", "https"):
         return await wrapped(*args, **kwargs)
 
-    pin = Pin()
-    if SANIC_PRE_21:
-        # Set span resource from the framework request
-        resource = "{} {}".format(request.method, _get_path(request))
-    else:
-        # The path is not available anymore in 21.x. Get it from
-        # the _run_request_middleware instrumented method.
-        resource = None
-        pin.onto(request.ctx)
-
-    headers = request.headers.copy()
-
-    trace_utils.activate_distributed_headers(ddtrace.tracer, int_config=config.sanic, request_headers=headers)
-
-    with pin.tracer.trace(
-        "sanic.request",
-        service=trace_utils.int_service(None, config.sanic),
-        resource=resource,
-        span_type=SpanTypes.WEB,
-    ) as span:
-        sample_rate = config.sanic.get_analytics_sample_rate(use_global_config=True)
-        if sample_rate is not None:
-            span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, sample_rate)
-
-        method = request.method
-        url = "{scheme}://{host}{path}".format(scheme=request.scheme, host=request.host, path=request.path)
-        query_string = request.query_string
-        if isinstance(query_string, bytes):
-            query_string = query_string.decode()
-        trace_utils.set_http_meta(
-            span, config.sanic, method=method, url=url, query=query_string, request_headers=headers
-        )
-
+    with _create_sanic_request_span(request) as span:
         if write_callback is not None:
             new_kwargs["write_callback"] = _wrap_response_callback(span, write_callback)
         if stream_callback is not None:
             new_kwargs["stream_callback"] = _wrap_response_callback(span, stream_callback)
 
         return await wrapped(request, **new_kwargs)
+
+
+def _create_sanic_request_span(request):
+    """Helper to create sanic.request span and attach a pin to request.ctx"""
+    pin = Pin()
+    pin.onto(request.ctx)
+
+    if SANIC_VERSION < (21, 0, 0):
+        # Set span resource from the framework request
+        resource = "{} {}".format(request.method, _get_path(request))
+    else:
+        # The path is not available anymore in 21.x. Get it from
+        # the _run_request_middleware instrumented method.
+        resource = None
+
+    headers = request.headers.copy()
+
+    trace_utils.activate_distributed_headers(ddtrace.tracer, int_config=config.sanic, request_headers=headers)
+
+    span = pin.tracer.trace(
+        "sanic.request",
+        service=trace_utils.int_service(None, config.sanic),
+        resource=resource,
+        span_type=SpanTypes.WEB,
+    )
+    sample_rate = config.sanic.get_analytics_sample_rate(use_global_config=True)
+    if sample_rate is not None:
+        span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, sample_rate)
+
+    method = request.method
+    url = "{scheme}://{host}{path}".format(scheme=request.scheme, host=request.host, path=request.path)
+    query_string = request.query_string
+    if isinstance(query_string, bytes):
+        query_string = query_string.decode()
+    trace_utils.set_http_meta(span, config.sanic, method=method, url=url, query=query_string, request_headers=headers)
+
+    return span
+
+
+async def sanic_http_lifecycle_handle(request):
+    """Lifecycle signal called when a new request is started."""
+    _create_sanic_request_span(request)
+
+
+async def sanic_http_routing_after(request, route, kwargs, handler):
+    """Lifecycle signal called after routing has been resolved."""
+    span = _get_current_span(request)
+    if not span:
+        return
+
+    pattern = route.raw_path
+    # Sanic 21.9.0 and newer strip the leading slash from `route.raw_path`
+    if not pattern.startswith("/"):
+        pattern = "/{}".format(pattern)
+    if route.regex:
+        pattern = route.pattern
+
+    span.resource = "{} {}".format(request.method, pattern)
+    span.set_tag("sanic.route.name", route.name)
+
+
+async def sanic_http_lifecycle_response(request, response):
+    """Lifecycle signal called when a response is starting.
+
+    Note: This signal does not get called when exceptions occur
+          in 21.9.x. The issue was resolved in 21.12.x
+    """
+    span = _get_current_span(request)
+    if not span:
+        return
+    try:
+        update_span(span, response)
+    finally:
+        span.finish()
+
+
+async def sanic_http_lifecycle_exception(request, exception):
+    """Lifecycle signal called when an exception occurs."""
+    span = _get_current_span(request)
+    if not span:
+        return
+
+    # Do not attach exception traceback on 404 errors
+    # DEV: We still need to set `__dd_span_call_finish` below
+    if not isinstance(exception, NotFound):
+        ex_type = type(exception)
+        ex_tb = getattr(exception, "__traceback__", None)
+        span.set_exc_info(ex_type, exception, ex_tb)
+
+    # Sanic 21.9.x does not dispatch `http.lifecycle.response` in `handle_exception`
+    #  so we need to indicate to `patch_request_respond` to finish the span
+    if (21, 9, 0) <= SANIC_VERSION < (21, 12, 0):
+        request.ctx.__dd_span_call_finish = True

--- a/releasenotes/notes/support-sanic-21.9.0-6c5de52c832f9dcc.yaml
+++ b/releasenotes/notes/support-sanic-21.9.0-6c5de52c832f9dcc.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add tracing support for ``sanic>=21.9.0``.

--- a/riotfile.py
+++ b/riotfile.py
@@ -1421,6 +1421,51 @@ venv = Venv(
             },
         ),
         Venv(
+            name="sanic",
+            command="pytest {cmdargs} tests/contrib/sanic",
+            pkgs={
+                "pytest-asyncio": latest,
+                "requests": latest,
+            },
+            venvs=[
+                Venv(
+                    pys=select_pys(min_version="3.7", max_version="3.9"),
+                    pkgs={
+                        "sanic": ["~=19.12", "~=20.12"],
+                        "pytest-sanic": ["~=1.6.2"],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version="3.7"),
+                    pkgs={
+                        "sanic": ["~=21.3.0"],
+                        "pytest-sanic": latest,
+                        "httpx": ["~=0.15.4"],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version="3.7"),
+                    pkgs={
+                        "sanic": [
+                            "~=21.6.0",
+                        ],
+                        "pytest-sanic": latest,
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version="3.7"),
+                    pkgs={
+                        "sanic": [
+                            "~=21.9.0",
+                            "~=21.12.0",
+                            latest,
+                        ],
+                        "sanic-testing": latest,
+                    },
+                ),
+            ],
+        ),
+        Venv(
             name="snowflake",
             command="pytest {cmdargs} tests/contrib/snowflake",
             pkgs={

--- a/tests/contrib/sanic/run_server.py
+++ b/tests/contrib/sanic/run_server.py
@@ -1,0 +1,44 @@
+import asyncio
+import os
+import random
+
+from sanic import Sanic
+from sanic.response import json
+
+from ddtrace import tracer
+from tests.webclient import PingFilter
+
+
+tracer.configure(
+    settings={
+        "FILTERS": [PingFilter()],
+    }
+)
+
+
+app = Sanic("test_sanic_server")
+
+
+@tracer.wrap()
+async def random_sleep():
+    await asyncio.sleep(random.random() * 0.1)
+
+
+@app.route("/hello")
+async def hello(request):
+    await random_sleep()
+    return json({"hello": "world"})
+
+
+@app.route("/internal_error")
+async def internal_error(request):
+    1 / 0
+
+
+@app.route("/shutdown-tracer")
+async def shutdown_tracer(request):
+    tracer.shutdown()
+    return json({"success": True})
+
+
+app.run(host="0.0.0.0", port=os.environ["SANIC_PORT"], access_log=False)

--- a/tests/contrib/sanic/test_sanic.py
+++ b/tests/contrib/sanic/test_sanic.py
@@ -4,9 +4,9 @@ import re
 
 import pytest
 from sanic import Sanic
+from sanic import __version__ as sanic_version
 from sanic.config import DEFAULT_CONFIG
 from sanic.exceptions import ServerError
-from sanic.exceptions import abort
 from sanic.response import json
 from sanic.response import stream
 from sanic.response import text
@@ -14,6 +14,9 @@ from sanic.server import HttpProtocol
 
 from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
+from ddtrace.constants import ERROR_TYPE
 from ddtrace.propagation import http as http_propagation
 from tests.utils import override_config
 from tests.utils import override_http_config
@@ -21,13 +24,17 @@ from tests.utils import override_http_config
 
 # Helpers for handling response objects across sanic versions
 
+sanic_version = tuple(map(int, sanic_version.split(".")))
+
 
 def _response_status(response):
     return getattr(response, "status_code", getattr(response, "status", None))
 
 
 async def _response_json(response):
-    resp_json = response.json()
+    resp_json = response.json
+    if callable(resp_json):
+        resp_json = response.json()
     if asyncio.iscoroutine(resp_json):
         resp_json = await resp_json
     return resp_json
@@ -48,7 +55,7 @@ def app(tracer):
     # with the same name if register is True.
     DEFAULT_CONFIG["REGISTER"] = False
     DEFAULT_CONFIG["RESPONSE_TIMEOUT"] = 1.0
-    app = Sanic(__name__)
+    app = Sanic("sanic")
 
     @tracer.wrap()
     async def random_sleep():
@@ -91,10 +98,6 @@ def app(tracer):
 
     @app.route("/<n:int>/count", methods=["GET"])
     async def count(request, n):
-        try:
-            pass
-        except Exception as e:
-            abort(500, e)
         return json({"hello": n})
 
     @app.exception(ServerError)
@@ -102,6 +105,31 @@ def app(tracer):
         return text(exception.args[0], exception.status_code)
 
     yield app
+
+
+# DEV: pytest-sanic is not compatible with sanic >= 21.9.0 so we instead
+#     are using sanic_testing, but need to create a compatible fixture/API
+if sanic_version >= (21, 9, 0):
+
+    @pytest.fixture
+    def client(app):
+        from sanic_testing.testing import SanicASGITestClient
+
+        # Create a test client compatible with pytest-sanic test client
+        class TestClient(SanicASGITestClient):
+            async def request(self, *args, **kwargs):
+                request, response = await super(TestClient, self).request(*args, **kwargs)
+                return response
+
+        return TestClient(app)
+
+
+else:
+
+    @pytest.fixture
+    @pytest.mark.asyncio
+    async def client(sanic_client, app):
+        return await sanic_client(app, protocol=HttpProtocol)
 
 
 @pytest.fixture(
@@ -144,11 +172,7 @@ def integration_http_config(request):
     return request.param
 
 
-@pytest.fixture
-def client(loop, app, sanic_client):
-    return loop.run_until_complete(sanic_client(app, protocol=HttpProtocol))
-
-
+@pytest.mark.asyncio
 async def test_basic_app(tracer, client, integration_config, integration_http_config, test_spans):
     """Test Sanic Patching"""
     with override_http_config("sanic", integration_http_config):
@@ -207,6 +231,7 @@ async def test_basic_app(tracer, client, integration_config, integration_http_co
         ("/hello/foo/bar", {"hello": "foo bar"}, "GET /hello/<first_name>/<surname>"),
     ],
 )
+@pytest.mark.asyncio
 async def test_resource_name(tracer, client, url, expected_json, expected_resource, test_spans):
     response = await client.get(url)
     assert _response_status(response) == 200
@@ -217,6 +242,7 @@ async def test_resource_name(tracer, client, url, expected_json, expected_resour
     assert request_span.resource == expected_resource
 
 
+@pytest.mark.asyncio
 async def test_streaming_response(tracer, client, test_spans):
     response = await client.get("/stream_response")
     assert _response_status(response) == 200
@@ -235,6 +261,7 @@ async def test_streaming_response(tracer, client, test_spans):
     assert request_span.get_tag("http.status_code") == "200"
 
 
+@pytest.mark.asyncio
 async def test_error_app(tracer, client, test_spans):
     response = await client.get("/nonexistent")
     assert _response_status(response) == 404
@@ -246,13 +273,20 @@ async def test_error_app(tracer, client, test_spans):
     request_span = spans[0][0]
     assert request_span.name == "sanic.request"
     assert request_span.service == "sanic"
+
+    # We do not attach exception info for 404s
     assert request_span.error == 0
+    assert request_span.get_tag(ERROR_MSG) is None
+    assert request_span.get_tag(ERROR_TYPE) is None
+    assert request_span.get_tag(ERROR_STACK) is None
+
     assert request_span.get_tag("http.method") == "GET"
     assert re.search("/nonexistent$", request_span.get_tag("http.url"))
     assert request_span.get_tag("http.query.string") is None
     assert request_span.get_tag("http.status_code") == "404"
 
 
+@pytest.mark.asyncio
 async def test_exception(tracer, client, test_spans):
     response = await client.get("/error")
     assert _response_status(response) == 500
@@ -271,6 +305,7 @@ async def test_exception(tracer, client, test_spans):
     assert request_span.get_tag("http.status_code") == "500"
 
 
+@pytest.mark.asyncio
 async def test_multiple_requests(tracer, client, test_spans):
     responses = await asyncio.gather(
         client.get("/hello"),
@@ -296,10 +331,10 @@ async def test_multiple_requests(tracer, client, test_spans):
     assert spans[1][1].parent_id == spans[1][0].span_id
 
 
+@pytest.mark.asyncio
 async def test_invalid_response_type_str(tracer, client, test_spans):
     response = await client.get("/invalid")
     assert _response_status(response) == 500
-    assert (await _response_text(response)).startswith("Invalid response type")
 
     spans = test_spans.pop_traces()
     assert len(spans) == 1
@@ -314,10 +349,10 @@ async def test_invalid_response_type_str(tracer, client, test_spans):
     assert request_span.get_tag("http.status_code") == "500"
 
 
+@pytest.mark.asyncio
 async def test_invalid_response_type_empty(tracer, client, test_spans):
     response = await client.get("/empty")
     assert _response_status(response) == 500
-    assert (await _response_text(response)).startswith("Invalid response type")
 
     spans = test_spans.pop_traces()
     assert len(spans) == 1
@@ -332,6 +367,7 @@ async def test_invalid_response_type_empty(tracer, client, test_spans):
     assert request_span.get_tag("http.status_code") == "500"
 
 
+@pytest.mark.asyncio
 async def test_http_request_header_tracing(tracer, client, test_spans):
     config.sanic.http.trace_headers(["my-header"])
 
@@ -350,6 +386,7 @@ async def test_http_request_header_tracing(tracer, client, test_spans):
     assert request_span.get_tag("http.request.headers.my-header") == "my_value"
 
 
+@pytest.mark.asyncio
 async def test_endpoint_with_numeric_arg(tracer, client, test_spans):
     response = await client.get("/42/count")
     assert _response_status(response) == 200

--- a/tests/contrib/sanic/test_sanic_server.py
+++ b/tests/contrib/sanic/test_sanic_server.py
@@ -1,100 +1,69 @@
-import asyncio
-import random
+import os
+import subprocess
 
-import httpx
 import pytest
-from sanic import Sanic
-from sanic.config import DEFAULT_CONFIG
-from sanic.response import json
+from sanic import __version__ as sanic_version
+
+from tests.webclient import Client
 
 
-# Handle naming of asynchronous client in older httpx versions used in sanic 19.12
-httpx_client = getattr(httpx, "AsyncClient", getattr(httpx, "Client"))
+RUN_SERVER_PY = os.path.abspath(os.path.join(os.path.dirname(__file__), "run_server.py"))
+SERVER_PORT = 8000
+
+sanic_version = tuple(map(int, sanic_version.split(".")))
 
 
-@pytest.fixture
-def app(tracer):
-    app = Sanic(__name__)
-
-    @tracer.wrap()
-    async def random_sleep():
-        await asyncio.sleep(random.random())
-
-    @app.route("/hello")
-    async def hello(request):
-        await random_sleep()
-        return json({"hello": "world"})
-
-    @app.route("/internal_error")
-    async def internal_error(request):
-        1 / 0
-
-    yield app
-
-
-@pytest.fixture
-async def sanic_http_server(app, unused_port, loop):
+@pytest.fixture()
+def sanic_client():
     """Fixture for using sanic async HTTP server rather than a asgi async server used by test client"""
-    DEFAULT_CONFIG["REGISTER"] = False
-    server = await app.create_server(debug=True, host="0.0.0.0", port=unused_port, return_asyncio_server=True)
-    yield server
-    server.close()
-    await server.wait_closed()
+    env = os.environ.copy()
+    env["SANIC_PORT"] = str(SERVER_PORT)
+    args = ["ddtrace-run", "python", RUN_SERVER_PY]
+    subp = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True, env=env)
+
+    client = Client("http://0.0.0.0:{}".format(SERVER_PORT))
+    client.wait(path="/hello")
+    try:
+        yield client
+    finally:
+        resp = client.get_ignored("/shutdown-tracer")
+        assert resp.status_code == 200
+        subp.terminate()
+        try:
+            # Give the server 3 seconds to shutdown, then kill it
+            subp.wait(3)
+        except subprocess.TimeoutExpired:
+            subp.kill()
 
 
-@pytest.mark.asyncio
-async def test_multiple_requests_sanic_http(tracer, sanic_http_server, unused_port):
-    url = "http://0.0.0.0:{}/hello".format(unused_port)
-    async with httpx_client() as client:
-        responses = await asyncio.gather(
-            client.get(url),
-            client.get(url),
-        )
+@pytest.mark.snapshot(
+    variants={
+        "": sanic_version >= (21, 9, 0),
+        "pre_21.9": sanic_version < (21, 9, 0),
+    },
+)
+def test_multiple_requests_sanic_http(sanic_client):
+    def assert_response(response):
+        assert response.status_code == 200
+        assert response.json() == {"hello": "world"}
 
-    assert len(responses) == 2
-    assert [r.status_code for r in responses] == [200] * 2
-    assert [r.json() for r in responses] == [{"hello": "world"}] * 2
-
-    spans = tracer.pop_traces()
-    assert len(spans) == 2
-    assert len(spans[0]) == 2
-    assert len(spans[1]) == 2
-
-    assert spans[0][0].name == "sanic.request"
-    assert spans[0][1].name == "tests.contrib.sanic.test_sanic_server.random_sleep"
-    assert spans[0][0].parent_id is None
-    assert spans[0][1].parent_id == spans[0][0].span_id
-    assert spans[0][0].get_tag("http.status_code") == "200"
-
-    assert spans[1][0].name == "sanic.request"
-    assert spans[1][1].name == "tests.contrib.sanic.test_sanic_server.random_sleep"
-    assert spans[1][0].parent_id is None
-    assert spans[1][1].parent_id == spans[1][0].span_id
-    assert spans[1][0].get_tag("http.status_code") == "200"
+    url = "http://0.0.0.0:{}/hello".format(SERVER_PORT)
+    assert_response(sanic_client.get(url))
+    assert_response(sanic_client.get(url))
 
 
-@pytest.mark.asyncio
-async def test_sanic_errors(tracer, sanic_http_server, unused_port):
-    url = "http://0.0.0.0:{}/not_found".format(unused_port)
-    async with httpx_client() as client:
-        response = await client.get(url)
-
+@pytest.mark.snapshot(
+    ignores=["meta.error.stack"],
+    variants={
+        "": sanic_version >= (21, 9, 0),
+        "pre_21.9": sanic_version < (21, 9, 0),
+    },
+)
+def test_sanic_errors(sanic_client):
+    url = "http://0.0.0.0:{}/not_found".format(SERVER_PORT)
+    response = sanic_client.get(url)
     assert response.status_code == 404
-    spans = tracer.pop_traces()
-    assert len(spans) == 1
-    assert len(spans[0]) == 1
-    assert spans[0][0].name == "sanic.request"
-    assert spans[0][0].get_tag("http.status_code") == "404"
-    assert spans[0][0].error == 0
 
-    url = "http://0.0.0.0:{}/internal_error".format(unused_port)
-    async with httpx_client() as client:
-        response = await client.get(url)
-
+    url = "http://0.0.0.0:{}/internal_error".format(SERVER_PORT)
+    response = sanic_client.get(url)
     assert response.status_code == 500
-    spans = tracer.pop_traces()
-    assert len(spans) == 1
-    assert len(spans[0]) == 1
-    assert spans[0][0].name == "sanic.request"
-    assert spans[0][0].get_tag("http.status_code") == "500"
-    assert spans[0][0].error == 1

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http.json
@@ -1,0 +1,72 @@
+[[
+  {
+    "name": "sanic.request",
+    "service": "sanic",
+    "resource": "GET /hello",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "meta": {
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:8000/hello",
+      "runtime-id": "193df935e05b4e1e889dff324daef541",
+      "sanic.route.name": "test_sanic_server.hello"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 90748
+    },
+    "duration": 85407000,
+    "start": 1643465627712966000
+  },
+     {
+       "name": "__main__.random_sleep",
+       "service": "sanic",
+       "resource": "__main__.random_sleep",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "duration": 84899000,
+       "start": 1643465627713142000
+     }],
+[
+  {
+    "name": "sanic.request",
+    "service": "sanic",
+    "resource": "GET /hello",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "meta": {
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:8000/hello",
+      "runtime-id": "193df935e05b4e1e889dff324daef541",
+      "sanic.route.name": "test_sanic_server.hello"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 90748
+    },
+    "duration": 50645000,
+    "start": 1643465627811584000
+  },
+     {
+       "name": "__main__.random_sleep",
+       "service": "sanic",
+       "resource": "__main__.random_sleep",
+       "trace_id": 1,
+       "span_id": 2,
+       "parent_id": 1,
+       "duration": 50094000,
+       "start": 1643465627811863000
+     }]]

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http_pre_21.9.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http_pre_21.9.json
@@ -1,0 +1,70 @@
+[[
+  {
+    "name": "sanic.request",
+    "service": "sanic",
+    "resource": "GET /hello",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "meta": {
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:8000/hello",
+      "runtime-id": "ab783dd2a67f4765a56bcc3715df0bb9"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 90727
+    },
+    "duration": 82987000,
+    "start": 1643465607624457000
+  },
+     {
+       "name": "__main__.random_sleep",
+       "service": "sanic",
+       "resource": "__main__.random_sleep",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "duration": 82299000,
+       "start": 1643465607624605000
+     }],
+[
+  {
+    "name": "sanic.request",
+    "service": "sanic",
+    "resource": "GET /hello",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "meta": {
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:8000/hello",
+      "runtime-id": "ab783dd2a67f4765a56bcc3715df0bb9"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 90727
+    },
+    "duration": 81765000,
+    "start": 1643465607721195000
+  },
+     {
+       "name": "__main__.random_sleep",
+       "service": "sanic",
+       "resource": "__main__.random_sleep",
+       "trace_id": 1,
+       "span_id": 2,
+       "parent_id": 1,
+       "duration": 81372000,
+       "start": 1643465607721297000
+     }]]

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors.json
@@ -1,0 +1,55 @@
+[[
+  {
+    "name": "sanic.request",
+    "service": "sanic",
+    "resource": "sanic.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "meta": {
+      "http.method": "GET",
+      "http.status_code": "404",
+      "http.url": "http://0.0.0.0:8000/not_found",
+      "runtime-id": "3d723a2da3d64eb9a002fc85bf8867b7"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 90749
+    },
+    "duration": 1497000,
+    "start": 1643465628968961000
+  }],
+[
+  {
+    "name": "sanic.request",
+    "service": "sanic",
+    "resource": "GET /internal_error",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 1,
+    "meta": {
+      "error.msg": "division by zero",
+      "error.stack": "Traceback (most recent call last):\n  File \"handle_request\", line 83, in handle_request\n    class Sanic(BaseSanic, metaclass=TouchUpMeta):\n  File \"/Users/brett.langdon/datadog/dd-trace-py/tests/contrib/sanic/run_server.py\", line 31, in internal_error\n    1 / 0\nZeroDivisionError: division by zero\n",
+      "error.type": "builtins.ZeroDivisionError",
+      "http.method": "GET",
+      "http.status_code": "500",
+      "http.url": "http://0.0.0.0:8000/internal_error",
+      "runtime-id": "3d723a2da3d64eb9a002fc85bf8867b7",
+      "sanic.route.name": "test_sanic_server.internal_error"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 90749
+    },
+    "duration": 733000,
+    "start": 1643465628981693000
+  }]]

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors_pre_21.9.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors_pre_21.9.json
@@ -1,0 +1,51 @@
+[[
+  {
+    "name": "sanic.request",
+    "service": "sanic",
+    "resource": "GET /not_found",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "meta": {
+      "http.method": "GET",
+      "http.status_code": "404",
+      "http.url": "http://0.0.0.0:8000/not_found",
+      "runtime-id": "a5a11207957a4131a14f34f5c2aa3c57"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 90728
+    },
+    "duration": 561000,
+    "start": 1643465608921691000
+  }],
+[
+  {
+    "name": "sanic.request",
+    "service": "sanic",
+    "resource": "GET /internal_error",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 1,
+    "meta": {
+      "http.method": "GET",
+      "http.status_code": "500",
+      "http.url": "http://0.0.0.0:8000/internal_error",
+      "runtime-id": "a5a11207957a4131a14f34f5c2aa3c57"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 90728
+    },
+    "duration": 1043000,
+    "start": 1643465608933455000
+  }]]

--- a/tox.ini
+++ b/tox.ini
@@ -54,8 +54,6 @@ envlist =
     pynamodb_contrib-py{27,35,36,37,38,39,310}-pynamodb{40,41,42,43,}-moto1
     pyodbc_contrib-py{27,35,36,37,38,39}-pyodbc{3,4}
     requests_contrib{,_autopatch}-py{27,35,36,37,38,39,310}-requests{208,209,210,211,212,213,219}
-    sanic_contrib-py{37,38,39}-sanic{1906,1909,1912,2003,2006,2103}
-    sanic_contrib-py{310}-sanic{2103}
     sqlite3_contrib-py{27,35,36,37,38,39,310}-sqlite3
     tornado_contrib-py{27,35,36,37,38,39}-tornado{44,45}
     tornado_contrib-py{37,38,39}-tornado{50,51,60,}
@@ -189,28 +187,6 @@ deps =
     pytest3: pytest>=3.0,<4.0
     redis: redis
     redis210: redis>=2.10,<2.11
-    sanic_contrib: pytest-asyncio==0.15.1
-    sanic1906: sanic~=19.6.0
-    sanic1906: pytest-sanic==1.6.2
-    sanic1906: httpx==0.9.3
-    sanic1909: sanic~=19.9.0
-    sanic1909: pytest-sanic==1.6.2
-    sanic1909: httpx==0.9.3
-    sanic1912: sanic~=19.12.0
-    sanic1912: pytest-sanic==1.6.2
-    sanic1912: httpx==0.9.3
-    sanic2003: sanic~=20.3.0
-    sanic2003: pytest-sanic==1.6.2
-    sanic2003: httpx==0.11.1
-    sanic2006: sanic~=20.6.0
-    sanic2006: pytest-sanic==1.6.2
-    sanic2006: httpx==0.11.1
-    sanic2103: sanic~=21.3.0
-    sanic2103: pytest-sanic==1.7.1
-    sanic2103: httpx==0.15.4
-    sanic: sanic
-    sanic: pytest-sanic==1.8.1
-    sanic: httpx==0.15.4
     sqlalchemy: sqlalchemy
     sslmodules3: aiohttp
     sslmodules3: aiobotocore
@@ -271,8 +247,6 @@ commands =
     pymysql_contrib: pytest {posargs} tests/contrib/pymysql
     pyodbc_contrib: pytest {posargs} tests/contrib/pyodbc
     kombu_contrib: pytest {posargs} tests/contrib/kombu
-    sanic_contrib: pytest {posargs} tests/contrib/sanic/test_sanic.py
-    sanic_contrib: pytest {posargs} tests/contrib/sanic/test_sanic_server.py
     sqlite3_contrib: pytest {posargs} tests/contrib/sqlite3
     tornado_contrib: pytest {posargs} tests/contrib/tornado
     vertica_contrib: pytest {posargs} tests/contrib/vertica/


### PR DESCRIPTION
Newer versions of Sanic will now "touchup" methods
on the `sanic.Sanic` class. This process involves
parsing an AST from the source function, then potentially
modifying the tree before compiling and evaling to get a
new codeobject for the method.

They also now have a `__setattr__` defined to block us
from overwriting methods on the `sanic.Sanic` class.

These together make our patching no longer work.

With Sanic 21.9.0 request lifecycle signals have been added.
In order to support newer versions we now patch `sanic.Sanic.__init__`
and automatically add signals for request start, routing, and response.

We now create a span on request start, attach it to the Sanic request
context, then in subsequent events we'll pull the span from the
request context and either modify or finish the span.

As well, `pytest-sanic` no longer works with latest versions of Sanic,
however there is now a `sanic-testing` package we are able to use.
We have tried to create compatible pytest fixtures to reduce necessary
changes to tests.
