### PR TITLE
fix(tracing): properly resolve when multiple trace agent url env variables are used

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -78,9 +78,6 @@ def update_patched_modules():
 try:
     from ddtrace import tracer
 
-    dd_hostname = os.getenv("DD_TRACE_AGENT_HOSTNAME")
-    hostname = os.getenv("DD_AGENT_HOST", dd_hostname)
-    port = os.getenv("DD_TRACE_AGENT_PORT")
     priority_sampling = os.getenv("DD_PRIORITY_SAMPLING")
     profiling = asbool(os.getenv("DD_PROFILING_ENABLED", False))
 
@@ -98,12 +95,7 @@ try:
         trace_enabled = True
     else:
         trace_enabled = False
-        opts["enabled"] = False
 
-    if hostname:
-        opts["hostname"] = hostname
-    if port:
-        opts["port"] = int(port)
     if priority_sampling:
         opts["priority_sampling"] = asbool(priority_sampling)
 

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -95,6 +95,7 @@ try:
         trace_enabled = True
     else:
         trace_enabled = False
+        opts["enabled"] = False
 
     if priority_sampling:
         opts["priority_sampling"] = asbool(priority_sampling)

--- a/ddtrace/internal/agent.py
+++ b/ddtrace/internal/agent.py
@@ -24,7 +24,7 @@ T = TypeVar("T")
 
 def get_trace_hostname(default=DEFAULT_HOSTNAME):
     # type: (Union[T, str]) -> Union[T, str]
-    return os.environ.get("DD_AGENT_HOST", os.environ.get("DATADOG_TRACE_AGENT_HOSTNAME", default))
+    return os.environ.get("DD_AGENT_HOST", os.environ.get("DD_TRACE_AGENT_HOSTNAME", default))
 
 
 def get_stats_hostname(default=DEFAULT_HOSTNAME):

--- a/releasenotes/notes/fix-ddtrace-run-url-envs-087ab03d4f25a732.yaml
+++ b/releasenotes/notes/fix-ddtrace-run-url-envs-087ab03d4f25a732.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    tracing: fix issue with ``ddtrace-run`` changing the priority order of tracer host/port/url env variable configuration.
+    tracing: fix issue with ``ddtrace-run`` having the wrong priority order of tracer host/port/url env variable configuration.

--- a/releasenotes/notes/fix-ddtrace-run-url-envs-087ab03d4f25a732.yaml
+++ b/releasenotes/notes/fix-ddtrace-run-url-envs-087ab03d4f25a732.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: fix issue with ``ddtrace-run`` changing the priority order of tracer host/port/url env variable configuration.


### PR DESCRIPTION
`ddtrace-run` will try to parse some env variables like `DD_TRACE_AGENT_HOSTNAME`,
`DD_AGENT_HOST`, and `DD_TRACE_AGENT_PORT` and used them to call `tracer.configure()`.

However, the existing default logic when configuring a tracer uses `agent.get_trace_url()`
which knows about these env variables and the appropriate priority order when configuring.

Fixes #3648