### PR TITLE
revert(ci): "fail fast when integration tests fail"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,7 +385,7 @@ jobs:
       - run:
           command: |
             mv .riot .ddriot
-            ./scripts/ddtest riot -v run --pass-env --exit-first -s 'integration-v5'
+            ./scripts/ddtest riot -v run --pass-env -s 'integration-v5'
 
   integration_agent:
     <<: *machine_executor
@@ -400,7 +400,7 @@ jobs:
       - run:
           command: |
             mv .riot .ddriot
-            ./scripts/ddtest riot -v run --pass-env --exit-first -s 'integration-latest'
+            ./scripts/ddtest riot -v run --pass-env -s 'integration-latest'
 
   integration_testagent:
     <<: *machine_executor
@@ -417,7 +417,7 @@ jobs:
             DD_TRACE_AGENT_URL: http://localhost:9126
           command: |
             mv .riot .ddriot
-            ./scripts/ddtest riot -v run --pass-env --exit-first -s 'integration-snapshot'
+            ./scripts/ddtest riot -v run --pass-env -s 'integration-snapshot'
 
   vendor:
     <<: *contrib_job_small

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -475,6 +475,5 @@ def test_partial_flush_log():
 def test_partial_flush_log_subprocess():
     from ddtrace import tracer
 
-    print(tracer._partial_flush_enabled)
     assert tracer._partial_flush_enabled is True
     assert tracer._partial_flush_min_spans == 2


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#3279


https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/14858/workflows/de2c5714-7c27-4d3f-bf6f-d1788fbce6a9/jobs/1034017

This flag is broken but somehow the test passes.

```
179c3509: Pulling fs layer
c67aaeb4: Pulling fs layer
734aa436: Pulling fs layer
c8775b19: Pulling fs layer
472d7196: Pulling fs layer
Digest: sha256:a0127e42e224fb60b02de71532fe7e3c2da7b90aa66ae76e286bc470ac4f5d78 28.28MB/28.28MBB
Status: Downloaded newer image for datadog/dd-trace-py:buster
Creating project_testrunner_run ... 
Creating project_testrunner_run ... done^@^@WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
[00:42:40] INFO     Generating virtual environments for interpreters ]8;id=821756;file:///root/.pyenv/versions/3.10.1/lib/python3.10/site-packages/riot/riot.py\riot.py]8;;\:]8;id=813128;file:///root/.pyenv/versions/3.10.1/lib/python3.10/site-packages/riot/riot.py#831\831]8;;\

-------------------summary-------------------
0 passed with 0 warnings, 0 failed

CircleCI received exit code 0

```