### PR TITLE
fix(docs): fix broken docs builds for 1.0 branch

### DIFF
--- a/docs/_release_notes_all.rst
+++ b/docs/_release_notes_all.rst
@@ -1,0 +1,1 @@
+.. release-notes::

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -8,7 +8,16 @@ Release Notes
 
 .. only:: spelling
 
-   .. release-notes::
+    .. toctree::
+        :hidden:
+
+        _release_notes_all
+
+
+
+.. release-notes::
+   :branch: 1.0
+   :earliest-version: v1.0.0rc1
 
 .. release-notes::
    :branch: 0.59

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,4 +1,5 @@
 ---
+default_branch: origin/1.x
 unreleased_version_title: Unreleased
 
 # The default is: (?P<pre_release>\.v?\d+(?:[ab]|rc)+\d*)$

--- a/releasenotes/notes/deprecate-span-get-set-meta-c6fb2528d198414c.yaml
+++ b/releasenotes/notes/deprecate-span-get-set-meta-c6fb2528d198414c.yaml
@@ -1,16 +1,6 @@
 ---
 deprecations:
-  - ".. _remove-span-set-meta:
-
-
-    ``ddtrace.Span.set_meta`` is removed. Use :py:meth:`ddtrace.Span.set_tag`
-    instead.
-
-    "
-  - ".. _remove-span-set-metas:
-
-
-    ``ddtrace.Span.set_metas`` is removed. Use :py:meth:`ddtrace.Span.set_tags`
-    instead.
-
-    "
+  - |
+    :py:meth:`ddtrace.Span.set_meta` is deprecated. Use :py:meth:`ddtrace.Span.set_tag` instead.
+  - |
+    :py:meth:`ddtrace.Span.set_metas` is deprecated. Use :py:meth:`ddtrace.Span.set_tags` instead.

--- a/releasenotes/notes/remove-span-get-set-meta-c6fb2528d198414d.yaml
+++ b/releasenotes/notes/remove-span-get-set-meta-c6fb2528d198414d.yaml
@@ -1,5 +1,5 @@
 ---
-deprecations:
+upgrade:
   - ".. _remove-span-set-meta:
 
 

--- a/releasenotes/notes/remove-span-get-set-meta-c6fb2528d198414d.yaml
+++ b/releasenotes/notes/remove-span-get-set-meta-c6fb2528d198414d.yaml
@@ -1,0 +1,16 @@
+---
+deprecations:
+  - ".. _remove-span-set-meta:
+
+
+    ``ddtrace.Span.set_meta`` is removed. Use :py:meth:`ddtrace.Span.set_tag`
+    instead.
+
+    "
+  - ".. _remove-span-set-metas:
+
+
+    ``ddtrace.Span.set_metas`` is removed. Use :py:meth:`ddtrace.Span.set_tags`
+    instead.
+
+    "


### PR DESCRIPTION
- [fix(docs): fix duplicate release note existing for 0.59 and 1.0](https://github.com/DataDog/dd-trace-py/commit/cd5095415be24ebe2d5780ec152e4637bdfa6bad)
- [fix(reno): set correct default branch name](https://github.com/DataDog/dd-trace-py/commit/7817d80ff14b675afaac100df49d7e5db834d512)
- [fix(docs): build all release notes for spell checking in a different file](https://github.com/DataDog/dd-trace-py/commit/2e5b61fe6744e236dc95ed9f9a83d719d01235ce)