### PR TITLE
fix(redis): alias format_command_args

### DIFF
--- a/ddtrace/contrib/redis/util.py
+++ b/ddtrace/contrib/redis/util.py
@@ -12,6 +12,9 @@ from ...ext import redis as redisx
 from ...internal.utils.formats import stringify_cache_args
 
 
+format_command_args = stringify_cache_args
+
+
 def _extract_conn_tags(conn_kwargs):
     """Transform redis conn info into dogtrace metas"""
     try:


### PR DESCRIPTION
#3299 moved a utility function in the redis integration as part of a refactoring. This breaks the library's versioning policy for a minor release. We add back this function as an alias to the new function.

## Checklist
- [ ] Library documentation is updated.
- [ ] [Corp site](https://github.com/DataDog/documentation/) documentation is updated (link to the PR).

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
