### PR TITLE
fix(tracer/writer): lock the connection

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -311,6 +311,9 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
         self._drop_sma = SimpleMovingAverage(DEFAULT_SMA_WINDOW)
         self._sync_mode = sync_mode
         self._conn = None  # type: Optional[ConnectionType]
+        # The connection has to be locked since there exists a race between
+        # the periodic thread of AgentWriter and other threads that might
+        # force a flush with `flush_queue()`.
         self._conn_lck = threading.RLock()  # type: threading.RLock
         self._retry_upload = tenacity.Retrying(
             # Retry RETRY_ATTEMPTS times within the first half of the processing


### PR DESCRIPTION
There existed a critical section with the connection object on writer as
the `periodic` logic of the writer could be invoked from the periodic
writer thread as well as from other threads calling `periodic`
(`tracer.flush()` or `tracer.shutdown()`). The critical section would
result in corrupted http connections. This bug was introduced in #2999.

The solution is to lock the connection when used. I don't suspect that
this would lead to any performance degradation for the vast majority of
users since there is little overhead added to the writer. A degradation
would occur if contending threads were calling `periodic()` as now the
connection is a shared resource.


Example symptom of the error if a race were to occur:
```
        except Exception as e:
            # Even though it's unlikely any traces have been sent, make the
            # final request to the test agent so that the test case is finished.
            conn = httplib.HTTPConnection(parsed.hostname, parsed.port)
            conn.request("GET", "/test/session/snapshot?ignores=%s&test_session_token=%s" % (",".join(ignores), token))
            conn.getresponse()
>           pytest.fail("Unexpected test failure during snapshot test: %s" % str(e), pytrace=True)
E           Failed: Unexpected test failure during snapshot test: 'NoneType' object has no attribute 'getresponse'
```

## Future

- If a manual flush is forced then use a new connection
- Connection pooling (maybe via https://urllib3.readthedocs.io/en/latest/reference/urllib3.connectionpool.html)