### PR TITLE
chore(profiling): remove unused import in collector._task

### DIFF
--- a/ddtrace/profiling/collector/_task.pyx
+++ b/ddtrace/profiling/collector/_task.pyx
@@ -1,4 +1,3 @@
-import threading
 import weakref
 
 from ddtrace.internal import compat


### PR DESCRIPTION
This can prevent some cases of circular imports.