### PR TITLE
feat(tracing): spans not sent to agent after tracer shut down (backport #3483)

### DIFF
--- a/releasenotes/notes/add-warning-after-shutdown-tracer-dd8799467c4d29c8.yaml
+++ b/releasenotes/notes/add-warning-after-shutdown-tracer-dd8799467c4d29c8.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Spans started after the tracer has been shut down will no longer be sent to the Datadog Agent.

--- a/tests/contrib/gevent/test_monkeypatch.py
+++ b/tests/contrib/gevent/test_monkeypatch.py
@@ -24,7 +24,8 @@ def test_gevent_warning(monkeypatch):
 def test_gevent_auto_patching():
     import ddtrace
 
-    ddtrace.patch_all()
+    # Disable tracing sqlite3 as it is used by coverage
+    ddtrace.patch_all(sqlite3=False)
     # Patch on import
     import gevent  # noqa
 

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -571,6 +571,21 @@ def test_tracer_shutdown():
     mock_write.assert_not_called()
 
 
+def test_tracer_shutdown_warning():
+    t = ddtrace.Tracer()
+    t.shutdown()
+
+    with mock.patch.object(logging.Logger, "warning") as mock_logger:
+        with t.trace("something"):
+            pass
+
+    mock_logger.assert_has_calls(
+        [
+            mock.call("Spans started after the tracer has been shut down will not be sent to the Datadog Agent."),
+        ]
+    )
+
+
 def test_tracer_dogstatsd_url():
     t = ddtrace.Tracer()
     assert t._writer.dogstatsd.host == "localhost"


### PR DESCRIPTION
Reopens this backport and fixes the conflicts: https://github.com/DataDog/dd-trace-py/pull/3518

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
