### PR TITLE
fix(internal): use correct max item size variable in log warning

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -476,7 +476,7 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
         except BufferItemTooLarge as e:
             payload_size = e.args[0]
             log.warning(
-                "trace (%db) larger than payload buffer limit (%db), dropping",
+                "trace (%db) larger than payload buffer item limit (%db), dropping",
                 payload_size,
                 self._encoder.max_item_size,
             )

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -478,7 +478,7 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
             log.warning(
                 "trace (%db) larger than payload buffer limit (%db), dropping",
                 payload_size,
-                self._buffer_size,
+                self._encoder.max_item_size,
             )
             self._metrics_dist("buffer.dropped.traces", 1, tags=["reason:t_too_big"])
             self._metrics_dist("buffer.dropped.bytes", payload_size, tags=["reason:t_too_big"])

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -257,7 +257,7 @@ def test_single_trace_too_large(encoding, monkeypatch):
                     s.set_tag("a" * 10, "b" * 10)
         t.shutdown()
 
-        calls = [mock.call("trace (%db) larger than payload buffer limit (%db), dropping", AnyInt(), AnyInt())]
+        calls = [mock.call("trace (%db) larger than payload buffer item limit (%db), dropping", AnyInt(), AnyInt())]
         log.warning.assert_has_calls(calls)
         log.error.assert_not_called()
 


### PR DESCRIPTION
fixes: #3209