### PR TITLE
chore(botocore): allow flaky test to fail

### DIFF
--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -14,6 +14,7 @@ from moto import mock_lambda
 from moto import mock_s3
 from moto import mock_sns
 from moto import mock_sqs
+import pytest
 
 
 # Older version of moto used kinesis to mock firehose
@@ -1013,6 +1014,7 @@ class BotocoreTest(TracerTestCase):
 
     @mock_sns
     @mock_sqs
+    @pytest.mark.xfail(strict=False)  # FIXME: flaky test
     def test_sns_send_message_trace_injection_with_message_attributes(self):
         sns = self.session.create_client("sns", region_name="us-east-1", endpoint_url="http://localhost:4566")
         sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")


### PR DESCRIPTION
https://github.com/DataDog/dd-trace-py/pull/3178 introduced a flaky
test, until it can be fixed we'll allow it to fail.
