### PR TITLE
fix(asm/appsec): header names must be lowercase when passed to the WAF

### DIFF
--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -38,11 +38,13 @@ def _transform_headers(data):
         if header in ("cookie", "set-cookie"):
             continue
         if header in normalized:  # if a header with the same lowercase name already exists, let's make it an array
-            if not isinstance(normalized[header], list):
-                normalized[header] = [normalized[header]]  # type: ignore
-            normalized[header].append(value)  # type: ignore
-            continue
-        normalized[header] = value
+            existing = normalized[header]
+            if isinstance(existing, list):
+                existing.append(value)
+            else:
+                normalized[header] = [existing, value]
+        else:
+            normalized[header] = value
     return normalized
 
 

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -93,6 +93,7 @@ def _set_headers(span, headers):
     # type: (Span, Dict) -> None
     for k in headers:
         if k.lower() in _COLLECTED_REQUEST_HEADERS:
+            # since the header value can now be a list, we can't write it as a str tag directly
             span.set_tag(_normalize_tag_name("request", k), headers[k])
 
 

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -33,7 +33,7 @@ def _transform_headers(data):
     normalized = {}
     for header, value in data.items():
         header = header.lower()
-        if header in ("cookie", "set-cookie"):   # TODO: Move this tuple to a frozenset ?
+        if header in ("cookie", "set-cookie"):  # TODO: Move this tuple to a frozenset ?
             continue
         if header in normalized:
             if not isinstance(normalized[header], list):

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -39,8 +39,8 @@ def _transform_headers(data):
             continue
         if header in normalized:  # if a header with the same lowercase name already exists, let's make it an array
             if not isinstance(normalized[header], list):
-                normalized[header] = [normalized[header]]
-            normalized[header].append(value)
+                normalized[header] = [normalized[header]]  # type: ignore
+            normalized[header].append(value)  # type: ignore
             continue
         normalized[header] = value
     return normalized

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -28,9 +28,9 @@ DEFAULT_RULES = os.path.join(ROOT_DIR, "rules.json")
 log = get_logger(__name__)
 
 
-def _no_cookies(data):
+def _transform_headers(data):
     # type: (Dict[str, str]) -> Dict[str, str]
-    return {key: value for key, value in data.items() if key.lower() not in ("cookie", "set-cookie")}
+    return {key.lower(): value for key, value in data.items() if key.lower() not in ("cookie", "set-cookie")}
 
 
 def get_rules():
@@ -155,7 +155,7 @@ class AppSecSpanProcessor(SpanProcessor):
         if self._is_needed(_Addresses.SERVER_REQUEST_HEADERS_NO_COOKIES):
             request_headers = _context.get_item("http.request.headers", span=span)
             if request_headers is not None:
-                data[_Addresses.SERVER_REQUEST_HEADERS_NO_COOKIES] = _no_cookies(request_headers)
+                data[_Addresses.SERVER_REQUEST_HEADERS_NO_COOKIES] = _transform_headers(request_headers)
 
         if self._is_needed(_Addresses.SERVER_REQUEST_URI_RAW):
             uri = _context.get_item("http.request.uri", span=span)
@@ -185,7 +185,7 @@ class AppSecSpanProcessor(SpanProcessor):
         if self._is_needed(_Addresses.SERVER_RESPONSE_HEADERS_NO_COOKIES):
             response_headers = _context.get_item("http.response.headers", span=span)
             if response_headers is not None:
-                data[_Addresses.SERVER_RESPONSE_HEADERS_NO_COOKIES] = _no_cookies(response_headers)
+                data[_Addresses.SERVER_RESPONSE_HEADERS_NO_COOKIES] = _transform_headers(response_headers)
 
         log.debug("[DDAS-001-00] Executing AppSec In-App WAF with parameters: %s", data)
         res = self._ddwaf.run(data)  # res is a serialized json

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -35,6 +35,11 @@ def _transform_headers(data):
         header = header.lower()
         if header in ("cookie", "set-cookie"):   # TODO: Move this tuple to a frozenset ?
             continue
+        if header in normalized:
+            if not isinstance(normalized[header], list):
+                normalized[header] = [normalized[header]]
+            normalized[header].append(value)
+            continue
         normalized[header] = value
     return normalized
 

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -93,7 +93,7 @@ def _set_headers(span, headers):
     # type: (Span, Dict) -> None
     for k in headers:
         if k.lower() in _COLLECTED_REQUEST_HEADERS:
-            # since the header value can now be a list, we can't write it as a str tag directly
+            # since the header value can be a list, use `set_tag()` to ensure it is converted to a string
             span.set_tag(_normalize_tag_name("request", k), headers[k])
 
 

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -2,8 +2,10 @@ import errno
 import json
 import os
 import os.path
-from typing import Set
+from typing import List
+from typing import Set, Any
 from typing import TYPE_CHECKING
+from typing import Union
 
 import attr
 
@@ -29,13 +31,13 @@ log = get_logger(__name__)
 
 
 def _transform_headers(data):
-    # type: (Dict[str, str]) -> Dict[str, str]
-    normalized = {}
+    # type: (Dict[str, str]) -> Dict[str, Union[str, List[str]]]
+    normalized = {}  # type: Dict[str, Union[str, List[str]]]
     for header, value in data.items():
         header = header.lower()
-        if header in ("cookie", "set-cookie"):  # TODO: Move this tuple to a frozenset ?
+        if header in ("cookie", "set-cookie"):
             continue
-        if header in normalized:
+        if header in normalized:  # if a header with the same lowercase name already exists, let's make it an array
             if not isinstance(normalized[header], list):
                 normalized[header] = [normalized[header]]
             normalized[header].append(value)

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -93,7 +93,7 @@ def _set_headers(span, headers):
     # type: (Span, Dict) -> None
     for k in headers:
         if k.lower() in _COLLECTED_REQUEST_HEADERS:
-            span._set_str_tag(_normalize_tag_name("request", k), headers[k])
+            span.set_tag(_normalize_tag_name("request", k), headers[k])
 
 
 @attr.s(eq=False)

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -30,7 +30,13 @@ log = get_logger(__name__)
 
 def _transform_headers(data):
     # type: (Dict[str, str]) -> Dict[str, str]
-    return {key.lower(): value for key, value in data.items() if key.lower() not in ("cookie", "set-cookie")}
+    normalized = {}
+    for header, value in data.items():
+        header = header.lower()
+        if header in ("cookie", "set-cookie"):   # TODO: Move this tuple to a frozenset ?
+            continue
+        normalized[header] = value
+    return normalized
 
 
 def get_rules():

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -3,7 +3,7 @@ import json
 import os
 import os.path
 from typing import List
-from typing import Set, Any
+from typing import Set
 from typing import TYPE_CHECKING
 from typing import Union
 

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -90,7 +90,7 @@ _COLLECTED_HEADER_PREFIX = "http.request.headers."
 
 
 def _set_headers(span, headers):
-    # type: (Span, Dict) -> None
+    # type: (Span, Dict[str, Union[str, List[str]]]) -> None
     for k in headers:
         if k.lower() in _COLLECTED_REQUEST_HEADERS:
             # since the header value can be a list, use `set_tag()` to ensure it is converted to a string

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -32,7 +32,7 @@ def _enable_appsec(tracer):
 
 
 def test_transform_headers():
-    assert _transform_headers(
+    transformed = _transform_headers(
         {
             "hello": "world",
             "Foo": "bar1",
@@ -41,9 +41,10 @@ def test_transform_headers():
             "BAR": "baz",
             "COOKIE": "secret",
         }
-    ) == {
+    )
+    assert transformed == {"hello": "world", "foo": ["bar1", "bar2", "bar3"], "bar": "baz",} or transformed == {
         "hello": "world",
-        "foo": ["bar1", "bar2", "bar3"],
+        "foo": ["bar3", "bar2", "bar1"],
         "bar": "baz",
     }
 

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -4,6 +4,7 @@ import os.path
 import pytest
 
 from ddtrace.appsec.processor import AppSecSpanProcessor
+from ddtrace.appsec.processor import _transform_headers
 from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.trace_utils import set_http_meta
 from ddtrace.ext import SpanTypes
@@ -28,6 +29,21 @@ def _enable_appsec(tracer):
     # Hack: need to pass an argument to configure so that the processors are recreated
     tracer.configure(api_version="v0.4")
     return tracer
+
+
+def test_transform_headers():
+    assert _transform_headers({
+        "hello": "world",
+        "Foo": "bar1",
+        "foo": "bar2",
+        "fOO": "bar3",
+        "     BAR": "baz",
+        "COOKIE": "secret",
+    }) == {
+        "hello": "world",
+        "foo": ["bar1", "bar2", "bar3"],
+        "     bar": "baz",
+    }
 
 
 def test_enable(tracer):

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -42,11 +42,9 @@ def test_transform_headers():
             "COOKIE": "secret",
         }
     )
-    assert transformed == {"hello": "world", "foo": ["bar1", "bar2", "bar3"], "bar": "baz",} or transformed == {
-        "hello": "world",
-        "foo": ["bar3", "bar2", "bar1"],
-        "bar": "baz",
-    }
+    assert transformed["hello"] == "world"
+    assert transformed["bar"] == "baz"
+    assert set(transformed["foo"]) == {"bar1", "bar2", "bar3"}
 
 
 def test_enable(tracer):

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -32,14 +32,16 @@ def _enable_appsec(tracer):
 
 
 def test_transform_headers():
-    assert _transform_headers({
-        "hello": "world",
-        "Foo": "bar1",
-        "foo": "bar2",
-        "fOO": "bar3",
-        "     BAR": "baz",
-        "COOKIE": "secret",
-    }) == {
+    assert _transform_headers(
+        {
+            "hello": "world",
+            "Foo": "bar1",
+            "foo": "bar2",
+            "fOO": "bar3",
+            "     BAR": "baz",
+            "COOKIE": "secret",
+        }
+    ) == {
         "hello": "world",
         "foo": ["bar1", "bar2", "bar3"],
         "     bar": "baz",

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -99,7 +99,7 @@ def test_header_attack(tracer):
     _enable_appsec(tracer)
 
     with tracer.trace("test", span_type=SpanTypes.WEB) as span:
-        set_http_meta(span, Config(), request_headers={"User-Agent": "Arachni/v1"})
+        set_http_meta(span, Config(), request_headers={"User-Agent": "Arachni/v1", "user-agent": "aa"})
 
     assert "triggers" in json.loads(span.get_tag("_dd.appsec.json"))
 

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -44,7 +44,7 @@ def test_transform_headers():
     ) == {
         "hello": "world",
         "foo": ["bar1", "bar2", "bar3"],
-        "     bar": "baz",
+        "bar": "baz",
     }
 
 

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -38,7 +38,7 @@ def test_transform_headers():
             "Foo": "bar1",
             "foo": "bar2",
             "fOO": "bar3",
-            "     BAR": "baz",
+            "BAR": "baz",
             "COOKIE": "secret",
         }
     ) == {

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -42,6 +42,7 @@ def test_transform_headers():
             "COOKIE": "secret",
         }
     )
+    assert set(transformed.keys()) == {"hello", "bar", "foo"}
     assert transformed["hello"] == "world"
     assert transformed["bar"] == "baz"
     assert set(transformed["foo"]) == {"bar1", "bar2", "bar3"}


### PR DESCRIPTION
The addresses specification states that header keys must be lowercase when passed to the WAF. Without it, some attacks can't be detected.