### PR TITLE
chore(tests): update brittle warning log assertion

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -783,7 +783,7 @@ def test_no_warnings():
     # which results in a trace being generated after the tracer shutdown
     # has been initiated which results in a deprecation warning.
     env["DD_TRACE_SQLITE3_ENABLED"] = "false"
-    out, err, status, pid = call_program("ddtrace-run", sys.executable, "-Wall", "-c", "'import ddtrace'", env=env)
+    out, err, _, _ = call_program("ddtrace-run", sys.executable, "-Wall", "-c", "'import ddtrace'", env=env)
     assert out == b"", out
 
     # Wrapt is using features deprecated in Python 3.10
@@ -791,11 +791,11 @@ def test_no_warnings():
     if sys.version_info < (3, 10, 0):
         assert err == b"", err
     else:
-        assert (
-            err
-            == (
+        # Assert that the only log lines in the output are import warnings
+        lines = err.splitlines()
+        assert len(lines) > 0, err
+        for line in lines:
+            assert line == (
                 b"<frozen importlib._bootstrap>:914: ImportWarning: "
-                b"ImportHookFinder.find_spec() not found; falling back to find_module()\n"
-            )
-            * 75
-        ), err
+                b"ImportHookFinder.find_spec() not found; falling back to find_module()"
+            ), err


### PR DESCRIPTION
Something changed causing the number of warning logs to change from 75 to something else. To us it doesn't matter if there are 75 or more warning logs, instead we want to assert that those are the only kind of logs on stderr.

This change changes to a loop and assertions over all log lines instead of trying to do an exact match.


Example failure from CI that prompted this change:

```
=================================== FAILURES ===================================
_______________________________ test_no_warnings _______________________________

    def test_no_warnings():
        env = os.environ.copy()
        # Have to disable sqlite3 as coverage uses it on process shutdown
        # which results in a trace being generated after the tracer shutdown
        # has been initiated which results in a deprecation warning.
        env["DD_TRACE_SQLITE3_ENABLED"] = "false"
        out, err, status, pid = call_program("ddtrace-run", sys.executable, "-Wall", "-c", "'import ddtrace'", env=env)
        assert out == b"", out
    
        # Wrapt is using features deprecated in Python 3.10
        # See https://github.com/GrahamDumpleton/wrapt/issues/200
        if sys.version_info < (3, 10, 0):
            assert err == b"", err
        else:
>           assert (
                err
                == (
                    b"<frozen importlib._bootstrap>:914: ImportWarning: "
                    b"ImportHookFinder.find_spec() not found; falling back to find_module()\n"
                )
                * 75
            ), err
E           AssertionError: b'<frozen importlib._bootstrap>:914: ImportWarning: ImportHookFinder.find_spec() not found; falling back to find_modul...ozen importlib._bootstrap>:914: ImportWarning: ImportHookFinder.find_spec() not found; falling back to find_module()
E             '
E           assert b'<frozen imp...nd_module()\n' == b'<frozen imp...nd_module()\n'
E             Use -v to get the full diff

tests/integration/test_integration.py:792: AssertionError
```