### PR TITLE
chore(tracing/context)!: remove Context.clone

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -8,7 +8,6 @@ from .constants import ORIGIN_KEY
 from .constants import SAMPLING_PRIORITY_KEY
 from .internal.compat import NumericType
 from .internal.logger import get_logger
-from .internal.utils.deprecation import deprecated
 
 
 if TYPE_CHECKING:
@@ -106,15 +105,6 @@ class Context(object):
                     del self._meta[ORIGIN_KEY]
                 return
             self._meta[ORIGIN_KEY] = value
-
-    @deprecated("Cloning contexts will no longer be required in 0.50", version="0.50")
-    def clone(self):
-        # type: () -> Context
-        """
-        Partially clones the current context.
-        It copies everything EXCEPT the registered and finished spans.
-        """
-        return self
 
     def __eq__(self, other):
         # type: (Any) -> bool

--- a/releasenotes/notes/remove-clone-context-3cc6f3d73f15345e.yaml
+++ b/releasenotes/notes/remove-clone-context-3cc6f3d73f15345e.yaml
@@ -1,4 +1,4 @@
 ---
 upgrade:
   - |
-    :py:meth:`ddrace.context.Context.clone` was removed. This is no longer need since ddtrace will now work out of the box with async frameworks.
+    :py:meth:`ddrace.context.Context.clone` was removed. This is no longer needed since the tracer now supports async frameworks out of the box.

--- a/releasenotes/notes/remove-clone-context-3cc6f3d73f15345e.yaml
+++ b/releasenotes/notes/remove-clone-context-3cc6f3d73f15345e.yaml
@@ -1,4 +1,4 @@
 ---
 upgrade:
   - |
-    :py:meth:`ddrace.context.Context.clone` was removed.
+    :py:meth:`ddrace.context.Context.clone` was removed. This is no longer need since ddtrace will now work out of the box with async frameworks.

--- a/releasenotes/notes/remove-clone-context-3cc6f3d73f15345e.yaml
+++ b/releasenotes/notes/remove-clone-context-3cc6f3d73f15345e.yaml
@@ -1,4 +1,4 @@
 ---
 upgrade:
   - |
-    :py:meth:`ddrace.context.Context.clone` was removed. This is no longer needed since the tracer now supports async frameworks out of the box.
+    ``ddrace.context.Context.clone`` was removed. This is no longer needed since the tracer now supports asynchronous frameworks out of the box.

--- a/releasenotes/notes/remove-clone-context-3cc6f3d73f15345e.yaml
+++ b/releasenotes/notes/remove-clone-context-3cc6f3d73f15345e.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    :py:meth:`ddrace.context.Context.clone` was removed.


### PR DESCRIPTION
Context.clone was deprecated in the following PR: https://github.com/DataDog/dd-trace-py/pull/2427

With the removal of [active span management](https://github.com/DataDog/dd-trace-py/pull/1936), a trace Context is managed internally and should not be accessed by users. 

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
