### PR TITLE
Pin protobuf to version 3 due to incompatibility with 4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -241,7 +241,7 @@ setup(
         "typing; python_version<'3.5'",
         "packaging>=17.1",
         "protobuf>=3,<3.18; python_version<'3.6'",
-        "protobuf>=3; python_version>='3.6'",
+        "protobuf>=3,<4; python_version>='3.6'",
         "tenacity>=5",
         "attrs>=19.2.0",
         "six>=1.12.0",


### PR DESCRIPTION
Latest release of [protobuf](https://pypi.org/project/protobuf/) breaks profiling with

```
Traceback (most recent call last):
  File "/usr/src/app/main.py", line 619, in <module>
    import ddtrace.profiling.auto  # noqa
  File "/usr/local/lib/python3.9/site-packages/ddtrace/profiling/__init__.py", line 5, in <module>
    from .profiler import Profiler  # noqa:F401
  File "/usr/local/lib/python3.9/site-packages/ddtrace/profiling/profiler.py", line 26, in <module>
    from ddtrace.profiling.exporter import file
  File "/usr/local/lib/python3.9/site-packages/ddtrace/profiling/exporter/file.py", line 6, in <module>
    from ddtrace.profiling.exporter import pprof
  File "ddtrace/profiling/exporter/pprof.pyx", line 33, in init ddtrace.profiling.exporter.pprof
  File "/usr/local/lib/python3.9/site-packages/ddtrace/profiling/exporter/pprof_pb2.py", line 38, in <module>
    _descriptor.FieldDescriptor(
  File "/usr/local/lib/python3.9/site-packages/google/protobuf/descriptor.py", line 560, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

<!-- Briefly describe the change and why it was required. -->

## Checklist
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
