### PR TITLE
chore: run slotscheck only on staged files

### DIFF
--- a/hooks/scripts/run-slotscheck.sh
+++ b/hooks/scripts/run-slotscheck.sh
@@ -1,2 +1,7 @@
 #!/bin/sh
-riot -v run slotscheck
+staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.py$')
+if [ -n "$staged_files" ]; then
+    riot -v run -s slotscheck $staged_files
+else
+    echo 'Run slotscheck skipped: No Python files were found in git diff --staged'
+fi

--- a/riotfile.py
+++ b/riotfile.py
@@ -162,7 +162,7 @@ venv = Venv(
             venvs=[
                 Venv(
                     name="slotscheck",
-                    command="python -m slotscheck -v ddtrace/",
+                    command="python -m slotscheck -v {cmdargs}",
                 ),
             ],
         ),


### PR DESCRIPTION
Reduce the check run time by only scanning staged files

<!-- Briefly describe the change and why it was required. -->

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
