### PR TITLE
ci: pin mypy version to less than 0.960

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -134,7 +134,7 @@ venv = Venv(
             command="mypy {cmdargs}",
             create=True,
             pkgs={
-                "mypy": latest,
+                "mypy": "<0.960",
                 "types-attrs": latest,
                 "types-docutils": latest,
                 "types-protobuf": latest,


### PR DESCRIPTION
With the release of `mypy==0.960` mypy fails with the following error:
```
Traceback (most recent call last):
  File "/home/circleci/project/.riot/venv_py3912_mypy_types-attrs_types-docutils_types-protobuf_types-PyYAML_types-setuptools_types-six_mock_pytest700_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451/bin/mypy", line 10, in <module>
    sys.exit(console_entry())
  File "/home/circleci/project/.riot/venv_py3912_mypy_types-attrs_types-docutils_types-protobuf_types-PyYAML_types-setuptools_types-six_mock_pytest700_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451/lib/python3.9/site-packages/mypy/__main__.py", line 12, in console_entry
    main(None, sys.stdout, sys.stderr)
  File "mypy/main.py", line 96, in main
  File "mypy/main.py", line 173, in run_build
  File "mypy/build.py", line 154, in build
  File "mypy/build.py", line 230, in _build
  File "mypy/build.py", line 2729, in dispatch
  File "mypy/build.py", line 3087, in process_graph
  File "mypy/build.py", line 3179, in process_stale_scc
  File "mypy/semanal_main.py", line 88, in semantic_analysis_for_scc
  File "mypy/semanal_main.py", line 414, in apply_class_plugin_hooks
  File "mypy/semanal_main.py", line 434, in apply_hooks_to_class
  File "mypy/plugins/attrs.py", line 309, in attr_class_maker_callback
  File "mypy/plugins/attrs.py", line 372, in _analyze_class
  File "mypy/plugins/attrs.py", line 498, in _attributes_from_assignment
  File "mypy/plugins/attrs.py", line 594, in _attribute_from_attrib_maker
  File "mypy/semanal.py", line 5450, in anal_type
  File "mypy/types.py", line 765, in accept
  File "mypy/typeanal.py", line 172, in visit_unbound_type
  File "mypy/typeanal.py", line 263, in visit_unbound_type_nonoptional
  File "mypy/typeanal.py", line 1168, in anal_array
  File "mypy/typeanal.py", line 1177, in anal_type
  File "mypy/types.py", line 765, in accept
  File "mypy/typeanal.py", line 172, in visit_unbound_type
  File "mypy/typeanal.py", line 180, in visit_unbound_type_nonoptional
  File "mypy/semanal.py", line 4563, in lookup_qualified
  File "mypy/semanal.py", line 4458, in lookup
  File "mypy/semanal.py", line 4508, in is_active_symbol_in_class_body
AssertionError
```

There's currently an open issue on mypy: https://github.com/python/mypy/issues/12868