### PR TITLE
chore: add package links to pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,7 @@ setup(
     description="Datadog APM client library",
     url="https://github.com/DataDog/dd-trace-py",
     package_urls={
-        "Changelog": "https://github.com/DataDog/dd-trace-py/blob/1.x/CHANGELOG.md",
+        "Changelog": "https://ddtrace.readthedocs.io/en/stable/release_notes.html",
         "Documentation": "https://ddtrace.readthedocs.io/en/stable/",
     },
     author="Datadog, Inc.",

--- a/setup.py
+++ b/setup.py
@@ -215,6 +215,10 @@ setup(
     name="ddtrace",
     description="Datadog APM client library",
     url="https://github.com/DataDog/dd-trace-py",
+    package_urls={
+        "Changelog": "https://github.com/DataDog/dd-trace-py/blob/1.x/CHANGELOG.md",
+        "Documentation": "https://ddtrace.readthedocs.io/en/stable/",
+    },
     author="Datadog, Inc.",
     author_email="dev@datadoghq.com",
     long_description=long_description,


### PR DESCRIPTION
Add a links to the sidebar on PyPI, to make it easier for folks to jump to the relevant pages. Example: https://pypi.org/project/django-htmx/ (PyPI adds the icons based on the link names).

You'll see this on the next release.

## Checklist
- N/A Added to the correct milestone.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- N/A Library documentation is updated.
- N/A [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
