### PR TITLE
fix(asgi): set hostname using request headers

### DIFF
--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -138,7 +138,9 @@ class TraceMiddleware:
                 try:
                     host_header = value.decode("ascii")
                 except UnicodeDecodeError:
-                    pass
+                    log.warning(
+                        "failed to decode host header, url will contain the hostname of the sever", exc_info=True
+                    )
                 break
 
         method = scope.get("method")

--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -81,6 +81,8 @@ class TraceMiddleware:
         tracer: Custom tracer. Defaults to the global tracer.
     """
 
+    default_ports = {"http": 80, "https": 443, "ws": 80, "wss": 443}
+
     def __init__(
         self,
         app,
@@ -130,13 +132,26 @@ class TraceMiddleware:
         if sample_rate is not None:
             span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, sample_rate)
 
+        host_header = None
+        for key, value in scope["headers"]:
+            if key == b"host":
+                try:
+                    host_header = value.decode("ascii")
+                except UnicodeDecodeError:
+                    pass
+                break
+
         method = scope.get("method")
         server = scope.get("server")
-        if server and len(server) == 2:
+        scheme = scope.get("scheme", "http")
+        full_path = scope.get("root_path", "") + scope.get("path", "")
+        if host_header:
+            url = "{}://{}{}".format(scheme, host_header, full_path)
+        elif server and len(server) == 2:
             port = server[1]
-            server_host = server[0] + (":" + str(port) if port is not None and port != 80 else "")
-            full_path = scope.get("root_path", "") + scope.get("path", "")
-            url = scope.get("scheme", "http") + "://" + server_host + full_path
+            default_port = self.default_ports.get(scheme, None)
+            server_host = server[0] + (":" + str(port) if port is not None and port != default_port else "")
+            url = "{}://{}{}".format(scheme, server_host, full_path)
         else:
             url = None
 

--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -139,7 +139,7 @@ class TraceMiddleware:
                     host_header = value.decode("ascii")
                 except UnicodeDecodeError:
                     log.warning(
-                        "failed to decode host header, url will contain the hostname of the sever", exc_info=True
+                        "failed to decode host header, host from http headers will not be considered", exc_info=True
                     )
                 break
 

--- a/releasenotes/notes/fix-asgi-middleware-url-tags-06051605794f88f7.yaml
+++ b/releasenotes/notes/fix-asgi-middleware-url-tags-06051605794f88f7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - | 
+    asgi: set the ``http.url`` tag using the hostname in the request header before defaulting to the hostname of the asgi server.

--- a/tests/contrib/fastapi/test_fastapi.py
+++ b/tests/contrib/fastapi/test_fastapi.py
@@ -578,3 +578,14 @@ def test_background_task(client, tracer, test_spans):
     # typical duration without background task should be in less than 10 ms
     # duration with background task will take approximately 1.1s
     assert request_span.duration < 1
+
+
+@pytest.mark.parametrize("host", ["hostserver", "hostserver:5454"])
+def test_host_header(client, tracer, test_spans, host):
+    """Tests if background tasks have been excluded from span duration"""
+    r = client.get("/asynctask", headers={"host": host})
+    assert r.status_code == 200
+
+    assert test_spans.spans
+    request_span = test_spans.spans[0]
+    assert request_span.get_tag("http.url") == "http://%s/asynctask" % (host,)

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -396,14 +396,15 @@ def test_table_query(client, tracer, test_spans):
     assert sql_span.get_tag("sql.db") == "test.db"
 
 
-def test_host_header(client, tracer, test_spans):
-    r = client.get("/200", headers={"host": "hostserver"})
+@pytest.mark.parametrize("host", ["hostserver", "hostserver:5454"])
+def test_host_header(client, tracer, test_spans, host):
+    r = client.get("/200", headers={"host": host})
 
     assert r.status_code == 200
     assert r.text == "Success"
 
     request_span = next(test_spans.filter_spans(name="starlette.request"))
-    assert request_span.get_tag("http.url") == "http://hostserver/200"
+    assert request_span.get_tag("http.url") == "http://%s/200" % (host,)
 
 
 @snapshot()

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -396,6 +396,16 @@ def test_table_query(client, tracer, test_spans):
     assert sql_span.get_tag("sql.db") == "test.db"
 
 
+def test_host_header(client, tracer, test_spans):
+    r = client.get("/200", headers={"host": "hostserver"})
+
+    assert r.status_code == 200
+    assert r.text == "Success"
+
+    request_span = next(test_spans.filter_spans(name="starlette.request"))
+    assert request_span.get_tag("http.url") == "http://hostserver/200"
+
+
 @snapshot()
 def test_subapp_snapshot(snapshot_client):
     response = snapshot_client.get("/sub-app/hello/name")

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_traced_simple_app.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_traced_simple_app.json
@@ -11,7 +11,7 @@
       "asgi.version": "3.0",
       "http.method": "GET",
       "http.status_code": "200",
-      "http.url": "http://127.0.0.1:8000/traced-simple-asgi-app/",
+      "http.url": "http://localhost:8000/traced-simple-asgi-app/",
       "http.version": "1.1",
       "runtime-id": "74a5040e28844593a7cbe579f49ab5e4"
     },


### PR DESCRIPTION
## Motivation

In the asgi `TraceMiddleware`, `http.url` span tag should be set using the value of the `host` request header. 
 If the `host` request header is not set, the host of the asgi server should be used. This fix will ensure forwarded requests are tagged with the original host name. 

## Implementation Details

Replace [the url parsing](https://github.com/DataDog/dd-trace-py/blob/v1.1.2/ddtrace/contrib/asgi/middleware.py#L131-L137) in ddtrace asgi middleware with the [starlette approach](https://github.com/encode/starlette/blob/e7a92ee4cd43b6d7acf4e2fdedb20fe0e86f9620/starlette/datastructures.py#L31-L47). 

- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
