### PR TITLE
feat(tracing): spans not sent to agent after tracer shut down

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -470,7 +470,7 @@ class Tracer(object):
         activate=False,  # type: bool
     ):
         # type: (...) -> Span
-        log.warning("Tracer was shutdown. Spans generated after a tracer is shutdown will not be sent to the agent.")
+        log.warning("Spans started after tracer has been shut down will not sent to the Datadog Agent.")
         return self._start_span(name, child_of, service, resource, span_type, activate)
 
     def _start_span(

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -470,7 +470,7 @@ class Tracer(object):
         activate=False,  # type: bool
     ):
         # type: (...) -> Span
-        log.warning("Spans started after tracer has been shut down will not sent to the Datadog Agent.")
+        log.warning("Spans started after the tracer has been shut down will not be sent to the Datadog Agent.")
         return self._start_span(name, child_of, service, resource, span_type, activate)
 
     def _start_span(

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -45,7 +45,6 @@ from .internal.processor.trace import TraceSamplingProcessor
 from .internal.processor.trace import TraceTagsProcessor
 from .internal.processor.trace import TraceTopLevelSpanProcessor
 from .internal.runtime import get_runtime_id
-from .internal.service import ServiceStatus
 from .internal.service import ServiceStatusError
 from .internal.utils.formats import asbool
 from .internal.writer import AgentWriter
@@ -471,8 +470,7 @@ class Tracer(object):
         activate=False,  # type: bool
     ):
         # type: (...) -> Span
-        if isinstance(self._writer, AgentWriter) and self._writer.status == ServiceStatus.STOPPED:
-            log.warning("Tracer was shutdown. Spans generated after a tracer is shutdown will not be sent.")
+        log.warning("Tracer was shutdown. Spans generated after a tracer is shutdown will not be sent to the agent.")
         return self._start_span(name, child_of, service, resource, span_type, activate)
 
     def _start_span(

--- a/releasenotes/notes/add-warning-after-shutdown-tracer-dd8799467c4d29c8.yaml
+++ b/releasenotes/notes/add-warning-after-shutdown-tracer-dd8799467c4d29c8.yaml
@@ -1,4 +1,4 @@
 ---
-features:
+upgrade:
   - |
     Log warning when :py:meth:`ddtrace.tracer.start_span` is called after a tracer is shutdown.

--- a/releasenotes/notes/add-warning-after-shutdown-tracer-dd8799467c4d29c8.yaml
+++ b/releasenotes/notes/add-warning-after-shutdown-tracer-dd8799467c4d29c8.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Log warning when :py:meth:`ddtrace.tracer.start_span` is called after a tracer is shutdown.

--- a/releasenotes/notes/add-warning-after-shutdown-tracer-dd8799467c4d29c8.yaml
+++ b/releasenotes/notes/add-warning-after-shutdown-tracer-dd8799467c4d29c8.yaml
@@ -1,4 +1,4 @@
 ---
 upgrade:
   - |
-    Log warning when :py:meth:`ddtrace.tracer.start_span` is called after a tracer is shutdown.
+    Spans started after the tracer has been shut down will no longer be sent to the Datadog Agent.

--- a/tests/contrib/gevent/test_monkeypatch.py
+++ b/tests/contrib/gevent/test_monkeypatch.py
@@ -24,7 +24,8 @@ def test_gevent_warning(monkeypatch):
 def test_gevent_auto_patching():
     import ddtrace
 
-    ddtrace.patch_all()
+    # Disable tracing sqlite3 as it is used by coverage
+    ddtrace.patch_all(sqlite3=False)
     # Patch on import
     import gevent  # noqa
 

--- a/tests/contrib/gevent/test_monkeypatch.py
+++ b/tests/contrib/gevent/test_monkeypatch.py
@@ -20,22 +20,17 @@ def test_gevent_warning(monkeypatch):
     assert b"RuntimeWarning: Loading ddtrace before using gevent monkey patching" in subp.stderr.read()
 
 
-def test_gevent_auto_patching(ddtrace_run_python_code_in_subprocess):
-    code = """
-import ddtrace
+@pytest.mark.subprocess
+def test_gevent_auto_patching():
+    import ddtrace
 
-ddtrace.patch_all()
-# Patch on import
-import gevent
+    ddtrace.patch_all()
+    # Patch on import
+    import gevent  # noqa
 
-from ddtrace.contrib.gevent import GeventContextProvider
+    from ddtrace.contrib.gevent import GeventContextProvider
 
-assert isinstance(ddtrace.tracer.context_provider, GeventContextProvider)
-"""
-
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code)
-    assert status == 0, err
-    assert out == b""
+    assert isinstance(ddtrace.tracer.context_provider, GeventContextProvider)
 
 
 def test_gevent_ddtrace_run_auto_patching(ddtrace_run_python_code_in_subprocess):

--- a/tests/contrib/gevent/test_monkeypatch.py
+++ b/tests/contrib/gevent/test_monkeypatch.py
@@ -20,17 +20,22 @@ def test_gevent_warning(monkeypatch):
     assert b"RuntimeWarning: Loading ddtrace before using gevent monkey patching" in subp.stderr.read()
 
 
-@pytest.mark.subprocess
-def test_gevent_auto_patching():
-    import ddtrace
+def test_gevent_auto_patching(ddtrace_run_python_code_in_subprocess):
+    code = """
+import ddtrace
 
-    ddtrace.patch_all()
-    # Patch on import
-    import gevent  # noqa
+ddtrace.patch_all()
+# Patch on import
+import gevent
 
-    from ddtrace.contrib.gevent import GeventContextProvider
+from ddtrace.contrib.gevent import GeventContextProvider
 
-    assert isinstance(ddtrace.tracer.context_provider, GeventContextProvider)
+assert isinstance(ddtrace.tracer.context_provider, GeventContextProvider)
+"""
+
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code)
+    assert status == 0, err
+    assert out == b""
 
 
 def test_gevent_ddtrace_run_auto_patching(ddtrace_run_python_code_in_subprocess):

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -560,6 +560,22 @@ def test_tracer_shutdown_timeout():
     t._writer.stop.assert_called_once_with(timeout=2)
 
 
+def test_send_traces_after_shutdown():
+    t = ddtrace.Tracer()
+    assert isinstance(t._writer, AgentWriter)
+    t.shutdown()
+
+    with mock.patch.object(logging.Logger, "warning") as mock_logger:
+        with t.trace("something"):
+            pass
+
+    mock_logger.assert_has_calls(
+        [
+            mock.call("Tracer was shutdown. Spans generated after a tracer is shutdown will not be sent."),
+        ]
+    )
+
+
 def test_tracer_dogstatsd_url():
     t = ddtrace.Tracer()
     assert t._writer.dogstatsd.host == "localhost"

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -560,9 +560,8 @@ def test_tracer_shutdown_timeout():
     t._writer.stop.assert_called_once_with(timeout=2)
 
 
-def test_send_traces_after_shutdown():
+def test_tracer_shutdown_warning():
     t = ddtrace.Tracer()
-    assert isinstance(t._writer, AgentWriter)
     t.shutdown()
 
     with mock.patch.object(logging.Logger, "warning") as mock_logger:
@@ -571,7 +570,7 @@ def test_send_traces_after_shutdown():
 
     mock_logger.assert_has_calls(
         [
-            mock.call("Tracer was shutdown. Spans generated after a tracer is shutdown will not be sent."),
+            mock.call("Spans started after tracer has been shut down will not sent to the Datadog Agent."),
         ]
     )
 

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -570,7 +570,7 @@ def test_tracer_shutdown_warning():
 
     mock_logger.assert_has_calls(
         [
-            mock.call("Spans started after tracer has been shut down will not sent to the Datadog Agent."),
+            mock.call("Spans started after the tracer has been shut down will not be sent to the Datadog Agent."),
         ]
     )
 


### PR DESCRIPTION
Warns users when ``Tracer.trace()`` or ``Tracer.start_span()`` is called after a tracer is shutdown.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
