### PR TITLE
chore: move flake8 configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,25 @@ universal=1
 [codespell]
 skip = *.json,*.cpp,*.c,.riot,.tox,.mypy_cache,.git,*ddtrace/vendor
 ignore-words-list = dne,fo,medias,ment,nin,ot,setttings,statics
+
+[flake8]
+max-line-length=120
+exclude=
+  .ddtox,.tox,.riot,.ddriot,.venv*
+  .git,__pycache__,
+  .eggs,*.egg,
+  build,
+  # We shouldn't lint our vendored dependencies
+  ddtrace/vendor/
+  ddtrace/profiling/exporter/pprof_pb2.py
+  ddtrace/profiling/exporter/pprof_pre312_pb2.py
+  tests/profiling/simple_program_gevent.py
+# Ignore:
+# A003: XXX is a python builtin, consider renaming the class attribute
+# G201 Logging: .exception(...) should be used instead of .error(..., exc_info=True)
+# E231,W503,E203: not respected by black
+# We ignore most of the D errors because there are too many; the goal is to fix them eventually
+ignore = W503,E231,A003,G201,D100,D101,D102,D103,D104,D105,D106,D107,D200,D202,D204,D205,D208,D210,D300,D400,D401,D403,D413,RST301,B902,E203
+enable-extensions=G
+rst-roles = class,meth,obj,ref
+rst-directives = py:data

--- a/tox.ini
+++ b/tox.ini
@@ -299,25 +299,3 @@ python_files = test*\.py
 filterwarnings =
     # Show any DeprecationWarnings once
     once::DeprecationWarning
-
-[flake8]
-max-line-length=120
-exclude=
-  .ddtox,.tox,.riot,.ddriot,.venv*
-  .git,__pycache__,
-  .eggs,*.egg,
-  build,
-  # We shouldn't lint our vendored dependencies
-  ddtrace/vendor/
-  ddtrace/profiling/exporter/pprof_pb2.py
-  ddtrace/profiling/exporter/pprof_pre312_pb2.py
-  tests/profiling/simple_program_gevent.py
-# Ignore:
-# A003: XXX is a python builtin, consider renaming the class attribute
-# G201 Logging: .exception(...) should be used instead of .error(..., exc_info=True)
-# E231,W503,E203: not respected by black
-# We ignore most of the D errors because there are too many; the goal is to fix them eventually
-ignore = W503,E231,A003,G201,D100,D101,D102,D103,D104,D105,D106,D107,D200,D202,D204,D205,D208,D210,D300,D400,D401,D403,D413,RST301,B902,E203
-enable-extensions=G
-rst-roles = class,meth,obj,ref
-rst-directives = py:data


### PR DESCRIPTION
Move the flake8 configuration out of `tox.ini` and into `setup.cfg`.

We cannot use `pyproject.toml` as flake8 does not yet support [PEP 518](https://www.python.org/dev/peps/pep-0518/). 

https://github.com/PyCQA/flake8/issues/234 