### PR TITLE
chore(ci/fastapi): cache fastapi dependency install

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -114,11 +114,18 @@ jobs:
           repository: tiangolo/fastapi
           ref: 0.75.0
           path: fastapi
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-fastapi
       #This step installs Flit, a way to put Python packages and modules on PyPI (More info at https://flit.readthedocs.io/en/latest/)
       - name: Install Flit
+        if: steps.cache.outputs.cache-hit != 'true'
         run: pip install flit
       #Installs all dependencies needed for FastAPI
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: flit install --symlink
       - name: Inject ddtrace
         run: pip install ../ddtrace


### PR DESCRIPTION
It takes 4+ hours to install the dependencies to test fastapi. Fastapi
themselves cache the install: https://github.com/tiangolo/fastapi/commit/d75126a4cef0b4b1ac01de79c42d4ce677eab4d4
