### PR TITLE
fix(tracing): add span processors shutdown

### DIFF
--- a/ddtrace/internal/processor/__init__.py
+++ b/ddtrace/internal/processor/__init__.py
@@ -1,4 +1,5 @@
 import abc
+from typing import Optional
 
 import attr
 import six
@@ -52,8 +53,8 @@ class SpanProcessor(six.with_metaclass(abc.ABCMeta)):
         """
         pass
 
-    def shutdown(self):
-        # type: () -> None
+    def shutdown(self, timeout):
+        # type: (Optional[float]) -> None
         """Called when the processor is done being used.
 
         Any clean-up or flushing should be performed with this method.

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -902,6 +902,7 @@ class Tracer(object):
         """
         try:
             self._writer.stop(timeout=timeout)
+            self._span_processors = []
         except service.ServiceStatusError:
             # It's possible the writer never got started in the first place :(
             pass

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -901,8 +901,8 @@ class Tracer(object):
         :type timeout: :obj:`int` | :obj:`float` | :obj:`None`
         """
         try:
-            self._writer.stop(timeout=timeout)
             self._span_processors = []
+            self._writer.stop(timeout=timeout)
         except service.ServiceStatusError:
             # It's possible the writer never got started in the first place :(
             pass

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -891,7 +891,7 @@ class Tracer(object):
 
     def shutdown(self, timeout=None):
         # type: (Optional[float]) -> None
-        """Shutdown the tracer and flush finished traces. Calling shutdown multiple times is undefined behavior
+        """Shutdown the tracer and flush finished traces. Avoid calling shutdown multiple times.
 
         :param timeout: How long in seconds to wait for the background worker to flush traces
             before exiting or :obj:`None` to block until flushing has successfully completed (default: :obj:`None`)

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -891,18 +891,18 @@ class Tracer(object):
 
     def shutdown(self, timeout=None):
         # type: (Optional[float]) -> None
-        """Shutdown the tracer.
-
-        This will call shutdown on all SpanProcessors and stop the AgentWriter.
+        """Shutdown the tracer and flush finished traces.
 
         :param timeout: How long in seconds to wait for the background worker to flush traces
             before exiting or :obj:`None` to block until flushing has successfully completed (default: :obj:`None`)
         :type timeout: :obj:`int` | :obj:`float` | :obj:`None`
         """
-        for processor in self._span_processors:
+        span_processors = self._span_processors
+        self._span_processors = []
+        for processor in span_processors:
             if hasattr(processor, "shutdown"):
                 processor.shutdown(timeout)
-        self._span_processors = []
+        
 
         with self._shutdown_lock:
             atexit.unregister(self._atexit)

--- a/releasenotes/notes/reset_span_processors_on_shutdown-3d63f33e1354cd5e.yaml
+++ b/releasenotes/notes/reset_span_processors_on_shutdown-3d63f33e1354cd5e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Spans should not be sent to the Agent after py:meth:`ddtrace.Tracer.shutdown` is called.

--- a/releasenotes/notes/reset_span_processors_on_shutdown-3d63f33e1354cd5e.yaml
+++ b/releasenotes/notes/reset_span_processors_on_shutdown-3d63f33e1354cd5e.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    Agent writer service is no longer restarted after the tracer is shut down.

--- a/releasenotes/notes/reset_span_processors_on_shutdown-3d63f33e1354cd5e.yaml
+++ b/releasenotes/notes/reset_span_processors_on_shutdown-3d63f33e1354cd5e.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Spans should not be sent to the Agent after py:meth:`ddtrace.Tracer.shutdown` is called.
+    Agent writer service is no longer restarted after the tracer is shut down.

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -560,6 +560,17 @@ def test_tracer_shutdown_timeout():
     t._writer.stop.assert_called_once_with(timeout=2)
 
 
+def test_tracer_shutdown():
+    t = ddtrace.Tracer()
+    t.shutdown()
+
+    with mock.patch.object(AgentWriter, "write") as mock_write:
+        with t.trace("something"):
+            pass
+
+    mock_write.assert_not_called()
+
+
 def test_tracer_dogstatsd_url():
     t = ddtrace.Tracer()
     assert t._writer.dogstatsd.host == "localhost"


### PR DESCRIPTION
Spans should not be sent to the agent after ``Tracer.shutown()`` is called

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
