### PR TITLE
Set telemetry integrations in app-started message to an empty list

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -167,6 +167,7 @@ class TelemetryWriter(PeriodicService):
 
         payload = {
             "dependencies": [{"name": pkg.project_name, "version": pkg.version} for pkg in pkg_resources.working_set],
+            "integrations": [],
             "configurations": [],
         }
         self.add_event(payload, "app-started")

--- a/tests/tracer/telemetry/test_writer.py
+++ b/tests/tracer/telemetry/test_writer.py
@@ -93,6 +93,7 @@ def test_add_app_started_event(mock_time, mock_send_request, telemetry_writer):
     # validate request body
     payload = {
         "dependencies": [{"name": pkg.project_name, "version": pkg.version} for pkg in pkg_resources.working_set],
+        "integrations": [],
         "configurations": [],
     }
     assert httpretty.last_request().parsed_body == _get_request_body(payload, "app-started")


### PR DESCRIPTION
The `integrations` field is required on telemetry app-started payloads according to our schema, even if left empty.
