### PR TITLE
fix(opentracer/Span): return self in methods

### DIFF
--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -94,9 +94,10 @@ class Span(OpenTracingSpan):
         return self.context.get_baggage_item(key)
 
     def set_operation_name(self, operation_name):
-        # type: (str) -> None
+        # type: (str) -> Span
         """Set the operation name."""
         self._dd_span.name = operation_name
+        return self
 
     def log_kv(self, key_values, timestamp=None):
         # type: (Dict[_TagNameType, Any], Optional[float]) -> Span
@@ -133,7 +134,7 @@ class Span(OpenTracingSpan):
         return self
 
     def set_tag(self, key, value):
-        # type: (_TagNameType, Any) -> None
+        # type: (_TagNameType, Any) -> Span
         """Set a tag on the span.
 
         This sets the tag on the underlying datadog span.
@@ -152,6 +153,7 @@ class Span(OpenTracingSpan):
             self._dd_span.context.sampling_priority = value
         else:
             self._dd_span.set_tag(key, value)
+        return self
 
     def _get_tag(self, key):
         # type: (_TagNameType) -> Optional[Text]

--- a/releasenotes/notes/opentracer-span-1abe3738df78d3c1.yaml
+++ b/releasenotes/notes/opentracer-span-1abe3738df78d3c1.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    opentracer: update ``set_tag`` and ``set_operation_name`` to return a
+      reference to the span to match the OpenTracing spec.

--- a/tests/opentracer/core/test_span.py
+++ b/tests/opentracer/core/test_span.py
@@ -37,8 +37,9 @@ class TestSpan(object):
 
     def test_tags(self, nop_span):
         """Set a tag and get it back."""
-        nop_span.set_tag("test", 23)
+        r = nop_span.set_tag("test", 23)
         assert nop_span._get_metric("test") == 23
+        assert r is nop_span
 
     def test_set_baggage(self, nop_span):
         """Test setting baggage."""
@@ -96,8 +97,9 @@ class TestSpan(object):
     def test_operation_name(self, nop_span):
         """Sanity check for setting the operation name."""
         # just try setting the operation name
-        nop_span.set_operation_name("new_op_name")
+        r = nop_span.set_operation_name("new_op_name")
         assert nop_span._dd_span.name == "new_op_name"
+        assert r is nop_span
 
     def test_context_manager(self, nop_span):
         """Test the span context manager."""


### PR DESCRIPTION
As pointed out in #3365 the opentracing Span object returns itself in
its set_tag and set_operation_name methods and our implementation should
match.

Fixes #3365 