### PR TITLE
fix(docs): Sphinx 4.4.0 has trouble resolving type hinted Tracer class

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -163,7 +163,7 @@ venv = Venv(
             pkgs={
                 "cython": latest,
                 "reno[sphinx]": latest,
-                "sphinx": latest,
+                "sphinx": "~=4.3.2",
                 "sphinxcontrib-spelling": latest,
                 "PyEnchant": latest,
             },


### PR DESCRIPTION
## Commit Message
<!-- Defaults to the title of the PR. Replace if desired. -->
{{title}}

Fixes:

```
dd-trace-py/ddtrace/span.py:docstring of ddtrace.span.Span::more than one target found for cross-reference 'Tracer': ddtrace.opentracer.Tracer, ddtrace.opentracer.tracer.Tracer, ddtrace.Tracer, ddtrace.tracer.Tracer
```
