### PR TITLE
Add milliseconds component of Event time for EventBridge events

### DIFF
--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -755,6 +755,7 @@ class BotocoreTest(TracerTestCase):
         assert headers is not None
         assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
         assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
+        assert headers["ms"] is not None
 
     @mock_events
     def test_eventbridge_muliple_entries_trace_injection(self):
@@ -815,19 +816,7 @@ class BotocoreTest(TracerTestCase):
         assert headers is not None
         assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
         assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
-
-        # the following doesn't work due to an issue in moto/localstack where
-        # an SQS message is generated per put_events rather than per event sent
-
-        # message = messages["Messages"][1]
-        # body = message.get("Body")
-        # assert body is not None
-        # body_obj = json.loads(body)
-        # detail = body_obj.get("detail")
-        # headers = detail.get("_datadog")
-        # assert headers is not None
-        # assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        # assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
+        assert headers["ms"] is not None
 
     @mock_kms
     def test_kms_client(self):


### PR DESCRIPTION
<!-- Briefly describe the change and why it was required. -->

Adds a small ms field to EventBridge event trace context that carries the millisecond portion of the time at which the EventBridge event was sent (AWS, for unknown reasons, truncates this). ms will be treated as optional by the event receiver, but will assist in starting the inferred span at the correct time.


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
