### PR TITLE
fix(docs): document runpy support for flask

### DIFF
--- a/ddtrace/contrib/flask/__init__.py
+++ b/ddtrace/contrib/flask/__init__.py
@@ -27,6 +27,7 @@ You may also enable Flask tracing automatically via ddtrace-run::
 
     ddtrace-run python app.py
 
+Note: ddtrace does not support runpy. Avoid using ``python -m`` to run your flask app.
 
 Configuration
 ~~~~~~~~~~~~~

--- a/releasenotes/notes/document-runpy-in-flask-documentation-34e7897ff38c15b6.yaml
+++ b/releasenotes/notes/document-runpy-in-flask-documentation-34e7897ff38c15b6.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Updates documentation to note running a flask app with ``python -m`` is not supported.


### PR DESCRIPTION
ddtrace flask integration does not support runpy but this functionality is documented in the flask quick [starter guide](https://flask.palletsprojects.com/en/2.1.x/quickstart/).

This PR adds a note that running ``ddtrace-run python -m flask run`` is not supported.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
