### PR TITLE
chore: add ddtrace v1 deprecation warning

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -1,5 +1,10 @@
+import os
+import warnings
+
 from ._monkey import patch  # noqa: E402
 from ._monkey import patch_all
+from .warnings import DDTraceDeprecationWarning
+from .internal.utils.formats import asbool
 from .pin import Pin  # noqa: E402
 from .settings import _config as config  # noqa: E402
 from .span import Span  # noqa: E402
@@ -22,6 +27,10 @@ __all__ = [
     "Tracer",
     "config",
 ]
+
+
+if asbool(os.getenv("DD_TRACE_RAISE_V1DEPRECATIONWARNING")):
+    warnings.filterwarnings(action="error", category=DDTraceDeprecationWarning)
 
 
 @remove(removal_version="1.0.0")

--- a/releasenotes/notes/add-deprecation-warning-category-1750b81349935713.yaml
+++ b/releasenotes/notes/add-deprecation-warning-category-1750b81349935713.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds new configuration for raising :py:class`ddtrace.warning.DDTraceDeprecationWarning` as an exception ``DD_TRACE_RAISE_V1DEPRECATIONWARNING``.

--- a/tests/contrib/celery/test_task_deprecation.py
+++ b/tests/contrib/celery/test_task_deprecation.py
@@ -3,6 +3,7 @@ import warnings
 
 from celery import Celery
 
+from ddtrace.warnings import DDTraceDeprecationWarning
 from ddtrace.contrib.celery import patch_task
 from ddtrace.contrib.celery import unpatch
 from ddtrace.contrib.celery import unpatch_task
@@ -34,7 +35,7 @@ class CeleryDeprecatedTaskPatch(unittest.TestCase):
                 return 42
 
             assert len(w) == 1
-            assert issubclass(w[-1].category, DeprecationWarning)
+            assert issubclass(w[-1].category, DDTraceDeprecationWarning)
             assert "patch(celery=True)" in str(w[-1].message)
 
     def test_unpatch_signals_diconnect(self):
@@ -49,5 +50,5 @@ class CeleryDeprecatedTaskPatch(unittest.TestCase):
                 return 42
 
             assert len(w) == 1
-            assert issubclass(w[-1].category, DeprecationWarning)
+            assert issubclass(w[-1].category, DDTraceDeprecationWarning)
             assert "unpatch()" in str(w[-1].message)

--- a/tests/tracer/test_constants.py
+++ b/tests/tracer/test_constants.py
@@ -2,6 +2,8 @@ import warnings
 
 import pytest
 
+from ddtrace.warnings import DDTraceDeprecationWarning
+
 
 def test_deprecated():
     import ddtrace
@@ -12,7 +14,7 @@ def test_deprecated():
         assert ddtrace.constants.FILTERS_KEY
 
         (w,) = ws
-        assert issubclass(w.category, DeprecationWarning)
+        assert issubclass(w.category, DDTraceDeprecationWarning)
         assert "ddtrace.constants.FILTERS_KEY is deprecated and will be removed in version '1.0.0'" == str(w.message)
 
     with warnings.catch_warnings(record=True) as ws:
@@ -21,7 +23,7 @@ def test_deprecated():
         assert ddtrace.constants.NUMERIC_TAGS
 
         (w,) = ws
-        assert issubclass(w.category, DeprecationWarning)
+        assert issubclass(w.category, DDTraceDeprecationWarning)
         assert "ddtrace.constants.NUMERIC_TAGS is deprecated and will be removed in version '1.0.0'" == str(w.message)
 
     with warnings.catch_warnings(record=True) as ws:
@@ -30,7 +32,7 @@ def test_deprecated():
         assert ddtrace.constants.LOG_SPAN_KEY
 
         (w,) = ws
-        assert issubclass(w.category, DeprecationWarning)
+        assert issubclass(w.category, DDTraceDeprecationWarning)
         assert "ddtrace.constants.LOG_SPAN_KEY is deprecated and will be removed in version '1.0.0'" == str(w.message)
 
 

--- a/tests/tracer/test_logger.py
+++ b/tests/tracer/test_logger.py
@@ -3,6 +3,7 @@ import logging
 import mock
 from pytest import warns
 
+from ddtrace.warnings import DDTraceDeprecationWarning
 from ddtrace.internal.logger import DDLogger
 from ddtrace.internal.logger import get_logger
 from tests.utils import BaseTestCase
@@ -145,7 +146,7 @@ class DDLoggerTestCase(BaseTestCase):
         self.assertEqual(log.level, logging.DEBUG)
 
     def test_logger_deprecated_rate_limit(self):
-        with self.override_env(dict(DD_LOGGING_RATE_LIMIT="10")), warns(DeprecationWarning):
+        with self.override_env(dict(DD_LOGGING_RATE_LIMIT="10")), warns(DDTraceDeprecationWarning):
             log = DDLogger("test.logger")
             self.assertEqual(log.rate_limit, 10)
 

--- a/tests/tracer/test_pin.py
+++ b/tests/tracer/test_pin.py
@@ -3,6 +3,7 @@ import warnings
 
 import pytest
 
+from ddtrace.warnings import DDTraceDeprecationWarning
 from ddtrace import Pin
 
 
@@ -196,7 +197,7 @@ def test_pin_app_deprecation():
 
         p = Pin(app="foo")
         assert len(ws) == 1
-        assert issubclass(ws[0].category, DeprecationWarning)
+        assert issubclass(ws[0].category, DDTraceDeprecationWarning)
 
     with warnings.catch_warnings(record=True) as ws:
         warnings.simplefilter("always")
@@ -204,5 +205,5 @@ def test_pin_app_deprecation():
         p = Pin(app="foo")
         assert p.app
         assert len(ws) == 2
-        assert issubclass(ws[0].category, DeprecationWarning)
-        assert issubclass(ws[1].category, DeprecationWarning)
+        assert issubclass(ws[0].category, DDTraceDeprecationWarning)
+        assert issubclass(ws[1].category, DDTraceDeprecationWarning)

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -18,6 +18,7 @@ import pytest
 import six
 
 import ddtrace
+from ddtrace.warnings import DDTraceDeprecationWarning
 from ddtrace.constants import AUTO_KEEP
 from ddtrace.constants import AUTO_REJECT
 from ddtrace.constants import ENV_KEY
@@ -535,7 +536,7 @@ def test_tracer_shutdown_no_timeout():
             pass
 
         (w,) = ws
-        assert issubclass(w.category, DeprecationWarning)
+        assert issubclass(w.category, DDTraceDeprecationWarning)
         assert (
             str(w.message)
             == "Tracing with a tracer that has been shut down is deprecated and will be removed in version '1.0.0': "

--- a/tests/tracer/test_utils.py
+++ b/tests/tracer/test_utils.py
@@ -8,6 +8,7 @@ import warnings
 import mock
 import pytest
 
+from ddtrace.warnings import DDTraceDeprecationWarning
 from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils import time
@@ -63,7 +64,7 @@ class TestUtils(unittest.TestCase):
             value = get_env("requests", "distributed_tracing")
             self.assertEqual(value, "1")
             self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertTrue(issubclass(w[-1].category, DDTraceDeprecationWarning))
             self.assertTrue("Use `DD_` prefix instead" in str(w[-1].message))
 
     def test_get_env_key_priority(self):


### PR DESCRIPTION
This change adds a custom ddtrace 1.0 deprecation warning category which will help users upgrade from ddtrace==0.59 to ddtrace==1.0. 

Setting the `PYTHONWARNINGS` configuration to "error::ddtrace.DDTraceDeprecationWarning" will log ddtrace v1.0 warnings as exceptions.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
