### PR TITLE
perf: update benchmarks for 1.x

### DIFF
--- a/benchmarks/encoder/utils.py
+++ b/benchmarks/encoder/utils.py
@@ -1,9 +1,17 @@
+from functools import partial
 import random
 import string
 
+from ddtrace import Span
+from ddtrace import __version__ as ddtrace_version
 from ddtrace.internal.encoding import MSGPACK_ENCODERS
-from ddtrace.span import Span
 
+
+_Span = Span
+
+# DEV: 1.x dropped tracer positional argument
+if ddtrace_version.split(".")[0] == "0":
+    _Span = partial(_Span, None)
 
 try:
     # the introduction of the buffered encoder changed the internal api
@@ -49,7 +57,7 @@ def gen_traces(config):
             span_name = random.choice(span_names)
             resource = random.choice(resources)
             service = random.choice(services)
-            with Span(span_name, resource=resource, service=service, parent_id=parent_id) as span:
+            with _Span(span_name, resource=resource, service=service, parent_id=parent_id) as span:
                 if i == 0 and config.dd_origin:
                     # Since we're not using the tracer API, a span's context isn't automatically propagated
                     # to its children. The encoder only checks the root span's context in a trace for dd_origin, so

--- a/benchmarks/span/scenario.py
+++ b/benchmarks/span/scenario.py
@@ -1,8 +1,6 @@
 import bm
 import utils
 
-from ddtrace import Span as dd_Span
-
 
 class Span(bm.Scenario):
     nspans = bm.var(type=int)
@@ -26,7 +24,7 @@ class Span(bm.Scenario):
         def _(loops):
             for _ in range(loops):
                 for i in range(self.nspans):
-                    s = dd_Span(None, "test." + str(i), resource="resource", service="service")
+                    s = utils.gen_span("test." + str(i))
                     if settags:
                         s.set_tags(tags)
                     if setmetrics:

--- a/benchmarks/span/utils.py
+++ b/benchmarks/span/utils.py
@@ -1,5 +1,20 @@
+from functools import partial
 import random
 import string
+
+from ddtrace import Span
+from ddtrace import __version__ as ddtrace_version
+
+
+_Span = Span
+
+# DEV: 1.x dropped tracer positional argument
+if ddtrace_version.split(".")[0] == "0":
+    _Span = partial(_Span, None)
+
+
+def gen_span(name):
+    return _Span(name, resource="resource", service="service")
 
 
 def gen_tags(scenario):


### PR DESCRIPTION
The expectation with the 0.x to 1.x migration is that changes to the API would not affect performance. With the understanding that noise has not been entirely controlled with runs, the comparisons below show that v0.60.1 is between 1.0 and 1.15 times slower than v1.0.0.rc3.

## Results

| Benchmark                                | 1.0.0rc3 | 0.60.1                |
|------------------------------------------|----------|-----------------------|
| encoder-one-trace                        | 324 us   | 373 us: 1.15x slower  |
| encoder-many-traces                      | 37.0 ms  | 41.2 ms: 1.11x slower |
| encoder-one-tag                          | 456 us   | 500 us: 1.10x slower  |
| encoder-one-metric                       | 461 us   | 496 us: 1.08x slower  |
| encoder-many-metrics                     | 1.92 ms  | 1.97 ms: 1.02x slower |
| encoder-one-trace-with-dd-origin         | 730 us   | 778 us: 1.07x slower  |
| encoder-one-trace-with-dd-origin-no-tags | 427 us   | 477 us: 1.12x slower  |
| encoder-many-traces-with-dd-origin       | 84.5 ms  | 88.8 ms: 1.05x slower |
| span-start                               | 2.62 ms  | 2.94 ms: 1.12x slower |
| span-add-tags                            | 63.9 ms  | 64.8 ms: 1.01x slower |
| span-start-finish                        | 4.09 ms  | 4.43 ms: 1.08x slower |
| tracer-small                             | 120 us   | 124 us: 1.04x slower  |
| tracer-medium                            | 1.05 ms  | 1.09 ms: 1.04x slower |
| tracer-large                             | 10.7 ms  | 11.2 ms: 1.04x slower |
| flasksimple-baseline                     | 1.56 ms  | 1.60 ms: 1.03x slower |
| flasksimple-profiler                     | 1.61 ms  | 1.60 ms: 1.01x faster |
| flasksimple-tracer-and-profiler          | 1.55 ms  | 1.60 ms: 1.04x slower |