### PR TITLE
fix(appsec): ddtrace.ext.SpanTypes not an Enum

### DIFF
--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -74,7 +74,7 @@ class AppSecSpanProcessor(SpanProcessor):
 
     def on_span_finish(self, span):
         # type: (Span) -> None
-        if span.span_type != SpanTypes.WEB.value:
+        if span.span_type != SpanTypes.WEB:
             return
         span.set_metric("_dd.appsec.enabled", 1.0)
         span._set_str_tag("_dd.runtime_family", "python")

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -18,7 +18,7 @@ RULES_MISSING_PATH = os.path.join(ROOT_DIR, "nonexistent")
 
 def test_enable(tracer):
     tracer._initialize_span_processors(appsec_enabled=True)
-    with tracer.trace("test", span_type=SpanTypes.WEB.value) as span:
+    with tracer.trace("test", span_type=SpanTypes.WEB) as span:
         span.set_tag("http.url", "http://example.com/.git")
         span.set_tag("http.status_code", "404")
 
@@ -48,7 +48,7 @@ def test_enable_bad_rules(rule, exc, tracer):
 def test_retain_traces(tracer):
     tracer._initialize_span_processors(appsec_enabled=True)
 
-    with tracer.trace("test", span_type=SpanTypes.WEB.value) as span:
+    with tracer.trace("test", span_type=SpanTypes.WEB) as span:
         span.set_tag("http.url", "http://example.com/.git")
         span.set_tag("http.status_code", "404")
 
@@ -58,7 +58,7 @@ def test_retain_traces(tracer):
 def test_valid_json(tracer):
     tracer._initialize_span_processors(appsec_enabled=True)
 
-    with tracer.trace("test", span_type=SpanTypes.WEB.value) as span:
+    with tracer.trace("test", span_type=SpanTypes.WEB) as span:
         span.set_tag("http.url", "http://example.com/.git")
         span.set_tag("http.status_code", "404")
 


### PR DESCRIPTION
Update from https://github.com/DataDog/dd-trace-py/pull/3192/ given new code added by https://github.com/DataDog/dd-trace-py/pull/3027.