### PR TITLE
chore(dbapi): deprecate Pin.app

### DIFF
--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -23,8 +23,7 @@ class AIOTracedCursor(wrapt.ObjectProxy):
     def __init__(self, cursor, pin):
         super(AIOTracedCursor, self).__init__(cursor)
         pin.onto(self)
-        name = pin.app or "sql"
-        self._datadog_name = "%s.query" % name
+        self._datadog_name = "postgres.query"
 
     @asyncio.coroutine
     def _trace_method(self, method, resource, extra_tags, *args, **kwargs):
@@ -78,7 +77,7 @@ class AIOTracedConnection(wrapt.ObjectProxy):
     def __init__(self, conn, pin=None, cursor_cls=AIOTracedCursor):
         super(AIOTracedConnection, self).__init__(conn)
         name = dbapi._get_vendor(conn)
-        db_pin = pin or Pin(service=name, app=name)
+        db_pin = pin or Pin(service=name)
         db_pin.onto(self)
         # wrapt requires prefix of `_self` for attributes that are only in the
         # proxy (since some of our source objects will use `__slots__`)

--- a/ddtrace/contrib/mariadb/patch.py
+++ b/ddtrace/contrib/mariadb/patch.py
@@ -16,6 +16,7 @@ config._add(
     dict(
         trace_fetch_methods=asbool(get_env("mariadb", "trace_fetch_methods", default=False)),
         _default_service="mariadb",
+        _dbapi_span_name_prefix="mariadb",
     ),
 )
 
@@ -42,7 +43,7 @@ def _connect(func, instance, args, kwargs):
         db.NAME: kwargs["database"],
     }
 
-    pin = Pin(app="mariadb", tags=tags)
+    pin = Pin(tags=tags)
 
     wrapped = TracedConnection(conn, pin=pin, cfg=config.mariadb)
     pin.onto(wrapped)

--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -15,6 +15,7 @@ config._add(
     "mysql",
     dict(
         _default_service="mysql",
+        _dbapi_span_name_prefix="mysql",
         trace_fetch_methods=asbool(get_env("mysql", "trace_fetch_methods", default=False)),
     ),
 )
@@ -49,7 +50,7 @@ def _connect(func, instance, args, kwargs):
 def patch_conn(conn):
 
     tags = {t: getattr(conn, a) for t, a in CONN_ATTR_BY_TAG.items() if getattr(conn, a, "") != ""}
-    pin = Pin(app="mysql", tags=tags)
+    pin = Pin(tags=tags)
 
     # grab the metadata from the conn
     wrapped = TracedConnection(conn, pin=pin, cfg=config.mysql)

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -16,6 +16,7 @@ config._add(
     "mysqldb",
     dict(
         _default_service="mysql",
+        _dbapi_span_name_prefix="mysql",
         trace_fetch_methods=asbool(get_env("mysqldb", "trace_fetch_methods", default=False)),
     ),
 )
@@ -65,7 +66,7 @@ def patch_conn(conn, *args, **kwargs):
         t: kwargs[k] if k in kwargs else args[p] for t, (k, p) in KWPOS_BY_TAG.items() if k in kwargs or len(args) > p
     }
     tags[net.TARGET_PORT] = conn.port
-    pin = Pin(app="mysql", tags=tags)
+    pin = Pin(tags=tags)
 
     # grab the metadata from the conn
     wrapped = TracedConnection(conn, pin=pin, cfg=config.mysqldb)

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -18,6 +18,7 @@ config._add(
     "psycopg",
     dict(
         _default_service="postgres",
+        _dbapi_span_name_prefix="postgres",
         trace_fetch_methods=asbool(get_env("psycopg", "trace_fetch_methods", default=False)),
     ),
 )
@@ -91,7 +92,7 @@ def patch_conn(conn, traced_conn_cls=Psycopg2TracedConnection):
         "db.application": dsn.get("application_name"),
     }
 
-    Pin(app="postgres", tags=tags).onto(c)
+    Pin(tags=tags).onto(c)
 
     return c
 

--- a/ddtrace/contrib/pymysql/patch.py
+++ b/ddtrace/contrib/pymysql/patch.py
@@ -16,6 +16,7 @@ config._add(
     dict(
         # TODO[v1.0] this should be "mysql"
         _default_service="pymysql",
+        _dbapi_span_name_prefix="pymysql",
         trace_fetch_methods=asbool(get_env("pymysql", "trace_fetch_methods", default=False)),
     ),
 )
@@ -44,7 +45,7 @@ def _connect(func, instance, args, kwargs):
 
 def patch_conn(conn):
     tags = {t: getattr(conn, a, "") for t, a in CONN_ATTR_BY_TAG.items()}
-    pin = Pin(app="pymysql", tags=tags)
+    pin = Pin(tags=tags)
 
     # grab the metadata from the conn
     wrapped = TracedConnection(conn, pin=pin, cfg=config.pymysql)

--- a/ddtrace/contrib/pyodbc/patch.py
+++ b/ddtrace/contrib/pyodbc/patch.py
@@ -14,6 +14,7 @@ config._add(
     "pyodbc",
     dict(
         _default_service="pyodbc",
+        _dbapi_span_name_prefix="pyodbc",
         trace_fetch_methods=asbool(get_env("pyodbc", "trace_fetch_methods", default=False)),
     ),
 )
@@ -38,7 +39,7 @@ def _connect(func, instance, args, kwargs):
 
 
 def patch_conn(conn):
-    pin = Pin(service=None, app="pyodbc")
+    pin = Pin(service=None)
     wrapped = PyODBCTracedConnection(conn, pin=pin)
     pin.onto(wrapped)
     return wrapped

--- a/ddtrace/contrib/snowflake/patch.py
+++ b/ddtrace/contrib/snowflake/patch.py
@@ -14,6 +14,12 @@ config._add(
     "snowflake",
     dict(
         _default_service="snowflake",
+        # FIXME: consistent prefix span names with other dbapi integrations
+        # The snowflake integration was introduced following a different pattern
+        # than all other dbapi-compliant integrations. It sets span names to
+        # `sql.query` whereas other dbapi-compliant integrations are set to
+        # `<integration>.query`.
+        _dbapi_span_name_prefix="sql",
         trace_fetch_methods=asbool(get_env("snowflake", "trace_fetch_methods", default=False)),
     ),
 )

--- a/ddtrace/contrib/sqlite3/patch.py
+++ b/ddtrace/contrib/sqlite3/patch.py
@@ -19,6 +19,7 @@ config._add(
     "sqlite",
     dict(
         _default_service="sqlite",
+        _dbapi_span_name_prefix="sqlite",
         trace_fetch_methods=asbool(get_env("sqlite", "trace_fetch_methods", default=False)),
     ),
 )
@@ -43,7 +44,7 @@ def traced_connect(func, _, args, kwargs):
 
 def patch_conn(conn):
     wrapped = TracedSQLite(conn)
-    Pin(app="sqlite").onto(wrapped)
+    Pin().onto(wrapped)
     return wrapped
 
 

--- a/ddtrace/contrib/vertica/constants.py
+++ b/ddtrace/contrib/vertica/constants.py
@@ -1,2 +1,0 @@
-# Service info
-APP = "vertica"

--- a/ddtrace/contrib/vertica/patch.py
+++ b/ddtrace/contrib/vertica/patch.py
@@ -14,7 +14,6 @@ from ...internal.logger import get_logger
 from ...internal.utils import get_argument_value
 from ...internal.utils.wrappers import unwrap
 from ...pin import Pin
-from .constants import APP
 
 
 log = get_logger(__name__)
@@ -48,7 +47,6 @@ def cursor_span_end(instance, cursor, _, conf, *args, **kwargs):
         tags[dbx.NAME] = instance.options["database"]
 
     pin = Pin(
-        app=APP,
         tags=tags,
         _config=config.vertica["patch"]["vertica_python.vertica.cursor.Cursor"],
     )
@@ -60,7 +58,7 @@ config._add(
     "vertica",
     {
         "_default_service": "vertica",
-        "app": "vertica",
+        "_dbapi_span_name_prefix": "vertica",
         "patch": {
             "vertica_python.vertica.connection.Connection": {
                 "routines": {
@@ -172,7 +170,6 @@ def _install_init(patch_item, patch_class, patch_mod, config):
 
         # create and attach a pin with the defaults
         Pin(
-            app=config["app"],
             tags=config.get("tags", {}),
             tracer=config.get("tracer", ddtrace.tracer),
             _config=config["patch"][patch_item],

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -98,37 +98,6 @@ class TestTracedCursor(TracerTestCase):
         traced_cursor.fetchall("arg_1", kwarg1="kwarg1")
         self.assert_has_no_spans()
 
-    def test_correct_span_names_can_be_overridden_by_pin(self):
-        cursor = self.cursor
-        tracer = self.tracer
-        cursor.rowcount = 0
-        pin = Pin("pin_name", app="changed", tracer=tracer)
-        traced_cursor = TracedCursor(cursor, pin, {})
-
-        traced_cursor.execute("arg_1", kwarg1="kwarg1")
-        self.assert_structure(dict(name="changed.query"))
-        assert_is_measured(self.get_root_span())
-        self.reset()
-
-        traced_cursor.executemany("arg_1", kwarg1="kwarg1")
-        self.assert_structure(dict(name="changed.query"))
-        assert_is_measured(self.get_root_span())
-        self.reset()
-
-        traced_cursor.callproc("arg_1", "arg2")
-        self.assert_structure(dict(name="changed.query"))
-        assert_is_measured(self.get_root_span())
-        self.reset()
-
-        traced_cursor.fetchone("arg_1", kwarg1="kwarg1")
-        self.assert_has_no_spans()
-
-        traced_cursor.fetchmany("arg_1", kwarg1="kwarg1")
-        self.assert_has_no_spans()
-
-        traced_cursor.fetchall("arg_1", kwarg1="kwarg1")
-        self.assert_has_no_spans()
-
     def test_when_pin_disabled_then_no_tracing(self):
         cursor = self.cursor
         tracer = self.tracer
@@ -166,7 +135,7 @@ class TestTracedCursor(TracerTestCase):
         cursor = self.cursor
         tracer = self.tracer
         cursor.rowcount = 123
-        pin = Pin("my_service", app="my_app", tracer=tracer, tags={"pin1": "value_pin1"})
+        pin = Pin("my_service", tracer=tracer, tags={"pin1": "value_pin1"})
         traced_cursor = TracedCursor(cursor, pin, {})
 
         def method():
@@ -190,7 +159,7 @@ class TestTracedCursor(TracerTestCase):
         cursor = self.cursor
         tracer = self.tracer
         cursor.rowcount = 123
-        pin = Pin(None, app="my_app", tracer=tracer, tags={"pin1": "value_pin1"})
+        pin = Pin(None, tracer=tracer, tags={"pin1": "value_pin1"})
         cfg = IntegrationConfig(None, "db-test", service="cfg-service")
         traced_cursor = TracedCursor(cursor, pin, cfg)
 
@@ -205,8 +174,9 @@ class TestTracedCursor(TracerTestCase):
         cursor = self.cursor
         tracer = self.tracer
         cursor.rowcount = 123
-        pin = Pin(None, app="my_app", tracer=tracer, tags={"pin1": "value_pin1"})
-        traced_cursor = TracedCursor(cursor, pin, None)
+        pin = Pin(None, tracer=tracer, tags={"pin1": "value_pin1"})
+
+        traced_cursor = TracedCursor(cursor, pin, {})
 
         def method():
             pass
@@ -219,7 +189,7 @@ class TestTracedCursor(TracerTestCase):
         cursor = self.cursor
         tracer = self.tracer
         cursor.rowcount = 123
-        pin = Pin(None, app="my_app", tracer=tracer, tags={"pin1": "value_pin1"})
+        pin = Pin(None, tracer=tracer, tags={"pin1": "value_pin1"})
         cfg = IntegrationConfig(None, "db-test", _default_service="default-svc")
         traced_cursor = TracedCursor(cursor, pin, cfg)
 
@@ -234,7 +204,7 @@ class TestTracedCursor(TracerTestCase):
         cursor = self.cursor
         tracer = self.tracer
         cursor.rowcount = 123
-        pin = Pin("pin-svc", app="my_app", tracer=tracer, tags={"pin1": "value_pin1"})
+        pin = Pin("pin-svc", tracer=tracer, tags={"pin1": "value_pin1"})
         cfg = IntegrationConfig(None, "db-test", _default_service="default-svc")
         traced_cursor = TracedCursor(cursor, pin, cfg)
 
@@ -252,8 +222,9 @@ class TestTracedCursor(TracerTestCase):
         # implementation with the generic dbapi traced cursor, we had to make sure to add the tag 'sql.rows' that was
         # set by the legacy replaced implementation.
         cursor.rowcount = 123
-        pin = Pin("my_service", app="my_app", tracer=tracer, tags={"pin1": "value_pin1"})
-        traced_cursor = TracedCursor(cursor, pin, {})
+        pin = Pin("my_service", tracer=tracer, tags={"pin1": "value_pin1"})
+        cfg = IntegrationConfig(None, "db-test")
+        traced_cursor = TracedCursor(cursor, pin, cfg)
 
         def method():
             pass
@@ -362,37 +333,6 @@ class TestFetchTracedCursor(TracerTestCase):
         self.assert_structure(dict(name="sql.query.fetchall"))
         self.reset()
 
-    def test_correct_span_names_can_be_overridden_by_pin(self):
-        cursor = self.cursor
-        tracer = self.tracer
-        cursor.rowcount = 0
-        pin = Pin("pin_name", app="changed", tracer=tracer)
-        traced_cursor = FetchTracedCursor(cursor, pin, {})
-
-        traced_cursor.execute("arg_1", kwarg1="kwarg1")
-        self.assert_structure(dict(name="changed.query"))
-        self.reset()
-
-        traced_cursor.executemany("arg_1", kwarg1="kwarg1")
-        self.assert_structure(dict(name="changed.query"))
-        self.reset()
-
-        traced_cursor.callproc("arg_1", "arg2")
-        self.assert_structure(dict(name="changed.query"))
-        self.reset()
-
-        traced_cursor.fetchone("arg_1", kwarg1="kwarg1")
-        self.assert_structure(dict(name="changed.query.fetchone"))
-        self.reset()
-
-        traced_cursor.fetchmany("arg_1", kwarg1="kwarg1")
-        self.assert_structure(dict(name="changed.query.fetchmany"))
-        self.reset()
-
-        traced_cursor.fetchall("arg_1", kwarg1="kwarg1")
-        self.assert_structure(dict(name="changed.query.fetchall"))
-        self.reset()
-
     def test_when_pin_disabled_then_no_tracing(self):
         cursor = self.cursor
         tracer = self.tracer
@@ -430,7 +370,7 @@ class TestFetchTracedCursor(TracerTestCase):
         cursor = self.cursor
         tracer = self.tracer
         cursor.rowcount = 123
-        pin = Pin("my_service", app="my_app", tracer=tracer, tags={"pin1": "value_pin1"})
+        pin = Pin("my_service", tracer=tracer, tags={"pin1": "value_pin1"})
         traced_cursor = FetchTracedCursor(cursor, pin, {})
 
         def method():
@@ -455,7 +395,7 @@ class TestFetchTracedCursor(TracerTestCase):
         # implementation with the generic dbapi traced cursor, we had to make sure to add the tag 'sql.rows' that was
         # set by the legacy replaced implementation.
         cursor.rowcount = 123
-        pin = Pin("my_service", app="my_app", tracer=tracer, tags={"pin1": "value_pin1"})
+        pin = Pin("my_service", tracer=tracer, tags={"pin1": "value_pin1"})
         traced_cursor = FetchTracedCursor(cursor, pin, {})
 
         def method():
@@ -507,7 +447,7 @@ class TestFetchTracedCursor(TracerTestCase):
         cursor = self.cursor
         tracer = self.tracer
         cursor.rowcount = Unknown()
-        pin = Pin("my_service", app="my_app", tracer=tracer, tags={"pin1": "value_pin1"})
+        pin = Pin("my_service", tracer=tracer, tags={"pin1": "value_pin1"})
         traced_cursor = FetchTracedCursor(cursor, pin, {})
 
         def method():

--- a/tests/contrib/mysql/test_mysql.py
+++ b/tests/contrib/mysql/test_mysql.py
@@ -404,10 +404,10 @@ class TestMysqlPatch(MySQLCore, TracerTestCase):
             # Ensure that the default pin is there, with its default value
             pin = Pin.get_from(self.conn)
             assert pin
-            # # assert pin.service == 'mysql'
-            # # Customize the service
-            # # we have to apply it on the existing one since new one won't inherit `app`
-            # pin.clone(tracer=self.tracer).onto(self.conn)
+            # assert pin.service == 'mysql'
+            # Customize the service
+            # we have to apply it on the existing one since new one won't inherit `app`
+            pin.clone(tracer=self.tracer).onto(self.conn)
 
             return self.conn, self.tracer
 

--- a/tests/contrib/mysql/test_mysql.py
+++ b/tests/contrib/mysql/test_mysql.py
@@ -404,10 +404,10 @@ class TestMysqlPatch(MySQLCore, TracerTestCase):
             # Ensure that the default pin is there, with its default value
             pin = Pin.get_from(self.conn)
             assert pin
-            # assert pin.service == 'mysql'
-            # Customize the service
-            # we have to apply it on the existing one since new one won't inherit `app`
-            pin.clone(tracer=self.tracer).onto(self.conn)
+            # # assert pin.service == 'mysql'
+            # # Customize the service
+            # # we have to apply it on the existing one since new one won't inherit `app`
+            # pin.clone(tracer=self.tracer).onto(self.conn)
 
             return self.conn, self.tracer
 


### PR DESCRIPTION
The dbapi `TracedCursor` uses the `Pin.app` to set span names. As we want to deprecate `Pin.app`, we need to add support for this functionality to dbapi itself. This PR adds support for `config._dbapi_span_name_prefix`. This approach is straightforward in all but the aiopg and django integration. The aiopg integration does not make use of the dbapi integration `TracedCursor` but we can make its span name fixed. The django integration needs to set the prefix based on the vendor of the database connection being patched. To support this an integration config is initialized specific to the database connection.