### PR TITLE
fix(internal): make collections safe

### DIFF
--- a/ddtrace/internal/safety.py
+++ b/ddtrace/internal/safety.py
@@ -1,4 +1,5 @@
 from typing import Any
+from typing import Iterator
 from typing import List
 from typing import Optional
 from typing import Set
@@ -7,10 +8,16 @@ from typing import Type
 from typing import Union
 
 from ddtrace.internal.compat import BUILTIN
-from ddtrace.internal.compat import CALLABLE_TYPES
+from ddtrace.internal.compat import PY3
 from ddtrace.internal.utils.attrdict import AttrDict
 from ddtrace.internal.utils.cache import cached
 from ddtrace.vendor import wrapt
+
+
+NoneType = type(None)
+
+if PY3:
+    long = int
 
 
 def _maybe_slots(obj):
@@ -67,14 +74,33 @@ class SafeObjectProxy(wrapt.ObjectProxy):
         # type: (str) -> Any
         return type(self).safe(super(SafeObjectProxy, self).__getattr__(name))
 
+    def __getitem__(self, item):
+        # type: (Any) -> Any
+        return type(self).safe(super(SafeObjectProxy, self).__getitem__(item))
+
+    def __iter__(self):
+        # type: () -> Any
+        return iter(type(self).safe(_) for _ in super(SafeObjectProxy, self).__iter__())
+
+    def items(self):
+        # type: () -> Iterator[Tuple[Any, Any]]
+        return (
+            (type(self).safe(k), type(self).safe(v)) for k, v in super(SafeObjectProxy, self).__getattr__("items")()
+        )
+
+    # Custom object representations might cause side-effects
+    def __str__(self):
+        return object.__repr__(self)
+
+    __repr__ = __str__
+
     @classmethod
     def safe(cls, obj):
         # type: (Any) -> Optional[Any]
         """Turn an object into a safe proxy."""
-        if _isinstance(obj, CALLABLE_TYPES):
-            return cls(obj)
+        _type = type(obj)
 
-        if isinstance(obj, type):
+        if _isinstance(obj, type):
             try:
                 if obj.__module__ == BUILTIN:
                     # We are assuming that builtin types are safe
@@ -83,15 +109,9 @@ class SafeObjectProxy(wrapt.ObjectProxy):
                 # No __module__ attribute. We'll use caution
                 pass
 
-            return cls(obj)
-
-        try:
-            if type(obj).__module__ == BUILTIN:
-                # We are assuming that builtin types are safe
-                return obj
-        except AttributeError:
-            # No __module__ attribute. We'll use caution
-            pass
+        elif _type in {str, int, float, bool, NoneType, bytes, complex, long}:
+            # We are assuming that scalar builtin type instances are safe
+            return obj
 
         try:
             return cls(AttrDict(object.__getattribute__(obj, "__dict__")))
@@ -103,4 +123,5 @@ class SafeObjectProxy(wrapt.ObjectProxy):
             # Handle slots objects
             return cls(AttrDict({k: object.__getattribute__(obj, k) for k in slots}))
 
-        raise TypeError("Unhandled object type: %s", type(obj))
+        # raise TypeError("Unhandled object type: %s", type(obj))
+        return cls(obj)


### PR DESCRIPTION
The current safety implementation treated builtin collection types as safe, thus allowing iteration over their elements, which in general might not be safe. This change ensures that elements retrieved from collections are wrapped by a safe object proxy.

<!-- Briefly describe the change and why it was required. -->

## Checklist
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
