### PR TITLE
ci: pin pytest < 7.0.0

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -75,7 +75,7 @@ def select_pys(min_version=MIN_PYTHON_VERSION, max_version=MAX_PYTHON_VERSION):
 venv = Venv(
     pkgs={
         "mock": latest,
-        "pytest": latest,
+        "pytest": "<7.0.0",
         "pytest-mock": latest,
         "coverage": latest,
         "pytest-cov": latest,


### PR DESCRIPTION
The tracer ci job began to fail for a single test file once pytest 7.0.0 was released:

```
collection failure
ImportError while importing test module '/root/project/tests/tracer/test_http.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../.pyenv/versions/3.9.9/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/tracer/test_http.py:3: in <module>
    from hypothesis.provisional import urls
.riot/venv_py399_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.9/site-packages/hypothesis/provisional.py:35: in <module>
    _tlds = read_text("hypothesis.vendor", "tlds-alpha-by-domain.txt").splitlines()
../.pyenv/versions/3.9.9/lib/python3.9/importlib/resources.py:139: in read_text
    with open_text(package, resource, encoding, errors) as fp:
../.pyenv/versions/3.9.9/lib/python3.9/importlib/resources.py:121: in open_text
    open_binary(package, resource), encoding=encoding, errors=errors)
../.pyenv/versions/3.9.9/lib/python3.9/importlib/resources.py:89: in open_binary
    reader = _get_resource_reader(package)
../.pyenv/versions/3.9.9/lib/python3.9/importlib/resources.py:76: in _get_resource_reader
    spec.loader.get_resource_reader(spec.name))
E   ModuleNotFoundError: No module named 'importlib.readers'
```

https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/14136/workflows/7d9d44a0-5fc1-4fa7-a64b-e0d6eaffe1e7/jobs/992534

We will pin pytest for now while we investigate the cause of the issue.