### PR TITLE
feat(tracing/fastapi): add support for tracing fastapi.routing.serialize_response

### DIFF
--- a/ddtrace/contrib/fastapi/patch.py
+++ b/ddtrace/contrib/fastapi/patch.py
@@ -1,6 +1,8 @@
 import fastapi
 from fastapi.middleware import Middleware
+import fastapi.routing
 
+from ddtrace import Pin
 from ddtrace import config
 from ddtrace.contrib.asgi.middleware import TraceMiddleware
 from ddtrace.contrib.starlette.patch import get_resource
@@ -35,12 +37,39 @@ def traced_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
 
 
+async def traced_serialize_response(wrapped, instance, args, kwargs):
+    """Wrapper for fastapi.routing.serialize_response function.
+
+    This function is called on all non-Response objects to
+    convert them to a serializable form.
+
+    This is the wrapper which calls ``jsonable_encoder``.
+
+    This function does not do the actual encoding from
+    obj -> json string  (e.g. json.dumps()). That is handled
+    by the Response.render function.
+
+    DEV: We do not wrap ``jsonable_encoder`` because it calls
+    itself recursively, so there is a chance the overhead
+    added by creating spans will be higher than desired for
+    the result.
+    """
+    pin = Pin.get_from(fastapi)
+    if not pin or not pin.enabled:
+        return await wrapped(*args, **kwargs)
+
+    with pin.tracer.trace("fastapi.serialize_response"):
+        return await wrapped(*args, **kwargs)
+
+
 def patch():
     if getattr(fastapi, "_datadog_patch", False):
         return
 
     setattr(fastapi, "_datadog_patch", True)
+    Pin().onto(fastapi)
     _w("fastapi.applications", "FastAPI.__init__", traced_init)
+    _w("fastapi.routing", "serialize_response", traced_serialize_response)
 
 
 def unpatch():
@@ -50,3 +79,4 @@ def unpatch():
     setattr(fastapi, "_datadog_patch", False)
 
     _u(fastapi.applications.FastAPI, "__init__")
+    _u(fastapi.routing, "serialize_response")

--- a/releasenotes/notes/fastapi-trace-serialize-response-7aa66e459cceb26c.yaml
+++ b/releasenotes/notes/fastapi-trace-serialize-response-7aa66e459cceb26c.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    fastapi: add support for tracing ``fastapi.routing.serialize_response``.
+
+    This will give an insight into how much time is spent calling ``jsonable_encoder``
+    within a given request. This does not provide visibility into how long it takes for
+    ``Response.render``/``json.dumps``.

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_table_query_snapshot.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_table_query_snapshot.json
@@ -12,18 +12,28 @@
       "http.status_code": "200",
       "http.url": "http://testserver/items/",
       "http.version": "1.1",
-      "runtime-id": "2f9a677918454fe5bd4c51af231454b2"
+      "runtime-id": "ca13d92107a949fcb9e9070e1bf4ffa3"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 715
+      "system.pid": 88983
     },
-    "duration": 544200,
-    "start": 1632157975162885300
-  }],
+    "duration": 1456000,
+    "start": 1646400964981676000
+  },
+     {
+       "name": "fastapi.serialize_response",
+       "service": "fastapi",
+       "resource": "fastapi.serialize_response",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "duration": 222000,
+       "start": 1646400964982594000
+     }],
 [
   {
     "name": "fastapi.request",
@@ -38,15 +48,25 @@
       "http.status_code": "200",
       "http.url": "http://testserver/items/test_id",
       "http.version": "1.1",
-      "runtime-id": "2f9a677918454fe5bd4c51af231454b2"
+      "runtime-id": "ca13d92107a949fcb9e9070e1bf4ffa3"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 715
+      "system.pid": 88983
     },
-    "duration": 724700,
-    "start": 1632157975166416700
-  }]]
+    "duration": 479000,
+    "start": 1646400964985955000
+  },
+     {
+       "name": "fastapi.serialize_response",
+       "service": "fastapi",
+       "resource": "fastapi.serialize_response",
+       "trace_id": 1,
+       "span_id": 2,
+       "parent_id": 1,
+       "duration": 112000,
+       "start": 1646400964986203000
+     }]]


### PR DESCRIPTION
We want to add visibility into the time spent calling `jsonable_enoder` for FastAPI. We could wrap `jsonable_encoder`, but because it is called recursively there is a chance we create an unwieldy trace and introduce a performance regression from tracing.

However, `jsonable_encoder` is called from` fastapi.routing.serialize_response`, so we can wrap this instead to get an overall time spent in `jsonable_encoder`.

This does not give us insight into how much time is spent calling `json.dumps()`/`orjson.dumps()`/`ujson.dumps()`/etc (or any time for any call to `Response.render`). `jsonable_encoder` only converts the response data into something that can be encoded as JSON.