### PR TITLE
fix(profiling): copy all profiler non-private attributes

### DIFF
--- a/releasenotes/notes/profiling-fix-profiler-copy-6d775a134ec2233f.yaml
+++ b/releasenotes/notes/profiling-fix-profiler-copy-6d775a134ec2233f.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    The profiler ``asyncio_loop_policy`` attribute has been renamed to
+    ``asyncio_loop_policy_class`` to accept a user-defined class. This
+    guarantees the same asyncio loop policy class can be used process children.
+fixes:
+  - |
+    The profiler now copy all user-provided attributes on fork.


### PR DESCRIPTION
The current code would miss copying some customer-provided attributes on fork.