### PR TITLE
chore(docs): add reviewer checklist PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 - [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
 
 ## Reviewer Checklist
-- [ ] Title is accurate and conforms to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
+- [ ] Title is accurate.
 - [ ] Description motivates each change.
 - [ ] No unnecessary changes were introduced in this PR.
 - [ ] PR cannot be broken up into smaller PRs.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,7 @@
 
 ## Reviewer Checklist
 - [ ] Title is accurate and conforms to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
-- [ ] Description motivates each change.```
-## Reviewer Checklist
+- [ ] Description motivates each change.
 - [ ] No unnecessary changes were introduced in this PR.
 - [ ] PR cannot be broken up into smaller PRs.
 - [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
@@ -15,4 +14,4 @@
 - [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
 - [ ] All relevant GitHub issues are correctly linked.
 - [ ] Add to milestone.
-- [ ] Be kind.
+- [ ] Be kind Kyle.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,5 +13,5 @@
 - [ ] Tests provided or description of manual testing performed is included in the code or PR.
 - [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
 - [ ] All relevant GitHub issues are correctly linked.
+- [ ] Backports are identified and tagged with Mergifyio.
 - [ ] Add to milestone.
-- [ ] Be kind Kyle.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,6 @@
 - [ ] No breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes are introduced.
 - [ ] Tests provided or description of manual testing performed is included in the code or PR.
 - [ ] Release note has been added (if necessary) and is meaningful for users.
-- [ ] All relevant github issues are correctly linked.
+- [ ] All relevant GitHub issues are correctly linked.
 - [ ] Added to the correct milestone.
 - [ ] Be Kind.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,11 +5,11 @@
 - [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
 
 ## Reviewer Checklist
-- [ ] PR title and description are accurate and comprehensive.The description should include motivation for the change, design decisions and concerns.
+- [ ] PR title and description are accurate and comprehensive. The description should include motivation for the change, design decisions and concerns.
 - [ ] PR should be focused. No unnecessary changes were introduced in this PR.
 - [ ] No breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes are introduced.
 - [ ] Tests provided or description of manual testing performed is included in the code or PR.
 - [ ] Release note has been added (if necessary) and is meaningful for users.
 - [ ] All relevant GitHub issues are correctly linked.
 - [ ] Added to the correct milestone.
-- [ ] Be Kind.
+- [ ] Be kind.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,14 +4,15 @@
 - [ ] Library documentation is updated.
 - [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
 
-## Triage Reviewer Checklist
-- [ ] Title and description are accurate and comprehensive. The description should include motivation for the change, design decisions and concerns.
+## Reviewer Checklist
+- [ ] Title is accurate and conforms to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
+- [ ] Description motivates each change.```
 ## Reviewer Checklist
 - [ ] No unnecessary changes were introduced in this PR.
 - [ ] PR cannot be broken up into smaller PRs.
 - [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
 - [ ] Tests provided or description of manual testing performed is included in the code or PR.
-- [ ] Release note has been added for fixes and features.
+- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
 - [ ] All relevant GitHub issues are correctly linked.
 - [ ] Add to milestone.
 - [ ] Be kind.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,15 @@
 <!-- Briefly describe the change and why it was required. -->
 
 ## Checklist
-- [ ] Added to the correct milestone.
-- [ ] Tests provided or description of manual testing performed is included in the code or PR.
 - [ ] Library documentation is updated.
 - [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
+
+## Reviewer Checklist
+- [ ] PR title and description are accurate and comprehensive.The description should include motivation for the change, design decisions and concerns.
+- [ ] PR should be focused. No unnecessary changes were introduced in this PR.
+- [ ] No breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes are introduced.
+- [ ] Tests provided or description of manual testing performed is included in the code or PR.
+- [ ] Release note has been added (if necessary) and is meaningful for users.
+- [ ] All relevant github issues are correctly linked.
+- [ ] Added to the correct milestone.
+- [ ] Be Kind.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,12 +4,14 @@
 - [ ] Library documentation is updated.
 - [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).
 
+## Triage Reviewer Checklist
+- [ ] Title and description are accurate and comprehensive. The description should include motivation for the change, design decisions and concerns.
 ## Reviewer Checklist
-- [ ] PR title and description are accurate and comprehensive. The description should include motivation for the change, design decisions and concerns.
-- [ ] PR should be focused. No unnecessary changes were introduced in this PR.
-- [ ] No breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes are introduced.
+- [ ] No unnecessary changes were introduced in this PR.
+- [ ] PR cannot be broken up into smaller PRs.
+- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
 - [ ] Tests provided or description of manual testing performed is included in the code or PR.
-- [ ] Release note has been added (if necessary) and is meaningful for users.
+- [ ] Release note has been added for fixes and features.
 - [ ] All relevant GitHub issues are correctly linked.
-- [ ] Added to the correct milestone.
+- [ ] Add to milestone.
 - [ ] Be kind.


### PR DESCRIPTION
This change updates the ddtrace pull request template to include action items for reviewers. This is meant to streamline the review process and provide a set of acceptance criteria to contributors.

## Checklist
- [ ] Added to the correct milestone.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).


## Reviewer Checklist
- [x] PR title and description are accurate and comprehensive.The description should include motivation for the change, design decisions and concerns.
- [x] PR should be focused. No unnecessary changes were introduced in this PR.
- [x] No breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes are introduced.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added (if necessary) and is meaningful for users.
- [x] All relevant github issues are correctly linked.
- [x] Added to the correct milestone.
- [x] Be Kind.