### PR TITLE
chore(ci): remove tests.cache.conftest early load

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -268,7 +268,7 @@ ignore_outcome=true
 # DEV: We use `conftest.py` as a local pytest plugin to configure hooks for collection
 [pytest]
 # --cov-report is intentionally empty else pytest-cov will default to generating a report
-addopts = -p tests.cache.conftest --cov=ddtrace/ --cov=tests/ --cov-append --cov-report= --durations=10 --junitxml=test-results/junit.xml
+addopts = --cov=ddtrace/ --cov=tests/ --cov-append --cov-report= --durations=10 --junitxml=test-results/junit.xml
 # DEV: The default is `test_*\.py` which will miss `test.py` files
 python_files = test*\.py
 filterwarnings =


### PR DESCRIPTION
Doesn't seem like this is necessary?

This fixes an issue with running the tests locally (on macOS)

```
    self.consider_pluginarg(parg)
  File "/Users/kverhoog/dev/dd-trace-py/.venv2/lib/python2.7/site-packages/_pytest/config/__init__.py", line 531, in consider_pluginarg
    self.import_plugin(arg, consider_entry_points=True)
  File "/Users/kverhoog/dev/dd-trace-py/.venv2/lib/python2.7/site-packages/_pytest/config/__init__.py", line 581, in import_plugin
    six.reraise(ImportError, new_exc, tb)
  File "/Users/kverhoog/dev/dd-trace-py/.venv2/lib/python2.7/site-packages/_pytest/config/__init__.py", line 572, in import_plugin
    __import__(importspec)
ImportError: Error importing plugin "tests.cache.conftest": No module named cache.conftest
```

as, for some reason, pytest locates and uses another `tests` module