### PR TITLE
chore(ci): use more parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,19 +372,21 @@ jobs:
 
   tracer:
     <<: *contrib_job
+    parallelism: 7
     steps:
       - run_test:
           pattern: "tracer"
 
   opentracer:
     <<: *contrib_job
+    parallelism: 7
     steps:
       - run_tox_scenario:
           pattern: '^py..-opentracer'
 
   profile:
     <<: *contrib_job
-    parallelism: 6
+    parallelism: 7
     steps:
       - run_tox_scenario:
           store_coverage: false
@@ -540,7 +542,7 @@ jobs:
 
   celery:
     <<: *contrib_job
-    parallelism: 6
+    parallelism: 7
     docker:
       - image: *ddtrace_dev_image
       - image: redis:4.0-alpine
@@ -933,6 +935,7 @@ jobs:
 
   kombu:
     <<: *contrib_job
+    parallelism: 7
     docker:
       - image: *ddtrace_dev_image
       - image: *rabbitmq_image


### PR DESCRIPTION
Some of the jobs were using parallelism 6 but we run with 7 versions of
Python so some parallel runners run two versions of Python. By bumping
the parallelism to 7 we effectively half the job duration of profiling,
opentracing, kombu and celery.

We missed this regression when we added support for Python 3.10.

This cuts down our cI time from ~40 mins to ~25 mins.