### PR TITLE
fix(ci): Re-enable spell checking for PR release notes

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+..
+    Load all release notes from the current branch when spell checking
+    DEV: Without this we won't get spell checking on PRs or release
+         notes that are not yet on a release branch.
+
+.. only:: spelling
+
+   .. release-notes::
+
+
 .. release-notes::
    :branch: 0.57
    :earliest-version: v0.57.0


### PR DESCRIPTION
In #3085 when we moved to manually specifying release branches
we stopped including any release notes on the current branch
in the docs build.

This means that spell checking for a release note won't occur
until it is merged into a release branch which is far too late.

With this change we will include the full change log entry list
for the current branch when we are using the 'spelling'
builder.
