### PR TITLE
refactor(tracer): move top level logic into helper function

### DIFF
--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -14,6 +14,7 @@ from ddtrace.internal.processor import SpanProcessor
 from ddtrace.internal.service import ServiceStatusError
 from ddtrace.internal.writer import TraceWriter
 from ddtrace.span import Span
+from ddtrace.span import _is_top_level
 
 
 log = get_logger(__name__)
@@ -95,9 +96,7 @@ class TraceTopLevelSpanProcessor(TraceProcessor):
 
         span_ids = {span.span_id for span in trace}
         for span in trace:
-            if span is span._local_root:
-                span.set_metric("_dd.top_level", 1)
-            elif span._parent and span.service != span._parent.service:
+            if _is_top_level(span):
                 span.set_metric("_dd.top_level", 1)
             elif span.parent_id and span.parent_id not in span_ids:
                 span.set_metric("_dd.top_level", 0)

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -487,3 +487,15 @@ class Span(object):
             self.parent_id,
             self.name,
         )
+
+
+def _is_top_level(span):
+    # type: (Span) -> bool
+    """Return whether the span is a "top level" span.
+
+    Top level meaning the root of the trace or a child span
+    whose service is different from its parent.
+    """
+    return (span._local_root is span) or (
+        span._parent is not None and span._parent.service != span.service and span.service is not None
+    )

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -35,6 +35,7 @@ from ddtrace.internal._encoding import MsgpackEncoderV05
 from ddtrace.internal.writer import AgentWriter
 from ddtrace.internal.writer import LogWriter
 from ddtrace.settings import Config
+from ddtrace.span import _is_top_level
 from ddtrace.tracer import Tracer
 from ddtrace.tracer import _has_aws_lambda_agent_extension
 from ddtrace.tracer import _in_aws_lambda
@@ -1702,3 +1703,21 @@ def test_tracer_memory_leak_span_processors(enabled):
     # Force gc
     gc.collect()
     assert len(spans) == 0
+
+
+def test_top_level(tracer):
+    with tracer.trace("parent", service="my-svc") as parent_span:
+        assert _is_top_level(parent_span)
+        with tracer.trace("child") as child_span:
+            assert not _is_top_level(child_span)
+            with tracer.trace("subchild") as subchild_span:
+                assert not _is_top_level(subchild_span)
+            with tracer.trace("subchild2", service="svc-2") as subchild_span2:
+                assert _is_top_level(subchild_span2)
+
+    with tracer.trace("parent", service="my-svc") as parent_span:
+        assert _is_top_level(parent_span)
+        with tracer.trace("child", service="child-svc") as child_span:
+            assert _is_top_level(child_span)
+        with tracer.trace("child2", service="child-svc") as child_span2:
+            assert _is_top_level(child_span2)


### PR DESCRIPTION
So it can be reused by other parts of the codebase.