### PR TITLE
chore(flake): ignore .ddriot directory

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -302,7 +302,7 @@ filterwarnings =
 [flake8]
 max-line-length=120
 exclude=
-  .ddtox,.tox,.riot,.venv*
+  .ddtox,.tox,.riot,.ddriot,.venv*
   .git,__pycache__,
   .eggs,*.egg,
   build,


### PR DESCRIPTION
The .ddriot directory can be large and does not need to be linted so it should be ignored.