### PR TITLE
fix(tracer): set top level header

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -272,6 +272,7 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
             "Datadog-Meta-Lang-Version": compat.PYTHON_VERSION,
             "Datadog-Meta-Lang-Interpreter": compat.PYTHON_INTERPRETER,
             "Datadog-Meta-Tracer-Version": ddtrace.__version__,
+            "Datadog-Client-Computed-Top-Level": "yes",
         }
         if headers:
             self._headers.update(headers)

--- a/releasenotes/notes/tracer-toplevel-a1600adc84be9039.yaml
+++ b/releasenotes/notes/tracer-toplevel-a1600adc84be9039.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Set required header to indicate top level span computation is done in the
+    client. This fixes an issue where spans were erroneously being marked as
+    top level when partial flushing or in certain asynchronous applications.

--- a/releasenotes/notes/tracer-toplevel-a1600adc84be9039.yaml
+++ b/releasenotes/notes/tracer-toplevel-a1600adc84be9039.yaml
@@ -2,5 +2,9 @@
 fixes:
   - |
     Set required header to indicate top level span computation is done in the
-    client. This fixes an issue where spans were erroneously being marked as
-    top level when partial flushing or in certain asynchronous applications.
+    client to the Datadog agent. This fixes an issue where spans were
+    erroneously being marked as top level when partial flushing or in certain
+    asynchronous applications.
+
+    The impact of this bug is the unintended computation of stats for non-top
+    level spans.


### PR DESCRIPTION
This header is required to indicate to the agent that the client is
computing the top level span (otherwise the top level tags the client
sets are ignored). This was missed in the top level implementation
(#2730).


## Concerns

There isn't really a way to integration test this functionality as we don't
have testing for what the agent passes on to the backend. So there isn't
a good way for us to enforce this functionality to ensure no regressions
in the future.

This fix was verified with a manual test case outlined here: https://gist.github.com/Kyle-Verhoog/928243fecb5e4a32c0270cf7ac2d7a0f

## Follow-up

According to the top level logic in the agent, we should not ever need to set
`_dd.top_level` to 0 since it is implicitly `0`. It only needs to be set to `1` for
actual top level spans. Not setting the tag should net some encoding performance.