### PR TITLE
fix(ci): use context instead of replacement for PR title

### DIFF
--- a/.github/workflows/pr-name.yml
+++ b/.github/workflows/pr-name.yml
@@ -28,7 +28,7 @@ jobs:
               extends: ['./commitlint.config.js'],
             };
 
-            const title = '${{ github.event.pull_request.title }}';
+            const title = context.payload.pull_request.title;
 
             core.info(`Linting: ${title}`);
 


### PR DESCRIPTION
If the PR title contains a `'` then it'll mess up the script, this is because GitHub Actions does a template replacement on `${{ ... }}` before executing the script. Instead we should use `context.payload` which is the contents of the GitHub Event.