### PR TITLE
chore(ciapp): add library_version tag to the root test span

### DIFF
--- a/ddtrace/ext/ci.py
+++ b/ddtrace/ext/ci.py
@@ -57,6 +57,9 @@ RUNTIME_NAME = "runtime.name"
 # Runtime Version
 RUNTIME_VERSION = "runtime.version"
 
+# Version of the ddtrace library
+LIBRARY_VERSION = "library_version"
+
 _RE_URL = re.compile(r"(https?://)[^/]*@")
 
 

--- a/ddtrace/filters.py
+++ b/ddtrace/filters.py
@@ -4,7 +4,9 @@ from typing import List
 from typing import Optional
 from typing import TYPE_CHECKING
 
+import ddtrace
 from ddtrace.ext import SpanTypes
+from ddtrace.ext import ci
 from ddtrace.internal.processor.trace import TraceProcessor
 
 from .ext import http
@@ -80,4 +82,9 @@ class TraceCiVisibilityFilter(TraceFilter):
             return trace
 
         local_root = trace[0]._local_root
-        return trace if local_root and local_root.span_type == SpanTypes.TEST else None
+        if not local_root or local_root.span_type != SpanTypes.TEST:
+            return None
+
+        # DEV: it might not be necessary to add library_version when using agentless mode
+        local_root.set_tag(ci.LIBRARY_VERSION, ddtrace.__version__)
+        return trace

--- a/tests/tracer/test_filters.py
+++ b/tests/tracer/test_filters.py
@@ -19,7 +19,7 @@ class TraceCiVisibilityFilterTests(TestCase):
         # Root span in trace is a test
         trace = [root_test_span]
         self.assertEqual(trace_filter.process_trace(trace), trace)
-        assert trace.get_span(ci.LIBRARY_VERSION) == ddtrace.__version__
+        assert root_test_span.get_span(ci.LIBRARY_VERSION) == ddtrace.__version__
 
         root_span = Span(name="span1")
         root_span._local_root = root_span

--- a/tests/tracer/test_filters.py
+++ b/tests/tracer/test_filters.py
@@ -19,7 +19,7 @@ class TraceCiVisibilityFilterTests(TestCase):
         # Root span in trace is a test
         trace = [root_test_span]
         self.assertEqual(trace_filter.process_trace(trace), trace)
-        assert root_test_span.get_span(ci.LIBRARY_VERSION) == ddtrace.__version__
+        assert root_test_span.get_tag(ci.LIBRARY_VERSION) == ddtrace.__version__
 
         root_span = Span(name="span1")
         root_span._local_root = root_span

--- a/tests/tracer/test_filters.py
+++ b/tests/tracer/test_filters.py
@@ -2,6 +2,8 @@ from unittest import TestCase
 
 import pytest
 
+import ddtrace
+from ddtrace.ext import ci
 from ddtrace.ext.http import URL
 from ddtrace.filters import FilterRequestsOnUrl
 from ddtrace.filters import TraceCiVisibilityFilter
@@ -17,6 +19,7 @@ class TraceCiVisibilityFilterTests(TestCase):
         # Root span in trace is a test
         trace = [root_test_span]
         self.assertEqual(trace_filter.process_trace(trace), trace)
+        assert trace.get_span(ci.LIBRARY_VERSION) == ddtrace.__version__
 
         root_span = Span(name="span1")
         root_span._local_root = root_span


### PR DESCRIPTION
Adds `library_version` to the root span which is missing in the CI Visibility intake track.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
