### PR TITLE
docs(logs): update docs for no basicConfig call

### DIFF
--- a/ddtrace/contrib/logging/__init__.py
+++ b/ddtrace/contrib/logging/__init__.py
@@ -6,43 +6,28 @@ attributes to the log record.
 
 2. Updating the log formatter used by the application. In order to inject
 tracing information into a log the formatter must be updated to include the
-tracing attributes from the log record. For more detail or instructions
-for how to do this manually see the manual section below.
-
-With these in place the trace information will be injected into a log entry
-which can be used to correlate the log and trace in Datadog.
+tracing attributes from the log record.
 
 
-ddtrace-run
------------
+Enabling
+--------
 
-When using ``ddtrace-run``, enable patching by setting the environment variable
-``DD_LOGS_INJECTION=true``. This will make the tracing correlation attributes
-available to be used in a log format (see below for the format to use).
+Patch ``logging``
+~~~~~~~~~~~~~~~~~
+
+If using :ref:`ddtrace-run<ddtracerun>` then set the environment variable ``DD_LOGS_INJECTION=true``.
+
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
+
+    from ddtrace import patch
+    patch(logging=True)
 
 
-    import logging
-    from ddtrace import tracer
-
-    log = logging.getLogger()
-    log.level = logging.INFO
-
-
-    @tracer.wrap()
-    def hello():
-        log.info('Hello, World!')
-
-    hello()
-
-Manual Instrumentation
-----------------------
-
-If you prefer to instrument manually, patch the logging library then update the
-log formatter as in the following example
+Update Log Format
+~~~~~~~~~~~~~~~~~
 
 Make sure that your log format exactly matches the following::
 
-    from ddtrace import patch_all; patch_all(logging=True)
     import logging
     from ddtrace import tracer
 

--- a/ddtrace/contrib/logging/__init__.py
+++ b/ddtrace/contrib/logging/__init__.py
@@ -6,8 +6,7 @@ attributes to the log record.
 
 2. Updating the log formatter used by the application. In order to inject
 tracing information into a log the formatter must be updated to include the
-tracing attributes from the log record. ``ddtrace-run`` will do this
-automatically for you by specifying a format. For more detail or instructions
+tracing attributes from the log record. For more detail or instructions
 for how to do this manually see the manual section below.
 
 With these in place the trace information will be injected into a log entry
@@ -18,8 +17,8 @@ ddtrace-run
 -----------
 
 When using ``ddtrace-run``, enable patching by setting the environment variable
-``DD_LOGS_INJECTION=true``. The logger by default will have a format that
-includes trace information::
+``DD_LOGS_INJECTION=true``. This will make the tracing correlation attributes
+available to be used in a log format (see below for the format to use).
 
     import logging
     from ddtrace import tracer

--- a/ddtrace/contrib/logging/__init__.py
+++ b/ddtrace/contrib/logging/__init__.py
@@ -20,6 +20,7 @@ When using ``ddtrace-run``, enable patching by setting the environment variable
 ``DD_LOGS_INJECTION=true``. This will make the tracing correlation attributes
 available to be used in a log format (see below for the format to use).
 
+
     import logging
     from ddtrace import tracer
 


### PR DESCRIPTION
We missed updating the logs injection documentation in response to the
change of basicConfig call logic in 1.0.
