### PR TITLE
removing upload_artifact step

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,9 +40,3 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
-
-    - name: upload_artifact
-      uses: actions/upload-artifact@v2
-      with:
-         name: CodeQL Analysis Sarif
-         path: /home/runner/work/dd-trace-py/results/python.sarif


### PR DESCRIPTION
`upload_artifact` is used only for debugging reasons (to export the SARIF results from the GitHub action). So, this PR removes the `upload_artifact` step 

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
