### PR TITLE
fix: Remove override of enter method that was preventing the context …

### DIFF
--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -122,15 +122,6 @@ class TracedCursor(wrapt.ObjectProxy):
         self._self_last_execute_operation = proc
         return self._trace_method(self.__wrapped__.callproc, self._self_datadog_name, proc, {}, proc, *args)
 
-    def __enter__(self):
-        # previous versions of the dbapi didn't support context managers. let's
-        # reference the func that would be called to ensure that errors
-        # messages will be the same.
-        self.__wrapped__.__enter__
-
-        # and finally, yield the traced cursor.
-        return self
-
 
 class FetchTracedCursor(TracedCursor):
     """


### PR DESCRIPTION
Related to https://github.com/DataDog/dd-trace-py/issues/3303

While investigating why ddtrace opens too much connections. I've found this piece of code related to the `TracedCursor` that changes the behaviour of the wrapped object since it does not call the parent enter method.

<!-- Briefly describe the change and why it was required. -->

## Checklist
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).

## Reviewer Checklist
- [ X] Title is accurate.
- [ X] Description motivates each change.
- [ X] No unnecessary changes were introduced in this PR.
- [ X] PR cannot be broken up into smaller PRs.
- [X ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.

cc @brettlangdon @Giaco9