### PR TITLE
chore(ci): increase operations-per-run for stale bot action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
+          # Increase the total API operations from 30 to 200
+          # DEV: GitHub Actions have an API rate limit of 1000 operations per hour per repository
+          #      This limit is shared across all actions
+          operations-per-run: 200
           # Mark issues and PRs as stale after 30 days of no updates
           days-before-stale: 30
           # Do not auto-close any issues or PRs


### PR DESCRIPTION
## Description
We have a lot of issues/PRs, right now stale bot doesn't go very far back for marking things as stale. Increasing the operations per run will help us mark more things from the backlog.

Default is 30, increasing to 200. GitHub Actions have an API rate limit of 1000 operations per hour per repository


## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
