### PR TITLE
ci: retry docker pulls if fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ commands:
         default: ""
     steps:
       # Retry pulls in case they fail
-      - run: for i in {1..3}; do docker-compose pull << parameters.services >> && break || sleep 3; fi; done
+      - run: for i in {1..3}; do docker-compose pull << parameters.services >> && break || sleep 3; done
       - run: << parameters.env >> docker-compose up -d << parameters.services >>
       - run:
           command: docker-compose logs -f

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -10,7 +10,7 @@ then
 fi
 
 # retry docker pull if fails
-docker-compose pull testrunner || docker-compose pull testrunner || docker-compose pull testrunner
+for i in {1..3}; do docker-compose pull testrunner && break || sleep 3; done
 
 # install and upgrade tox and riot in case testrunner image has not been updated
 docker-compose run -e CIRCLE_NODE_TOTAL -e CIRCLE_NODE_INDEX -e DD_TRACE_AGENT_URL --rm testrunner bash -c "pip install -q --disable-pip-version-check riot tox && $CMD"


### PR DESCRIPTION
We have found CI failing when pulling image layers when docker services are needed for test runs (see [example failure](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/16975/workflows/55ae252b-2207-45b2-a760-c65a1b11e280/jobs/1160325/parallel-runs/0/steps/0-105)).

The mitigation here is to retry the pulls twice.