### PR TITLE
feat: add 0.x upgrade guide for deprecations

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -1,5 +1,10 @@
+import os
+import warnings
+
 from ._monkey import patch  # noqa: E402
 from ._monkey import patch_all
+from .internal.utils.deprecations import DDTraceDeprecationWarning
+from .internal.utils.formats import asbool
 from .pin import Pin  # noqa: E402
 from .settings import _config as config  # noqa: E402
 from .span import Span  # noqa: E402
@@ -24,11 +29,15 @@ __all__ = [
 ]
 
 
-@remove(removal_version="1.0.0")
+if asbool(os.getenv("DD_TRACE_RAISE_DEPRECATIONWARNING")):
+    warnings.filterwarnings(action="error", category=DDTraceDeprecationWarning)
+
+
+@remove(category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def install_excepthook():
     """Install a hook that intercepts unhandled exception and send metrics about them."""
 
 
-@remove(removal_version="1.0.0")
+@remove(category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def uninstall_excepthook():
     """Uninstall the global tracer except hook."""

--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing import Callable
 from typing import List
 
+from ddtrace.internal.utils.deprecation import DDTraceDeprecationWarning
 from ddtrace.vendor.wrapt.importer import when_imported
 
 from .internal.logger import get_logger
@@ -202,7 +203,7 @@ def patch(raise_errors=True, **patch_modules):
     )
 
 
-@remove(removal_version="1.0.0")
+@remove(category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def patch_module(module, raise_errors=True):
     # type: (str, bool) -> bool
     return _patch_module(module, raise_errors=raise_errors)
@@ -227,7 +228,7 @@ def _patch_module(module, raise_errors=True):
         return False
 
 
-@remove(removal_version="1.0.0")
+@remove(category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def get_patched_modules():
     # type: () -> List[str]
     return _get_patched_modules()

--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -1,3 +1,5 @@
+from ddtrace.internal.utils.deprecation import DDTraceDeprecationWarning
+
 from .internal.compat import CONTEXTVARS_IS_AVAILABLE
 from .internal.compat import NumericType
 from .internal.compat import PY2
@@ -74,5 +76,6 @@ __all__ = [
 
 removed_module(
     module="ddtrace.compat",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -1,4 +1,5 @@
 from ddtrace.internal.compat import ensure_pep562
+from ddtrace.internal.utils.deprecation import DDTraceDeprecationWarning
 from ddtrace.vendor import debtcollector
 
 
@@ -56,6 +57,7 @@ def __getattr__(name):
     if name in _DEPRECATED:
         debtcollector.deprecate(
             ("%s.%s is deprecated" % (__name__, name)),
+            category=DDTraceDeprecationWarning,
             removal_version="1.0.0",
         )
         return _DEPRECATED[name]

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -4,6 +4,8 @@ from typing import Optional
 from typing import TYPE_CHECKING
 from typing import Text
 
+from ddtrace.internal.utils.deprecation import DDTraceDeprecationWarning
+
 from .constants import ORIGIN_KEY
 from .constants import SAMPLING_PRIORITY_KEY
 from .internal.compat import NumericType
@@ -107,7 +109,11 @@ class Context(object):
                 return
             self._meta[ORIGIN_KEY] = value
 
-    @remove(message="Cloning contexts will no longer be required in 0.50", removal_version="1.0.0")
+    @remove(
+        message="Cloning contexts will no longer be required in 0.50",
+        category=DDTraceDeprecationWarning,
+        removal_version="1.0.0",
+    )
     def clone(self):
         # type: () -> Context
         """

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -6,6 +6,7 @@ import sys
 import cassandra.cluster
 
 from ddtrace import config
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import ERROR_MSG
@@ -278,7 +279,7 @@ def _sanitize_query(span, query):
 #
 # DEPRECATED
 #
-@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
+@remove(message="Use patching instead (see the docs).", category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def get_traced_cassandra(*args, **kwargs):
     return _get_traced_cluster(*args, **kwargs)
 

--- a/ddtrace/contrib/celery/task.py
+++ b/ddtrace/contrib/celery/task.py
@@ -1,3 +1,5 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ...vendor.debtcollector import deprecate
 from .app import patch_app
 
@@ -10,6 +12,7 @@ def patch_task(task, pin=None):
     deprecate(
         "ddtrace.contrib.celery.patch_task is deprecated",
         message="Use `patch(celery=True)` or `ddtrace-run` script instead",
+        category=DDTraceDeprecationWarning,
         removal_version="1.0.0",
     )
 
@@ -26,6 +29,7 @@ def unpatch_task(task):
     deprecate(
         "ddtrace.contrib.celery.patch_task is deprecated",
         message="Use `unpatch()` instead",
+        category=DDTraceDeprecationWarning,
         removal_version="1.0.0",
     )
     return task

--- a/ddtrace/contrib/flask/middleware.py
+++ b/ddtrace/contrib/flask/middleware.py
@@ -6,6 +6,7 @@ import flask.templating
 from ddtrace import config
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_TYPE
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 
 from .. import trace_utils
 from ...ext import SpanTypes
@@ -28,7 +29,7 @@ def _normalize_resource(resource):
 
 
 class TraceMiddleware(object):
-    @remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
+    @remove(message="Use patching instead (see the docs).", category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def __init__(self, app, tracer, service="flask", use_signals=True, distributed_tracing=None):
         self.app = app
         log.debug("flask: initializing trace middleware")

--- a/ddtrace/contrib/mongoengine/patch.py
+++ b/ddtrace/contrib/mongoengine/patch.py
@@ -1,5 +1,7 @@
 import mongoengine
 
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ...vendor.debtcollector.removals import remove
 from .trace import WrappedConnect
 
@@ -16,6 +18,6 @@ def unpatch():
     setattr(mongoengine, "connect", _connect)
 
 
-@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
+@remove(message="Use patching instead (see the docs).", category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def trace_mongoengine(*args, **kwargs):
     return _connect

--- a/ddtrace/contrib/mysql/tracers.py
+++ b/ddtrace/contrib/mysql/tracers.py
@@ -1,8 +1,10 @@
 import mysql.connector
 
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ...vendor.debtcollector.removals import remove
 
 
-@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
+@remove(message="Use patching instead (see the docs).", category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def get_traced_mysql_connection(*args, **kwargs):
     return mysql.connector.MySQLConnection

--- a/ddtrace/contrib/psycopg/connection.py
+++ b/ddtrace/contrib/psycopg/connection.py
@@ -6,6 +6,8 @@ import functools
 from psycopg2.extensions import connection
 from psycopg2.extensions import cursor
 
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanTypes
 from ...ext import db
@@ -14,7 +16,7 @@ from ...ext import sql
 from ...vendor.debtcollector.removals import remove
 
 
-@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
+@remove(message="Use patching instead (see the docs).", category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def connection_factory(tracer, service="postgres"):
     """Return a connection factory class that will can be used to trace
     postgres queries.

--- a/ddtrace/contrib/pymongo/patch.py
+++ b/ddtrace/contrib/pymongo/patch.py
@@ -5,6 +5,7 @@ import pymongo
 from ddtrace import Pin
 from ddtrace import config
 from ddtrace.contrib import trace_utils
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from ...constants import SPAN_MEASURED_KEY
@@ -40,7 +41,7 @@ def unpatch():
     setattr(pymongo, "MongoClient", _MongoClient)
 
 
-@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
+@remove(message="Use patching instead (see the docs).", category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def trace_mongo_client(client, tracer, service=mongox.SERVICE):
     traced_client = TracedMongoClient(client)
     Pin(service=service, tracer=tracer).onto(traced_client)

--- a/ddtrace/contrib/pymysql/tracers.py
+++ b/ddtrace/contrib/pymysql/tracers.py
@@ -1,8 +1,10 @@
 import pymysql.connections
 
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ...vendor.debtcollector.removals import remove
 
 
-@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
+@remove(message="Use patching instead (see the docs).", category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def get_traced_pymysql_connection(*args, **kwargs):
     return pymysql.connections.Connection

--- a/ddtrace/contrib/redis/tracers.py
+++ b/ddtrace/contrib/redis/tracers.py
@@ -1,17 +1,19 @@
 from redis import StrictRedis
 
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ...vendor.debtcollector.removals import remove
 
 
 DEFAULT_SERVICE = "redis"
 
 
-@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
+@remove(message="Use patching instead (see the docs).", category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def get_traced_redis(ddtracer, service=DEFAULT_SERVICE, meta=None):
     return _get_traced_redis(ddtracer, StrictRedis, service, meta)
 
 
-@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
+@remove(message="Use patching instead (see the docs).", category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def get_traced_redis_from(ddtracer, baseclass, service=DEFAULT_SERVICE, meta=None):
     return _get_traced_redis(ddtracer, baseclass, service, meta)
 

--- a/ddtrace/contrib/requests/legacy.py
+++ b/ddtrace/contrib/requests/legacy.py
@@ -1,6 +1,7 @@
 # [Deprecation]: this module contains deprecated functions
 # that will be removed in newer versions of the Tracer.
 from ddtrace import config
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 
 from ...vendor.debtcollector import deprecate
 
@@ -13,6 +14,7 @@ def _distributed_tracing(self):
     deprecate(
         "client.distributed_tracing is deprecated",
         message="Use the configuration object instead `config.get_from(client)['distributed_tracing']`",
+        category=DDTraceDeprecationWarning,
         removal_version="1.0.0",
     )
     return config.get_from(self)["distributed_tracing"]
@@ -26,6 +28,7 @@ def _distributed_tracing_setter(self, value):
     deprecate(
         "client.distributed_tracing is deprecated",
         message="Use the configuration object instead `config.get_from(client)['distributed_tracing']` = value`",
+        category=DDTraceDeprecationWarning,
         removal_version="1.0.0",
     )
     config.get_from(self)["distributed_tracing"] = value

--- a/ddtrace/contrib/sqlite3/connection.py
+++ b/ddtrace/contrib/sqlite3/connection.py
@@ -1,8 +1,10 @@
 from sqlite3 import Connection
 
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ...vendor.debtcollector.removals import remove
 
 
-@remove(message="Use patching instead (see the docs).", removal_version="1.0.0")
+@remove(message="Use patching instead (see the docs).", category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def connection_factory(*args, **kwargs):
     return Connection

--- a/ddtrace/contrib/util.py
+++ b/ddtrace/contrib/util.py
@@ -1,4 +1,7 @@
 # [Backward compatibility]: keep importing modules functions
+
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils.importlib import func_name
 from ..internal.utils.importlib import module_name
 from ..internal.utils.importlib import require_modules
@@ -7,6 +10,7 @@ from ..vendor.debtcollector.removals import removed_module
 
 removed_module(
     module="ddtrace.contrib.util",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )
 

--- a/ddtrace/encoding.py
+++ b/ddtrace/encoding.py
@@ -1,3 +1,5 @@
+from ddtrace.internal.utils.deprecation import DDTraceDeprecationWarning
+
 from .internal.encoding import JSONEncoder
 from .internal.encoding import JSONEncoderV2
 from .internal.encoding import MsgpackEncoderV03 as MsgpackEncoder
@@ -17,5 +19,6 @@ __all__ = (
 
 removed_module(
     module="ddtrace.encoding",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/ext/errors.py
+++ b/ddtrace/ext/errors.py
@@ -7,6 +7,7 @@ import traceback
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 
 from ..vendor.debtcollector.removals import remove
 from ..vendor.debtcollector.removals import removed_module
@@ -18,6 +19,7 @@ removed_module(
     module="ddtrace.ext.errors",
     replacement="ddtrace.constants",
     message="ERROR_MSG, ERROR_TYPE, and ERROR_STACK.",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )
 
@@ -27,7 +29,7 @@ TYPE = ERROR_TYPE
 STACK = ERROR_STACK
 
 
-@remove(removal_version="1.0.0")
+@remove(category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def get_traceback(tb=None, error=None):
     t = None
     if error:

--- a/ddtrace/ext/priority.py
+++ b/ddtrace/ext/priority.py
@@ -17,6 +17,7 @@ from ddtrace.constants import AUTO_KEEP
 from ddtrace.constants import AUTO_REJECT
 from ddtrace.constants import USER_KEEP
 from ddtrace.constants import USER_REJECT
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 
 from ..vendor.debtcollector.removals import removed_module
 
@@ -24,6 +25,7 @@ from ..vendor.debtcollector.removals import removed_module
 removed_module(
     module="ddtrace.ext.priority",
     replacement="ddtrace.constants",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )
 

--- a/ddtrace/ext/system.py
+++ b/ddtrace/ext/system.py
@@ -2,6 +2,7 @@
 Standard system tags
 """
 from ddtrace.constants import PID
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 
 from ..vendor.debtcollector.removals import removed_module
 
@@ -9,6 +10,7 @@ from ..vendor.debtcollector.removals import removed_module
 removed_module(
     module="ddtrace.ext.system",
     replacement="ddtrace.constants",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )
 

--- a/ddtrace/helpers.py
+++ b/ddtrace/helpers.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from typing import Tuple
 
 import ddtrace
+from ddtrace.internal.utils.deprecation import DDTraceDeprecationWarning
 
 from .vendor.debtcollector.removals import remove
 
@@ -11,7 +12,11 @@ if TYPE_CHECKING:
     from ddtrace.tracer import Tracer
 
 
-@remove(message="Use 'ddtrace.Tracer.get_log_correlation_context()' instead.", removal_version="1.0.0")
+@remove(
+    message="Use 'ddtrace.Tracer.get_log_correlation_context()' instead.",
+    category=DDTraceDeprecationWarning,
+    removal_version="1.0.0",
+)
 def get_correlation_ids(tracer=None):
     # type: (Optional[Tracer]) -> Tuple[Optional[int], Optional[int]]
     """Retrieves the Correlation Identifiers for the current active ``Trace``.

--- a/ddtrace/http/__init__.py
+++ b/ddtrace/http/__init__.py
@@ -1,3 +1,5 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..vendor.debtcollector.removals import removed_module
 from .headers import store_request_headers
 from .headers import store_response_headers
@@ -11,5 +13,6 @@ __all__ = [
 removed_module(
     module="ddtrace.http",
     replacement="ddtrace.contrib.trace_utils",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/http/headers.py
+++ b/ddtrace/http/headers.py
@@ -6,6 +6,7 @@ from ddtrace.contrib.trace_utils import _normalized_header_name
 from ddtrace.contrib.trace_utils import _store_headers
 from ddtrace.contrib.trace_utils import _store_request_headers as store_request_headers
 from ddtrace.contrib.trace_utils import _store_response_headers as store_response_headers
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 
 from ..vendor.debtcollector.removals import removed_module
 
@@ -21,8 +22,10 @@ __all__ = (
     "_normalize_tag_name",
 )
 
+
 removed_module(
     module="ddtrace.http.headers",
     replacement="ddtrace.contrib.trace_utils",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -6,6 +6,8 @@ from typing import DefaultDict
 from typing import Tuple
 from typing import cast
 
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils.formats import get_env
 from ..vendor.debtcollector import deprecate
 
@@ -116,6 +118,7 @@ class DDLogger(logging.Logger):
                 deprecate(
                     "DD_LOGGING_RATE_LIMIT is deprecated",
                     message="Use `DD_TRACE_LOGGING_RATE` instead",
+                    category=DDTraceDeprecationWarning,
                     removal_version="1.0.0",
                 )
 

--- a/ddtrace/internal/utils/deprecation.py
+++ b/ddtrace/internal/utils/deprecation.py
@@ -10,6 +10,7 @@ import warnings
 from ddtrace.vendor.debtcollector.removals import remove
 
 from ...vendor import debtcollector
+from .deprecations import DDTraceDeprecationWarning
 
 
 def format_message(name, message, version=None):
@@ -26,7 +27,9 @@ def format_message(name, message, version=None):
     )
 
 
-@remove(message="Use debtcollector.removals.remove instead.", removal_version="1.0.0")
+@remove(
+    message="Use debtcollector.removals.remove instead.", category=DDTraceDeprecationWarning, removal_version="1.0.0"
+)
 def deprecated(message="", version=None):
     # type: (str, Optional[str]) -> Callable[[Callable[..., Any]], Callable[..., Any]]
     """Decorator function to report a ``DeprecationWarning``. Bear
@@ -74,6 +77,7 @@ def get_service_legacy(default=None):
                 "Refer to our release notes on Github: https://github.com/DataDog/dd-trace-py/releases/tag/v0.36.0 "
                 "for the improvements being made for service names."
             ),
+            category=DDTraceDeprecationWarning,
             removal_version="1.0.0",
         )
         return os.getenv("DD_SERVICE_NAME")
@@ -85,6 +89,7 @@ def get_service_legacy(default=None):
                 "Refer to our release notes on Github: https://github.com/DataDog/dd-trace-py/releases/tag/v0.36.0 "
                 "for the improvements being made for service names."
             ),
+            category=DDTraceDeprecationWarning,
             removal_version="1.0.0",
         )
         return os.getenv("DATADOG_SERVICE_NAME")

--- a/ddtrace/internal/utils/deprecations.py
+++ b/ddtrace/internal/utils/deprecations.py
@@ -1,0 +1,9 @@
+class DDTraceDeprecationWarning(DeprecationWarning):
+    pass
+
+
+# Override module to simplify adding warning filters by querying for
+# ddtrace.DDTraceDeprecationWarning but not have to expose this in the
+# public API. This also allows us to avoid circular imports that would occur if
+# it was contained in the top-level ddtrace package.
+DDTraceDeprecationWarning.__module__ = "ddtrace"

--- a/ddtrace/internal/utils/formats.py
+++ b/ddtrace/internal/utils/formats.py
@@ -7,6 +7,8 @@ from typing import Optional
 from typing import TypeVar
 from typing import Union
 
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ...vendor.debtcollector import deprecate
 
 
@@ -51,6 +53,7 @@ def get_env(*parts, **kwargs):
         deprecate(
             "DATADOG_ is deprecated",
             message="Use `DD_` prefix instead",
+            category=DDTraceDeprecationWarning,
             removal_version="1.0.0",
         )
 

--- a/ddtrace/internal/utils/wrappers.py
+++ b/ddtrace/internal/utils/wrappers.py
@@ -5,6 +5,7 @@ from typing import Optional
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.vendor import wrapt
 
 from ...vendor.debtcollector.removals import remove
@@ -31,7 +32,7 @@ def unwrap(obj, attr):
     setattr(obj, attr, f.__wrapped__)
 
 
-@remove(message="`wrapt` library is used instead", removal_version="1.0.0")
+@remove(message="`wrapt` library is used instead", category=DDTraceDeprecationWarning, removal_version="1.0.0")
 def safe_patch(
     patchable,  # type: Any
     key,  # type: str

--- a/ddtrace/monkey.py
+++ b/ddtrace/monkey.py
@@ -7,6 +7,8 @@ A library instrumentation can be configured (for instance, to report as another 
 using Pin. For that, check its documentation.
 """
 
+from ddtrace.internal.utils.deprecation import DDTraceDeprecationWarning
+
 from ._monkey import ModuleNotFoundException  # noqa
 from ._monkey import PATCH_MODULES  # noqa
 from ._monkey import PatchException  # noqa
@@ -20,5 +22,6 @@ from .vendor.debtcollector.removals import removed_module
 removed_module(
     module="ddtrace.monkey",
     message="Import the patch and patch_all functions directly from the ddtrace module instead",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -4,6 +4,7 @@ from typing import Optional
 from typing import TYPE_CHECKING
 
 import ddtrace
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.vendor import debtcollector
 
 from .internal.logger import get_logger
@@ -37,8 +38,8 @@ class Pin(object):
 
     __slots__ = ["_app", "tags", "tracer", "_target", "_config", "_initialized"]
 
-    @debtcollector.removals.removed_kwarg("app", removal_version="1.0.0")
-    @debtcollector.removals.removed_kwarg("app_type", removal_version="1.0.0")
+    @debtcollector.removals.removed_kwarg("app", category=DDTraceDeprecationWarning, removal_version="1.0.0")
+    @debtcollector.removals.removed_kwarg("app_type", category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def __init__(
         self,
         service=None,  # type: Optional[str]
@@ -69,7 +70,7 @@ class Pin(object):
         """
         return self._config["service_name"]
 
-    @debtcollector.removals.removed_property(removal_version="1.0.0")
+    @debtcollector.removals.removed_property(category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def app(self):
         return self._app
 
@@ -128,8 +129,8 @@ class Pin(object):
         return pin
 
     @classmethod
-    @debtcollector.removals.removed_kwarg("app", removal_version="1.0.0")
-    @debtcollector.removals.removed_kwarg("app_type", removal_version="1.0.0")
+    @debtcollector.removals.removed_kwarg("app", category=DDTraceDeprecationWarning, removal_version="1.0.0")
+    @debtcollector.removals.removed_kwarg("app_type", category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def override(
         cls,
         obj,  # type: Any
@@ -193,8 +194,8 @@ class Pin(object):
         except AttributeError:
             log.debug("can't remove pin from object. skipping", exc_info=True)
 
-    @debtcollector.removals.removed_kwarg("app", removal_version="1.0.0")
-    @debtcollector.removals.removed_kwarg("app_type", removal_version="1.0.0")
+    @debtcollector.removals.removed_kwarg("app", category=DDTraceDeprecationWarning, removal_version="1.0.0")
+    @debtcollector.removals.removed_kwarg("app_type", category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def clone(
         self,
         service=None,  # type: Optional[str]

--- a/ddtrace/propagation/utils.py
+++ b/ddtrace/propagation/utils.py
@@ -1,3 +1,5 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..vendor.debtcollector.removals import removed_module
 from ._utils import from_wsgi_header  # noqa
 from ._utils import get_wsgi_header  # noqa
@@ -5,5 +7,6 @@ from ._utils import get_wsgi_header  # noqa
 
 removed_module(
     module="ddtrace.propagation.utils",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -13,6 +13,8 @@ from typing import Tuple
 
 import six
 
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from .constants import AUTO_KEEP
 from .constants import AUTO_REJECT
 from .constants import ENV_KEY
@@ -254,7 +256,7 @@ class DatadogSampler(RateByServiceSampler):
 
         log.debug("initialized %r", self)
 
-    @removed_property(removal_version="1.0.0")
+    @removed_property(category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def default_sampler(self):
         if self.rules:
             return self.rules[-1]

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -5,6 +5,7 @@ from typing import Optional
 from typing import Tuple
 
 from ddtrace.internal.utils.cache import cachedmethod
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 
 from ..internal.logger import get_logger
 from ..internal.utils.deprecation import get_service_legacy
@@ -244,6 +245,6 @@ class Config(object):
         integrations = ", ".join(self._config.keys())
         return "{}.{}({})".format(cls.__module__, cls.__name__, integrations)
 
-    @remove(removal_version="1.0.0")
+    @remove(category=DDTraceDeprecationWarning, removal_version="1.0.0")
     class HTTPServerConfig(_HTTPServerConfig):
         pass

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -13,6 +13,8 @@ from typing import Union
 
 import six
 
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from . import config
 from .constants import ANALYTICS_SAMPLE_RATE_KEY
 from .constants import ERROR_MSG
@@ -155,6 +157,7 @@ class Span(object):
             deprecate(
                 "ddtrace.Span.tracer is deprecated",
                 message="Use Span(tracer=None, name, ...) instead.",
+                category=DDTraceDeprecationWarning,
                 removal_version="1.0.0",
             )
             self._tracer = tracer
@@ -175,7 +178,7 @@ class Span(object):
         else:
             self._ignored_exceptions.append(exc)
 
-    @removed_property(removal_version="1.0.0")
+    @removed_property(category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def tracer(self):
         # type: () -> Optional[Tracer]
         return self._tracer
@@ -386,6 +389,7 @@ class Span(object):
 
     @removed_property(
         message="Use Span.set_tag, Span.set_tags or Span.get_tag methods instead.",
+        category=DDTraceDeprecationWarning,
         removal_version="1.0.0",
     )
     def meta(self):
@@ -395,12 +399,12 @@ class Span(object):
     def meta(self, value):
         self._meta = value
 
-    @remove(message="Use Span.set_tag instead.", removal_version="1.0.0")
+    @remove(message="Use Span.set_tag instead.", category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def set_meta(self, k, v):
         # type: (_TagNameType, NumericType) -> None
         self.set_tag(k, v)
 
-    @remove(message="Use Span.set_tags.", removal_version="1.0.0")
+    @remove(message="Use Span.set_tags.", category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def set_metas(self, kvs):
         # type: (_MetaDictType) -> None
         self.set_tags(kvs)
@@ -440,6 +444,7 @@ class Span(object):
 
     @removed_property(
         message="Use Span.get_metric or Span.set_metric instead.",
+        category=DDTraceDeprecationWarning,
         removal_version="1.0.0",
     )
     def metrics(self):
@@ -543,7 +548,7 @@ class Span(object):
         self._remove_tag(ERROR_TYPE)
         self._remove_tag(ERROR_STACK)
 
-    @removed_property(removal_version="1.0.0")
+    @removed_property(category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def pprint(self):
         return self._pprint()
 

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -17,6 +17,7 @@ from typing import Union
 
 from ddtrace import config
 from ddtrace.filters import TraceFilter
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.vendor import debtcollector
 
 from . import _hooks
@@ -151,7 +152,10 @@ class Tracer(object):
         pfms_default_value = 500
         if "DD_TRACER_PARTIAL_FLUSH_ENABLED" in os.environ or "DD_TRACER_PARTIAL_FLUSH_MIN_SPANS" in os.environ:
             debtcollector.deprecate(
-                "DD_TRACER_... is deprecated", message="use DD_TRACE_... instead", removal_version="1.0.0"
+                "DD_TRACER_... is deprecated",
+                message="use DD_TRACE_... instead",
+                category=DDTraceDeprecationWarning,
+                removal_version="1.0.0",
             )
             pfe_default_value = asbool(get_env("tracer", "partial_flush_enabled", default=pfe_default_value))
             pfms_default_value = int(
@@ -205,7 +209,9 @@ class Tracer(object):
         self._hooks.deregister(self.__class__.start_span, func)
         return func
 
-    @removals.removed_property(message="Use ddtrace.tracer.log instead", removal_version="1.0.0")
+    @removals.removed_property(
+        message="Use ddtrace.tracer.log instead", category=DDTraceDeprecationWarning, removal_version="1.0.0"
+    )
     def log(self):
         # type: () -> logging.Logger
         return log
@@ -221,21 +227,24 @@ class Tracer(object):
         return log.isEnabledFor(logging.DEBUG)
 
     @debug_logging.setter  # type: ignore[misc]
-    @removals.remove(message="Use logging.setLevel instead", removal_version="1.0.0")
+    @removals.remove(
+        message="Use logging.setLevel instead", category=DDTraceDeprecationWarning, removal_version="1.0.0"
+    )
     def debug_logging(self, value):
         # type: (bool) -> None
         log.setLevel(logging.DEBUG if value else logging.WARN)
 
-    @removals.remove(removal_version="1.0.0")
+    @removals.remove(category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def __call__(self):
         return self
 
-    @removals.remove(removal_version="1.0.0")
+    @removals.remove(category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def global_excepthook(self, tp, value, traceback):
         """The global tracer except hook."""
 
     @removals.remove(
         message="Call context has been superseded by trace context. Please use current_trace_context() instead.",
+        category=DDTraceDeprecationWarning,
         removal_version="1.0.0",
     )
     def get_call_context(self, *args, **kwargs):
@@ -812,6 +821,7 @@ class Tracer(object):
 
     @debtcollector.removals.remove(
         message="Writing spans through a tracer is no longer supported",
+        category=DDTraceDeprecationWarning,
         removal_version="1.0.0",
     )
     def write(self, spans):
@@ -834,7 +844,7 @@ class Tracer(object):
         if spans is not None:
             self._writer.write(spans=spans)
 
-    @removals.removed_property(removal_version="1.0.0")
+    @removals.removed_property(category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def priority_sampler(self):
         # type: () -> Optional[BasePrioritySampler]
         return self._priority_sampler
@@ -854,7 +864,7 @@ class Tracer(object):
         # type: (BaseSampler) -> None
         self._sampler = val
 
-    @removals.removed_property(removal_version="1.0.0")
+    @removals.removed_property(category=DDTraceDeprecationWarning, removal_version="1.0.0")
     def tags(self):
         # type: () -> dict[str, str]
         return self._tags
@@ -881,7 +891,11 @@ class Tracer(object):
         """Flush the buffer of the trace writer. This does nothing if an unbuffered trace writer is used."""
         self._writer.flush_queue()
 
-    @removals.remove(message="Manually setting service info is no longer necessary", removal_version="1.0.0")
+    @removals.remove(
+        message="Manually setting service info is no longer necessary",
+        category=DDTraceDeprecationWarning,
+        removal_version="1.0.0",
+    )
     def set_service_info(self, *args, **kwargs):
         """Set the information about the given service."""
         return
@@ -1007,6 +1021,7 @@ class Tracer(object):
             debtcollector.deprecate(
                 "Tracing with a tracer that has been shut down is deprecated",
                 message="A new tracer should be created for generating new traces.",
+                category=DDTraceDeprecationWarning,
                 removal_version="1.0.0",
             )
 

--- a/ddtrace/util.py
+++ b/ddtrace/util.py
@@ -1,4 +1,6 @@
 # [Backward compatibility]: keep importing modules functions
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from .internal.utils.deprecation import deprecated
 from .internal.utils.formats import asbool
 from .internal.utils.formats import deep_getattr
@@ -10,6 +12,7 @@ from .vendor.debtcollector.removals import removed_module
 
 removed_module(
     module="ddtrace.util",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )
 

--- a/ddtrace/utils/__init__.py
+++ b/ddtrace/utils/__init__.py
@@ -1,3 +1,5 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils import ArgumentError  # noqa
 from ..internal.utils import get_argument_value  # noqa
 from ..vendor.debtcollector.removals import removed_module
@@ -5,5 +7,6 @@ from ..vendor.debtcollector.removals import removed_module
 
 removed_module(
     module="ddtrace.utils.__init__",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/utils/attr.py
+++ b/ddtrace/utils/attr.py
@@ -1,3 +1,5 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils.attr import T  # noqa
 from ..internal.utils.attr import from_env  # noqa
 from ..vendor.debtcollector.removals import removed_module
@@ -5,5 +7,6 @@ from ..vendor.debtcollector.removals import removed_module
 
 removed_module(
     module="ddtrace.utils.attr",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/utils/attrdict.py
+++ b/ddtrace/utils/attrdict.py
@@ -1,8 +1,11 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils.attrdict import AttrDict  # noqa
 from ..vendor.debtcollector.removals import removed_module
 
 
 removed_module(
     module="ddtrace.utils.attrdict",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/utils/cache.py
+++ b/ddtrace/utils/cache.py
@@ -1,3 +1,5 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils.cache import CachedMethodDescriptor  # noqa
 from ..internal.utils.cache import F  # noqa
 from ..internal.utils.cache import M  # noqa
@@ -11,5 +13,6 @@ from ..vendor.debtcollector.removals import removed_module
 
 removed_module(
     module="ddtrace.utils.cache",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/utils/config.py
+++ b/ddtrace/utils/config.py
@@ -1,8 +1,11 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils.config import get_application_name  # noqa
 from ..vendor.debtcollector.removals import removed_module
 
 
 removed_module(
     module="ddtrace.utils.config",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/utils/deprecation.py
+++ b/ddtrace/utils/deprecation.py
@@ -1,8 +1,11 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils.deprecation import get_service_legacy  # noqa
 from ..vendor.debtcollector.removals import removed_module
 
 
 removed_module(
     module="ddtrace.utils.deprecation",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/utils/formats.py
+++ b/ddtrace/utils/formats.py
@@ -1,3 +1,5 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils.formats import T  # noqa
 from ..internal.utils.formats import asbool  # noqa
 from ..internal.utils.formats import deep_getattr  # noqa
@@ -9,5 +11,6 @@ from ..vendor.debtcollector.removals import removed_module
 
 removed_module(
     module="ddtrace.utils.formats",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/utils/http.py
+++ b/ddtrace/utils/http.py
@@ -1,3 +1,5 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils.http import normalize_header_name  # noqa
 from ..internal.utils.http import strip_query_string  # noqa
 from ..vendor.debtcollector.removals import removed_module
@@ -5,5 +7,6 @@ from ..vendor.debtcollector.removals import removed_module
 
 removed_module(
     module="ddtrace.utils.http",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/utils/importlib.py
+++ b/ddtrace/utils/importlib.py
@@ -1,3 +1,5 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils.importlib import func_name  # noqa
 from ..internal.utils.importlib import module_name  # noqa
 from ..internal.utils.importlib import require_modules  # noqa
@@ -6,5 +8,6 @@ from ..vendor.debtcollector.removals import removed_module
 
 removed_module(
     module="ddtrace.utils.importlib",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/utils/time.py
+++ b/ddtrace/utils/time.py
@@ -1,8 +1,11 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils.time import StopWatch  # noqa
 from ..vendor.debtcollector.removals import removed_module
 
 
 removed_module(
     module="ddtrace.utils.time",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/utils/version.py
+++ b/ddtrace/utils/version.py
@@ -1,8 +1,11 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils.version import parse_version  # noqa
 from ..vendor.debtcollector.removals import removed_module
 
 
 removed_module(
     module="ddtrace.utils.version",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/ddtrace/utils/wrappers.py
+++ b/ddtrace/utils/wrappers.py
@@ -1,3 +1,5 @@
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+
 from ..internal.utils.wrappers import F  # noqa
 from ..internal.utils.wrappers import iswrapped  # noqa
 from ..internal.utils.wrappers import safe_patch  # noqa
@@ -7,5 +9,6 @@ from ..vendor.debtcollector.removals import removed_module
 
 removed_module(
     module="ddtrace.utils.wrappers",
+    category=DDTraceDeprecationWarning,
     removal_version="1.0.0",
 )

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -297,15 +297,26 @@ propagate a `rpc_metadata` dictionary over the wire::
             span.set_tag('my_rpc_method', method)
 
 
-Resolving deprecation warnings
-------------------------------
-Before upgrading, it’s a good idea to resolve any deprecation warnings raised by your project.
-These warnings must be fixed before upgrading, otherwise the ``ddtrace`` library
-will not work as expected. Our deprecation messages include the version where
-the behavior is altered or removed.
+.. _`Upgrading and deprecation warnings`:
 
-In Python, deprecation warnings are silenced by default. To enable them you may
-add the following flag or environment variable::
+Upgrading and deprecation warnings
+----------------------------------
+
+Before upgrading, we recommend resolving any deprecation warnings raised in your application. The messages for the deprecation warnings include the version when the API will be changed or removed.
+
+As of v0.59.0, you can enable warning filters for ddtrace library deprecations.
+
+For those using pytest, add a filter for the ``ddtrace.DDTraceDeprecationWarning`` warning category::
+
+    pytest -W "error::ddtrace.DDTraceDeprecationWarning" tests.py
+
+
+Otherwise, you must set the environment variable ``DD_TRACE_RAISE_DEPRECATIONWARNING`` which will configure the warning filter::
+
+    DD_TRACE_RAISE_DEPRECATIONWARNING=1 python app.py
+
+
+Before v0.59.0, you can still enable all deprecation warnings and filter the application or tests logs for deprecations specific the ``ddtrace`` library::
 
     $ python -Wall app.py
 
@@ -755,4 +766,3 @@ API
 
 .. toctree::
    :maxdepth: 2
-   

--- a/releasenotes/notes/add-ddtrace-deprecation-category-f435cd2447d97899.yaml
+++ b/releasenotes/notes/add-ddtrace-deprecation-category-f435cd2447d97899.yaml
@@ -1,0 +1,6 @@
+---
+prelude: >
+  In preparation for the upcoming v1.0.0 release, we recommend users enable deprecation warnings after having installed ``ddtrace>=0.59.0,<1.0.0``. See the :ref:`Upgrading and deprecation warnings` section for further details.
+features:
+  - |
+    Add environment variable ``DD_TRACE_RAISE_DEPRECATIONWARNING`` to raise library deprecation warnings as errors for those unable to configure warning filters otherwise.

--- a/tests/contrib/celery/test_task_deprecation.py
+++ b/tests/contrib/celery/test_task_deprecation.py
@@ -6,6 +6,7 @@ from celery import Celery
 from ddtrace.contrib.celery import patch_task
 from ddtrace.contrib.celery import unpatch
 from ddtrace.contrib.celery import unpatch_task
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 
 
 class CeleryDeprecatedTaskPatch(unittest.TestCase):
@@ -34,7 +35,7 @@ class CeleryDeprecatedTaskPatch(unittest.TestCase):
                 return 42
 
             assert len(w) == 1
-            assert issubclass(w[-1].category, DeprecationWarning)
+            assert issubclass(w[-1].category, DDTraceDeprecationWarning)
             assert "patch(celery=True)" in str(w[-1].message)
 
     def test_unpatch_signals_diconnect(self):
@@ -49,5 +50,5 @@ class CeleryDeprecatedTaskPatch(unittest.TestCase):
                 return 42
 
             assert len(w) == 1
-            assert issubclass(w[-1].category, DeprecationWarning)
+            assert issubclass(w[-1].category, DDTraceDeprecationWarning)
             assert "unpatch()" in str(w[-1].message)

--- a/tests/tracer/test_constants.py
+++ b/tests/tracer/test_constants.py
@@ -2,6 +2,8 @@ import warnings
 
 import pytest
 
+from ddtrace import DDTraceDeprecationWarning
+
 
 def test_deprecated():
     import ddtrace
@@ -12,7 +14,7 @@ def test_deprecated():
         assert ddtrace.constants.FILTERS_KEY
 
         (w,) = ws
-        assert issubclass(w.category, DeprecationWarning)
+        assert issubclass(w.category, DDTraceDeprecationWarning)
         assert "ddtrace.constants.FILTERS_KEY is deprecated and will be removed in version '1.0.0'" == str(w.message)
 
     with warnings.catch_warnings(record=True) as ws:
@@ -21,7 +23,7 @@ def test_deprecated():
         assert ddtrace.constants.NUMERIC_TAGS
 
         (w,) = ws
-        assert issubclass(w.category, DeprecationWarning)
+        assert issubclass(w.category, DDTraceDeprecationWarning)
         assert "ddtrace.constants.NUMERIC_TAGS is deprecated and will be removed in version '1.0.0'" == str(w.message)
 
     with warnings.catch_warnings(record=True) as ws:
@@ -30,7 +32,7 @@ def test_deprecated():
         assert ddtrace.constants.LOG_SPAN_KEY
 
         (w,) = ws
-        assert issubclass(w.category, DeprecationWarning)
+        assert issubclass(w.category, DDTraceDeprecationWarning)
         assert "ddtrace.constants.LOG_SPAN_KEY is deprecated and will be removed in version '1.0.0'" == str(w.message)
 
 

--- a/tests/tracer/test_logger.py
+++ b/tests/tracer/test_logger.py
@@ -5,6 +5,7 @@ from pytest import warns
 
 from ddtrace.internal.logger import DDLogger
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from tests.utils import BaseTestCase
 
 
@@ -145,7 +146,7 @@ class DDLoggerTestCase(BaseTestCase):
         self.assertEqual(log.level, logging.DEBUG)
 
     def test_logger_deprecated_rate_limit(self):
-        with self.override_env(dict(DD_LOGGING_RATE_LIMIT="10")), warns(DeprecationWarning):
+        with self.override_env(dict(DD_LOGGING_RATE_LIMIT="10")), warns(DDTraceDeprecationWarning):
             log = DDLogger("test.logger")
             self.assertEqual(log.rate_limit, 10)
 

--- a/tests/tracer/test_pin.py
+++ b/tests/tracer/test_pin.py
@@ -4,6 +4,7 @@ import warnings
 import pytest
 
 from ddtrace import Pin
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 
 
 class PinTestCase(TestCase):
@@ -196,7 +197,7 @@ def test_pin_app_deprecation():
 
         p = Pin(app="foo")
         assert len(ws) == 1
-        assert issubclass(ws[0].category, DeprecationWarning)
+        assert issubclass(ws[0].category, DDTraceDeprecationWarning)
 
     with warnings.catch_warnings(record=True) as ws:
         warnings.simplefilter("always")
@@ -204,5 +205,5 @@ def test_pin_app_deprecation():
         p = Pin(app="foo")
         assert p.app
         assert len(ws) == 2
-        assert issubclass(ws[0].category, DeprecationWarning)
-        assert issubclass(ws[1].category, DeprecationWarning)
+        assert issubclass(ws[0].category, DDTraceDeprecationWarning)
+        assert issubclass(ws[1].category, DDTraceDeprecationWarning)

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -34,6 +34,7 @@ from ddtrace.context import Context
 from ddtrace.ext import priority
 from ddtrace.internal._encoding import MsgpackEncoderV03
 from ddtrace.internal._encoding import MsgpackEncoderV05
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.writer import AgentWriter
 from ddtrace.internal.writer import LogWriter
 from ddtrace.settings import Config
@@ -535,7 +536,7 @@ def test_tracer_shutdown_no_timeout():
             pass
 
         (w,) = ws
-        assert issubclass(w.category, DeprecationWarning)
+        assert issubclass(w.category, DDTraceDeprecationWarning)
         assert (
             str(w.message)
             == "Tracing with a tracer that has been shut down is deprecated and will be removed in version '1.0.0': "

--- a/tests/tracer/test_utils.py
+++ b/tests/tracer/test_utils.py
@@ -15,6 +15,7 @@ from ddtrace.internal.utils.cache import cached
 from ddtrace.internal.utils.cache import cachedmethod
 from ddtrace.internal.utils.deprecation import deprecated
 from ddtrace.internal.utils.deprecation import format_message
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import get_env
 from ddtrace.internal.utils.formats import parse_tags_str
@@ -63,7 +64,7 @@ class TestUtils(unittest.TestCase):
             value = get_env("requests", "distributed_tracing")
             self.assertEqual(value, "1")
             self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertTrue(issubclass(w[-1].category, DDTraceDeprecationWarning))
             self.assertTrue("Use `DD_` prefix instead" in str(w[-1].message))
 
     def test_get_env_key_priority(self):


### PR DESCRIPTION
Add `DD_TRACE_RAISE_DEPRECATIONWARNING` and `ddtrace.internal.utils.deprecations.DDTraceDeprecationWarning`. Release note for next minor version on 0.x will also include upgrade steps in preparation for v1.0.0. The docs for deprecation warnings are also updated.