### PR TITLE
chore: add stale bot to label inactive issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: 'Label stale issues and PRs'
+on:
+  schedule:
+    # 00:00:000 UTC
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          # Mark issues and PRs as stale after 30 days of no updates
+          days-before-stale: 30
+          # Do not auto-close any issues or PRs
+          days-before-close: -1
+          # Ignore issues and PRs with the following labels
+          exempt-issue-labels: 'feature-request,proposal'
+          exempt-pr-labels: 'feature-request,proposal'


### PR DESCRIPTION
## Description
At 00:00:00 UTC, label any issues and PRs which have had no activity
in the past 30 days with the `Stale` label.

We will not comment on the issues/PR, and we will not auto-close them.

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
