### PR TITLE
fix(stack,asyncio): add missing CPU time in asyncio apps

### DIFF
--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -286,66 +286,66 @@ cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_tim
     stack_events = []
     exc_events = []
 
-    for thread_id, thread_native_id, thread_name, frame, exception, span, cpu_time in running_threads:
-        task_id, task_name, task_frame = _task.get_task(thread_id)
+    for thread_id, thread_native_id, thread_name, thread_pyframes, exception, span, cpu_time in running_threads:
+        thread_task_id, thread_task_name, thread_task_frame = _task.get_task(thread_id)
 
         # When gevent thread monkey-patching is enabled, our PeriodicCollector non-real-threads are gevent tasks.
         # Therefore, they run in the main thread and their samples are collected by `collect_threads`.
         # We ignore them here:
-        if task_id in thread_id_ignore_list:
+        if thread_task_id in thread_id_ignore_list:
             continue
 
         tasks = _task.list_tasks(thread_id)
 
+        # This boolean value is used to know if we injected a sample that accounts for the CPU time.
+        # In the case of a gevent program this can be injected into a task.
+        # In other cases, it's injected in a regular sample.
+        cpu_time_accounted_for = False
+
         # Inject wall time for all running tasks
-        for task_id, task_name, task_frame in tasks:
-            # Inject the task frame and replace the thread frame: this is especially handy for gevent as it allows us to
-            # replace the "hub" stack trace by the latest active greenlet, which is more interesting to show and account
-            # resources for.
-            if task_frame is not None:
-               frame = task_frame
+        for task_id, task_name, task_pyframes in tasks:
 
-            frames, nframes = _traceback.pyframe_to_frames(frame, max_nframes)
+            # Ignore tasks with no frames; nothing to show.
+            if task_pyframes is None:
+                continue
 
-            if task_id == compat.main_thread.ident:
-                event = stack_event.StackSampleEvent(
-                    thread_id=thread_id,
-                    thread_native_id=thread_native_id,
-                    thread_name=thread_name,
-                    task_id=task_id,
-                    task_name=task_name,
-                    nframes=nframes, frames=frames,
-                    wall_time_ns=wall_time,
-                    cpu_time_ns=cpu_time,
-                    sampling_period=int(interval * 1e9),
-                )
+            if task_id in thread_id_ignore_list:
+                continue
 
-                # FIXME: we only trace spans per thread, so we assign the span to the main thread for now
-                # we'd need to leverage the greenlet tracer to also store the active span
-                event.set_trace_info(span, collect_endpoint)
-            else:
-                event = stack_event.StackSampleEvent(
-                    thread_id=thread_id,
-                    thread_native_id=thread_native_id,
-                    thread_name=thread_name,
-                    task_id=task_id,
-                    task_name=task_name,
-                    nframes=nframes, frames=frames,
-                    wall_time_ns=wall_time,
-                    # we don't have CPU time per task
-                    sampling_period=int(interval * 1e9),
-                )
-
-            stack_events.append(event)
-
-        # If a thread has no task, we inject the "regular" thread samples
-        if len(tasks) == 0:
-            frames, nframes = _traceback.pyframe_to_frames(frame, max_nframes)
+            frames, nframes = _traceback.pyframe_to_frames(task_pyframes, max_nframes)
 
             event = stack_event.StackSampleEvent(
                 thread_id=thread_id,
                 thread_native_id=thread_native_id,
                 thread_name=thread_name,
+                task_id=task_id,
+                task_name=task_name,
+                nframes=nframes, frames=frames,
+                wall_time_ns=wall_time,
+                sampling_period=int(interval * 1e9),
+            )
+
+            # This only works for gevent
+            if task_id == compat.main_thread.ident:
+                event.cpu_time_ns = cpu_time
+                # FIXME: we only trace spans per thread, so we assign the span to the main thread for now
+                # we'd need to leverage the greenlet tracer to also store the active span
+                event.set_trace_info(span, collect_endpoint)
+
+                cpu_time_accounted_for = True
+
+            stack_events.append(event)
+
+        # If a thread has no task, we inject the "regular" thread samples
+        if not cpu_time_accounted_for:
+            frames, nframes = _traceback.pyframe_to_frames(thread_pyframes, max_nframes)
+
+            event = stack_event.StackSampleEvent(
+                thread_id=thread_id,
+                thread_native_id=thread_native_id,
+                thread_name=thread_name,
+                task_id=thread_task_id,
+                task_name=thread_task_name,
                 nframes=nframes,
                 frames=frames,
                 wall_time_ns=wall_time,
@@ -364,8 +364,8 @@ cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_tim
                 thread_id=thread_id,
                 thread_name=thread_name,
                 thread_native_id=thread_native_id,
-                task_id=task_id,
-                task_name=task_name,
+                task_id=thread_task_id,
+                task_name=thread_task_name,
                 nframes=nframes,
                 frames=frames,
                 sampling_period=int(interval * 1e9),

--- a/releasenotes/notes/profiling-asyncio-fix-missing-main-thread-dec4b0759094c571.yaml
+++ b/releasenotes/notes/profiling-asyncio-fix-missing-main-thread-dec4b0759094c571.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The CPU profiler now reports the main thread CPU usage even when asyncio
+    tasks are running.

--- a/tests/profiling/collector/test_stack_asyncio.py
+++ b/tests/profiling/collector/test_stack_asyncio.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections
+import os
 
 import pytest
 
@@ -8,6 +9,9 @@ from ddtrace.profiling import profiler
 from ddtrace.profiling.collector import stack_event
 
 from . import _asyncio_compat
+
+
+TESTING_GEVENT = os.getenv("DD_PROFILE_TEST_GEVENT", False)
 
 
 @pytest.mark.skipif(not _asyncio_compat.PY36_AND_LATER, reason="Python > 3.5 needed")
@@ -45,6 +49,7 @@ def test_asyncio(tmp_path, monkeypatch) -> None:
     t1_name = _asyncio._task_get_name(t1)
     t2_name = _asyncio._task_get_name(t2)
 
+    cpu_time_found = False
     for event in events[stack_event.StackSampleEvent]:
 
         wall_time_ns[event.task_name] += event.wall_time_ns
@@ -53,16 +58,31 @@ def test_asyncio(tmp_path, monkeypatch) -> None:
         if _asyncio_compat.PY37_AND_LATER:
             if event.task_name == "main":
                 assert event.thread_name == "MainThread"
-                assert event.frames == [(__file__, 25, "hello")]
+                assert event.frames == [(__file__, 29, "hello")]
                 assert event.nframes == 1
             elif event.task_name == t1_name:
                 assert event.thread_name == "MainThread"
-                assert event.frames == [(__file__, 19, "stuff")]
+                assert event.frames == [(__file__, 23, "stuff")]
                 assert event.nframes == 1
             elif event.task_name == t2_name:
                 assert event.thread_name == "MainThread"
-                assert event.frames == [(__file__, 19, "stuff")]
+                assert event.frames == [(__file__, 23, "stuff")]
                 assert event.nframes == 1
+
+        if event.thread_name == "MainThread" and (
+            # The task name is empty in asyncio (it's not a task) but the main thread is seen as a task in gevent
+            (event.task_name is None and not TESTING_GEVENT)
+            or (event.task_name == "MainThread" and TESTING_GEVENT)
+        ):
+            # Make sure we account CPU time
+            if event.cpu_time_ns > 0:
+                cpu_time_found = True
+
+            for frame in event.frames:
+                if frame[0] == __file__ and frame[2] == "test_asyncio":
+                    break
+            else:
+                pytest.fail("unable to find expected main thread frame: %r" % event.frames)
 
     if _asyncio_compat.PY38_AND_LATER:
         # We don't know the name of this task for Python < 3.8
@@ -70,3 +90,4 @@ def test_asyncio(tmp_path, monkeypatch) -> None:
 
     assert wall_time_ns[t1_name] > 0
     assert wall_time_ns[t2_name] > 0
+    assert cpu_time_found


### PR DESCRIPTION
The current asyncio code does not report CPU time for the main thread when
there are tasks running.

The code expects one of the task to be the main thread; this is only true for
gevent. Asyncio does not have this behaviour, which means we only can account
wall time for tasks.

The CPU time must be assigned to the regular main thread, just like we'd do for
a non-async program.

Fixes #3572