### PR TITLE
chore(asgi): enable scope to hold multiple request spans if needed

### DIFF
--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -70,11 +70,7 @@ def _default_handle_exception_span(exc, span):
 def span_from_scope(scope):
     # type: (Mapping[str, Any]) -> Optional[Span]
     """Retrieve the top-level ASGI span from the scope."""
-    if "request_spans" in scope.get("datadog", {}):
-        try:
-            return scope.get("datadog", {}).get("request_spans")[0]
-        except ValueError:
-            return {}
+    return scope.get("datadog", {}).get("request_spans", [{}])[0]
 
 
 class TraceMiddleware:

--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -70,13 +70,16 @@ def _default_handle_exception_span(exc, span):
 def span_from_scope(scope):
     # type: (Mapping[str, Any]) -> Optional[Span]
     """Retrieve the top-level ASGI span from the scope."""
-    return scope.get("datadog", {}).get("request_span")
+    if "request_spans" in scope.get("datadog", {}):
+        try:
+            return scope.get("datadog", {}).get("request_spans")[0]
+        except ValueError:
+            return {}
 
 
 class TraceMiddleware:
     """
     ASGI application middleware that traces the requests.
-
     Args:
         app: The ASGI application.
         tracer: Custom tracer. Defaults to the global tracer.
@@ -119,7 +122,10 @@ class TraceMiddleware:
             span_type=SpanTypes.WEB,
         )
 
-        scope["datadog"] = {"request_span": span}
+        if "datadog" not in scope:
+            scope["datadog"] = {"request_spans": [span]}
+        else:
+            scope["datadog"]["request_spans"].append(span)
 
         if self.span_modifier:
             self.span_modifier(span, scope)

--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -70,7 +70,7 @@ def _default_handle_exception_span(exc, span):
 def span_from_scope(scope):
     # type: (Mapping[str, Any]) -> Optional[Span]
     """Retrieve the top-level ASGI span from the scope."""
-    return scope.get("datadog", {}).get("request_spans", [{}])[0]
+    return scope.get("datadog", {}).get("request_spans", [None])[0]
 
 
 class TraceMiddleware:

--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -7,6 +7,7 @@ from asgiref.testing import ApplicationCommunicator
 import httpx
 import pytest
 
+from ddtrace import Span
 from ddtrace.contrib.asgi import TraceMiddleware
 from ddtrace.contrib.asgi import span_from_scope
 from ddtrace.propagation import http as http_propagation
@@ -386,6 +387,25 @@ async def test_get_asgi_span(tracer, test_spans):
         async with httpx.AsyncClient(app=app) as client:
             response = await client.get("http://testserver/")
             assert response.status_code == 200
+
+    async def test_app_that_generates_multiple_request_spans(scope, receive, send):
+        message = await receive()
+        if message.get("type") == "http.request":
+            # Put an extra span in the request_spans dict to make sure that span_from_scope() can handle
+            span = Span("extra.span")
+            scope["datadog"]["request_spans"].append(span)
+            assert len(scope["datadog"]["request_spans"]) == 2
+            asgi_span = span_from_scope(scope)
+            assert asgi_span is not None
+            assert asgi_span.name == "asgi.request"
+            assert asgi_span == scope["datadog"]["request_spans"][0]
+            await send({"type": "http.response.start", "status": 200, "headers": [[b"Content-Type", b"text/plain"]]})
+            await send({"type": "http.response.body", "body": b""})
+
+    app = TraceMiddleware(test_app_that_generates_multiple_request_spans, tracer=tracer)
+    async with httpx.AsyncClient(app=app) as client:
+        response = await client.get("http://testserver/")
+        assert response.status_code == 200
 
     async def test_app(scope, receive, send):
         message = await receive()


### PR DESCRIPTION
## Description
This PR to change fastapi and starlette resource naming requires that we add each request span to the scope so that they can be accessed to assign the correct resource name: https://github.com/DataDog/dd-trace-py/pull/3612 

This PR covers the "add each request span to the scope" part.

Asgi applications can call back into themselves to process a "single incoming request", causing multiple request spans to be created. One example of this happening is when starlette or FastAPI applications use sub apps, each additional sub app causes the middleware to be hit again: https://fastapi.tiangolo.com/advanced/sub-applications/

## Testing Strategy
There were already a lot of tests around the function `span_from_scope` to make sure that this change did not affect that behavior. In addition, I added another test where we insert an additional span into `scope["datadog"]["request_spans"]` to make sure `span_from_scope` can still pull out the correct span.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] PR cannot be broken up into smaller PRs.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
