### PR TITLE
fix(telemetry): ensure integrations are queued on startup

### DIFF
--- a/tests/tracer/telemetry/test_writer.py
+++ b/tests/tracer/telemetry/test_writer.py
@@ -43,8 +43,9 @@ def telemetry_writer():
 @pytest.fixture
 def telemetry_writer_disabled():
     telemetry_writer = TelemetryWriter()
-    # TelemetryWriter should be disabled by default
-    assert telemetry_writer._enabled is False
+    # TelemetryWriter _enabled should be None by default
+    assert telemetry_writer._enabled is None
+    telemetry_writer._enabled = False
     yield telemetry_writer
 
 


### PR DESCRIPTION
Currently integrations are not sent to the trace agent (telemetry is enabled after patching occurs). 

This change ensures integrations are queued when ``patch`` or ``patch_all()`` is called. 

If telemetry is never enabled we will queue configuration data for up to 64 integrations and these values will persist in memory. The cost of each integration entry is ~100 bytes.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
