### PR TITLE
test: pypy support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,6 +345,18 @@ jobs:
       - run_test:
           pattern: "tracer"
 
+  tracer-p37-pypy3:
+    <<: *contrib_job
+    steps:
+      - run:
+          command: |
+            mv .riot .ddriot
+            ./scripts/ddtest
+            pyenv local pypy3.7-7.3.5
+            pypy -m ensurepip
+            pip install riot
+            riot -v run -p3.7 tracer
+
   opentracer:
     <<: *contrib_job
     steps:

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -76,8 +76,9 @@ RUN \
   && pyenv install 3.8.12 \
   && pyenv install 3.9.9 \
   && pyenv install 3.10.1 \
+  && pyenv install pypy3.7-7.3.5 \
   # Order matters: first version is the global one
-  && pyenv global 3.10.1 2.7.18 3.5.10 3.6.15 3.7.12 3.8.12 3.9.9 \
+  && pyenv global 3.10.1 2.7.18 3.5.10 3.6.15 3.7.12 3.8.12 3.9.9 pypy3.7-7.3.5 \
   && pip install --upgrade pip
 
 

--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -11,6 +11,9 @@ from ddtrace.constants import ORIGIN_KEY
 DEF MSGPACK_ARRAY_LENGTH_PREFIX_SIZE = 5
 DEF MSGPACK_STRING_TABLE_LENGTH_PREFIX_SIZE = 6
 
+# Use python_implementation to override implementation CPYTHON function: _PyFloat_Pack8()
+# from platform import python_implementation
+# IS_PYPY = (1 if python_implementation() == "PyPy" else 0)
 
 cdef extern from "Python.h":
     const char* PyUnicode_AsUTF8(object o)

--- a/setup.py
+++ b/setup.py
@@ -134,15 +134,15 @@ else:
 
 if sys.version_info[:2] >= (3, 4):
     ext_modules = [
-        Extension(
-            "ddtrace.profiling.collector._memalloc",
-            sources=[
-                "ddtrace/profiling/collector/_memalloc.c",
-                "ddtrace/profiling/collector/_memalloc_tb.c",
-                "ddtrace/profiling/collector/_memalloc_heap.c",
-            ],
-            extra_compile_args=debug_compile_args,
-        ),
+        # Extension(
+        #     "ddtrace.profiling.collector._memalloc",
+        #     sources=[
+        #         "ddtrace/profiling/collector/_memalloc.c",
+        #         "ddtrace/profiling/collector/_memalloc_tb.c",
+        #         "ddtrace/profiling/collector/_memalloc_heap.c",
+        #     ],
+        #     extra_compile_args=debug_compile_args,
+        # ),
     ]
 else:
     ext_modules = []
@@ -224,12 +224,12 @@ setup(
                 libraries=encoding_libraries,
                 define_macros=encoding_macros,
             ),
-            Cython.Distutils.Extension(
-                "ddtrace.profiling.collector.stack",
-                sources=["ddtrace/profiling/collector/stack.pyx"],
-                language="c",
-                extra_compile_args=extra_compile_args,
-            ),
+            # Cython.Distutils.Extension(
+            #     "ddtrace.profiling.collector.stack",
+            #     sources=["ddtrace/profiling/collector/stack.pyx"],
+            #     language="c",
+            #     extra_compile_args=extra_compile_args,
+            # ),
             Cython.Distutils.Extension(
                 "ddtrace.profiling.collector._traceback",
                 sources=["ddtrace/profiling/collector/_traceback.pyx"],
@@ -264,6 +264,6 @@ setup(
         force=True,
         annotate=os.getenv("_DD_CYTHON_ANNOTATE") == "1",
     )
-    + get_exts_for("wrapt")
+    # + get_exts_for("wrapt")
     + get_exts_for("psutil"),
 )


### PR DESCRIPTION
## Draft PR to experiment with pypy support.

The following C extensions fail to compile in pypy: 
   - `ddtrace/vendor/wrapt/_wrappers.c`
   - `ddtrace/profiling/collector/stack.c`
   - `ddtrace/internal/_encoding.c` (warnings)
   - `ddtrace/profiling/collector/_memalloc.c`
 
### Wrapt Errors

`gcc -pthread -DNDEBUG -O2 -fPIC -I/opt/pypy/include -c ddtrace/vendor/wrapt/_wrappers.c -o build/temp.linux-x86_64-3.7/ddtrace/vendor/wrapt/_wrappers.o`

```
    ddtrace/vendor/wrapt/_wrappers.c: In function ‘WraptObjectProxy_reversed’:
    ddtrace/vendor/wrapt/_wrappers.c:1270:54: error: ‘PyReversed_Type’ undeclared (first use in this function)
     1270 |     return PyObject_CallFunctionObjArgs((PyObject *)&PyReversed_Type,
          |                                                      ^~~~~~~~~~~~~~~
    ddtrace/vendor/wrapt/_wrappers.c:1270:54: note: each undeclared identifier is reported only once for each function it appears in
    ddtrace/vendor/wrapt/_wrappers.c: In function ‘WraptFunctionWrapper_init’:
    ddtrace/vendor/wrapt/_wrappers.c:2909:51: error: ‘PyClassMethod_Type’ undeclared (first use in this function); did you mean ‘PyClassMethod_New’?
     2909 |     if (PyObject_IsInstance(wrapped, (PyObject *)&PyClassMethod_Type)) {
          |                                                   ^~~~~~~~~~~~~~~~~~
          |                                                   PyClassMethod_New
```

### Stack Error

`gcc -pthread -DNDEBUG -O2 -fPIC -I/opt/pypy/include -c ddtrace/profiling/collector/stack.c -o build/temp.linux-x86_64-3.7/ddtrace/profiling/collector/stack.o -DPy_BUILD_CORE`

```
    ddtrace/profiling/collector/stack.c:704:10: fatal error: internal/pystate.h: No such file or directory
      704 | #include <internal/pystate.h>
          |          ^~~~~~~~~~~~~~~~~~~~
    compilation terminated.
```

### Encoding Warnings

`gcc -pthread -DNDEBUG -O2 -fPIC -D__LITTLE_ENDIAN__=1 -Iddtrace/internal -I./ddtrace/internal -I. -I/opt/pypy/include -c ddtrace/internal/_encoding.c -o build/temp.linux-x86_64-3.7/ddtrace/internal/_encoding.o`
```
    In file included from ddtrace/internal/pack.h:64,
                     from ddtrace/internal/_encoding.c:711:
    ddtrace/internal/pack_template.h: In function ‘msgpack_pack_double’:
    ddtrace/internal/pack_template.h:561:5: warning: implicit declaration of function ‘_PyFloat_Pack8’; did you mean ‘_PyPyFloat_Unpack8’? [-Wimplicit-function-declaration]
      561 |     _PyFloat_Pack8(d, &buf[1], 0);
          |     ^~~~~~~~~~~~~~
          |     _PyPyFloat_Unpack8
    ddtrace/internal/_encoding.c: In function ‘__pyx_f_7ddtrace_8internal_9_encoding_17MsgpackEncoderV03_get_dd_origin_ref’:
    ddtrace/internal/_encoding.c:11667:11: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
    11667 |   __pyx_r = __pyx_f_7ddtrace_8internal_9_encoding_string_to_buff(__pyx_v_dd_origin);
          |           ^
    ddtrace/internal/_encoding.c: In function ‘__pyx_f_7ddtrace_8internal_9_encoding_17MsgpackEncoderV03__pack_meta’:
    ddtrace/internal/_encoding.c:12006:104: warning: passing argument 2 of ‘__pyx_f_7ddtrace_8internal_9_encoding_pack_bytes’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
    12006 |         __pyx_v_ret = __pyx_f_7ddtrace_8internal_9_encoding_pack_bytes((&__pyx_v_self->__pyx_base.pk), __pyx_v_7ddtrace_8internal_9_encoding__ORIGIN_KEY, __pyx_v_7ddtrace_8internal_9_encoding__ORIGIN_KEY_LEN);
          |                                                                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ddtrace/internal/_encoding.c:2464:116: note: expected ‘char *’ but argument is of type ‘const char *’
     2464 | static CYTHON_INLINE int __pyx_f_7ddtrace_8internal_9_encoding_pack_bytes(struct msgpack_packer *__pyx_v_pk, char *__pyx_v_bs, Py_ssize_t __pyx_v_l) {
          |                                                                                                              ~~~~~~^~~~~~~~~~
    ddtrace/internal/_encoding.c: In function ‘__pyx_f_7ddtrace_8internal_9_encoding_17MsgpackEncoderV05_pack_span’:
    ddtrace/internal/_encoding.c:15274:72: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    15274 |     __pyx_v_ret = msgpack_pack_uint32((&__pyx_v_self->__pyx_base.pk), ((uint32_t)__pyx_v_dd_origin));
```

### Memalloc Errors

`gcc -pthread -DNDEBUG -O2 -fPIC -I/opt/pypy/include -c ddtrace/profiling/collector/_memalloc.c -o build/temp.linux-x86_64-3.7/ddtrace/profiling/collector/_memalloc.o`

```
    ddtrace/profiling/collector/_memalloc.c:15:5: error: unknown type name ‘PyMemAllocatorEx’
       15 |     PyMemAllocatorEx pymem_allocator_obj;
          |     ^~~~~~~~~~~~~~~~
    ddtrace/profiling/collector/_memalloc.c: In function ‘memalloc_free’:
    ddtrace/profiling/collector/_memalloc.c:74:5: error: unknown type name ‘PyMemAllocatorEx’
       74 |     PyMemAllocatorEx* alloc = (PyMemAllocatorEx*)ctx;
          |     ^~~~~~~~~~~~~~~~
    ddtrace/profiling/collector/_memalloc.c:74:32: error: ‘PyMemAllocatorEx’ undeclared (first use in this function)
       74 |     PyMemAllocatorEx* alloc = (PyMemAllocatorEx*)ctx;
          |                                ^~~~~~~~~~~~~~~~
    ddtrace/profiling/collector/_memalloc.c:74:32: note: each undeclared identifier is reported only once for each function it appears in
    ddtrace/profiling/collector/_memalloc.c:74:49: error: expected expression before ‘)’ token
       74 |     PyMemAllocatorEx* alloc = (PyMemAllocatorEx*)ctx;
          |                                                 ^
    ddtrace/profiling/collector/_memalloc.c:81:10: error: request for member ‘free’ in something not a structure or union
       81 |     alloc->free(alloc->ctx, ptr);
          |          ^~
    ddtrace/profiling/collector/_memalloc.c:81:22: error: request for member ‘ctx’ in something not a structure or union
       81 |     alloc->free(alloc->ctx, ptr);
          |                      ^~
    ddtrace/profiling/collector/_memalloc.c: In function ‘memalloc_alloc’:
    ddtrace/profiling/collector/_memalloc.c:91:48: error: request for member ‘calloc’ in something not a structure or union
       91 |         ptr = memalloc_ctx->pymem_allocator_obj.calloc(memalloc_ctx->pymem_allocator_obj.ctx, nelem, elsize);
          |                                                ^
    ddtrace/profiling/collector/_memalloc.c:91:89: error: request for member ‘ctx’ in something not a structure or union
       91 |         ptr = memalloc_ctx->pymem_allocator_obj.calloc(memalloc_ctx->pymem_allocator_obj.ctx, nelem, elsize);
          |                                                                                         ^
    ddtrace/profiling/collector/_memalloc.c:93:48: error: request for member ‘malloc’ in something not a structure or union
       93 |         ptr = memalloc_ctx->pymem_allocator_obj.malloc(memalloc_ctx->pymem_allocator_obj.ctx, nelem * elsize);
          |                                                ^
    ddtrace/profiling/collector/_memalloc.c:93:89: error: request for member ‘ctx’ in something not a structure or union
       93 |         ptr = memalloc_ctx->pymem_allocator_obj.malloc(memalloc_ctx->pymem_allocator_obj.ctx, nelem * elsize);
          |                                                                                         ^
    ddtrace/profiling/collector/_memalloc.c: In function ‘memalloc_realloc’:
    ddtrace/profiling/collector/_memalloc.c:119:51: error: request for member ‘realloc’ in something not a structure or union
      119 |     void* ptr2 = memalloc_ctx->pymem_allocator_obj.realloc(memalloc_ctx->pymem_allocator_obj.ctx, ptr, new_size);
          |                                                   ^
    ddtrace/profiling/collector/_memalloc.c:119:93: error: request for member ‘ctx’ in something not a structure or union
      119 |     void* ptr2 = memalloc_ctx->pymem_allocator_obj.realloc(memalloc_ctx->pymem_allocator_obj.ctx, ptr, new_size);
          |                                                                                             ^
    ddtrace/profiling/collector/_memalloc.c: In function ‘memalloc_start’:
    ddtrace/profiling/collector/_memalloc.c:195:5: error: unknown type name ‘PyMemAllocatorEx’
      195 |     PyMemAllocatorEx alloc;
          |     ^~~~~~~~~~~~~~~~
    ddtrace/profiling/collector/_memalloc.c:197:10: error: request for member ‘malloc’ in something not a structure or union
      197 |     alloc.malloc = memalloc_malloc;
          |          ^
    ddtrace/profiling/collector/_memalloc.c:198:10: error: request for member ‘calloc’ in something not a structure or union
      198 |     alloc.calloc = memalloc_calloc;
          |          ^
    ddtrace/profiling/collector/_memalloc.c:199:10: error: request for member ‘realloc’ in something not a structure or union
      199 |     alloc.realloc = memalloc_realloc;
          |          ^
    ddtrace/profiling/collector/_memalloc.c:200:10: error: request for member ‘free’ in something not a structure or union
      200 |     alloc.free = memalloc_free;
          |          ^
    ddtrace/profiling/collector/_memalloc.c:202:10: error: request for member ‘ctx’ in something not a structure or union
      202 |     alloc.ctx = &global_memalloc_ctx;
          |          ^
    ddtrace/profiling/collector/_memalloc.c:206:5: warning: implicit declaration of function ‘PyMem_GetAllocator’ [-Wimplicit-function-declaration]
      206 |     PyMem_GetAllocator(PYMEM_DOMAIN_OBJ, &global_memalloc_ctx.pymem_allocator_obj);
          |     ^~~~~~~~~~~~~~~~~~
    ddtrace/profiling/collector/_memalloc.c:206:24: error: ‘PYMEM_DOMAIN_OBJ’ undeclared (first use in this function)
      206 |     PyMem_GetAllocator(PYMEM_DOMAIN_OBJ, &global_memalloc_ctx.pymem_allocator_obj);
          |                        ^~~~~~~~~~~~~~~~
    ddtrace/profiling/collector/_memalloc.c:207:5: warning: implicit declaration of function ‘PyMem_SetAllocator’ [-Wimplicit-function-declaration]
      207 |     PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &alloc);
          |     ^~~~~~~~~~~~~~~~~~
    ddtrace/profiling/collector/_memalloc.c: In function ‘memalloc_stop’:
    ddtrace/profiling/collector/_memalloc.c:227:24: error: ‘PYMEM_DOMAIN_OBJ’ undeclared (first use in this function)
      227 |     PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &global_memalloc_ctx.pymem_allocator_obj);
          |                
```

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
