### PR TITLE
chore(tracing): deprecate Tracer.tags

### DIFF
--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -142,7 +142,7 @@ def collect(tracer):
         dd_version=ddtrace.config.version or "",
         priority_sampling_enabled=tracer._priority_sampler is not None,
         global_tags=os.getenv("DD_TAGS", ""),
-        tracer_tags=tags_to_str(tracer.tags),
+        tracer_tags=tags_to_str(tracer._tags),
         integrations=integration_configs,
         partial_flush_enabled=tracer._partial_flush_enabled,
         partial_flush_min_spans=tracer._partial_flush_min_spans,

--- a/ddtrace/internal/runtime/tag_collectors.py
+++ b/ddtrace/internal/runtime/tag_collectors.py
@@ -24,8 +24,8 @@ class TracerTagCollector(RuntimeTagCollector):
         ddtrace = self.modules.get("ddtrace")
         # make sure to copy _services to avoid RuntimeError: Set changed size during iteration
         tags = [(SERVICE, service) for service in list(ddtrace.tracer._services)]
-        if ENV_KEY in ddtrace.tracer.tags:
-            tags.append((ENV_KEY, ddtrace.tracer.tags[ENV_KEY]))
+        if ddtrace.tracer._tags.get(ENV_KEY):
+            tags.append((ENV_KEY, ddtrace.tracer._tags.get(ENV_KEY)))
         return tags
 
 

--- a/ddtrace/internal/runtime/tag_collectors.py
+++ b/ddtrace/internal/runtime/tag_collectors.py
@@ -24,7 +24,7 @@ class TracerTagCollector(RuntimeTagCollector):
         ddtrace = self.modules.get("ddtrace")
         # make sure to copy _services to avoid RuntimeError: Set changed size during iteration
         tags = [(SERVICE, service) for service in list(ddtrace.tracer._services)]
-        if ddtrace.tracer._tags.get(ENV_KEY):
+        if ENV_KEY in ddtrace.tracer._tags:
             tags.append((ENV_KEY, ddtrace.tracer._tags.get(ENV_KEY)))
         return tags
 

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -119,7 +119,7 @@ class Tracer(object):
         self._filters = []  # type: List[TraceFilter]
 
         # globally set tags
-        self.tags = config.tags.copy()
+        self._tags = config.tags.copy()
 
         # a buffer for service info so we don't perpetually send the same things
         self._services = set()  # type: Set[str]
@@ -606,8 +606,8 @@ class Tracer(object):
             span._metrics[PID] = self._pid
 
         # Apply default global tags.
-        if self.tags:
-            span.set_tags(self.tags)
+        if self._tags:
+            span.set_tags(self._tags)
 
         if config.env:
             span._set_str_tag(ENV_KEY, config.env)
@@ -839,6 +839,16 @@ class Tracer(object):
         # type: (BaseSampler) -> None
         self._sampler = val
 
+    @removals.removed_property(removal_version="1.0.0")
+    def tags(self):
+        # type: () -> dict[str, str]
+        return self._tags
+
+    @tags.setter  # type: ignore
+    def tags(self, t):
+        # type: (dict[str, str]) -> None
+        self._tags = t
+
     @removals.removed_property(message="Use Tracer.flush instead to flush buffered traces to agent", version="1.0.0")
     def writer(self):
         return self._writer
@@ -965,7 +975,7 @@ class Tracer(object):
 
         :param dict tags: dict of tags to set at tracer level
         """
-        self.tags.update(tags)
+        self._tags.update(tags)
 
     def _restore_from_shutdown(self):
         with self._shutdown_lock:

--- a/releasenotes/notes/deprecate-tracer-tags-attribute-e1b3706820110a09.yaml
+++ b/releasenotes/notes/deprecate-tracer-tags-attribute-e1b3706820110a09.yaml
@@ -1,4 +1,4 @@
 ---
 deprecations:
   - |
-    :py:attr:`ddtrace.Tracer.tags` is deprecated. Use :py:meth:`ddtrace.Tracer.set_tag` and :py:meth:`ddtrace.Tracer.get_tag` instead.
+    :py:attr:`ddtrace.Tracer.tags` is deprecated. Use the environment variable :ref:`DD_TAGS<dd-tags>` to set the global tags instead.

--- a/releasenotes/notes/deprecate-tracer-tags-attribute-e1b3706820110a09.yaml
+++ b/releasenotes/notes/deprecate-tracer-tags-attribute-e1b3706820110a09.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    :py:attr:`ddtrace.Tracer.tags` is deprecated. Use :py:meth:`ddtrace.Tracer.set_tag` and :py:meth:`ddtrace.Tracer.get_tag` instead.

--- a/tests/commands/ddtrace_run_env.py
+++ b/tests/commands/ddtrace_run_env.py
@@ -2,5 +2,5 @@ from ddtrace import tracer
 
 
 if __name__ == "__main__":
-    assert tracer.tags["env"] == "test"
+    assert tracer._tags.get("env") == "test"
     print("Test success")

--- a/tests/commands/ddtrace_run_global_tags.py
+++ b/tests/commands/ddtrace_run_global_tags.py
@@ -2,7 +2,7 @@ from ddtrace import tracer
 
 
 if __name__ == "__main__":
-    assert tracer.tags["a"] == "True"
-    assert tracer.tags["b"] == "0"
-    assert tracer.tags["c"] == "C"
+    assert tracer._tags.get("a") == "True"
+    assert tracer._tags.get("b") == "0"
+    assert tracer._tags.get("c") == "C"
     print("Test success")

--- a/tests/contrib/tornado/test_config.py
+++ b/tests/contrib/tornado/test_config.py
@@ -42,7 +42,8 @@ class TestTornadoSettings(TornadoTestCase):
 
     def test_tracer_is_properly_configured(self):
         # the tracer must be properly configured
-        assert self.tracer.tags == {"env": "production", "debug": "false"}
+        assert self.tracer._tags.get("env") == "production"
+        assert self.tracer._tags.get("debug") == "false"
         assert self.tracer.enabled is False
         assert self.tracer.agent_trace_url == "http://dd-agent.service.consul:8126"
 

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -837,14 +837,14 @@ class EnvTracerTestCase(TracerTestCase):
 
     @run_in_subprocess(env_overrides=dict(DD_TAGS="key1:value1,key2:value2"))
     def test_dd_tags(self):
-        assert self.tracer.tags["key1"] == "value1"
-        assert self.tracer.tags["key2"] == "value2"
+        assert self.tracer._tags.get("key1") == "value1"
+        assert self.tracer._tags.get("key2") == "value2"
 
     @run_in_subprocess(env_overrides=dict(DD_TAGS="key1:value1,key2:value2,key3"))
     def test_dd_tags_invalid(self):
-        assert "key1" in self.tracer.tags
-        assert "key2" in self.tracer.tags
-        assert "key3" not in self.tracer.tags
+        assert self.tracer._tags.get("key1")
+        assert self.tracer._tags.get("key2")
+        assert self.tracer._tags.get("key3") is None
 
     @run_in_subprocess(env_overrides=dict(DD_TAGS="service:mysvc,env:myenv,version:myvers"))
     def test_tags_from_DD_TAGS(self):


### PR DESCRIPTION
Global tags should be set via environment variable `DD_TAGS<dd-tags>`

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
