### PR TITLE
test: add marker for running tests in subprocess

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -28,6 +28,25 @@ hypothesis.settings.load_profile("default")
 # Hook for dynamic configuration of pytest in CI
 # https://docs.pytest.org/en/6.2.1/reference.html#pytest.hookspec.pytest_configure
 def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        """subprocess(status, out, err, args, env, parametrize, ddtrace_run):
+            Mark test functions whose body is to be run as stand-alone Python
+            code in a subprocess.
+
+            Arguments:
+                status: the expected exit code of the subprocess.
+                out: the expected stdout of the subprocess, or None to ignore.
+                err: the expected stderr of the subprocess, or None to ignore.
+                args: the command line arguments to pass to the subprocess.
+                env: the environment variables to override for the subprocess.
+                parametrize: whether to parametrize the test function. This is
+                    similar to the `parametrize` marker, but arguments are
+                    passed to the subprocess via environment variables.
+                ddtrace_run: whether to run the test using ddtrace-run.
+        """,
+    )
+
     if os.getenv("CI") != "true":
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,15 @@
+import ast
 import contextlib
+from itertools import product
 import os
 import sys
+from tempfile import NamedTemporaryFile
+import time
 
+from _pytest.runner import CallInfo
+from _pytest.runner import TestReport
 import pytest
+from six import PY2
 
 from tests.utils import DummyTracer
 from tests.utils import TracerSpanContainer
@@ -89,3 +96,143 @@ def snapshot_context(request):
             yield snapshot
 
     return _snapshot
+
+
+# DEV: The dump_code_to_file function is adapted from the compile function in
+# the py_compile module of the Python standard library. It generates .pyc files
+# with the right format.
+if PY2:
+    import marshal
+    from py_compile import MAGIC
+    from py_compile import wr_long
+
+    from _pytest._code.code import ExceptionInfo
+
+    def dump_code_to_file(code, file):
+        file.write(MAGIC)
+        wr_long(file, long(time.time()))  # noqa
+        marshal.dump(code, file)
+        file.flush()
+
+
+else:
+    import importlib
+
+    code_to_pyc = getattr(
+        importlib._bootstrap_external, "_code_to_bytecode" if sys.version_info < (3, 7) else "_code_to_timestamp_pyc"
+    )
+
+    def dump_code_to_file(code, file):
+        file.write(code_to_pyc(code, time.time(), len(code.co_code)))
+        file.flush()
+
+
+def unwind_params(params):
+    if params is None:
+        yield None
+        return
+
+    for _ in product(*(((k, v) for v in vs) for k, vs in params.items())):
+        yield dict(_)
+
+
+class FunctionDefFinder(ast.NodeVisitor):
+    def __init__(self, func_name):
+        super(FunctionDefFinder, self).__init__()
+        self.func_name = func_name
+        self._body = None
+
+    def generic_visit(self, node):
+        return self._body or super(FunctionDefFinder, self).generic_visit(node)
+
+    def visit_FunctionDef(self, node):
+        if node.name == self.func_name:
+            self._body = node.body
+
+    def find(self, file):
+        with open(file) as f:
+            t = ast.parse(f.read())
+            self.visit(t)
+            t.body = self._body
+            return t
+
+
+def run_function_from_file(item, params=None):
+    file, _, func = item.location
+    marker = item.get_closest_marker("subprocess")
+
+    file_index = 1
+    args = marker.kwargs.get("args", [])
+    args.insert(0, None)
+    args.insert(0, sys.executable)
+    if marker.kwargs.get("ddtrace_run", False):
+        file_index += 1
+        args.insert(0, "ddtrace-run")
+
+    env = os.environ.copy()
+    env.update(marker.kwargs.get("env", {}))
+    if params is not None:
+        env.update(params)
+
+    expected_status = marker.kwargs.get("status", 0)
+
+    expected_out = marker.kwargs.get("out", "")
+    if expected_out is not None:
+        expected_out = expected_out.encode("utf-8")
+
+    expected_err = marker.kwargs.get("err", "")
+    if expected_err is not None:
+        expected_err = expected_err.encode("utf-8")
+
+    with NamedTemporaryFile(mode="wb", suffix=".pyc") as fp:
+        dump_code_to_file(compile(FunctionDefFinder(func).find(file), file, "exec"), fp.file)
+
+        start = time.time()
+        args[file_index] = fp.name
+        out, err, status, _ = call_program(*args, env=env)
+        end = time.time()
+        excinfo = None
+
+        if status != expected_status:
+            excinfo = AssertionError(
+                "Expected status %s, got %s.\n=== Captured STDERR ===\n%s=== End of captured STDERR ==="
+                % (expected_status, status, err.decode("utf-8"))
+            )
+        elif expected_out is not None and out != expected_out:
+            excinfo = AssertionError("STDOUT: Expected [%s] got [%s]" % (expected_out, out))
+        elif expected_err is not None and err != expected_err:
+            excinfo = AssertionError("STDERR: Expected [%s] got [%s]" % (expected_err, err))
+
+        if PY2 and excinfo is not None:
+            try:
+                raise excinfo
+            except Exception:
+                excinfo = ExceptionInfo(sys.exc_info())
+
+        call_info_args = dict(result=None, excinfo=excinfo, start=start, stop=end, when="call")
+        if not PY2:
+            call_info_args["duration"] = end - start
+
+        return TestReport.from_item_and_call(item, CallInfo(**call_info_args))
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_protocol(item):
+    marker = item.get_closest_marker("subprocess")
+    if marker:
+        params = marker.kwargs.get("parametrize", None)
+        ihook = item.ihook
+        base_name = item.nodeid
+
+        for ps in unwind_params(params):
+            nodeid = (base_name + str(ps)) if ps is not None else base_name
+
+            ihook.pytest_runtest_logstart(nodeid=nodeid, location=item.location)
+
+            report = run_function_from_file(item, ps)
+            report.nodeid = nodeid
+            ihook.pytest_runtest_logreport(report=report)
+
+            ihook.pytest_runtest_logfinish(nodeid=nodeid, location=item.location)
+
+        return True

--- a/tests/contrib/gevent/test_monkeypatch.py
+++ b/tests/contrib/gevent/test_monkeypatch.py
@@ -20,20 +20,17 @@ def test_gevent_warning(monkeypatch):
     assert b"RuntimeWarning: Loading ddtrace before using gevent monkey patching" in subp.stderr.read()
 
 
-def test_gevent_auto_patching(run_python_code_in_subprocess):
-    code = """
-import ddtrace; ddtrace.patch_all()
+@pytest.mark.subprocess
+def test_gevent_auto_patching():
+    import ddtrace
 
-import gevent  # Patch on import
-from ddtrace.contrib.gevent import GeventContextProvider
+    ddtrace.patch_all()
+    # Patch on import
+    import gevent  # noqa
 
+    from ddtrace.contrib.gevent import GeventContextProvider
 
-assert isinstance(ddtrace.tracer.context_provider, GeventContextProvider)
-"""
-
-    out, err, status, pid = run_python_code_in_subprocess(code)
-    assert status == 0, err
-    assert out == b""
+    assert isinstance(ddtrace.tracer.context_provider, GeventContextProvider)
 
 
 def test_gevent_ddtrace_run_auto_patching(ddtrace_run_python_code_in_subprocess):

--- a/tests/contrib/httpx/test_httpx.py
+++ b/tests/contrib/httpx/test_httpx.py
@@ -1,5 +1,3 @@
-import os
-
 import httpx
 import pytest
 import six
@@ -140,84 +138,77 @@ async def test_configure_service_name_pin(tracer, test_spans):
     assert_spans(test_spans, service="async-client")
 
 
-def test_configure_service_name_env(run_python_code_in_subprocess):
+@pytest.mark.subprocess(
+    env=dict(
+        DD_HTTPX_SERVICE="env-overridden-service-name",
+        DD_SERVICE="global-service-name",
+    )
+)
+def test_configure_service_name_env():
     """
     When setting DD_HTTPX_SERVICE env variable
         When DD_SERVICE is also set
             We use the value from DD_HTTPX_SERVICE
     """
-    code = """
-import asyncio
-import sys
+    import asyncio
+    import sys
 
-import httpx
+    import httpx
 
-from ddtrace.contrib.httpx import patch
-from tests.contrib.httpx.test_httpx import get_url
-from tests.utils import snapshot_context
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
 
-patch()
-url = get_url("/status/200")
+    patch()
+    url = get_url("/status/200")
 
-async def test():
-    token = "tests.contrib.httpx.test_httpx.test_configure_service_name_env"
-    with snapshot_context(token=token):
-        httpx.get(url)
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_configure_service_name_env"
+        with snapshot_context(token=token):
+            httpx.get(url)
 
-    with snapshot_context(token=token):
-        async with httpx.AsyncClient() as client:
-            await client.get(url)
+        with snapshot_context(token=token):
+            async with httpx.AsyncClient() as client:
+                await client.get(url)
 
-if sys.version_info >= (3, 7, 0):
-    asyncio.run(test())
-else:
-    asyncio.get_event_loop().run_until_complete(test())
-    """
-    env = os.environ.copy()
-    env["DD_HTTPX_SERVICE"] = "env-overridden-service-name"
-    env["DD_SERVICE"] = "global-service-name"
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
-    assert status == 0, err
-    assert err == b""
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
 
 
-def test_configure_global_service_name_env(run_python_code_in_subprocess):
+@pytest.mark.subprocess(env=dict(DD_SERVICE="global-service-name"))
+def test_configure_global_service_name_env():
     """
     When only setting DD_SERVICE
         We use the value from DD_SERVICE for the service name
     """
-    code = """
-import asyncio
-import sys
 
-import httpx
+    import asyncio
+    import sys
 
-from ddtrace.contrib.httpx import patch
-from tests.contrib.httpx.test_httpx import get_url
-from tests.utils import snapshot_context
+    import httpx
 
-patch()
-url = get_url("/status/200")
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
 
-async def test():
-    token = "tests.contrib.httpx.test_httpx.test_configure_global_service_name_env"
-    with snapshot_context(token=token):
-        httpx.get(url)
+    patch()
+    url = get_url("/status/200")
 
-    with snapshot_context(token=token):
-        async with httpx.AsyncClient() as client:
-            await client.get(url)
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_configure_global_service_name_env"
+        with snapshot_context(token=token):
+            httpx.get(url)
 
-if sys.version_info >= (3, 7, 0):
-    asyncio.run(test())
-else:
-    asyncio.get_event_loop().run_until_complete(test())
-    """
-    env = os.environ.copy()
-    env["DD_SERVICE"] = "global-service-name"
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
-    assert status == 0, err
-    assert err == b""
+        with snapshot_context(token=token):
+            async with httpx.AsyncClient() as client:
+                await client.get(url)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
 
 
 @pytest.mark.asyncio
@@ -346,44 +337,39 @@ async def test_distributed_tracing_disabled():
             assert_request_headers(resp)
 
 
-def test_distributed_tracing_disabled_env(run_python_code_in_subprocess):
+@pytest.mark.subprocess(env=dict(DD_HTTPX_DISTRIBUTED_TRACING="false"))
+def test_distributed_tracing_disabled_env():
     """
     When disabling distributed tracing via env variable
         We do not add distributed tracing headers to outbound requests
     """
-    code = """
-import asyncio
-import sys
 
-import httpx
+    import asyncio
+    import sys
 
-from ddtrace.contrib.httpx import patch
-from tests.contrib.httpx.test_httpx import get_url, override_config
+    import httpx
 
-patch()
-url = get_url("/headers")
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
 
-async def test():
-    def assert_request_headers(response):
-        data = response.json()
-        assert "X-Datadog-Trace-Id" not in data["headers"]
-        assert "X-Datadog-Parent-Id" not in data["headers"]
-        assert "X-Datadog-Sampling-Priority" not in data["headers"]
+    patch()
+    url = get_url("/headers")
 
-    resp = httpx.get(url)
-    assert_request_headers(resp)
+    async def test():
+        def assert_request_headers(response):
+            data = response.json()
+            assert "X-Datadog-Trace-Id" not in data["headers"]
+            assert "X-Datadog-Parent-Id" not in data["headers"]
+            assert "X-Datadog-Sampling-Priority" not in data["headers"]
 
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(url)
+        resp = httpx.get(url)
         assert_request_headers(resp)
 
-if sys.version_info >= (3, 7, 0):
-    asyncio.run(test())
-else:
-    asyncio.get_event_loop().run_until_complete(test())
-    """
-    env = os.environ.copy()
-    env["DD_HTTPX_DISTRIBUTED_TRACING"] = "false"
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
-    assert status == 0, err
-    assert err == b""
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url)
+            assert_request_headers(resp)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())

--- a/tests/contrib/mariadb/test_mariadb.py
+++ b/tests/contrib/mariadb/test_mariadb.py
@@ -1,5 +1,3 @@
-import os
-
 import mariadb
 import pytest
 
@@ -117,51 +115,52 @@ def test_analytics_default(connection, tracer):
     assert span.get_metric(ANALYTICS_SAMPLE_RATE_KEY) is None
 
 
-test_user_specified_code = """
-from ddtrace import config
-from ddtrace import patch
-from ddtrace import tracer
-import mariadb
-patch(mariadb=True)
-from tests.contrib.config import MARIADB_CONFIG
-connection = mariadb.connect(**MARIADB_CONFIG)
-cursor = connection.cursor()
-cursor.execute("SELECT 1")
-rows = cursor.fetchall()
-assert len(rows) == 1
-tracer.shutdown()
-"""
-
-
+@pytest.mark.subprocess(env=dict(DD_SERVICE="mysvc"))
 @snapshot(async_mode=False)
-def test_user_specified_dd_service_snapshot(run_python_code_in_subprocess):
+def test_user_specified_dd_service_snapshot():
     """
     When a user specifies a service for the app
         The mariadb integration should not use it.
     """
-    env = os.environ.copy()
-    env["DD_SERVICE"] = "mysvc"
-    out, err, status, pid = run_python_code_in_subprocess(
-        test_user_specified_code,
-        env=env,
-    )
-    assert status == 0, err
+    import mariadb
+
+    from ddtrace import config  # noqa
+    from ddtrace import patch
+    from ddtrace import tracer
+
+    patch(mariadb=True)
+    from tests.contrib.config import MARIADB_CONFIG
+
+    connection = mariadb.connect(**MARIADB_CONFIG)
+    cursor = connection.cursor()
+    cursor.execute("SELECT 1")
+    rows = cursor.fetchall()
+    assert len(rows) == 1
+    tracer.shutdown()
 
 
+@pytest.mark.subprocess(env=dict(DD_MARIADB_SERVICE="mysvc"))
 @snapshot(async_mode=False)
-def test_user_specified_dd_mariadb_service_snapshot(run_python_code_in_subprocess):
+def test_user_specified_dd_mariadb_service_snapshot():
     """
     When a user specifies a service for the app
         The mariadb integration should not use it.
     """
+    import mariadb
 
-    env = os.environ.copy()
-    env["DD_MARIADB_SERVICE"] = "mysvc"
-    out, err, status, pid = run_python_code_in_subprocess(
-        test_user_specified_code,
-        env=env,
-    )
-    assert status == 0, err
+    from ddtrace import config  # noqa
+    from ddtrace import patch
+    from ddtrace import tracer
+
+    patch(mariadb=True)
+    from tests.contrib.config import MARIADB_CONFIG
+
+    connection = mariadb.connect(**MARIADB_CONFIG)
+    cursor = connection.cursor()
+    cursor.execute("SELECT 1")
+    rows = cursor.fetchall()
+    assert len(rows) == 1
+    tracer.shutdown()
 
 
 @snapshot(include_tracer=True)

--- a/tests/contrib/snowflake/test_snowflake.py
+++ b/tests/contrib/snowflake/test_snowflake.py
@@ -153,29 +153,24 @@ def test_snowflake_analytics_without_rate(client):
             assert cur.fetchone() == ("4.30.2",)
 
 
+@pytest.mark.subprocess(env=dict(DD_SNOWFLAKE_SERVICE="env-svc"), err=None)
 @snapshot()
-def test_snowflake_service_env(run_python_code_in_subprocess, monkeypatch):
-    monkeypatch.setenv("DD_SNOWFLAKE_SERVICE", "env-svc")
+def test_snowflake_service_env():
+    from tests.contrib.snowflake.test_snowflake import _client
+    from tests.contrib.snowflake.test_snowflake import add_snowflake_query_response
+    from tests.contrib.snowflake.test_snowflake import req_mock
 
-    out, err, status, pid = run_python_code_in_subprocess(
-        """
-from tests.contrib.snowflake.test_snowflake import _client, add_snowflake_query_response, req_mock
+    with _client() as c:
+        with req_mock:
+            add_snowflake_query_response(
+                rowtype=["TEXT"],
+                rows=[("4.30.2",)],
+            )
 
-with _client() as c:
-    with req_mock:
-        add_snowflake_query_response(
-            rowtype=["TEXT"],
-            rows=[("4.30.2",)],
-        )
-
-        with c.cursor() as cur:
-            res = cur.execute("select current_version();")
-            assert res == cur
-            assert cur.fetchone() == ("4.30.2",)
-    """
-    )
-
-    assert status == 0, (out, err)
+            with c.cursor() as cur:
+                res = cur.execute("select current_version();")
+                assert res == cur
+                assert cur.fetchone() == ("4.30.2",)
 
 
 @snapshot()

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -449,7 +449,7 @@ def test_debug_span_log():
     assert b"finishing span name='span'" in stderr
 
 
-def test_partial_flush_log(run_python_code_in_subprocess):
+def test_partial_flush_log():
     tracer = ddtrace.Tracer()
 
     tracer.configure(
@@ -465,20 +465,16 @@ def test_partial_flush_log(run_python_code_in_subprocess):
     assert partial_flush_enabled is True
     assert partial_flush_min_spans == 300
 
-    partial_flush_min_spans = "2"
-    env = os.environ.copy()
-    env["DD_TRACE_PARTIAL_FLUSH_ENABLED"] = "true"
-    env["DD_TRACE_PARTIAL_FLUSH_MIN_SPANS"] = partial_flush_min_spans
 
-    out, err, status, pid = run_python_code_in_subprocess(
-        """
-from ddtrace import tracer
-
-print(tracer._partial_flush_enabled)
-assert tracer._partial_flush_enabled == True
-assert tracer._partial_flush_min_spans == 2
-""",
-        env=env,
+@pytest.mark.subprocess(
+    env=dict(
+        DD_TRACE_PARTIAL_FLUSH_ENABLED="true",
+        DD_TRACE_PARTIAL_FLUSH_MIN_SPANS="2",
     )
+)
+def test_partial_flush_log_subprocess():
+    from ddtrace import tracer
 
-    assert status == 0, (out, err)
+    print(tracer._partial_flush_enabled)
+    assert tracer._partial_flush_enabled is True
+    assert tracer._partial_flush_min_spans == 2

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -651,36 +651,28 @@ print(len(root.handlers))
         assert out == six.b("0\n")
 
 
-def test_writer_env_configuration(run_python_code_in_subprocess):
-    env = os.environ.copy()
-    env["DD_TRACE_WRITER_BUFFER_SIZE_BYTES"] = "1000"
-    env["DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES"] = "5000"
-    env["DD_TRACE_WRITER_INTERVAL_SECONDS"] = "5.0"
-
-    out, err, status, pid = run_python_code_in_subprocess(
-        """
-import ddtrace
-
-assert ddtrace.tracer._writer._encoder.max_size == 1000
-assert ddtrace.tracer._writer._encoder.max_item_size == 1000
-assert ddtrace.tracer._writer._interval == 5.0
-""",
-        env=env,
+@pytest.mark.subprocess(
+    env=dict(
+        DD_TRACE_WRITER_BUFFER_SIZE_BYTES="1000",
+        DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES="5000",
+        DD_TRACE_WRITER_INTERVAL_SECONDS="5.0",
     )
-    assert status == 0, (out, err)
+)
+def test_writer_env_configuration():
+    import ddtrace
+
+    assert ddtrace.tracer._writer._encoder.max_size == 1000
+    assert ddtrace.tracer._writer._encoder.max_item_size == 1000
+    assert ddtrace.tracer._writer._interval == 5.0
 
 
-def test_writer_env_configuration_defaults(run_python_code_in_subprocess):
-    out, err, status, pid = run_python_code_in_subprocess(
-        """
-import ddtrace
+@pytest.mark.subprocess
+def test_writer_env_configuration_defaults():
+    import ddtrace
 
-assert ddtrace.tracer._writer._encoder.max_size == 8 << 20
-assert ddtrace.tracer._writer._encoder.max_item_size == 8 << 20
-assert ddtrace.tracer._writer._interval == 1.0
-""",
-    )
-    assert status == 0, (out, err)
+    assert ddtrace.tracer._writer._encoder.max_size == 8 << 20
+    assert ddtrace.tracer._writer._encoder.max_item_size == 8 << 20
+    assert ddtrace.tracer._writer._interval == 1.0
 
 
 def test_writer_env_configuration_ddtrace_run(ddtrace_run_python_code_in_subprocess):

--- a/tests/runtime/test_runtime_metrics_api.py
+++ b/tests/runtime/test_runtime_metrics_api.py
@@ -27,23 +27,19 @@ def test_runtime_metrics_api_idempotency():
     RuntimeMetrics.disable()
 
 
-def test_manually_start_runtime_metrics(run_python_code_in_subprocess):
+@pytest.mark.subprocess
+def test_manually_start_runtime_metrics():
     """
     When importing and manually starting runtime metrics
         Runtime metrics worker starts and there are no errors
     """
-    out, err, status, pid = run_python_code_in_subprocess(
-        """
-from ddtrace.runtime import RuntimeMetrics
+    from ddtrace.runtime import RuntimeMetrics
 
-RuntimeMetrics.enable()
-assert RuntimeMetrics._enabled
+    RuntimeMetrics.enable()
+    assert RuntimeMetrics._enabled
 
-RuntimeMetrics.disable()
-assert not RuntimeMetrics._enabled
-""",
-    )
-    assert status == 0
+    RuntimeMetrics.disable()
+    assert not RuntimeMetrics._enabled
 
 
 def test_start_runtime_metrics_via_env_var(monkeypatch, ddtrace_run_python_code_in_subprocess):

--- a/tests/tracer/telemetry/test_data.py
+++ b/tests/tracer/telemetry/test_data.py
@@ -45,27 +45,24 @@ def test_get_application_with_values():
     assert application["env"] == "staging"
 
 
-def test_application_with_setenv(run_python_code_in_subprocess, monkeypatch):
+@pytest.mark.subprocess(
+    env=dict(
+        DD_SERVICE="test_service",
+        DD_VERSION="12.34.56",
+        DD_ENV="prod",
+    )
+)
+def test_application_with_setenv():
     """
     validates the return value of get_application when DD_SERVICE, DD_VERSION, and DD_ENV environment variables are set
     """
-    monkeypatch.setenv("DD_SERVICE", "test_service")
-    monkeypatch.setenv("DD_VERSION", "12.34.56")
-    monkeypatch.setenv("DD_ENV", "prod")
+    from ddtrace import config
+    from ddtrace.internal.telemetry.data import get_application
 
-    out, err, status, _ = run_python_code_in_subprocess(
-        """
-from ddtrace.internal.telemetry.data import get_application
-from ddtrace import config
-
-application = get_application(config.service, config.version, config.env)
-assert application["service_name"] == "test_service"
-assert application["service_version"] == "12.34.56"
-assert application["env"] == "prod"
-"""
-    )
-
-    assert status == 0, (out, err)
+    application = get_application(config.service, config.version, config.env)
+    assert application["service_name"] == "test_service"
+    assert application["service_version"] == "12.34.56"
+    assert application["env"] == "prod"
 
 
 def test_get_application_is_cached():

--- a/tests/tracer/test_atexit.py
+++ b/tests/tracer/test_atexit.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ddtrace.internal import atexit
 
 
@@ -10,35 +12,23 @@ def test_register():
     atexit.unregister(foobar)
 
 
-def test_prog_register(run_python_code_in_subprocess):
-    out, err, status, pid = run_python_code_in_subprocess(
-        """
-from ddtrace.internal import atexit
+@pytest.mark.subprocess(out="hello\nworld\n")
+def test_prog_register():
+    from ddtrace.internal import atexit
 
-def foobar(what):
-    print("hello")
-    print(what)
+    def foobar(what):
+        print("hello")
+        print(what)
 
-atexit.register(foobar, "world")
-"""
-    )
-    assert status == 0
-    assert out == b"hello\nworld\n"
-    assert err == b""
+    atexit.register(foobar, "world")
 
 
-def test_prog_unregister(run_python_code_in_subprocess):
-    out, err, status, pid = run_python_code_in_subprocess(
-        """
-from ddtrace.internal import atexit
+@pytest.mark.subprocess
+def test_prog_unregister():
+    from ddtrace.internal import atexit
 
-def foobar():
-    print("hello")
+    def foobar():
+        print("hello")
 
-atexit.register(foobar)
-atexit.unregister(foobar)
-"""
-    )
-    assert status == 0
-    assert out == b""
-    assert err == b""
+    atexit.register(foobar)
+    atexit.unregister(foobar)

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -638,51 +638,44 @@ def test_custom_msgpack_encode_thread_safe(encoding):
     assert unpacked is not None
 
 
-@pytest.mark.parametrize("encoder_cls", ["JSONEncoder", "JSONEncoderV2"])
-def test_json_encoder_traces_bytes(encoder_cls, run_python_code_in_subprocess):
+@pytest.mark.subprocess(parametrize={"encoder_cls": ["JSONEncoder", "JSONEncoderV2"]})
+def test_json_encoder_traces_bytes():
     """
     Regression test for: https://github.com/DataDog/dd-trace-py/issues/3115
 
     Ensure we properly decode `bytes` objects when encoding with the JSONEncoder
     """
-    # Run test in a subprocess to test without setting file encoding to utf-8
-    code = """
-import json
+    import json
+    import os
 
-from ddtrace.internal.compat import PY3
-from ddtrace.internal.encoding import {0}
-from ddtrace.span import Span
+    from ddtrace.internal.compat import PY3
+    import ddtrace.internal.encoding as encoding
+    from ddtrace.span import Span
 
-encoder = {0}()
-data = encoder.encode_traces(
-         [
-             [
-                 Span(name=b"\\x80span.a"),
-                 Span(name=u"\\x80span.b"),
-                 Span(name="\\x80span.b"),
-             ]
-         ]
+    encoder_class_name = os.getenv("encoder_cls")
+
+    encoder = getattr(encoding, encoder_class_name)()
+    data = encoder.encode_traces(
+        [
+            [
+                Span(name=b"\x80span.a"),
+                Span(name=u"\x80span.b"),
+                Span(name="\x80span.b"),
+            ]
+        ]
     )
-traces = json.loads(data)
-if "{0}" == "JSONEncoderV2":
-    traces = traces["traces"]
+    traces = json.loads(data)
+    if encoder_class_name == "JSONEncoderV2":
+        traces = traces["traces"]
 
-assert len(traces) == 1
-span_a, span_b, span_c = traces[0]
+    assert len(traces) == 1
+    span_a, span_b, span_c = traces[0]
 
-if PY3:
-    assert "\\\\x80span.a" == span_a["name"]
-    assert u"\\x80span.b" == span_b["name"]
-    assert u"\\x80span.b" == span_c["name"]
-else:
-    assert u"\\ufffdspan.a" == span_a["name"]
-    assert u"\\x80span.b" == span_b["name"]
-    assert u"\\ufffdspan.b" == span_c["name"]
-""".format(
-        encoder_cls
-    )
-
-    out, err, status, pid = run_python_code_in_subprocess(code)
-    assert status == 0, err
-    assert out == b""
-    assert err == b""
+    if PY3:
+        assert "\\x80span.a" == span_a["name"]
+        assert u"\x80span.b" == span_b["name"]
+        assert u"\x80span.b" == span_c["name"]
+    else:
+        assert u"\ufffdspan.a" == span_a["name"], span_a["name"]
+        assert u"\x80span.b" == span_b["name"]
+        assert u"\ufffdspan.b" == span_c["name"]


### PR DESCRIPTION
The `subprocess` pytest marker can be used to run arbitrary Python code in a Python
subprocess. This is meant to replace the existing fixture to allow actual
Python code to be written and tested, instead of using literal strings.

<!-- Briefly describe the change and why it was required. -->

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
