### PR TITLE
chore(tests): skip unpatch tests when no unpatch method given

### DIFF
--- a/tests/contrib/django/test_django_patch.py
+++ b/tests/contrib/django/test_django_patch.py
@@ -17,10 +17,10 @@ class TestDjangoPatch(PatchTestCase.Base):
             self.assert_wrapped(django.urls.path)
             self.assert_wrapped(django.urls.re_path)
         self.assert_wrapped(django.views.generic.base.View.as_view)
-        self.assert_wrapped(django.db.connections.__setitem__)
 
     def assert_not_module_patched(self, django):
         self.assert_not_wrapped(django.apps.registry.Apps.populate)
+        import django.core.handlers.base
         self.assert_not_wrapped(django.core.handlers.base.BaseHandler.load_middleware)
         self.assert_not_wrapped(django.core.handlers.base.BaseHandler.get_response)
         self.assert_not_wrapped(django.template.base.Template.render)
@@ -28,7 +28,6 @@ class TestDjangoPatch(PatchTestCase.Base):
             self.assert_not_wrapped(django.urls.path)
             self.assert_not_wrapped(django.urls.re_path)
         self.assert_not_wrapped(django.views.generic.base.View.as_view)
-        self.assert_not_wrapped(django.db.connections.__setitem__)
 
     def assert_not_module_double_patched(self, django):
         self.assert_not_double_wrapped(django.apps.registry.Apps.populate)
@@ -39,4 +38,3 @@ class TestDjangoPatch(PatchTestCase.Base):
             self.assert_not_double_wrapped(django.urls.path)
             self.assert_not_double_wrapped(django.urls.re_path)
         self.assert_not_double_wrapped(django.views.generic.base.View.as_view)
-        self.assert_not_double_wrapped(django.db.connections.__setitem__)

--- a/tests/contrib/django/test_django_patch.py
+++ b/tests/contrib/django/test_django_patch.py
@@ -21,6 +21,7 @@ class TestDjangoPatch(PatchTestCase.Base):
     def assert_not_module_patched(self, django):
         self.assert_not_wrapped(django.apps.registry.Apps.populate)
         import django.core.handlers.base
+
         self.assert_not_wrapped(django.core.handlers.base.BaseHandler.load_middleware)
         self.assert_not_wrapped(django.core.handlers.base.BaseHandler.get_response)
         self.assert_not_wrapped(django.template.base.Template.render)

--- a/tests/contrib/django/test_django_patch.py
+++ b/tests/contrib/django/test_django_patch.py
@@ -28,6 +28,8 @@ class TestDjangoPatch(PatchTestCase.Base):
         if django.VERSION >= (2, 0, 0):
             self.assert_not_wrapped(django.urls.path)
             self.assert_not_wrapped(django.urls.re_path)
+        import django.views.generic
+
         self.assert_not_wrapped(django.views.generic.base.View.as_view)
 
     def assert_not_module_double_patched(self, django):

--- a/tests/contrib/patch.py
+++ b/tests/contrib/patch.py
@@ -71,9 +71,6 @@ def raise_if_no_attrs(f):
 
     @functools.wraps(f)
     def checked_method(self, *args, **kwargs):
-        if getattr(self, "__unpatch_func__") is None:
-            return
-
         for attr in required_attrs:
             if not getattr(self, attr):
                 raise NotImplementedError(f.__doc__)
@@ -91,7 +88,7 @@ def noop_if_no_unpatch(f):
     @functools.wraps(f)
     def wrapper(self, *args, **kwargs):
         if getattr(self, "__unpatch_func__") is None:
-            return
+            self.skipTest(reason="No unpatch function given")
         return f(self, *args, **kwargs)
 
     return wrapper
@@ -310,7 +307,6 @@ class PatchTestCase(object):
                 ddtrace.patch(redis=True)
                 self.assert_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             module = importlib.import_module(self.__module_name__)
             self.assert_not_module_patched(module)
             self.__patch_func__()
@@ -329,7 +325,6 @@ class PatchTestCase(object):
                 ddtrace.patch(redis=True)
                 self.assert_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             module = importlib.import_module(self.__module_name__)
             self.__patch_func__()
             self.assert_module_patched(module)
@@ -349,7 +344,6 @@ class PatchTestCase(object):
                 ddtrace.patch(redis=True)
                 self.assert_not_module_double_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             self.__patch_func__()
             module = importlib.import_module(self.__module_name__)
             self.assert_module_patched(module)
@@ -371,7 +365,6 @@ class PatchTestCase(object):
                 ddtrace.patch(redis=True)
                 self.assert_not_module_double_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             self.__patch_func__()
             module = importlib.import_module(self.__module_name__)
             self.assert_module_patched(module)
@@ -392,13 +385,13 @@ class PatchTestCase(object):
                 import redis
                 self.assert_not_double_wrapped(redis.StrictRedis.execute_command)
             """
-            self.assert_not_module_imported(self.__module_name__)
             self.__patch_func__()
             self.__patch_func__()
             module = importlib.import_module(self.__module_name__)
             self.assert_module_patched(module)
             self.assert_not_module_double_patched(module)
 
+        @noop_if_no_unpatch
         @raise_if_no_attrs
         def test_import_patch_unpatch_patch(self):
             """
@@ -416,7 +409,6 @@ class PatchTestCase(object):
                 ddtrace.patch(redis=True)
                 self.assert_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             module = importlib.import_module(self.__module_name__)
             self.__patch_func__()
             self.assert_module_patched(module)
@@ -426,6 +418,7 @@ class PatchTestCase(object):
             self.__patch_func__()
             self.assert_module_patched(module)
 
+        @noop_if_no_unpatch
         @raise_if_no_attrs
         def test_patch_import_unpatch_patch(self):
             """
@@ -443,7 +436,6 @@ class PatchTestCase(object):
                 ddtrace.patch(redis=True)
                 self.assert_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             self.__patch_func__()
             module = importlib.import_module(self.__module_name__)
             self.assert_module_patched(module)
@@ -452,6 +444,7 @@ class PatchTestCase(object):
             self.__patch_func__()
             self.assert_module_patched(module)
 
+        @noop_if_no_unpatch
         @raise_if_no_attrs
         def test_patch_unpatch_import_patch(self):
             """
@@ -469,7 +462,6 @@ class PatchTestCase(object):
                 ddtrace.patch(redis=True)
                 self.assert_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             self.__patch_func__()
             self.__unpatch_func__()
             module = importlib.import_module(self.__module_name__)
@@ -477,6 +469,7 @@ class PatchTestCase(object):
             self.__patch_func__()
             self.assert_module_patched(module)
 
+        @noop_if_no_unpatch
         @raise_if_no_attrs
         def test_patch_unpatch_patch_import(self):
             """
@@ -494,13 +487,13 @@ class PatchTestCase(object):
                 import redis
                 self.assert_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             self.__patch_func__()
             self.__unpatch_func__()
             self.__patch_func__()
             module = importlib.import_module(self.__module_name__)
             self.assert_module_patched(module)
 
+        @noop_if_no_unpatch
         @raise_if_no_attrs
         def test_unpatch_patch_import(self):
             """
@@ -514,13 +507,13 @@ class PatchTestCase(object):
                 import redis
                 self.assert_not_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             self.__unpatch_func__()
             self.__patch_func__()
             self.__patch_func__()
             module = importlib.import_module(self.__module_name__)
             self.assert_module_patched(module)
 
+        @noop_if_no_unpatch
         @raise_if_no_attrs
         def test_patch_unpatch_import(self):
             """
@@ -536,12 +529,12 @@ class PatchTestCase(object):
                 import redis
                 self.assert_not_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             self.__patch_func__()
             self.__unpatch_func__()
             module = importlib.import_module(self.__module_name__)
             self.assert_not_module_patched(module)
 
+        @noop_if_no_unpatch
         @raise_if_no_attrs
         def test_import_unpatch_patch(self):
             """
@@ -556,13 +549,13 @@ class PatchTestCase(object):
                 unpatch()
                 self.assert_not_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             module = importlib.import_module(self.__module_name__)
             self.__unpatch_func__()
             self.assert_not_module_patched(module)
             self.__patch_func__()
             self.assert_module_patched(module)
 
+        @noop_if_no_unpatch
         @raise_if_no_attrs
         def test_import_patch_unpatch(self):
             """
@@ -577,7 +570,6 @@ class PatchTestCase(object):
                 unpatch()
                 self.assert_not_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             module = importlib.import_module(self.__module_name__)
             self.assert_not_module_patched(module)
             self.__patch_func__()
@@ -585,6 +577,7 @@ class PatchTestCase(object):
             self.__unpatch_func__()
             self.assert_not_module_patched(module)
 
+        @noop_if_no_unpatch
         @raise_if_no_attrs
         def test_patch_import_unpatch(self):
             """
@@ -599,13 +592,13 @@ class PatchTestCase(object):
                 unpatch()
                 self.assert_not_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             self.__patch_func__()
             module = importlib.import_module(self.__module_name__)
             self.assert_module_patched(module)
             self.__unpatch_func__()
             self.assert_not_module_patched(module)
 
+        @noop_if_no_unpatch
         @raise_if_no_attrs
         def test_import_patch_unpatch_unpatch(self):
             """
@@ -623,7 +616,6 @@ class PatchTestCase(object):
                 unpatch()
                 self.assert_not_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             module = importlib.import_module(self.__module_name__)
             self.__patch_func__()
             self.assert_module_patched(module)
@@ -632,6 +624,7 @@ class PatchTestCase(object):
             self.__unpatch_func__()
             self.assert_not_module_patched(module)
 
+        @noop_if_no_unpatch
         @raise_if_no_attrs
         def test_patch_unpatch_import_unpatch(self):
             """
@@ -648,7 +641,6 @@ class PatchTestCase(object):
                 unpatch()
                 self.assert_not_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             self.__patch_func__()
             self.__unpatch_func__()
             module = importlib.import_module(self.__module_name__)
@@ -656,6 +648,7 @@ class PatchTestCase(object):
             self.__unpatch_func__()
             self.assert_not_module_patched(module)
 
+        @noop_if_no_unpatch
         @raise_if_no_attrs
         def test_patch_unpatch_unpatch_import(self):
             """
@@ -671,7 +664,6 @@ class PatchTestCase(object):
                 import redis
                 self.assert_not_module_patched(redis)
             """
-            self.assert_not_module_imported(self.__module_name__)
             self.__patch_func__()
             self.__unpatch_func__()
             self.__unpatch_func__()

--- a/tests/contrib/snowflake/test_snowflake_patch.py
+++ b/tests/contrib/snowflake/test_snowflake_patch.py
@@ -9,10 +9,10 @@ class TestSnowflakePatch(PatchTestCase.Base):
     __unpatch_func__ = None
 
     def assert_module_patched(self, snowflake):
-        self.assert_wrapped(snowflake.SnowflakeConnector.connect)
+        self.assert_wrapped(snowflake.connect)
 
     def assert_not_module_patched(self, snowflake):
-        self.assert_not_wrapped(snowflake.SnowflakeConnector.connect)
+        self.assert_not_wrapped(snowflake.connect)
 
     def assert_not_module_double_patched(self, snowflake):
-        self.assert_not_double_wrapped(snowflake.SnowflakeConnector.connect)
+        self.assert_not_double_wrapped(snowflake.connect)

--- a/tests/contrib/urllib3/test_urllib3_patch.py
+++ b/tests/contrib/urllib3/test_urllib3_patch.py
@@ -1,4 +1,5 @@
 from ddtrace.contrib.urllib3 import patch
+from ddtrace.contrib.urllib3 import unpatch
 from tests.contrib.patch import PatchTestCase
 
 
@@ -6,7 +7,7 @@ class TestUrllib3Patch(PatchTestCase.Base):
     __integration_name__ = "urllib3"
     __module_name__ = "urllib3"
     __patch_func__ = patch
-    __unpatch_func__ = None
+    __unpatch_func__ = unpatch
 
     def assert_module_patched(self, urllib3):
         self.assert_wrapped(urllib3.connectionpool.HTTPConnectionPool.urlopen)


### PR DESCRIPTION
Also remove the assertion that the module be not imported for a bunch of
the tests as almost all of our integrations import the patched module when
the patch method is imported.

Unfortunately it seems like the `self.skipTest()` call doesn't show up as a
skipped test since we just mark the test case as successful if the subprocess
returned an exit code of 0 so there isn't a good way to know if the test passed
or was skipped.
