### PR TITLE
fix(profiling): do not clear thread-loop link too often

### DIFF
--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -72,5 +72,4 @@ class DdtraceProfilerEventLoopPolicy(DefaultEventLoopPolicy):
 
     def _ddtrace_get_loop(self, thread_id):
         # type: (...) -> typing.Optional[asyncio.AbstractEventLoop]
-        self._clear_threads()
         return self.loop_per_thread.get_object(thread_id)

--- a/releasenotes/notes/profiling-asyncio-less-clear-threads-33d3436ab76ea158.yaml
+++ b/releasenotes/notes/profiling-asyncio-less-clear-threads-33d3436ab76ea158.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes a performance issue with the profiler when used in an asyncio application.


### PR DESCRIPTION
The current code calls DdtraceProfilerEventLoopPolicy.clear_threads each time a
task is resolved, which can be up to 100 times a second. This is way too much
and we don't expect for the thread->loop mapping to change that often.

Instead we often try to clear the mapping when a new loop is attached to a
thread. In a regular application, this is the expected workflow: a thread
appears and gets a new loop, so we clear the old ones.

The worst case scenario would be an app spawning 100 threads with 100 loops and
then not doing that ever again, which would make the profiler keep a reference
on the 100 loops — until a new loop is attached, which if never, would kept the
reference forever.

Since this far from being a common pattern, it should be safe to switch to a
simpler model like this.