### PR TITLE
docs: add versioning policy

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -193,5 +193,6 @@ Indices and tables
     benchmarks
     contributing
     troubleshooting
+    versioning
     api
     release_notes

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,3 +1,4 @@
+AArch
 AnyCallable
 CPython
 Fargate
@@ -8,6 +9,7 @@ INfo
 IPv
 MySQL
 OpenTracing
+Runtimes
 SpanContext
 aiobotocore
 aiohttp
@@ -134,6 +136,7 @@ respawn
 rq
 runnable
 runtime
+runtimes
 runtime-id
 sanic
 screenshots

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -1,0 +1,118 @@
+**********
+Versioning
+**********
+
+
+Release support
+===============
+
+
+.. list-table::
+   :header-rows: 1
+
+   * - Release
+     - :ref:`Support level<versioning_support_levels>`
+     - Minimum Trace Agent
+   * - 0.x
+     - :ref:`Maintenance<versioning_support_maintenace>`
+     -
+   * - 1.x
+     - :ref:`General Availability<versioning_support_ga>`
+     - 7.28
+
+
+Versions
+========
+
+
+The non-negative integer components of the **version format** (``v<MAJOR>.<MINOR>.<PATCH>``) are incremented by the criteria:
+
+MAJOR
+    Incompatible changes to the public :ref:`interface<versioning_interfaces>`
+
+    Removing support for a :ref:`runtime<versioning_supported_runtimes>`.
+
+MINOR
+    Backwards compatible changes to the public :ref:`interface<versioning_interfaces>`
+
+    Any backwards compatible or incompatible changes to the internal :ref:`interface<versioning_interfaces>`
+
+    Adding a support for :ref:`runtime<versioning_supported_runtimes>`
+
+PATCH
+    Bug fixes that are backwards compatible
+
+    Security fixes that are backwards compatible
+
+.. _versioning_interfaces:
+
+Interfaces
+==========
+
+
+The definition of the **internal** interface:
+    The ``ddtrace.internal`` package is internal
+
+    The ``ddtrace.vendor`` package is internal
+
+    Any module, function, class or attribute that is prefixed with a single underscore is internal
+
+    Any package, module, function, class or attribute that is contained within an internal package is internal
+
+
+The definition of the **public** interface:
+    Any package, module, function, class or attribute that is not internal
+
+
+.. _versioning_supported_runtimes:
+
+Supported runtimes
+==================
+
+
+.. list-table::
+   :header-rows: 1
+
+   * - OS
+     - CPU
+     - Runtime
+     - Runtime version
+     - Supported Release
+   * - Linux
+     - x86-64, i686, AArch64
+     - CPython
+     - 3.10, 3.9, 3.8, 3.7, 3.6, 3.5, 2.7
+     - 1.x
+   * - MacOS
+     - Intel, Apple Silicon
+     - CPython
+     - 3.10, 3.9, 3.8, 3.7, 3.6, 3.5, 2.7
+     - 1.x
+   * - Windows
+     - 64bit, 32bit
+     - CPython
+     - 3.10, 3.9, 3.8, 3.7, 3.6, 3.5, 2.7
+     - 1.x
+
+
+.. _versioning_support_levels:
+
+Support levels
+==============
+
+
+.. list-table::
+   :header-rows: 1
+
+   * - Level
+     - Policy
+
+       .. _versioning_support_ga:
+   * - General Availability (GA)
+     - Full implementation of all features. Full support for new features, bug & security fixes.
+
+       .. _versioning_support_maintenace:
+   * - Maintenance
+     - Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.
+   * - End-of-life
+     - No support.

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -86,12 +86,12 @@ Supported runtimes
    * - MacOS
      - Intel, Apple Silicon
      - CPython
-     - 3.10, 3.9, 3.8, 3.7, 3.6, 3.5, 2.7
+     - 2.7, 3.5-3.10
      - 1.x
    * - Windows
      - 64bit, 32bit
      - CPython
-     - 3.10, 3.9, 3.8, 3.7, 3.6, 3.5, 2.7
+     - 2.7, 3.5-3.10
      - 1.x
 
 

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -51,13 +51,13 @@ Interfaces
 
 
 The definition of the **internal** interface:
-    The ``ddtrace.internal`` package is internal
+    The ``ddtrace.internal`` module is internal
 
-    The ``ddtrace.vendor`` package is internal
+    The ``ddtrace.vendor`` module is internal
 
     Any module, function, class or attribute that is prefixed with a single underscore is internal
 
-    Any package, module, function, class or attribute that is contained within an internal package is internal
+    Any module, function, class or attribute that is contained within an internal module is internal
 
 
 The definition of the **public** interface:

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -12,7 +12,7 @@ Release support
 
    * - Release
      - :ref:`Support level<versioning_support_levels>`
-     - Minimum Trace Agent
+     - Minimum Datadog Agent
    * - 0.x
      - :ref:`Maintenance<versioning_support_maintenace>`
      -
@@ -37,7 +37,7 @@ MINOR
 
     Any backwards compatible or incompatible changes to the internal :ref:`interface<versioning_interfaces>`
 
-    Adding a support for :ref:`runtime<versioning_supported_runtimes>`
+    Adding support for a :ref:`runtime<versioning_supported_runtimes>`
 
 PATCH
     Bug fixes that are backwards compatible
@@ -61,7 +61,7 @@ The definition of the **internal** interface:
 
 
 The definition of the **public** interface:
-    Any package, module, function, class or attribute that is not internal
+    Any module, function, class or attribute that is not internal
 
 
 .. _versioning_supported_runtimes:
@@ -81,7 +81,7 @@ Supported runtimes
    * - Linux
      - x86-64, i686, AArch64
      - CPython
-     - 3.10, 3.9, 3.8, 3.7, 3.6, 3.5, 2.7
+     - 2.7, 3.5-3.10
      - 1.x
    * - MacOS
      - Intel, Apple Silicon

--- a/riotfile.py
+++ b/riotfile.py
@@ -192,6 +192,7 @@ venv = Venv(
                 "sphinx": "~=4.3.2",
                 "sphinxcontrib-spelling": latest,
                 "PyEnchant": latest,
+                "sphinxemoji": latest,
             },
             command="scripts/build-docs",
         ),

--- a/riotfile.py
+++ b/riotfile.py
@@ -192,7 +192,6 @@ venv = Venv(
                 "sphinx": "~=4.3.2",
                 "sphinxcontrib-spelling": latest,
                 "PyEnchant": latest,
-                "sphinxemoji": latest,
             },
             command="scripts/build-docs",
         ),


### PR DESCRIPTION
This adds a versioning section to the library docs that:

- defines internal and public interfaces
- sets out when versions are incremented
- development on release lines

[Preview](https://output.circle-artifacts.com/output/job/904716c3-5067-45fa-97ca-9d672dd0cb71/artifacts/0/tmp/docs/versioning.html)