### PR TITLE
fix: update deprecation warning for get_correlation_ids to include alternative

### DIFF
--- a/ddtrace/helpers.py
+++ b/ddtrace/helpers.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from ddtrace.tracer import Tracer
 
 
-@deprecated("This method and module will be removed altogether", "1.0.0")
+@deprecated("This method and module will be removed altogether. Use 'ddtrace.Tracer.get_log_correlation_context()' instead.", "1.0.0")
 def get_correlation_ids(tracer=None):
     # type: (Optional[Tracer]) -> Tuple[Optional[int], Optional[int]]
     """Retrieves the Correlation Identifiers for the current active ``Trace``.

--- a/ddtrace/helpers.py
+++ b/ddtrace/helpers.py
@@ -10,7 +10,10 @@ if TYPE_CHECKING:
     from ddtrace.tracer import Tracer
 
 
-@deprecated("This method and module will be removed altogether. Use 'ddtrace.Tracer.get_log_correlation_context()' instead.", "1.0.0")
+@deprecated(
+    "This method and module will be removed altogether. Use 'ddtrace.Tracer.get_log_correlation_context()' instead.",
+    "1.0.0",
+)
 def get_correlation_ids(tracer=None):
     # type: (Optional[Tracer]) -> Tuple[Optional[int], Optional[int]]
     """Retrieves the Correlation Identifiers for the current active ``Trace``.


### PR DESCRIPTION
<!-- Briefly describe the change and why it was required. -->
As per the title.
IMO, it's important to show the alternative when a function or something gets deprecated.
The alternative is only shown in [the releasenote](https://github.com/DataDog/dd-trace-py/blob/master/releasenotes/notes/log-correlation-context-22d56ee0b5cc9cfa.yaml).

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
