### PR TITLE
ci: use wagoid/commitlint-github-action

### DIFF
--- a/.github/workflows/pr-name.yml
+++ b/.github/workflows/pr-name.yml
@@ -4,10 +4,10 @@ on:
     types: ['opened', 'edited', 'reopened', 'synchronize']
 
 jobs:
-  lint:
+  commitlint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Dependencies
-      run: npm install @commitlint/config-conventional
-    - uses: JulienKode/pull-request-name-linter-action@v0.5.0
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4


### PR DESCRIPTION
The main reason to use `wagoid/commitlint-github-action` for linting PR titles is that it outputs more detailed information in the log output than the current action `JulienKode/pull-request-name-linter-action`.