### PR TITLE
fix(tracing/aiohttp): fix error importing `aiohttp_jinja2` integration from `aiohttp`

### DIFF
--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -105,7 +105,7 @@ def _patch_client(aiohttp):
 
 def patch():
     # Legacy patch aiohttp_jinja2
-    from ddtrace.contrib.aiohttp_jinja2 import patch as aiohttp_jinja2_patch
+    from ddtrace.contrib.aiohttp_jinja2.patch import patch as aiohttp_jinja2_patch
 
     aiohttp_jinja2_patch()
 
@@ -125,7 +125,7 @@ def _unpatch_client(aiohttp):
 
 
 def unpatch():
-    from ddtrace.contrib.aiohttp_jinja2 import unpatch as aiohttp_jinja2_unpatch
+    from ddtrace.contrib.aiohttp_jinja2.patch import unpatch as aiohttp_jinja2_unpatch
 
     aiohttp_jinja2_unpatch()
 

--- a/releasenotes/notes/fix-aiohttp-jinja2-import-2b7e29a14a58efdc.yaml
+++ b/releasenotes/notes/fix-aiohttp-jinja2-import-2b7e29a14a58efdc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    aiohttp: fix issue causing ``ddtrace.contrib.aiohttp_jinja2.patch`` module to be imported instead of the ``patch()`` function.


### PR DESCRIPTION
It is possible for Python to try and import the `ddtrace.contrib.aiohttp_jinja2.patch` module instead of the `ddtrace.contrib.aiohttp_jinja2.patch()` function.

Import `patch()` from the `patch` module directly to be more clear.

```
$ docker run --rm -it python:3.9.9 bash

root@413e57731dd1:/# pip install ddtrace==0.60.0rc1
root@413e57731dd1:/# python -c $'from ddtrace.contrib.aiohttp_jinja2 import patch\nprint(patch)'
<module 'ddtrace.contrib.aiohttp_jinja2.patch' from '/usr/local/lib/python3.9/site-packages/ddtrace/contrib/aiohttp_jinja2/patch.py'>

root@413e57731dd1:/# pip install aiohttp_jinja2
root@413e57731dd1:/# python -c $'from ddtrace.contrib.aiohttp_jinja2 import patch\nprint(patch)'
<function patch at 0x7f21ba6fd1f0>
```