### PR TITLE
chore(ci): make docker pulls quiet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ commands:
         default: ""
     steps:
       # Retry pulls in case they fail
-      - run: for i in {1..3}; do docker-compose pull << parameters.services >> && break || sleep 3; done
+      - run: for i in {1..3}; do docker-compose pull -q << parameters.services >> && break || sleep 3; done
       - run: << parameters.env >> docker-compose up -d << parameters.services >>
       - run:
           command: docker-compose logs -f

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -10,9 +10,9 @@ then
 fi
 
 # retry docker pull if fails
-for i in {1..3}; do docker-compose pull testrunner && break || sleep 3; done
+for i in {1..3}; do docker-compose pull -q testrunner && break || sleep 3; done
 
 # install and upgrade tox and riot in case testrunner image has not been updated
 # DEV: Use `--no-TTY` when running in CircleCI
 NO_TTY=$([[ "${CIRCLECI}" = "true" ]] && echo "--no-TTY")
-docker-compose run -e CIRCLE_NODE_TOTAL -e CIRCLE_NODE_INDEX -e DD_TRACE_AGENT_URL "${NO_TTY}" --rm testrunner bash -c "pip install -q --disable-pip-version-check riot tox && $CMD"
+docker-compose run -e CIRCLE_NODE_TOTAL -e CIRCLE_NODE_INDEX -e DD_TRACE_AGENT_URL "${NO_TTY}" --quiet-pull --rm testrunner bash -c "pip install -q --disable-pip-version-check riot tox && $CMD"


### PR DESCRIPTION
Remove the unnecessary progress bars for docker pulls from output of jobs.