### PR TITLE
fix (python 2.7): profiler raises a typing error when Span.resource is unicode

### DIFF
--- a/ddtrace/profiling/exporter/pprof.pyx
+++ b/ddtrace/profiling/exporter/pprof.pyx
@@ -7,6 +7,7 @@ import attr
 import six
 
 from ddtrace import ext
+from ddtrace.internal.compat import ensure_text
 from ddtrace.internal.utils import config
 from ddtrace.profiling import event
 from ddtrace.profiling import exporter
@@ -552,7 +553,7 @@ class PprofExporter(exporter.Exporter):
         # Do not export trace_resource for non Web spans for privacy concerns.
         if event.trace_resource_container and event.trace_type == ext.SpanTypes.WEB.value:
             (trace_resource,) = event.trace_resource_container
-        return str(trace_resource)
+        return ensure_text(trace_resource, errors="backslashreplace")
 
     def export(self, events: recorder.EventsType, start_time_ns: int, end_time_ns: int) -> pprof_ProfileType:
         """Convert events to pprof format.

--- a/ddtrace/profiling/exporter/pprof.pyx
+++ b/ddtrace/profiling/exporter/pprof.pyx
@@ -552,7 +552,7 @@ class PprofExporter(exporter.Exporter):
         # Do not export trace_resource for non Web spans for privacy concerns.
         if event.trace_resource_container and event.trace_type == ext.SpanTypes.WEB.value:
             (trace_resource,) = event.trace_resource_container
-        return trace_resource
+        return str(trace_resource)
 
     def export(self, events: recorder.EventsType, start_time_ns: int, end_time_ns: int) -> pprof_ProfileType:
         """Convert events to pprof format.

--- a/ddtrace/profiling/exporter/pprof.pyx
+++ b/ddtrace/profiling/exporter/pprof.pyx
@@ -7,7 +7,7 @@ import attr
 import six
 
 from ddtrace import ext
-from ddtrace.internal.compat import ensure_text
+from ddtrace.internal.compat import ensure_str
 from ddtrace.internal.utils import config
 from ddtrace.profiling import event
 from ddtrace.profiling import exporter
@@ -553,7 +553,7 @@ class PprofExporter(exporter.Exporter):
         # Do not export trace_resource for non Web spans for privacy concerns.
         if event.trace_resource_container and event.trace_type == ext.SpanTypes.WEB.value:
             (trace_resource,) = event.trace_resource_container
-        return ensure_text(trace_resource, errors="backslashreplace")
+        return ensure_str(trace_resource, errors="backslashreplace")
 
     def export(self, events: recorder.EventsType, start_time_ns: int, end_time_ns: int) -> pprof_ProfileType:
         """Convert events to pprof format.

--- a/tests/profiling/exporter/test_pprof.py
+++ b/tests/profiling/exporter/test_pprof.py
@@ -353,7 +353,7 @@ TEST_EVENTS = {
             local_root_span_id=1322219321,
             span_id=24930,
             trace_type="sql",
-            trace_resource_container=["notme"],
+            trace_resource_container=[u"\x1bnotme"],
             frames=[
                 ("foobar.py", 23, "func1"),
                 ("foobar.py", 44, "func2"),
@@ -460,7 +460,7 @@ TEST_EVENTS = {
             local_root_span_id=23435,
             span_id=345432,
             trace_type=ext.SpanTypes.WEB.value,
-            trace_resource_container=["myresource"],
+            trace_resource_container=[u"myresource"],
             nframes=3,
             wait_time_ns=74839,
             sampling_pct=10,
@@ -473,7 +473,7 @@ TEST_EVENTS = {
             local_root_span_id=23435,
             span_id=345432,
             trace_type="sql",
-            trace_resource_container=["notme"],
+            trace_resource_container=[b"notme"],
             frames=[
                 ("foobar.py", 23, "func1"),
                 ("foobar.py", 44, "func2"),


### PR DESCRIPTION
## Commit Message
<!-- Defaults to the title of the PR. Replace if desired. -->
{{title}}

In python 2.7 the profiler fails to export http events if the resource name is unicode (commit which introduced typing in the profiler 652021270e81922cbb1edb60180e42619c7203a2). 

This error was introduced in v0.57.0. In a recent release to dogweb there was a significant increase in errors. 

Sample Error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/ddtrace/profiling/scheduler.py", line 53, in flush
    exp.export(events, start, self._last_export)
  File "/usr/local/lib/python2.7/site-packages/ddtrace/profiling/exporter/http.py", line 150, in export
    profile = super(PprofHTTPExporter, self).export(events, start_time_ns, end_time_ns)
  File "ddtrace/profiling/exporter/pprof.pyx", line 594, in ddtrace.profiling.exporter.pprof.PprofExporter.export
  File "ddtrace/profiling/exporter/pprof.pyx", line 493, in ddtrace.profiling.exporter.pprof.PprofExporter._group_stack_events
  File "ddtrace/profiling/exporter/pprof.pyx", line 482, in ddtrace.profiling.exporter.pprof.PprofExporter._stack_event_group_key
  File "ddtrace/profiling/exporter/pprof.pyx", line 555, in ddtrace.profiling.exporter.pprof.PprofExporter._get_event_trace_resource
TypeError: Expected str, got unicode
```

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
