### PR TITLE
chore: use psycopg2-binary for django test env

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -505,7 +505,7 @@ venv = Venv(
                 "daphne": [latest],
                 "requests": [latest],
                 "redis": ">=2.10,<2.11",
-                "psycopg2": ["~=2.8.0"],
+                "psycopg2-binary": [">=2.8.6"],  # We need <2.9.0 for Python 2.7, and >2.9.0 for 3.9+
                 "pytest-django": "==3.10.0",
                 "pylibmc": latest,
                 "python-memcached": latest,


### PR DESCRIPTION
This will help speed up installing `psycopg2` since it will use pre-built wheels when possible.