### PR TITLE
fix: correct import to not reference `__init__`

### DIFF
--- a/ddtrace/utils/__init__.py
+++ b/ddtrace/utils/__init__.py
@@ -1,5 +1,5 @@
-from ..internal.utils.__init__ import ArgumentError  # noqa
-from ..internal.utils.__init__ import get_argument_value  # noqa
+from ..internal.utils import ArgumentError  # noqa
+from ..internal.utils import get_argument_value  # noqa
 from ..internal.utils.deprecation import deprecation
 
 

--- a/releasenotes/notes/fix-utils-import-c0f574d76de77261.yaml
+++ b/releasenotes/notes/fix-utils-import-c0f574d76de77261.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes import path to not reference ``__init__``. This could otherwise be a problem for mypy.

--- a/releasenotes/notes/fix-utils-import-c0f574d76de77261.yaml
+++ b/releasenotes/notes/fix-utils-import-c0f574d76de77261.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fixes import path to not reference ``__init__``. This could otherwise be a problem for mypy.
+    Fixes import path to not reference ``__init__``. This could otherwise be a problem for ``mypy``.


### PR DESCRIPTION
Fixes: #3242

This will otherwise bring up the following error from mypy when type checking a code base that import ddtrace:

> Source file found twice under different module names: "ddtrace.internal.utils" and "ddtrace.internal.utils.__init__"

This error didn't occur with version 0.57.3 but did with 0.58.0.