### PR TITLE
chore(ci): update script for linting PR title

### DIFF
--- a/.github/workflows/pr-name.yml
+++ b/.github/workflows/pr-name.yml
@@ -4,10 +4,51 @@ on:
     types: ['opened', 'edited', 'reopened', 'synchronize']
 
 jobs:
-  commitlint:
+  pr_name_lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v4
+      - uses: actions/setup-node@v3
+        name: Install Node.js
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: |
+          npm install @commitlint/lint @commitlint/load @commitlint/config-conventional @actions/core
+      - name: Lint PR name
+        uses: actions/github-script@v6.1.0
+        with:
+          script: |
+            const load = require('@commitlint/load').default;
+            const lint = require('@commitlint/lint').default;
+
+            const CONFIG = {
+              extends: ['./commitlint.config.js'],
+            };
+
+            const title = '${{ github.event.pull_request.title }}';
+
+            core.info(`Linting: ${title}`);
+
+            load(CONFIG)
+              .then((opts) => {
+                lint(
+                  title,
+                  opts.rules,
+                  opts.parserPreset ? {parserOpts: opts.parserPreset.parserOpts} : {}
+                ).then((report) => {
+                  report.warnings.forEach((warning) => {
+                    core.warning(warning.message);
+                  });
+
+                  report.errors.forEach((error) => {
+                    core.error(error.message);
+                  });
+
+                  if (!report.valid) {
+                    core.setFailed("PR title linting failed");
+                  }
+                });
+              });


### PR DESCRIPTION
Fixes the current PR title conventional commit linting.

This is closer to what we had in the past, but uses the GitHub Action `core.*` APIs to expose error messages in a nicer way.