### PR TITLE
revert(tracer): reusing connections (#2999)

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -5,7 +5,6 @@ from json import loads
 import logging
 import os
 import sys
-from typing import Dict
 from typing import List
 from typing import Optional
 from typing import TYPE_CHECKING
@@ -40,8 +39,6 @@ from .sma import SimpleMovingAverage
 if TYPE_CHECKING:
     from ddtrace import Span
 
-    from .agent import ConnectionType
-
 
 log = get_logger(__name__)
 
@@ -56,7 +53,6 @@ DEFAULT_SMA_WINDOW = 10
 DEFAULT_BUFFER_SIZE = 8 << 20  # 8 MB
 DEFAULT_MAX_PAYLOAD_SIZE = 8 << 20  # 8 MB
 DEFAULT_PROCESSING_INTERVAL = 1.0
-DEFAULT_REUSE_CONNECTIONS = False
 
 
 def get_writer_buffer_size():
@@ -72,11 +68,6 @@ def get_writer_max_payload_size():
 def get_writer_interval_seconds():
     # type: () -> float
     return float(os.getenv("DD_TRACE_WRITER_INTERVAL_SECONDS", default=DEFAULT_PROCESSING_INTERVAL))
-
-
-def get_writer_reuse_connections():
-    # type: () -> bool
-    return asbool(os.getenv("DD_TRACE_WRITER_REUSE_CONNECTIONS", DEFAULT_REUSE_CONNECTIONS))
 
 
 def _human_size(nbytes):
@@ -250,7 +241,6 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
         report_metrics=False,  # type: bool
         sync_mode=False,  # type: bool
         api_version=None,  # type: Optional[str]
-        reuse_connections=None,  # type: Optional[bool]
     ):
         # type: (...) -> None
         # Pre-conditions:
@@ -306,7 +296,6 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
         self._metrics_reset()
         self._drop_sma = SimpleMovingAverage(DEFAULT_SMA_WINDOW)
         self._sync_mode = sync_mode
-        self._conn = None  # type: Optional[ConnectionType]
         self._retry_upload = tenacity.Retrying(
             # Retry RETRY_ATTEMPTS times within the first half of the processing
             # interval, using a Fibonacci policy with jitter
@@ -317,7 +306,6 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
             retry=tenacity.retry_if_exception_type((compat.httplib.HTTPException, OSError, IOError)),
         )
         self._log_error_payloads = asbool(os.environ.get("_DD_TRACE_WRITER_LOG_ERROR_PAYLOADS", False))
-        self._reuse_connections = get_writer_reuse_connections() if reuse_connections is None else reuse_connections
 
     @property
     def _agent_endpoint(self):
@@ -370,21 +358,13 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
             api_version=self._api_version,
         )
 
-    def _reset_connection(self):
-        # type: () -> None
-        if self._conn:
-            self._conn.close()
-            self._conn = None
-
     def _put(self, data, headers):
-        # type: (bytes, Dict[str, str]) -> Response
+        conn = get_connection(self.agent_url, self._timeout)
+
         with StopWatch() as sw:
-            if self._conn is None:
-                log.debug("creating new agent connection to %s with timeout %d", self.agent_url, self._timeout)
-                self._conn = get_connection(self.agent_url, self._timeout)
             try:
-                self._conn.request("PUT", self._endpoint, data, headers)
-                resp = compat.get_connection_response(self._conn)
+                conn.request("PUT", self._endpoint, data, headers)
+                resp = compat.get_connection_response(conn)
                 t = sw.elapsed()
                 if t >= self.interval:
                     log_level = logging.WARNING
@@ -392,12 +372,8 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
                     log_level = logging.DEBUG
                 log.log(log_level, "sent %s in %.5fs to %s", _human_size(len(data)), t, self._agent_endpoint)
                 return Response.from_http_response(resp)
-            except Exception:
-                self._reset_connection()
-                raise
             finally:
-                if self._conn and not self._reuse_connections:
-                    self._reset_connection()
+                conn.close()
 
     def _downgrade(self, payload, response):
         if self._endpoint == "v0.5/traces":
@@ -576,8 +552,4 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
         super(AgentWriter, self)._stop_service()
         self.join(timeout=timeout)
 
-    def on_shutdown(self):
-        try:
-            self.periodic()
-        finally:
-            self._reset_connection()
+    on_shutdown = periodic

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -550,34 +550,3 @@ def test_writer_recreate_api_version(init_api_version, api_version, endpoint, en
     assert writer._api_version == api_version
     assert writer._endpoint == endpoint
     assert isinstance(writer._encoder, encoder_cls)
-
-
-def test_writer_reuse_connections_envvar(monkeypatch):
-    monkeypatch.setenv("DD_TRACE_WRITER_REUSE_CONNECTIONS", "false")
-    writer = AgentWriter(agent_url="http://localhost:9126")
-    assert not writer._reuse_connections
-
-    monkeypatch.setenv("DD_TRACE_WRITER_REUSE_CONNECTIONS", "true")
-    writer = AgentWriter(agent_url="http://localhost:9126")
-    assert writer._reuse_connections
-
-
-def test_writer_reuse_connections():
-    # Ensure connection is not reused
-    writer = AgentWriter(agent_url="http://localhost:9126", reuse_connections=True)
-    # Do an initial flush to get a connection
-    writer.flush_queue()
-    assert writer._conn is None
-    writer.flush_queue()
-    assert writer._conn is None
-
-
-def test_writer_reuse_connections_false():
-    # Ensure connection is reused
-    writer = AgentWriter(agent_url="http://localhost:9126", reuse_connections=False)
-    # Do an initial flush to get a connection
-    writer.flush_queue()
-    conn = writer._conn
-    # And another to potentially have it reset
-    writer.flush_queue()
-    assert writer._conn is conn


### PR DESCRIPTION
Issues with reusing connections were detected when testing in the environment.

With the timing of 1.0 we're pushing this feature off until version 1.1.
