### PR TITLE
ci: dockerfile optimizations

### DIFF
--- a/docker/Dockerfile.buster
+++ b/docker/Dockerfile.buster
@@ -9,10 +9,13 @@ ENV LANG C.UTF-8
 
 # https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-
 ENV PYTHONUNBUFFERED=1
-ENV NODE_VERSION=node_16.x
 # Configure PATH environment for pyenv
-ENV PYENV_ROOT /root/.pyenv
-ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:$PATH
+ENV PYENV_ROOT=/root/.pyenv
+ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:$PATH
+ENV PYTHON_CONFIGURE_OPTS=--enable-shared
+
+# Use .python-version to specify all Python versions for testing
+COPY .python-version /root/
 
 RUN \
   # Install system dependencies
@@ -46,34 +49,17 @@ RUN \
       patch \
       python-openssl\
       unixodbc-dev \
-      valgrind \
       wget \
       zlib1g-dev \
-  # Setup Node.js package repository
-  # DEV: The nodejs available with the main repo doesn't install npm
-  # https://github.com/nodesource/distributions/blob/025fe79908872abd39c590a45893b59929cb91e6/README.md#debmanual
-  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
-  && echo "deb https://deb.nodesource.com/${NODE_VERSION} buster main" | tee /etc/apt/sources.list.d/nodesource.list \
-  && echo "deb-src https://deb.nodesource.com/${NODE_VERSION} buster main" | tee -a /etc/apt/sources.list.d/nodesource.list \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends nodejs \
-  && apt-get install -y libmariadb3 \
+  && apt-get install -y --no-install-recommends libmariadb3 \
   # Cleaning up apt cache space
-  && rm -rf /var/lib/apt/lists/*
-
-
-# Use .python-version to specify all Python versions for testing
-COPY .python-version /root/
-
-# Install pyenv
-RUN \
-  git clone --depth 1 --branch v2.2.5 https://github.com/pyenv/pyenv "${PYENV_ROOT}" \
+  && rm -rf /var/lib/apt/lists/* \
+  # Install pyenv
+  && git clone --depth 1 --branch v2.2.5 https://github.com/pyenv/pyenv "${PYENV_ROOT}" \
   && cd /root \
-  && pyenv local | xargs -L 1 pyenv install --keep \
-  && pip install --upgrade pip
-
-# Install datadog-ci tool for uploading JUnit XML reports
-# https://www.npmjs.com/package/@datadog/datadog-ci
-RUN npm install -g @datadog/datadog-ci
+  && pyenv local | xargs -L 1 pyenv install \
+  && cd - \
+  # Install datadog-ci tool for uploading JUnit XML reports
+  && curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Optimizations:

- Squash run commands
- Use binary for ci-app (https://github.com/DataDog/datadog-ci/blob/4518a88465af66d13a838b339fdfb6be7fb96c06/README.md?plain=1#L36-L40)
- Delete node (only needed for installing ci-app)
- Use `--enable-shared` when installing Pythons instead of `--keep` which should replace saving the entire Python source with just the dev headers.
- Remove no longer required packages

This should save some disk space


```
test                                                 latest        056956e4e0fc   About a minute ago   1.79GB
datadog/dd-trace-py                                  latest        5c0d1a225d7a   5 days ago      3.95GB
```

seems to be about 2.16gb (uncompressed) (54% reduction)