### PR TITLE
fix(pymongo): use generic arguments for write_command

### DIFF
--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -17,6 +17,7 @@ from ...ext import mongo as mongox
 from ...ext import net as netx
 from ...internal.compat import iteritems
 from ...internal.logger import get_logger
+from ...internal.utils import get_argument_value
 from .parse import parse_msg
 from .parse import parse_query
 from .parse import parse_spec
@@ -190,7 +191,8 @@ class TracedSocket(ObjectProxy):
         with self.__trace(cmd):
             return self.__wrapped__.command(dbname, spec, *args, **kwargs)
 
-    def write_command(self, request_id, msg):
+    def write_command(self, *args, **kwargs):
+        msg = get_argument_value(args, kwargs, 1, "msg")
         cmd = None
         try:
             cmd = parse_msg(msg)
@@ -200,10 +202,10 @@ class TracedSocket(ObjectProxy):
         pin = ddtrace.Pin.get_from(self)
         # if we couldn't parse it, don't try to trace it.
         if not cmd or not pin or not pin.enabled():
-            return self.__wrapped__.write_command(request_id, msg)
+            return self.__wrapped__.write_command(*args, **kwargs)
 
         with self.__trace(cmd) as s:
-            result = self.__wrapped__.write_command(request_id, msg)
+            result = self.__wrapped__.write_command(*args, **kwargs)
             if result:
                 s.set_metric(mongox.ROWS, result.get("n", -1))
             return result

--- a/releasenotes/notes/pymongo-4.0.2-1f5d2b6af5c158d2.yaml
+++ b/releasenotes/notes/pymongo-4.0.2-1f5d2b6af5c158d2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    pymongo: fix ``write_command`` being patched with the wrong method signature.


### PR DESCRIPTION
Pymongo 4.0.2 released which introduced a breaking change to the method signature of `Socket.write_command`: https://github.com/mongodb/mongo-python-driver/compare/4.0.1...4.0.2#diff-43b0ab0dab45c7b3e339879a4452c7dcb43a659ef6603532348a745e6405afd4R819

The patching attempted to match the signature exactly so the fix is trivial in just accepting args/kwargs and extracting what is needed from them.