### PR TITLE
fix(profiling): add logging in prifling.auto

### DIFF
--- a/ddtrace/profiling/auto.py
+++ b/ddtrace/profiling/auto.py
@@ -1,5 +1,9 @@
 """Automatically starts a collector when imported."""
+from ddtrace.internal.logger import get_logger
 from ddtrace.profiling.bootstrap import sitecustomize  # noqa
 
+
+log = get_logger(__name__)
+log.debug("Enabling the profiler by auto import")
 
 start_profiler = sitecustomize.start_profiler


### PR DESCRIPTION
## Commit Message
<!-- Defaults to the title of the PR. Replace if desired. -->
{{title}}

Added a log debug statement in ddtrace.profiling.auto to log if the profiler has been enabled automatically on module import.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
