### PR TITLE
fix(trace): make Context pickleable

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -138,3 +138,14 @@ class Context(object):
         )
 
     __str__ = __repr__
+
+    def __getstate__(self):
+        return {
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "_meta": self._meta.copy(),
+            "_metrics": self._metrics.copy(),
+        }
+
+    def __setstate__(self, state):
+        pass

--- a/releasenotes/notes/context-pickle-2b87f5ef82eb73fc.yaml
+++ b/releasenotes/notes/context-pickle-2b87f5ef82eb73fc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Make ``Context`` pickleable again.


### PR DESCRIPTION
Context was made unpickleable when the switch over to attrs occurred.

For some reason we didn't have an actual multiprocessing context
propagation test case in our test suite so one is added as a regression
test.