### PR TITLE
feat(redis): add asyncio support of redis >= 4.2

### DIFF
--- a/ddtrace/contrib/redis/asyncio_patch.py
+++ b/ddtrace/contrib/redis/asyncio_patch.py
@@ -1,0 +1,29 @@
+from ddtrace import config
+
+from ...internal.utils.formats import stringify_cache_args
+from ...pin import Pin
+from .util import _trace_redis_cmd
+from .util import _trace_redis_execute_pipeline
+
+
+#
+# tracing async functions
+#
+async def traced_async_execute_command(func, instance, args, kwargs):
+    pin = Pin.get_from(instance)
+    if not pin or not pin.enabled():
+        return await func(*args, **kwargs)
+
+    with _trace_redis_cmd(pin, config.redis, instance, args):
+        return await func(*args, **kwargs)
+
+
+async def traced_async_execute_pipeline(func, instance, args, kwargs):
+    pin = Pin.get_from(instance)
+    if not pin or not pin.enabled():
+        return await func(*args, **kwargs)
+
+    cmds = [stringify_cache_args(c) for c, _ in instance.command_stack]
+    resource = "\n".join(cmds)
+    with _trace_redis_execute_pipeline(pin, config.redis, resource, instance):
+        return await func(*args, **kwargs)

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -36,6 +36,14 @@ def patch():
         _w("redis", "Redis.pipeline", traced_pipeline)
         _w("redis.client", "Pipeline.execute", traced_execute_pipeline)
         _w("redis.client", "Pipeline.immediate_execute_command", traced_execute_command)
+        if redis.VERSION >= (4, 2, 0):
+            from .asyncio_patch import traced_async_execute_command
+            from .asyncio_patch import traced_async_execute_pipeline
+
+            _w("redis.asyncio.client", "Redis.execute_command", traced_async_execute_command)
+            _w("redis.asyncio.client", "Redis.pipeline", traced_pipeline)
+            _w("redis.asyncio.client", "Pipeline.execute", traced_async_execute_pipeline)
+            _w("redis.asyncio.client", "Pipeline.immediate_execute_command", traced_async_execute_command)
     Pin(service=None).onto(redis.StrictRedis)
 
 
@@ -54,6 +62,11 @@ def unpatch():
             unwrap(redis.Redis, "pipeline")
             unwrap(redis.client.Pipeline, "execute")
             unwrap(redis.client.Pipeline, "immediate_execute_command")
+            if redis.VERSION >= (4, 2, 0):
+                unwrap(redis.asyncio.client.Redis, "execute_command")
+                unwrap(redis.asyncio.client.Redis, "pipeline")
+                unwrap(redis.asyncio.client.Pipeline, "execute")
+                unwrap(redis.asyncio.client.Pipeline, "immediate_execute_command")
 
 
 #

--- a/releasenotes/notes/redis-asyncio-4b0b6a2a9d8f58c0.yaml
+++ b/releasenotes/notes/redis-asyncio-4b0b6a2a9d8f58c0.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add asyncio support of redis ≥ 4.2.0

--- a/riotfile.py
+++ b/riotfile.py
@@ -1602,20 +1602,34 @@ venv = Venv(
         ),
         Venv(
             name="redis",
-            pys=select_pys(),
-            command="pytest {cmdargs} tests/contrib/redis",
-            pkgs={
-                "redis": [
-                    ">=2.10,<2.11",
-                    ">=3.0,<3.1",
-                    ">=3.1,<3.2",
-                    ">=3.2,<3.3",
-                    ">=3.3,<3.4",
-                    ">=3.4,<3.5",
-                    ">=3.5,<3.6",
-                    latest,
-                ]
-            },
+            venvs=[
+                Venv(
+                    pys=select_pys(),
+                    command="pytest {cmdargs} --ignore-glob='*asyncio*' tests/contrib/redis",
+                    pkgs={
+                        "redis": [
+                            ">=2.10,<2.11",
+                            ">=3.0,<3.1",
+                            ">=3.1,<3.2",
+                            ">=3.2,<3.3",
+                            ">=3.3,<3.4",
+                            ">=3.4,<3.5",
+                            ">=3.5,<3.6",
+                        ],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version="3.6"),
+                    command="pytest {cmdargs} tests/contrib/redis",
+                    pkgs={
+                        "pytest-asyncio": latest,
+                        "redis": [
+                            ">=4.2,<4.3",
+                            latest,
+                        ],
+                    },
+                ),
+            ],
         ),
         Venv(
             name="aredis",

--- a/tests/contrib/redis/test_redis_asyncio.py
+++ b/tests/contrib/redis/test_redis_asyncio.py
@@ -1,0 +1,211 @@
+import pytest
+import redis
+import redis.asyncio
+
+from ddtrace import Pin
+from ddtrace import tracer
+from ddtrace.contrib.redis.patch import patch
+from ddtrace.contrib.redis.patch import unpatch
+from ddtrace.vendor.wrapt import ObjectProxy
+from tests.utils import override_config
+
+from ..config import REDIS_CONFIG
+
+
+def get_redis_instance(max_connections: int):
+    return redis.asyncio.from_url("redis://127.0.0.1:%s" % REDIS_CONFIG["port"], max_connections=max_connections)
+
+
+@pytest.mark.asyncio
+@pytest.fixture
+def redis_client():
+    r = get_redis_instance(max_connections=10)  # default values
+    yield r
+
+
+@pytest.mark.asyncio
+@pytest.fixture
+def single_pool_redis_client():
+    r = get_redis_instance(max_connections=1)
+    yield r
+
+
+@pytest.mark.asyncio
+@pytest.fixture(autouse=True)
+async def traced_redis(redis_client):
+    await redis_client.flushall()
+
+    patch()
+    try:
+        yield
+    finally:
+        unpatch()
+    await redis_client.flushall()
+
+
+def test_patching():
+    """
+    When patching redis library
+        We wrap the correct methods
+    When unpatching  redis library
+        We unwrap the correct methods
+    """
+    assert isinstance(redis.asyncio.client.Redis.execute_command, ObjectProxy)
+    assert isinstance(redis.asyncio.client.Redis.pipeline, ObjectProxy)
+    assert isinstance(redis.asyncio.client.Pipeline.pipeline, ObjectProxy)
+    unpatch()
+    assert not isinstance(redis.asyncio.client.Redis.execute_command, ObjectProxy)
+    assert not isinstance(redis.asyncio.client.Redis.pipeline, ObjectProxy)
+    assert not isinstance(redis.asyncio.client.Pipeline.pipeline, ObjectProxy)
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_basic_request(redis_client):
+    val = await redis_client.get("cheese")
+    assert val is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_unicode_request(redis_client):
+    val = await redis_client.get("😐")
+    assert val is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_decoding_non_utf8_args(redis_client):
+    await redis_client.set(b"\x80foo", b"\x80abc")
+    val = await redis_client.get(b"\x80foo")
+    assert val == b"\x80abc"
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_decoding_non_utf8_pipeline_args(redis_client):
+    p = redis_client.pipeline()
+    p.set(b"\x80blah", "boo")
+    p.set("foo", b"\x80abc")
+    p.get(b"\x80blah")
+    p.get("foo")
+
+    response_list = await p.execute()
+    assert response_list[0] is True  # response from redis.set is OK if successfully pushed
+    assert response_list[1] is True
+    assert response_list[2].decode() == "boo"
+    assert response_list[3] == b"\x80abc"
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_long_command(redis_client):
+    length = 1000
+    val_list = await redis_client.mget(*range(length))
+    assert len(val_list) == length
+    for val in val_list:
+        assert val is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_override_service_name(redis_client):
+    with override_config("redis", dict(service_name="myredis")):
+        val = await redis_client.get("cheese")
+        assert val is None
+        await redis_client.set("cheese", "my-cheese")
+        val = await redis_client.get("cheese")
+        if isinstance(val, bytes):
+            val = val.decode()
+        assert val == "my-cheese"
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_pin(redis_client):
+    Pin.override(redis_client, service="my-redis")
+    val = await redis_client.get("cheese")
+    assert val is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_pipeline_traced(redis_client):
+    p = redis_client.pipeline(transaction=False)
+    p.set("blah", "boo")
+    p.set("foo", "bar")
+    p.get("blah")
+    p.get("foo")
+
+    response_list = await p.execute()
+    assert response_list[0] is True  # response from redis.set is OK if successfully pushed
+    assert response_list[1] is True
+    assert (
+        response_list[2].decode() == "boo"
+    )  # response from hset is 'Integer reply: The number of fields that were added.'
+    assert response_list[3].decode() == "bar"
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_pipeline_traced_context_manager_transaction(redis_client):
+    """
+    Regression test for: https://github.com/DataDog/dd-trace-py/issues/3106
+
+    Example::
+
+        async def main():
+            redis = await redis.from_url("redis://localhost")
+            async with redis.pipeline(transaction=True) as pipe:
+                ok1, ok2 = await (pipe.set("key1", "value1").set("key2", "value2").execute())
+            assert ok1
+            assert ok2
+    """
+
+    async with redis_client.pipeline(transaction=True) as p:
+        set_1, set_2, get_1, get_2 = await (p.set("blah", "boo").set("foo", "bar").get("blah").get("foo").execute())
+
+    # response from redis.set is OK if successfully pushed
+    assert set_1 is True
+    assert set_2 is True
+    assert get_1.decode() == "boo"
+    assert get_2.decode() == "bar"
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_two_traced_pipelines(redis_client):
+
+    with tracer.trace("web-request", service="test"):
+        if redis.VERSION >= (2, 0):
+            p1 = await redis_client.pipeline(transaction=False)
+            p2 = await redis_client.pipeline(transaction=False)
+            await p1.set("blah", "boo")
+            await p2.set("foo", "bar")
+            await p1.get("blah")
+            await p2.get("foo")
+        else:
+            p1 = redis_client.pipeline()
+            p2 = redis_client.pipeline()
+            p1.set("blah", "boo")
+            p2.set("foo", "bar")
+            p1.get("blah")
+            p2.get("foo")
+
+        response_list1 = await p1.execute()
+        response_list2 = await p2.execute()
+
+    assert response_list1[0] is True  # response from redis.set is OK if successfully pushed
+    assert response_list2[0] is True
+    assert (
+        response_list1[1].decode() == "boo"
+    )  # response from hset is 'Integer reply: The number of fields that were added.'
+    assert response_list2[1].decode() == "bar"
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_parenting(redis_client):
+    with tracer.trace("web-request", service="test"):
+        await redis_client.set("blah", "boo")
+        await redis_client.get("blah")

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_parenting.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_parenting.json
@@ -1,0 +1,21 @@
+[[
+  {
+    "name": "web-request",
+    "service": "test",
+    "resource": "web-request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "meta": {
+      "runtime-id": "0c93831d9ac140e5ad4ab9dc71c5a6e9"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 2222
+    },
+    "duration": 3311083,
+    "start": 1652285578127326342
+  }]]

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pin.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pin.json
@@ -1,0 +1,28 @@
+[[
+  {
+    "name": "redis.command",
+    "service": "my-redis",
+    "resource": "GET cheese",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "redis",
+    "meta": {
+      "out.host": "127.0.0.1",
+      "redis.raw_command": "GET cheese",
+      "runtime-id": "d2394c05e43247faaad2c8b67e080681"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "out.port": 6379,
+      "out.redis_db": 0,
+      "redis.args_length": 2,
+      "system.pid": 17499
+    },
+    "duration": 2505500,
+    "start": 1652264897108194757
+  }]]

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_two_traced_pipelines.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_two_traced_pipelines.json
@@ -1,0 +1,21 @@
+[[
+  {
+    "name": "web-request",
+    "service": "test",
+    "resource": "web-request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "meta": {
+      "runtime-id": "0c93831d9ac140e5ad4ab9dc71c5a6e9"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 2222
+    },
+    "duration": 4411458,
+    "start": 1652285578066009467
+  }]]


### PR DESCRIPTION
# Integration

This PR adds support for asyncio part of redis >= 4.2

## Links

https://github.com/redis/redis-py#python-notice
https://redis-py.readthedocs.io/en/stable/connections.html#async-client
https://github.com/redis/redis-py/tree/master/redis/asyncio

- Integration docs: ???
- Corp docs PR: ???

## Checklist

- [ ] Usage and configuration documentation added in `__init__.py`, `docs/index.rst` and `docs/integrations.rst`.
- [ ] [Corp docs](https://github.com/Datadog/documentation) PR to add new integration to documentation.
- [x] Span metadata
  - [x] Service (use [`int_service`](https://github.com/DataDog/dd-trace-py/blob/90d1d5981c72ea312c21ac04e5be47521d0f0f2e/ddtrace/contrib/trace_utils.py#L55) or [`ext_service`](https://github.com/DataDog/dd-trace-py/blob/90d1d5981c72ea312c21ac04e5be47521d0f0f2e/ddtrace/contrib/trace_utils.py#L87)).
  - [x] Span type should be one of [these](https://github.com/DataDog/dd-trace-py/blob/90d1d5981c72ea312c21ac04e5be47521d0f0f2e/ddtrace/ext/__init__.py#L7).
  - [x] Resource
  - [x] Measured tag
  - [x] Sample analytics
- [x] Global configuration
  - [x] `ddtrace.config` entry is specified.
  - [x] Environment variables are provided for config options.
- [x] Instance configuration
  - [x] Pin overriding.
  - [x] Service name override (if applicable).
- [ ] Async
  - [ ] Span parenting behaves as expected.
  - [ ] Context propagation across async contexts.
- [ ] HTTP
  - [ ] Distributed tracing propagation is implemented.
  - [ ] Use [`trace_utils.set_http_meta`](https://github.com/DataDog/dd-trace-py/blob/90d1d5981c72ea312c21ac04e5be47521d0f0f2e/ddtrace/contrib/trace_utils.py#L143-L152) to set http tags
- [x] Tests
  - [x] Use `pytest` fixtures found in `tests/conftest.py` or the test helpers on `TracerTestCase` if
    writing `unittest` style test cases.
  - [x] Tests are provided for all the above.
  - [x] Tests are added to CI (`.circleci/config.yml`).
  - [x] Functionality is maintained from original library.
  - [x] Patch test cases are added (see `test_django_patch.py` for an example).
  - [x] All Python versions that the library supports are tested.
  - [x] All significant library versions (including the latest) are tested. This typically includes every minor release going back a few years.
