### PR TITLE
fix(profiling): copy greenlet list before iterating

### DIFF
--- a/ddtrace/profiling/collector/_task.pyx
+++ b/ddtrace/profiling/collector/_task.pyx
@@ -110,7 +110,7 @@ cpdef list_tasks(thread_id):
             (greenlet_id,
              _threading.get_thread_name(greenlet_id),
              greenlet.gr_frame)
-            for greenlet_id, greenlet in compat.iteritems(_gevent_tracer.greenlets)
+            for greenlet_id, greenlet in list(compat.iteritems(_gevent_tracer.greenlets))
             if not greenlet.dead
         ])
 


### PR DESCRIPTION
There is a short window of time where the list can be modified by the coroutine
tracer which triggers this kind of errors:

Unhandled exception in thread started by <bound method _GeventPeriodicThread.run of <_GeventPeriodicThread(ddtrace.profiling.collector.stack:StackCollector, initial daemon)>>
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/ddtrace/internal/periodic.py", line 141, in run
    self._target()
  File "/usr/local/lib/python2.7/site-packages/ddtrace/profiling/collector/__init__.py", line 42, in periodic
    for events in self.collect():
  File "ddtrace/profiling/collector/stack.pyx", line 480, in ddtrace.profiling.collector.stack.StackCollector.collect
  File "ddtrace/profiling/collector/stack.pyx", line 298, in ddtrace.profiling.collector.stack.stack_collect
  File "ddtrace/profiling/collector/_task.pyx", line 96, in ddtrace.profiling.collector._task.list_tasks
  File "ddtrace/profiling/collector/_task.pyx", line 114, in ddtrace.profiling.collector._task.list_tasks
  File "/usr/local/lib/python2.7/weakref.py", line 157, in iteritems
    for wr in self.data.itervalues():
RuntimeError: dictionary changed size during iteration

This might be quite specific to Python 2.7, but this should help fixing this.