### PR TITLE
chore(ci): reduce number of celery tests

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -371,18 +371,6 @@ venv = Venv(
                         "kombu": "~=4.3.0",
                     },
                 ),
-                Venv(
-                    pys=select_pys(max_version="3.6"),
-                    pkgs={
-                        "pytest": "~=3.10",
-                        "celery": [
-                            "~=4.0.2",
-                            "~=4.1.1",
-                        ],
-                        "redis": "~=3.5",
-                        "kombu": "~=4.4.0",
-                    },
-                ),
                 # Celery 4.2 is now limited to Kombu 4.3
                 # https://github.com/celery/celery/commit/1571d414461f01ae55be63a03e2adaa94dbcb15d
                 Venv(
@@ -417,9 +405,7 @@ venv = Venv(
                     },
                     pkgs={
                         "celery": [
-                            # Pin until https://github.com/celery/celery/issues/6829 is resolved.
-                            # "~=5.0.5",
-                            "==5.0.5",
+                            "~=5.0.5",
                             "~=5.0",  # most recent 5.x
                             latest,
                         ],


### PR DESCRIPTION
celery is the longest running job in CI and we were running many different configurations of the tests (with different kombu versions)