### PR TITLE
test: pin MarkupSafe dependency

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -94,7 +94,7 @@ jobs:
         # django.tests.requests module interferes with requests library patching in the tracer -> disable requests patch
         run: DD_TRACE_REQUESTS_ENABLED=0 ddtrace-run tests/runtests.py
 
-  fastapi-testsuite-0_63:
+  fastapi-testsuite-0_75:
     runs-on: ubuntu-latest
     env:
       DD_TESTING_RAISE: true
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: tiangolo/fastapi
-          ref: 0.63.0
+          ref: 0.75.0
           path: fastapi
       #This step installs Flit, a way to put Python packages and modules on PyPI (More info at https://flit.readthedocs.io/en/latest/)
       - name: Install Flit
@@ -120,13 +120,10 @@ jobs:
       #Installs all dependencies needed for FastAPI
       - name: Install Dependencies
         run: flit install --symlink
-      #Reverts SQLalchemy to v1.3.24. Newest version breaks tests due to RowProxy module being deprecated in latest v1.4.11 More info: (https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#rowproxy-is-no-longer-a-proxy-is-now-called-row-and-behaves-like-an-enhanced-named-tuple)
-      - name: Downgrade SQLalchemy
-        run: pip install --force-reinstall SQLAlchemy==1.3.24
       - name: Inject ddtrace
         run: pip install ../ddtrace
       - name: Test
-        run: ddtrace-run pytest tests
+        run: ddtrace-run pytest -p no:warnings tests
 
   flask-testsuite-1_1_4:
     runs-on: ubuntu-latest
@@ -153,13 +150,16 @@ jobs:
         run: pip install tox
       - name: Create tox env
         run: tox -e py38 --notest
-      - name: Inject ddtrace
-        run: .tox/py38/bin/pip install ../ddtrace
       - name: Add pytest configuration for ddtrace
         run: echo -e "[pytest]\nddtrace-patch-all = 1" > pytest.ini
       - name: Run tests
         # test_exception_propagation is broken upstream
-        run: tox -e py38 -- -k 'not test_exception_propagation and not test_memory_consumption'
+        run: |
+          source .tox/py38/bin/activate
+          pip install ../ddtrace
+          pip install -e .
+          pip install --upgrade MarkupSafe==2.0.1
+          pytest -p no:warnings -k 'not test_exception_propagation and not test_memory_consumption' tests/
 
   httpx-testsuite-0_22_0:
     runs-on: ubuntu-latest
@@ -276,6 +276,8 @@ jobs:
         run: pip install ../ddtrace
       - name: Install dependencies
         run: "make init"
+      - name: MarkupSafe fix
+        run: pip install --upgrade MarkupSafe==2.0.1
       - name: Run tests
         run: ddtrace-run pytest -p no:warnings tests
 


### PR DESCRIPTION
The 2.1.0 release of MarkupSafe comes with some changes that break some
of the projects that depend on it. We fix the framework tests by pinning
the version to the latest 2.0 release for now.

<!-- Briefly describe the change and why it was required. -->

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
