### PR TITLE
chore(asm/appsec): add support for parsed query and use it on Flask and Django

### DIFF
--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -292,6 +292,7 @@ def _after_request_tags(pin, span, request, response):
                 raw_uri=raw_uri,
                 status_code=status,
                 query=request.META.get("QUERY_STRING", None),
+                parsed_query=request.GET,
                 request_headers=request_headers,
                 response_headers=response_headers,
                 request_cookies=request.COOKIES,

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -327,6 +327,7 @@ def traced_wsgi_app(pin, wrapped, instance, args, kwargs):
             url=request.base_url,
             raw_uri=request.url,
             query=request.query_string,
+            parsed_query=request.args,
             request_headers=request.headers,
             request_path_params=request.args,
         )

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -241,6 +241,7 @@ def set_http_meta(
     status_code=None,  # type: Optional[Union[int, str]]
     status_msg=None,  # type: Optional[str]
     query=None,  # type: Optional[str]
+    parsed_query=None,  # type: Optional[Mapping[str, str]]
     request_headers=None,  # type: Optional[Mapping[str, str]]
     response_headers=None,  # type: Optional[Mapping[str, str]]
     retries_remain=None,  # type: Optional[Union[int, str]]
@@ -257,6 +258,7 @@ def set_http_meta(
     :param status_code: the HTTP status code
     :param status_msg: the HTTP status message
     :param query: the HTTP query part of the URI as a string
+    :param parsed_query: the HTTP query part of the URI as parsed by the framework and forwarded to the user code
     :param request_headers: the HTTP request headers
     :param response_headers: the HTTP response headers
     :param raw_uri: the full raw HTTP URI (including ports and query)
@@ -305,6 +307,7 @@ def set_http_meta(
                     ("http.request.uri", raw_uri),
                     ("http.request.method", method),
                     ("http.request.cookies", request_cookies),
+                    ("http.request.query", parsed_query),
                     ("http.request.headers", request_headers),
                     ("http.response.headers", response_headers),
                     ("http.response.status", status_code),

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -12,3 +12,4 @@ def test_django_simple_attack(client, test_spans, tracer):
     assert "triggers" in json.loads(root_span.get_tag("_dd.appsec.json"))
     assert _context.get_item("http.request.uri", span=root_span) == "http://testserver/.git?q=1"
     assert _context.get_item("http.request.headers", span=root_span) is not None
+    assert _context.get_item("http.request.query", span=root_span)["q"] == "1"

--- a/tests/contrib/flask/test_flask_appsec.py
+++ b/tests/contrib/flask/test_flask_appsec.py
@@ -16,3 +16,4 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
 
         assert "triggers" in json.loads(root_span.get_tag("_dd.appsec.json"))
         assert _context.get_item("http.request.uri", span=root_span) == "http://localhost/.git?q=1"
+        assert _context.get_item("http.request.query", span=root_span)["q"] == "1"


### PR DESCRIPTION
This PR introduces `parsed_query` in `set_http_meta`. This argument is designed to host the parsed query object as it is provided by the framework. Some layers of the host application parse the querystring and may transform it. AppSec need to runs the WAF on such parameters. Also, this avoids us from making mistakes when parsing the query or when decoding the raw querystring to `str`
