### PR TITLE
chore(ci): run nightly builds of 0.x and 1.x branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1042,7 +1042,7 @@ requires_tests: &requires_tests
 
 workflows:
   version: 2
-  test:
+  test: &workflow_test
     jobs:
       # Pre-checking before running all jobs
       - pre_check
@@ -1129,3 +1129,14 @@ workflows:
 
       # Final reports
       - coverage_report: *requires_tests
+
+  test_nightly:
+    <<: *workflow_test
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - 0.x
+                - 1.x


### PR DESCRIPTION
The goal is to ensure a regular cadence of builds for our currently active and maintenance release lines. This should help us validate that maintenance branches are still building properly.