### PR TITLE
chore(tracer): deprecate Tracer.log attribute

### DIFF
--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -108,6 +108,8 @@ def collect(tracer):
 
     pip_version = packages_available.get("pip", "N/A")
 
+    from ddtrace.tracer import log
+
     return dict(
         # Timestamp UTC ISO 8601
         date=datetime.datetime.utcnow().isoformat(),
@@ -133,7 +135,7 @@ def collect(tracer):
         priority_sampler_type=type(tracer.priority_sampler).__name__ if tracer.priority_sampler else "N/A",
         sampler_rules=sampler_rules,
         service=ddtrace.config.service or "",
-        debug=ddtrace.tracer.log.isEnabledFor(logging.DEBUG),
+        debug=log.isEnabledFor(logging.DEBUG),
         enabled_cli="ddtrace" in os.getenv("PYTHONPATH", ""),
         analytics_enabled=ddtrace.config.analytics_enabled,
         log_injection_enabled=ddtrace.config.logs_injection,

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -115,7 +115,6 @@ class Tracer(object):
         :param url: The Datadog agent URL.
         :param dogstatsd_url: The DogStatsD URL.
         """
-        self.log = log
         self._filters = []  # type: List[TraceFilter]
 
         # globally set tags
@@ -207,15 +206,26 @@ class Tracer(object):
         self._hooks.deregister(self.__class__.start_span, func)
         return func
 
+    @removals.removed_property(message="Use ddtrace.tracer.log instead", removal_version="1.0.0")
+    def log(self):
+        # type: () -> logging.Logger
+        return log
+
+    @log.setter  # type: ignore
+    def log(self, value):
+        # type: (logging.Logger) -> None
+        global log
+        log = value
+
     @property
     def debug_logging(self):
-        return self.log.isEnabledFor(logging.DEBUG)
+        return log.isEnabledFor(logging.DEBUG)
 
     @debug_logging.setter  # type: ignore[misc]
     @deprecated(message="Use logging.setLevel instead", version="1.0.0")
     def debug_logging(self, value):
         # type: (bool) -> None
-        self.log.setLevel(logging.DEBUG if value else logging.WARN)
+        log.setLevel(logging.DEBUG if value else logging.WARN)
 
     @deprecated("Use .tracer, not .tracer()", "1.0.0")
     def __call__(self):
@@ -418,7 +428,7 @@ class Tracer(object):
                 msg = "Failed to collect start-up logs: %s" % e
                 self._log_compat(logging.WARNING, "- DATADOG TRACER DIAGNOSTIC - %s" % msg)
             else:
-                if self.log.isEnabledFor(logging.INFO):
+                if log.isEnabledFor(logging.INFO):
                     msg = "- DATADOG TRACER CONFIGURATION - %s" % json.dumps(info)
                     self._log_compat(logging.INFO, msg)
 
@@ -650,17 +660,15 @@ class Tracer(object):
         # Debug check: if the finishing span has a parent and its parent
         # is not the next active span then this is an error in synchronous tracing.
         if span._parent is not None and active is not span._parent:
-            self.log.debug(
-                "span %r closing after its parent %r, this is an error when not using async", span, span._parent
-            )
+            log.debug("span %r closing after its parent %r, this is an error when not using async", span, span._parent)
 
         # Only call span processors if the tracer is enabled
         if self.enabled:
             for p in self._span_processors:
                 p.on_span_finish(span)
 
-        if self.log.isEnabledFor(logging.DEBUG):
-            self.log.debug("finishing span %s (enabled:%s)", span._pprint(), self.enabled)
+        if log.isEnabledFor(logging.DEBUG):
+            log.debug("finishing span %s (enabled:%s)", span._pprint(), self.enabled)
 
     def _initialize_span_processors(self, appsec_enabled=asbool(get_env("appsec", "enabled", default=False))):
         # type: (Optional[bool]) -> None
@@ -710,10 +718,10 @@ class Tracer(object):
         to import the tracer as early as possible, it will likely be the case
         that there are no handlers installed yet.
         """
-        if compat.PY2 and not hasHandlers(self.log):
+        if compat.PY2 and not hasHandlers(log):
             sys.stderr.write("%s\n" % msg)
         else:
-            self.log.log(level, msg)
+            log.log(level, msg)
 
     def _trace(self, name, service=None, resource=None, span_type=None):
         # type: (str, Optional[str], Optional[str], Optional[str]) -> Span
@@ -808,10 +816,10 @@ class Tracer(object):
         if not spans:
             return  # nothing to do
 
-        if self.log.isEnabledFor(logging.DEBUG):
-            self.log.debug("writing %s spans (enabled:%s)", len(spans), self.enabled)
+        if log.isEnabledFor(logging.DEBUG):
+            log.debug("writing %s spans (enabled:%s)", len(spans), self.enabled)
             for span in spans:
-                self.log.debug("\n%s", span._pprint())
+                log.debug("\n%s", span._pprint())
 
         if not self.enabled:
             return

--- a/releasenotes/notes/deprecate-tracer-log-attribute-a7fb4c9c23d5b7b4.yaml
+++ b/releasenotes/notes/deprecate-tracer-log-attribute-a7fb4c9c23d5b7b4.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    :py:attr:`ddtrace.Tracer.log` is deprecated. Use :py:data:`ddtrace.tracer.log` instead.

--- a/tests/commands/ddtrace_run_debug.py
+++ b/tests/commands/ddtrace_run_debug.py
@@ -1,8 +1,8 @@
 import logging
 
-from ddtrace import tracer
+from ddtrace.tracer import log
 
 
 if __name__ == "__main__":
-    assert tracer.log.isEnabledFor(logging.DEBUG)
+    assert log.isEnabledFor(logging.DEBUG)
     print("Test success")

--- a/tests/commands/ddtrace_run_no_debug.py
+++ b/tests/commands/ddtrace_run_no_debug.py
@@ -1,8 +1,8 @@
 import logging
 
-from ddtrace import tracer
+from ddtrace.tracer import log
 
 
 if __name__ == "__main__":
-    assert not tracer.log.isEnabledFor(logging.DEBUG)
+    assert not log.isEnabledFor(logging.DEBUG)
     print("Test success")

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -8,7 +8,6 @@ import sys
 from typing import List
 from typing import Optional
 
-import mock
 import pytest
 
 import ddtrace
@@ -147,7 +146,12 @@ def test_debug_post_configure():
     assert re.match("^Agent not reachable.*No such file or directory", agent_error)
 
 
+@pytest.mark.usefixtures("caplog")
 class TestGlobalConfig(SubprocessTestCase):
+    @pytest.fixture(autouse=True)
+    def use_caplog(self, caplog):
+        self._caplog = caplog
+
     @run_in_subprocess(
         env_overrides=dict(
             DD_AGENT_HOST="0.0.0.0",
@@ -187,6 +191,7 @@ class TestGlobalConfig(SubprocessTestCase):
         f = debug.collect(ddtrace.tracer)
         assert f.get("agent_url") == "http://0.0.0.0:1234"
 
+    @pytest.mark.usefixtures("caplog")
     @run_in_subprocess(
         env_overrides=dict(
             DD_TRACE_AGENT_URL="http://localhost:8126",
@@ -195,9 +200,10 @@ class TestGlobalConfig(SubprocessTestCase):
     )
     def test_tracer_loglevel_info_connection(self):
         tracer = ddtrace.Tracer()
-        tracer.log = mock.MagicMock()
-        tracer.configure()
-        assert tracer.log.log.mock_calls == [mock.call(logging.INFO, re_matcher("- DATADOG TRACER CONFIGURATION - "))]
+
+        with self._caplog.at_level(logging.DEBUG, logger="ddtrace.tracer"):
+            tracer.configure()
+            assert re_matcher("- DATADOG TRACER CONFIGURATION - ") in self._caplog.messages
 
     @run_in_subprocess(
         env_overrides=dict(
@@ -207,14 +213,13 @@ class TestGlobalConfig(SubprocessTestCase):
     )
     def test_tracer_loglevel_info_no_connection(self):
         tracer = ddtrace.Tracer()
-        tracer.log = mock.MagicMock()
-        tracer.configure()
-        # Python 2 logs will go to stderr directly since there's no log handler
-        if PY3:
-            assert tracer.log.log.mock_calls == [
-                mock.call(logging.INFO, re_matcher("- DATADOG TRACER CONFIGURATION - ")),
-                mock.call(logging.WARNING, re_matcher("- DATADOG TRACER DIAGNOSTIC - ")),
-            ]
+
+        with self._caplog.at_level(logging.WARNING, logger="ddtrace.tracer"):
+            # Python 2 logs will go to stderr directly since there's no log handler
+            tracer.configure()
+            if PY3:
+                assert re_matcher("- DATADOG TRACER CONFIGURATION - ") in self._caplog.messages
+                assert re_matcher("-  DATADOG TRACER DIAGNOSTIC - ") in self._caplog.messages
 
     @run_in_subprocess(
         env_overrides=dict(
@@ -223,11 +228,11 @@ class TestGlobalConfig(SubprocessTestCase):
     )
     def test_tracer_loglevel_info_no_connection_py2_handler(self):
         tracer = ddtrace.Tracer()
-        tracer.log = mock.MagicMock()
-        logging.basicConfig()
-        tracer.configure()
-        if PY2:
-            assert tracer.log.log.mock_calls == []
+        with self._caplog.at_level(logging.DEBUG, logger="ddtrace.tracer"):
+            logging.basicConfig()
+            tracer.configure()
+            if PY2:
+                assert self._caplog.messages == []
 
     @run_in_subprocess(
         env_overrides=dict(
@@ -237,9 +242,9 @@ class TestGlobalConfig(SubprocessTestCase):
     )
     def test_tracer_log_disabled_error(self):
         tracer = ddtrace.Tracer()
-        tracer.log = mock.MagicMock()
-        tracer.configure()
-        assert tracer.log.log.mock_calls == []
+        with self._caplog.at_level(logging.DEBUG, logger="ddtrace.tracer"):
+            tracer.configure()
+            assert self._caplog.messages == []
 
     @run_in_subprocess(
         env_overrides=dict(
@@ -249,9 +254,9 @@ class TestGlobalConfig(SubprocessTestCase):
     )
     def test_tracer_log_disabled(self):
         tracer = ddtrace.Tracer()
-        tracer.log = mock.MagicMock()
-        tracer.configure()
-        assert tracer.log.log.mock_calls == []
+        with self._caplog.at_level(logging.DEBUG, logger="ddtrace.tracer"):
+            tracer.configure()
+            assert self._caplog.messages == []
 
     @run_in_subprocess(
         env_overrides=dict(
@@ -261,9 +266,9 @@ class TestGlobalConfig(SubprocessTestCase):
     def test_tracer_info_level_log(self):
         logging.basicConfig(level=logging.INFO)
         tracer = ddtrace.Tracer()
-        tracer.log = mock.MagicMock()
-        tracer.configure()
-        assert tracer.log.log.mock_calls == []
+        with self._caplog.at_level(logging.INFO, logger="ddtrace.tracer"):
+            tracer.configure()
+            assert self._caplog.messages == []
 
 
 def test_runtime_metrics_enabled_via_manual_start(ddtrace_run_python_code_in_subprocess):

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1118,17 +1118,17 @@ def test_filters(tracer, test_spans):
         assert s.get_tag("boop") == "beep"
 
 
-def test_early_exit(caplog, tracer, test_spans):
+def test_early_exit(tracer, test_spans):
     s1 = tracer.trace("1")
     s2 = tracer.trace("2")
-
-    with caplog.at_level(logging.DEBUG, logger="ddtrace.tracer"):
+    with mock.patch.object(logging.Logger, "debug") as mock_logger:
         s1.finish()
         s2.finish()
-        assert (
-            "span %r closing after its parent %r, this is an error when not using async" % (s2, s1) in caplog.messages
-        )
 
+    calls = [
+        mock.call("span %r closing after its parent %r, this is an error when not using async", s2, s1),
+    ]
+    mock_logger.assert_has_calls(calls)
     assert s1.parent_id is None
     assert s2.parent_id is s1.span_id
 

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -4,6 +4,7 @@ tests for Tracer and utilities.
 """
 import contextlib
 import gc
+import logging
 import multiprocessing
 import os
 from os import getpid
@@ -1117,16 +1118,17 @@ def test_filters(tracer, test_spans):
         assert s.get_tag("boop") == "beep"
 
 
-def test_early_exit(tracer, test_spans):
+def test_early_exit(caplog, tracer, test_spans):
     s1 = tracer.trace("1")
     s2 = tracer.trace("2")
-    s1.finish()
-    tracer.log = mock.MagicMock(wraps=tracer.log)
-    s2.finish()
-    calls = [
-        mock.call("span %r closing after its parent %r, this is an error when not using async", s2, s1),
-    ]
-    tracer.log.debug.assert_has_calls(calls)
+
+    with caplog.at_level(logging.DEBUG, logger="ddtrace.tracer"):
+        s1.finish()
+        s2.finish()
+        assert (
+            "span %r closing after its parent %r, this is an error when not using async" % (s2, s1) in caplog.messages
+        )
+
     assert s1.parent_id is None
     assert s2.parent_id is s1.span_id
 


### PR DESCRIPTION
This change makes logging consistent with the other ddtrace modules (ex. writer.py). 

Note: `from ddtrace.tracer import log` is used to avoid import conflicts with the global tracer's log attribute (`ddtrace.tracer.log` -> Tracer.log)

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
