### PR TITLE
chore(tracing): internalize Tracer.sampler and Tracer.priority_sampler

### DIFF
--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -67,8 +67,8 @@ def collect(tracer):
         agent_error = None
 
     sampler_rules = None
-    if isinstance(tracer.sampler, DatadogSampler):
-        sampler_rules = [str(rule) for rule in tracer.sampler.rules]
+    if isinstance(tracer._sampler, DatadogSampler):
+        sampler_rules = [str(rule) for rule in tracer._sampler.rules]
 
     is_venv = in_venv()
 
@@ -129,8 +129,8 @@ def collect(tracer):
         is_global_tracer=tracer == ddtrace.tracer,
         enabled_env_setting=os.getenv("DATADOG_TRACE_ENABLED"),
         tracer_enabled=tracer.enabled,
-        sampler_type=type(tracer.sampler).__name__ if tracer.sampler else "N/A",
-        priority_sampler_type=type(tracer.priority_sampler).__name__ if tracer.priority_sampler else "N/A",
+        sampler_type=type(tracer._sampler).__name__ if tracer._sampler else "N/A",
+        priority_sampler_type=type(tracer._priority_sampler).__name__ if tracer._priority_sampler else "N/A",
         sampler_rules=sampler_rules,
         service=ddtrace.config.service or "",
         debug=ddtrace.tracer.log.isEnabledFor(logging.DEBUG),
@@ -140,7 +140,7 @@ def collect(tracer):
         health_metrics_enabled=ddtrace.config.health_metrics_enabled,
         runtime_metrics_enabled=RuntimeWorker.enabled,
         dd_version=ddtrace.config.version or "",
-        priority_sampling_enabled=tracer.priority_sampler is not None,
+        priority_sampling_enabled=tracer._priority_sampler is not None,
         global_tags=os.getenv("DD_TAGS", ""),
         tracer_tags=tags_to_str(tracer.tags),
         integrations=integration_configs,

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -130,8 +130,8 @@ class Tracer(object):
 
         self.enabled = asbool(get_env("trace", "enabled", default=True))
         self.context_provider = DefaultContextProvider()
-        self.sampler = DatadogSampler()  # type: BaseSampler
-        self.priority_sampler = RateByServiceSampler()  # type: Optional[BasePrioritySampler]
+        self._sampler = DatadogSampler()  # type: BaseSampler
+        self._priority_sampler = RateByServiceSampler()  # type: Optional[BasePrioritySampler]
         self._dogstatsd_url = agent.get_stats_url() if dogstatsd_url is None else dogstatsd_url
 
         if self._use_log_writer() and url is None:
@@ -142,8 +142,8 @@ class Tracer(object):
 
             writer = AgentWriter(
                 agent_url=url,
-                sampler=self.sampler,
-                priority_sampler=self.priority_sampler,
+                sampler=self._sampler,
+                priority_sampler=self._priority_sampler,
                 dogstatsd=get_dogstatsd_client(self._dogstatsd_url),
                 report_metrics=config.health_metrics_enabled,
                 sync_mode=self._use_sync_mode(),
@@ -338,14 +338,14 @@ class Tracer(object):
             self._partial_flush_min_spans = partial_flush_min_spans
 
         # If priority sampling is not set or is True and no priority sampler is set yet
-        if priority_sampling in (None, True) and not self.priority_sampler:
-            self.priority_sampler = RateByServiceSampler()
+        if priority_sampling in (None, True) and not self._priority_sampler:
+            self._priority_sampler = RateByServiceSampler()
         # Explicitly disable priority sampling
         elif priority_sampling is False:
-            self.priority_sampler = None
+            self._priority_sampler = None
 
         if sampler is not None:
-            self.sampler = sampler
+            self._sampler = sampler
 
         self._dogstatsd_url = dogstatsd_url or self._dogstatsd_url
 
@@ -391,8 +391,8 @@ class Tracer(object):
             agent.verify_url(url)
             self._writer = AgentWriter(
                 url,
-                sampler=self.sampler,
-                priority_sampler=self.priority_sampler,
+                sampler=self._sampler,
+                priority_sampler=self._priority_sampler,
                 dogstatsd=get_dogstatsd_client(self._dogstatsd_url),
                 report_metrics=config.health_metrics_enabled,
                 sync_mode=self._use_sync_mode(),
@@ -575,26 +575,26 @@ class Tracer(object):
             span._local_root = span
             if config.report_hostname:
                 span._set_str_tag(HOSTNAME_KEY, hostname.get_hostname())
-            span.sampled = self.sampler.sample(span)
+            span.sampled = self._sampler.sample(span)
             # Old behavior
             # DEV: The new sampler sets metrics and priority sampling on the span for us
-            if not isinstance(self.sampler, DatadogSampler):
+            if not isinstance(self._sampler, DatadogSampler):
                 if span.sampled:
                     # When doing client sampling in the client, keep the sample rate so that we can
                     # scale up statistics in the next steps of the pipeline.
-                    if isinstance(self.sampler, RateSampler):
-                        span.set_metric(SAMPLE_RATE_METRIC_KEY, self.sampler.sample_rate)
+                    if isinstance(self._sampler, RateSampler):
+                        span.set_metric(SAMPLE_RATE_METRIC_KEY, self._sampler.sample_rate)
 
-                    if self.priority_sampler:
+                    if self._priority_sampler:
                         # At this stage, it's important to have the service set. If unset,
                         # priority sampler will use the default sampling rate, which might
                         # lead to oversampling (that is, dropping too many traces).
-                        if self.priority_sampler.sample(span):
+                        if self._priority_sampler.sample(span):
                             context.sampling_priority = AUTO_KEEP
                         else:
                             context.sampling_priority = AUTO_REJECT
                 else:
-                    if self.priority_sampler:
+                    if self._priority_sampler:
                         # If dropped by the local sampler, distributed instrumentation can drop it too.
                         context.sampling_priority = AUTO_REJECT
             else:
@@ -818,6 +818,26 @@ class Tracer(object):
 
         if spans is not None:
             self._writer.write(spans=spans)
+
+    @removals.removed_property(removal_version="1.0.0")
+    def priority_sampler(self):
+        # type: () -> Optional[BasePrioritySampler]
+        return self._priority_sampler
+
+    @priority_sampler.setter  # type: ignore[no-redef]
+    def priority_sampler(self, val):
+        # type: (Optional[BasePrioritySampler]) -> None
+        self._priority_sampler = val
+
+    @removals.removed_property(removal_version="1.0.0")
+    def sampler(self):
+        # type: () -> BaseSampler
+        return self._sampler
+
+    @sampler.setter  # type: ignore[no-redef]
+    def sampler(self, val):
+        # type: (BaseSampler) -> None
+        self._sampler = val
 
     @removals.removed_property(message="Use Tracer.flush instead to flush buffered traces to agent", version="1.0.0")
     def writer(self):

--- a/releasenotes/notes/deprecate-tracer-sampler-attribute-c7c9d0523a8162a7.yaml
+++ b/releasenotes/notes/deprecate-tracer-sampler-attribute-c7c9d0523a8162a7.yaml
@@ -1,0 +1,3 @@
+deprecations:
+  - |
+    :py:attr:`ddtrace.Tracer.sampler` and :py:attr:`ddtrace.Tracer.priority_sampler` are deprecated.

--- a/releasenotes/notes/deprecate-tracer-sampler-attribute-c7c9d0523a8162a7.yaml
+++ b/releasenotes/notes/deprecate-tracer-sampler-attribute-c7c9d0523a8162a7.yaml
@@ -1,3 +1,5 @@
 deprecations:
   - |
-    :py:attr:`ddtrace.Tracer.sampler` and :py:attr:`ddtrace.Tracer.priority_sampler` are deprecated.
+    :py:attr:`ddtrace.Tracer.sampler` is deprecated.
+  - |
+    :py:attr:`ddtrace.Tracer.priority_sampler` is deprecated.

--- a/tests/commands/ddtrace_run_priority_sampling.py
+++ b/tests/commands/ddtrace_run_priority_sampling.py
@@ -2,5 +2,5 @@ from ddtrace import tracer
 
 
 if __name__ == "__main__":
-    assert tracer.priority_sampler is not None
+    assert tracer._priority_sampler is not None
     print("Test success")

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -285,7 +285,7 @@ async def test_distributed_tracing(app_tracer, aiohttp_client):
 async def test_distributed_tracing_with_sampling_true(app_tracer, aiohttp_client):
     app, tracer = app_tracer
     client = await aiohttp_client(app)
-    tracer.priority_sampler = RateSampler(0.1)
+    tracer._priority_sampler = RateSampler(0.1)
 
     tracing_headers = {
         "x-datadog-trace-id": "100",
@@ -311,7 +311,7 @@ async def test_distributed_tracing_with_sampling_true(app_tracer, aiohttp_client
 async def test_distributed_tracing_with_sampling_false(app_tracer, aiohttp_client):
     app, tracer = app_tracer
     client = await aiohttp_client(app)
-    tracer.priority_sampler = RateSampler(0.9)
+    tracer._priority_sampler = RateSampler(0.9)
 
     tracing_headers = {
         "x-datadog-trace-id": "100",
@@ -361,7 +361,7 @@ async def test_distributed_tracing_disabled(app_tracer, aiohttp_client):
 async def test_distributed_tracing_sub_span(app_tracer, aiohttp_client):
     app, tracer = app_tracer
     client = await aiohttp_client(app)
-    tracer.priority_sampler = RateSampler(1.0)
+    tracer._priority_sampler = RateSampler(1.0)
 
     # activate distributed tracing
     tracing_headers = {

--- a/tests/integration/test_integration_snapshots.py
+++ b/tests/integration/test_integration_snapshots.py
@@ -58,7 +58,7 @@ def test_filters(writer, tracer):
     if writer == "sync":
         writer = AgentWriter(
             tracer.writer.agent_url,
-            priority_sampler=tracer.priority_sampler,
+            priority_sampler=tracer._priority_sampler,
             sync_mode=True,
         )
         # Need to copy the headers which contain the test token to associate
@@ -99,7 +99,7 @@ def test_sampling(writer, tracer):
     if writer == "sync":
         writer = AgentWriter(
             tracer.writer.agent_url,
-            priority_sampler=tracer.priority_sampler,
+            priority_sampler=tracer._priority_sampler,
             sync_mode=True,
         )
         # Need to copy the headers which contain the test token to associate
@@ -166,7 +166,7 @@ def test_sampling(writer, tracer):
 @snapshot(async_mode=False)
 def test_synchronous_writer():
     tracer = Tracer()
-    writer = AgentWriter(tracer._writer.agent_url, sync_mode=True, priority_sampler=tracer.priority_sampler)
+    writer = AgentWriter(tracer._writer.agent_url, sync_mode=True, priority_sampler=tracer._priority_sampler)
     tracer.configure(writer=writer)
     with tracer.trace("operation1", service="my-svc"):
         with tracer.trace("child1"):

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -67,7 +67,7 @@ class RateSamplerTest(unittest.TestCase):
         for sample_rate in [0.1, 0.25, 0.5, 1]:
             tracer = DummyTracer()
 
-            tracer.sampler = RateSampler(sample_rate)
+            tracer._sampler = RateSampler(sample_rate)
 
             iterations = int(1e4 / sample_rate)
 
@@ -88,7 +88,7 @@ class RateSamplerTest(unittest.TestCase):
         """Test that for a given trace ID, the result is always the same"""
         tracer = DummyTracer()
 
-        tracer.sampler = RateSampler(0.5)
+        tracer._sampler = RateSampler(0.5)
 
         for i in range(10):
             span = tracer.trace(str(i))
@@ -99,20 +99,20 @@ class RateSamplerTest(unittest.TestCase):
             sampled = 1 == len(samples)
             for j in range(10):
                 other_span = Span(None, str(i), trace_id=span.trace_id)
-                assert sampled == tracer.sampler.sample(
+                assert sampled == tracer._sampler.sample(
                     other_span
                 ), "sampling should give the same result for a given trace_id"
 
     def test_negative_sample_rate_raises_error(self):
         tracer = DummyTracer()
         with pytest.raises(ValueError, match="sample_rate of -0.5 is negative"):
-            tracer.sampler = RateSampler(sample_rate=-0.5)
+            tracer._sampler = RateSampler(sample_rate=-0.5)
 
     def test_sample_rate_0_does_not_reset_to_1(self):
         # Regression test for case where a sample rate of 0 caused the sample rate to be reset to 1
         tracer = DummyTracer()
-        tracer.sampler = RateSampler(sample_rate=0)
-        assert tracer.sampler.sample_rate == 0
+        tracer._sampler = RateSampler(sample_rate=0)
+        assert tracer._sampler.sample_rate == 0
 
 
 class RateByServiceSamplerTest(unittest.TestCase):
@@ -138,7 +138,7 @@ class RateByServiceSamplerTest(unittest.TestCase):
             # is priority sampling aware and pass it a reference on the
             # priority sampler to send the feedback it gets from the agent
             assert writer is not tracer._writer, "writer should have been updated by configure"
-            tracer.priority_sampler.set_sample_rate(sample_rate)
+            tracer._priority_sampler.set_sample_rate(sample_rate)
 
             iterations = int(1e4 / sample_rate)
 
@@ -184,7 +184,7 @@ class RateByServiceSamplerTest(unittest.TestCase):
 
         tracer = DummyTracer()
         tracer.configure(sampler=AllSampler())
-        priority_sampler = tracer.priority_sampler
+        priority_sampler = tracer._priority_sampler
         for case in cases:
             priority_sampler.update_rate_by_service_sample_rates(case)
             rates = {}


### PR DESCRIPTION
Addes deprecations warnings to Tracer.sampler and Tracer.priority_sampler. These attributes will be removed from the public api in v1.0

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
