### PR TITLE
fix(docs): pin dulwich version

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -198,6 +198,10 @@ venv = Venv(
                 "sphinx": "~=4.3.2",
                 "sphinxcontrib-spelling": latest,
                 "PyEnchant": latest,
+                # Pin due to dulwich not publishing wheels and the env doesn't have
+                # the dependencies required to build the package.
+                # https://github.com/jelmer/dulwich/issues/963.
+                "dulwich": "<0.20.36",
             },
             command="scripts/build-docs",
         ),


### PR DESCRIPTION
dulwich released a new version but did not publish wheels for the
version. Our build-docs job does not have the required dependencies
to build the package.

See: https://github.com/jelmer/dulwich/issues/963