### PR TITLE
chore: ignore dependabot for pr-name

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,10 @@
-module.exports = {extends: ['@commitlint/config-conventional']}
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  ignores: [
+    /*
+     * dependabot cannot be configured to match commitlint configuration
+     * https://github.com/dependabot/dependabot-core/issues/1666
+     */
+    (commit) => commit.includes("chore(deps): Bump"),
+  ],
+};


### PR DESCRIPTION
Dependabot is creating PRs with sentence case which breaks commitlint used in the pr-name action. 

See https://github.com/dependabot/dependabot-core/issues/1666