### PR TITLE
fix(docs): add formatter to spelling wordlist

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -61,6 +61,7 @@ entrypoints
 env
 enqueuer
 fastapi
+formatter
 gRPC
 gevent
 greenlet


### PR DESCRIPTION
This doesn't get picked up locally, but CircleCI jobs just started failing all of a sudden with this.

## Commit Message
<!-- Defaults to the title of the PR. Replace if desired. -->
{{title}}