### PR TITLE
fix(starlette/fastapi): add back `aggregate_resources` feature

### DIFF
--- a/ddtrace/contrib/starlette/patch.py
+++ b/ddtrace/contrib/starlette/patch.py
@@ -98,6 +98,7 @@ def traced_handler(wrapped, instance, args, kwargs):
         deprecate(
             "ddtrace.contrib.starlette.patch",
             message="`aggregate_resources` is deprecated and will be removed in tracer version 2.0.0",
+            category=DDTraceDeprecationWarning,
         )
 
         return wrapped(*args, **kwargs)

--- a/ddtrace/contrib/starlette/patch.py
+++ b/ddtrace/contrib/starlette/patch.py
@@ -12,6 +12,7 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.span import Span
+from ddtrace.vendor.debtcollector import deprecate
 from ddtrace.vendor.wrapt import ObjectProxy
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
@@ -69,6 +70,14 @@ def unpatch():
 
 
 def traced_handler(wrapped, instance, args, kwargs):
+    if config.starlette.get("aggregate_resources") != True or not config.fastapi.get("aggregate_resources") != True:
+        deprecate(
+            "ddtrace.contrib.starlette.patch",
+            message="`aggregate_resources` is deprecated and will be removed in tracer version 2.0.0",
+        )
+
+        return wrapped(*args, **kwargs)
+
     # Since handle can be called multiple times for one request, we take the path of each instance
     # Then combine them at the end to get the correct resource names
     scope = get_argument_value(args, kwargs, 0, "scope")  # type: Optional[Dict[str, Any]]

--- a/ddtrace/contrib/starlette/patch.py
+++ b/ddtrace/contrib/starlette/patch.py
@@ -70,7 +70,7 @@ def unpatch():
 
 
 def traced_handler(wrapped, instance, args, kwargs):
-    if config.starlette.get("aggregate_resources") != True or not config.fastapi.get("aggregate_resources") != True:
+    if config.starlette.get("aggregate_resources") is False or config.fastapi.get("aggregate_resources") is False:
         deprecate(
             "ddtrace.contrib.starlette.patch",
             message="`aggregate_resources` is deprecated and will be removed in tracer version 2.0.0",

--- a/releasenotes/notes/add-back-starlette-fastapi-aggregate-resources-21855734c8b45d45.yaml
+++ b/releasenotes/notes/add-back-starlette-fastapi-aggregate-resources-21855734c8b45d45.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    starlette: Add back removed ``aggregate_resources`` feature.
+  - |
+    fastapi: Add back removed ``aggregate_resources`` feature.

--- a/tests/contrib/fastapi/test_fastapi.py
+++ b/tests/contrib/fastapi/test_fastapi.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 import ddtrace
+from ddtrace import config
 from ddtrace.contrib.fastapi import patch as fastapi_patch
 from ddtrace.contrib.fastapi import unpatch as fastapi_unpatch
 from ddtrace.contrib.starlette.patch import patch as patch_starlette
@@ -518,6 +519,14 @@ def test_w_patch_starlette(client, tracer, test_spans):
 def test_subapp_snapshot(snapshot_client):
     response = snapshot_client.get("/sub-app/hello/name")
     assert response.status_code == 200
+
+
+@snapshot()
+def test_subapp_no_aggregate_snapshot(snapshot_client):
+    config.fastapi["aggregate_resources"] = False
+    response = snapshot_client.get("/sub-app/hello/name")
+    assert response.status_code == 200
+    config.fastapi["aggregate_resources"] = True
 
 
 @snapshot(token_override="tests.contrib.fastapi.test_fastapi.test_subapp_snapshot")

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -343,7 +343,7 @@ def test_path_param_no_aggregate(client, tracer, test_spans):
     request_span = next(test_spans.filter_spans(name="starlette.request"))
     assert request_span.service == "starlette"
     assert request_span.name == "starlette.request"
-    assert request_span.resource == "GET /users/{userid:int}"
+    assert request_span.resource == "GET /users/1"
     assert request_span.error == 0
     assert request_span.get_tag("http.method") == "GET"
     assert request_span.get_tag("http.url") == "http://testserver/users/1"
@@ -401,6 +401,15 @@ def test_subapp_snapshot(snapshot_client):
     response = snapshot_client.get("/sub-app/hello/name")
     assert response.status_code == 200
     assert response.text == "Success"
+
+
+@snapshot()
+def test_subapp_no_aggregate_snapshot(snapshot_client):
+    config.starlette["aggregate_resources"] = False
+    response = snapshot_client.get("/sub-app/hello/name")
+    assert response.status_code == 200
+    assert response.text == "Success"
+    config.starlette["aggregate_resources"] = True
 
 
 @snapshot()

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_no_aggregate_snapshot.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_no_aggregate_snapshot.json
@@ -1,0 +1,53 @@
+[[
+  {
+    "name": "fastapi.request",
+    "service": "fastapi",
+    "resource": "GET /sub-app/hello/name",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "meta": {
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.url": "http://testserver/sub-app/hello/name",
+      "http.version": "1.1",
+      "runtime-id": "d50032509ff546a097099afbd5c5f19d"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 63299
+    },
+    "duration": 828000,
+    "start": 1655940415124654000
+  },
+     {
+       "name": "fastapi.request",
+       "service": "fastapi",
+       "resource": "GET /hello/name",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "web",
+       "meta": {
+         "http.method": "GET",
+         "http.status_code": "200",
+         "http.url": "http://testserver/sub-app/hello/name",
+         "http.version": "1.1"
+       },
+       "duration": 540000,
+       "start": 1655940415124952000
+     },
+        {
+          "name": "fastapi.serialize_response",
+          "service": "fastapi",
+          "resource": "fastapi.serialize_response",
+          "trace_id": 0,
+          "span_id": 3,
+          "parent_id": 2,
+          "duration": 34000,
+          "start": 1655940415125284000
+        }]]

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_no_aggregate_snapshot.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_no_aggregate_snapshot.json
@@ -1,0 +1,43 @@
+[[
+  {
+    "name": "starlette.request",
+    "service": "starlette",
+    "resource": "GET /sub-app/hello/name",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "meta": {
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.url": "http://testserver/sub-app/hello/name",
+      "http.version": "1.1",
+      "runtime-id": "b09fdf648040415eafff0458ac0bdff7"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 46438
+    },
+    "duration": 405000,
+    "start": 1655933684228033000
+  },
+     {
+       "name": "starlette.request",
+       "service": "starlette",
+       "resource": "GET /hello/name",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "web",
+       "meta": {
+         "http.method": "GET",
+         "http.status_code": "200",
+         "http.url": "http://testserver/sub-app/hello/name",
+         "http.version": "1.1"
+       },
+       "duration": 185000,
+       "start": 1655933684228270000
+     }]]


### PR DESCRIPTION
## Description
`aggregate_resources` was removed by https://github.com/DataDog/dd-trace-py/pull/3612 which breaks our public interface contract.

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.



## Testing strategy
Added tests to Fastapi and Starlette as well as recorrected the test that was supposed to test this feature.



## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
