### PR TITLE
fix: update libddwaf to 1.0.18

### DIFF
--- a/ddtrace/appsec/CMakeLists.txt
+++ b/ddtrace/appsec/CMakeLists.txt
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libddwaf
     GIT_REPOSITORY https://github.com/DataDog/libddwaf.git
-    GIT_TAG 1.0.16
+    GIT_TAG 1.0.18
     INSTALL_DIR ${CMAKE_SOURCE_DIR}
     CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}


### PR DESCRIPTION
This updates libddwaf to the latest version with an updated version of RE2. This should close #3260 

cc @brettlangdon and @Kyle-Verhoog 
