### PR TITLE
docs: make tracer import explicit

### DIFF
--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -11,7 +11,7 @@ from .vendor import wrapt
 
 
 if TYPE_CHECKING:
-    from .tracer import Tracer
+    import ddtrace.tracer
 
 
 log = get_logger(__name__)
@@ -44,7 +44,7 @@ class Pin(object):
         app=None,  # type: Optional[str]
         app_type=None,
         tags=None,  # type: Optional[Dict[str, str]]
-        tracer=None,  # type: Optional[Tracer]
+        tracer=None,  # type: Optional[ddtrace.tracer.Tracer]
         _config=None,  # type: Optional[Dict[str, Any]]
     ):
         # type: (...) -> None
@@ -131,7 +131,7 @@ class Pin(object):
         app=None,  # type: Optional[str]
         app_type=None,
         tags=None,  # type: Optional[Dict[str, str]]
-        tracer=None,  # type: Optional[Tracer]
+        tracer=None,  # type: Optional[ddtrace.tracer.Tracer]
     ):
         # type: (...) -> None
         """Override an object with the given attributes.
@@ -194,7 +194,7 @@ class Pin(object):
         app=None,  # type: Optional[str]
         app_type=None,
         tags=None,  # type: Optional[Dict[str, str]]
-        tracer=None,  # type: Optional[Tracer]
+        tracer=None,  # type: Optional[ddtrace.tracer.Tracer]
     ):
         # type: (...) -> Pin
         """Return a clone of the pin with the given attributes replaced."""

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -43,7 +43,7 @@ from .internal.logger import get_logger
 
 
 if TYPE_CHECKING:
-    from .tracer import Tracer
+    import ddtrace.tracer
 
 
 _TagNameType = Union[Text, bytes]
@@ -83,7 +83,7 @@ class Span(object):
 
     def __init__(
         self,
-        tracer,  # type: Optional[Tracer]
+        tracer,  # type: Optional[ddtrace.tracer.Tracer]
         name,  # type: str
         service=None,  # type: Optional[str]
         resource=None,  # type: Optional[str]
@@ -147,7 +147,7 @@ class Span(object):
         self.trace_id = trace_id or _rand.rand64bits()  # type: int
         self.span_id = span_id or _rand.rand64bits()  # type: int
         self.parent_id = parent_id  # type: Optional[int]
-        self.tracer = tracer  # type: Optional[Tracer]
+        self.tracer = tracer  # type: Optional[ddtrace.tracer.Tracer]
         self._on_finish_callbacks = [] if on_finish is None else on_finish
 
         # sampling


### PR DESCRIPTION
Sphinx 4.4.0 complains with errors like:

  docstring of ddtrace.pin.Pin::more than one target found for cross-reference
  'Tracer': ddtrace.opentracer.Tracer, ddtrace.opentracer.tracer.Tracer,
  ddtrace.Tracer, ddtrace.tracer.Tracer

We now make it more explicit what we import in type checking.