### PR TITLE
chore(docs): remove unnecessary release note

### DIFF
--- a/releasenotes/notes/fix-profile-max-event-float-93288688036f669f.yaml
+++ b/releasenotes/notes/fix-profile-max-event-float-93288688036f669f.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    profiling: fix an issue where ``stack_event.StackExceptionSampleEvent`` used a float instead of an int for its max events.


### PR DESCRIPTION
This fix was for something that was not yet released, so no note is necessary