### PR TITLE
chore(internal): add higher-level metrics interface

### DIFF
--- a/ddtrace/internal/dogstatsd.py
+++ b/ddtrace/internal/dogstatsd.py
@@ -5,11 +5,8 @@ from ddtrace.vendor.dogstatsd import DogStatsd
 from ddtrace.vendor.dogstatsd import base
 
 
-def get_dogstatsd_client(url):
-    # type: (str) -> Optional[DogStatsd]
-    if not url:
-        return None
-
+def get_dogstatsd_client(url, namespace=None):
+    # type: (str, Optional[str]) -> DogStatsd
     # url can be either of the form `udp://<host>:<port>` or `unix://<path>`
     # also support without url scheme included
     if url.startswith("/"):
@@ -20,8 +17,12 @@ def get_dogstatsd_client(url):
     parsed = parse.urlparse(url)
 
     if parsed.scheme == "unix":
-        return DogStatsd(socket_path=parsed.path)
+        return DogStatsd(socket_path=parsed.path, namespace=namespace)
     elif parsed.scheme == "udp":
-        return DogStatsd(host=parsed.hostname, port=base.DEFAULT_PORT if parsed.port is None else parsed.port)
+        return DogStatsd(
+            host=parsed.hostname,
+            port=base.DEFAULT_PORT if parsed.port is None else parsed.port,
+            namespace=namespace,
+        )
 
     raise ValueError("Unknown scheme `%s` for DogStatsD URL `{}`".format(parsed.scheme))

--- a/ddtrace/internal/metrics.py
+++ b/ddtrace/internal/metrics.py
@@ -1,0 +1,69 @@
+from typing import Dict
+from typing import Optional
+
+from ddtrace.internal import agent
+from ddtrace.internal.dogstatsd import get_dogstatsd_client
+
+
+class Metrics(object):
+    """Higher-level DogStatsD interface.
+
+    This class provides automatic handling of namespaces for metrics, with the
+    possibility of enabling and disabling them at runtime.
+
+    Example::
+        The following example shows how to create the counter metric
+        'datadog.tracer.writer.success' and how to increment it. Note that
+        metrics are emitted only while the metrics object is enabled.
+
+            >>> tracer_metrics = Metrics(namespace='datadog.tracer')
+            >>> tracer_metrics.enable()
+            >>> writer_meter = dd_metrics.get_meter('writer')
+            >>> writer_meter.increment('success')
+            >>> tracer_metrics.disable()
+            >>> writer_meter.increment('success')  # won't be emitted
+    """
+
+    def __init__(self, dogstats_url=None, namespace=None):
+        # type: (Optional[str], Optional[str]) -> None
+        self.dogstats_url = dogstats_url
+        self.namespace = namespace
+        self.enabled = False
+
+        self._client = get_dogstatsd_client(dogstats_url or agent.get_stats_url(), namespace=namespace)
+
+    class Meter(object):
+        def __init__(self, metrics, name):
+            # type: (Metrics, str) -> None
+            self.metrics = metrics
+            self.name = name
+
+        def increment(self, name, value=1.0, tags=None):
+            # type: (str, float, Optional[Dict[str, str]]) -> None
+            if not self.metrics.enabled:
+                return None
+
+            self.metrics._client.increment(
+                ".".join((self.name, name)), value, [":".join(_) for _ in tags.items()] if tags else None
+            )
+
+        def distribution(self, name, value=1.0, tags=None):
+            # type: (str, float, Optional[Dict[str, str]]) -> None
+            if not self.metrics.enabled:
+                return None
+
+            self.metrics._client.distribution(
+                ".".join((self.name, name)), value, [":".join(_) for _ in tags.items()] if tags else None
+            )
+
+    def enable(self):
+        # type: () -> None
+        self.enabled = True
+
+    def disable(self):
+        # type: () -> None
+        self.enabled = False
+
+    def get_meter(self, name):
+        # type: (str) -> Metrics.Meter
+        return self.Meter(self, name)

--- a/tests/internal/test_metrics.py
+++ b/tests/internal/test_metrics.py
@@ -1,0 +1,35 @@
+from contextlib import contextmanager
+
+import mock
+import pytest
+
+from ddtrace.internal.metrics import Metrics
+
+
+@contextmanager
+def mock_metrics(namespace=None):
+    metrics = Metrics(namespace=namespace)
+    try:
+        metrics._client = mock.Mock()
+        metrics.enable()
+        yield metrics
+    finally:
+        metrics.disable()
+
+
+@pytest.mark.parametrize("namespace", [None, "namespace"])
+def test_metrics_names(namespace):
+    PI = 3.14159265359
+    with mock_metrics(namespace) as metrics:
+        client = metrics._client
+        m = metrics.get_meter("foo.bar")
+        m.increment("my.counter")
+        m.distribution("my.dist", PI)
+
+    # The meter gets disabled when the context manager returns, so the client
+    # should not have these calls
+    m.increment("my.counter2")
+    m.distribution("my.dist2", PI)
+
+    assert client.increment.mock_calls == [mock.call("foo.bar.my.counter", 1.0, None)]
+    assert client.distribution.mock_calls == [mock.call("foo.bar.my.dist", PI, None)]


### PR DESCRIPTION
This change introduces a higher-level interface to DogStatsD that allows for the handling of metrics namespaces and run-time enablement control.

<!-- Briefly describe the change and why it was required. -->

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
