### PR TITLE
fix(tests): use non-local task functions in multiprocessing tests

### DIFF
--- a/tests/tracer/test_rand.py
+++ b/tests/tracer/test_rand.py
@@ -78,14 +78,15 @@ def test_fork_pid_check():
             os._exit(0)
 
 
+def _test_multiprocess_target(q):
+    assert sum((_ is _rand.seed for _ in forksafe._registry)) == 1
+    q.put([_rand.rand64bits() for _ in range(100)])
+
+
 def test_multiprocess():
     q = MPQueue()
 
-    def target(q):
-        assert sum((_ is _rand.seed for _ in forksafe._registry)) == 1
-        q.put([_rand.rand64bits() for _ in range(100)])
-
-    ps = [mp.Process(target=target, args=(q,)) for _ in range(30)]
+    ps = [mp.Process(target=_test_multiprocess_target, args=(q,)) for _ in range(30)]
     for p in ps:
         p.start()
 
@@ -107,6 +108,13 @@ def test_multiprocess():
         ids = ids | child_ids  # accumulate the ids
 
 
+def _test_threadsafe_target(q):
+    # Generate a bunch of numbers to try to maximize the chance that
+    # two threads will be calling rand64bits at the same time.
+    rngs = [_rand.rand64bits() for _ in range(200000)]
+    q.put(rngs)
+
+
 def test_threadsafe():
     # Check that the PRNG is thread-safe.
     # This obviously won't guarantee thread safety, but it's something
@@ -126,13 +134,7 @@ def test_threadsafe():
 
     q = Queue()
 
-    def _target():
-        # Generate a bunch of numbers to try to maximize the chance that
-        # two threads will be calling rand64bits at the same time.
-        rngs = [_rand.rand64bits() for _ in range(200000)]
-        q.put(rngs)
-
-    ts = [threading.Thread(target=_target) for _ in range(5)]
+    ts = [threading.Thread(target=_test_threadsafe_target, args=(q,)) for _ in range(5)]
 
     for t in ts:
         t.start()
@@ -187,6 +189,11 @@ def test_tracer_usage_fork():
             os._exit(0)
 
 
+def _test_tracer_usage_multiprocess_target(q):
+    ids_list = list(chain.from_iterable((s.span_id, s.trace_id) for s in [tracer.start_span("s") for _ in range(10)]))
+    q.put(ids_list)
+
+
 def test_tracer_usage_multiprocess():
     q = MPQueue()
 
@@ -196,14 +203,7 @@ def test_tracer_usage_multiprocess():
 
     # Note that we have to be wary of the size of the underlying
     # pipe in the queue: https://bugs.python.org/msg143081
-
-    def target(q):
-        ids_list = list(
-            chain.from_iterable((s.span_id, s.trace_id) for s in [tracer.start_span("s") for _ in range(10)])
-        )
-        q.put(ids_list)
-
-    ps = [mp.Process(target=target, args=(q,)) for _ in range(30)]
+    ps = [mp.Process(target=_test_tracer_usage_multiprocess_target, args=(q,)) for _ in range(30)]
     for p in ps:
         p.start()
 

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -865,19 +865,20 @@ def test_tracer_set_runtime_tags():
     assert span.get_tag("runtime-id") == span2.get_tag("runtime-id")
 
 
+def _test_tracer_runtime_tags_fork_task(tracer, q):
+    span = tracer.start_span("foobaz")
+    q.put(span.get_tag("runtime-id"))
+    span.finish()
+
+
 def test_tracer_runtime_tags_fork():
     tracer = ddtrace.Tracer()
-
-    def task(tracer, q):
-        span = tracer.start_span("foobaz")
-        q.put(span.get_tag("runtime-id"))
-        span.finish()
 
     span = tracer.start_span("foobar")
     span.finish()
 
     q = multiprocessing.Queue()
-    p = multiprocessing.Process(target=task, args=(tracer, q))
+    p = multiprocessing.Process(target=_test_tracer_runtime_tags_fork_task, args=(tracer, q))
     p.start()
     p.join()
 


### PR DESCRIPTION
For some reason multiprocessing tests on macOS and Python 3.8 and above
fail because functions are not pickleable and all locals are pickled which
included the target functions. For some reasons these tests pass fine in Linux
though.

Locally on macOS:

```
obj = <Process name='Process-1' parent=18589 initial>, file = <_io.BytesIO object at 0x106bd0d60>, protocol = None

    def dump(obj, file, protocol=None):
        '''Replacement for pickle.dump() using ForkingPickler.'''
>       ForkingPickler(file, protocol).dump(obj)
E       AttributeError: Can't pickle local object 'test_tracer_usage_multiprocess.<locals>.target'

/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/reduction.py:60: AttributeError
```