### PR TITLE
perf: avoid exceptions in extract headers

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -52,10 +52,8 @@ _POSSIBLE_HTTP_HEADER_B3_FLAGS = _possible_header(_HTTP_HEADER_B3_FLAGS)
 def _extract_header_value(possible_header_names, headers, default=None):
     # type: (FrozenSet[str], Dict[str, str], Optional[str]) -> Optional[str]
     for header in possible_header_names:
-        try:
+        if header in headers:
             return headers[header]
-        except KeyError:
-            pass
 
     return default
 


### PR DESCRIPTION
Suggested in https://github.com/DataDog/dd-trace-py/pull/3625#discussion_r862080605

```
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| Benchmark                                            | /artifacts/3fd8f93f-09ab-49af-88ef-e7ee2243d0b7/http_propagation_extract/1.1.0rc2.dev37+gd363d6c4//results.json | /artifacts/3fd8f93f-09ab-49af-88ef-e7ee2243d0b7/http_propagation_extract/1.1.0rc2.dev37+g91fb4af9//results.json |
+======================================================+=================================================================================================================+=================================================================================================================+
| httppropagationextract-empty_headers                 | 449 ns                                                                                                          | 454 ns: 1.01x slower                                                                                            |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-medium_header_no_matches      | 2.88 us                                                                                                         | 2.67 us: 1.08x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-large_header_no_matches       | 10.6 us                                                                                                         | 10.4 us: 1.02x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-valid_headers_basic           | 2.21 us                                                                                                         | 1.70 us: 1.30x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-valid_headers_all             | 2.18 us                                                                                                         | 1.85 us: 1.18x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-medium_valid_headers_all      | 4.14 us                                                                                                         | 3.78 us: 1.09x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-large_valid_headers_all       | 11.8 us                                                                                                         | 11.4 us: 1.03x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-invalid_trace_id_header       | 2.73 us                                                                                                         | 2.41 us: 1.13x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-invalid_span_id_header        | 2.23 us                                                                                                         | 1.84 us: 1.21x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-invalid_priority_header       | 2.69 us                                                                                                         | 2.37 us: 1.13x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-wsgi_empty_headers            | 454 ns                                                                                                          | 450 ns: 1.01x faster                                                                                            |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-wsgi_medium_header_no_matches | 2.92 us                                                                                                         | 2.71 us: 1.08x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-wsgi_large_header_no_matches  | 10.6 us                                                                                                         | 10.5 us: 1.01x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-wsgi_valid_headers_basic      | 2.24 us                                                                                                         | 1.70 us: 1.32x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-wsgi_valid_headers_all        | 2.20 us                                                                                                         | 1.87 us: 1.18x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-wsgi_medium_valid_headers_all | 4.09 us                                                                                                         | 3.82 us: 1.07x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-wsgi_large_valid_headers_all  | 11.7 us                                                                                                         | 11.5 us: 1.02x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-wsgi_invalid_trace_id_header  | 2.73 us                                                                                                         | 2.44 us: 1.12x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-wsgi_invalid_span_id_header   | 449 ns                                                                                                          | 463 ns: 1.03x slower                                                                                            |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| httppropagationextract-wsgi_invalid_priority_header  | 2.65 us                                                                                                         | 2.41 us: 1.10x faster                                                                                           |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
| Geometric mean                                       | (ref)                                                                                                           | 1.10x faster                                                                                                    |
+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
```