### PR TITLE
fix(docs): unpin dulwich version

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -198,10 +198,6 @@ venv = Venv(
                 "sphinx": "~=4.3.2",
                 "sphinxcontrib-spelling": latest,
                 "PyEnchant": latest,
-                # Pin due to dulwich not publishing wheels and the env doesn't have
-                # the dependencies required to build the package.
-                # https://github.com/jelmer/dulwich/issues/963.
-                "dulwich": "<0.20.36",
             },
             command="scripts/build-docs",
         ),


### PR DESCRIPTION
Undo pinning of dulwich.

0.20.37 now has been published with wheels.

Sorry about breaking this. We've committed some improvements to make it less
likely that this breaks in the future. See
https://github.com/jelmer/dulwich/issues/963 for details.
