### PR TITLE
chore!: deprecate DD_CALL_BASIC_CONFIG

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -73,6 +73,12 @@ DD_LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] 
     " dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] "
 )
 if debug_mode and not hasHandlers(log) and call_basic_config:
+    deprecation(
+        name="ddtrace.tracer.logging.basicConfig",
+        message="ddtrace will no longer handle basic configuration for a logging system.\
+        `logging.basicConfig()` should be called in a user's application",
+        version="1.0.0",
+    )
     if config.logs_injection:
         # We need to ensure logging is patched in case the tracer logs during initialization
         patch(logging=True)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -92,6 +92,11 @@ below:
      - False
      - Enables :ref:`Logs Injection`.
 
+       .. _dd-call-basic-config:
+   * - ``DD_CALL_BASIC_CONFIG``
+     - Boolean
+     - True
+     - Controls whether ``logging.basicConfig`` is called in ``ddtrace-run`` or when debug mode is enabled.
 
        .. _dd-trace-agent-url:
    * - ``DD_TRACE_AGENT_URL``

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -92,11 +92,6 @@ below:
      - False
      - Enables :ref:`Logs Injection`.
 
-       .. _dd-call-basic-config:
-   * - ``DD_CALL_BASIC_CONFIG``
-     - Boolean
-     - True
-     - Controls whether ``logging.basicConfig`` is called in ``ddtrace-run`` or when debug mode is enabled.
 
        .. _dd-trace-agent-url:
    * - ``DD_TRACE_AGENT_URL``

--- a/releasenotes/notes/deprecate-basic-config-in-master-63ce18595182a1b2.yaml
+++ b/releasenotes/notes/deprecate-basic-config-in-master-63ce18595182a1b2.yaml
@@ -1,6 +1,6 @@
 ---
 upgrade:
   - |
-    ddtrace will no longer handle basic configuration of a logging system. `logging.basicConfig()` should be called in a client application.
+    ddtrace will no longer call logging.baseConfig() on startup.
 
     ``DD_CALL_BASIC_CONFIG`` is no longer supported in the ddtrace api.

--- a/releasenotes/notes/deprecate-basic-config-in-master-63ce18595182a1b2.yaml
+++ b/releasenotes/notes/deprecate-basic-config-in-master-63ce18595182a1b2.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    ddtrace will no longer handle basic configuration of a logging system. `logging.basicConfig()` should be called in a client application.
+
+    ``DD_CALL_BASIC_CONFIG`` is no longer supported in the ddtrace api.


### PR DESCRIPTION
Deprecate ``DD_CALL_BASIC_CONFIG`` configuration.
 
This change removes all invocations of logging.basicConfig from tracing instrumentation: #3168.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
