### PR TITLE
ci: add conventional commits linter

### DIFF
--- a/.github/workflows/pr-name.yml
+++ b/.github/workflows/pr-name.yml
@@ -10,4 +10,6 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install Dependencies
       run: npm install @commitlint/config-conventional
+    - name: Show pull request title
+      run: echo "${{ github.event.pull_request.title }}"
     - uses: JulienKode/pull-request-name-linter-action@v0.2.0

--- a/.github/workflows/pr-name.yml
+++ b/.github/workflows/pr-name.yml
@@ -1,0 +1,13 @@
+name: pr-name
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Dependencies
+      run: npm install @commitlint/config-conventional
+    - uses: JulienKode/pull-request-name-linter-action@v0.2.0

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']}


### PR DESCRIPTION
Use [commitlint](https://commitlint.js.org/) for ensuring the PR titles used for squash merges will follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

Output for invalid PR title: https://github.com/DataDog/dd-trace-py/runs/5009766892?check_suite_focus=true