### PR TITLE
fix(ci): pin redis version

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -299,7 +299,7 @@ venv = Venv(
             command="pytest {cmdargs} --no-cov tests/commands/test_runner.py",
             pys=select_pys(),
             pkgs={
-                "redis": latest,
+                "redis": "<4.3",  # redis 4.3 drops support for Python 3.6
                 "gevent": latest,
             },
         ),


### PR DESCRIPTION
redis 4.3 has dropped support for Python 3.6. The redis library is
used in the ddtrace-run test suite so it should be pinned.

The latest release of 4.3 [broke the ddtrace-run tests](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/18006/workflows/cb0e0665-7590-4579-b9a6-3776be308f6c/jobs/1224065) due to what I suspect was some kind of connection error.

## Checklist
- [x] Library documentation is updated.
- [x] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
