### PR TITLE
fix: readthedocs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+cmake
 cython
 sphinx
 opentracing


### PR DESCRIPTION
The docs build is failing on readthedocs due to a missing dependency

```
/home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/latest/lib/python3.8/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /home/docs/checkouts/readthedocs.org/user_builds/ddtrace/checkouts/latest/ddtrace/profiling/_build.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
/home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/latest/lib/python3.8/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /home/docs/checkouts/readthedocs.org/user_builds/ddtrace/checkouts/latest/ddtrace/profiling/collector/_task.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
/home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/latest/lib/python3.8/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /home/docs/checkouts/readthedocs.org/user_builds/ddtrace/checkouts/latest/ddtrace/profiling/collector/_threading.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
/home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/latest/lib/python3.8/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /home/docs/checkouts/readthedocs.org/user_builds/ddtrace/checkouts/latest/ddtrace/profiling/collector/_traceback.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
/home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/latest/lib/python3.8/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /home/docs/checkouts/readthedocs.org/user_builds/ddtrace/checkouts/latest/ddtrace/profiling/collector/stack.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
/home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/latest/lib/python3.8/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /home/docs/checkouts/readthedocs.org/user_builds/ddtrace/checkouts/latest/ddtrace/profiling/exporter/pprof.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
error: [Errno 2] No such file or directory: 'cmake'
```

https://readthedocs.org/projects/ddtrace/builds/15967236/