### PR TITLE
fix: Pymongo raises an AttributeError when the tracer is disabled

### DIFF
--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -121,7 +121,10 @@ class TracedServer(ObjectProxy):
     if VERSION >= (3, 12, 0):
 
         def run_operation(self, sock_info, operation, *args, **kwargs):
-            with self._datadog_trace_operation(operation) as span:
+            span = self._datadog_trace_operation(operation)
+            if span is None:
+                return self.__wrapped__.run_operation(sock_info, operation, *args, **kwargs)
+            with span:
                 result = self.__wrapped__.run_operation(sock_info, operation, *args, **kwargs)
                 if result and result.address:
                     set_address_tags(span, result.address)
@@ -131,7 +134,10 @@ class TracedServer(ObjectProxy):
     elif (3, 9, 0) <= VERSION < (3, 12, 0):
 
         def run_operation_with_response(self, sock_info, operation, *args, **kwargs):
-            with self._datadog_trace_operation(operation) as span:
+            span = self._datadog_trace_operation(operation)
+            if span is None:
+                return self.__wrapped__.run_operation_with_response(sock_info, operation, *args, **kwargs)
+            with span:
                 result = self.__wrapped__.run_operation_with_response(sock_info, operation, *args, **kwargs)
                 if result and result.address:
                     set_address_tags(span, result.address)
@@ -141,7 +147,10 @@ class TracedServer(ObjectProxy):
     else:
 
         def send_message_with_response(self, operation, *args, **kwargs):
-            with self._datadog_trace_operation(operation) as span:
+            span = self._datadog_trace_operation(operation)
+            if span is None:
+                return self.__wrapped__.send_message_with_response(operation, *args, **kwargs)
+            with span:
                 result = self.__wrapped__.send_message_with_response(operation, *args, **kwargs)
                 if result and result.address:
                     set_address_tags(span, result.address)

--- a/releasenotes/notes/pymongo-disabled-tracer-bug-fix-d7782296afe5c1a9.yaml
+++ b/releasenotes/notes/pymongo-disabled-tracer-bug-fix-d7782296afe5c1a9.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Pymongo raises an AttributeError when ``tracer.enabled == False``
+    Pymongo instrumentation raises an AttributeError when ``tracer.enabled == False``

--- a/releasenotes/notes/pymongo-disabled-tracer-bug-fix-d7782296afe5c1a9.yaml
+++ b/releasenotes/notes/pymongo-disabled-tracer-bug-fix-d7782296afe5c1a9.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Pymongo raises an AttributeError when ``tracer.enabled == False``


### PR DESCRIPTION
Currently we attempt to wrap pymongo operations in a span when `tracer.enabled == False`. This raises an exception since spans are not generated on a disabled tracer. An example of this error is linked below:

Fix: https://github.com/DataDog/dd-trace-py/issues/3140


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
