### PR TITLE
ci: cache pip downloads per test node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,20 @@ commands:
           paths:
             - ".tox"
 
+  save_pip_cache:
+    description: "Save pip cache directory"
+    steps:
+      - save_cache:
+          key: pip-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ checksum "riotfile.py" }}-{{ checksum "setup.py" }}
+          paths:
+            - ".cache/pip"
+
+  restore_pip_cache:
+    description: "Restore pip cache directory"
+    steps:
+      - restore_cache:
+          key: pip-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ checksum "riotfile.py" }}-{{ checksum "setup.py" }}
+
   run_test:
     description: "Run tests matching a pattern"
     parameters:
@@ -112,6 +126,7 @@ commands:
       - attach_workspace:
           at: .
       - checkout
+      - restore_pip_cache
       - when:
           condition:
               << parameters.snapshot >>
@@ -143,6 +158,7 @@ commands:
             - setup_riot
             - run:
                 command: "./scripts/tested_pythons | circleci tests split | xargs -I PY riot -v run --python=PY --exitfirst --pass-env -s '<< parameters.pattern >>'"
+      - save_pip_cache
       - when:
           condition:
             << parameters.store_coverage >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,7 @@ commands:
     description: "Save pip cache directory"
     steps:
       - save_cache:
+          # DEV: Cache misses can still occur as venvs are not necessarily always created on the same node index
           key: pip-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ checksum "riotfile.py" }}-{{ checksum "setup.py" }}
           paths:
             - ".cache/pip"


### PR DESCRIPTION
We already cache the tox folder but do not do any caching for riot. This PR caches the pip download cache for all riot jobs. The cache is specific to the parallel node where venvs are created and run.