### PR TITLE
refactor(profiling): split lock profiling in two parts

### DIFF
--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -1,0 +1,230 @@
+from __future__ import absolute_import
+
+import abc
+import os.path
+import sys
+import typing
+
+import attr
+
+from ddtrace.internal import compat
+from ddtrace.internal import nogevent
+from ddtrace.internal.utils import attr as attr_utils
+from ddtrace.internal.utils import formats
+from ddtrace.profiling import _threading
+from ddtrace.profiling import collector
+from ddtrace.profiling import event
+from ddtrace.profiling.collector import _task
+from ddtrace.profiling.collector import _traceback
+from ddtrace.vendor import wrapt
+
+
+@event.event_class
+class LockEventBase(event.StackBasedEvent):
+    """Base Lock event."""
+
+    lock_name = attr.ib(default="<unknown lock name>", type=str)
+    sampling_pct = attr.ib(default=0, type=int)
+
+
+@event.event_class
+class LockAcquireEvent(LockEventBase):
+    """A lock has been acquired."""
+
+    wait_time_ns = attr.ib(default=0, type=int)
+
+
+@event.event_class
+class LockReleaseEvent(LockEventBase):
+    """A lock has been released."""
+
+    locked_for_ns = attr.ib(default=0, type=int)
+
+
+def _current_thread():
+    # type: (...) -> typing.Tuple[int, str]
+    thread_id = nogevent.thread_get_ident()
+    return thread_id, _threading.get_thread_name(thread_id)
+
+
+# We need to know if wrapt is compiled in C or not. If it's not using the C module, then the wrappers function will
+# appear in the stack trace and we need to hide it.
+if os.environ.get("WRAPT_DISABLE_EXTENSIONS"):
+    WRAPT_C_EXT = False
+else:
+    try:
+        import ddtrace.vendor.wrapt._wrappers as _w  # noqa: F401
+    except ImportError:
+        WRAPT_C_EXT = False
+    else:
+        WRAPT_C_EXT = True
+        del _w
+
+
+class _ProfiledLock(wrapt.ObjectProxy):
+
+    ACQUIRE_EVENT_CLASS = LockAcquireEvent
+    RELEASE_EVENT_CLASS = LockReleaseEvent
+
+    def __init__(self, wrapped, recorder, tracer, max_nframes, capture_sampler, endpoint_collection_enabled):
+        wrapt.ObjectProxy.__init__(self, wrapped)
+        self._self_recorder = recorder
+        self._self_tracer = tracer
+        self._self_max_nframes = max_nframes
+        self._self_capture_sampler = capture_sampler
+        self._self_endpoint_collection_enabled = endpoint_collection_enabled
+        frame = sys._getframe(2 if WRAPT_C_EXT else 3)
+        code = frame.f_code
+        self._self_name = "%s:%d" % (os.path.basename(code.co_filename), frame.f_lineno)
+
+    def acquire(self, *args, **kwargs):
+        if not self._self_capture_sampler.capture():
+            return self.__wrapped__.acquire(*args, **kwargs)
+
+        start = compat.monotonic_ns()
+        try:
+            return self.__wrapped__.acquire(*args, **kwargs)
+        finally:
+            try:
+                end = self._self_acquired_at = compat.monotonic_ns()
+                thread_id, thread_name = _current_thread()
+                task_id, task_name, task_frame = _task.get_task(thread_id)
+
+                if task_frame is None:
+                    frame = sys._getframe(1)
+                else:
+                    frame = task_frame
+
+                frames, nframes = _traceback.pyframe_to_frames(frame, self._self_max_nframes)
+
+                event = self.ACQUIRE_EVENT_CLASS(
+                    lock_name=self._self_name,
+                    frames=frames,
+                    nframes=nframes,
+                    thread_id=thread_id,
+                    thread_name=thread_name,
+                    task_id=task_id,
+                    task_name=task_name,
+                    wait_time_ns=end - start,
+                    sampling_pct=self._self_capture_sampler.capture_pct,
+                )
+
+                if self._self_tracer is not None:
+                    event.set_trace_info(self._self_tracer.current_span(), self._self_endpoint_collection_enabled)
+
+                self._self_recorder.push_event(event)
+            except Exception:
+                pass
+
+    def release(
+        self,
+        *args,  # type: typing.Any
+        **kwargs  # type: typing.Any
+    ):
+        # type: (...) -> None
+        try:
+            return self.__wrapped__.release(*args, **kwargs)
+        finally:
+            try:
+                if hasattr(self, "_self_acquired_at"):
+                    try:
+                        end = compat.monotonic_ns()
+                        thread_id, thread_name = _current_thread()
+                        task_id, task_name, task_frame = _task.get_task(thread_id)
+
+                        if task_frame is None:
+                            frame = sys._getframe(1)
+                        else:
+                            frame = task_frame
+
+                        frames, nframes = _traceback.pyframe_to_frames(frame, self._self_max_nframes)
+
+                        event = self.RELEASE_EVENT_CLASS(  # type: ignore[call-arg]
+                            lock_name=self._self_name,
+                            frames=frames,
+                            nframes=nframes,
+                            thread_id=thread_id,
+                            thread_name=thread_name,
+                            task_id=task_id,
+                            task_name=task_name,
+                            locked_for_ns=end - self._self_acquired_at,
+                            sampling_pct=self._self_capture_sampler.capture_pct,
+                        )
+
+                        if self._self_tracer is not None:
+                            event.set_trace_info(
+                                self._self_tracer.current_span(), self._self_endpoint_collection_enabled
+                            )
+
+                        self._self_recorder.push_event(event)
+                    finally:
+                        del self._self_acquired_at
+            except Exception:
+                pass
+
+    acquire_lock = acquire
+
+
+class FunctionWrapper(wrapt.FunctionWrapper):
+    # Override the __get__ method: whatever happens, _allocate_lock is always considered by Python like a "static"
+    # method, even when used as a class attribute. Python never tried to "bind" it to a method, because it sees it is a
+    # builtin function. Override default wrapt behavior here that tries to detect bound method.
+    def __get__(self, instance, owner=None):
+        return self
+
+
+@attr.s
+class LockCollector(collector.CaptureSamplerCollector):
+    """Record lock usage."""
+
+    nframes = attr.ib(factory=attr_utils.from_env("DD_PROFILING_MAX_FRAMES", 64, int))
+    endpoint_collection_enabled = attr.ib(
+        factory=attr_utils.from_env("DD_PROFILING_ENDPOINT_COLLECTION_ENABLED", True, formats.asbool)
+    )
+    tracer = attr.ib(default=None)
+
+    _original = attr.ib(init=False, repr=False, type=typing.Any, cmp=False)
+
+    @abc.abstractmethod
+    def _get_original(self):
+        # type: (...) -> typing.Any
+        pass
+
+    @abc.abstractmethod
+    def _set_original(
+        self, value  # type: typing.Any
+    ):
+        # type: (...) -> None
+        pass
+
+    def _start_service(self):  # type: ignore[override]
+        # type: (...) -> None
+        """Start collecting lock usage."""
+        self.patch()
+        super(LockCollector, self)._start_service()
+
+    def _stop_service(self):  # type: ignore[override]
+        # type: (...) -> None
+        """Stop collecting lock usage."""
+        super(LockCollector, self)._stop_service()
+        self.unpatch()
+
+    def patch(self):
+        # type: (...) -> None
+        """Patch the module for tracking lock allocation."""
+        # We only patch the lock from the `threading` module.
+        # Nobody should use locks from `_thread`; if they do so, then it's deliberate and we don't profile.
+        self.original = self._get_original()
+
+        def _allocate_lock(wrapped, instance, args, kwargs):
+            lock = wrapped(*args, **kwargs)
+            return self.PROFILED_LOCK_CLASS(
+                lock, self.recorder, self.tracer, self.nframes, self._capture_sampler, self.endpoint_collection_enabled
+            )
+
+        self._set_original(FunctionWrapper(self.original, _allocate_lock))
+
+    def unpatch(self):
+        # type: (...) -> None
+        """Unpatch the threading module for tracking lock allocation."""
+        self._set_original(self.original)

--- a/ddtrace/profiling/collector/threading.py
+++ b/ddtrace/profiling/collector/threading.py
@@ -1,230 +1,42 @@
 from __future__ import absolute_import
 
-import os.path
-import sys
 import threading
 import typing
 
 import attr
 
-import ddtrace
-from ddtrace.internal import compat
-from ddtrace.internal import nogevent
-from ddtrace.internal.utils import attr as attr_utils
-from ddtrace.internal.utils import formats
-from ddtrace.profiling import _threading
-from ddtrace.profiling import collector
-from ddtrace.profiling import event
-from ddtrace.profiling.collector import _task
-from ddtrace.profiling.collector import _traceback
-from ddtrace.vendor import wrapt
-
-
-if typing.TYPE_CHECKING:
-    from ddtrace.profiling import recorder as ddrecorder
+from . import _lock
+from .. import event
 
 
 @event.event_class
-class LockEventBase(event.StackBasedEvent):
-    """Base Lock event."""
-
-    lock_name = attr.ib(default="<unknown lock name>", type=str)
-    sampling_pct = attr.ib(default=0, type=int)
+class ThreadingLockAcquireEvent(_lock.LockAcquireEvent):
+    """A threading.Lock has been acquired."""
 
 
 @event.event_class
-class LockAcquireEvent(LockEventBase):
-    """A lock has been acquired."""
-
-    wait_time_ns = attr.ib(default=0, type=int)
+class ThreadingLockReleaseEvent(_lock.LockReleaseEvent):
+    """A threading.Lock has been released."""
 
 
-@event.event_class
-class LockReleaseEvent(LockEventBase):
-    """A lock has been released."""
+class _ProfiledThreadingLock(_lock._ProfiledLock):
 
-    locked_for_ns = attr.ib(default=0, type=int)
-
-
-def _current_thread():
-    # type: (...) -> typing.Tuple[int, str]
-    thread_id = nogevent.thread_get_ident()
-    return thread_id, _threading.get_thread_name(thread_id)
-
-
-# We need to know if wrapt is compiled in C or not. If it's not using the C module, then the wrappers function will
-# appear in the stack trace and we need to hide it.
-if os.environ.get("WRAPT_DISABLE_EXTENSIONS"):
-    WRAPT_C_EXT = False
-else:
-    try:
-        import ddtrace.vendor.wrapt._wrappers as _w  # noqa: F401
-    except ImportError:
-        WRAPT_C_EXT = False
-    else:
-        WRAPT_C_EXT = True
-        del _w
-
-
-class _ProfiledLock(wrapt.ObjectProxy):
-    def __init__(
-        self,
-        wrapped,  # type: threading.Lock
-        recorder,  # type: ddrecorder.Recorder
-        tracer,  # type: ddtrace.Tracer
-        max_nframes,  # type: int
-        capture_sampler,  # type: collector.CaptureSampler
-        endpoint_collection_enabled,  # type: bool
-    ):
-        # type: (...) -> None
-        wrapt.ObjectProxy.__init__(self, wrapped)
-        self._self_recorder = recorder
-        self._self_tracer = tracer
-        self._self_max_nframes = max_nframes
-        self._self_capture_sampler = capture_sampler
-        self._self_endpoint_collection_enabled = endpoint_collection_enabled
-        frame = sys._getframe(2 if WRAPT_C_EXT else 3)
-        code = frame.f_code
-        self._self_name = "%s:%d" % (
-            os.path.basename(code.co_filename),
-            0 if frame.f_lineno is None else frame.f_lineno,
-        )
-
-    def acquire(self, *args, **kwargs):
-        if not self._self_capture_sampler.capture():
-            return self.__wrapped__.acquire(*args, **kwargs)
-
-        start = compat.monotonic_ns()
-        try:
-            return self.__wrapped__.acquire(*args, **kwargs)
-        finally:
-            try:
-                end = self._self_acquired_at = compat.monotonic_ns()
-                thread_id, thread_name = _current_thread()
-                task_id, task_name, task_frame = _task.get_task(thread_id)
-
-                if task_frame is None:
-                    frame = sys._getframe(1)
-                else:
-                    frame = task_frame
-
-                frames, nframes = _traceback.pyframe_to_frames(frame, self._self_max_nframes)
-
-                event = LockAcquireEvent(
-                    lock_name=self._self_name,
-                    frames=frames,
-                    nframes=nframes,
-                    thread_id=thread_id,
-                    thread_name=thread_name,
-                    task_id=task_id,
-                    task_name=task_name,
-                    wait_time_ns=end - start,
-                    sampling_pct=self._self_capture_sampler.capture_pct,
-                )
-
-                if self._self_tracer is not None:
-                    event.set_trace_info(self._self_tracer.current_span(), self._self_endpoint_collection_enabled)
-
-                self._self_recorder.push_event(event)
-            except Exception:
-                pass
-
-    def release(
-        self,
-        *args,  # type: typing.Any
-        **kwargs  # type: typing.Any
-    ):
-        # type: (...) -> None
-        try:
-            return self.__wrapped__.release(*args, **kwargs)
-        finally:
-            try:
-                if hasattr(self, "_self_acquired_at"):
-                    try:
-                        end = compat.monotonic_ns()
-                        thread_id, thread_name = _current_thread()
-                        task_id, task_name, task_frame = _task.get_task(thread_id)
-
-                        if task_frame is None:
-                            frame = sys._getframe(1)
-                        else:
-                            frame = task_frame
-
-                        frames, nframes = _traceback.pyframe_to_frames(frame, self._self_max_nframes)
-
-                        event = LockReleaseEvent(  # type: ignore[call-arg]
-                            lock_name=self._self_name,
-                            frames=frames,
-                            nframes=nframes,
-                            thread_id=thread_id,
-                            thread_name=thread_name,
-                            task_id=task_id,
-                            task_name=task_name,
-                            locked_for_ns=end - self._self_acquired_at,
-                            sampling_pct=self._self_capture_sampler.capture_pct,
-                        )
-
-                        if self._self_tracer is not None:
-                            event.set_trace_info(
-                                self._self_tracer.current_span(), self._self_endpoint_collection_enabled
-                            )
-
-                        self._self_recorder.push_event(event)
-                    finally:
-                        del self._self_acquired_at
-            except Exception:
-                pass
-
-    acquire_lock = acquire
-
-
-class FunctionWrapper(wrapt.FunctionWrapper):
-    # Override the __get__ method: whatever happens, _allocate_lock is always considered by Python like a "static"
-    # method, even when used as a class attribute. Python never tried to "bind" it to a method, because it sees it is a
-    # builtin function. Override default wrapt behavior here that tries to detect bound method.
-    def __get__(self, instance, owner=None):
-        return self
+    ACQUIRE_EVENT_CLASS = ThreadingLockAcquireEvent
+    RELEASE_EVENT_CLASS = ThreadingLockReleaseEvent
 
 
 @attr.s
-class LockCollector(collector.CaptureSamplerCollector):
-    """Record lock usage."""
+class ThreadingLockCollector(_lock.LockCollector):
+    """Record threading.Lock usage."""
 
-    nframes = attr.ib(factory=attr_utils.from_env("DD_PROFILING_MAX_FRAMES", 64, int))
-    endpoint_collection_enabled = attr.ib(
-        factory=attr_utils.from_env("DD_PROFILING_ENDPOINT_COLLECTION_ENABLED", True, formats.asbool)
-    )
+    PROFILED_LOCK_CLASS = _ProfiledThreadingLock
 
-    tracer = attr.ib(default=None)
+    def _get_original(self):
+        # type: (...) -> typing.Any
+        return threading.Lock
 
-    def _start_service(self):  # type: ignore[override]
+    def _set_original(
+        self, value  # type: typing.Any
+    ):
         # type: (...) -> None
-        """Start collecting `threading.Lock` usage."""
-        self.patch()
-        super(LockCollector, self)._start_service()
-
-    def _stop_service(self):  # type: ignore[override]
-        # type: (...) -> None
-        """Stop collecting `threading.Lock` usage."""
-        super(LockCollector, self)._stop_service()
-        self.unpatch()
-
-    def patch(self):
-        # type: (...) -> None
-        """Patch the threading module for tracking lock allocation."""
-        # We only patch the lock from the `threading` module.
-        # Nobody should use locks from `_thread`; if they do so, then it's deliberate and we don't profile.
-        self.original = threading.Lock
-
-        def _allocate_lock(wrapped, instance, args, kwargs):
-            lock = wrapped(*args, **kwargs)
-            return _ProfiledLock(
-                lock, self.recorder, self.tracer, self.nframes, self._capture_sampler, self.endpoint_collection_enabled
-            )
-
-        threading.Lock = FunctionWrapper(self.original, _allocate_lock)  # type: ignore[misc]
-
-    def unpatch(self):
-        # type: (...) -> None
-        """Unpatch the threading module for tracking lock allocation."""
-        threading.Lock = self.original  # type: ignore[misc]
+        threading.Lock = value  # type: ignore[misc]

--- a/ddtrace/profiling/exporter/pprof.pyi
+++ b/ddtrace/profiling/exporter/pprof.pyi
@@ -84,7 +84,7 @@ class _PprofConverter:
         trace_type: str,
         frames: HashableStackTraceType,
         nframes: int,
-        events: typing.List[threading.LockAcquireEvent],
+        events: typing.List[threading.ThreadingLockAcquireEvent],
         sampling_ratio: float,
     ) -> None: ...
     def convert_lock_release_event(
@@ -100,7 +100,7 @@ class _PprofConverter:
         trace_type: str,
         frames: HashableStackTraceType,
         nframes: int,
-        events: typing.List[threading.LockReleaseEvent],
+        events: typing.List[threading.ThreadingLockReleaseEvent],
         sampling_ratio: float,
     ) -> None: ...
     def convert_stack_exception_event(

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -187,7 +187,7 @@ class _ProfilerInstance(service.Service):
         self._collectors = [
             stack.StackCollector(r, tracer=self.tracer),
             memalloc.MemoryCollector(r),
-            threading.LockCollector(r, tracer=self.tracer),
+            threading.ThreadingLockCollector(r, tracer=self.tracer),
         ]
 
         exporters = self._build_default_exporters()

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -16,8 +16,8 @@ TESTING_GEVENT = os.getenv("DD_PROFILE_TEST_GEVENT", False)
 
 def test_repr():
     test_collector._test_repr(
-        collector_threading.LockCollector,
-        "LockCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
+        collector_threading.ThreadingLockCollector,
+        "ThreadingLockCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
         "recorder=Recorder(default_max_events=32768, max_events={}), capture_pct=2.0, nframes=64, "
         "endpoint_collection_enabled=True, tracer=None)",
     )
@@ -25,7 +25,7 @@ def test_repr():
 
 def test_wrapper():
     r = recorder.Recorder()
-    collector = collector_threading.LockCollector(r)
+    collector = collector_threading.ThreadingLockCollector(r)
     with collector:
 
         class Foobar(object):
@@ -48,7 +48,7 @@ def test_wrapper():
 def test_patch():
     r = recorder.Recorder()
     lock = threading.Lock
-    collector = collector_threading.LockCollector(r)
+    collector = collector_threading.ThreadingLockCollector(r)
     collector.start()
     assert lock == collector.original
     # wrapt makes this true
@@ -60,12 +60,12 @@ def test_patch():
 
 def test_lock_acquire_events():
     r = recorder.Recorder()
-    with collector_threading.LockCollector(r, capture_pct=100):
+    with collector_threading.ThreadingLockCollector(r, capture_pct=100):
         lock = threading.Lock()
         lock.acquire()
-    assert len(r.events[collector_threading.LockAcquireEvent]) == 1
-    assert len(r.events[collector_threading.LockReleaseEvent]) == 0
-    event = r.events[collector_threading.LockAcquireEvent][0]
+    assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
+    assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 0
+    event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
     assert event.lock_name == "test_threading.py:64"
     assert event.thread_id == nogevent.thread_get_ident()
     assert event.wait_time_ns > 0
@@ -80,7 +80,7 @@ def test_lock_events_tracer(tracer):
     resource = str(uuid.uuid4())
     span_type = str(uuid.uuid4())
     r = recorder.Recorder()
-    with collector_threading.LockCollector(r, tracer=tracer, capture_pct=100):
+    with collector_threading.ThreadingLockCollector(r, tracer=tracer, capture_pct=100):
         lock = threading.Lock()
         lock.acquire()
         with tracer.trace("test", resource=resource, span_type=span_type) as t:
@@ -92,7 +92,7 @@ def test_lock_events_tracer(tracer):
         lock2.release()
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
-    for event_type in (collector_threading.LockAcquireEvent, collector_threading.LockReleaseEvent):
+    for event_type in (collector_threading.ThreadingLockAcquireEvent, collector_threading.ThreadingLockReleaseEvent):
         assert {"test_threading.py:84", "test_threading.py:87"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
             if event.name == "test_threading.py:84":
@@ -111,7 +111,7 @@ def test_lock_events_tracer_late_finish(tracer):
     resource = str(uuid.uuid4())
     span_type = str(uuid.uuid4())
     r = recorder.Recorder()
-    with collector_threading.LockCollector(r, tracer=tracer, capture_pct=100):
+    with collector_threading.ThreadingLockCollector(r, tracer=tracer, capture_pct=100):
         lock = threading.Lock()
         lock.acquire()
         span = tracer.start_span("test", span_type=span_type)
@@ -125,7 +125,7 @@ def test_lock_events_tracer_late_finish(tracer):
     span.finish()
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
-    for event_type in (collector_threading.LockAcquireEvent, collector_threading.LockReleaseEvent):
+    for event_type in (collector_threading.ThreadingLockAcquireEvent, collector_threading.ThreadingLockReleaseEvent):
         assert {"test_threading.py:115", "test_threading.py:118"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
             if event.name == "test_threading.py:115":
@@ -145,7 +145,7 @@ def test_resource_not_collected(monkeypatch, tracer):
     resource = str(uuid.uuid4())
     span_type = str(uuid.uuid4())
     r = recorder.Recorder()
-    with collector_threading.LockCollector(r, tracer=tracer, capture_pct=100):
+    with collector_threading.ThreadingLockCollector(r, tracer=tracer, capture_pct=100):
         lock = threading.Lock()
         lock.acquire()
         with tracer.trace("test", resource=resource, span_type=span_type) as t:
@@ -157,7 +157,7 @@ def test_resource_not_collected(monkeypatch, tracer):
         lock2.release()
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
-    for event_type in (collector_threading.LockAcquireEvent, collector_threading.LockReleaseEvent):
+    for event_type in (collector_threading.ThreadingLockAcquireEvent, collector_threading.ThreadingLockReleaseEvent):
         assert {"test_threading.py:149", "test_threading.py:152"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
             if event.name == "test_threading.py:149":
@@ -174,13 +174,13 @@ def test_resource_not_collected(monkeypatch, tracer):
 
 def test_lock_release_events():
     r = recorder.Recorder()
-    with collector_threading.LockCollector(r, capture_pct=100):
+    with collector_threading.ThreadingLockCollector(r, capture_pct=100):
         lock = threading.Lock()
         lock.acquire()
         lock.release()
-    assert len(r.events[collector_threading.LockAcquireEvent]) == 1
-    assert len(r.events[collector_threading.LockReleaseEvent]) == 1
-    event = r.events[collector_threading.LockReleaseEvent][0]
+    assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
+    assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 1
+    event = r.events[collector_threading.ThreadingLockReleaseEvent][0]
     assert event.lock_name == "test_threading.py:178"
     assert event.thread_id == nogevent.thread_get_ident()
     assert event.locked_for_ns >= 0.1
@@ -200,15 +200,15 @@ def test_lock_gevent_tasks():
         lock.acquire()
         lock.release()
 
-    with collector_threading.LockCollector(r, capture_pct=100):
+    with collector_threading.ThreadingLockCollector(r, capture_pct=100):
         t = threading.Thread(name="foobar", target=play_with_lock)
         t.start()
         t.join()
 
-    assert len(r.events[collector_threading.LockAcquireEvent]) >= 1
-    assert len(r.events[collector_threading.LockReleaseEvent]) >= 1
+    assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) >= 1
+    assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) >= 1
 
-    for event in r.events[collector_threading.LockAcquireEvent]:
+    for event in r.events[collector_threading.ThreadingLockAcquireEvent]:
         if event.lock_name == "test_threading.py:199":
             assert event.thread_id == nogevent.main_thread_id
             assert event.wait_time_ns >= 0
@@ -225,7 +225,7 @@ def test_lock_gevent_tasks():
     else:
         pytest.fail("Lock event not found")
 
-    for event in r.events[collector_threading.LockReleaseEvent]:
+    for event in r.events[collector_threading.ThreadingLockReleaseEvent]:
         if event.lock_name == "test_threading.py:199":
             assert event.thread_id == nogevent.main_thread_id
             assert event.locked_for_ns >= 0.1
@@ -248,7 +248,7 @@ def test_lock_gevent_tasks():
 )
 def test_lock_create_speed_patched(benchmark):
     r = recorder.Recorder()
-    with collector_threading.LockCollector(r):
+    with collector_threading.ThreadingLockCollector(r):
         benchmark(threading.Lock)
 
 
@@ -273,7 +273,7 @@ def _lock_acquire_release(lock):
 )
 def test_lock_acquire_release_speed_patched(benchmark, pct):
     r = recorder.Recorder()
-    with collector_threading.LockCollector(r, capture_pct=pct):
+    with collector_threading.ThreadingLockCollector(r, capture_pct=pct):
         benchmark(_lock_acquire_release, threading.Lock())
 
 

--- a/tests/profiling/collector/test_threading_asyncio.py
+++ b/tests/profiling/collector/test_threading_asyncio.py
@@ -35,7 +35,7 @@ def test_lock_acquire_events(tmp_path, monkeypatch):
     p.stop()
 
     lock_found = 0
-    for event in events[collector_threading.LockAcquireEvent]:
+    for event in events[collector_threading.ThreadingLockAcquireEvent]:
         if event.lock_name == "test_threading_asyncio.py:18":
             assert event.task_name.startswith("Task-")
             lock_found += 1

--- a/tests/profiling/exporter/test_pprof.py
+++ b/tests/profiling/exporter/test_pprof.py
@@ -4,9 +4,9 @@ import mock
 import six
 
 from ddtrace import ext
+from ddtrace.profiling.collector import _lock
 from ddtrace.profiling.collector import memalloc
 from ddtrace.profiling.collector import stack_event
-from ddtrace.profiling.collector import threading
 from ddtrace.profiling.exporter import pprof
 
 
@@ -444,8 +444,8 @@ TEST_EVENTS = {
             nframes=3,
         ),
     ],
-    threading.LockAcquireEvent: [
-        threading.LockAcquireEvent(
+    _lock.LockAcquireEvent: [
+        _lock.LockAcquireEvent(
             lock_name="foobar.py:12",
             timestamp=1,
             thread_id=67892304,
@@ -465,7 +465,7 @@ TEST_EVENTS = {
             wait_time_ns=74839,
             sampling_pct=10,
         ),
-        threading.LockAcquireEvent(
+        _lock.LockAcquireEvent(
             lock_name="foobar.py:12",
             timestamp=2,
             thread_id=67892304,
@@ -483,7 +483,7 @@ TEST_EVENTS = {
             wait_time_ns=7483,
             sampling_pct=10,
         ),
-        threading.LockAcquireEvent(
+        _lock.LockAcquireEvent(
             lock_name="foobar.py:12",
             timestamp=3,
             thread_id=67892304,
@@ -497,7 +497,7 @@ TEST_EVENTS = {
             wait_time_ns=7489,
             sampling_pct=10,
         ),
-        threading.LockAcquireEvent(
+        _lock.LockAcquireEvent(
             lock_name="foobar.py:12",
             timestamp=4,
             thread_id=67892304,
@@ -511,7 +511,7 @@ TEST_EVENTS = {
             wait_time_ns=4839,
             sampling_pct=10,
         ),
-        threading.LockAcquireEvent(
+        _lock.LockAcquireEvent(
             lock_name="foobar.py:12",
             timestamp=5,
             thread_id=67892304,
@@ -525,7 +525,7 @@ TEST_EVENTS = {
             wait_time_ns=748394,
             sampling_pct=10,
         ),
-        threading.LockAcquireEvent(
+        _lock.LockAcquireEvent(
             lock_name="foobar.py:12",
             timestamp=6,
             thread_id=67892304,
@@ -539,7 +539,7 @@ TEST_EVENTS = {
             wait_time_ns=748339,
             sampling_pct=10,
         ),
-        threading.LockAcquireEvent(
+        _lock.LockAcquireEvent(
             lock_name="foobar.py:12",
             timestamp=7,
             thread_id=67892304,
@@ -554,8 +554,8 @@ TEST_EVENTS = {
             sampling_pct=10,
         ),
     ],
-    threading.LockReleaseEvent: [
-        threading.LockReleaseEvent(
+    _lock.LockReleaseEvent: [
+        _lock.LockReleaseEvent(
             lock_name="foobar.py:12",
             timestamp=1,
             thread_id=67892304,
@@ -569,7 +569,7 @@ TEST_EVENTS = {
             locked_for_ns=74839,
             sampling_pct=5,
         ),
-        threading.LockReleaseEvent(
+        _lock.LockReleaseEvent(
             lock_name="foobar.py:12",
             timestamp=2,
             thread_id=67892304,
@@ -583,7 +583,7 @@ TEST_EVENTS = {
             locked_for_ns=7483,
             sampling_pct=5,
         ),
-        threading.LockReleaseEvent(
+        _lock.LockReleaseEvent(
             lock_name="foobar.py:12",
             timestamp=3,
             thread_id=67892304,
@@ -597,7 +597,7 @@ TEST_EVENTS = {
             locked_for_ns=7489,
             sampling_pct=5,
         ),
-        threading.LockReleaseEvent(
+        _lock.LockReleaseEvent(
             lock_name="foobar.py:12",
             timestamp=4,
             thread_id=67892304,
@@ -611,7 +611,7 @@ TEST_EVENTS = {
             locked_for_ns=4839,
             sampling_pct=5,
         ),
-        threading.LockReleaseEvent(
+        _lock.LockReleaseEvent(
             lock_name="foobar.py:12",
             timestamp=5,
             thread_id=67892304,
@@ -625,7 +625,7 @@ TEST_EVENTS = {
             locked_for_ns=748394,
             sampling_pct=5,
         ),
-        threading.LockReleaseEvent(
+        _lock.LockReleaseEvent(
             lock_name="foobar.py:12",
             timestamp=6,
             thread_id=67892304,
@@ -639,7 +639,7 @@ TEST_EVENTS = {
             locked_for_ns=748339,
             sampling_pct=5,
         ),
-        threading.LockReleaseEvent(
+        _lock.LockReleaseEvent(
             lock_name="foobar.py:12",
             timestamp=7,
             thread_id=67892304,

--- a/tests/profiling/simple_program_fork.py
+++ b/tests/profiling/simple_program_fork.py
@@ -34,23 +34,23 @@ if child_pid == 0:
     lock.release()
 
     # We don't track it
-    assert test_lock_name not in set(e.lock_name for e in recorder.reset()[cthreading.LockReleaseEvent])
+    assert test_lock_name not in set(e.lock_name for e in recorder.reset()[cthreading.ThreadingLockReleaseEvent])
 
     # We track this one though
     lock = threading.Lock()
     test_lock_name = "simple_program_fork.py:40"
-    assert test_lock_name not in set(e.lock_name for e in recorder.reset()[cthreading.LockAcquireEvent])
+    assert test_lock_name not in set(e.lock_name for e in recorder.reset()[cthreading.ThreadingLockAcquireEvent])
     lock.acquire()
     events = recorder.reset()
-    assert test_lock_name in set(e.lock_name for e in events[cthreading.LockAcquireEvent])
-    assert test_lock_name not in set(e.lock_name for e in events[cthreading.LockReleaseEvent])
+    assert test_lock_name in set(e.lock_name for e in events[cthreading.ThreadingLockAcquireEvent])
+    assert test_lock_name not in set(e.lock_name for e in events[cthreading.ThreadingLockReleaseEvent])
     lock.release()
-    assert test_lock_name in set(e.lock_name for e in recorder.reset()[cthreading.LockReleaseEvent])
+    assert test_lock_name in set(e.lock_name for e in recorder.reset()[cthreading.ThreadingLockReleaseEvent])
 
     parent_events = parent_recorder.reset()
     # Let's sure our copy of the parent recorder does not receive it since the parent profiler has been stopped
-    assert test_lock_name not in set(e.lock_name for e in parent_events[cthreading.LockAcquireEvent])
-    assert test_lock_name not in set(e.lock_name for e in parent_events[cthreading.LockReleaseEvent])
+    assert test_lock_name not in set(e.lock_name for e in parent_events[cthreading.ThreadingLockAcquireEvent])
+    assert test_lock_name not in set(e.lock_name for e in parent_events[cthreading.ThreadingLockReleaseEvent])
 
     # This can run forever if anything is broken!
     while not recorder.events[stack_event.StackSampleEvent]:
@@ -58,9 +58,9 @@ if child_pid == 0:
 else:
     recorder = ddtrace.profiling.bootstrap.profiler._profiler._recorder
     assert recorder is parent_recorder
-    assert test_lock_name not in set(e.lock_name for e in recorder.reset()[cthreading.LockReleaseEvent])
+    assert test_lock_name not in set(e.lock_name for e in recorder.reset()[cthreading.ThreadingLockReleaseEvent])
     lock.release()
-    assert test_lock_name in set(e.lock_name for e in recorder.reset()[cthreading.LockReleaseEvent])
+    assert test_lock_name in set(e.lock_name for e in recorder.reset()[cthreading.ThreadingLockReleaseEvent])
     assert ddtrace.profiling.bootstrap.profiler.status == service.ServiceStatus.RUNNING
     print(child_pid)
     pid, status = os.waitpid(child_pid, 0)


### PR DESCRIPTION
This splits the lock profiling code to be able to profile any type of lock.