### PR TITLE
fix(docs): use pip to build the readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,5 +9,5 @@ python:
   version: 3.8
   install:
     - requirements: docs/requirements.txt
-    - method: setuptools
+    - method: pip
       path: .


### PR DESCRIPTION
The docs build was [broken](https://readthedocs.org/projects/ddtrace/builds/15975056/) in #3027 due to needing additional dependencies like `ninja` and `cmake` and readthedocs not supporting custom build runners.

Particularly the `python setup.py build --force` command fails (which also does for me locally).