### PR TITLE
chore: use debtcollector instead of internal deprecation module

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -1,10 +1,10 @@
 from ._monkey import patch  # noqa: E402
 from ._monkey import patch_all
-from .internal.utils.deprecation import deprecated  # noqa: E402
 from .pin import Pin  # noqa: E402
 from .settings import _config as config  # noqa: E402
 from .span import Span  # noqa: E402
 from .tracer import Tracer  # noqa: E402
+from .vendor.debtcollector.removals import remove
 from .version import get_version
 
 
@@ -24,11 +24,11 @@ __all__ = [
 ]
 
 
-@deprecated("This method will be removed altogether", "1.0.0")
+@remove(removal_version="1.0.0")
 def install_excepthook():
     """Install a hook that intercepts unhandled exception and send metrics about them."""
 
 
-@deprecated("This method will be removed altogether", "1.0.0")
+@remove(removal_version="1.0.0")
 def uninstall_excepthook():
     """Uninstall the global tracer except hook."""

--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -11,8 +11,8 @@ from ddtrace.vendor.wrapt.importer import when_imported
 from .internal.logger import get_logger
 from .internal.telemetry import telemetry_writer
 from .internal.utils import formats
-from .internal.utils.deprecation import deprecated
 from .settings import _config as config
+from .vendor.debtcollector.removals import remove
 
 
 log = get_logger(__name__)
@@ -202,10 +202,7 @@ def patch(raise_errors=True, **patch_modules):
     )
 
 
-@deprecated(
-    message="This function will be removed.",
-    version="1.0.0",
-)
+@remove(removal_version="1.0.0")
 def patch_module(module, raise_errors=True):
     # type: (str, bool) -> bool
     return _patch_module(module, raise_errors=raise_errors)
@@ -230,10 +227,7 @@ def _patch_module(module, raise_errors=True):
         return False
 
 
-@deprecated(
-    message="This function will be removed.",
-    version="1.0.0",
-)
+@remove(removal_version="1.0.0")
 def get_patched_modules():
     # type: () -> List[str]
     return _get_patched_modules()

--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -1,5 +1,3 @@
-from ddtrace.internal.utils.deprecation import deprecation
-
 from .internal.compat import CONTEXTVARS_IS_AVAILABLE
 from .internal.compat import NumericType
 from .internal.compat import PY2
@@ -34,6 +32,7 @@ from .internal.compat import stringify
 from .internal.compat import time_ns
 from .internal.compat import to_unicode
 from .internal.compat import urlencode
+from .vendor.debtcollector.removals import removed_module
 
 
 __all__ = [
@@ -73,8 +72,7 @@ __all__ = [
     "urlencode",
 ]
 
-deprecation(
-    name="ddtrace.compat",
-    message="The compat module has been moved to ddtrace.internal and will no longer be part of the public API.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.compat",
+    removal_version="1.0.0",
 )

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -8,7 +8,7 @@ from .constants import ORIGIN_KEY
 from .constants import SAMPLING_PRIORITY_KEY
 from .internal.compat import NumericType
 from .internal.logger import get_logger
-from .internal.utils.deprecation import deprecated
+from .vendor.debtcollector.removals import remove
 
 
 if TYPE_CHECKING:
@@ -107,7 +107,7 @@ class Context(object):
                 return
             self._meta[ORIGIN_KEY] = value
 
-    @deprecated("Cloning contexts will no longer be required in 0.50", version="0.50")
+    @remove(message="Cloning contexts will no longer be required in 0.50", removal_version="1.0.0")
     def clone(self):
         # type: () -> Context
         """

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -18,10 +18,10 @@ from ...internal.compat import maybe_stringify
 from ...internal.compat import stringify
 from ...internal.logger import get_logger
 from ...internal.utils import get_argument_value
-from ...internal.utils.deprecation import deprecated
 from ...internal.utils.formats import deep_getattr
 from ...pin import Pin
 from ...vendor import wrapt
+from ...vendor.debtcollector.removals import remove
 
 
 log = get_logger(__name__)
@@ -278,9 +278,7 @@ def _sanitize_query(span, query):
 #
 # DEPRECATED
 #
-
-
-@deprecated(message="Use patching instead (see the docs).", version="1.0.0")
+@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
 def get_traced_cassandra(*args, **kwargs):
     return _get_traced_cluster(*args, **kwargs)
 

--- a/ddtrace/contrib/celery/task.py
+++ b/ddtrace/contrib/celery/task.py
@@ -1,4 +1,4 @@
-from ...internal.utils.deprecation import deprecation
+from ...vendor.debtcollector import deprecate
 from .app import patch_app
 
 
@@ -7,10 +7,10 @@ def patch_task(task, pin=None):
     patch(celery=True) or through `ddtrace-run` script. Using this API
     enables instrumentation on all tasks.
     """
-    deprecation(
-        name="ddtrace.contrib.celery.patch_task",
+    deprecate(
+        "ddtrace.contrib.celery.patch_task is deprecated",
         message="Use `patch(celery=True)` or `ddtrace-run` script instead",
-        version="1.0.0",
+        removal_version="1.0.0",
     )
 
     # Enable instrumentation everywhere
@@ -23,9 +23,9 @@ def unpatch_task(task):
     via unpatch() API. This API is now a no-op implementation so it doesn't
     affect instrumented tasks.
     """
-    deprecation(
-        name="ddtrace.contrib.celery.patch_task",
+    deprecate(
+        "ddtrace.contrib.celery.patch_task is deprecated",
         message="Use `unpatch()` instead",
-        version="1.0.0",
+        removal_version="1.0.0",
     )
     return task

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -13,7 +13,7 @@ from ...ext import http
 from ...internal import compat
 from ...internal.logger import get_logger
 from ...internal.utils.cache import cached
-from ...internal.utils.deprecation import deprecated
+from ...vendor.debtcollector.removals import remove
 
 
 log = get_logger(__name__)
@@ -28,7 +28,7 @@ def _normalize_resource(resource):
 
 
 class TraceMiddleware(object):
-    @deprecated(message="Use patching instead (see the docs).", version="1.0.0")
+    @remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
     def __init__(self, app, tracer, service="flask", use_signals=True, distributed_tracing=None):
         self.app = app
         log.debug("flask: initializing trace middleware")

--- a/ddtrace/contrib/mongoengine/patch.py
+++ b/ddtrace/contrib/mongoengine/patch.py
@@ -1,6 +1,6 @@
 import mongoengine
 
-from ...internal.utils.deprecation import deprecated
+from ...vendor.debtcollector.removals import remove
 from .trace import WrappedConnect
 
 
@@ -16,6 +16,6 @@ def unpatch():
     setattr(mongoengine, "connect", _connect)
 
 
-@deprecated(message="Use patching instead (see the docs).", version="1.0.0")
+@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
 def trace_mongoengine(*args, **kwargs):
     return _connect

--- a/ddtrace/contrib/mysql/tracers.py
+++ b/ddtrace/contrib/mysql/tracers.py
@@ -1,8 +1,8 @@
 import mysql.connector
 
-from ...internal.utils.deprecation import deprecated
+from ...vendor.debtcollector.removals import remove
 
 
-@deprecated(message="Use patching instead (see the docs).", version="1.0.0")
+@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
 def get_traced_mysql_connection(*args, **kwargs):
     return mysql.connector.MySQLConnection

--- a/ddtrace/contrib/psycopg/connection.py
+++ b/ddtrace/contrib/psycopg/connection.py
@@ -11,10 +11,10 @@ from ...ext import SpanTypes
 from ...ext import db
 from ...ext import net
 from ...ext import sql
-from ...internal.utils.deprecation import deprecated
+from ...vendor.debtcollector.removals import remove
 
 
-@deprecated(message="Use patching instead (see the docs).", version="1.0.0")
+@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
 def connection_factory(tracer, service="postgres"):
     """Return a connection factory class that will can be used to trace
     postgres queries.

--- a/ddtrace/contrib/pymongo/patch.py
+++ b/ddtrace/contrib/pymongo/patch.py
@@ -10,7 +10,7 @@ from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanTypes
 from ...ext import mongo as mongox
-from ...internal.utils.deprecation import deprecated
+from ...vendor.debtcollector.removals import remove
 from ..trace_utils import unwrap as _u
 from .client import TracedMongoClient
 from .client import set_address_tags
@@ -40,7 +40,7 @@ def unpatch():
     setattr(pymongo, "MongoClient", _MongoClient)
 
 
-@deprecated(message="Use patching instead (see the docs).", version="1.0.0")
+@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
 def trace_mongo_client(client, tracer, service=mongox.SERVICE):
     traced_client = TracedMongoClient(client)
     Pin(service=service, tracer=tracer).onto(traced_client)

--- a/ddtrace/contrib/pymysql/tracers.py
+++ b/ddtrace/contrib/pymysql/tracers.py
@@ -1,8 +1,8 @@
 import pymysql.connections
 
-from ...internal.utils.deprecation import deprecated
+from ...vendor.debtcollector.removals import remove
 
 
-@deprecated(message="Use patching instead (see the docs).", version="1.0.0")
+@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
 def get_traced_pymysql_connection(*args, **kwargs):
     return pymysql.connections.Connection

--- a/ddtrace/contrib/redis/tracers.py
+++ b/ddtrace/contrib/redis/tracers.py
@@ -1,17 +1,17 @@
 from redis import StrictRedis
 
-from ...internal.utils.deprecation import deprecated
+from ...vendor.debtcollector.removals import remove
 
 
 DEFAULT_SERVICE = "redis"
 
 
-@deprecated(message="Use patching instead (see the docs).", version="1.0.0")
+@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
 def get_traced_redis(ddtracer, service=DEFAULT_SERVICE, meta=None):
     return _get_traced_redis(ddtracer, StrictRedis, service, meta)
 
 
-@deprecated(message="Use patching instead (see the docs).", version="1.0.0")
+@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
 def get_traced_redis_from(ddtracer, baseclass, service=DEFAULT_SERVICE, meta=None):
     return _get_traced_redis(ddtracer, baseclass, service, meta)
 

--- a/ddtrace/contrib/requests/legacy.py
+++ b/ddtrace/contrib/requests/legacy.py
@@ -2,7 +2,7 @@
 # that will be removed in newer versions of the Tracer.
 from ddtrace import config
 
-from ...internal.utils.deprecation import deprecation
+from ...vendor.debtcollector import deprecate
 
 
 def _distributed_tracing(self):
@@ -10,10 +10,10 @@ def _distributed_tracing(self):
     the configuration system. It will be removed in newer versions
     of the Tracer.
     """
-    deprecation(
-        name="client.distributed_tracing",
-        message="Use the configuration object instead `config.get_from(client)['distributed_tracing'`",
-        version="1.0.0",
+    deprecate(
+        "client.distributed_tracing is deprecated",
+        message="Use the configuration object instead `config.get_from(client)['distributed_tracing']`",
+        removal_version="1.0.0",
     )
     return config.get_from(self)["distributed_tracing"]
 
@@ -23,9 +23,9 @@ def _distributed_tracing_setter(self, value):
     the configuration system. It will be removed in newer versions
     of the Tracer.
     """
-    deprecation(
-        name="client.distributed_tracing",
-        message="Use the configuration object instead `config.get_from(client)['distributed_tracing'] = value`",
-        version="1.0.0",
+    deprecate(
+        "client.distributed_tracing is deprecated",
+        message="Use the configuration object instead `config.get_from(client)['distributed_tracing']` = value`",
+        removal_version="1.0.0",
     )
     config.get_from(self)["distributed_tracing"] = value

--- a/ddtrace/contrib/sqlite3/connection.py
+++ b/ddtrace/contrib/sqlite3/connection.py
@@ -1,8 +1,8 @@
 from sqlite3 import Connection
 
-from ...internal.utils.deprecation import deprecated
+from ...vendor.debtcollector.removals import remove
 
 
-@deprecated(message="Use patching instead (see the docs).", version="1.0.0")
+@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
 def connection_factory(*args, **kwargs):
     return Connection

--- a/ddtrace/contrib/util.py
+++ b/ddtrace/contrib/util.py
@@ -1,14 +1,13 @@
 # [Backward compatibility]: keep importing modules functions
-from ..internal.utils.deprecation import deprecation
 from ..internal.utils.importlib import func_name
 from ..internal.utils.importlib import module_name
 from ..internal.utils.importlib import require_modules
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.contrib.util",
-    message="`ddtrace.contrib.util` module will be removed in 1.0.0",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.contrib.util",
+    removal_version="1.0.0",
 )
 
 __all__ = [

--- a/ddtrace/encoding.py
+++ b/ddtrace/encoding.py
@@ -1,7 +1,7 @@
 from .internal.encoding import JSONEncoder
 from .internal.encoding import JSONEncoderV2
 from .internal.encoding import MsgpackEncoderV03 as MsgpackEncoder
-from .internal.utils.deprecation import deprecation
+from .vendor.debtcollector.removals import removed_module
 
 
 Encoder = MsgpackEncoder
@@ -15,8 +15,7 @@ __all__ = (
 )
 
 
-deprecation(
-    name="ddtrace.encoding",
-    message="The encoding module has been moved to ddtrace.internal and will no longer be part of the public API.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.encoding",
+    removal_version="1.0.0",
 )

--- a/ddtrace/ext/errors.py
+++ b/ddtrace/ext/errors.py
@@ -7,19 +7,18 @@ import traceback
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
-from ddtrace.internal.utils.deprecation import deprecated
-from ddtrace.internal.utils.deprecation import deprecation
+
+from ..vendor.debtcollector.removals import remove
+from ..vendor.debtcollector.removals import removed_module
 
 
 __all__ = [ERROR_MSG, ERROR_TYPE, ERROR_STACK]
 
-deprecation(
-    name="ddtrace.ext.errors",
-    message=(
-        "Use `ddtrace.constants` module instead. "
-        "Shorthand error constants will be removed. Use ERROR_MSG, ERROR_TYPE, and ERROR_STACK instead."
-    ),
-    version="1.0.0",
+removed_module(
+    module="ddtrace.ext.errors",
+    replacement="ddtrace.constants",
+    message="Use ERROR_MSG, ERROR_TYPE, and ERROR_STACK instead.",
+    removal_version="1.0.0",
 )
 
 # shorthand for ERROR constants to be removed in v1.0-----^
@@ -28,7 +27,7 @@ TYPE = ERROR_TYPE
 STACK = ERROR_STACK
 
 
-@deprecated("This method and module will be removed altogether", "1.0.0")
+@remove(removal_version="1.0.0")
 def get_traceback(tb=None, error=None):
     t = None
     if error:

--- a/ddtrace/ext/errors.py
+++ b/ddtrace/ext/errors.py
@@ -17,7 +17,7 @@ __all__ = [ERROR_MSG, ERROR_TYPE, ERROR_STACK]
 removed_module(
     module="ddtrace.ext.errors",
     replacement="ddtrace.constants",
-    message="Use ERROR_MSG, ERROR_TYPE, and ERROR_STACK instead.",
+    message="ERROR_MSG, ERROR_TYPE, and ERROR_STACK.",
     removal_version="1.0.0",
 )
 

--- a/ddtrace/ext/priority.py
+++ b/ddtrace/ext/priority.py
@@ -17,13 +17,14 @@ from ddtrace.constants import AUTO_KEEP
 from ddtrace.constants import AUTO_REJECT
 from ddtrace.constants import USER_KEEP
 from ddtrace.constants import USER_REJECT
-from ddtrace.internal.utils.deprecation import deprecation
+
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.ext.priority",
-    message="Use `ddtrace.constants` module instead",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.ext.priority",
+    replacement="ddtrace.constants",
+    removal_version="1.0.0",
 )
 
 __all__ = ["USER_REJECT", "AUTO_REJECT", "AUTO_KEEP", "USER_KEEP"]

--- a/ddtrace/ext/system.py
+++ b/ddtrace/ext/system.py
@@ -2,13 +2,14 @@
 Standard system tags
 """
 from ddtrace.constants import PID
-from ddtrace.internal.utils.deprecation import deprecation
+
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.ext.system",
-    message="Use `ddtrace.constants` module instead",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.ext.system",
+    replacement="ddtrace.constants",
+    removal_version="1.0.0",
 )
 
 __all__ = ["PID"]

--- a/ddtrace/helpers.py
+++ b/ddtrace/helpers.py
@@ -3,17 +3,15 @@ from typing import TYPE_CHECKING
 from typing import Tuple
 
 import ddtrace
-from ddtrace.internal.utils.deprecation import deprecated
+
+from .vendor.debtcollector.removals import remove
 
 
 if TYPE_CHECKING:
     from ddtrace.tracer import Tracer
 
 
-@deprecated(
-    "This method and module will be removed altogether. Use 'ddtrace.Tracer.get_log_correlation_context()' instead.",
-    "1.0.0",
-)
+@remove(message="Use 'ddtrace.Tracer.get_log_correlation_context()' instead.", removal_version="1.0.0")
 def get_correlation_ids(tracer=None):
     # type: (Optional[Tracer]) -> Tuple[Optional[int], Optional[int]]
     """Retrieves the Correlation Identifiers for the current active ``Trace``.

--- a/ddtrace/http/__init__.py
+++ b/ddtrace/http/__init__.py
@@ -1,5 +1,4 @@
-from ddtrace.internal.utils.deprecation import deprecation
-
+from ..vendor.debtcollector.removals import removed_module
 from .headers import store_request_headers
 from .headers import store_response_headers
 
@@ -9,8 +8,8 @@ __all__ = [
     "store_response_headers",
 ]
 
-deprecation(
-    name="ddtrace.http",
-    message="The http module has been merged into ddtrace.contrib.trace_utils",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.http",
+    replacement="ddtrace.contrib.trace_utils",
+    removal_version="1.0.0",
 )

--- a/ddtrace/http/headers.py
+++ b/ddtrace/http/headers.py
@@ -6,7 +6,8 @@ from ddtrace.contrib.trace_utils import _normalized_header_name
 from ddtrace.contrib.trace_utils import _store_headers
 from ddtrace.contrib.trace_utils import _store_request_headers as store_request_headers
 from ddtrace.contrib.trace_utils import _store_response_headers as store_response_headers
-from ddtrace.internal.utils.deprecation import deprecation
+
+from ..vendor.debtcollector.removals import removed_module
 
 
 __all__ = (
@@ -20,8 +21,8 @@ __all__ = (
     "_normalize_tag_name",
 )
 
-deprecation(
-    name="ddtrace.http.headers",
-    message="The http.headers module has been merged into ddtrace.contrib.trace_utils",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.http.headers",
+    replacement="ddtrace.contrib.trace_utils",
+    removal_version="1.0.0",
 )

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -6,8 +6,8 @@ from typing import DefaultDict
 from typing import Tuple
 from typing import cast
 
-from ..internal.utils.deprecation import deprecation
 from ..internal.utils.formats import get_env
+from ..vendor.debtcollector import deprecate
 
 
 def get_logger(name):
@@ -113,10 +113,10 @@ class DDLogger(logging.Logger):
             # DEV: If not set, look at the deprecated (DD/DATADOG)_LOGGING_RATE_LIMIT
             rate_limit = get_env("logging", "rate_limit")
             if rate_limit is not None:
-                deprecation(
-                    name="DD_LOGGING_RATE_LIMIT",
+                deprecate(
+                    "DD_LOGGING_RATE_LIMIT is deprecated",
                     message="Use `DD_TRACE_LOGGING_RATE` instead",
-                    version="1.0.0",
+                    removal_version="1.0.0",
                 )
 
         if rate_limit is not None:

--- a/ddtrace/internal/utils/deprecation.py
+++ b/ddtrace/internal/utils/deprecation.py
@@ -7,11 +7,9 @@ from typing import Optional
 from typing import Tuple
 import warnings
 
+from ddtrace.vendor.debtcollector.removals import remove
+
 from ...vendor import debtcollector
-
-
-class RemovedInDDTrace10Warning(DeprecationWarning):
-    pass
 
 
 def format_message(name, message, version=None):
@@ -28,27 +26,7 @@ def format_message(name, message, version=None):
     )
 
 
-def warn(message, stacklevel=2):
-    # type: (str, int) -> None
-    """Helper function used as a ``DeprecationWarning``."""
-    warnings.warn(message, RemovedInDDTrace10Warning, stacklevel=stacklevel)
-
-
-def deprecation(name="", message="", version=None):
-    # type: (str, str, Optional[str]) -> None
-    """Function to report a ``DeprecationWarning``. Bear in mind that `DeprecationWarning`
-    are ignored by default so they're not available in user logs. To show them,
-    the application must be launched with a special flag:
-
-        $ python -Wall script.py
-
-    This approach is used by most of the frameworks, including Django
-    (ref: https://docs.djangoproject.com/en/2.0/howto/upgrade-version/#resolving-deprecation-warnings)
-    """
-    msg = format_message(name, message, version)
-    warn(msg, stacklevel=4)
-
-
+@remove(message="Use debtcollector.removals.remove instead.", removal_version="1.0.0")
 def deprecated(message="", version=None):
     # type: (str, Optional[str]) -> Callable[[Callable[..., Any]], Callable[..., Any]]
     """Decorator function to report a ``DeprecationWarning``. Bear
@@ -68,7 +46,7 @@ def deprecated(message="", version=None):
         def wrapper(*args, **kwargs):
             # type: (Tuple[Any], Dict[str, Any]) -> Any
             msg = format_message(func.__name__, message, version)
-            warn(msg, stacklevel=3)
+            warnings.warn(msg, DeprecationWarning, stacklevel=3)
             return func(*args, **kwargs)
 
         return wrapper
@@ -96,7 +74,7 @@ def get_service_legacy(default=None):
                 "Refer to our release notes on Github: https://github.com/DataDog/dd-trace-py/releases/tag/v0.36.0 "
                 "for the improvements being made for service names."
             ),
-            removal_version="2.0.0",
+            removal_version="1.0.0",
         )
         return os.getenv("DD_SERVICE_NAME")
     elif "DATADOG_SERVICE_NAME" in os.environ:
@@ -107,7 +85,7 @@ def get_service_legacy(default=None):
                 "Refer to our release notes on Github: https://github.com/DataDog/dd-trace-py/releases/tag/v0.36.0 "
                 "for the improvements being made for service names."
             ),
-            removal_version="2.0.0",
+            removal_version="1.0.0",
         )
         return os.getenv("DATADOG_SERVICE_NAME")
 

--- a/ddtrace/internal/utils/deprecation.py
+++ b/ddtrace/internal/utils/deprecation.py
@@ -7,7 +7,7 @@ from typing import Optional
 from typing import Tuple
 import warnings
 
-from ddtrace.vendor import debtcollector
+from ...vendor import debtcollector
 
 
 class RemovedInDDTrace10Warning(DeprecationWarning):
@@ -87,15 +87,24 @@ def get_service_legacy(default=None):
     If the environment variables are not in use, no deprecation warning is
     produced and `default` is returned.
     """
-    for old_env_key in ["DD_SERVICE_NAME", "DATADOG_SERVICE_NAME"]:
-        if old_env_key in os.environ:
-            debtcollector.deprecate(
-                (
-                    "'{}' is deprecated and will be removed in a future version. Please use DD_SERVICE instead. "
-                    "Refer to our release notes on Github: https://github.com/DataDog/dd-trace-py/releases/tag/v0.36.0 "
-                    "for the improvements being made for service names."
-                ).format(old_env_key)
-            )
-            return os.getenv(old_env_key)
+
+    if "DD_SERVICE_NAME" in os.environ:
+        debtcollector.deprecate(
+            "DD_SERVICE_NAME is deprecated",
+            message="Use DD_SERVICE instead."
+            "Refer to our release notes on Github: https://github.com/DataDog/dd-trace-py/releases/tag/v0.36.0 "
+            "for the improvements being made for service names.",
+            removal_version="2.0.0",
+        )
+        return os.getenv("DD_SERVICE_NAME")
+    elif "DATADOG_SERVICE_NAME" in os.environ:
+        debtcollector.deprecate(
+            "DATADOG_SERVICE_NAME is deprecated",
+            message="Use DD_SERVICE instead."
+            "Refer to our release notes on Github: https://github.com/DataDog/dd-trace-py/releases/tag/v0.36.0 "
+            "for the improvements being made for service names.",
+            removal_version="2.0.0",
+        )
+        return os.getenv("DATADOG_SERVICE_NAME")
 
     return default

--- a/ddtrace/internal/utils/deprecation.py
+++ b/ddtrace/internal/utils/deprecation.py
@@ -91,18 +91,22 @@ def get_service_legacy(default=None):
     if "DD_SERVICE_NAME" in os.environ:
         debtcollector.deprecate(
             "DD_SERVICE_NAME is deprecated",
-            message="Use DD_SERVICE instead."
-            "Refer to our release notes on Github: https://github.com/DataDog/dd-trace-py/releases/tag/v0.36.0 "
-            "for the improvements being made for service names.",
+            message=(
+                "Use DD_SERVICE instead. "
+                "Refer to our release notes on Github: https://github.com/DataDog/dd-trace-py/releases/tag/v0.36.0 "
+                "for the improvements being made for service names."
+            ),
             removal_version="2.0.0",
         )
         return os.getenv("DD_SERVICE_NAME")
     elif "DATADOG_SERVICE_NAME" in os.environ:
         debtcollector.deprecate(
             "DATADOG_SERVICE_NAME is deprecated",
-            message="Use DD_SERVICE instead."
-            "Refer to our release notes on Github: https://github.com/DataDog/dd-trace-py/releases/tag/v0.36.0 "
-            "for the improvements being made for service names.",
+            message=(
+                "Use DD_SERVICE instead. "
+                "Refer to our release notes on Github: https://github.com/DataDog/dd-trace-py/releases/tag/v0.36.0 "
+                "for the improvements being made for service names."
+            ),
             removal_version="2.0.0",
         )
         return os.getenv("DATADOG_SERVICE_NAME")

--- a/ddtrace/internal/utils/formats.py
+++ b/ddtrace/internal/utils/formats.py
@@ -7,7 +7,7 @@ from typing import Optional
 from typing import TypeVar
 from typing import Union
 
-from .deprecation import deprecation
+from ...vendor.debtcollector import deprecate
 
 
 T = TypeVar("T")
@@ -48,10 +48,10 @@ def get_env(*parts, **kwargs):
     legacy = os.getenv(legacy_env)
     if legacy:
         # Deprecation: `DATADOG_` variables are deprecated
-        deprecation(
-            name="DATADOG_",
+        deprecate(
+            "DATADOG_ is deprecated",
             message="Use `DD_` prefix instead",
-            version="1.0.0",
+            removal_version="1.0.0",
         )
 
     value = value or legacy

--- a/ddtrace/internal/utils/wrappers.py
+++ b/ddtrace/internal/utils/wrappers.py
@@ -7,7 +7,7 @@ from typing import TypeVar
 
 from ddtrace.vendor import wrapt
 
-from .deprecation import deprecated
+from ...vendor.debtcollector.removals import remove
 
 
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ def unwrap(obj, attr):
     setattr(obj, attr, f.__wrapped__)
 
 
-@deprecated("`wrapt` library is used instead", version="1.0.0")
+@remove(message="`wrapt` library is used instead", removal_version="1.0.0")
 def safe_patch(
     patchable,  # type: Any
     key,  # type: str

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -14,11 +14,11 @@ from ._monkey import get_patched_modules  # noqa
 from ._monkey import patch  # noqa
 from ._monkey import patch_all  # noqa
 from ._monkey import patch_module  # noqa
-from .internal.utils.deprecation import deprecation
+from .vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.monkey",
+removed_module(
+    module="ddtrace.monkey",
     message="Import the patch and patch_all functions directly from the ddtrace module instead",
-    version="1.0.0",
+    removal_version="1.0.0",
 )

--- a/ddtrace/propagation/utils.py
+++ b/ddtrace/propagation/utils.py
@@ -1,10 +1,9 @@
-from ..internal.utils.deprecation import deprecation
+from ..vendor.debtcollector.removals import removed_module
 from ._utils import from_wsgi_header  # noqa
 from ._utils import get_wsgi_header  # noqa
 
 
-deprecation(
-    name="ddtrace.propagation.utils",
-    message="This module will be removed in v1.0.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.propagation.utils",
+    removal_version="1.0.0",
 )

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -7,12 +7,12 @@ from typing import Tuple
 from ddtrace.internal.utils.cache import cachedmethod
 
 from ..internal.logger import get_logger
-from ..internal.utils.deprecation import deprecated
 from ..internal.utils.deprecation import get_service_legacy
 from ..internal.utils.formats import asbool
 from ..internal.utils.formats import get_env
 from ..internal.utils.formats import parse_tags_str
 from ..pin import Pin
+from ..vendor.debtcollector.removals import remove
 from .http import HttpConfig
 from .integration import IntegrationConfig
 
@@ -244,9 +244,6 @@ class Config(object):
         integrations = ", ".join(self._config.keys())
         return "{}.{}({})".format(cls.__module__, cls.__name__, integrations)
 
-    @deprecated(
-        message="HttpServerConfig will be removed",
-        version="1.0.0",
-    )
+    @remove(removal_version="1.0.0")
     class HTTPServerConfig(_HTTPServerConfig):
         pass

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -40,8 +40,7 @@ from .internal.compat import numeric_types
 from .internal.compat import stringify
 from .internal.compat import time_ns
 from .internal.logger import get_logger
-from .internal.utils.deprecation import deprecated
-from .internal.utils.deprecation import deprecation
+from .vendor.debtcollector import deprecate
 from .vendor.debtcollector.removals import removed_property
 
 
@@ -151,10 +150,10 @@ class Span(object):
         self.parent_id = parent_id  # type: Optional[int]
         self._tracer = None  # type: Optional[Tracer]
         if tracer is not None:
-            deprecation(
-                name="ddtrace.Span.tracer",
+            deprecate(
+                "ddtrace.Span.tracer is deprecated",
                 message="Use Span(tracer=None, name, ...) instead.",
-                version="1.0.0",
+                removal_version="1.0.0",
             )
             self._tracer = tracer
         self._on_finish_callbacks = [] if on_finish is None else on_finish
@@ -394,12 +393,12 @@ class Span(object):
     def meta(self, value):
         self._meta = value
 
-    @deprecated(message="Span.set_meta will be removed. Use Span.set_tag.", version="1.0.0")
+    @removed_property(message="Use Span.set_tag instead.", removal_version="1.0.0")
     def set_meta(self, k, v):
         # type: (_TagNameType, NumericType) -> None
         self.set_tag(k, v)
 
-    @deprecated(message="Span.set_metas will be removed. Use Span.set_tags.", version="1.0.0")
+    @removed_property(message="Use Span.set_tags.", removal_version="1.0.0")
     def set_metas(self, kvs):
         # type: (_MetaDictType) -> None
         self.set_tags(kvs)
@@ -542,7 +541,7 @@ class Span(object):
         self._remove_tag(ERROR_TYPE)
         self._remove_tag(ERROR_STACK)
 
-    @deprecated(message="Span.pprint will be removed.", version="1.0.0")
+    @removed_property(removal_version="1.0.0")
     def pprint(self):
         return self._pprint()
 

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -17,7 +17,6 @@ from typing import Union
 
 from ddtrace import config
 from ddtrace.filters import TraceFilter
-from ddtrace.internal.utils.deprecation import deprecation
 from ddtrace.vendor import debtcollector
 
 from . import _hooks
@@ -48,7 +47,6 @@ from .internal.processor.trace import TraceSamplingProcessor
 from .internal.processor.trace import TraceTagsProcessor
 from .internal.processor.trace import TraceTopLevelSpanProcessor
 from .internal.runtime import get_runtime_id
-from .internal.utils.deprecation import deprecated
 from .internal.utils.formats import asbool
 from .internal.utils.formats import get_env
 from .internal.writer import AgentWriter
@@ -154,7 +152,9 @@ class Tracer(object):
         pfe_default_value = False
         pfms_default_value = 500
         if "DD_TRACER_PARTIAL_FLUSH_ENABLED" in os.environ or "DD_TRACER_PARTIAL_FLUSH_MIN_SPANS" in os.environ:
-            deprecation("DD_TRACER_... use DD_TRACE_... instead", version="1.0.0")
+            debtcollector.deprecate(
+                "DD_TRACER_... is deprecated", message="use DD_TRACE_... instead", removal_version="1.0.0"
+            )
             pfe_default_value = asbool(get_env("tracer", "partial_flush_enabled", default=pfe_default_value))
             pfms_default_value = int(
                 get_env("tracer", "partial_flush_min_spans", default=pfms_default_value)  # type: ignore[arg-type]
@@ -212,21 +212,22 @@ class Tracer(object):
         return self.log.isEnabledFor(logging.DEBUG)
 
     @debug_logging.setter  # type: ignore[misc]
-    @deprecated(message="Use logging.setLevel instead", version="1.0.0")
+    @removals.remove(message="Use logging.setLevel instead", removal_version="1.0.0")
     def debug_logging(self, value):
         # type: (bool) -> None
         self.log.setLevel(logging.DEBUG if value else logging.WARN)
 
-    @deprecated("Use .tracer, not .tracer()", "1.0.0")
+    @removals.remove(removal_version="1.0.0")
     def __call__(self):
         return self
 
-    @deprecated("This method will be removed altogether", "1.0.0")
+    @removals.remove(removal_version="1.0.0")
     def global_excepthook(self, tp, value, traceback):
         """The global tracer except hook."""
 
-    @deprecated(
-        "Call context has been superseded by trace context. Please use current_trace_context() instead.", "1.0.0"
+    @removals.remove(
+        message="Call context has been superseded by trace context. Please use current_trace_context() instead.",
+        removal_version="1.0.0",
     )
     def get_call_context(self, *args, **kwargs):
         # type: (...) -> Context
@@ -866,7 +867,7 @@ class Tracer(object):
         """Flush the buffer of the trace writer. This does nothing if an unbuffered trace writer is used."""
         self._writer.flush_queue()
 
-    @deprecated(message="Manually setting service info is no longer necessary", version="1.0.0")
+    @removals.remove(message="Manually setting service info is no longer necessary", removal_version="1.0.0")
     def set_service_info(self, *args, **kwargs):
         """Set the information about the given service."""
         return
@@ -990,9 +991,9 @@ class Tracer(object):
             self.trace = self._trace
 
             debtcollector.deprecate(
-                "Tracing with a tracer that has been shut down is being deprecated. "
-                "A new tracer should be created for generating new traces",
-                version="1.0.0",
+                "Tracing with a tracer that has been shut down is deprecated",
+                message="A new tracer should be created for generating new traces.",
+                removal_version="1.0.0",
             )
 
     def _shutdown_start_span(

--- a/ddtrace/util.py
+++ b/ddtrace/util.py
@@ -10,7 +10,6 @@ from .vendor.debtcollector.removals import removed_module
 
 removed_module(
     module="ddtrace.util",
-    replacement="ddtrace.utils",
     removal_version="1.0.0",
 )
 

--- a/ddtrace/util.py
+++ b/ddtrace/util.py
@@ -1,17 +1,17 @@
 # [Backward compatibility]: keep importing modules functions
 from .internal.utils.deprecation import deprecated
-from .internal.utils.deprecation import deprecation
 from .internal.utils.formats import asbool
 from .internal.utils.formats import deep_getattr
 from .internal.utils.formats import get_env
 from .internal.utils.wrappers import safe_patch
 from .internal.utils.wrappers import unwrap
+from .vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.util",
-    message="Use `ddtrace.utils` package instead",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.util",
+    replacement="ddtrace.utils",
+    removal_version="1.0.0",
 )
 
 __all__ = [

--- a/ddtrace/utils/__init__.py
+++ b/ddtrace/utils/__init__.py
@@ -1,10 +1,9 @@
 from ..internal.utils import ArgumentError  # noqa
 from ..internal.utils import get_argument_value  # noqa
-from ..internal.utils.deprecation import deprecation
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.utils.__init__",
-    message="This module will be removed in v1.0.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.utils.__init__",
+    removal_version="1.0.0",
 )

--- a/ddtrace/utils/attr.py
+++ b/ddtrace/utils/attr.py
@@ -1,10 +1,9 @@
 from ..internal.utils.attr import T  # noqa
 from ..internal.utils.attr import from_env  # noqa
-from ..internal.utils.deprecation import deprecation
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.utils.attr",
-    message="This module will be removed in v1.0.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.utils.attr",
+    removal_version="1.0.0",
 )

--- a/ddtrace/utils/attrdict.py
+++ b/ddtrace/utils/attrdict.py
@@ -1,9 +1,8 @@
 from ..internal.utils.attrdict import AttrDict  # noqa
-from ..internal.utils.deprecation import deprecation
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.utils.attrdict",
-    message="This module will be removed in v1.0.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.utils.attrdict",
+    removal_version="1.0.0",
 )

--- a/ddtrace/utils/cache.py
+++ b/ddtrace/utils/cache.py
@@ -6,11 +6,10 @@ from ..internal.utils.cache import T  # noqa
 from ..internal.utils.cache import cached  # noqa
 from ..internal.utils.cache import cachedmethod  # noqa
 from ..internal.utils.cache import miss  # noqa
-from ..internal.utils.deprecation import deprecation
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.utils.cache",
-    message="This module will be removed in v1.0.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.utils.cache",
+    removal_version="1.0.0",
 )

--- a/ddtrace/utils/config.py
+++ b/ddtrace/utils/config.py
@@ -1,9 +1,8 @@
 from ..internal.utils.config import get_application_name  # noqa
-from ..internal.utils.deprecation import deprecation
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.utils.config",
-    message="This module will be removed in v1.0.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.utils.config",
+    removal_version="1.0.0",
 )

--- a/ddtrace/utils/deprecation.py
+++ b/ddtrace/utils/deprecation.py
@@ -1,13 +1,12 @@
 from ..internal.utils.deprecation import RemovedInDDTrace10Warning  # noqa
 from ..internal.utils.deprecation import deprecated  # noqa
-from ..internal.utils.deprecation import deprecation
 from ..internal.utils.deprecation import format_message  # noqa
 from ..internal.utils.deprecation import get_service_legacy  # noqa
 from ..internal.utils.deprecation import warn  # noqa
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.utils.deprecation",
-    message="This module will be removed in v1.0.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.utils.deprecation",
+    removal_version="1.0.0",
 )

--- a/ddtrace/utils/deprecation.py
+++ b/ddtrace/utils/deprecation.py
@@ -1,8 +1,4 @@
-from ..internal.utils.deprecation import RemovedInDDTrace10Warning  # noqa
-from ..internal.utils.deprecation import deprecated  # noqa
-from ..internal.utils.deprecation import format_message  # noqa
 from ..internal.utils.deprecation import get_service_legacy  # noqa
-from ..internal.utils.deprecation import warn  # noqa
 from ..vendor.debtcollector.removals import removed_module
 
 

--- a/ddtrace/utils/formats.py
+++ b/ddtrace/utils/formats.py
@@ -1,14 +1,13 @@
-from ..internal.utils.deprecation import deprecation
 from ..internal.utils.formats import T  # noqa
 from ..internal.utils.formats import asbool  # noqa
 from ..internal.utils.formats import deep_getattr  # noqa
 from ..internal.utils.formats import get_env  # noqa
 from ..internal.utils.formats import log  # noqa
 from ..internal.utils.formats import parse_tags_str  # noqa
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.utils.formats",
-    message="This module will be removed in v1.0.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.utils.formats",
+    removal_version="1.0.0",
 )

--- a/ddtrace/utils/http.py
+++ b/ddtrace/utils/http.py
@@ -1,10 +1,9 @@
-from ..internal.utils.deprecation import deprecation
 from ..internal.utils.http import normalize_header_name  # noqa
 from ..internal.utils.http import strip_query_string  # noqa
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.utils.http",
-    message="This module will be removed in v1.0.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.utils.http",
+    removal_version="1.0.0",
 )

--- a/ddtrace/utils/importlib.py
+++ b/ddtrace/utils/importlib.py
@@ -1,11 +1,10 @@
-from ..internal.utils.deprecation import deprecation
 from ..internal.utils.importlib import func_name  # noqa
 from ..internal.utils.importlib import module_name  # noqa
 from ..internal.utils.importlib import require_modules  # noqa
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.utils.importlib",
-    message="This module will be removed in v1.0.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.utils.importlib",
+    removal_version="1.0.0",
 )

--- a/ddtrace/utils/time.py
+++ b/ddtrace/utils/time.py
@@ -1,9 +1,8 @@
-from ..internal.utils.deprecation import deprecation
 from ..internal.utils.time import StopWatch  # noqa
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.utils.time",
-    message="This module will be removed in v1.0.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.utils.time",
+    removal_version="1.0.0",
 )

--- a/ddtrace/utils/version.py
+++ b/ddtrace/utils/version.py
@@ -1,9 +1,8 @@
-from ..internal.utils.deprecation import deprecation
 from ..internal.utils.version import parse_version  # noqa
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.utils.version",
-    message="This module will be removed in v1.0.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.utils.version",
+    removal_version="1.0.0",
 )

--- a/ddtrace/utils/wrappers.py
+++ b/ddtrace/utils/wrappers.py
@@ -1,12 +1,11 @@
-from ..internal.utils.deprecation import deprecation
 from ..internal.utils.wrappers import F  # noqa
 from ..internal.utils.wrappers import iswrapped  # noqa
 from ..internal.utils.wrappers import safe_patch  # noqa
 from ..internal.utils.wrappers import unwrap  # noqa
+from ..vendor.debtcollector.removals import removed_module
 
 
-deprecation(
-    name="ddtrace.utils.wrappers",
-    message="This module will be removed in v1.0.",
-    version="1.0.0",
+removed_module(
+    module="ddtrace.utils.wrappers",
+    removal_version="1.0.0",
 )

--- a/tests/tracer/test_logger.py
+++ b/tests/tracer/test_logger.py
@@ -5,7 +5,6 @@ from pytest import warns
 
 from ddtrace.internal.logger import DDLogger
 from ddtrace.internal.logger import get_logger
-from ddtrace.internal.utils.deprecation import RemovedInDDTrace10Warning
 from tests.utils import BaseTestCase
 
 
@@ -146,7 +145,7 @@ class DDLoggerTestCase(BaseTestCase):
         self.assertEqual(log.level, logging.DEBUG)
 
     def test_logger_deprecated_rate_limit(self):
-        with self.override_env(dict(DD_LOGGING_RATE_LIMIT="10")), warns(RemovedInDDTrace10Warning):
+        with self.override_env(dict(DD_LOGGING_RATE_LIMIT="10")), warns(DeprecationWarning):
             log = DDLogger("test.logger")
             self.assertEqual(log.rate_limit, 10)
 

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -164,9 +164,8 @@ class SpanTestCase(TracerTestCase):
             Span(self.tracer, "test_span")
             assert len(ws) == 1
             assert (
-                str(ws[0].message)
-                == "'ddtrace.Span.tracer' is deprecated and will be remove in future versions (1.0.0)."
-                " Use Span(tracer=None, name, ...) instead."
+                str(ws[0].message) == "ddtrace.Span.tracer is deprecated and will be removed in version '1.0.0': "
+                "Use Span(tracer=None, name, ...) instead."
             )
 
     def test_accessing_tracer_from_span(self):

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -536,8 +536,9 @@ def test_tracer_shutdown_no_timeout():
         (w,) = ws
         assert issubclass(w.category, DeprecationWarning)
         assert (
-            str(w.message) == "Tracing with a tracer that has been shut down is being deprecated. "
-            "A new tracer should be created for generating new traces in version '1.0.0'"
+            str(w.message)
+            == "Tracing with a tracer that has been shut down is deprecated and will be removed in version '1.0.0': "
+            "A new tracer should be created for generating new traces."
         )
 
     with t.trace("something"):

--- a/tests/tracer/test_utils.py
+++ b/tests/tracer/test_utils.py
@@ -14,7 +14,6 @@ from ddtrace.internal.utils import time
 from ddtrace.internal.utils.cache import cached
 from ddtrace.internal.utils.cache import cachedmethod
 from ddtrace.internal.utils.deprecation import deprecated
-from ddtrace.internal.utils.deprecation import deprecation
 from ddtrace.internal.utils.deprecation import format_message
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import get_env
@@ -86,15 +85,6 @@ class TestUtils(unittest.TestCase):
             "use something else instead"
         )
         self.assertEqual(msg, expected)
-
-    def test_deprecation(self):
-        # ensure `deprecation` properly raise a DeprecationWarning
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            deprecation(name="fn", message="message", version="1.0.0")
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("message", str(w[-1].message))
 
     def test_deprecated_decorator(self):
         # ensure `deprecated` decorator properly raise a DeprecationWarning


### PR DESCRIPTION
Update all deprecation warnings to use vendored debtcollector. This change ensures all deprecation warnings have a consistent format.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
