### PR TITLE
docs: remove Alpine installation instructions

### DIFF
--- a/docs/installation_quickstart.rst
+++ b/docs/installation_quickstart.rst
@@ -24,17 +24,6 @@ Install with :code:`pip`::
     It is strongly suggested to pin the version of the library you deploy.
 
 
-Installation on Alpine
-~~~~~~~~~~~~~~~~~~~~~~
-
-Binary distributions are not available for Alpine so build dependencies must be installed first.
-
-.. code-block:: bash
-
-    apk add gcc musl-dev linux-headers
-    pip install ddtrace
-
-
 Quickstart
 ----------
 


### PR DESCRIPTION
## Commit Message
{{title}}

We now publish `musllinux` wheels so installing from source is
no longer required