### PR TITLE
fix(sanic): don't send error traces on non 500s errors

### DIFF
--- a/ddtrace/contrib/sanic/patch.py
+++ b/ddtrace/contrib/sanic/patch.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import sanic
-from sanic.exceptions import NotFound
 
 import ddtrace
 from ddtrace import config
@@ -258,7 +257,7 @@ async def sanic_http_lifecycle_exception(request, exception):
 
     # Do not attach exception traceback on 404 errors
     # DEV: We still need to set `__dd_span_call_finish` below
-    if not isinstance(exception, NotFound):
+    if not hasattr(exception, "status_code") or 500 <= exception.status_code < 600:
         ex_type = type(exception)
         ex_tb = getattr(exception, "__traceback__", None)
         span.set_exc_info(ex_type, exception, ex_tb)

--- a/ddtrace/contrib/sanic/patch.py
+++ b/ddtrace/contrib/sanic/patch.py
@@ -257,7 +257,7 @@ async def sanic_http_lifecycle_exception(request, exception):
 
     # Do not attach exception traceback on 404 errors
     # DEV: We still need to set `__dd_span_call_finish` below
-    if not hasattr(exception, "status_code") or 500 <= exception.status_code < 600:
+    if not hasattr(exception, "status_code") or config.http_server.is_error_code(exception.status_code):
         ex_type = type(exception)
         ex_tb = getattr(exception, "__traceback__", None)
         span.set_exc_info(ex_type, exception, ex_tb)

--- a/ddtrace/contrib/sanic/patch.py
+++ b/ddtrace/contrib/sanic/patch.py
@@ -255,7 +255,8 @@ async def sanic_http_lifecycle_exception(request, exception):
     if not span:
         return
 
-    # Do not attach exception traceback on 404 errors
+    # Do not attach exception for exceptions not considered as errors
+    # ex: Http 400s
     # DEV: We still need to set `__dd_span_call_finish` below
     if not hasattr(exception, "status_code") or config.http_server.is_error_code(exception.status_code):
         ex_type = type(exception)

--- a/releasenotes/notes/fix-sanic-dont-send-error-traces-on-non-500s-b194927b887ad9d9.yaml
+++ b/releasenotes/notes/fix-sanic-dont-send-error-traces-on-non-500s-b194927b887ad9d9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    sanic: Don't send non-500s error traces.


### PR DESCRIPTION
<!-- Briefly describe the change and why it was required. -->
Currently, only `NotFound` exceptions are excluded from sending the error traces. That causes 400 and others to show up on APM as an error making it harder to create SLOs and use other functionalities. This is more in line with how the Django integration also works.

## Checklist
- [ ] Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
