### PR TITLE
fix: fix install requires python_version constraint for protobuf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -241,7 +241,7 @@ setup(
         "typing; python_version<'3.5'",
         "packaging>=17.1",
         "protobuf>=3; python_version>='3.7'",
-        "protobuf>=3,<4.0; python_version<'3.7'",
+        "protobuf>=3,<4.0; python_version=='3.6'",
         "protobuf>=3,<3.18; python_version<'3.6'",
         "tenacity>=5",
         "attrs>=19.2.0",


### PR DESCRIPTION
When using overlapping `python_version` constraints sometimes the wrong one is chosen and causes installation issues.

In our CI this resulted in:

```
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (protobuf 3.19.4 (/root/project/.riot/venv_py3510/lib/python3.5/site-packages), Requirement.parse('protobuf<3.18,>=3'), {'ddtrace'})
```


## Checklist
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
