### PR TITLE
chore(logging)!: set default value of DD_CALL_BASIC_CONFIG to False

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -26,6 +26,7 @@ from ddtrace.internal.utils.formats import asbool  # noqa
 from ddtrace.internal.utils.formats import parse_tags_str
 from ddtrace.tracer import DD_LOG_FORMAT  # noqa
 from ddtrace.tracer import debug_mode
+from ddtrace.vendor.debtcollector import deprecate
 
 
 if config.logs_injection:
@@ -40,8 +41,13 @@ if config.logs_injection:
 # upon initializing it the first time.
 # See https://github.com/python/cpython/blob/112e4afd582515fcdcc0cde5012a4866e5cfda12/Lib/logging/__init__.py#L1550
 # Debug mode from the tracer will do a basicConfig so only need to do this otherwise
-call_basic_config = asbool(os.environ.get("DD_CALL_BASIC_CONFIG", "true"))
+call_basic_config = asbool(os.environ.get("DD_CALL_BASIC_CONFIG", "false"))
 if not debug_mode and call_basic_config:
+    deprecate(
+        "ddtrace.tracer.logging.basicConfig",
+        message="`logging.basicConfig()` should be called in a user's application."
+        " ``DD_CALL_BASIC_CONFIG`` will be removed in a future version.",
+    )
     if config.logs_injection:
         logging.basicConfig(format=DD_LOG_FORMAT)
     else:

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -64,13 +64,18 @@ from .vendor.debtcollector import removals
 log = get_logger(__name__)
 
 debug_mode = asbool(os.getenv("DD_TRACE_DEBUG", default=False))
-call_basic_config = asbool(os.environ.get("DD_CALL_BASIC_CONFIG", "true"))
+call_basic_config = asbool(os.environ.get("DD_CALL_BASIC_CONFIG", "false"))
 
 DD_LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] {}- %(message)s".format(
     "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s"
     " dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] "
 )
 if debug_mode and not hasHandlers(log) and call_basic_config:
+    debtcollector.deprecate(
+        "ddtrace.tracer.logging.basicConfig",
+        message="`logging.basicConfig()` should be called in a user's application."
+        " ``DD_CALL_BASIC_CONFIG`` will be removed in a future version.",
+    )
     if config.logs_injection:
         # We need to ensure logging is patched in case the tracer logs during initialization
         patch(logging=True)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -95,7 +95,7 @@ below:
        .. _dd-call-basic-config:
    * - ``DD_CALL_BASIC_CONFIG``
      - Boolean
-     - True
+     - False
      - Controls whether ``logging.basicConfig`` is called in ``ddtrace-run`` or when debug mode is enabled.
 
        .. _dd-trace-agent-url:

--- a/releasenotes/notes/ddtrace-1.0-disable-basic-config-call-by-default-b677844e4a13a794.yaml
+++ b/releasenotes/notes/ddtrace-1.0-disable-basic-config-call-by-default-b677844e4a13a794.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Default value of ``DD_CALL_BASIC_CONFIG`` was updated from ``True`` to `False`. Call `logging.basicConfig()` to configure logging in your application.
+deprecations:
+  - |
+    DD_CALL_BASIC_CONFIG is deprecated and will be removed in a future version.

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -380,7 +380,9 @@ def test_startup_logs_sampling_rules():
 def test_error_output_ddtracerun_debug_mode():
     p = subprocess.Popen(
         ["ddtrace-run", "python", "tests/integration/hello.py"],
-        env=dict(DD_TRACE_AGENT_URL="http://localhost:8126", DD_TRACE_DEBUG="true", **os.environ),
+        env=dict(
+            DD_TRACE_AGENT_URL="http://localhost:8126", DD_TRACE_DEBUG="true", DD_CALL_BASIC_CONFIG="true", **os.environ
+        ),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
@@ -392,7 +394,9 @@ def test_error_output_ddtracerun_debug_mode():
     # No connection to agent, debug mode enabled
     p = subprocess.Popen(
         ["ddtrace-run", "python", "tests/integration/hello.py"],
-        env=dict(DD_TRACE_AGENT_URL="http://localhost:4321", DD_TRACE_DEBUG="true", **os.environ),
+        env=dict(
+            DD_TRACE_AGENT_URL="http://localhost:4321", DD_TRACE_DEBUG="true", DD_CALL_BASIC_CONFIG="true", **os.environ
+        ),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
@@ -434,7 +438,9 @@ def test_error_output_ddtracerun():
 def test_debug_span_log():
     p = subprocess.Popen(
         ["python", "-c", 'import os; print(os.environ);import ddtrace; ddtrace.tracer.trace("span").finish()'],
-        env=dict(DD_TRACE_AGENT_URL="http://localhost:8126", DD_TRACE_DEBUG="true", **os.environ),
+        env=dict(
+            DD_TRACE_AGENT_URL="http://localhost:8126", DD_TRACE_DEBUG="true", DD_CALL_BASIC_CONFIG="true", **os.environ
+        ),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -56,7 +56,7 @@ def test_debug_mode():
 
     p = subprocess.Popen(
         [sys.executable, "-c", "import ddtrace"],
-        env=dict(DD_TRACE_DEBUG="true"),
+        env=dict(DD_TRACE_DEBUG="true", DD_CALL_BASIC_CONFIG="true"),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
@@ -600,6 +600,7 @@ s2.finish()
         env=dict(
             DD_TRACE_LOGS_INJECTION=str(logs_injection).lower(),
             DD_TRACE_DEBUG=str(debug_mode).lower(),
+            DD_CALL_BASIC_CONFIG="true",
         ),
     )
     try:
@@ -622,7 +623,7 @@ def test_call_basic_config(ddtrace_run_python_code_in_subprocess, call_basic_con
         When false
             We do not call logging.basicConfig()
         When not set
-            We call logging.basicConfig()
+            We do not call logging.basicConfig()
     """
     env = os.environ.copy()
 
@@ -632,7 +633,7 @@ def test_call_basic_config(ddtrace_run_python_code_in_subprocess, call_basic_con
         env["DD_CALL_BASIC_CONFIG"] = str(call_basic_config).lower()
         has_root_handlers = call_basic_config
     else:
-        has_root_handlers = True
+        has_root_handlers = False
 
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """
@@ -756,6 +757,7 @@ def test_ddtrace_run_startup_logging_injection(ddtrace_run_python_code_in_subpro
     env = os.environ.copy()
     env["DD_TRACE_DEBUG"] = "true"
     env["DD_LOGS_INJECTION"] = "true"
+    env["DD_CALL_BASIC_CONFIG"] = "true"
 
     # DEV: We don't actually have to execute any code to validate this
     out, err, status, pid = ddtrace_run_python_code_in_subprocess("", env=env)


### PR DESCRIPTION
ddtrace should not call `logging.basicConfig` since it is not a logging library.  

This PR updates the default value of ``DD_CALL_BASIC_CONFIG`` to False and logs a deprecation warning if DD_CALL_BASIC_CONFIG configuration is set to True.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
