### PR TITLE
ci: decrease wait before encoder profiling

### DIFF
--- a/scripts/profiles/encoders/run.sh
+++ b/scripts/profiles/encoders/run.sh
@@ -19,7 +19,7 @@ function profile {
     ver=${1}
 
     PYTHONPATH="." python scripts/profiles/encoders/run.py ${ver} &
-    sleep 2
+    sleep 1
     sudo ${PREFIX}/austinp -si ${AUSTIN_INTERVAL} -x ${AUSTIN_EXPOSURE} -p $! > ${PREFIX}/artifacts/${ver/./_}.austin
     python ${PREFIX}/austin/utils/resolve.py ${PREFIX}/artifacts/${ver/./_}.austin > ${PREFIX}/artifacts/${ver/./_}.resolved.austin || true
 }


### PR DESCRIPTION
Due to recent performance improvements, the import and run time
of the encoders profiling job might have decreased, resulting in
scarse data collection. We reduce the wait between the job start
and the profiling process to increase the chances of collecting
data.

<!-- Briefly describe the change and why it was required. -->

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
