### PR TITLE
fix(celery): remove deprecated Pin.app

### DIFF
--- a/ddtrace/contrib/celery/app.py
+++ b/ddtrace/contrib/celery/app.py
@@ -4,7 +4,6 @@ from ddtrace import Pin
 from ddtrace import config
 from ddtrace.pin import _DD_PIN_NAME
 
-from .constants import APP
 from .signals import trace_after_publish
 from .signals import trace_before_publish
 from .signals import trace_failure
@@ -24,7 +23,6 @@ def patch_app(app, pin=None):
     # attach the PIN object
     pin = pin or Pin(
         service=config.celery["worker_service_name"],
-        app=APP,
         _config=config.celery,
     )
     pin.onto(app)

--- a/releasenotes/notes/remove-app-arg-from-celery-instrumentation-4742d04f4e6474d2.yaml
+++ b/releasenotes/notes/remove-app-arg-from-celery-instrumentation-4742d04f4e6474d2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Remove Pin.app deprecation warning from celery instrumentation.


### PR DESCRIPTION
The following deprecation warning is logged when celery instrumentation is enabled and a Pin object is not set.

```
/usr/local/lib/python2.7/site-packages/ddtrace/contrib/celery/app.py:28: DDTraceDeprecationWarning: Using the 'app' argument is deprecated and will be removed in version '1.0.0'
```
## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
