### PR TITLE
docs: fix warning filter for v1 deprecations

### DIFF
--- a/releasenotes/notes/release-1.0-758fc917e40d7eb3.yaml
+++ b/releasenotes/notes/release-1.0-758fc917e40d7eb3.yaml
@@ -18,10 +18,10 @@ prelude: >
 
 
   .. note::
-  Before upgrading to v1.0.0, we recommend running tests with `warning filters <https://docs.python.org/3.8/library/warnings.html#warning-filter>`_ set to turning warnings into exceptions. For example::
+  Before upgrading to v1.0.0, we recommend installing ``ddtrace>=0.59.0,<1.0.0`` and running tests with `warning filters <https://docs.python.org/3.8/library/warnings.html#warning-filter>`_ set to raise ``ddtrace.warnings.DDTraceV1DeprecationWarning`` as errors or set the environment variable ``DD_TRACE_RAISE_DEPRECATIONWARNING``. For example::
 
-    $ PYTHONWARNINGS="error::DeprecationWarning:ddtrace[.*]" python tests.py
-    $ pytest -W="error::DeprecationWarning:ddtrace[.*]" tests.py
+    $ DD_TRACE_RAISE_DEPRECATIONWARNING=1 python tests.py
+    $ pytest -W "error::ddtrace.warnings.DDTraceDeprecationWarning" tests.py
     
   Once all deprecation warnings are addressed you can safely upgrade to v1.0.0.
 

--- a/releasenotes/notes/remove-v1deprecationwarning-2c251ca219182b97.yaml
+++ b/releasenotes/notes/remove-v1deprecationwarning-2c251ca219182b97.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    ``ddtrace.warnings.DDTraceDeprecationWarning`` is removed.
+  - |
+    ``DD_TRACE_RAISE_DEPRECATIONWARNING`` environment variable is removed.


### PR DESCRIPTION
The `ddtrace.V1DeprecationWarning` category will be introduced with #3333 and released in v0.59.0 which will be the guidance for those looking to upgrade to v1.0.0.