### PR TITLE
fix(ciapp/pytest): do not access XFAIL reason unsafely

### DIFF
--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -207,8 +207,8 @@ def pytest_runtest_makereport(item, call):
     else:
         if xfail and not has_skip_keyword:
             # XPass (strict=True) are recorded failed by pytest, longrepr contains reason
-            span.set_tag(test.XFAIL_REASON, getattr(result, "longrepr", "XFail"))
-            span.set_tag(test.RESULT, test.Status.XPASS.value)
+            span.set_tag(test.XFAIL_REASON, getattr(result, "wasxfail", "XFail"))
+            span.set_tag(test.RESULT, test.Status.XFAIL.value)
         span.set_tag(test.STATUS, test.Status.FAIL.value)
         if call.excinfo:
             span.set_exc_info(call.excinfo.type, call.excinfo.value, call.excinfo.tb)

--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -191,7 +191,7 @@ def pytest_runtest_makereport(item, call):
         if xfail and not has_skip_keyword:
             # XFail tests that fail are recorded skipped by pytest, should be passed instead
             span.set_tag(test.RESULT, test.Status.XFAIL.value)
-            span.set_tag(test.XFAIL_REASON, result.wasxfail)
+            span.set_tag(test.XFAIL_REASON, getattr(result, "wasxfail", "XFail"))
             span.set_tag(test.STATUS, test.Status.PASS.value)
         else:
             span.set_tag(test.STATUS, test.Status.SKIP.value)
@@ -207,7 +207,7 @@ def pytest_runtest_makereport(item, call):
     else:
         if xfail and not has_skip_keyword:
             # XPass (strict=True) are recorded failed by pytest, longrepr contains reason
-            span.set_tag(test.XFAIL_REASON, result.longrepr)
+            span.set_tag(test.XFAIL_REASON, getattr(result, "longrepr", "XFail"))
             span.set_tag(test.RESULT, test.Status.XPASS.value)
         span.set_tag(test.STATUS, test.Status.FAIL.value)
         if call.excinfo:

--- a/releasenotes/notes/pytest-fix-xfail-unsafe-access-f579fef50d5bd4fa.yaml
+++ b/releasenotes/notes/pytest-fix-xfail-unsafe-access-f579fef50d5bd4fa.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Only for CI Visibility (``pytest`` integration): fix unsafe access to pytest's xfail reason.

--- a/releasenotes/notes/pytest-fix-xfail-unsafe-access-f579fef50d5bd4fa.yaml
+++ b/releasenotes/notes/pytest-fix-xfail-unsafe-access-f579fef50d5bd4fa.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Only for CI Visibility (``pytest`` integration): fix unsafe access to pytest's xfail reason.
+    pytest: fix unsafe access to xfail reason.

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -343,8 +343,6 @@ class TestPytest(TracerTestCase):
 
         assert len(spans) == 1
         assert spans[0].get_tag(test.STATUS) == test.Status.FAIL.value
-        assert spans[0].get_tag(test.RESULT) == test.Status.XFAIL.value
-        assert spans[0].get_tag(test.XFAIL_REASON) == "XFail"
 
     def test_xfail_runxfail_passes(self):
         """Test xfail with --runxfail flags should not crash when passing."""
@@ -364,8 +362,6 @@ class TestPytest(TracerTestCase):
 
         assert len(spans) == 1
         assert spans[0].get_tag(test.STATUS) == test.Status.PASS.value
-        assert spans[0].get_tag(test.RESULT) == test.Status.XPASS.value
-        assert spans[0].get_tag(test.XFAIL_REASON) == "XFail"
 
     def test_xpass_not_strict(self):
         """Test xpass (unexpected passing) with strict=False, should be marked as pass."""

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -325,6 +325,48 @@ class TestPytest(TracerTestCase):
         assert spans[1].get_tag(test.RESULT) == test.Status.XFAIL.value
         assert spans[1].get_tag(test.XFAIL_REASON) == "test should xfail"
 
+    def test_xfail_runxfail_fails(self):
+        """Test xfail with --runxfail flags should not crash when failing."""
+        py_file = self.testdir.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.xfail(reason='should fail')
+            def test_should_fail():
+                assert 0
+
+        """
+        )
+        file_name = os.path.basename(py_file.strpath)
+        self.inline_run("--ddtrace", "--runxfail", file_name)
+        spans = self.pop_spans()
+
+        assert len(spans) == 1
+        assert spans[0].get_tag(test.STATUS) == test.Status.FAIL.value
+        assert spans[0].get_tag(test.RESULT) == test.Status.XFAIL.value
+        assert spans[0].get_tag(test.XFAIL_REASON) == "XFail"
+
+    def test_xfail_runxfail_passes(self):
+        """Test xfail with --runxfail flags should not crash when passing."""
+        py_file = self.testdir.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.xfail(reason='should fail')
+            def test_should_pass():
+                assert 1
+
+        """
+        )
+        file_name = os.path.basename(py_file.strpath)
+        self.inline_run("--ddtrace", "--runxfail", file_name)
+        spans = self.pop_spans()
+
+        assert len(spans) == 1
+        assert spans[0].get_tag(test.STATUS) == test.Status.PASS.value
+        assert spans[0].get_tag(test.RESULT) == test.Status.XPASS.value
+        assert spans[0].get_tag(test.XFAIL_REASON) == "XFail"
+
     def test_xpass_not_strict(self):
         """Test xpass (unexpected passing) with strict=False, should be marked as pass."""
         py_file = self.testdir.makepyfile(


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-py/issues/3276

It seems we were aware `wasxfail` might not be in `result` according to https://github.com/DataDog/dd-trace-py/blob/master/ddtrace/contrib/pytest/plugin.py#L205. This just extends this safe access to every time we use it. 

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
