### PR TITLE
ci: add benchmark trigger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,9 @@ variables:
   FORCE_TRIGGER:
     value: "false"
     description: "Set to true to override rules in the reliability-env pipeline (e.g. override 'only deploy master')"
+  DOWNSTREAM_MB_BRANCH:
+    value: "python"
+    description: "Run a specific benchmark branch downstream"
     
 .common: &common
   tags: [ "runner:main", "size:large" ]
@@ -24,3 +27,15 @@ deploy_to_reliability_env:
     UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
     FORCE_TRIGGER: $FORCE_TRIGGER
+
+trigger_mb:
+  stage: deploy
+  when: manual
+  trigger:
+    project: DataDog/apm-reliability/relenv-env-checks
+    branch: $DOWNSTREAM_MB_BRANCH
+  variables:
+    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
+    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
+    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
+    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,9 +8,10 @@ variables:
   FORCE_TRIGGER:
     value: "false"
     description: "Set to true to override rules in the reliability-env pipeline (e.g. override 'only deploy master')"
-  DOWNSTREAM_MB_BRANCH:
-    value: "python"
-    description: "Run a specific benchmark branch downstream"
+  DOWNSTREAM_MBP_BRANCH:
+    value: "dd-trace-py"
+    description: "Run a specific relenv-microbenchmarking-platform branch downstream"
+
     
 .common: &common
   tags: [ "runner:main", "size:large" ]
@@ -28,12 +29,12 @@ deploy_to_reliability_env:
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
     FORCE_TRIGGER: $FORCE_TRIGGER
 
-trigger_mb:
+trigger_microbenchmarking_platform:
   stage: deploy
   when: manual
   trigger:
-    project: DataDog/apm-reliability/relenv-env-checks
-    branch: $DOWNSTREAM_MB_BRANCH
+    project: DataDog/apm-reliability/relenv-microbenchmarking-platform
+    branch: $DOWNSTREAM_MBP_BRANCH
   variables:
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME


### PR DESCRIPTION
## Description

Add trigger for running benchmark scenario. The execution of the job will be manual.

## Checklist
- [X] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [X] Add additional sections for `feat` and `fix` pull requests.
- [X] Ensure tests are passing for affected code.
- [X] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation

Run benchmarks in an environment where we can ensure reproducible results.

## Design 

Downstream Gitlab trigger which runs perf scripts for executing benchmark scenarios.

## Testing strategy

Manual execution