### PR TITLE
chore: fix coverage report in 0.59 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,8 +322,8 @@ jobs:
       # Print tests/ report to stdout
       # DEV: "--ignore-errors" to skip over files that are missing
       - run: coverage report --ignore-errors --omit=ddtrace/
-      # Print diff-cover report to stdout (compares against origin/master)
-      - run: diff-cover --compare-branch origin/master coverage.xml
+      # Print diff-cover report to stdout (compares against origin/0.x)
+      - run: diff-cover --compare-branch origin/0.x coverage.xml
 
   build_base_venvs:
     executor: ddtrace_dev


### PR DESCRIPTION
``origin/master`` branch no longer exists, this change generates a coverage report against 0.x

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
