### PR TITLE
fix(tracing/internal): fix encoding of propagated internal tags

### DIFF
--- a/ddtrace/internal/_tagset.pyx
+++ b/ddtrace/internal/_tagset.pyx
@@ -152,7 +152,7 @@ cdef bint _value_is_valid(str value):
         return 0
 
     for c in value:
-        if not is_valid_key_char(ord(c)):
+        if not is_valid_value_char(ord(c)):
             return 0
     return 1
 

--- a/releasenotes/notes/fix-encode-tagset-value-2b8bb877a88bc75a.yaml
+++ b/releasenotes/notes/fix-encode-tagset-value-2b8bb877a88bc75a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing/internal: fix encoding of propagated internal tags.

--- a/tests/tracer/test_tagset.py
+++ b/tests/tracer/test_tagset.py
@@ -92,9 +92,16 @@ def test_decode_tagset_string_malformed(header):
         ({}, ""),
         # Single key/value
         ({"key": "value"}, "key=value"),
+        # Allow equals in values
+        ({"key": "value=with=equals"}, "key=value=with=equals"),
         # Multiple key/values
         # DEV: Use OrderedDict to ensure consistent iteration for encoding
         (OrderedDict([("a", "1"), ("b", "2"), ("c", "3")]), "a=1,b=2,c=3"),
+        # Realistic example
+        (
+            {"_dd.p.upstream_services": "Z3JwYy1jbGllbnQ=|1|0|1.0000"},
+            "_dd.p.upstream_services=Z3JwYy1jbGllbnQ=|1|0|1.0000",
+        ),
     ],
 )
 def test_encode_tagset_values(values, expected):
@@ -125,7 +132,6 @@ def test_encode_tagset_values_strip_spaces():
         {"key": "value,with,commas"},
         # disallow equals
         {"key=with=equals": "value"},
-        {"key": "value=with=equals"},
         # Empty key or value
         {"": "value"},
         {"key": ""},


### PR DESCRIPTION
`=` is an allowed character in a tag value, but not a tag key.

Fixes: #3318