### PR TITLE
refactor: extract shared config from the tracer config

### DIFF
--- a/benchmarks/threading/scenario.py
+++ b/benchmarks/threading/scenario.py
@@ -9,7 +9,7 @@ import bm
 
 from ddtrace.internal.writer import TraceWriter
 from ddtrace.span import Span
-from ddtrace.tracer import Tracer
+from ddtrace.tracing.tracer import Tracer
 
 
 class NoopWriter(TraceWriter):

--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -1,9 +1,9 @@
 from ._monkey import patch  # noqa: E402
 from ._monkey import patch_all
 from .pin import Pin  # noqa: E402
-from .settings import _config as config  # noqa: E402
 from .span import Span  # noqa: E402
-from .tracer import Tracer  # noqa: E402
+from .tracing.config import config  # noqa: E402
+from .tracing.tracer import Tracer  # noqa: E402
 from .version import get_version
 
 

--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -12,7 +12,7 @@ from .internal.logger import get_logger
 from .internal.telemetry import telemetry_writer
 from .internal.utils import formats
 from .internal.utils.importlib import require_modules
-from .settings import _config as config
+from .tracing.config import config
 
 
 log = get_logger(__name__)

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -17,15 +17,15 @@ if os.environ.get("DD_GEVENT_PATCH_ALL", "false").lower() in ("true", "1"):
     gevent.monkey.patch_all()
 
 
-from ddtrace import config  # noqa
 from ddtrace import constants
 from ddtrace.internal.logger import get_logger  # noqa
 from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.utils.formats import asbool  # noqa
 from ddtrace.internal.utils.formats import parse_tags_str
-from ddtrace.tracer import DD_LOG_FORMAT  # noqa
-from ddtrace.tracer import debug_mode
+from ddtrace.tracing.config import config  # noqa
+from ddtrace.tracing.tracer import DD_LOG_FORMAT  # noqa
+from ddtrace.tracing.tracer import debug_mode
 from ddtrace.vendor.debtcollector import deprecate
 
 

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -179,7 +179,8 @@ def distributed_tracing_enabled(int_config, default=False):
     return default
 
 
-def int_service(pin, int_config, default=None):
+def int_service(pin, int_config=None, default=None):
+    # type: (Optional[Pin], Optional[IntegrationConfig], Optional[str]) -> Optional[str]
     """Returns the service name for an integration which is internal
     to the application. Internal meaning that the work belongs to the
     user's application. Eg. Web framework, sqlalchemy, web servers.
@@ -187,26 +188,26 @@ def int_service(pin, int_config, default=None):
     For internal integrations we prioritize overrides, then global defaults and
     lastly the default provided by the integration.
     """
-    int_config = int_config or {}
 
     # Pin has top priority since it is user defined in code
-    if pin and pin.service:
+    if pin is not None and pin.service:
         return pin.service
 
-    # Config is next since it is also configured via code
-    # Note that both service and service_name are used by
-    # integrations.
-    if "service" in int_config and int_config.service is not None:
-        return int_config.service
-    if "service_name" in int_config and int_config.service_name is not None:
-        return int_config.service_name
+    if int_config is not None:
+        # Config is next since it is also configured via code
+        # Note that both service and service_name are used by
+        # integrations.
+        if "service" in int_config and int_config.service is not None:
+            return int_config.service
+        if "service_name" in int_config and int_config.service_name is not None:
+            return int_config.service_name
 
-    global_service = int_config.global_config._get_service()
-    if global_service:
-        return global_service
+        global_service = int_config.global_config._get_service()
+        if global_service:
+            return global_service
 
-    if "_default_service" in int_config and int_config._default_service is not None:
-        return int_config._default_service
+        if "_default_service" in int_config and int_config._default_service is not None:
+            return int_config._default_service
 
     return default
 

--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -13,6 +13,7 @@ import ddtrace
 from ddtrace.internal.writer import AgentWriter
 from ddtrace.internal.writer import LogWriter
 from ddtrace.sampler import DatadogSampler
+from ddtrace.settings.config import config as _config
 
 from .logger import get_logger
 
@@ -108,7 +109,7 @@ def collect(tracer):
 
     pip_version = packages_available.get("pip", "N/A")
 
-    from ddtrace.tracer import log
+    from ddtrace.tracing.tracer import log
 
     return dict(
         # Timestamp UTC ISO 8601
@@ -127,21 +128,21 @@ def collect(tracer):
         in_virtual_env=is_venv,
         agent_url=agent_url,
         agent_error=agent_error,
-        env=ddtrace.config.env or "",
+        env=_config.env or "",
         is_global_tracer=tracer == ddtrace.tracer,
         enabled_env_setting=os.getenv("DATADOG_TRACE_ENABLED"),
         tracer_enabled=tracer.enabled,
         sampler_type=type(tracer._sampler).__name__ if tracer._sampler else "N/A",
         priority_sampler_type=type(tracer._priority_sampler).__name__ if tracer._priority_sampler else "N/A",
         sampler_rules=sampler_rules,
-        service=ddtrace.config.service or "",
+        service=_config.service or "",
         debug=log.isEnabledFor(logging.DEBUG),
         enabled_cli="ddtrace" in os.getenv("PYTHONPATH", ""),
         analytics_enabled=ddtrace.config.analytics_enabled,
         log_injection_enabled=ddtrace.config.logs_injection,
         health_metrics_enabled=ddtrace.config.health_metrics_enabled,
         runtime_metrics_enabled=RuntimeWorker.enabled,
-        dd_version=ddtrace.config.version or "",
+        dd_version=_config.version or "",
         priority_sampling_enabled=tracer._priority_sampler is not None,
         global_tags=os.getenv("DD_TAGS", ""),
         tracer_tags=tags_to_str(tracer._tags),

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -10,7 +10,7 @@ from .vendor import wrapt
 
 
 if TYPE_CHECKING:
-    from .tracer import Tracer
+    from .tracing.tracer import Tracer
 
 
 log = get_logger(__name__)

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -2,7 +2,7 @@ from typing import Dict
 from typing import FrozenSet
 from typing import Optional
 
-from ddtrace import config
+from ddtrace.tracing.config import config
 
 from ..constants import AUTO_KEEP
 from ..constants import AUTO_REJECT

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -1,172 +1,22 @@
-from copy import deepcopy
 import os
-from typing import List
-from typing import Optional
-from typing import Tuple
 
-from ddtrace.internal.utils.cache import cachedmethod
-
-from ..internal.constants import PROPAGATION_STYLE_ALL
-from ..internal.constants import PROPAGATION_STYLE_DATADOG
 from ..internal.logger import get_logger
 from ..internal.utils.formats import asbool
 from ..internal.utils.formats import parse_tags_str
-from ..pin import Pin
-from .http import HttpConfig
-from .integration import IntegrationConfig
 
 
 log = get_logger(__name__)
 
 
-def _parse_propagation_styles(name, default):
-    # type: (str, str) -> set[str]
-    """Helper to parse http propagation extract/inject styles via env variables.
-
-    The expected format is::
-
-        <style>[,<style>...]
-
-
-    The allowed values are:
-
-    - "datadog"
-    - "b3"
-    - "b3 single header"
-
-
-    The default value is ``"datadog"``.
-
-
-    Examples::
-
-        # Extract trace context from "x-datadog-*" or "x-b3-*" headers from upstream headers
-        DD_TRACE_PROPAGATION_STYLE_EXTRACT="datadog,b3"
-
-        # Inject the "b3: *" header into downstream requests headers
-        DD_TRACE_PROPAGATION_STYLE_INJECT="b3 single header"
-    """
-    styles = set()
-    envvar = os.getenv(name, default=default)
-    for style in envvar.split(","):
-        style = style.strip().lower()
-        if not style:
-            continue
-        if style not in PROPAGATION_STYLE_ALL:
-            raise ValueError(
-                "Unknown style {!r} provided for {!r}, allowed values are {!r}".format(
-                    style, name, PROPAGATION_STYLE_ALL
-                )
-            )
-        styles.add(style)
-    return styles
-
-
-# Borrowed from: https://stackoverflow.com/questions/20656135/python-deep-merge-dictionary-data#20666342
-def _deepmerge(source, destination):
-    """
-    Merge the first provided ``dict`` into the second.
-
-    :param dict source: The ``dict`` to merge into ``destination``
-    :param dict destination: The ``dict`` that should get updated
-    :rtype: dict
-    :returns: ``destination`` modified
-    """
-    for key, value in source.items():
-        if isinstance(value, dict):
-            # get node or create one
-            node = destination.setdefault(key, {})
-            _deepmerge(value, node)
-        else:
-            destination[key] = value
-
-    return destination
-
-
-def get_error_ranges(error_range_str):
-    # type: (str) -> List[Tuple[int, int]]
-    error_ranges = []
-    error_range_str = error_range_str.strip()
-    error_ranges_str = error_range_str.split(",")
-    for error_range in error_ranges_str:
-        values = error_range.split("-")
-        try:
-            # Note: mypy does not like variable type changing
-            values = [int(v) for v in values]  # type: ignore[misc]
-        except ValueError:
-            log.exception("Error status codes was not a number %s", values)
-            continue
-        error_range = (min(values), max(values))  # type: ignore[assignment]
-        error_ranges.append(error_range)
-    return error_ranges  # type: ignore[return-value]
-
-
 class Config(object):
-    """Configuration object that exposes an API to set and retrieve
-    global settings for each integration. All integrations must use
-    this instance to register their defaults, so that they're public
-    available and can be updated by users.
-    """
-
-    class _HTTPServerConfig(object):
-        _error_statuses = "500-599"  # type: str
-        _error_ranges = get_error_ranges(_error_statuses)  # type: List[Tuple[int, int]]
-
-        @property
-        def error_statuses(self):
-            # type: () -> str
-            return self._error_statuses
-
-        @error_statuses.setter
-        def error_statuses(self, value):
-            # type: (str) -> None
-            self._error_statuses = value
-            self._error_ranges = get_error_ranges(value)
-            # Mypy can't catch cached method's invalidate()
-            self.is_error_code.invalidate()  # type: ignore[attr-defined]
-
-        @property
-        def error_ranges(self):
-            # type: () -> List[Tuple[int, int]]
-            return self._error_ranges
-
-        @cachedmethod()
-        def is_error_code(self, status_code):
-            # type: (int) -> bool
-            """Returns a boolean representing whether or not a status code is an error code.
-            Error status codes by default are 500-599.
-            You may also enable custom error codes::
-
-                from ddtrace import config
-                config.http_server.error_statuses = '401-404,419'
-
-            Ranges and singular error codes are permitted and can be separated using commas.
-            """
-            for error_range in self.error_ranges:
-                if error_range[0] <= status_code <= error_range[1]:
-                    return True
-            return False
+    """Shared configuration object."""
 
     def __init__(self):
-        # use a dict as underlying storing mechanism
-        self._config = {}
-
-        header_tags = parse_tags_str(os.getenv("DD_TRACE_HEADER_TAGS", ""))
-        self.http = HttpConfig(header_tags=header_tags)
-
-        # Master switch for turning on and off trace search by default
-        # this weird invocation of getenv is meant to read the DD_ANALYTICS_ENABLED
-        # legacy environment variable. It should be removed in the future
-        legacy_config_value = os.getenv("DD_ANALYTICS_ENABLED", default=False)
-
-        self.analytics_enabled = asbool(os.getenv("DD_TRACE_ANALYTICS_ENABLED", default=legacy_config_value))
-
         self.tags = parse_tags_str(os.getenv("DD_TAGS") or "")
 
         self.env = os.getenv("DD_ENV") or self.tags.get("env")
         self.service = os.getenv("DD_SERVICE", default=self.tags.get("service"))
         self.version = os.getenv("DD_VERSION", default=self.tags.get("version"))
-        self.http_server = self._HTTPServerConfig()
 
         self.service_mapping = parse_tags_str(os.getenv("DD_SERVICE_MAPPING", default=""))
 
@@ -179,111 +29,15 @@ class Config(object):
         if self.version and "version" in self.tags:
             del self.tags["version"]
 
-        self.logs_injection = asbool(os.getenv("DD_LOGS_INJECTION", default=False))
-
-        self.report_hostname = asbool(os.getenv("DD_TRACE_REPORT_HOSTNAME", default=False))
-
-        self.health_metrics_enabled = asbool(os.getenv("DD_TRACE_HEALTH_METRICS_ENABLED", default=False))
-
-        # Propagation styles
-        self._propagation_style_extract = _parse_propagation_styles(
-            "DD_TRACE_PROPAGATION_STYLE_EXTRACT", default=PROPAGATION_STYLE_DATADOG
-        )
-        self._propagation_style_inject = _parse_propagation_styles(
-            "DD_TRACE_PROPAGATION_STYLE_INJECT", default=PROPAGATION_STYLE_DATADOG
-        )
-
         # Raise certain errors only if in testing raise mode to prevent crashing in production with non-critical errors
         self._raise = asbool(os.getenv("DD_TESTING_RAISE", False))
-        self._trace_compute_stats = asbool(os.getenv("DD_TRACE_COMPUTE_STATS", False))
+        # TODO: move?
         self._appsec_enabled = asbool(os.getenv("DD_APPSEC_ENABLED", False))
-
-    def __getattr__(self, name):
-        if name not in self._config:
-            self._config[name] = IntegrationConfig(self, name)
-
-        return self._config[name]
-
-    def get_from(self, obj):
-        """Retrieves the configuration for the given object.
-        Any object that has an attached `Pin` must have a configuration
-        and if a wrong object is given, an empty `dict` is returned
-        for safety reasons.
-        """
-        pin = Pin.get_from(obj)
-        if pin is None:
-            log.debug("No configuration found for %s", obj)
-            return {}
-
-        return pin._config
-
-    def _add(self, integration, settings, merge=True):
-        """Internal API that registers an integration with given default
-        settings.
-
-        :param str integration: The integration name (i.e. `requests`)
-        :param dict settings: A dictionary that contains integration settings;
-            to preserve immutability of these values, the dictionary is copied
-            since it contains integration defaults.
-        :param bool merge: Whether to merge any existing settings with those provided,
-            or if we should overwrite the settings with those provided;
-            Note: when merging existing settings take precedence.
-        """
-        # DEV: Use `getattr()` to call our `__getattr__` helper
-        existing = getattr(self, integration)
-        settings = deepcopy(settings)
-
-        if merge:
-            # DEV: This may appear backwards keeping `existing` as the "source" and `settings` as
-            #   the "destination", but we do not want to let `_add(..., merge=True)` overwrite any
-            #   existing settings
-            #
-            # >>> config.requests['split_by_domain'] = True
-            # >>> config._add('requests', dict(split_by_domain=False))
-            # >>> config.requests['split_by_domain']
-            # True
-            self._config[integration] = IntegrationConfig(self, integration, _deepmerge(existing, settings))
-        else:
-            self._config[integration] = IntegrationConfig(self, integration, settings)
-
-    def trace_headers(self, whitelist):
-        """
-        Registers a set of headers to be traced at global level or integration level.
-        :param whitelist: the case-insensitive list of traced headers
-        :type whitelist: list of str or str
-        :return: self
-        :rtype: HttpConfig
-        """
-        self.http.trace_headers(whitelist)
-        return self
-
-    def header_is_traced(self, header_name):
-        # type: (str) -> bool
-        """
-        Returns whether or not the current header should be traced.
-        :param header_name: the header name
-        :type header_name: str
-        :rtype: bool
-        """
-        return self.http.header_is_traced(header_name)
-
-    def _header_tag_name(self, header_name):
-        # type: (str) -> Optional[str]
-        return self.http._header_tag_name(header_name)
-
-    def _get_service(self, default=None):
-        """
-        Returns the globally configured service or the default if none is configured.
-
-        :param default: the default service to use if none is configured or
-            found.
-        :type default: str
-        :rtype: str|None
-        """
-        # TODO: This method can be replaced with `config.service`.
-        return self.service if self.service is not None else default
 
     def __repr__(self):
         cls = self.__class__
-        integrations = ", ".join(self._config.keys())
-        return "{}.{}({})".format(cls.__module__, cls.__name__, integrations)
+        values = ", ".join(("%s=%r" % (k, v) for k, v in self.__dict__.items()))
+        return "{}.{}({})".format(cls.__module__, cls.__name__, values)
+
+
+config = Config()

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -27,7 +27,7 @@ class IntegrationConfig(AttrDict):
     def __init__(self, global_config, name, *args, **kwargs):
         """
         :param global_config:
-        :type global_config: Config
+        :type global_config: TracerConfig
         :param args:
         :param kwargs:
         """

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -12,7 +12,8 @@ from typing import Union
 
 import six
 
-from . import config
+from ddtrace.settings.config import config
+
 from .constants import ANALYTICS_SAMPLE_RATE_KEY
 from .constants import ERROR_MSG
 from .constants import ERROR_STACK

--- a/ddtrace/tracing/config.py
+++ b/ddtrace/tracing/config.py
@@ -1,0 +1,280 @@
+from copy import deepcopy
+import os
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from ddtrace.internal.utils.cache import cachedmethod
+from ddtrace.settings.config import config as shared_config
+from ddtrace.settings.http import HttpConfig
+from ddtrace.settings.integration import IntegrationConfig
+
+from ..internal.constants import PROPAGATION_STYLE_ALL
+from ..internal.constants import PROPAGATION_STYLE_DATADOG
+from ..internal.logger import get_logger
+from ..internal.utils.formats import asbool
+from ..internal.utils.formats import parse_tags_str
+from ..pin import Pin
+
+
+log = get_logger(__name__)
+
+
+def _parse_propagation_styles(name, default):
+    # type: (str, str) -> set[str]
+    """Helper to parse http propagation extract/inject styles via env variables.
+
+    The expected format is::
+
+        <style>[,<style>...]
+
+
+    The allowed values are:
+
+    - "datadog"
+    - "b3"
+    - "b3 single header"
+
+
+    The default value is ``"datadog"``.
+
+
+    Examples::
+
+        # Extract trace context from "x-datadog-*" or "x-b3-*" headers from upstream headers
+        DD_TRACE_PROPAGATION_STYLE_EXTRACT="datadog,b3"
+
+        # Inject the "b3: *" header into downstream requests headers
+        DD_TRACE_PROPAGATION_STYLE_INJECT="b3 single header"
+    """
+    styles = set()
+    envvar = os.getenv(name, default=default)
+    for style in envvar.split(","):
+        style = style.strip().lower()
+        if not style:
+            continue
+        if style not in PROPAGATION_STYLE_ALL:
+            raise ValueError(
+                "Unknown style {!r} provided for {!r}, allowed values are {!r}".format(
+                    style, name, PROPAGATION_STYLE_ALL
+                )
+            )
+        styles.add(style)
+    return styles
+
+
+# Borrowed from: https://stackoverflow.com/questions/20656135/python-deep-merge-dictionary-data#20666342
+def _deepmerge(source, destination):
+    """
+    Merge the first provided ``dict`` into the second.
+
+    :param dict source: The ``dict`` to merge into ``destination``
+    :param dict destination: The ``dict`` that should get updated
+    :rtype: dict
+    :returns: ``destination`` modified
+    """
+    for key, value in source.items():
+        if isinstance(value, dict):
+            # get node or create one
+            node = destination.setdefault(key, {})
+            _deepmerge(value, node)
+        else:
+            destination[key] = value
+
+    return destination
+
+
+def get_error_ranges(error_range_str):
+    # type: (str) -> List[Tuple[int, int]]
+    error_ranges = []
+    error_range_str = error_range_str.strip()
+    error_ranges_str = error_range_str.split(",")
+    for error_range in error_ranges_str:
+        values = error_range.split("-")
+        try:
+            # Note: mypy does not like variable type changing
+            values = [int(v) for v in values]  # type: ignore[misc]
+        except ValueError:
+            log.exception("Error status codes was not a number %s", values)
+            continue
+        error_range = (min(values), max(values))  # type: ignore[assignment]
+        error_ranges.append(error_range)
+    return error_ranges  # type: ignore[return-value]
+
+
+class TracerConfig(object):
+    """Tracer configuration object.
+
+    It exposes an API to set and retrieve global settings for each integration.
+    All integrations must use this instance to register their defaults, so that
+    they're public available and can be updated by users.
+    """
+
+    class _HTTPServerConfig(object):
+        _error_statuses = "500-599"  # type: str
+        _error_ranges = get_error_ranges(_error_statuses)  # type: List[Tuple[int, int]]
+
+        @property
+        def error_statuses(self):
+            # type: () -> str
+            return self._error_statuses
+
+        @error_statuses.setter
+        def error_statuses(self, value):
+            # type: (str) -> None
+            self._error_statuses = value
+            self._error_ranges = get_error_ranges(value)
+            # Mypy can't catch cached method's invalidate()
+            self.is_error_code.invalidate()  # type: ignore[attr-defined]
+
+        @property
+        def error_ranges(self):
+            # type: () -> List[Tuple[int, int]]
+            return self._error_ranges
+
+        @cachedmethod()
+        def is_error_code(self, status_code):
+            # type: (int) -> bool
+            """Returns a boolean representing whether or not a status code is an error code.
+            Error status codes by default are 500-599.
+            You may also enable custom error codes::
+
+                from ddtrace import config
+                config.http_server.error_statuses = '401-404,419'
+
+            Ranges and singular error codes are permitted and can be separated using commas.
+            """
+            for error_range in self.error_ranges:
+                if error_range[0] <= status_code <= error_range[1]:
+                    return True
+            return False
+
+    def __init__(self):
+        # use a dict as underlying storing mechanism
+        self._config = {}
+
+        header_tags = parse_tags_str(os.getenv("DD_TRACE_HEADER_TAGS", ""))
+        self.http = HttpConfig(header_tags=header_tags)
+
+        # Master switch for turning on and off trace search by default
+        # this weird invocation of getenv is meant to read the DD_ANALYTICS_ENABLED
+        # legacy environment variable. It should be removed in the future
+        legacy_config_value = os.getenv("DD_ANALYTICS_ENABLED", default=False)
+
+        self.analytics_enabled = asbool(os.getenv("DD_TRACE_ANALYTICS_ENABLED", default=legacy_config_value))
+
+        self.http_server = self._HTTPServerConfig()
+
+        self.logs_injection = asbool(os.getenv("DD_LOGS_INJECTION", default=False))
+
+        self.report_hostname = asbool(os.getenv("DD_TRACE_REPORT_HOSTNAME", default=False))
+
+        self.health_metrics_enabled = asbool(os.getenv("DD_TRACE_HEALTH_METRICS_ENABLED", default=False))
+
+        # Propagation styles
+        self._propagation_style_extract = _parse_propagation_styles(
+            "DD_TRACE_PROPAGATION_STYLE_EXTRACT", default=PROPAGATION_STYLE_DATADOG
+        )
+        self._propagation_style_inject = _parse_propagation_styles(
+            "DD_TRACE_PROPAGATION_STYLE_INJECT", default=PROPAGATION_STYLE_DATADOG
+        )
+
+        # Raise certain errors only if in testing raise mode to prevent crashing in production with non-critical errors
+        self._trace_compute_stats = asbool(os.getenv("DD_TRACE_COMPUTE_STATS", False))
+
+    def __getattr__(self, name):
+        try:
+            return self._config[name]
+        except KeyError:
+            try:
+                val = getattr(shared_config, name)
+            except AttributeError:
+                val = self._config[name] = IntegrationConfig(self, name)
+            return val
+
+    def get_from(self, obj):
+        """Retrieves the configuration for the given object.
+        Any object that has an attached `Pin` must have a configuration
+        and if a wrong object is given, an empty `dict` is returned
+        for safety reasons.
+        """
+        pin = Pin.get_from(obj)
+        if pin is None:
+            log.debug("No configuration found for %s", obj)
+            return {}
+
+        return pin._config
+
+    def _add(self, integration, settings, merge=True):
+        """Internal API that registers an integration with given default
+        settings.
+
+        :param str integration: The integration name (i.e. `requests`)
+        :param dict settings: A dictionary that contains integration settings;
+            to preserve immutability of these values, the dictionary is copied
+            since it contains integration defaults.
+        :param bool merge: Whether to merge any existing settings with those provided,
+            or if we should overwrite the settings with those provided;
+            Note: when merging existing settings take precedence.
+        """
+        # DEV: Use `getattr()` to call our `__getattr__` helper
+        existing = getattr(self, integration)
+        settings = deepcopy(settings)
+
+        if merge:
+            # DEV: This may appear backwards keeping `existing` as the "source" and `settings` as
+            #   the "destination", but we do not want to let `_add(..., merge=True)` overwrite any
+            #   existing settings
+            #
+            # >>> config.requests['split_by_domain'] = True
+            # >>> config._add('requests', dict(split_by_domain=False))
+            # >>> config.requests['split_by_domain']
+            # True
+            self._config[integration] = IntegrationConfig(self, integration, _deepmerge(existing, settings))
+        else:
+            self._config[integration] = IntegrationConfig(self, integration, settings)
+
+    def trace_headers(self, whitelist):
+        """
+        Registers a set of headers to be traced at global level or integration level.
+        :param whitelist: the case-insensitive list of traced headers
+        :type whitelist: list of str or str
+        :return: self
+        :rtype: HttpConfig
+        """
+        self.http.trace_headers(whitelist)
+        return self
+
+    def header_is_traced(self, header_name):
+        # type: (str) -> bool
+        """
+        Returns whether or not the current header should be traced.
+        :param header_name: the header name
+        :type header_name: str
+        :rtype: bool
+        """
+        return self.http.header_is_traced(header_name)
+
+    def _header_tag_name(self, header_name):
+        # type: (str) -> Optional[str]
+        return self.http._header_tag_name(header_name)
+
+    def _get_service(self, default=None):
+        """
+        Returns the globally configured service or the default if none is configured.
+
+        :param default: the default service to use if none is configured or
+            found.
+        :type default: str
+        :rtype: str|None
+        """
+        # TODO: This method can be replaced with `config.service`.
+        return self.service if self.service is not None else default
+
+    def __repr__(self):
+        cls = self.__class__
+        integrations = ", ".join(self._config.keys())
+        return "{}.{}({})".format(cls.__module__, cls.__name__, integrations)
+
+
+config = TracerConfig()

--- a/tests/commands/ddtrace_run_debug.py
+++ b/tests/commands/ddtrace_run_debug.py
@@ -1,6 +1,6 @@
 import logging
 
-from ddtrace.tracer import log
+from ddtrace.tracing.tracer import log
 
 
 if __name__ == "__main__":

--- a/tests/commands/ddtrace_run_no_debug.py
+++ b/tests/commands/ddtrace_run_no_debug.py
@@ -1,6 +1,6 @@
 import logging
 
-from ddtrace.tracer import log
+from ddtrace.tracing.tracer import log
 
 
 if __name__ == "__main__":

--- a/tests/contrib/flask_cache/test_utils.py
+++ b/tests/contrib/flask_cache/test_utils.py
@@ -6,7 +6,7 @@ from ddtrace.contrib.flask_cache import get_traced_cache
 from ddtrace.contrib.flask_cache.utils import _extract_client
 from ddtrace.contrib.flask_cache.utils import _extract_conn_tags
 from ddtrace.contrib.flask_cache.utils import _resource_from_cache_prefix
-from ddtrace.tracer import Tracer
+from ddtrace.tracing.tracer import Tracer
 
 from ..config import MEMCACHED_CONFIG
 from ..config import REDIS_CONFIG

--- a/tests/contrib/tornado/test_config.py
+++ b/tests/contrib/tornado/test_config.py
@@ -1,5 +1,5 @@
 from ddtrace.filters import TraceFilter
-from ddtrace.tracer import Tracer
+from ddtrace.tracing.tracer import Tracer
 from tests.utils import DummyWriter
 
 from .utils import TornadoTestCase

--- a/tests/contrib/vertica/test_vertica.py
+++ b/tests/contrib/vertica/test_vertica.py
@@ -9,7 +9,7 @@ from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.vertica.patch import patch
 from ddtrace.contrib.vertica.patch import unpatch
-from ddtrace.settings.config import _deepmerge
+from ddtrace.tracing.config import _deepmerge
 from ddtrace.vendor import wrapt
 from tests.contrib.config import VERTICA_CONFIG
 from tests.opentracer.utils import init_tracer

--- a/tests/tracer/test_correlation_log_context.py
+++ b/tests/tracer/test_correlation_log_context.py
@@ -2,10 +2,10 @@ import pytest
 import structlog
 
 from ddtrace import Tracer
-from ddtrace import config
 from ddtrace import tracer
 from ddtrace.context import Context
 from ddtrace.opentracer.tracer import Tracer as OT_Tracer
+from ddtrace.settings.config import config
 from tests.utils import override_global_config
 
 

--- a/tests/tracer/test_global_config.py
+++ b/tests/tracer/test_global_config.py
@@ -5,6 +5,7 @@ import pytest
 
 from ddtrace import config as global_config
 from ddtrace.settings import Config
+from ddtrace.tracing.config import TracerConfig
 
 from ..utils import DummyTracer
 from ..utils import override_env
@@ -14,7 +15,7 @@ class GlobalConfigTestCase(TestCase):
     """Test the `Configuration` class that stores integration settings"""
 
     def setUp(self):
-        self.config = Config()
+        self.config = TracerConfig()
         self.tracer = DummyTracer()
 
     def test_registration(self):
@@ -53,7 +54,7 @@ class GlobalConfigTestCase(TestCase):
 
     def test_global_configuration(self):
         # ensure a global configuration is available in the `ddtrace` module
-        assert isinstance(global_config, Config)
+        assert isinstance(global_config, TracerConfig)
 
     def test_settings_merge(self):
         """

--- a/tests/tracer/test_settings.py
+++ b/tests/tracer/test_settings.py
@@ -3,6 +3,7 @@ import pytest
 from ddtrace.settings import Config
 from ddtrace.settings import HttpConfig
 from ddtrace.settings import IntegrationConfig
+from ddtrace.tracing.config import TracerConfig
 from tests.utils import BaseTestCase
 from tests.utils import override_env
 
@@ -10,45 +11,45 @@ from tests.utils import override_env
 class TestConfig(BaseTestCase):
     def test_environment_analytics_enabled(self):
         with self.override_env(dict(DD_ANALYTICS_ENABLED="True")):
-            config = Config()
+            config = TracerConfig()
             self.assertTrue(config.analytics_enabled)
 
         with self.override_env(dict(DD_ANALYTICS_ENABLED="False")):
-            config = Config()
+            config = TracerConfig()
             self.assertFalse(config.analytics_enabled)
 
         with self.override_env(dict(DD_TRACE_ANALYTICS_ENABLED="True")):
-            config = Config()
+            config = TracerConfig()
             self.assertTrue(config.analytics_enabled)
 
         with self.override_env(dict(DD_TRACE_ANALYTICS_ENABLED="False")):
-            config = Config()
+            config = TracerConfig()
             self.assertFalse(config.analytics_enabled)
 
     def test_environment_analytics_overrides(self):
         with self.override_env(dict(DD_ANALYTICS_ENABLED="False", DD_TRACE_ANALYTICS_ENABLED="True")):
-            config = Config()
+            config = TracerConfig()
             self.assertTrue(config.analytics_enabled)
 
         with self.override_env(dict(DD_ANALYTICS_ENABLED="False", DD_TRACE_ANALYTICS_ENABLED="False")):
-            config = Config()
+            config = TracerConfig()
             self.assertFalse(config.analytics_enabled)
 
         with self.override_env(dict(DD_ANALYTICS_ENABLED="True", DD_TRACE_ANALYTICS_ENABLED="True")):
-            config = Config()
+            config = TracerConfig()
             self.assertTrue(config.analytics_enabled)
 
         with self.override_env(dict(DD_ANALYTICS_ENABLED="True", DD_TRACE_ANALYTICS_ENABLED="False")):
-            config = Config()
+            config = TracerConfig()
             self.assertFalse(config.analytics_enabled)
 
     def test_logs_injection(self):
         with self.override_env(dict(DD_LOGS_INJECTION="True")):
-            config = Config()
+            config = TracerConfig()
             self.assertTrue(config.logs_injection)
 
         with self.override_env(dict(DD_LOGS_INJECTION="false")):
-            config = Config()
+            config = TracerConfig()
             self.assertFalse(config.logs_injection)
 
     def test_service(self):
@@ -62,7 +63,7 @@ class TestConfig(BaseTestCase):
             self.assertEqual(config.service, "my-service")
 
     def test_http_config(self):
-        config = Config()
+        config = TracerConfig()
         config._add("django", dict())
         assert config.django.trace_query_string is None
         config.http.trace_query_string = True
@@ -70,7 +71,7 @@ class TestConfig(BaseTestCase):
         assert config.django.trace_query_string is True
 
         # Integration usage
-        config = Config()
+        config = TracerConfig()
         config._add("django", dict())
         config.django.http.trace_query_string = True
         assert config.http.trace_query_string is None
@@ -134,7 +135,7 @@ class TestHttpConfig(BaseTestCase):
 
 class TestIntegrationConfig(BaseTestCase):
     def setUp(self):
-        self.config = Config()
+        self.config = TracerConfig()
         self.integration_config = IntegrationConfig(self.config, "test")
 
     def test_is_a_dict(self):
@@ -184,40 +185,40 @@ class TestIntegrationConfig(BaseTestCase):
         self.assertIsNone(self.config.foo.analytics_enabled)
 
         with self.override_env(dict(DD_ANALYTICS_ENABLED="True")):
-            config = Config()
+            config = TracerConfig()
             self.assertTrue(config.analytics_enabled)
             self.assertIsNone(config.foo.analytics_enabled)
 
         with self.override_env(dict(DD_TRACE_ANALYTICS_ENABLED="True")):
-            config = Config()
+            config = TracerConfig()
             self.assertTrue(config.analytics_enabled)
             self.assertIsNone(config.foo.analytics_enabled)
 
         with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED="True")):
-            config = Config()
+            config = TracerConfig()
             self.assertTrue(config.foo.analytics_enabled)
             self.assertEqual(config.foo.analytics_sample_rate, 1.0)
 
         with self.override_env(dict(DD_TRACE_FOO_ANALYTICS_ENABLED="True")):
-            config = Config()
+            config = TracerConfig()
             self.assertTrue(config.foo.analytics_enabled)
             self.assertEqual(config.foo.analytics_sample_rate, 1.0)
 
         with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED="False")):
-            config = Config()
+            config = TracerConfig()
             self.assertFalse(config.foo.analytics_enabled)
 
         with self.override_env(dict(DD_TRACE_FOO_ANALYTICS_ENABLED="False")):
-            config = Config()
+            config = TracerConfig()
             self.assertFalse(config.foo.analytics_enabled)
 
         with self.override_env(dict(DD_FOO_ANALYTICS_ENABLED="True", DD_FOO_ANALYTICS_SAMPLE_RATE="0.5")):
-            config = Config()
+            config = TracerConfig()
             self.assertTrue(config.foo.analytics_enabled)
             self.assertEqual(config.foo.analytics_sample_rate, 0.5)
 
         with self.override_env(dict(DD_TRACE_FOO_ANALYTICS_ENABLED="True", DD_TRACE_FOO_ANALYTICS_SAMPLE_RATE="0.5")):
-            config = Config()
+            config = TracerConfig()
             self.assertTrue(config.foo.analytics_enabled)
             self.assertEqual(config.foo.analytics_sample_rate, 0.5)
 
@@ -249,22 +250,22 @@ class TestIntegrationConfig(BaseTestCase):
         self.assertIsNone(ic.get_analytics_sample_rate())
 
         with self.override_env(dict(DD_ANALYTICS_ENABLED="True")):
-            config = Config()
+            config = TracerConfig()
             ic = IntegrationConfig(config, "foo")
             self.assertEqual(ic.get_analytics_sample_rate(use_global_config=True), 1.0)
 
         with self.override_env(dict(DD_TRACE_ANALYTICS_ENABLED="True")):
-            config = Config()
+            config = TracerConfig()
             ic = IntegrationConfig(config, "foo")
             self.assertEqual(ic.get_analytics_sample_rate(use_global_config=True), 1.0)
 
         with self.override_env(dict(DD_ANALYTICS_ENABLED="False")):
-            config = Config()
+            config = TracerConfig()
             ic = IntegrationConfig(config, "foo")
             self.assertIsNone(ic.get_analytics_sample_rate(use_global_config=True))
 
         with self.override_env(dict(DD_TRACE_ANALYTICS_ENABLED="False")):
-            config = Config()
+            config = TracerConfig()
             ic = IntegrationConfig(config, "foo")
             self.assertIsNone(ic.get_analytics_sample_rate(use_global_config=True))
 
@@ -296,7 +297,7 @@ class TestIntegrationConfig(BaseTestCase):
     ),
 )
 def test_config_is_header_tracing_configured(global_headers, int_headers, expected):
-    config = Config()
+    config = TracerConfig()
     integration_config = config.myint
 
     if global_headers is not None:
@@ -313,7 +314,7 @@ def test_config_is_header_tracing_configured(global_headers, int_headers, expect
 
 def test_environment_header_tags():
     with override_env(dict(DD_TRACE_HEADER_TAGS="Host:http.host,User-agent:http.user_agent")):
-        config = Config()
+        config = TracerConfig()
 
     assert config.http.is_header_tracing_configured
     assert config._header_tag_name("Host") == "http.host"

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -20,14 +20,14 @@ from ddtrace.internal import _context
 from ddtrace.internal.compat import stringify
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
-from ddtrace.settings import Config
 from ddtrace.settings import IntegrationConfig
+from ddtrace.tracing.config import TracerConfig
 from tests.utils import override_global_config
 
 
 @pytest.fixture
 def int_config():
-    c = Config()
+    c = TracerConfig()
     c._add("myint", dict())
     return c
 
@@ -46,7 +46,7 @@ class TestHeaders(object):
 
     @pytest.fixture()
     def config(self):
-        yield Config()
+        yield TracerConfig()
 
     @pytest.fixture()
     def integration_config(self, config):
@@ -276,8 +276,6 @@ def test_int_service_integration(int_config):
     assert trace_utils.int_service(pin, int_config.myint) is None
 
     with override_global_config(dict(service="global-svc")):
-        assert trace_utils.int_service(pin, int_config.myint) is None
-
         with tracer.trace("something", service=trace_utils.int_service(pin, int_config.myint)) as s:
             assert s.service == "global-svc"
 
@@ -406,7 +404,7 @@ def test_set_http_meta(
             assert _context.get_item("http.request.path_params", span=span) == path_params
 
 
-@mock.patch("ddtrace.settings.config.log")
+@mock.patch("ddtrace.tracing.config.log")
 @pytest.mark.parametrize(
     "error_codes,status_code,error,log_call",
     [

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -35,10 +35,11 @@ from ddtrace.internal._encoding import MsgpackEncoderV05
 from ddtrace.internal.writer import AgentWriter
 from ddtrace.internal.writer import LogWriter
 from ddtrace.settings import Config
+from ddtrace.settings.config import config
 from ddtrace.span import _is_top_level
-from ddtrace.tracer import Tracer
-from ddtrace.tracer import _has_aws_lambda_agent_extension
-from ddtrace.tracer import _in_aws_lambda
+from ddtrace.tracing.tracer import Tracer
+from ddtrace.tracing.tracer import _has_aws_lambda_agent_extension
+from ddtrace.tracing.tracer import _in_aws_lambda
 from tests.subprocesstest import run_in_subprocess
 from tests.utils import TracerTestCase
 from tests.utils import override_global_config
@@ -843,9 +844,9 @@ class EnvTracerTestCase(TracerTestCase):
     @run_in_subprocess(env_overrides=dict(DD_TAGS="service:mysvc,env:myenv,version:myvers"))
     def test_tags_from_DD_TAGS_override(self):
         t = ddtrace.Tracer()
-        ddtrace.config.env = "env"
-        ddtrace.config.service = "service"
-        ddtrace.config.version = "0.123"
+        config.env = "env"
+        config.service = "service"
+        config.version = "0.123"
         with t.trace("test") as s:
             assert s.service == "service"
             assert s.get_tag("env") == "env"
@@ -1441,10 +1442,10 @@ def test_service_mapping():
     @contextlib.contextmanager
     def override_service_mapping(service_mapping):
         with override_env(dict(DD_SERVICE_MAPPING=service_mapping)):
-            assert ddtrace.config.service_mapping == {}
-            ddtrace.config.service_mapping = Config().service_mapping
+            assert config.service_mapping == {}
+            config.service_mapping = Config().service_mapping
             yield
-            ddtrace.config.service_mapping = {}
+            config.service_mapping = {}
 
     # Test single mapping
     with override_service_mapping("foo:bar"), ddtrace.Tracer().trace("renaming", service="foo") as span:


### PR DESCRIPTION
This change proposes refactoring the configuration object for the tracer by moving tracer-specific sources under the new tracing submodule. The existing config module is used for the shared parameters, whereas the new ddtrace.tracing.config module houses the tracer-specific configuration.

<!-- Briefly describe the change and why it was required. -->

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
