### PR TITLE
fix(profiling/heap): check correctly maximum number of tracked allocs

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.c
+++ b/ddtrace/profiling/collector/_memalloc_heap.c
@@ -174,8 +174,10 @@ memalloc_heap_track(uint16_t max_nframe, void* ptr, size_t size)
     if (global_heap_tracker.allocated_memory < global_heap_tracker.current_sample_size)
         return false;
 
-    /* Cannot add more sample */
-    if (global_heap_tracker.allocs.count >= TRACEBACK_ARRAY_MAX_COUNT)
+    /* Check if we can add more samples: the sum of the freezer + alloc tracker
+     cannot be greater than what the alloc tracker can handle: when the alloc
+     tracker is thawed, all the allocs in the freezer will be moved there!*/
+    if ((global_heap_tracker.freezer.allocs.count + global_heap_tracker.allocs.count) >= TRACEBACK_ARRAY_MAX_COUNT)
         return false;
 
     traceback_t* tb = memalloc_get_traceback(max_nframe, ptr, global_heap_tracker.allocated_memory);

--- a/releasenotes/notes/profiler-heap-max-alloc-bugfix-646423cdd7f7811f.yaml
+++ b/releasenotes/notes/profiler-heap-max-alloc-bugfix-646423cdd7f7811f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a possible bug in the heap memory profiler that could trigger an
+    overflow when too many allocations were being tracked.


### PR DESCRIPTION
There's a possibility that the number of tracked allocs overflow the maximum
if, e.g., 65k allocs are stored in the alloc tracker and then 1k allocs are
stored in the freezer: when the freezer is merged back in the alloc tracker,
then it will overflow.