### PR TITLE
chore(tracing/grpc): add patch/unpatch tests for grpc integration

### DIFF
--- a/tests/contrib/grpc/test_grpc_patch.py
+++ b/tests/contrib/grpc/test_grpc_patch.py
@@ -1,0 +1,33 @@
+from ddtrace.contrib.grpc import patch
+from tests.contrib.patch import PatchTestCase
+
+
+class TestSnowflakePatch(PatchTestCase.Base):
+    __integration_name__ = "grpc"
+    __module_name__ = "grpc"
+    __patch_func__ = patch
+    __unpatch_func__ = None
+
+    def assert_module_patched(self, grpc):
+        # Client Wrapping
+        self.assert_wrapped(grpc.insecure_channel)
+        self.assert_wrapped(grpc.secure_channel)
+        self.assert_wrapped(grpc.intercept_channel)
+        # Server Wrapping
+        self.assert_wrapped(grpc.server)
+
+    def assert_not_module_patched(self, grpc):
+        # Client Wrapping
+        self.assert_not_wrapped(grpc.insecure_channel)
+        self.assert_not_wrapped(grpc.secure_channel)
+        self.assert_not_wrapped(grpc.intercept_channel)
+        # Server Wrapping
+        self.assert_not_wrapped(grpc.server)
+
+    def assert_not_module_double_patched(self, grpc):
+        # Client Wrapping
+        self.assert_not_double_wrapped(grpc.insecure_channel)
+        self.assert_not_double_wrapped(grpc.secure_channel)
+        self.assert_not_double_wrapped(grpc.intercept_channel)
+        # Server Wrapping
+        self.assert_not_double_wrapped(grpc.server)

--- a/tests/contrib/grpc/test_grpc_patch.py
+++ b/tests/contrib/grpc/test_grpc_patch.py
@@ -2,7 +2,7 @@ from ddtrace.contrib.grpc import patch
 from tests.contrib.patch import PatchTestCase
 
 
-class TestSnowflakePatch(PatchTestCase.Base):
+class TestGRPCPatch(PatchTestCase.Base):
     __integration_name__ = "grpc"
     __module_name__ = "grpc"
     __patch_func__ = patch


### PR DESCRIPTION
Adds tests for patching and unpatching of the GRPC integration.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
