### PR TITLE
fix(tracer): tracer log deprecation warning

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -210,7 +210,9 @@ class Tracer(object):
         return func
 
     @removals.removed_property(
-        message="Use ddtrace.tracer.log instead", category=DDTraceDeprecationWarning, removal_version="1.0.0"
+        message="Use logging.getLogger('ddtrace.tracer') instead",
+        category=DDTraceDeprecationWarning,
+        removal_version="1.0.0",
     )
     def log(self):
         # type: () -> logging.Logger

--- a/releasenotes/notes/deprecate-tracer-log-attribute-a7fb4c9c23d5b7b4.yaml
+++ b/releasenotes/notes/deprecate-tracer-log-attribute-a7fb4c9c23d5b7b4.yaml
@@ -1,4 +1,4 @@
 ---
 deprecations:
   - |
-    ``ddtrace.Tracer.log`` is deprecated. Use :py:data:`logging.getLogger("ddtrace.tracer")` instead.
+    :py:attr:`ddtrace.Tracer.log` is deprecated. Use :py:data:`ddtrace.tracer.log` instead.

--- a/releasenotes/notes/deprecate-tracer-log-attribute-a7fb4c9c23d5b7b4.yaml
+++ b/releasenotes/notes/deprecate-tracer-log-attribute-a7fb4c9c23d5b7b4.yaml
@@ -1,4 +1,4 @@
 ---
 deprecations:
   - |
-    :py:attr:`ddtrace.Tracer.log` is deprecated. Use :py:data:`ddtrace.tracer.log` instead.
+    ``ddtrace.Tracer.log`` is deprecated. Use :py:data:`logging.getLogger("ddtrace.tracer")` instead.

--- a/releasenotes/notes/fix-tracer-log-deprecation-f0664631263c6fda.yaml
+++ b/releasenotes/notes/fix-tracer-log-deprecation-f0664631263c6fda.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    ``ddtrace.Tracer.log`` is deprecated. Use :py:data:`logging.getLogger("ddtrace.tracer")` instead.

--- a/releasenotes/notes/fix-tracer-log-deprecation-f0664631263c6fda.yaml
+++ b/releasenotes/notes/fix-tracer-log-deprecation-f0664631263c6fda.yaml
@@ -1,4 +1,4 @@
 ---
 deprecations:
   - |
-    ``ddtrace.Tracer.log`` is deprecated. Use :py:data:`logging.getLogger("ddtrace.tracer")` instead.
+    ``ddtrace.Tracer.log`` is deprecated. Use ``logging.getLogger("ddtrace.tracer")`` instead.


### PR DESCRIPTION
``dtrace.tracer.log`` is no longer supported. ``logging.getLogger("ddtrace.tracer")`` should be used instead.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
