### PR TITLE
chore(ci): pin hypothesis to unblock ci

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -80,7 +80,7 @@ venv = Venv(
         "coverage": latest,
         "pytest-cov": latest,
         "opentracing": latest,
-        "hypothesis": latest,
+        "hypothesis": "<6.45.1",
     },
     env={
         "DD_TESTING_RAISE": "1",


### PR DESCRIPTION
With the release of `hypothesis==6.45.1` the following import statement fails on python3.10: `from hypothesis.provisional import urls`

ci failure: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/16770/workflows/d4563b9b-a000-47c6-810b-e5bf2b839d7a/jobs/1147108/parallel-runs/1?filterBy=ALL 

This regression was introduced by this commit: https://github.com/HypothesisWorks/hypothesis/commit/7edec743be8d1b52dae5c056bd7299b779f0da67


## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
