### PR TITLE
test: run pytest as a module

### DIFF
--- a/tests/opentracer/core/test_tracer.py
+++ b/tests/opentracer/core/test_tracer.py
@@ -31,7 +31,7 @@ class TestTracerConfig(object):
     def test_no_service_name(self):
         """A service_name should be generated if one is not provided."""
         tracer = Tracer()
-        assert tracer._service_name in {"pytest", "__main__.py"}
+        assert tracer._service_name in {"pytest.py", "pytest", "__main__.py"}
 
     def test_multiple_tracer_configs(self):
         """Ensure that a tracer config is a copy of the passed config."""

--- a/tests/opentracer/core/test_tracer.py
+++ b/tests/opentracer/core/test_tracer.py
@@ -31,7 +31,7 @@ class TestTracerConfig(object):
     def test_no_service_name(self):
         """A service_name should be generated if one is not provided."""
         tracer = Tracer()
-        assert tracer._service_name == "pytest"
+        assert tracer._service_name in {"pytest", "__main__.py"}
 
     def test_multiple_tracer_configs(self):
         """Ensure that a tracer config is a copy of the passed config."""

--- a/tox.ini
+++ b/tox.ini
@@ -219,37 +219,37 @@ passenv=
 
 commands =
 # run only essential tests related to the tracing client
-    tracer: pytest {posargs} tests/tracer
+    tracer: python -m pytest {posargs} tests/tracer
     py27-profile: python -m tests.profiling.run pytest --capture=no --verbose --benchmark-disable --ignore-glob="*asyncio*" {posargs} tests/profiling
     # Coverage is excluded from profile because of an issue with Python 3.5.
     py3{5,6,7,8,9,10}-profile: python -m tests.profiling.run pytest --no-cov --capture=no --verbose --benchmark-disable {posargs} tests/profiling
 # run only the opentrace tests
-    opentracer: pytest {posargs} tests/opentracer/core
-    opentracer_asyncio: pytest {posargs} tests/opentracer/test_tracer_asyncio.py
-    opentracer_tornado-tornado{40,41,42,43,44}: pytest {posargs} tests/opentracer/test_tracer_tornado.py
-    opentracer_gevent: pytest {posargs} tests/opentracer/test_tracer_gevent.py
+    opentracer: python -m pytest {posargs} tests/opentracer/core
+    opentracer_asyncio: python -m pytest {posargs} tests/opentracer/test_tracer_asyncio.py
+    opentracer_tornado-tornado{40,41,42,43,44}: python -m pytest {posargs} tests/opentracer/test_tracer_tornado.py
+    opentracer_gevent: python -m pytest {posargs} tests/opentracer/test_tracer_gevent.py
 # Contribs
-    algoliasearch_contrib: pytest {posargs} tests/contrib/algoliasearch
-    asyncio_contrib: pytest {posargs} tests/contrib/asyncio
-    bottle_contrib: pytest {posargs} --ignore="tests/contrib/bottle/test_autopatch.py" tests/contrib/bottle/
+    algoliasearch_contrib: python -m pytest {posargs} tests/contrib/algoliasearch
+    asyncio_contrib: python -m pytest {posargs} tests/contrib/asyncio
+    bottle_contrib: python -m pytest {posargs} --ignore="tests/contrib/bottle/test_autopatch.py" tests/contrib/bottle/
     bottle_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/bottle/test_autopatch.py
-    consul_contrib: pytest {posargs} tests/contrib/consul
-    dbapi_contrib: pytest {posargs} tests/contrib/dbapi
-    dogpile_contrib: pytest {posargs} tests/contrib/dogpile_cache
-    futures_contrib: pytest {posargs} tests/contrib/futures
-    gevent_contrib: pytest {posargs} tests/contrib/gevent
-    httplib_contrib: pytest {posargs} tests/contrib/httplib
-    molten_contrib: pytest {posargs} tests/contrib/molten
-    mysql_contrib: pytest {posargs} tests/contrib/mysql
-    mysqldb_contrib: pytest {posargs} tests/contrib/mysqldb
-    pylibmc_contrib: pytest {posargs} tests/contrib/pylibmc
+    consul_contrib: python -m pytest {posargs} tests/contrib/consul
+    dbapi_contrib: python -m pytest {posargs} tests/contrib/dbapi
+    dogpile_contrib: python -m pytest {posargs} tests/contrib/dogpile_cache
+    futures_contrib: python -m pytest {posargs} tests/contrib/futures
+    gevent_contrib: python -m pytest {posargs} tests/contrib/gevent
+    httplib_contrib: python -m pytest {posargs} tests/contrib/httplib
+    molten_contrib: python -m pytest {posargs} tests/contrib/molten
+    mysql_contrib: python -m pytest {posargs} tests/contrib/mysql
+    mysqldb_contrib: python -m pytest {posargs} tests/contrib/mysqldb
+    pylibmc_contrib: python -m pytest {posargs} tests/contrib/pylibmc
     pylons_contrib: python -m pytest {posargs} tests/contrib/pylons
-    pymysql_contrib: pytest {posargs} tests/contrib/pymysql
-    pyodbc_contrib: pytest {posargs} tests/contrib/pyodbc
-    kombu_contrib: pytest {posargs} tests/contrib/kombu
-    sqlite3_contrib: pytest {posargs} tests/contrib/sqlite3
-    tornado_contrib: pytest {posargs} tests/contrib/tornado
-    vertica_contrib: pytest {posargs} tests/contrib/vertica/
+    pymysql_contrib: python -m pytest {posargs} tests/contrib/pymysql
+    pyodbc_contrib: python -m pytest {posargs} tests/contrib/pyodbc
+    kombu_contrib: python -m pytest {posargs} tests/contrib/kombu
+    sqlite3_contrib: python -m pytest {posargs} tests/contrib/sqlite3
+    tornado_contrib: python -m pytest {posargs} tests/contrib/tornado
+    vertica_contrib: python -m pytest {posargs} tests/contrib/vertica/
 
 [testenv:wait]
 skip_install=true


### PR DESCRIPTION
Running pytest as an entry point in tox started causing import
errors. Running it as a module fixes this.

<!-- Briefly describe the change and why it was required. -->

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
