### PR TITLE
fix(appsec): remove SpanType Enum

### DIFF
--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -70,7 +70,7 @@ def test_valid_json(tracer):
 def test_appsec_span_tags_snapshot(tracer):
     tracer._initialize_span_processors(appsec_enabled=True)
 
-    with tracer.trace("test", span_type=SpanTypes.WEB.value) as span:
+    with tracer.trace("test", span_type=SpanTypes.WEB) as span:
         span.set_tag("http.url", "http://example.com/.git")
         span.set_tag("http.status_code", "404")
 


### PR DESCRIPTION
SpanType is no longer an Enum in ddtrace v1.0.  This change updates an appsec snapshot test which was introduced in this PR DataDog/dd-trace-py/pull/3239. 

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
