### PR TITLE
chore: deprecate Pin.app

### DIFF
--- a/ddtrace/contrib/aiobotocore/patch.py
+++ b/ddtrace/contrib/aiobotocore/patch.py
@@ -33,7 +33,7 @@ def patch():
     setattr(aiobotocore.client, "_datadog_patch", True)
 
     wrapt.wrap_function_wrapper("aiobotocore.client", "AioBaseClient._make_api_call", _wrapped_api_call)
-    Pin(service=config.service or "aws", app="aws").onto(aiobotocore.client.AioBaseClient)
+    Pin(service=config.service or "aws").onto(aiobotocore.client.AioBaseClient)
 
 
 def unpatch():

--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -41,7 +41,7 @@ def patch():
 
         _w = wrapt.wrap_function_wrapper
         _w("aiohttp_jinja2", "render_template", _trace_render_template)
-        Pin(app="aiohttp", service=config.service).onto(aiohttp_jinja2)
+        Pin(service=config.service).onto(aiohttp_jinja2)
 
 
 def unpatch():

--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -34,7 +34,7 @@ def patch():
 
     setattr(algoliasearch, "_datadog_patch", True)
 
-    pin = Pin(app=APP_NAME)
+    pin = Pin()
 
     if algoliasearch_version < (2, 0) and algoliasearch_version >= (1, 0):
         _w(algoliasearch.index, "Index.search", _patched_search)

--- a/ddtrace/contrib/aredis/patch.py
+++ b/ddtrace/contrib/aredis/patch.py
@@ -3,7 +3,6 @@ import aredis
 from ddtrace import config
 from ddtrace.vendor import wrapt
 
-from ...ext import redis as redisx
 from ...pin import Pin
 from ...utils.wrappers import unwrap
 from ..redis.util import _trace_redis_cmd
@@ -26,7 +25,7 @@ def patch():
     _w("aredis.client", "StrictRedis.pipeline", traced_pipeline)
     _w("aredis.pipeline", "StrictPipeline.execute", traced_execute_pipeline)
     _w("aredis.pipeline", "StrictPipeline.immediate_execute_command", traced_execute_command)
-    Pin(service=None, app=redisx.APP).onto(aredis.StrictRedis)
+    Pin(service=None).onto(aredis.StrictRedis)
 
 
 def unpatch():

--- a/ddtrace/contrib/boto/patch.py
+++ b/ddtrace/contrib/boto/patch.py
@@ -42,8 +42,8 @@ def patch():
     # For example EC2 uses AWSQueryConnection and S3 uses AWSAuthConnection
     wrapt.wrap_function_wrapper("boto.connection", "AWSQueryConnection.make_request", patched_query_request)
     wrapt.wrap_function_wrapper("boto.connection", "AWSAuthConnection.make_request", patched_auth_request)
-    Pin(service="aws", app="aws").onto(boto.connection.AWSQueryConnection)
-    Pin(service="aws", app="aws").onto(boto.connection.AWSAuthConnection)
+    Pin(service="aws").onto(boto.connection.AWSQueryConnection)
+    Pin(service="aws").onto(boto.connection.AWSAuthConnection)
 
 
 def unpatch():

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -258,7 +258,7 @@ def patch():
     setattr(botocore.client, "_datadog_patch", True)
 
     wrapt.wrap_function_wrapper("botocore.client", "BaseClient._make_api_call", patched_api_call)
-    Pin(service="aws", app="aws").onto(botocore.client.BaseClient)
+    Pin(service="aws").onto(botocore.client.BaseClient)
 
 
 def unpatch():

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -38,7 +38,7 @@ _connect = cassandra.cluster.Cluster.connect
 def patch():
     """patch will add tracing to the cassandra library."""
     setattr(cassandra.cluster.Cluster, "connect", wrapt.FunctionWrapper(_connect, traced_connect))
-    Pin(service=SERVICE, app=SERVICE).onto(cassandra.cluster.Cluster)
+    Pin(service=SERVICE).onto(cassandra.cluster.Cluster)
 
 
 def unpatch():

--- a/ddtrace/contrib/consul/patch.py
+++ b/ddtrace/contrib/consul/patch.py
@@ -20,7 +20,7 @@ def patch():
         return
     setattr(consul, "__datadog_patch", True)
 
-    pin = Pin(service=consulx.SERVICE, app=consulx.APP)
+    pin = Pin(service=consulx.SERVICE)
     pin.onto(consul.Consul.KV)
 
     for f_name in _KV_FUNCS:

--- a/ddtrace/contrib/dogpile_cache/patch.py
+++ b/ddtrace/contrib/dogpile_cache/patch.py
@@ -24,7 +24,7 @@ def patch():
     _w("dogpile.cache.region", "CacheRegion.get_or_create_multi", _wrap_get_create_multi)
     _w("dogpile.lock", "Lock.__init__", _wrap_lock_ctor)
 
-    Pin(app="dogpile.cache", service="dogpile.cache").onto(dogpile.cache)
+    Pin(service="dogpile.cache").onto(dogpile.cache)
 
 
 def unpatch():

--- a/ddtrace/contrib/httplib/patch.py
+++ b/ddtrace/contrib/httplib/patch.py
@@ -33,7 +33,7 @@ config._add(
 
 
 def _wrap_init(func, instance, args, kwargs):
-    Pin(app="httplib", service=None, _config=config.httplib).onto(instance)
+    Pin(service=None, _config=config.httplib).onto(instance)
     return func(*args, **kwargs)
 
 

--- a/ddtrace/contrib/httpx/patch.py
+++ b/ddtrace/contrib/httpx/patch.py
@@ -141,7 +141,7 @@ def patch():
     _w(httpx.AsyncClient, "send", _wrapped_async_send)
     _w(httpx.Client, "send", _wrapped_sync_send)
 
-    pin = Pin(app="httpx")
+    pin = Pin()
     pin.onto(httpx.AsyncClient)
     pin.onto(httpx.Client)
 

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -64,10 +64,9 @@ def patch():
 
     Pin(
         service=prod_service,
-        app="kombu",
     ).onto(kombu.messaging.Producer)
 
-    Pin(service=config.kombu["service_name"], app="kombu").onto(kombu.messaging.Consumer)
+    Pin(service=config.kombu["service_name"]).onto(kombu.messaging.Consumer)
 
 
 def unpatch():

--- a/ddtrace/contrib/mako/patch.py
+++ b/ddtrace/contrib/mako/patch.py
@@ -19,7 +19,7 @@ def patch():
         return
     setattr(mako, "__datadog_patch", True)
 
-    Pin(service=config.service or "mako", app="mako").onto(Template)
+    Pin(service=config.service or "mako").onto(Template)
 
     _w(mako, "template.Template.render", _wrap_render)
     _w(mako, "template.Template.render_unicode", _wrap_render)

--- a/ddtrace/contrib/molten/patch.py
+++ b/ddtrace/contrib/molten/patch.py
@@ -41,7 +41,7 @@ def patch():
         return
     setattr(molten, "_datadog_patch", True)
 
-    pin = Pin(app=config.molten["app"])
+    pin = Pin()
 
     # add pin to module since many classes use __slots__
     pin.onto(molten)

--- a/ddtrace/contrib/pymemcache/patch.py
+++ b/ddtrace/contrib/pymemcache/patch.py
@@ -28,7 +28,7 @@ def patch():
         pymemcache.client.hash.HashClient.client_class = WrappedClient
 
     # Create a global pin with default configuration for our pymemcache clients
-    Pin(app=memcachedx.SERVICE, service=memcachedx.SERVICE).onto(pymemcache)
+    Pin(service=memcachedx.SERVICE).onto(pymemcache)
 
 
 def unpatch():

--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -62,7 +62,7 @@ class TracedMongoClient(ObjectProxy):
             client._topology = TracedTopology(client._topology)
 
         # Default Pin
-        ddtrace.Pin(service=mongox.SERVICE, app=mongox.SERVICE).onto(self)
+        ddtrace.Pin(service=mongox.SERVICE).onto(self)
 
     def __setddpin__(self, pin):
         pin.onto(self._topology)

--- a/ddtrace/contrib/pymongo/patch.py
+++ b/ddtrace/contrib/pymongo/patch.py
@@ -51,7 +51,7 @@ def patch_pymongo_module():
     if getattr(pymongo, "_datadog_patch", False):
         return
     setattr(pymongo, "_datadog_patch", True)
-    Pin(app=mongox.SERVICE).onto(pymongo.server.Server)
+    Pin().onto(pymongo.server.Server)
 
     # Whenever a pymongo command is invoked, the lib either:
     # - Creates a new socket & performs a TCP handshake

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -3,7 +3,6 @@ import redis
 from ddtrace import config
 from ddtrace.vendor import wrapt
 
-from ...ext import redis as redisx
 from ...pin import Pin
 from ..trace_utils import unwrap
 from .util import _trace_redis_cmd
@@ -37,7 +36,7 @@ def patch():
         _w("redis", "Redis.pipeline", traced_pipeline)
         _w("redis.client", "Pipeline.execute", traced_execute_pipeline)
         _w("redis.client", "Pipeline.immediate_execute_command", traced_execute_command)
-    Pin(service=None, app=redisx.APP).onto(redis.StrictRedis)
+    Pin(service=None).onto(redis.StrictRedis)
 
 
 def unpatch():

--- a/ddtrace/contrib/rediscluster/patch.py
+++ b/ddtrace/contrib/rediscluster/patch.py
@@ -31,12 +31,12 @@ def patch():
         _w("rediscluster", "client.RedisCluster.execute_command", traced_execute_command)
         _w("rediscluster", "client.RedisCluster.pipeline", traced_pipeline)
         _w("rediscluster", "pipeline.ClusterPipeline.execute", traced_execute_pipeline)
-        Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP).onto(rediscluster.RedisCluster)
+        Pin(service=redisx.DEFAULT_SERVICE).onto(rediscluster.RedisCluster)
     else:
         _w("rediscluster", "StrictRedisCluster.execute_command", traced_execute_command)
         _w("rediscluster", "StrictRedisCluster.pipeline", traced_pipeline)
         _w("rediscluster", "StrictClusterPipeline.execute", traced_execute_pipeline)
-        Pin(service=redisx.DEFAULT_SERVICE, app=redisx.APP).onto(rediscluster.StrictRedisCluster)
+        Pin(service=redisx.DEFAULT_SERVICE).onto(rediscluster.StrictRedisCluster)
 
 
 def unpatch():

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -30,7 +30,7 @@ def patch():
     setattr(requests, "__datadog_patch", True)
 
     _w("requests", "Session.send", _wrap_send)
-    Pin(app="requests", _config=config.requests).onto(requests.Session)
+    Pin(_config=config.requests).onto(requests.Session)
 
     # [Backward compatibility]: `session.distributed_tracing` should point and
     # update the `Pin` configuration instead. This block adds a property so that

--- a/ddtrace/contrib/sqlalchemy/engine.py
+++ b/ddtrace/contrib/sqlalchemy/engine.py
@@ -62,7 +62,7 @@ class EngineTracer(object):
         self.name = "%s.query" % self.vendor
 
         # attach the PIN
-        Pin(app=self.vendor, tracer=tracer, service=self.service).onto(engine)
+        Pin(tracer=tracer, service=self.service).onto(engine)
 
         listen(engine, "before_cursor_execute", self._before_cur_exec)
         listen(engine, "after_cursor_execute", self._after_cur_exec)

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -55,4 +55,4 @@ def tracer_config(__init__, app, args, kwargs):
         tracer.set_tags(tags)
 
     # configure the PIN object for template rendering
-    ddtrace.Pin(app="tornado", service=service, tracer=tracer).onto(template)
+    ddtrace.Pin(service=service, tracer=tracer).onto(template)

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -73,10 +73,6 @@ class Pin(object):
     def app(self):
         return self._app
 
-    @app.setter
-    def app(self, val):
-        self._app = val
-
     def __setattr__(self, name, value):
         if getattr(self, "_initialized", False) and name != "_target":
             raise AttributeError("can't mutate a pin, use override() or clone() instead")

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -35,9 +35,10 @@ class Pin(object):
         >>> conn = sqlite.connect('/tmp/image.db')
     """
 
-    __slots__ = ["app", "tags", "tracer", "_target", "_config", "_initialized"]
+    __slots__ = ["tags", "tracer", "_target", "_config", "_initialized"]
 
-    @debtcollector.removals.removed_kwarg("app_type")
+    @debtcollector.removals.removed_kwarg("app", removal_version="1.0.0")
+    @debtcollector.removals.removed_kwarg("app_type", removal_version="1.0.0")
     def __init__(
         self,
         service=None,  # type: Optional[str]
@@ -49,7 +50,7 @@ class Pin(object):
     ):
         # type: (...) -> None
         tracer = tracer or ddtrace.tracer
-        self.app = app
+        self._app = app
         self.tags = tags
         self.tracer = tracer
         self._target = None  # type: Optional[int]
@@ -68,13 +69,21 @@ class Pin(object):
         """
         return self._config["service_name"]
 
+    @debtcollector.removals.removed_property(removal_version="1.0.0")
+    def app(self):
+        return self._app
+
+    @app.setter
+    def app(self, val):
+        self._app = val
+
     def __setattr__(self, name, value):
         if getattr(self, "_initialized", False) and name != "_target":
             raise AttributeError("can't mutate a pin, use override() or clone() instead")
         super(Pin, self).__setattr__(name, value)
 
     def __repr__(self):
-        return "Pin(service=%s, app=%s, tags=%s, tracer=%s)" % (self.service, self.app, self.tags, self.tracer)
+        return "Pin(service=%s, tags=%s, tracer=%s)" % (self.service, self.tags, self.tracer)
 
     @staticmethod
     def _find(*objs):
@@ -83,7 +92,7 @@ class Pin(object):
         Return the first :class:`ddtrace.pin.Pin` found on any of the provided objects or `None` if none were found
 
 
-            >>> pin = Pin._find(wrapper, instance, conn, app)
+            >>> pin = Pin._find(wrapper, instance, conn)
 
         :param objs: The objects to search for a :class:`ddtrace.pin.Pin` on
         :type objs: List of objects
@@ -123,7 +132,8 @@ class Pin(object):
         return pin
 
     @classmethod
-    @debtcollector.removals.removed_kwarg("app_type")
+    @debtcollector.removals.removed_kwarg("app", removal_version="1.0.0")
+    @debtcollector.removals.removed_kwarg("app_type", removal_version="1.0.0")
     def override(
         cls,
         obj,  # type: Any
@@ -148,9 +158,9 @@ class Pin(object):
 
         pin = cls.get_from(obj)
         if pin is None:
-            Pin(service=service, app=app, tags=tags, tracer=tracer).onto(obj)
+            Pin(service=service, tags=tags, tracer=tracer).onto(obj)
         else:
-            pin.clone(service=service, app=app, tags=tags, tracer=tracer).onto(obj)
+            pin.clone(service=service, tags=tags, tracer=tracer).onto(obj)
 
     def enabled(self):
         # type: () -> bool
@@ -187,7 +197,8 @@ class Pin(object):
         except AttributeError:
             log.debug("can't remove pin from object. skipping", exc_info=True)
 
-    @debtcollector.removals.removed_kwarg("app_type")
+    @debtcollector.removals.removed_kwarg("app", removal_version="1.0.0")
+    @debtcollector.removals.removed_kwarg("app_type", removal_version="1.0.0")
     def clone(
         self,
         service=None,  # type: Optional[str]
@@ -212,7 +223,6 @@ class Pin(object):
 
         return Pin(
             service=service or self.service,
-            app=app or self.app,
             tags=tags,
             tracer=tracer or self.tracer,  # do not clone the Tracer
             _config=config,

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -35,7 +35,7 @@ class Pin(object):
         >>> conn = sqlite.connect('/tmp/image.db')
     """
 
-    __slots__ = ["tags", "tracer", "_target", "_config", "_initialized"]
+    __slots__ = ["_app", "tags", "tracer", "_target", "_config", "_initialized"]
 
     @debtcollector.removals.removed_kwarg("app", removal_version="1.0.0")
     @debtcollector.removals.removed_kwarg("app_type", removal_version="1.0.0")

--- a/releasenotes/notes/deprecate-pin-app-de153348b61a9905.yaml
+++ b/releasenotes/notes/deprecate-pin-app-de153348b61a9905.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    ``Pin.app`` is deprecated.

--- a/tests/tracer/test_pin.py
+++ b/tests/tracer/test_pin.py
@@ -77,13 +77,11 @@ class PinTestCase(TestCase):
 
     def test_copy(self):
         # ensure a Pin is copied when using the clone methods
-        p1 = Pin(service="metrics", app="flask", tags={"key": "value"})
+        p1 = Pin(service="metrics", tags={"key": "value"})
         p2 = p1.clone(service="intake")
         # values are the same
         assert p1.service == "metrics"
         assert p2.service == "intake"
-        assert p1.app == "flask"
-        assert p2.app == "flask"
         # but it's a copy
         assert p1.tags is not p2.tags
         assert p1._config is not p2._config
@@ -104,14 +102,12 @@ class PinTestCase(TestCase):
         class A(object):
             pass
 
-        Pin(service="metrics", app="flask").onto(A)
+        Pin(service="metrics").onto(A)
         a = A()
-        Pin.override(a, app="django")
-        assert Pin.get_from(a).app == "django"
+        Pin.override(a)
         assert Pin.get_from(a).service == "metrics"
 
         b = A()
-        assert Pin.get_from(b).app == "flask"
         assert Pin.get_from(b).service == "metrics"
 
     def test_override_missing(self):

--- a/tests/tracer/test_pin.py
+++ b/tests/tracer/test_pin.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+import warnings
 
 import pytest
 
@@ -187,3 +188,21 @@ class PinTestCase(TestCase):
 
         assert global_pin._config["distributed_tracing"] is True
         assert pin._config["distributed_tracing"] is False
+
+
+def test_pin_app_deprecation():
+    with warnings.catch_warnings(record=True) as ws:
+        warnings.simplefilter("always")
+
+        p = Pin(app="foo")
+        assert len(ws) == 1
+        assert issubclass(ws[0].category, DeprecationWarning)
+
+    with warnings.catch_warnings(record=True) as ws:
+        warnings.simplefilter("always")
+
+        p = Pin(app="foo")
+        assert p.app
+        assert len(ws) == 2
+        assert issubclass(ws[0].category, DeprecationWarning)
+        assert issubclass(ws[1].category, DeprecationWarning)


### PR DESCRIPTION
Deprecate `Pin.app`. Though this property is set in many integrations, it is not set on span data.