### PR TITLE
ci: fix encoders profile job

### DIFF
--- a/scripts/profiles/encoders/run.sh
+++ b/scripts/profiles/encoders/run.sh
@@ -18,7 +18,7 @@ test -d ${PREFIX}/artifacts && rm -rf ${PREFIX}/artifacts || mkdir -p ${PREFIX}/
 function profile {
     ver=${1}
 
-    python scripts/profiles/encoders/run.py ${ver} &
+    PYTHONPATH="." python scripts/profiles/encoders/run.py ${ver} &
     sleep 2
     sudo ${PREFIX}/austinp -si ${AUSTIN_INTERVAL} -x ${AUSTIN_EXPOSURE} -p $! > ${PREFIX}/artifacts/${ver/./_}.austin
     python ${PREFIX}/austin/utils/resolve.py ${PREFIX}/artifacts/${ver/./_}.austin > ${PREFIX}/artifacts/${ver/./_}.resolved.austin || true


### PR DESCRIPTION
Adding the current working directory to the `PYTHONPATH` to allow Python to locate the `tests` package. Why this is now required beats me.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
