### PR TITLE
chore(ci): pin aiobotocore<=2.3.1 for gevent tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -189,7 +189,9 @@ deps =
     redis210: redis>=2.10,<2.11
     sqlalchemy: sqlalchemy
     sslmodules3: aiohttp
-    sslmodules3: aiobotocore
+    # 2.3.2 included `tests` module in the distribution, pin to 2.3.1 until this issue is resolved
+    # https://github.com/aio-libs/aiobotocore/issues/937
+    sslmodules3: aiobotocore<=2.3.1
     sslmodules: botocore
     sslmodules: requests
     sslmodules: elasticsearch


### PR DESCRIPTION
`aiobotocore==2.3.2` included `tests` module in it's distribution
this causes conflicts with our `tests` module.

Pin until https://github.com/aio-libs/aiobotocore/issues/937 is resolved
