### PR TITLE
docs: add release notes for 1.0

### DIFF
--- a/ddtrace/contrib/aioredis/__init__.py
+++ b/ddtrace/contrib/aioredis/__init__.py
@@ -7,9 +7,9 @@ Enabling
 ~~~~~~~~
 
 The aioredis integration is enabled automatically when using
-:ref:`ddtrace-run <ddtracerun>` or :ref:`patch_all() <patch_all>`.
+:ref:`ddtrace-run <ddtracerun>` or :func:`patch_all() <ddtrace.patch_all>`.
 
-Or use :ref:`patch() <patch>` to manually enable the integration::
+Or use :func:`patch() <ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(aioredis=True)

--- a/ddtrace/contrib/aredis/__init__.py
+++ b/ddtrace/contrib/aredis/__init__.py
@@ -6,9 +6,9 @@ Enabling
 ~~~~~~~~
 
 The aredis integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(aredis=True)
@@ -30,7 +30,7 @@ Global Configuration
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To configure particular aredis instances use the :ref:`Pin<Pin>` API::
+To configure particular aredis instances use the :class:`Pin <ddtrace.Pin>` API::
 
     import aredis
     from ddtrace import Pin

--- a/ddtrace/contrib/botocore/__init__.py
+++ b/ddtrace/contrib/botocore/__init__.py
@@ -6,9 +6,9 @@ Enabling
 ~~~~~~~~
 
 The botocore integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(botocore=True)

--- a/ddtrace/contrib/elasticsearch/__init__.py
+++ b/ddtrace/contrib/elasticsearch/__init__.py
@@ -5,9 +5,9 @@ Enabling
 ~~~~~~~~
 
 The elasticsearch integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     from elasticsearch import Elasticsearch

--- a/ddtrace/contrib/fastapi/__init__.py
+++ b/ddtrace/contrib/fastapi/__init__.py
@@ -5,9 +5,9 @@ Enabling
 ~~~~~~~~
 
 The fastapi integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     from fastapi import FastAPI

--- a/ddtrace/contrib/futures/__init__.py
+++ b/ddtrace/contrib/futures/__init__.py
@@ -8,9 +8,9 @@ Enabling
 ~~~~~~~~
 
 The futures integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(futures=True)

--- a/ddtrace/contrib/gevent/__init__.py
+++ b/ddtrace/contrib/gevent/__init__.py
@@ -27,9 +27,9 @@ Enabling
 ~~~~~~~~
 
 The integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(gevent=True)

--- a/ddtrace/contrib/grpc/__init__.py
+++ b/ddtrace/contrib/grpc/__init__.py
@@ -6,9 +6,9 @@ Enabling
 ~~~~~~~~
 
 The gRPC integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(grpc=True)

--- a/ddtrace/contrib/httplib/__init__.py
+++ b/ddtrace/contrib/httplib/__init__.py
@@ -13,7 +13,7 @@ environment variable::
     DD_TRACE_HTTPLIB_ENABLED=true ddtrace-run ....
 
 The integration can also be enabled manually in code with
-:ref:`patch_all()<patch_all>`::
+:func:`patch_all()<ddtrace.patch_all>`::
 
     from ddtrace import patch_all
     patch_all(httplib=True)

--- a/ddtrace/contrib/httpx/__init__.py
+++ b/ddtrace/contrib/httpx/__init__.py
@@ -6,9 +6,9 @@ Enabling
 ~~~~~~~~
 
 The ``httpx`` integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Alternatively, use :ref:`patch()<patch>` to manually enable the integration::
+Alternatively, use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(httpx=True)
@@ -57,7 +57,7 @@ Global Configuration
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To configure particular ``httpx`` client instances use the :ref:`Pin<Pin>` API::
+To configure particular ``httpx`` client instances use the :class:`Pin <ddtrace.Pin>` API::
 
     import httpx
     from ddtrace import Pin

--- a/ddtrace/contrib/mariadb/__init__.py
+++ b/ddtrace/contrib/mariadb/__init__.py
@@ -7,9 +7,9 @@ Enabling
 ~~~~~~~~
 
 The MariaDB integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(mariadb=True)

--- a/ddtrace/contrib/mysql/__init__.py
+++ b/ddtrace/contrib/mysql/__init__.py
@@ -6,9 +6,9 @@ Enabling
 ~~~~~~~~
 
 The mysql integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(mysql=True)

--- a/ddtrace/contrib/mysqldb/__init__.py
+++ b/ddtrace/contrib/mysqldb/__init__.py
@@ -5,9 +5,9 @@ Enabling
 ~~~~~~~~
 
 The integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(mysqldb=True)

--- a/ddtrace/contrib/psycopg/__init__.py
+++ b/ddtrace/contrib/psycopg/__init__.py
@@ -6,9 +6,9 @@ Enabling
 ~~~~~~~~
 
 The psycopg integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(psycopg=True)

--- a/ddtrace/contrib/pymysql/__init__.py
+++ b/ddtrace/contrib/pymysql/__init__.py
@@ -6,9 +6,9 @@ Enabling
 ~~~~~~~~
 
 The integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(pymysql=True)

--- a/ddtrace/contrib/pynamodb/__init__.py
+++ b/ddtrace/contrib/pynamodb/__init__.py
@@ -6,9 +6,9 @@ Enabling
 ~~~~~~~~
 
 The PynamoDB integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     import pynamodb
     from ddtrace import patch, config

--- a/ddtrace/contrib/pyodbc/__init__.py
+++ b/ddtrace/contrib/pyodbc/__init__.py
@@ -6,9 +6,9 @@ Enabling
 ~~~~~~~~
 
 The integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(pyodbc=True)

--- a/ddtrace/contrib/redis/__init__.py
+++ b/ddtrace/contrib/redis/__init__.py
@@ -6,9 +6,9 @@ Enabling
 ~~~~~~~~
 
 The redis integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(redis=True)
@@ -30,7 +30,7 @@ Global Configuration
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To configure particular redis instances use the :ref:`Pin<Pin>` API::
+To configure particular redis instances use the :class:`Pin <ddtrace.Pin>` API::
 
     import redis
     from ddtrace import Pin

--- a/ddtrace/contrib/requests/__init__.py
+++ b/ddtrace/contrib/requests/__init__.py
@@ -9,9 +9,9 @@ Enabling
 ~~~~~~~~
 
 The requests integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(requests=True)

--- a/ddtrace/contrib/rq/__init__.py
+++ b/ddtrace/contrib/rq/__init__.py
@@ -6,9 +6,9 @@ Usage
 ~~~~~
 
 The rq integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(rq=True)

--- a/ddtrace/contrib/snowflake/__init__.py
+++ b/ddtrace/contrib/snowflake/__init__.py
@@ -7,9 +7,9 @@ Enabling
 ~~~~~~~~
 
 The integration is not enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Use :ref:`patch()<patch>` to manually enable the integration::
+Use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch, patch_all
     patch(snowflake=True)

--- a/ddtrace/contrib/sqlite3/__init__.py
+++ b/ddtrace/contrib/sqlite3/__init__.py
@@ -6,9 +6,9 @@ Enabling
 ~~~~~~~~
 
 The integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(sqlite=True)

--- a/ddtrace/contrib/starlette/__init__.py
+++ b/ddtrace/contrib/starlette/__init__.py
@@ -6,9 +6,9 @@ Enabling
 ~~~~~~~~
 
 The starlette integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     from starlette.applications import Starlette

--- a/ddtrace/contrib/urllib3/__init__.py
+++ b/ddtrace/contrib/urllib3/__init__.py
@@ -8,7 +8,7 @@ Enabling
 
 The ``urllib3`` integration is not enabled by default. Use ``patch_all()``
 with the environment variable ``DD_TRACE_URLLIB3_ENABLED`` set, or call
-:ref:`patch()<patch>` with the ``urllib3`` argument set to ``True`` to manually
+:func:`patch()<ddtrace.patch>` with the ``urllib3`` argument set to ``True`` to manually
 enable the integration, before importing and using ``urllib3``::
 
     from ddtrace import patch

--- a/ddtrace/contrib/yaaredis/__init__.py
+++ b/ddtrace/contrib/yaaredis/__init__.py
@@ -6,9 +6,9 @@ Enabling
 ~~~~~~~~
 
 The yaaredis integration is enabled automatically when using
-:ref:`ddtrace-run<ddtracerun>` or :ref:`patch_all()<patch_all>`.
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
 
-Or use :ref:`patch()<patch>` to manually enable the integration::
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(yaaredis=True)
@@ -30,7 +30,7 @@ Global Configuration
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To configure particular yaaredis instances use the :ref:`Pin<Pin>` API::
+To configure particular yaaredis instances use the :class:`Pin <ddtrace.Pin>` API::
 
     import yaaredis
     from ddtrace import Pin

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -253,8 +253,7 @@ on the other side, the metadata is retrieved and the trace can continue.
 To propagate the tracing information, HTTP headers are used to transmit the
 required metadata to piece together the trace.
 
-.. autoclass:: ddtrace.propagation.http.HTTPPropagator
-    :members:
+See :py:class:`HTTPPropagator <ddtrace.propagation.http.HTTPPropagator>` for details.
 
 Custom
 ^^^^^^
@@ -707,51 +706,3 @@ There are different options to make that happen:
 
 - Use a `post_worker_init <https://docs.gunicorn.org/en/stable/settings.html#post-worker-init>`_
   hook to import ``ddtrace.bootstrap.sitecustomize``.
-
-API
----
-
-``Tracer``
-^^^^^^^^^^
-.. autoclass:: ddtrace.Tracer
-    :members:
-    :special-members: __init__
-
-
-``Span``
-^^^^^^^^
-.. autoclass:: ddtrace.Span
-    :members:
-    :special-members: __init__
-
-
-``Context``
-^^^^^^^^^^^
-.. autoclass:: ddtrace.context.Context
-    :members:
-    :special-members: __init__
-
-``Pin``
-^^^^^^^
-
-.. _Pin:
-
-.. autoclass:: ddtrace.Pin
-    :members:
-    :special-members: __init__
-
-.. _patch_all:
-
-``patch_all``
-^^^^^^^^^^^^^
-
-.. autofunction:: ddtrace.patch_all
-
-.. _patch:
-
-``patch``
-^^^^^^^^^
-.. autofunction:: ddtrace.patch
-
-.. toctree::
-   :maxdepth: 2

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,41 @@
+***
+API
+***
+
+Tracing
+=======
+
+.. py:module:: ddtrace
+
+.. autofunction:: ddtrace.patch_all
+
+.. autofunction:: ddtrace.patch
+
+.. autoclass:: ddtrace.Tracer
+    :members:
+
+.. autoclass:: ddtrace.Span
+    :members:
+
+.. autoclass:: ddtrace.Pin
+    :members:
+
+.. autoclass:: ddtrace.context.Context
+    :members:
+    :undoc-members:
+
+.. autoclass:: ddtrace.sampler.DatadogSampler
+    :members:
+
+.. autoclass:: ddtrace.sampler.SamplingRule
+    :members:
+
+.. autoclass:: ddtrace.propagation.http.HTTPPropagator
+    :members:
+
+
+Runtime Metrics
+===============
+
+.. autoclass:: ddtrace.runtime.RuntimeMetrics
+    :members:

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -27,7 +27,7 @@ used.
 the application, they must be patched *prior* to being imported. So make sure
 to call ``patch_all`` *before* importing libraries that are to be instrumented.
 
-More information about ``patch_all`` is available in the :ref:`patch_all` API
+More information about ``patch_all`` is available in the :py:func:`patch_all<ddtrace.patch_all>` API
 documentation.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -188,5 +188,6 @@ Indices and tables
     advanced_usage
     benchmarks
     contributing
-    release_notes
     troubleshooting
+    api
+    release_notes

--- a/docs/installation_quickstart.rst
+++ b/docs/installation_quickstart.rst
@@ -55,7 +55,7 @@ being picked up correctly and that the tracer will be able to connect to the Dat
 Note: ``--info`` Only reflects configurations made via environment variables, not those made in code.
 
 
-If ``ddtrace-run`` isn't suitable for your application then :ref:`patch_all`
+If ``ddtrace-run`` isn't suitable for your application then :py:func:`ddtrace.patch_all`
 can be used::
 
     from ddtrace import config, patch_all

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,11 +1,14 @@
+AnyCallable
 CPython
 Fargate
 Firehose
 Gunicorn
+HTTPPropagator
 INfo
 IPv
 MySQL
 OpenTracing
+SpanContext
 aiobotocore
 aiohttp
 aiopg

--- a/releasenotes/notes/1.0-remove-default-sampler-d1f6bcb2b23ca8a7.yaml
+++ b/releasenotes/notes/1.0-remove-default-sampler-d1f6bcb2b23ca8a7.yaml
@@ -1,4 +1,8 @@
 ---
 upgrade:
-  - |
-    The deprecated ``ddtrace.Sampler.default_sampler`` attribute is removed.
+  - ".. _remove-default-sampler:
+
+
+    The deprecated attribute ``ddtrace.Sampler.default_sampler`` is removed.
+
+    "

--- a/releasenotes/notes/ddtrace-1.0-disable-basic-config-call-by-default-b677844e4a13a794.yaml
+++ b/releasenotes/notes/ddtrace-1.0-disable-basic-config-call-by-default-b677844e4a13a794.yaml
@@ -1,7 +1,16 @@
 ---
 upgrade:
-  - |
-    Default value of ``DD_CALL_BASIC_CONFIG`` was updated from ``True`` to `False`. Call `logging.basicConfig()` to configure logging in your application.
+  - ".. _disable-basic-config-call-by-default:
+
+
+    Default value of ``DD_CALL_BASIC_CONFIG`` was updated from ``True`` to ``False``.
+    Call ``logging.basicConfig()`` to configure logging in your application.
+
+    "
 deprecations:
-  - |
-    DD_CALL_BASIC_CONFIG is deprecated and will be removed in a future version.
+  - ".. _deprecate-basic-config-call:
+
+
+    ``DD_CALL_BASIC_CONFIG`` is deprecated.
+
+    "

--- a/releasenotes/notes/deprecate-span-get-set-meta-c6fb2528d198414c.yaml
+++ b/releasenotes/notes/deprecate-span-get-set-meta-c6fb2528d198414c.yaml
@@ -1,6 +1,16 @@
 ---
 deprecations:
-  - |
-    :py:meth:`ddtrace.Span.set_meta` is deprecated. Use :py:meth:`ddtrace.Span.set_tag` instead.
-  - |
-    :py:meth:`ddtrace.Span.set_metas` is deprecated. Use :py:meth:`ddtrace.Span.set_tags` instead.
+  - ".. _remove-span-set-meta:
+
+
+    ``ddtrace.Span.set_meta`` is removed. Use :py:meth:`ddtrace.Span.set_tag`
+    instead.
+
+    "
+  - ".. _remove-span-set-metas:
+
+
+    ``ddtrace.Span.set_metas`` is removed. Use :py:meth:`ddtrace.Span.set_tags`
+    instead.
+
+    "

--- a/releasenotes/notes/internalize_http_server-06721b67e63dde1d.yaml
+++ b/releasenotes/notes/internalize_http_server-06721b67e63dde1d.yaml
@@ -1,4 +1,8 @@
 ---
 upgrade:
-  - |
-    ``ddtrace.settings.Config.HTTPServerConfig`` was removed from the public api.
+  - ".. _remove-config-httpserver:
+
+
+    ``ddtrace.settings.Config.HTTPServerConfig`` is removed.
+
+    "

--- a/releasenotes/notes/release-1.0-758fc917e40d7eb3.yaml
+++ b/releasenotes/notes/release-1.0-758fc917e40d7eb3.yaml
@@ -1,0 +1,81 @@
+---
+prelude: >
+  The Datadog APM Python team is happy to announce the release of v1.0.0 of
+  ddtrace.
+
+
+  The first commit to the library was made on June 20, 2016. Nearly sixty minor
+  releases later, the library has grown immensely. The library now includes over
+  60 integrations for libraries. Moreover, the library has expanded out from
+  tracing to support the Continuous Profiler, CI Visibility, and Application
+  Security.
+
+
+  Our motivations for this major version release were:
+
+    - Clarify and simplify the public API.
+    - Introduce a versioning policy.
+    - Provide users a painless upgrade path.
+
+
+  .. note::
+  Before upgrading to v1.0.0, we recommend running tests with `warning filters <https://docs.python.org/3.8/library/warnings.html#warning-filter>`_ set to turning warnings into exceptions. For example::
+
+    $ PYTHONWARNINGS="error::DeprecationWarning:ddtrace[.*]" python tests.py
+    $ pytest -W="error::DeprecationWarning:ddtrace[.*]" tests.py
+
+
+  .. csv-table:: Upgrade from 0.x
+   :widths: 30, 70
+   :header: "Note", "Affected"
+
+    :ref:`Removed <remove-datadog-envs>`,``DATADOG_*``
+    :ref:`Removed <remove-legacy-service-name-envs>`,``DATADOG_SERVICE_NAME``
+    ":ref:`Disabled <disable-basic-config-call-by-default>`, :ref:`Deprecated <deprecate-basic-config-call>`",``DD_CALL_BASIC_CONFIG``
+    :ref:`Removed <remove-logging-env>`,``DD_LOGGING_RATE_LIMIT``
+    :ref:`Removed <remove-legacy-service-name-envs>`,``DD_SERVICE_NAME``
+    :ref:`Removed <remove-partial-flush-enabled-env>`,``DD_TRACER_PARTIAL_FLUSH_ENABLED``
+    :ref:`Removed <remove-partial-flush-min-envs>`,``DD_TRACER_PARTIAL_FLUSH_MIN_SPANS``
+    :ref:`Removed <remove-tracer-debug-logging>`,``ddtrace.Tracer.debug_logging``
+    :ref:`Removed <remove-tracer-get-call-context>`,``ddtrace.Tracer.get_call_context``
+    :ref:`Removed <remove-tracer-tags>`,``ddtrace.Tracer.tags``
+    :ref:`Removed <remove-tracer-writer>`,``ddtrace.Tracer.writer``
+    :ref:`Removed <remove-tracer-call>`,``ddtrace.Tracer.__call__``
+    :ref:`Removed <remove-tracer-global-excepthook>`,``ddtrace.Tracer.global_excepthook``
+    :ref:`Removed <remove-tracer-log>`,``ddtrace.Tracer.log``
+    :ref:`Removed <remove-tracer-priority-sampler>`,``ddtrace.Tracer.priority_sampler``
+    :ref:`Removed <remove-tracer-sampler>`,``ddtrace.Tracer.sampler``
+    :ref:`Removed <remove-tracer-set-service-info>`,``ddtrace.Tracer.set_service_info``
+    :ref:`Removed <remove-span-tracer>`,``ddtrace.Span.tracer``
+    :ref:`Removed <remove-span-init-tracer>`,``ddtrace.Span.__init__(tracer=)``
+    :ref:`Removed <remove-span-meta>`,``ddtrace.Span.meta``
+    :ref:`Removed <remove-span-metrics>`,``ddtrace.Span.metrics``
+    :ref:`Removed <remove-span-set-meta>`,``ddtrace.Span.set_meta``
+    :ref:`Removed <remove-span-set-metas>`,``ddtrace.Span.set_metas``
+    :ref:`Removed <remove-span-pprint>`,``ddtrace.Span.pprint``
+    :ref:`Removed <remove-pin-app>`,``ddtrace.Pin.app``
+    :ref:`Removed <remove-pin-apptype>`,``ddtrace.Pin.app_type``
+    :ref:`Removed <remove-clone-context>`,``ddtrace.context.Context.clone``
+    :ref:`Removed <remove-ddtrace-compat>`,``ddtrace.compat``
+    :ref:`Removed <remove-contrib-util>`,``ddtrace.contrib.util``
+    :ref:`Removed <remove-ddtrace-encoding>`,``ddtrace.encoding``
+    :ref:`Removed <remove-span-types-enum>`,``ddtrace.ext.SpanTypes``
+    :ref:`Removed <remove-ext-errors>`,``ddtrace.ext.errors``
+    :ref:`Removed <remove-ext-priority>`,``ddtrace.ext.priority``
+    :ref:`Removed <remove-ext-system>`,``ddtrace.ext.system``
+    :ref:`Removed <remove-helpers>`,``ddtrace.helpers.get_correlation_ids``
+    :ref:`Removed <remove-http>`,``ddtrace.http``
+    :ref:`Removed <remove-ddtrace-monkey>`,``ddtrace.monkey``
+    :ref:`Removed <remove-ddtrace-propagation-utils>`,``ddtrace.propagation.utils``
+    :ref:`Removed <remove-default-sampler>`,``ddtrace.Sampler.default_sampler``
+    :ref:`Removed <remove-config-httpserver>`,``ddtrace.settings.Config.HTTPServerConfig``
+    :ref:`Removed <remove-ddtrace-util>`,``ddtrace.util``
+    :ref:`Removed <remove-ddtrace-utils>`,``ddtrace.utils``
+    :ref:`Removed <remove-cassandra-traced>`,``ddtrace.contrib.cassandra.get_traced_cassandra``
+    :ref:`Removed <remove-celery-patch-task>`,``ddtrace.contrib.celery.patch_task``
+    :ref:`Removed <remove-celery-unpatch-task>`,``ddtrace.contrib.celery.unpatch_task``
+    :ref:`Removed <remove-mongoengine-traced>`,``ddtrace.contrib.mongoengine.trace_mongoengine``
+    :ref:`Removed <remove-mysql-legacy>`,``ddtrace.contrib.mysql.get_traced_mysql_connection``
+    :ref:`Removed <remove-psycopg-legacy>`,``ddtrace.contrib.psycopg.connection_factory``
+    :ref:`Removed <remove-requests-legacy-distributed>`,``ddtrace.contrib.requests.legacy``
+    :ref:`Removed <remove-sqlite3-legacy>`,``ddtrace.contrib.sqlite3.connection_factory``

--- a/releasenotes/notes/release-1.0-758fc917e40d7eb3.yaml
+++ b/releasenotes/notes/release-1.0-758fc917e40d7eb3.yaml
@@ -23,6 +23,8 @@ prelude: >
 
     $ PYTHONWARNINGS="error::DeprecationWarning:ddtrace[.*]" python tests.py
     $ pytest -W="error::DeprecationWarning:ddtrace[.*]" tests.py
+    
+  Once all deprecation warnings are addressed you can safely upgrade to v1.0.0.
 
 
   .. csv-table:: Upgrade from 0.x

--- a/releasenotes/notes/release-1.0-758fc917e40d7eb3.yaml
+++ b/releasenotes/notes/release-1.0-758fc917e40d7eb3.yaml
@@ -7,8 +7,7 @@ prelude: >
   The first commit to the library was made on June 20, 2016. Nearly sixty minor
   releases later, the library has grown immensely. The library now includes over
   60 integrations for libraries. Moreover, the library has expanded out from
-  tracing to support the Continuous Profiler, CI Visibility, and Application
-  Security.
+  tracing to support the Continuous Profiler, and CI Visibility.
 
 
   Our motivations for this major version release were:

--- a/releasenotes/notes/remove-cassandra-traced-1b3211d1f9071e6f.yaml
+++ b/releasenotes/notes/remove-cassandra-traced-1b3211d1f9071e6f.yaml
@@ -1,4 +1,8 @@
 ---
 upgrade:
-  - |
-    cassandra: The deprecated method ``ddtrace.contrib.cassandra.get_traced_cassandra`` is removed. Use ``ddtrace.patch(cassandra=True)`` or ``ddtrace.patch_all()`` instead.
+  - ".. _remove-cassandra-traced:
+
+
+    cassandra: ``get_traced_cassandra`` is removed. Use ``ddtrace.patch(cassandra=True)`` or ``ddtrace.patch_all()`` instead.
+
+    "

--- a/releasenotes/notes/remove-celery-patch-task-3ad91299e26259d0.yaml
+++ b/releasenotes/notes/remove-celery-patch-task-3ad91299e26259d0.yaml
@@ -1,6 +1,16 @@
 ---
 upgrade:
-  - |
-    celery: The deprecated method ``ddtrace.contrib.celery.patch_task`` is removed. Use ``ddtrace.patch(celery=True)`` or ``ddtrace.patch_all()`` instead.
-  - |
-    celery: The deprecated method ``ddtrace.contrib.celery.unpatch_task`` is removed. Use ``ddtrace.contrib.celery.unpatch()`` instead.
+  - ".. _remove-celery-patch-task:
+
+
+    celery: ``ddtrace.contrib.celery.patch_task`` is removed.
+    Use ``ddtrace.patch(celery=True)`` or ``ddtrace.patch_all()`` instead.
+
+    "
+  - ".. _remove-celery-unpatch-task:
+
+
+    celery: ``ddtrace.contrib.celery.unpatch_task`` is removed.
+    Use ``ddtrace.contrib.celery.unpatch()`` instead.
+
+    "

--- a/releasenotes/notes/remove-clone-context-3cc6f3d73f15345e.yaml
+++ b/releasenotes/notes/remove-clone-context-3cc6f3d73f15345e.yaml
@@ -1,4 +1,9 @@
 ---
 upgrade:
-  - |
-    ``ddrace.context.Context.clone`` was removed. This is no longer needed since the tracer now supports asynchronous frameworks out of the box.
+  - ".. _remove-clone-context:
+
+
+    ``ddrace.context.Context.clone`` is removed. This is no longer needed since the
+    tracer now supports asynchronous frameworks out of the box.
+
+    "

--- a/releasenotes/notes/remove-contrib-util-e4a33ee4684b457a.yaml
+++ b/releasenotes/notes/remove-contrib-util-e4a33ee4684b457a.yaml
@@ -1,4 +1,8 @@
 ---
 upgrade:
-  - |
+  - ".. _remove-contrib-util:
+
+
     The deprecated module ``ddtrace.contrib.util`` is removed.
+
+    "

--- a/releasenotes/notes/remove-ddtrace-compat-4146d5adc293bf17.yaml
+++ b/releasenotes/notes/remove-ddtrace-compat-4146d5adc293bf17.yaml
@@ -1,4 +1,8 @@
 ---
 upgrade:
-  - |
+  - ".. _remove-ddtrace-compat:
+
+
     The deprecated module ``ddtrace.compat`` is removed.
+
+    "

--- a/releasenotes/notes/remove-ddtrace-encoding-5e35232cc5b3f855.yaml
+++ b/releasenotes/notes/remove-ddtrace-encoding-5e35232cc5b3f855.yaml
@@ -1,4 +1,8 @@
 ---
 upgrade:
-  - |
+  - ".. _remove-ddtrace-encoding:
+
+
     The deprecated module ``ddtrace.encoding`` is removed.
+
+    "

--- a/releasenotes/notes/remove-ddtrace-http-affe61bc13f9c613.yaml
+++ b/releasenotes/notes/remove-ddtrace-http-affe61bc13f9c613.yaml
@@ -1,4 +1,10 @@
 ---
 upgrade:
-  - |
-    The deprecated modules ``ddtrace.http`` and ``ddtrace.http.headers`` are removed. Use ``ddtrace.contrib.trace_utils.set_http_meta`` to store request and response headers on a span.
+  - ".. _remove-http:
+
+
+    The deprecated modules ``ddtrace.http`` and ``ddtrace.http.headers`` are removed.
+    Use ``ddtrace.contrib.trace_utils.set_http_meta`` to store request and response
+    headers on a span.
+
+    "

--- a/releasenotes/notes/remove-ddtrace-install-excepthooks-8107b679a9f51ef3.yaml
+++ b/releasenotes/notes/remove-ddtrace-install-excepthooks-8107b679a9f51ef3.yaml
@@ -1,6 +1,14 @@
 ---
 upgrade:
-  - |
+  - ".. _remove-ddtrace-install-excepthooks:
+
+
     Remove deprecated ``ddtrace.install_excepthook``.
-  - |
+
+    "
+  - ".. _remove-ddtrace-uninstall-excepthooks:
+
+
     Remove deprecated ``ddtrace.uninstall_excepthook``.
+
+    "

--- a/releasenotes/notes/remove-ddtrace-monkey-16e56038dc409769.yaml
+++ b/releasenotes/notes/remove-ddtrace-monkey-16e56038dc409769.yaml
@@ -1,4 +1,9 @@
 ---
 upgrade:
-  - |
-    The deprecated module ``ddtrace.monkey`` is removed. Use :ref:`ddtrace.patch <patch>` or :ref:`ddtrace.patch_all <patch_all>` instead.
+  - ".. _remove-ddtrace-monkey:
+
+
+    The deprecated module ``ddtrace.monkey`` is removed. Use :py:func:`ddtrace.patch <ddtrace.patch>`
+    or :py:func:`ddtrace.patch_all <ddtrace.patch_all>` instead.
+
+    "

--- a/releasenotes/notes/remove-ddtrace-propagation-utils-171fa44d0479028f.yaml
+++ b/releasenotes/notes/remove-ddtrace-propagation-utils-171fa44d0479028f.yaml
@@ -1,4 +1,8 @@
 ---
 upgrade:
-  - |
+  - ".. _remove-ddtrace-propagation-utils:
+
+
     The deprecated module ``ddtrace.propagation.utils`` is removed.
+
+    "

--- a/releasenotes/notes/remove-ddtrace-utils-ae7231d2e4f130b2.yaml
+++ b/releasenotes/notes/remove-ddtrace-utils-ae7231d2e4f130b2.yaml
@@ -1,15 +1,7 @@
 ---
 upgrade:
-  - |
-    The deprecated module ``ddtrace.utils`` and its submodules are removed:
-      - ``ddtrace.utils.attr``
-      - ``ddtrace.utils.attrdict``
-      - ``ddtrace.utils.cache``
-      - ``ddtrace.utils.config``
-      - ``ddtrace.utils.deprecation``
-      - ``ddtrace.utils.formats``
-      - ``ddtrace.utils.http``
-      - ``ddtrace.utils.importlib``
-      - ``ddtrace.utils.time``
-      - ``ddtrace.utils.version``
-      - ``ddtrace.utils.wrappers``
+  - ".. _remove-ddtrace-utils:\n\nThe deprecated module ``ddtrace.utils`` and its
+    submodules are removed:\n  - ``ddtrace.utils.attr``\n  - ``ddtrace.utils.attrdict``\n
+    \ - ``ddtrace.utils.cache``\n  - ``ddtrace.utils.config``\n  - ``ddtrace.utils.deprecation``\n
+    \ - ``ddtrace.utils.formats``\n  - ``ddtrace.utils.http``\n  - ``ddtrace.utils.importlib``\n
+    \ - ``ddtrace.utils.time``\n  - ``ddtrace.utils.version``\n  - ``ddtrace.utils.wrappers``\n"

--- a/releasenotes/notes/remove-deprecated-tracer-attributes-4bb24b794a1aacb9.yaml
+++ b/releasenotes/notes/remove-deprecated-tracer-attributes-4bb24b794a1aacb9.yaml
@@ -1,10 +1,27 @@
 ---
 upgrade:
-  - |
-    :py:attr:`ddtrace.Tracer.sampler` was removed.
-  - |
-    :py:attr:`ddtrace.Tracer.priority_sampler` was removed.
-  - |
-    :py:attr:`ddtrace.Tracer.tags` was removed. Use the environment variable :ref:`DD_TAGS<dd-tags>` to set the global tags instead.
-  - |
+  - ".. _remove-tracer-sampler:
+
+
+    ``ddtrace.Tracer.sampler`` is removed.
+
+    "
+  - ".. _remove-tracer-priority-sampler:
+
+
+    ``ddtrace.Tracer.priority_sampler`` is removed.
+
+    "
+  - ".. _remove-tracer-tags:
+
+
+    ``ddtrace.Tracer.tags`` is removed. Use the environment variable :ref:`DD_TAGS<dd-tags>`
+    to set the global tags instead.
+
+    "
+  - ".. _remove-tracer-log:
+
+
     :py:attr:`ddtrace.Tracer.log` was removed.
+
+    "

--- a/releasenotes/notes/remove-ext-errors-43d7aca3e1765807.yaml
+++ b/releasenotes/notes/remove-ext-errors-43d7aca3e1765807.yaml
@@ -1,8 +1,6 @@
 ---
 upgrade:
-  - |
-    The deprecated module ``ddtrace.ext.errors`` is removed. Use the ``ddtrace.constants`` module instead::
-
-      from ddtrace.constants import ERROR_MSG
-      from ddtrace.constants import ERROR_STACK
-      from ddtrace.constants import ERROR_TYPE
+  - ".. _remove-ext-errors:\n\nThe deprecated module ``ddtrace.ext.errors`` is removed.
+    Use the ``ddtrace.constants`` module instead::\n\n  from ddtrace.constants import
+    ERROR_MSG\n  from ddtrace.constants import ERROR_STACK\n  from ddtrace.constants
+    import ERROR_TYPE\n"

--- a/releasenotes/notes/remove-ext-priority-be59e69e52c65ec9.yaml
+++ b/releasenotes/notes/remove-ext-priority-be59e69e52c65ec9.yaml
@@ -1,7 +1,6 @@
 ---
 upgrade:
-  - |
-    The deprecated module ``ddtrace.ext.priority`` is removed. Use the ``ddtrace.constants`` module instead for setting sampling priority tags::
-
-      from ddtrace.constants import USER_KEEP
-      from ddtrace.constants import USER_REJECT
+  - ".. _remove-ext-priority:\n\nThe deprecated module ``ddtrace.ext.priority`` is
+    removed. Use the ``ddtrace.constants`` module instead for setting sampling priority
+    tags::\n\n  from ddtrace.constants import USER_KEEP\n  from ddtrace.constants import
+    USER_REJECT\n"

--- a/releasenotes/notes/remove-ext-system-a70c1fbbec3b32ff.yaml
+++ b/releasenotes/notes/remove-ext-system-a70c1fbbec3b32ff.yaml
@@ -1,4 +1,9 @@
 ---
 upgrade:
-  - |
-    The deprecated module ``ddtrace.ext.system`` is removed. Use ``ddtrace.constants.PID`` instead.
+  - ".. _remove-ext-system:
+
+
+    The deprecated module ``ddtrace.ext.system`` is removed. Use ``ddtrace.constants.PID``
+    instead.
+
+    "

--- a/releasenotes/notes/remove-helpers-f3c274e83104ff2a.yaml
+++ b/releasenotes/notes/remove-helpers-f3c274e83104ff2a.yaml
@@ -1,4 +1,9 @@
 ---
 upgrade:
-  - |
-    The deprecated method ``ddtrace.helpers.get_correlation_ids`` is removed. Use :py:meth:`ddtrace.Tracer.get_log_correlation_context` instead.
+  - ".. _remove-helpers:
+
+
+    The deprecated method ``ddtrace.helpers.get_correlation_ids`` is removed. Use :py:meth:`ddtrace.Tracer.get_log_correlation_context`
+    instead.
+
+    "

--- a/releasenotes/notes/remove-legacy-service-name-365da3952e073dd5.yaml
+++ b/releasenotes/notes/remove-legacy-service-name-365da3952e073dd5.yaml
@@ -1,4 +1,9 @@
 ---
 upgrade:
-  - |
-    The legacy environment variables ``DD_SERVICE_NAME`` and ``DATADOG_SERVICE_NAME`` are removed.
+  - ".. _remove-legacy-service-name-envs:
+
+
+    The legacy environment variables ``DD_SERVICE_NAME`` and ``DATADOG_SERVICE_NAME``
+    are removed. Use ``DD_SERVICE`` instead.
+
+    "

--- a/releasenotes/notes/remove-mongoengine-traced-4e00b1175e6e5ca0.yaml
+++ b/releasenotes/notes/remove-mongoengine-traced-4e00b1175e6e5ca0.yaml
@@ -1,4 +1,9 @@
 ---
 upgrade:
-  - |
-    mongoengine: The deprecated method ``ddtrace.contrib.mongoengine.trace_mongoengine`` is removed. Use ``ddtrace.patch(mongoengine=True)`` or ``ddtrace.patch()`` instead.
+  - ".. _remove-mongoengine-traced:
+
+
+    mongoengine: The deprecated method ``ddtrace.contrib.mongoengine.trace_mongoengine``
+    is removed. Use ``ddtrace.patch(mongoengine=True)`` or ``ddtrace.patch()`` instead.
+
+    "

--- a/releasenotes/notes/remove-mysql-legacy-c09206695dcaf541.yaml
+++ b/releasenotes/notes/remove-mysql-legacy-c09206695dcaf541.yaml
@@ -1,4 +1,9 @@
 ---
 upgrade:
-  - |
-    mysql: The deprecated method ``ddtrace.contrib.mysql.get_traced_mysql_connection`` is removed. Use ``ddtrace.patch(mysql=True)`` or ``ddtrace.patch_all()`` instead.
+  - ".. _remove-mysql-legacy:
+
+
+    mysql: The deprecated method ``ddtrace.contrib.mysql.get_traced_mysql_connection``
+    is removed. Use ``ddtrace.patch(mysql=True)`` or ``ddtrace.patch_all()`` instead.
+
+    "

--- a/releasenotes/notes/remove-pin-app-apptype-8d0addd243deb7f9.yaml
+++ b/releasenotes/notes/remove-pin-app-apptype-8d0addd243deb7f9.yaml
@@ -1,4 +1,14 @@
 ---
 upgrade:
-  - |
-    The deprecated properties ``Pin.app`` and ``Pin.app_type`` are removed.
+  - ".. _remove-pin-app:
+
+
+    ``Pin.app`` is removed.
+
+    "
+  - ".. _remove-pin-apptype:
+
+
+    ``Pin.app_type`` is removed.
+
+    "

--- a/releasenotes/notes/remove-psycopg-factory-98769b2b2e040dd8.yaml
+++ b/releasenotes/notes/remove-psycopg-factory-98769b2b2e040dd8.yaml
@@ -1,4 +1,9 @@
 ---
 upgrade:
-  - |
-    psycopg: ``ddtrace.contrib.psycopg.connection_factory`` is removed. Use ``ddtrace.patch(psycopg=True)`` or ``ddtrace.patch_all()`` instead.
+  - ".. _remove-psycopg-legacy:
+
+
+    psycopg: ``ddtrace.contrib.psycopg.connection_factory`` is removed. Use ``ddtrace.patch(psycopg=True)``
+    or ``ddtrace.patch_all()`` instead.
+
+    "

--- a/releasenotes/notes/remove-requests-legacy-distributed-302154022c58186a.yaml
+++ b/releasenotes/notes/remove-requests-legacy-distributed-302154022c58186a.yaml
@@ -1,4 +1,8 @@
 ---
 upgrade:
-  - |
-    requests: The legacy distributed tracing is removed. Use :ref:`ddtrace.config.requests['distributed_tracing']<requests-config-distributed-tracing>` instead.
+  - ".. _remove-requests-legacy-distributed:
+
+
+    requests: The legacy distributed tracing configuration is removed. Use :ref:`ddtrace.config.requests['distributed_tracing']<requests-config-distributed-tracing>` instead.
+
+    "

--- a/releasenotes/notes/remove-span-deprecated-51fa2f55f53aebd5.yaml
+++ b/releasenotes/notes/remove-span-deprecated-51fa2f55f53aebd5.yaml
@@ -1,8 +1,22 @@
 ---
 upgrade:
-  - |
-    The deprecated property ``ddtrace.Span.meta`` is removed.
-  - |
-    The deprecated property ``ddtrace.Span.metrics`` is removed.
-  - |
-    The deprecated method ``ddtrace.Span.pprint`` is removed.
+  - ".. _remove-span-meta:
+
+
+    ``ddtrace.Span.meta`` is removed. Use :py:meth:`ddtrace.Span.get_tag`
+    and :py:meth:`ddtrace.Span.set_tag` instead.
+
+    "
+  - ".. _remove-span-metrics:
+
+
+    ``ddtrace.Span.metrics`` is removed. Use :py:meth:`ddtrace.Span.get_metric`
+    and :py:meth:`ddtrace.Span.set_metric` instead.
+
+    "
+  - ".. _remove-span-pprint:
+
+
+    ``ddtrace.Span.pprint`` is removed.
+
+    "

--- a/releasenotes/notes/remove-span-tracer-ddtrace-1-0-bc0ced48b2806e3c.yaml
+++ b/releasenotes/notes/remove-span-tracer-ddtrace-1-0-bc0ced48b2806e3c.yaml
@@ -1,6 +1,14 @@
 ---
 upgrade:
-  - |
-    The deprecated property ``Span.tracer`` is removed. 
-  - |
+  - ".. _remove-span-tracer:
+
+
+    ``Span.tracer`` is removed.
+
+    "
+  - ".. _remove-span-init-tracer:
+
+
     The deprecated `tracer` argument is removed from :py:meth:`ddtrace.Span.__init__`.
+
+    "

--- a/releasenotes/notes/remove-sqlite3-connection-f641a48c5fa90e1f.yaml
+++ b/releasenotes/notes/remove-sqlite3-connection-f641a48c5fa90e1f.yaml
@@ -1,4 +1,9 @@
 ---
 upgrade:
-  - |
-    sqlite3: ``ddtrace.contrib.sqlite3.connection_factory`` is removed. Use ``ddtrace.patch(sqlite3=True)`` or ``ddtrace.patch_all()`` instead.
+  - ".. _remove-sqlite3-legacy:
+
+
+    sqlite3: ``ddtrace.contrib.sqlite3.connection_factory`` is removed. Use ``ddtrace.patch(sqlite3=True)``
+    or ``ddtrace.patch_all()`` instead.
+
+    "

--- a/releasenotes/notes/remove-tracer-deprecations-c0abaecda9c24b79.yaml
+++ b/releasenotes/notes/remove-tracer-deprecations-c0abaecda9c24b79.yaml
@@ -1,17 +1,30 @@
 ---
 upgrade:
-  - |
-    Remove deprecated attribute ``ddtrace.Tracer.debug_logging``. Set the logging level for the ``ddtrace.tracer`` logger instead::
+  - ".. _remove-tracer-debug-logging:\n\nRemove deprecated attribute ``ddtrace.Tracer.debug_logging``.
+    Set the logging level for the ``ddtrace.tracer`` logger instead::\n\n  import logging\n
+    \ log = logging.getLogger(\"ddtrace.tracer\")\n  log.setLevel(logging.DEBUG)\n"
+  - ".. _remove-tracer-call:
 
-      import logging
-      log = logging.getLogger("ddtrace.tracer")
-      log.setLevel(logging.DEBUG)
 
-  - |
-    Remove deprecated ``ddtrace.Tracer.__call__``.
-  - |
-    Remove deprecated method ``ddtrace.Tracer.global_excepthook``.
-  - |
-    Remove deprecated method ``ddtrace.Tracer.get_call_context``. Use :py:meth:`ddtrace.Tracer.current_trace_context` instead.
-  - |
-    Remove deprecated method ``ddtrace.Tracer.set_service_info``.
+    ``ddtrace.Tracer.__call__`` is removed.
+
+    "
+  - ".. _remove-tracer-global-excepthook:
+
+
+    ``ddtrace.Tracer.global_excepthook`` is removed.
+
+    "
+  - ".. _remove-tracer-get-call-context:
+
+
+    ``ddtrace.Tracer.get_call_context`` is removed. Use :py:meth:`ddtrace.Tracer.current_trace_context`
+    instead.
+
+    "
+  - ".. _remove-tracer-set-service-info:
+
+
+    ``ddtrace.Tracer.set_service_info`` is removed.
+
+    "

--- a/releasenotes/notes/remove-tracer-writer-b1875a1fa3230236.yaml
+++ b/releasenotes/notes/remove-tracer-writer-b1875a1fa3230236.yaml
@@ -1,4 +1,9 @@
 ---
 upgrade:
-  - |
-    ``ddtrace.Tracer.writer`` has been removed. To force flushing of buffered traces to the agent, use :py:meth:`ddtrace.Tracer.flush` instead.
+  - ".. _remove-tracer-writer:
+
+
+    ``ddtrace.Tracer.writer`` is removed. To force flushing of buffered traces
+    to the agent, use :py:meth:`ddtrace.Tracer.flush` instead.
+
+    "

--- a/releasenotes/notes/remove_deprecated_environment_variables-3ed446513ab21409.yaml
+++ b/releasenotes/notes/remove_deprecated_environment_variables-3ed446513ab21409.yaml
@@ -1,10 +1,30 @@
 ---
 upgrade:
-  - |
-    The deprecated environment variables prefixed with ``DATADOG_`` are removed. Use environment variables prefixed with ``DD_`` instead.
-  - |
-    The deprecated environment variable ``DD_LOGGING_RATE_LIMIT`` is removed. Use ``DD_TRACE_LOGGING_RATE`` instead.
-  - |
-    The deprecated environment variable ``DD_TRACER_PARTIAL_FLUSH_ENABLED`` is removed. Use ``DD_TRACE_PARTIAL_FLUSH_ENABLED`` instead.
-  - |
-    The deprecated environment variable ``DD_TRACER_PARTIAL_FLUSH_MIN_SPANS`` is removed. Use ``DD_TRACE_PARTIAL_FLUSH_MIN_SPANS`` instead.
+  - ".. _remove-datadog-envs:
+
+
+    The environment variables prefixed with ``DATADOG_`` are removed. Use
+    environment variables prefixed with ``DD_`` instead.
+
+    "
+  - ".. _remove-logging-env:
+
+
+    The environment variable ``DD_LOGGING_RATE_LIMIT`` is removed. Use ``DD_TRACE_LOGGING_RATE``
+    instead.
+
+    "
+  - ".. _remove-partial-flush-enabled-env:
+
+
+    The environment variable ``DD_TRACER_PARTIAL_FLUSH_ENABLED`` is removed.
+    Use ``DD_TRACE_PARTIAL_FLUSH_ENABLED`` instead.
+
+    "
+  - ".. _remove-partial-flush-min-envs:
+
+
+    The environment variable ``DD_TRACER_PARTIAL_FLUSH_MIN_SPANS`` is removed.
+    Use ``DD_TRACE_PARTIAL_FLUSH_MIN_SPANS`` instead.
+
+    "

--- a/releasenotes/notes/removed_ddtrace.util.py-0d0f48aefa6d9779.yaml
+++ b/releasenotes/notes/removed_ddtrace.util.py-0d0f48aefa6d9779.yaml
@@ -1,4 +1,8 @@
 ---
 upgrade:
-  - |
-    The ``ddtrace.util`` module has been removed.
+  - ".. _remove-ddtrace-util:
+
+
+    ``ddtrace.util`` is removed.
+
+    "

--- a/releasenotes/notes/span-types-enum-5ca7cb35031a199e.yaml
+++ b/releasenotes/notes/span-types-enum-5ca7cb35031a199e.yaml
@@ -1,4 +1,8 @@
 ---
 upgrade:
-  - |
-    ``SpanTypes`` is no longer an ``Enum``.
+  - ".. _remove-span-types-enum:
+
+
+    ``ddtrace.ext.SpanTypes`` is no longer an ``Enum``. Use ``SpanTypes.TYPE`` instead of ``SpanTypes.TYPE.value``.
+
+    "

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,5 +24,5 @@ exclude=
 # We ignore most of the D errors because there are too many; the goal is to fix them eventually
 ignore = W503,E231,A003,G201,D100,D101,D102,D103,D104,D105,D106,D107,D200,D202,D204,D205,D208,D210,D300,D400,D401,D403,D413,RST301,B902,E203
 enable-extensions=G
-rst-roles = class,meth,obj,ref
+rst-roles = class,meth,obj,ref,func
 rst-directives = py:data

--- a/templates/integration/__init__.py
+++ b/templates/integration/__init__.py
@@ -7,9 +7,9 @@ Enabling
 ~~~~~~~~
 
 The foo integration is enabled automatically when using
-:ref:`ddtrace-run <ddtracerun>` or :ref:`patch_all() <patch_all>`.
+:ref:`ddtrace-run <ddtracerun>` or :func:`patch_all() <ddtrace.patch_all>`.
 
-Or use :ref:`patch() <patch>` to manually enable the integration::
+Or use :func:`patch() <ddtrace.patch>` to manually enable the integration::
 
     from ddtrace import patch
     patch(foo=True)


### PR DESCRIPTION
This PR adds the following to the library docs:

- add release note for 1.0 with a summary of changes
- reorganize all autodoc blocks into a new api page 

Preview of release notes:

https://gist.github.com/majorgreys/b6a6f5840eda58c03311c6da6ec79414