### PR TITLE
ci: fix ddtest on != CircleCI

### DIFF
--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -12,7 +12,24 @@ fi
 # retry docker pull if fails
 for i in {1..3}; do docker-compose pull -q testrunner && break || sleep 3; done
 
+FULL_CMD="pip install -q --disable-pip-version-check riot tox && $CMD"
+
 # install and upgrade tox and riot in case testrunner image has not been updated
-# DEV: Use `--no-TTY` when running in CircleCI
-NO_TTY=$([[ "${CIRCLECI}" = "true" ]] && echo "--no-TTY")
-docker-compose run -e CIRCLE_NODE_TOTAL -e CIRCLE_NODE_INDEX -e DD_TRACE_AGENT_URL "${NO_TTY}" --quiet-pull --rm testrunner bash -c "pip install -q --disable-pip-version-check riot tox && $CMD"
+# DEV: Use `--no-TTY` and `--quiet-pull` when running in CircleCI
+if [[ "${CIRCLECI}" = "true" ]]; then
+    docker-compose run \
+                   -e CIRCLE_NODE_TOTAL \
+                   -e CIRCLE_NODE_INDEX \
+                   -e DD_TRACE_AGENT_URL \
+                   --no-TTY \
+                   --quiet-pull \
+                   --rm \
+                   testrunner \
+                   bash -c "$FULL_CMD"
+else
+    docker-compose run \
+                   -e DD_TRACE_AGENT_URL \
+                   --rm \
+                   testrunner \
+                   bash -c "$FULL_CMD"
+fi


### PR DESCRIPTION
If the script is used on something else than CircleCI, then the test return
`false` and `set -e` makes the script exit with 1, therefore never running
docker-compose.

It would also passe "" as an argument to docker-compose making it fail.

The --quiet-pull does not exist (at least on Docker Desktop) so avoid using it
if not in CircleCI.