### PR TITLE
feat(botocore): allow specifying which http status codes are errors

### DIFF
--- a/ddtrace/contrib/botocore/__init__.py
+++ b/ddtrace/contrib/botocore/__init__.py
@@ -37,6 +37,21 @@ Configuration
     Default: ``False``
 
 
+.. py:data:: ddtrace.config.botocore['s3_head_object_404_as_error']
+
+    Whether any ``botocore.exceptions.ClientError`` exceptions raise for 404 responses to
+    S3 ``HeadObject`` API calls should mark the representing span as an error.
+
+    By default we mark these spans as having an exception.
+
+    You can disable this behavior (ignore the exception) by configuring
+    ``ddtrace.config.botocore.s3_head_object_404_as_error = True`` or by setting the environment
+    variable ``DD_BOTOCORE_S3_HEAD_OBJECT_404_AS_ERROR=true``.
+
+
+    Default: ``True``
+
+
 Example::
 
     from ddtrace import config

--- a/ddtrace/contrib/botocore/__init__.py
+++ b/ddtrace/contrib/botocore/__init__.py
@@ -37,19 +37,20 @@ Configuration
     Default: ``False``
 
 
-.. py:data:: ddtrace.config.botocore['s3_head_object_404_as_error']
+.. py:data:: ddtrace.config.botocore['error_statuses'][<operation>].error_statuses = "<error statuses>"
 
-    Whether any ``botocore.exceptions.ClientError`` exceptions raise for 404 responses to
-    S3 ``HeadObject`` API calls should mark the representing span as an error.
+    Definition of which HTTP status codes to consider for making a span as an error span.
 
-    By default we mark these spans as having an exception.
+    By default response status codes of ``'500-599'`` are considered as errors for all endpoints.
 
-    You can disable this behavior (ignore the exception) by configuring
-    ``ddtrace.config.botocore.s3_head_object_404_as_error = True`` or by setting the environment
-    variable ``DD_BOTOCORE_S3_HEAD_OBJECT_404_AS_ERROR=true``.
+    Example marking 404, and 5xx as errors for ``s3.headobject`` API calls::
+
+        from ddtrace import config
+
+        config.botocore['error_statuses']['s3.headobject'].error_statuses = '404,500-599'
 
 
-    Default: ``True``
+    See `HTTP - Custom Error Codes` <_http-custom-error> documentation for more examples.
 
 
 Example::

--- a/ddtrace/contrib/botocore/__init__.py
+++ b/ddtrace/contrib/botocore/__init__.py
@@ -50,7 +50,7 @@ Configuration
         config.botocore['error_statuses']['s3.headobject'].error_statuses = '404,500-599'
 
 
-    See `HTTP - Custom Error Codes` <_http-custom-error> documentation for more examples.
+    See :ref:`HTTP - Custom Error Codes<http-custom-error>` documentation for more examples.
 
 
 Example::

--- a/ddtrace/contrib/botocore/__init__.py
+++ b/ddtrace/contrib/botocore/__init__.py
@@ -37,7 +37,7 @@ Configuration
     Default: ``False``
 
 
-.. py:data:: ddtrace.config.botocore['error_statuses'][<operation>].error_statuses = "<error statuses>"
+.. py:data:: ddtrace.config.botocore['operations'][<operation>].error_statuses = "<error statuses>"
 
     Definition of which HTTP status codes to consider for making a span as an error span.
 
@@ -47,7 +47,7 @@ Configuration
 
         from ddtrace import config
 
-        config.botocore['error_statuses']['s3.headobject'].error_statuses = '404,500-599'
+        config.botocore['operations']['s3.headobject'].error_statuses = '404,500-599'
 
 
     See :ref:`HTTP - Custom Error Codes<http-custom-error>` documentation for more examples.

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -373,8 +373,7 @@ def patched_api_call(original_func, instance, args, kwargs):
             if span.resource in client_error_ignores:
                 status_code = span.get_tag(http.STATUS_CODE)
                 if status_code:
-                    status_code = int(status_code)
-                    if client_error_ignores[span.resource].is_error_code(status_code):
+                    if client_error_ignores[span.resource].is_error_code(int(status_code)):
                         span._ignore_exception(botocore.exceptions.ClientError)
             raise
 

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -7,7 +7,6 @@ import json
 import os
 import typing
 from typing import Any
-from typing import DefaultDict
 from typing import Dict
 from typing import List
 from typing import Optional

--- a/releasenotes/notes/allow-disabling-s3-headobject-404-fd69f83dfd2eac4e.yaml
+++ b/releasenotes/notes/allow-disabling-s3-headobject-404-fd69f83dfd2eac4e.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    botocore: allow omitting exceptions from S3 ``HeadObject`` 404 responses from span metadata.
+
+    See our :ref:`botocore` document for more information on how to enable this feature.

--- a/releasenotes/notes/botocore-error-statuses-fd69f83dfd2eac4e.yaml
+++ b/releasenotes/notes/botocore-error-statuses-fd69f83dfd2eac4e.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    botocore: allow omitting exceptions from S3 ``HeadObject`` 404 responses from span metadata.
+    botocore: allow defining error status codes for specific API operations.
 
     See our :ref:`botocore` document for more information on how to enable this feature.

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -183,13 +183,13 @@ class BotocoreTest(TracerTestCase):
         # We need a bucket for this test
         s3.create_bucket(Bucket="test", CreateBucketConfiguration=dict(LocationConstraint="us-west-2"))
 
-        config.botocore.error_statuses["s3.headobject"].error_statuses = "404,500-599"
+        config.botocore.operations["s3.headobject"].error_statuses = "404,500-599"
         try:
             with pytest.raises(botocore.exceptions.ClientError):
                 s3.head_object(Bucket="test", Key="unknown")
         finally:
             # Make sure we reset the config when we are done
-            del config.botocore.error_statuses["s3.headobject"]
+            del config.botocore.operations["s3.headobject"]
 
             # Make sure to always delete the bucket after we are done
             s3.delete_bucket(Bucket="test")


### PR DESCRIPTION
Adds a new `ddtrace.config.botocore["error_statuses"][<operation.name>].error_status = "500-599"` configuration option to allowing configuring the which HTTP response status codes will mark the span as an error.

The default is `500-599` for all operations.

Example setting `404` from `s3.headobject` as an error:

```python
from ddtrace import config

config.botocore["error_statuses"]["s3.headobject"].error_statuses = "404,500-599"
```