### PR TITLE
chore(docs): allow specifying reno options per-version

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -138,6 +138,7 @@ venv = Venv(
                 "types-attrs": latest,
                 "types-docutils": latest,
                 "types-protobuf": latest,
+                "types-PyYAML": latest,
                 "types-setuptools": latest,
                 "types-six": latest,
             },


### PR DESCRIPTION
This PR introduces the ability to define per-version reno options
for generating release notes.

The config is a yaml encoded map of release version to reno options.

```rst
.. ddtrace-release-notes::
    "1.0.0":
      ignore_notes:
        - "keep-alive-b5ec5febb435daad"
```