### PR TITLE
fix(ci): do not rely on env variable to get PR base ref

### DIFF
--- a/scripts/check-releasenotes
+++ b/scripts/check-releasenotes
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# If we are running outside a GitHub action, default to `master`
-BASE_REF="${GITHUB_BASE_REF:-master}"
-
-# Print input data
-echo "Base ref: origin/${BASE_REF}"
 echo "GitHub event path: ${GITHUB_EVENT_PATH}"
 echo "JQ: $(which jq)"
 
@@ -16,6 +11,16 @@ then
     echo "PR has label 'changelog/no-changelog', skipping validation"
     exit 0
 fi
+
+if [[ -f "${GITHUB_EVENT_PATH}" ]];
+then
+    # If we have an event, grab the PR base ref from the event data
+    BASE_REF="$(jq -er '.pull_request?.base.ref' "${GITHUB_EVENT_PATH}")"
+else
+    # If we are running outside a GitHub action, default to `master`
+    BASE_REF="${GITHUB_BASE_REF:-master}"
+fi
+echo "Base ref: origin/${BASE_REF}"
 
 # Check if they added a new file to releasenotes/notes
 if git diff --name-only --diff-filter=A "origin/${BASE_REF}" | grep releasenotes/notes;


### PR DESCRIPTION
We have seen examples of where GITHUB_BASE_REF env variable was
not set. This means any PR that does not target origin/master
will potentially have a false positive from this check.

Example: https://github.com/DataDog/dd-trace-py/runs/4968319691?check_suite_focus=true

Since we cannot always rely on GITHUB_BASE_REF, we will try
to pull the PR base ref from the event json that triggered
the workflow, and then fallback to the env variable or master
if there is no event json present
