### PR TITLE
chore(tracer)!: remove Tracer.writer

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -61,7 +61,6 @@ from .sampler import DatadogSampler
 from .sampler import RateByServiceSampler
 from .sampler import RateSampler
 from .span import Span
-from .vendor.debtcollector import removals
 
 
 log = get_logger(__name__)
@@ -813,10 +812,6 @@ class Tracer(object):
 
         if spans is not None:
             self._writer.write(spans=spans)
-
-    @removals.removed_property(message="Use Tracer.flush instead to flush buffered traces to agent", version="1.0.0")
-    def writer(self):
-        return self._writer
 
     @property
     def agent_trace_url(self):

--- a/releasenotes/notes/remove-tracer-writer-b1875a1fa3230236.yaml
+++ b/releasenotes/notes/remove-tracer-writer-b1875a1fa3230236.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    ``ddtrace.Tracer.writer`` has been removed. To force flushing of buffered traces to the agent, use :py:meth:`ddtrace.Tracer.flush` instead.

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -459,7 +459,7 @@ async def test_analytics_integration_enabled(app_tracer, aiohttp_client):
     await request.text()
 
     # Assert root span sets the appropriate metric
-    root = get_root_span(tracer.writer.spans)
+    root = get_root_span(tracer.pop())
     root.assert_structure(dict(name="aiohttp.request", metrics={ANALYTICS_SAMPLE_RATE_KEY: 0.5}))
 
 
@@ -471,7 +471,7 @@ async def test_analytics_integration_default(app_tracer, aiohttp_client):
     await request.text()
 
     # Assert root span does not have the appropriate metric
-    root = get_root_span(tracer.writer.spans)
+    root = get_root_span(tracer.pop())
     assert root.get_metric(ANALYTICS_SAMPLE_RATE_KEY) is None
 
 
@@ -484,5 +484,5 @@ async def test_analytics_integration_disabled(app_tracer, aiohttp_client):
     await request.text()
 
     # Assert root span does not have the appropriate metric
-    root = get_root_span(tracer.writer.spans)
+    root = get_root_span(tracer.pop())
     assert root.get_metric(ANALYTICS_SAMPLE_RATE_KEY) is None

--- a/tests/contrib/falcon/test_suite.py
+++ b/tests/contrib/falcon/test_suite.py
@@ -29,7 +29,7 @@ class FalconTestCase(FalconTestMixin):
 
     def test_404(self):
         self.make_test_call("/fake_endpoint", expected_status_code=404)
-        traces = self.tracer.writer.pop_traces()
+        traces = self.tracer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 1
         span = traces[0][0]
@@ -53,7 +53,7 @@ class FalconTestCase(FalconTestMixin):
             if FALCON_VERSION < (3, 0, 0):
                 assert 0
 
-        traces = self.tracer.writer.pop_traces()
+        traces = self.tracer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 1
         span = traces[0][0]
@@ -71,7 +71,7 @@ class FalconTestCase(FalconTestMixin):
         out = self.make_test_call("/200", expected_status_code=200, query_string=query_string)
         assert out.content.decode("utf-8") == "Success"
 
-        traces = self.tracer.writer.pop_traces()
+        traces = self.tracer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 1
         span = traces[0][0]
@@ -161,7 +161,7 @@ class FalconTestCase(FalconTestMixin):
         assert out.status_code == 201
         assert out.content.decode("utf-8") == "Success"
 
-        traces = self.tracer.writer.pop_traces()
+        traces = self.tracer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 1
         span = traces[0][0]
@@ -179,7 +179,7 @@ class FalconTestCase(FalconTestMixin):
         out = self.make_test_call("/500", expected_status_code=500)
         assert out.content.decode("utf-8") == "Failure"
 
-        traces = self.tracer.writer.pop_traces()
+        traces = self.tracer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 1
         span = traces[0][0]
@@ -196,7 +196,7 @@ class FalconTestCase(FalconTestMixin):
     def test_404_exception(self):
         self.make_test_call("/not_found", expected_status_code=404)
 
-        traces = self.tracer.writer.pop_traces()
+        traces = self.tracer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 1
         span = traces[0][0]
@@ -214,7 +214,7 @@ class FalconTestCase(FalconTestMixin):
         # it should not have the stacktrace when a 404 exception is raised
         self.make_test_call("/not_found", expected_status_code=404)
 
-        traces = self.tracer.writer.pop_traces()
+        traces = self.tracer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 1
         span = traces[0][0]
@@ -229,7 +229,7 @@ class FalconTestCase(FalconTestMixin):
 
     def test_200_ot(self):
         """OpenTracing version of test_200."""
-        writer = self.tracer.writer
+        writer = self.tracer._writer
         ot_tracer = init_tracer("my_svc", self.tracer)
         ot_tracer._dd_tracer.configure(writer=writer)
 
@@ -237,7 +237,7 @@ class FalconTestCase(FalconTestMixin):
             out = self.make_test_call("/200", expected_status_code=200)
         assert out.content.decode("utf-8") == "Success"
 
-        traces = self.tracer.writer.pop_traces()
+        traces = self.tracer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 2
         ot_span, dd_span = traces[0]
@@ -265,7 +265,7 @@ class FalconTestCase(FalconTestMixin):
         out = self.make_test_call("/200", expected_status_code=200)
         assert out.content.decode("utf-8") == "Success"
 
-        traces = self.tracer.writer.pop_traces()
+        traces = self.tracer.pop_traces()
         assert len(traces) == 1
         assert len(traces[0]) == 1
         span = traces[0][0]
@@ -282,7 +282,7 @@ class FalconTestCase(FalconTestMixin):
         with self.override_config("falcon", {}):
             config.falcon.http.trace_headers(["my-header", "my-response-header"])
             self.make_test_call("/200", headers={"my-header": "my_value"})
-            traces = self.tracer.writer.pop_traces()
+            traces = self.tracer.pop_traces()
 
         assert len(traces) == 1
         assert len(traces[0]) == 1

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -660,9 +660,9 @@ def test_writer_env_configuration(run_python_code_in_subprocess):
         """
 import ddtrace
 
-assert ddtrace.tracer.writer._encoder.max_size == 1000
-assert ddtrace.tracer.writer._encoder.max_item_size == 1000
-assert ddtrace.tracer.writer._interval == 5.0
+assert ddtrace.tracer._writer._encoder.max_size == 1000
+assert ddtrace.tracer._writer._encoder.max_item_size == 1000
+assert ddtrace.tracer._writer._interval == 5.0
 """,
         env=env,
     )
@@ -674,9 +674,9 @@ def test_writer_env_configuration_defaults(run_python_code_in_subprocess):
         """
 import ddtrace
 
-assert ddtrace.tracer.writer._encoder.max_size == 8 << 20
-assert ddtrace.tracer.writer._encoder.max_item_size == 8 << 20
-assert ddtrace.tracer.writer._interval == 1.0
+assert ddtrace.tracer._writer._encoder.max_size == 8 << 20
+assert ddtrace.tracer._writer._encoder.max_item_size == 8 << 20
+assert ddtrace.tracer._writer._interval == 1.0
 """,
     )
     assert status == 0, (out, err)
@@ -692,9 +692,9 @@ def test_writer_env_configuration_ddtrace_run(ddtrace_run_python_code_in_subproc
         """
 import ddtrace
 
-assert ddtrace.tracer.writer._encoder.max_size == 1000
-assert ddtrace.tracer.writer._encoder.max_item_size == 1000
-assert ddtrace.tracer.writer._interval == 5.0
+assert ddtrace.tracer._writer._encoder.max_size == 1000
+assert ddtrace.tracer._writer._encoder.max_item_size == 1000
+assert ddtrace.tracer._writer._interval == 5.0
 """,
         env=env,
     )
@@ -706,9 +706,9 @@ def test_writer_env_configuration_ddtrace_run_defaults(ddtrace_run_python_code_i
         """
 import ddtrace
 
-assert ddtrace.tracer.writer._encoder.max_size == 8 << 20
-assert ddtrace.tracer.writer._encoder.max_item_size == 8 << 20
-assert ddtrace.tracer.writer._interval == 1.0
+assert ddtrace.tracer._writer._encoder.max_size == 8 << 20
+assert ddtrace.tracer._writer._encoder.max_item_size == 8 << 20
+assert ddtrace.tracer._writer._interval == 1.0
 """,
     )
     assert status == 0, (out, err)

--- a/tests/integration/test_integration_snapshots.py
+++ b/tests/integration/test_integration_snapshots.py
@@ -57,15 +57,15 @@ def test_multiple_traces(tracer):
 def test_filters(writer, tracer):
     if writer == "sync":
         writer = AgentWriter(
-            tracer.writer.agent_url,
+            tracer.agent_trace_url,
             priority_sampler=tracer.priority_sampler,
             sync_mode=True,
         )
         # Need to copy the headers which contain the test token to associate
         # traces with this test case.
-        writer._headers = tracer.writer._headers
+        writer._headers = tracer._writer._headers
     else:
-        writer = tracer.writer
+        writer = tracer._writer
 
     class FilterMutate(object):
         def __init__(self, key, value):
@@ -98,15 +98,15 @@ def test_filters(writer, tracer):
 def test_sampling(writer, tracer):
     if writer == "sync":
         writer = AgentWriter(
-            tracer.writer.agent_url,
+            tracer.agent_trace_url,
             priority_sampler=tracer.priority_sampler,
             sync_mode=True,
         )
         # Need to copy the headers which contain the test token to associate
         # traces with this test case.
-        writer._headers = tracer.writer._headers
+        writer._headers = tracer._writer._headers
     else:
-        writer = tracer.writer
+        writer = tracer._writer
 
     tracer.configure(writer=writer)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -691,7 +691,7 @@ class TracerSpanContainer(TestSpanContainer):
         :returns: List of spans attached to this tracer
         :rtype: list
         """
-        return self.tracer.writer.spans
+        return self.tracer._writer.spans
 
     def pop(self):
         return self.tracer.pop()


### PR DESCRIPTION
The `Tracer.writer` is exposed as part of the public API but is in fact an internal structure. This PR moves the writer to a private attribute `_writer`, following the convention in the codebase without exposing this attribute as a property.
