### PR TITLE
add note that aiohttp requires additional setup

### DIFF
--- a/ddtrace/contrib/aiohttp/__init__.py
+++ b/ddtrace/contrib/aiohttp/__init__.py
@@ -1,4 +1,6 @@
 """
+Note: This integration requires additional setup for automatic instrumentation to be applied.
+
 The ``aiohttp`` integration traces all requests defined in the application handlers.
 Auto instrumentation is available using the ``trace_app`` function::
 


### PR DESCRIPTION
Adding note that aiohttp requires additional configuration. This is due to user confusion about expected traces OOTB and not being aware of aiohttp integration requiring additional configuration.



## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
