### PR TITLE
fix: set_meta and set_metas deprecation warnings

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -41,6 +41,7 @@ from .internal.compat import stringify
 from .internal.compat import time_ns
 from .internal.logger import get_logger
 from .vendor.debtcollector import deprecate
+from .vendor.debtcollector.removals import remove
 from .vendor.debtcollector.removals import removed_property
 
 
@@ -394,12 +395,12 @@ class Span(object):
     def meta(self, value):
         self._meta = value
 
-    @removed_property(message="Use Span.set_tag instead.", removal_version="1.0.0")
+    @remove(message="Use Span.set_tag instead.", removal_version="1.0.0")
     def set_meta(self, k, v):
         # type: (_TagNameType, NumericType) -> None
         self.set_tag(k, v)
 
-    @removed_property(message="Use Span.set_tags.", removal_version="1.0.0")
+    @remove(message="Use Span.set_tags.", removal_version="1.0.0")
     def set_metas(self, kvs):
         # type: (_MetaDictType) -> None
         self.set_tags(kvs)

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -86,6 +86,16 @@ class SpanTestCase(TracerTestCase):
         assert d["meta"] == dict(true="True", false="False")
         assert "metrics" not in d
 
+    def test_deprecated_set_meta(self):
+        s = Span(tracer=None, name="test.span")
+        s.set_meta("munir-1", "hi")
+        assert s.get_tag("munir-1") == "hi"
+
+    def test_deprecated_set_metas(self):
+        s = Span(tracer=None, name="test.span")
+        s.set_metas({"hi-1": "munir"})
+        assert s.get_tag("hi-1") == "munir"
+
     def test_set_tag_metric(self):
         s = Span(tracer=None, name="test.span")
 


### PR DESCRIPTION
This bug was introduced in 0.59.0rc1. This fix should be backported before 0.59.0 is released 

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
