### PR TITLE
docs: fix missing ref

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -296,6 +296,8 @@ propagate a `rpc_metadata` dictionary over the wire::
             span.set_tag('my_rpc_method', method)
 
 
+.. _`Upgrading and deprecation warnings`:
+
 Upgrading and deprecation warnings
 ----------------------------------
 


### PR DESCRIPTION
#3347 forward ported with a cherry-pick from #3338 of the changes to the advanced section. The section label was missing so the docs were failing to build but we had gone ahead with merging because of another known issue with the docs build.