### PR TITLE
refactor(profiling/heap): do not use global heap tracker

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.c
+++ b/ddtrace/profiling/collector/_memalloc_heap.c
@@ -77,8 +77,8 @@ heap_tracker_untrack_thawed(heap_tracker_t* heap_tracker, void* ptr)
        of the time this is where the untracked ptr is (the most recent object
        get de-allocated first usually). This might be a good enough
        trade-off. */
-    for (TRACEBACK_ARRAY_COUNT_TYPE i = global_heap_tracker.allocs.count; i > 0; i--) {
-        traceback_t** tb = &global_heap_tracker.allocs.tab[i - 1];
+    for (TRACEBACK_ARRAY_COUNT_TYPE i = heap_tracker->allocs.count; i > 0; i--) {
+        traceback_t** tb = &heap_tracker->allocs.tab[i - 1];
 
         if (ptr == (*tb)->ptr) {
             /* Free the traceback */


### PR DESCRIPTION
This should use the heap tracker passed as argument.
Since there's only one heap tracker currently, this does not change anything in
practice.