### PR TITLE
chore(tracer): deprecate tracer.write method

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -809,6 +809,10 @@ class Tracer(object):
         active = self.context_provider.active()
         return active if isinstance(active, Span) else None
 
+    @debtcollector.removals.remove(
+        message="Writing spans through a tracer is no longer supported",
+        removal_version="1.0.0",
+    )
     def write(self, spans):
         # type: (Optional[List[Span]]) -> None
         """

--- a/releasenotes/notes/tracer-write-5d46dc5c4e870b9b.yaml
+++ b/releasenotes/notes/tracer-write-5d46dc5c4e870b9b.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    ``Tracer.write()`` is deprecated. Writing spans to the writer through the tracer is not supported.


### PR DESCRIPTION
The write method is no longer used by the library and it's not a
use-case that we'd like to support.

If a user desires to write spans to a writer then it can be done
manually by using a writer reference.