### PR TITLE
fix(ci): disable code coverage for Flask tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -586,6 +586,8 @@ jobs:
     steps:
       - run_test:
           # Run both flask and flask_cache test suites
+          # TODO: Re-enable coverage for Flask tests
+          store_coverage: false
           pattern: 'flask(_cache)?'
 
   gevent:

--- a/riotfile.py
+++ b/riotfile.py
@@ -680,7 +680,8 @@ venv = Venv(
         ),
         Venv(
             name="flask",
-            command="pytest {cmdargs} tests/contrib/flask",
+            # TODO: Re-enable coverage for Flask tests
+            command="pytest --no-cov {cmdargs} tests/contrib/flask",
             pkgs={"blinker": latest},
             venvs=[
                 # Flask == 0.12.0
@@ -694,7 +695,8 @@ venv = Venv(
                 ),
                 Venv(
                     pys=select_pys(max_version="3.9"),
-                    command="python tests/ddtrace_run.py pytest {cmdargs} tests/contrib/flask_autopatch",
+                    # TODO: Re-enable coverage for Flask tests
+                    command="python tests/ddtrace_run.py pytest --no-cov {cmdargs} tests/contrib/flask_autopatch",
                     env={
                         "DATADOG_SERVICE_NAME": "test.flask.service",
                         "DATADOG_PATCH_MODULES": "jinja2:false",
@@ -714,7 +716,8 @@ venv = Venv(
                 ),
                 Venv(
                     pys=select_pys(),
-                    command="python tests/ddtrace_run.py pytest {cmdargs} tests/contrib/flask_autopatch",
+                    # TODO: Re-enable coverage for Flask tests
+                    command="python tests/ddtrace_run.py pytest --no-cov {cmdargs} tests/contrib/flask_autopatch",
                     env={
                         "DATADOG_SERVICE_NAME": "test.flask.service",
                         "DATADOG_PATCH_MODULES": "jinja2:false",
@@ -740,7 +743,8 @@ venv = Venv(
                 ),
                 Venv(
                     pys=select_pys(min_version="3.6"),
-                    command="python tests/ddtrace_run.py pytest {cmdargs} tests/contrib/flask_autopatch",
+                    # TODO: Re-enable coverage for Flask tests
+                    command="python tests/ddtrace_run.py pytest --no-cov {cmdargs} tests/contrib/flask_autopatch",
                     env={
                         "DATADOG_SERVICE_NAME": "test.flask.service",
                         "DATADOG_PATCH_MODULES": "jinja2:false",
@@ -757,7 +761,8 @@ venv = Venv(
         ),
         Venv(
             name="flask_cache",
-            command="pytest {cmdargs} tests/contrib/flask_cache",
+            # TODO: Re-enable coverage for Flask tests
+            command="pytest --no-cov {cmdargs} tests/contrib/flask_cache",
             pkgs={
                 "python-memcached": latest,
                 "redis": "~=2.0",


### PR DESCRIPTION
Disabling coverage reporting will avoid this `coverage` error.

```
internal error
Traceback (most recent call last):
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/_pytest/main.py, line 269, in wrap_session
    session.exitstatus = doit(config, session) or 0
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/_pytest/main.py, line 323, in _main
    config.hook.pytest_runtestloop(session=session)
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/pluggy/_hooks.py, line 265, in __call__
    return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/pluggy/_manager.py, line 80, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/pluggy/_callers.py, line 55, in _multicall
    gen.send(outcome)
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/pytest_cov/plugin.py, line 294, in pytest_runtestloop
    self.cov_controller.finish()
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/pytest_cov/engine.py, line 44, in ensure_topdir_wrapper
    return meth(self, *args, **kwargs)
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/pytest_cov/engine.py, line 231, in finish
    self.cov.save()
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/coverage/control.py, line 680, in save
    data = self.get_data()
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/coverage/control.py, line 749, in get_data
    if self._collector and self._collector.flush_data():
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/coverage/collector.py, line 473, in flush_data
    self.covdata.add_lines(self.mapped_file_dict(self.data))
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/coverage/sqldata.py, line 236, in _wrapped
    return method(self, *args, **kwargs)
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/coverage/sqldata.py, line 469, in add_lines
    linemap = nums_to_numbits(linenos)
  File /root/project/.riot/venv_py3101_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/coverage/numbits.py, line 44, in nums_to_numbits
    b = bytearray(nbytes)
ValueError: negative count
```