### PR TITLE
chore(debugging): add function store

### DIFF
--- a/ddtrace/debugging/_function/store.py
+++ b/ddtrace/debugging/_function/store.py
@@ -1,0 +1,107 @@
+from types import CodeType
+from types import FunctionType
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import cast
+
+from ddtrace.debugging._function.discovery import FullyNamed
+from ddtrace.internal.injection import HookInfoType
+from ddtrace.internal.injection import HookType
+from ddtrace.internal.injection import eject_hooks
+from ddtrace.internal.injection import inject_hooks
+from ddtrace.internal.wrapping import Wrapper
+from ddtrace.internal.wrapping import WrapperFunction
+from ddtrace.internal.wrapping import unwrap
+from ddtrace.internal.wrapping import wrap
+
+
+WrapperType = Callable[[FunctionType, Any, Any, Any], Any]
+
+
+class FullyNamedWrapperFunction(FullyNamed, WrapperFunction):
+    """A fully named wrapper function."""
+
+
+class FunctionStore(object):
+    """Function object store.
+
+    This class provides a storage layer for patching operations, allowing to
+    store the original code object of functions being patched with either hook
+    injections or wrapping.
+
+    If extra attributes are defined during the patching process, they will get
+    removed when the functions are restored.
+    """
+
+    def __init__(self, extra_attrs=None):
+        # type: (Optional[List[str]]) -> None
+        self._code_map = {}  # type: Dict[FunctionType, CodeType]
+        self._extra_attrs = ["__dd_wrapped__"]
+        if extra_attrs:
+            self._extra_attrs.extend(extra_attrs)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.restore_all()
+
+    def _store(self, function):
+        # type: (FunctionType) -> None
+        if function not in self._code_map:
+            self._code_map[function] = function.__code__
+
+    def inject_hooks(self, function, hooks):
+        # type: (FullyNamedWrapperFunction, List[Tuple[HookType, int, Any]]) -> None
+        """Bulk-inject hooks into a function."""
+        try:
+            self.inject_hooks(cast(FullyNamedWrapperFunction, function.__dd_wrapped__), hooks)
+        except AttributeError:
+            f = cast(FunctionType, function)
+            self._store(f)
+            inject_hooks(f, hooks)
+
+    def eject_hooks(self, function, hooks):
+        # type: (FunctionType, List[HookInfoType]) -> None
+        """Bulk-eject hooks from a function."""
+        try:
+            # f = cast(FullyNamedWrapperFunction, function).__dd_wrapped__
+            self.eject_hooks(cast(FunctionType, cast(FullyNamedWrapperFunction, function).__dd_wrapped__), hooks)
+        except AttributeError:
+            cast(FullyNamedWrapperFunction, eject_hooks(function, hooks))
+
+    def inject_hook(self, function, hook, line, arg):
+        # type: (FullyNamedWrapperFunction, HookType, int, Any) -> None
+        """Inject a hook into a function."""
+        return self.inject_hooks(function, [(hook, line, arg)])
+
+    def eject_hook(self, function, hook, line, arg):
+        # type: (FunctionType, HookType, int, Any) -> None
+        """Eject a hook from a function."""
+        return self.eject_hooks(function, [(hook, line, arg)])
+
+    def wrap(self, function, wrapper):
+        # type: (FunctionType, Wrapper) -> None
+        """Wrap a function with a hook."""
+        self._store(function)
+        wrap(function, wrapper)
+
+    def unwrap(self, function):
+        # type: (FullyNamedWrapperFunction) -> None
+        """Unwrap a hook around a wrapped function."""
+        unwrap(function)
+
+    def restore_all(self):
+        # type: () -> None
+        """Restore all the patched functions to their original form."""
+        for function, code in self._code_map.items():
+            function.__code__ = code
+            for attr in self._extra_attrs:
+                try:
+                    delattr(function, attr)
+                except AttributeError:
+                    pass

--- a/tests/debugging/function/test_store.py
+++ b/tests/debugging/function/test_store.py
@@ -1,0 +1,228 @@
+import sys
+
+import mock
+from mock.mock import call
+import pytest
+from six import PY2
+
+from ddtrace.debugging._function.discovery import FunctionDiscovery
+from ddtrace.debugging._function.store import FunctionStore
+from ddtrace.internal.utils.inspection import linenos
+import tests.submod.stuff as stuff
+
+
+def gen_wrapper(*arg):
+    def _wrapper(wrapped, args, kwargs):
+        # take a snapshot of args and kwargs before they are modified by the
+        # wrapped function
+        try:
+            result = wrapped(*args, **kwargs)
+            # capture the return value
+            mock, v = arg
+            mock(v)
+            return result
+        except Exception:
+            # capture the exception
+            raise
+        finally:
+            # finalise and push the snapshot
+            pass
+
+    return _wrapper
+
+
+def test_function_inject():
+    with FunctionStore() as store:
+        lo = min(linenos(stuff.modulestuff))
+        function = FunctionDiscovery.from_module(stuff).at_line(lo)[0]
+        hook = mock.Mock()()
+
+        store.inject_hook(function, hook, lo, 42)
+        stuff.modulestuff(None)
+        hook.assert_called_once_with(42)
+
+    stuff.modulestuff(None)
+    hook.assert_called_once_with(42)
+
+
+def test_function_wrap():
+    with FunctionStore() as store:
+        function = FunctionDiscovery.from_module(stuff).by_name(stuff.modulestuff.__name__)
+
+        assert function is stuff.modulestuff
+
+        arg = mock.Mock()
+        store.wrap(function, gen_wrapper(arg, 42))
+
+        stuff.modulestuff(None)
+
+        arg.assert_called_once_with(42)
+
+    stuff.modulestuff(None)
+    arg.assert_called_once_with(42)
+
+
+def test_function_inject_wrap():
+    with FunctionStore() as store:
+        # Function retrieval
+        lo = min(linenos(stuff.modulestuff))
+        function = FunctionDiscovery.from_module(stuff).at_line(lo)[0]
+        assert function is FunctionDiscovery.from_module(stuff).by_name(function.__name__)
+        assert function is stuff.modulestuff
+
+        # Injection
+        hook = mock.Mock()()
+        store.inject_hook(function, hook, lo, 42)
+        stuff.modulestuff(None)
+        hook.assert_called_once_with(42)
+
+        # Wrapping
+        arg = mock.Mock()
+        store.wrap(stuff.modulestuff, gen_wrapper(arg, 42))
+        stuff.modulestuff(None)
+        arg.assert_called_once_with(42)
+
+        # Restore
+        store.restore_all()
+        stuff.modulestuff(None)
+        hook.assert_has_calls([call(42), call(42)])
+        arg.assert_called_once_with(42)
+
+
+def test_function_wrap_inject():
+    with FunctionStore() as store:
+        # Function retrieval
+        lo = min(linenos(stuff.modulestuff))
+        function = FunctionDiscovery.from_module(stuff).by_name(stuff.modulestuff.__name__)
+        assert function is FunctionDiscovery.from_module(stuff).at_line(lo)[0]
+
+        # Wrapping
+        arg = mock.Mock()
+        store.wrap(function, gen_wrapper(arg, 42))
+        stuff.modulestuff(None)
+        arg.assert_called_once_with(42)
+
+        # Injection
+        hook = mock.Mock()()
+        store.inject_hook(function, hook, lo, 42)
+        stuff.modulestuff(None)
+        hook.assert_called_once_with(42)
+
+        # Restore
+        store.restore_all()
+        stuff.modulestuff(None)
+        hook.assert_called_once_with(42)
+        arg.assert_has_calls([call(42), call(42)])
+
+
+def test_function_wrap_property():
+    with FunctionStore() as store:
+        function = FunctionDiscovery.from_module(stuff).by_name(
+            ".".join((stuff.Stuff.__name__, stuff.Stuff.propertystuff.fget.__name__, "getter"))
+        )
+
+        assert function is stuff.Stuff.propertystuff.fget
+
+        arg = mock.Mock()
+        store.wrap(function, gen_wrapper(arg, 42))
+
+        s = stuff.Stuff()
+        s.propertystuff
+
+        arg.assert_called_once_with(42)
+
+        store.restore_all()
+        s.propertystuff
+        arg.assert_called_once_with(42)
+
+
+@pytest.mark.xfail(
+    sys.version_info < (3, 6),
+    reason="Support for decorated methods is currently not available for this version of Python",
+)
+def test_function_wrap_decorated():
+    with FunctionStore() as store:
+        function = FunctionDiscovery.from_module(stuff).by_name(
+            ".".join((stuff.Stuff.__name__, stuff.Stuff.doublydecoratedstuff.__name__))
+        )
+
+        if PY2:
+            assert function.__code__ is stuff.Stuff.doublydecoratedstuff.__func__.__code__
+        else:
+            assert function is stuff.Stuff.doublydecoratedstuff
+
+        arg = mock.Mock()
+        store.wrap(function, gen_wrapper(arg, 42))
+
+        s = stuff.Stuff()
+        s.doublydecoratedstuff()
+
+        arg.assert_called_once_with(42)
+
+        store.restore_all()
+        s.doublydecoratedstuff()
+        arg.assert_called_once_with(42)
+
+
+def test_function_unwrap():
+    with FunctionStore() as store:
+        function = FunctionDiscovery.from_module(stuff).by_name(stuff.modulestuff.__name__)
+        assert function is stuff.modulestuff
+        code = function.__code__
+
+        store.wrap(function, gen_wrapper(None, 42))
+        assert code is not stuff.modulestuff.__code__
+
+        store.unwrap(stuff.modulestuff)
+        assert code is stuff.modulestuff.__code__
+
+
+def test_function_inject_wrap_commutativity():
+    with FunctionStore() as store:
+        code = stuff.modulestuff.__code__
+
+        # Injection
+        lo = min(linenos(stuff.modulestuff))
+        function = FunctionDiscovery.from_module(stuff).at_line(lo)[0]
+        hook = mock.Mock()()
+        store.inject_hook(function, hook, lo, 42)
+
+        # Wrapping
+        function = FunctionDiscovery.from_module(stuff).by_name(stuff.modulestuff.__name__)
+        assert function.__code__ is stuff.modulestuff.__code__
+        store.wrap(function, gen_wrapper(None, 42))
+        assert code is not stuff.modulestuff.__code__
+
+        # Ejection
+        assert stuff.modulestuff.__code__ is not code
+        store.eject_hook(stuff.modulestuff, hook, lo, 42)
+
+        # Unwrapping
+        store.unwrap(stuff.modulestuff)
+
+        assert stuff.modulestuff.__code__ is not code and stuff.modulestuff.__code__ == code
+
+
+def test_function_wrap_inject_commutativity():
+    with FunctionStore() as store:
+        # Wrapping
+        function = FunctionDiscovery.from_module(stuff).by_name(stuff.modulestuff.__name__)
+        assert function is stuff.modulestuff
+        code = function.__code__
+        store.wrap(function, gen_wrapper(None, 42))
+        assert code is not stuff.modulestuff.__code__
+
+        # Injection
+        lo = min(linenos(stuff.modulestuff.__dd_wrapped__))
+        function = FunctionDiscovery.from_module(stuff).at_line(lo)[0]
+        hook = mock.Mock()()
+        store.inject_hook(function, hook, lo, 42)
+
+        # Unwrapping
+        store.unwrap(stuff.modulestuff)
+
+        # Ejection
+        assert stuff.modulestuff.__code__ is not code
+        store.eject_hook(stuff.modulestuff, hook, lo, 42)
+
+        assert stuff.modulestuff.__code__ is not code and stuff.modulestuff.__code__ == code


### PR DESCRIPTION
## Description

The function store is an interface around injections and wrapping that allows storing original function code objects so that they can be restored to their original value.

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
