### PR TITLE
fix: spantypes in ddtrace1.0

### DIFF
--- a/ddtrace/filters.py
+++ b/ddtrace/filters.py
@@ -80,4 +80,4 @@ class TraceCiVisibilityFilter(TraceFilter):
             return trace
 
         local_root = trace[0]._local_root
-        return trace if local_root and local_root.span_type == SpanTypes.TEST.value else None
+        return trace if local_root and local_root.span_type == SpanTypes.TEST else None


### PR DESCRIPTION
fixes flake8 error introduced by a merge conflict
## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
