### PR TITLE
chore(ci): pin pyenv version

### DIFF
--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -64,7 +64,7 @@ ENV PYENV_ROOT /root/.pyenv
 ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:$PATH
 
 # Install pyenv
-RUN git clone git://github.com/pyenv/pyenv.git "${PYENV_ROOT}"
+RUN git clone --depth 1 --branch v2.2.4 git://github.com/pyenv/pyenv.git "${PYENV_ROOT}"
 
 
 # Install all required python versions


### PR DESCRIPTION
This change is meant to avoid issues from pyenv when we rebuild our test image.