### PR TITLE
chore!: remove Span.tracer property

### DIFF
--- a/benchmarks/encoder/utils.py
+++ b/benchmarks/encoder/utils.py
@@ -49,7 +49,7 @@ def gen_traces(config):
             span_name = random.choice(span_names)
             resource = random.choice(resources)
             service = random.choice(services)
-            with Span(None, span_name, resource=resource, service=service, parent_id=parent_id) as span:
+            with Span(span_name, resource=resource, service=service, parent_id=parent_id) as span:
                 if i == 0 and config.dd_origin:
                     # Since we're not using the tracer API, a span's context isn't automatically propagated
                     # to its children. The encoder only checks the root span's context in a trace for dd_origin, so

--- a/benchmarks/sampling_rule_matches/scenario.py
+++ b/benchmarks/sampling_rule_matches/scenario.py
@@ -34,10 +34,7 @@ class SamplingRules(bm.Scenario):
         operation_names = [rands() for _ in range(self.num_operations)]
 
         # Generate all possible permutations of service and operation names
-        spans = [
-            Span(tracer=None, service=service, name=name)
-            for service, name in itertools.product(services, operation_names)
-        ]
+        spans = [Span(service=service, name=name) for service, name in itertools.product(services, operation_names)]
 
         # Create a single rule to use for all matches
         # Pick a random service/operation name

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -42,9 +42,7 @@ class Span(OpenTracingSpan):
         self.finished = False
         self._lock = threading.Lock()
         # use a datadog span
-        dd_span = DatadogSpan(None, operation_name, context=context._dd_context)
-        dd_span._tracer = tracer._dd_tracer
-        self._dd_span = dd_span
+        self._dd_span = DatadogSpan(operation_name, context=context._dd_context)
 
     def finish(self, finish_time=None):
         # type: (Optional[float]) -> None

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -7,7 +7,6 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Text
 from typing import Union
 
@@ -40,12 +39,7 @@ from .internal.compat import stringify
 from .internal.compat import time_ns
 from .internal.logger import get_logger
 from .internal.utils.deprecation import deprecated
-from .internal.utils.deprecation import deprecation
 from .vendor.debtcollector.removals import removed_property
-
-
-if TYPE_CHECKING:
-    from .tracer import Tracer
 
 
 _TagNameType = Union[Text, bytes]
@@ -71,7 +65,6 @@ class Span(object):
         "span_type",
         "start_ns",
         "duration_ns",
-        "_tracer",
         # Sampler attributes
         "sampled",
         # Internal attributes
@@ -85,7 +78,6 @@ class Span(object):
 
     def __init__(
         self,
-        tracer,  # type: Optional[Tracer]
         name,  # type: str
         service=None,  # type: Optional[str]
         resource=None,  # type: Optional[str]
@@ -105,7 +97,6 @@ class Span(object):
         that it was created in. Using a ``Span`` from within a child process
         could result in a deadlock or unexpected behavior.
 
-        :param ddtrace.Tracer tracer: deprecated. Pass ``None`` instead.
         :param str name: the name of the traced operation.
 
         :param str service: the service name
@@ -147,14 +138,6 @@ class Span(object):
         self.trace_id = trace_id or _rand.rand64bits()  # type: int
         self.span_id = span_id or _rand.rand64bits()  # type: int
         self.parent_id = parent_id  # type: Optional[int]
-        self._tracer = None  # type: Optional[Tracer]
-        if tracer is not None:
-            deprecation(
-                name="ddtrace.Span.tracer",
-                message="Use Span(tracer=None, name, ...) instead.",
-                version="1.0.0",
-            )
-            self._tracer = tracer
         self._on_finish_callbacks = [] if on_finish is None else on_finish
 
         # sampling
@@ -171,16 +154,6 @@ class Span(object):
             self._ignored_exceptions = [exc]
         else:
             self._ignored_exceptions.append(exc)
-
-    @removed_property(removal_version="1.0.0")
-    def tracer(self):
-        # type: () -> Optional[Tracer]
-        return self._tracer
-
-    @tracer.setter  # type: ignore
-    def tracer(self, t):
-        # type: (Optional[Tracer]) -> None
-        self._tracer = t
 
     @property
     def start(self):

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -541,7 +541,6 @@ class Tracer(object):
         if trace_id:
             # child_of a non-empty context, so either a local child span or from a remote context
             span = Span(
-                tracer=None,
                 name=name,
                 context=context,
                 trace_id=trace_id,
@@ -563,7 +562,6 @@ class Tracer(object):
         else:
             # this is the root span of a new trace
             span = Span(
-                tracer=None,
                 name=name,
                 context=context,
                 service=mapped_service,
@@ -634,9 +632,6 @@ class Tracer(object):
         if self.enabled:
             for p in self._span_processors:
                 p.on_span_start(span)
-
-        # Set Span.tracer for backwards compatibility, will be removed in v1.0
-        span._tracer = self
 
         self._hooks.emit(self.__class__.start_span, span)
         return span

--- a/releasenotes/notes/remove-span-tracer-ddtrace-1-0-bc0ced48b2806e3c.yaml
+++ b/releasenotes/notes/remove-span-tracer-ddtrace-1-0-bc0ced48b2806e3c.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Deprecated ``Span.tracer`` property was removed. Deprecated tracer parameter in :py:meth:`ddtrace.Span.__init__()` was also removed.

--- a/releasenotes/notes/remove-span-tracer-ddtrace-1-0-bc0ced48b2806e3c.yaml
+++ b/releasenotes/notes/remove-span-tracer-ddtrace-1-0-bc0ced48b2806e3c.yaml
@@ -1,4 +1,6 @@
 ---
 upgrade:
   - |
-    Deprecated ``Span.tracer`` property was removed. Deprecated tracer parameter in :py:meth:`ddtrace.Span.__init__()` was also removed.
+    The deprecated property ``Span.tracer`` is removed. 
+  - |
+    The deprecated `tracer` argument is removed from :py:meth:`ddtrace.Span.__init__`.

--- a/tests/contrib/celery/test_utils.py
+++ b/tests/contrib/celery/test_utils.py
@@ -30,7 +30,7 @@ class CeleryTagsTest(CeleryBaseTestCase):
             "custom_meta": "custom_value",
         }
 
-        span = Span(None, "test")
+        span = Span("test")
         set_tags_from_context(span, context)
         metas = span._get_tags()
         metrics = span._get_metrics()
@@ -49,7 +49,7 @@ class CeleryTagsTest(CeleryBaseTestCase):
 
     def test_tags_from_context_empty_keys(self):
         # it should not extract empty keys
-        span = Span(None, "test")
+        span = Span("test")
         context = {
             "correlation_id": None,
             "exchange": "",

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -626,7 +626,7 @@ def test_handle_response_future_like():
     from ddtrace.contrib.grpc.client_interceptor import _handle_response
     from ddtrace.span import Span
 
-    span = Span(None, None)
+    span = Span(None)
 
     def finish_span():
         span.finish()

--- a/tests/tracer/test_context.py
+++ b/tests/tracer/test_context.py
@@ -22,7 +22,7 @@ def test_eq(ctx1, ctx2):
 @pytest.mark.parametrize(
     "ctx1,ctx2",
     [
-        (Context(), Span(None, "")),
+        (Context(), Span("")),
         (Context(), None),
         (Context(), object()),
         (None, Context()),

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -161,16 +161,16 @@ class TestEncoders(TestCase):
         # test encoding for JSON format
         traces = [
             [
-                Span(name="client.testing", tracer=None),
-                Span(name="client.testing", tracer=None),
+                Span(name="client.testing"),
+                Span(name="client.testing"),
             ],
             [
-                Span(name="client.testing", tracer=None),
-                Span(name="client.testing", tracer=None),
+                Span(name="client.testing"),
+                Span(name="client.testing"),
             ],
             [
-                Span(name=b"client.testing", tracer=None),
-                Span(name=b"client.testing", tracer=None),
+                Span(name=b"client.testing"),
+                Span(name=b"client.testing"),
             ],
         ]
 
@@ -193,16 +193,16 @@ class TestEncoders(TestCase):
         # test encoding for JSON format
         traces = [
             [
-                Span(name="client.testing", tracer=None, span_id=0xAAAAAA),
-                Span(name="client.testing", tracer=None, span_id=0xAAAAAA),
+                Span(name="client.testing", span_id=0xAAAAAA),
+                Span(name="client.testing", span_id=0xAAAAAA),
             ],
             [
-                Span(name="client.testing", tracer=None, span_id=0xAAAAAA),
-                Span(name="client.testing", tracer=None, span_id=0xAAAAAA),
+                Span(name="client.testing", span_id=0xAAAAAA),
+                Span(name="client.testing", span_id=0xAAAAAA),
             ],
             [
-                Span(name=b"client.testing", tracer=None, span_id=0xAAAAAA),
-                Span(name=b"client.testing", tracer=None, span_id=0xAAAAAA),
+                Span(name=b"client.testing", span_id=0xAAAAAA),
+                Span(name=b"client.testing", span_id=0xAAAAAA),
             ],
         ]
 
@@ -227,20 +227,20 @@ class TestEncoders(TestCase):
         encoder = MsgpackEncoderV03(2 << 10, 2 << 10)
         encoder.put(
             [
-                Span(name="client.testing", tracer=None),
-                Span(name="client.testing", tracer=None),
+                Span(name="client.testing"),
+                Span(name="client.testing"),
             ]
         )
         encoder.put(
             [
-                Span(name="client.testing", tracer=None),
-                Span(name="client.testing", tracer=None),
+                Span(name="client.testing"),
+                Span(name="client.testing"),
             ]
         )
         encoder.put(
             [
-                Span(name=b"client.testing", tracer=None),
-                Span(name=b"client.testing", tracer=None),
+                Span(name=b"client.testing"),
+                Span(name=b"client.testing"),
             ]
         )
 
@@ -319,7 +319,7 @@ def test_custom_msgpack_encode(encoding):
     encoder.put([])
     assert decode(refencoder.encode_traces([[]])) == decode(encoder.encode())
 
-    s = Span(None, None)
+    s = Span(None)
     # Need to .finish() to have a duration since the old implementation will not encode
     # duration_ns, the new one will encode as None
     s.finish()
@@ -328,7 +328,7 @@ def test_custom_msgpack_encode(encoding):
 
 
 def span_type_span():
-    s = Span(None, "span_name")
+    s = Span("span_name")
     s.span_type = SpanTypes.WEB
     return s
 
@@ -337,9 +337,9 @@ def span_type_span():
 @pytest.mark.parametrize(
     "span",
     [
-        Span(None, "span_name", span_type=SpanTypes.WEB),
-        Span(None, "span_name", resource="/my-resource"),
-        Span(None, "span_name", service="my-svc"),
+        Span("span_name", span_type=SpanTypes.WEB),
+        Span("span_name", resource="/my-resource"),
+        Span("span_name", service="my-svc"),
         span_type_span(),
     ],
 )
@@ -371,13 +371,13 @@ class SubFloat(float):
 @pytest.mark.parametrize(
     "span, tags",
     [
-        (Span(None, "name"), {"int": SubInt(123)}),
-        (Span(None, "name"), {"float": SubFloat(123.213)}),
-        (Span(None, SubString("name")), {SubString("test"): SubString("test")}),
-        (Span(None, "name"), {"unicode": u"😐"}),
-        (Span(None, "name"), {u"😐": u"😐"}),
+        (Span("name"), {"int": SubInt(123)}),
+        (Span("name"), {"float": SubFloat(123.213)}),
+        (Span(SubString("name")), {SubString("test"): SubString("test")}),
+        (Span("name"), {"unicode": u"😐"}),
+        (Span("name"), {u"😐": u"😐"}),
         (
-            Span(None, u"span_name", service="test-service", resource="test-resource", span_type=SpanTypes.WEB),
+            Span(u"span_name", service="test-service", resource="test-resource", span_type=SpanTypes.WEB),
             {"metric1": 123, "metric2": "1", "metric3": 12.3, "metric4": "12.0", "tag1": "test", u"tag2": u"unicode"},
         ),
     ],
@@ -432,7 +432,7 @@ def test_encoder_propagates_dd_origin(Encoder, item):
 @settings(max_examples=200)
 def test_custom_msgpack_encode_trace_size(encoding, name, service, resource, meta, metrics, error, span_type):
     encoder = MSGPACK_ENCODERS[encoding](1 << 20, 1 << 20)
-    span = Span(tracer=None, name=name, service=service, resource=resource)
+    span = Span(name=name, service=service, resource=resource)
     span.set_tags(meta)
     span.set_metrics(metrics)
     span.error = error
@@ -447,7 +447,7 @@ def test_encoder_buffer_size_limit_v03():
     buffer_size = 1 << 10
     encoder = MsgpackEncoderV03(buffer_size, buffer_size)
 
-    trace = [Span(tracer=None, name="test")]
+    trace = [Span(name="test")]
     encoder.put(trace)
     trace_size = encoder.size - 1  # This includes the global msgpack array size prefix
 
@@ -465,7 +465,7 @@ def test_encoder_buffer_size_limit_v05():
     buffer_size = 1 << 10
     encoder = MsgpackEncoderV05(buffer_size, buffer_size)
 
-    trace = [Span(tracer=None, name="test")]
+    trace = [Span(name="test")]
     encoder.put(trace)
     base_size = encoder.size
     encoder.put(trace)
@@ -486,7 +486,7 @@ def test_encoder_buffer_item_size_limit_v03():
     max_item_size = 1 << 10
     encoder = MsgpackEncoderV03(max_item_size << 1, max_item_size)
 
-    span = Span(tracer=None, name="test")
+    span = Span(name="test")
     trace = [span]
     encoder.put(trace)
     trace_size = encoder.size - 1  # This includes the global msgpack array size prefix
@@ -499,7 +499,7 @@ def test_encoder_buffer_item_size_limit_v05():
     max_item_size = 1 << 10
     encoder = MsgpackEncoderV05(max_item_size << 1, max_item_size)
 
-    span = Span(tracer=None, name="test")
+    span = Span(name="test")
     trace = [span]
     encoder.put(trace)
     base_size = encoder.size
@@ -516,9 +516,9 @@ def test_custom_msgpack_encode_v05():
     assert encoder.max_size == 2 << 20
     assert encoder.max_item_size == 2 << 20
     trace = [
-        Span(tracer=None, name="v05-test", service="foo", resource="GET"),
-        Span(tracer=None, name="v05-test", service="foo", resource="POST"),
-        Span(tracer=None, name=None, service="bar"),
+        Span(name="v05-test", service="foo", resource="GET"),
+        Span(name="v05-test", service="foo", resource="POST"),
+        Span(name=None, service="bar"),
     ]
 
     encoder.put(trace)
@@ -596,7 +596,7 @@ def test_list_string_table():
 def test_encoding_invalid_data(data):
     encoder = MsgpackEncoderV03(1 << 20, 1 << 20)
 
-    span = Span(tracer=None, name="test")
+    span = Span(name="test")
     for key, value in data.items():
         setattr(span, key, value)
 
@@ -613,7 +613,7 @@ def test_custom_msgpack_encode_thread_safe(encoding):
         def __init__(self, encoder, span_count, trace_count):
             super(TracingThread, self).__init__()
             trace = [
-                Span(tracer=None, name="span-{}-{}".format(self.name, _), service="threads", resource="TEST")
+                Span(name="span-{}-{}".format(self.name, _), service="threads", resource="TEST")
                 for _ in range(span_count)
             ]
             self._encoder = encoder
@@ -658,9 +658,9 @@ encoder = {0}()
 data = encoder.encode_traces(
          [
              [
-                 Span(name=b"\\x80span.a", tracer=None),
-                 Span(name=u"\\x80span.b", tracer=None),
-                 Span(name="\\x80span.b", tracer=None),
+                 Span(name=b"\\x80span.a"),
+                 Span(name=u"\\x80span.b"),
+                 Span(name="\\x80span.b"),
              ]
          ]
     )

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -66,7 +66,6 @@ def gen_trace(nspans=1000, ntags=50, key_size=15, value_size=20, nmetrics=10):
     for i in range(0, nspans):
         parent_id = root.span_id if root else None
         with Span(
-            None,
             "span_name",
             resource="/fsdlajfdlaj/afdasd%s" % i,
             service="myservice",

--- a/tests/tracer/test_filters.py
+++ b/tests/tracer/test_filters.py
@@ -12,13 +12,13 @@ from ddtrace.span import Span
 class TraceCiVisibilityFilterTests(TestCase):
     def test_filters_non_test_root_spans(self):
         trace_filter = TraceCiVisibilityFilter()
-        root_test_span = Span(tracer=None, name="span1", span_type="test")
+        root_test_span = Span(name="span1", span_type="test")
         root_test_span._local_root = root_test_span
         # Root span in trace is a test
         trace = [root_test_span]
         self.assertEqual(trace_filter.process_trace(trace), trace)
 
-        root_span = Span(tracer=None, name="span1")
+        root_span = Span(name="span1")
         root_span._local_root = root_span
         # Root span in trace is not a test
         trace = [root_span]
@@ -27,28 +27,28 @@ class TraceCiVisibilityFilterTests(TestCase):
 
 class FilterRequestOnUrlTests(TestCase):
     def test_is_match(self):
-        span = Span(name="Name", tracer=None)
+        span = Span(name="Name")
         span.set_tag(URL, r"http://example.com")
         filtr = FilterRequestsOnUrl("http://examp.*.com")
         trace = filtr.process_trace([span])
         self.assertIsNone(trace)
 
     def test_is_not_match(self):
-        span = Span(name="Name", tracer=None)
+        span = Span(name="Name")
         span.set_tag(URL, r"http://anotherexample.com")
         filtr = FilterRequestsOnUrl("http://examp.*.com")
         trace = filtr.process_trace([span])
         self.assertIsNotNone(trace)
 
     def test_list_match(self):
-        span = Span(name="Name", tracer=None)
+        span = Span(name="Name")
         span.set_tag(URL, r"http://anotherdomain.example.com")
         filtr = FilterRequestsOnUrl([r"http://domain\.example\.com", r"http://anotherdomain\.example\.com"])
         trace = filtr.process_trace([span])
         self.assertIsNone(trace)
 
     def test_list_no_match(self):
-        span = Span(name="Name", tracer=None)
+        span = Span(name="Name")
         span.set_tag(URL, r"http://cooldomain.example.com")
         filtr = FilterRequestsOnUrl([r"http://domain\.example\.com", r"http://anotherdomain\.example\.com"])
         trace = filtr.process_trace([span])

--- a/tests/tracer/test_processors.py
+++ b/tests/tracer/test_processors.py
@@ -58,7 +58,7 @@ def test_aggregator_single_span():
         writer=writer,
     )
 
-    span = Span(None, "span", on_finish=[aggr.on_span_finish])
+    span = Span("span", on_finish=[aggr.on_span_finish])
     aggr.on_span_start(span)
     span.finish()
 
@@ -91,7 +91,7 @@ def test_aggregator_bad_processor():
         writer=writer,
     )
 
-    span = Span(None, "span", on_finish=[aggr.on_span_finish])
+    span = Span("span", on_finish=[aggr.on_span_finish])
     aggr.on_span_start(span)
     span.finish()
 
@@ -106,9 +106,9 @@ def test_aggregator_multi_span():
     aggr = SpanAggregator(partial_flush_enabled=False, partial_flush_min_spans=0, trace_processors=[], writer=writer)
 
     # Normal usage
-    parent = Span(None, "parent", on_finish=[aggr.on_span_finish])
+    parent = Span("parent", on_finish=[aggr.on_span_finish])
     aggr.on_span_start(parent)
-    child = Span(None, "child", on_finish=[aggr.on_span_finish])
+    child = Span("child", on_finish=[aggr.on_span_finish])
     child.trace_id = parent.trace_id
     child.parent_id = parent.span_id
     aggr.on_span_start(child)
@@ -120,9 +120,9 @@ def test_aggregator_multi_span():
     assert writer.pop() == [parent, child]
 
     # Parent closes before child
-    parent = Span(None, "parent", on_finish=[aggr.on_span_finish])
+    parent = Span("parent", on_finish=[aggr.on_span_finish])
     aggr.on_span_start(parent)
-    child = Span(None, "child", on_finish=[aggr.on_span_finish])
+    child = Span("child", on_finish=[aggr.on_span_finish])
     child.trace_id = parent.trace_id
     child.parent_id = parent.span_id
     aggr.on_span_start(child)
@@ -139,9 +139,9 @@ def test_aggregator_partial_flush_0_spans():
     aggr = SpanAggregator(partial_flush_enabled=True, partial_flush_min_spans=0, trace_processors=[], writer=writer)
 
     # Normal usage
-    parent = Span(None, "parent", on_finish=[aggr.on_span_finish])
+    parent = Span("parent", on_finish=[aggr.on_span_finish])
     aggr.on_span_start(parent)
-    child = Span(None, "child", on_finish=[aggr.on_span_finish])
+    child = Span("child", on_finish=[aggr.on_span_finish])
     child.trace_id = parent.trace_id
     child.parent_id = parent.span_id
     aggr.on_span_start(child)
@@ -153,9 +153,9 @@ def test_aggregator_partial_flush_0_spans():
     assert writer.pop() == [parent]
 
     # Parent closes before child
-    parent = Span(None, "parent", on_finish=[aggr.on_span_finish])
+    parent = Span("parent", on_finish=[aggr.on_span_finish])
     aggr.on_span_start(parent)
-    child = Span(None, "child", on_finish=[aggr.on_span_finish])
+    child = Span("child", on_finish=[aggr.on_span_finish])
     child.trace_id = parent.trace_id
     child.parent_id = parent.span_id
     aggr.on_span_start(child)
@@ -172,9 +172,9 @@ def test_aggregator_partial_flush_2_spans():
     aggr = SpanAggregator(partial_flush_enabled=True, partial_flush_min_spans=2, trace_processors=[], writer=writer)
 
     # Normal usage
-    parent = Span(None, "parent", on_finish=[aggr.on_span_finish])
+    parent = Span("parent", on_finish=[aggr.on_span_finish])
     aggr.on_span_start(parent)
-    child = Span(None, "child", on_finish=[aggr.on_span_finish])
+    child = Span("child", on_finish=[aggr.on_span_finish])
     child.trace_id = parent.trace_id
     child.parent_id = parent.span_id
     aggr.on_span_start(child)
@@ -186,9 +186,9 @@ def test_aggregator_partial_flush_2_spans():
     assert writer.pop() == [parent, child]
 
     # Parent closes before child
-    parent = Span(None, "parent", on_finish=[aggr.on_span_finish])
+    parent = Span("parent", on_finish=[aggr.on_span_finish])
     aggr.on_span_start(parent)
-    child = Span(None, "child", on_finish=[aggr.on_span_finish])
+    child = Span("child", on_finish=[aggr.on_span_finish])
     child.trace_id = parent.trace_id
     child.parent_id = parent.span_id
     aggr.on_span_start(child)
@@ -200,13 +200,13 @@ def test_aggregator_partial_flush_2_spans():
     assert writer.pop() == [parent, child]
 
     # Partial flush
-    parent = Span(None, "parent", on_finish=[aggr.on_span_finish])
+    parent = Span("parent", on_finish=[aggr.on_span_finish])
     aggr.on_span_start(parent)
-    child1 = Span(None, "child1", on_finish=[aggr.on_span_finish])
+    child1 = Span("child1", on_finish=[aggr.on_span_finish])
     child1.trace_id = parent.trace_id
     child1.parent_id = parent.span_id
     aggr.on_span_start(child1)
-    child2 = Span(None, "child2", on_finish=[aggr.on_span_finish])
+    child2 = Span("child2", on_finish=[aggr.on_span_finish])
     child2.trace_id = parent.trace_id
     child2.parent_id = parent.span_id
     aggr.on_span_start(child2)
@@ -297,6 +297,6 @@ def test_trace_top_level_span_processor_trace_return_val():
     trace = []
     assert trace_processors.process_trace(trace) == trace
 
-    trace = [Span(None, "span1"), Span(None, "span2"), Span(None, "span3")]
+    trace = [Span("span1"), Span("span2"), Span("span3")]
     # Test return value contains all spans in the argument
     assert trace_processors.process_trace(trace[:]) == trace

--- a/tests/tracer/test_rand.py
+++ b/tests/tracer/test_rand.py
@@ -230,9 +230,7 @@ def test_span_api_fork():
 
     if pid > 0:
         # parent
-        parent_ids_list = list(
-            chain.from_iterable((s.span_id, s.trace_id) for s in [Span(None, None) for _ in range(100)])
-        )
+        parent_ids_list = list(chain.from_iterable((s.span_id, s.trace_id) for s in [Span(None) for _ in range(100)]))
         parent_ids = set(parent_ids_list)
         assert len(parent_ids) == len(parent_ids_list), "Collisions found in parent process ids"
 
@@ -245,9 +243,7 @@ def test_span_api_fork():
     else:
         # child
         try:
-            child_ids = list(
-                chain.from_iterable((s.span_id, s.trace_id) for s in [Span(None, None) for _ in range(100)])
-            )
+            child_ids = list(chain.from_iterable((s.span_id, s.trace_id) for s in [Span(None) for _ in range(100)]))
             q.put(child_ids)
         finally:
             os._exit(0)

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -98,7 +98,7 @@ class RateSamplerTest(unittest.TestCase):
             assert len(samples) <= 1, "there should be 0 or 1 spans"
             sampled = 1 == len(samples)
             for j in range(10):
-                other_span = Span(None, str(i), trace_id=span.trace_id)
+                other_span = Span(str(i), trace_id=span.trace_id)
                 assert sampled == tracer.sampler.sample(
                     other_span
                 ), "sampling should give the same result for a given trace_id"
@@ -590,7 +590,7 @@ def test_sampling_rule_sample(sample_rate):
     rule = SamplingRule(sample_rate=sample_rate)
 
     iterations = int(1e4 / sample_rate)
-    sampled = sum(rule.sample(Span(None, name=str(i))) for i in range(iterations))
+    sampled = sum(rule.sample(Span(name=str(i))) for i in range(iterations))
 
     # Less than 5% deviation when 'enough' iterations (arbitrary, just check if it converges)
     deviation = abs(sampled - (iterations * sample_rate)) / (iterations * sample_rate)
@@ -603,14 +603,14 @@ def test_sampling_rule_sample_rate_1():
     rule = SamplingRule(sample_rate=1)
 
     iterations = int(1e4)
-    assert all(rule.sample(Span(tracer=None, name=str(i))) for i in range(iterations))
+    assert all(rule.sample(Span(name=str(i))) for i in range(iterations))
 
 
 def test_sampling_rule_sample_rate_0():
     rule = SamplingRule(sample_rate=0)
 
     iterations = int(1e4)
-    assert sum(rule.sample(Span(tracer=None, name=str(i))) for i in range(iterations)) == 0
+    assert sum(rule.sample(Span(name=str(i))) for i in range(iterations)) == 0
 
 
 def test_datadog_sampler_init():

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -41,7 +41,7 @@ def span(tracer):
 class TestHeaders(object):
     @pytest.fixture()
     def span(self):
-        yield Span(None, "some_span")
+        yield Span("some_span")
 
     @pytest.fixture()
     def config(self):
@@ -575,7 +575,7 @@ def test_sanitized_url_in_http_meta(span, int_config):
 )
 def test_set_flattened_tags_is_flat(items):
     """Ensure that flattening of a nested dict results in a normalized, 1-level dict"""
-    span = Span(None, "test")
+    span = Span("test")
     trace_utils.set_flattened_tags(span, items)
     assert isinstance(span._get_tags(), dict)
     assert not any(isinstance(v, dict) for v in span._get_tags().values())
@@ -585,7 +585,7 @@ def test_set_flattened_tags_keys():
     """Ensure expected keys in flattened dictionary"""
     d = dict(A=1, B=2, C=dict(A=3, B=4, C=dict(A=5, B=6)))
     e = dict(A=1, B=2, C_A=3, C_B=4, C_C_A=5, C_C_B=6)
-    span = Span(None, "test")
+    span = Span("test")
     trace_utils.set_flattened_tags(span, d.items(), sep="_")
     assert span._get_metrics() == e
 
@@ -594,7 +594,7 @@ def test_set_flattened_tags_exclude_policy():
     """Ensure expected keys in flattened dictionary with exclusion set"""
     d = dict(A=1, B=2, C=dict(A=3, B=4, C=dict(A=5, B=6)))
     e = dict(A=1, B=2, C_B=4)
-    span = Span(None, "test")
+    span = Span("test")
 
     trace_utils.set_flattened_tags(span, d.items(), sep="_", exclude_policy=lambda tag: tag in {"C_A", "C_C"})
     assert span._get_metrics() == e

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1737,10 +1737,3 @@ def test_tracer_memory_leak_span_processors(enabled):
     # Force gc
     gc.collect()
     assert len(spans) == 0
-
-
-def test_trace_with_tracer():
-    # ensure Tracer.trace() sets tracer property on Span
-    t = Tracer()
-    with t.trace("test span") as span:
-        assert span.tracer == t

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -44,9 +44,7 @@ class AgentWriterTests(BaseTestCase):
         statsd = mock.Mock()
         writer = AgentWriter(agent_url="http://asdf:1234", dogstatsd=statsd, report_metrics=False)
         for i in range(10):
-            writer.write(
-                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
-            )
+            writer.write([Span(name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
         writer.stop()
         writer.join()
 
@@ -57,9 +55,7 @@ class AgentWriterTests(BaseTestCase):
         statsd = mock.Mock()
         writer = AgentWriter(agent_url="http://asdf:1234", dogstatsd=statsd, report_metrics=True)
         for i in range(10):
-            writer.write(
-                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
-            )
+            writer.write([Span(name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
         writer.stop()
         writer.join()
 
@@ -78,12 +74,8 @@ class AgentWriterTests(BaseTestCase):
         statsd = mock.Mock()
         writer = AgentWriter(agent_url="http://asdf:1234", dogstatsd=statsd, report_metrics=True)
         for i in range(10):
-            writer.write(
-                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
-            )
-        writer.write(
-            [Span(tracer=None, name="a" * 5000, trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(2 ** 10)]
-        )
+            writer.write([Span(name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
+        writer.write([Span(name="a" * 5000, trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(2 ** 10)])
         writer.stop()
         writer.join()
 
@@ -104,9 +96,7 @@ class AgentWriterTests(BaseTestCase):
         statsd = mock.Mock()
         writer = AgentWriter(agent_url="http://asdf:1234", dogstatsd=statsd, report_metrics=True)
         for i in range(10):
-            writer.write(
-                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
-            )
+            writer.write([Span(name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
         writer.flush_queue()
         statsd.distribution.assert_has_calls(
             [
@@ -122,9 +112,7 @@ class AgentWriterTests(BaseTestCase):
         statsd.reset_mock()
 
         for i in range(10):
-            writer.write(
-                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
-            )
+            writer.write([Span(name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
         writer.stop()
         writer.join()
 
@@ -142,7 +130,7 @@ class AgentWriterTests(BaseTestCase):
     def test_write_sync(self):
         statsd = mock.Mock()
         writer = AgentWriter(agent_url="http://asdf:1234", dogstatsd=statsd, report_metrics=True, sync_mode=True)
-        writer.write([Span(tracer=None, name="name", trace_id=1, span_id=j, parent_id=j - 1 or None) for j in range(5)])
+        writer.write([Span(name="name", trace_id=1, span_id=j, parent_id=j - 1 or None) for j in range(5)])
         statsd.distribution.assert_has_calls(
             [
                 mock.call("datadog.tracer.buffer.accepted.traces", 1, tags=[]),
@@ -160,9 +148,7 @@ class AgentWriterTests(BaseTestCase):
         writer = AgentWriter(agent_url="http://asdf:1234", dogstatsd=statsd, report_metrics=False)
         writer._metrics_reset = writer_metrics_reset
         for i in range(10):
-            writer.write(
-                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
-            )
+            writer.write([Span(name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
         writer.stop()
         writer.join()
 
@@ -177,12 +163,8 @@ class AgentWriterTests(BaseTestCase):
         writer = AgentWriter(agent_url="http://asdf:1234", dogstatsd=statsd, report_metrics=False)
         writer._metrics_reset = writer_metrics_reset
         for i in range(10):
-            writer.write(
-                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
-            )
-        writer.write(
-            [Span(tracer=None, name="a" * 5000, trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(2 ** 10)]
-        )
+            writer.write([Span(name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
+        writer.write([Span(name="a" * 5000, trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(2 ** 10)])
         writer.stop()
         writer.join()
 
@@ -197,10 +179,8 @@ class AgentWriterTests(BaseTestCase):
         writer = AgentWriter(agent_url="http://asdf:1234", buffer_size=5300, dogstatsd=statsd, report_metrics=False)
         writer._metrics_reset = writer_metrics_reset
         for i in range(10):
-            writer.write(
-                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
-            )
-        writer.write([Span(tracer=None, name="a", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
+            writer.write([Span(name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
+        writer.write([Span(name="a", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
         writer.stop()
         writer.join()
 
@@ -220,9 +200,7 @@ class AgentWriterTests(BaseTestCase):
         writer._encoder = writer_encoder
         writer._metrics_reset = writer_metrics_reset
         for i in range(n_traces):
-            writer.write(
-                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
-            )
+            writer.write([Span(name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
 
         writer.stop()
         writer.join()
@@ -241,12 +219,11 @@ class AgentWriterTests(BaseTestCase):
         writer._put = writer_put
 
         traces = [
-            [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)]
-            for i in range(4)
+            [Span(name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)] for i in range(4)
         ]
 
         traces_too_big = [
-            [Span(tracer=None, name="a" * 5000, trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(2 ** 10)]
+            [Span(name="a" * 5000, trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(2 ** 10)]
             for i in range(4)
         ]
 
@@ -315,9 +292,7 @@ class LogWriterTests(BaseTestCase):
         self.output = DummyOutput()
         writer = LogWriter(out=self.output)
         for i in range(self.N_TRACES):
-            writer.write(
-                [Span(tracer=None, name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(7)]
-            )
+            writer.write([Span(name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(7)])
         return writer
 
     def test_log_writer(self):
@@ -463,18 +438,18 @@ def test_agent_url_path(endpoint_assert_path):
     # test without base path
     endpoint_assert_path("/v0.")
     writer = AgentWriter(agent_url="http://%s:%s/" % (_HOST, _PORT))
-    writer._encoder.put([Span(None, "foobar")])
+    writer._encoder.put([Span("foobar")])
     writer.flush_queue(raise_exc=True)
 
     # test without base path nor trailing slash
     writer = AgentWriter(agent_url="http://%s:%s" % (_HOST, _PORT))
-    writer._encoder.put([Span(None, "foobar")])
+    writer._encoder.put([Span("foobar")])
     writer.flush_queue(raise_exc=True)
 
     # test with a base path
     endpoint_assert_path("/test/v0.")
     writer = AgentWriter(agent_url="http://%s:%s/test/" % (_HOST, _PORT))
-    writer._encoder.put([Span(None, "foobar")])
+    writer._encoder.put([Span("foobar")])
     writer.flush_queue(raise_exc=True)
 
 
@@ -485,14 +460,14 @@ def test_flush_connection_timeout_connect():
     else:
         exc_type = socket.error
     with pytest.raises(exc_type):
-        writer._encoder.put([Span(None, "foobar")])
+        writer._encoder.put([Span("foobar")])
         writer.flush_queue(raise_exc=True)
 
 
 def test_flush_connection_timeout(endpoint_test_timeout_server):
     writer = AgentWriter(agent_url="http://%s:%s" % (_HOST, _TIMEOUT_PORT))
     with pytest.raises(socket.timeout):
-        writer._encoder.put([Span(None, "foobar")])
+        writer._encoder.put([Span("foobar")])
         writer.flush_queue(raise_exc=True)
 
 
@@ -503,13 +478,13 @@ def test_flush_connection_reset(endpoint_test_reset_server):
     else:
         exc_types = (httplib.BadStatusLine,)
     with pytest.raises(exc_types):
-        writer._encoder.put([Span(None, "foobar")])
+        writer._encoder.put([Span("foobar")])
         writer.flush_queue(raise_exc=True)
 
 
 def test_flush_connection_uds(endpoint_uds_server):
     writer = AgentWriter(agent_url="unix://%s" % endpoint_uds_server.server_address)
-    writer._encoder.put([Span(None, "foobar")])
+    writer._encoder.put([Span("foobar")])
     writer.flush_queue(raise_exc=True)
 
 
@@ -530,7 +505,7 @@ def test_racing_start():
     writer = AgentWriter(agent_url="http://dne:1234")
 
     def do_write(i):
-        writer.write([Span(None, str(i))])
+        writer.write([Span(str(i))])
 
     ts = [threading.Thread(target=do_write, args=(i,)) for i in range(100)]
     for t in ts:


### PR DESCRIPTION
Deprecated `Span.tracer` was removed. Tracer parameter was also removed from Span.__init__() 

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
