### PR TITLE
fix(asm): remove path_params for flask

### DIFF
--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -328,8 +328,7 @@ def traced_wsgi_app(pin, wrapped, instance, args, kwargs):
             raw_uri=request.url,
             query=request.query_string,
             parsed_query=request.args,
-            request_headers=request.headers,
-            request_path_params=request.args,
+            request_headers=request.headers
         )
 
         return wrapped(environ, start_response)

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -328,7 +328,7 @@ def traced_wsgi_app(pin, wrapped, instance, args, kwargs):
             raw_uri=request.url,
             query=request.query_string,
             parsed_query=request.args,
-            request_headers=request.headers
+            request_headers=request.headers,
         )
 
         return wrapped(environ, start_response)

--- a/tests/contrib/flask/test_flask_appsec.py
+++ b/tests/contrib/flask/test_flask_appsec.py
@@ -23,7 +23,6 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
 
     @pytest.skip("broken for now")
     def test_flask_dynamic_url_param(self):
-
         @self.app.route("/params/<item>")
         def dynamic_url(item):
             return item
@@ -36,8 +35,6 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         spans = self.pop_spans()
         root_span = spans[0]
         assert dict(_context.get_item("http.request.path_params", span=root_span)) == {"item": "attack"}
-
-
 
     def test_flask_querystrings(self):
         self.tracer._appsec_enabled = True

--- a/tests/contrib/flask/test_flask_appsec.py
+++ b/tests/contrib/flask/test_flask_appsec.py
@@ -21,7 +21,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         query = dict(_context.get_item("http.request.query", span=root_span))
         assert query == {"q": "1"} or query == {"q": ["1"]}
 
-    @pytest.skip("broken for now")
+    @pytest.mark.skip("broken for now")
     def test_flask_dynamic_url_param(self):
         @self.app.route("/params/<item>")
         def dynamic_url(item):


### PR DESCRIPTION
On Flask, path_params is broken. I used the wrong data first and the call to `set_http_meta` happens before the call to the method that makes the dispatch in the framework. Meaning we will need to update the instrumentation to cover this.

Let's put it on the side for now (to not have buggy code) and I will find a solution for it later this week/early next week.
