### PR TITLE
fix(profiling/heap): use the right integer type to iterate over freezer frees

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.c
+++ b/ddtrace/profiling/collector/_memalloc_heap.c
@@ -103,7 +103,7 @@ heap_tracker_thaw(heap_tracker_t* heap_tracker)
        array together to be sure that there's no free in the freezer matching
        an alloc that is also in the freezer; heap_tracker_untrack_thawed does
        not care about the freezer, by definition. */
-    for (TRACEBACK_ARRAY_COUNT_TYPE i = 0; i < heap_tracker->freezer.frees.count; i++)
+    for (MEMALLOC_HEAP_PTR_ARRAY_COUNT_TYPE i = 0; i < heap_tracker->freezer.frees.count; i++)
         heap_tracker_untrack_thawed(heap_tracker, heap_tracker->freezer.frees.tab[i]);
 
     /* Reset the count to zero so we can reused the array and overwrite previous values */
@@ -137,9 +137,9 @@ memalloc_heap_untrack(void* ptr)
            enough space, we ignore the untrack. That's sad as there is a change
            the heap profile won't be valid anymore. However, that's the best we
            can do since reporting an error is not an option here. What's gonna
-           free more than 2^64 pointer anyway?!
+           free more than 2^64 pointers anyway?!
         */
-        if (global_heap_tracker.freezer.frees.count < MEMALLOC_HEAP_PTR_ARRAY_MAX)
+        if (global_heap_tracker.freezer.frees.count < MEMALLOC_HEAP_PTR_ARRAY_MAX_COUNT)
             ptr_array_append(&global_heap_tracker.freezer.frees, ptr);
     } else
         heap_tracker_untrack_thawed(&global_heap_tracker, ptr);

--- a/ddtrace/profiling/collector/_memalloc_heap.h
+++ b/ddtrace/profiling/collector/_memalloc_heap.h
@@ -25,7 +25,8 @@ memalloc_heap_track(uint16_t max_nframe, void* ptr, size_t size);
 void
 memalloc_heap_untrack(void* ptr);
 
-#define MEMALLOC_HEAP_PTR_ARRAY_MAX UINT64_MAX
-DO_ARRAY(void *, ptr, uint64_t, DO_NOTHING)
+#define MEMALLOC_HEAP_PTR_ARRAY_COUNT_TYPE uint64_t
+#define MEMALLOC_HEAP_PTR_ARRAY_MAX_COUNT UINT64_MAX
+DO_ARRAY(void *, ptr, MEMALLOC_HEAP_PTR_ARRAY_COUNT_TYPE, DO_NOTHING)
 
 #endif

--- a/releasenotes/notes/profielr-heap-iterate-freezer-frees-a366cc6dbeadd188.yaml
+++ b/releasenotes/notes/profielr-heap-iterate-freezer-frees-a366cc6dbeadd188.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a bug in the heap profiler that could be triggered if more than 2^16
+    memory items were freed during heap data collection.


### PR DESCRIPTION
The current type that was being used was a uint16_t, which would overflow if
there was more than 2^16 frees in the freezer. The freezer can contain up to
2^64 frees.