### PR TITLE
fix(docs): also consider tag refs for identifying docs version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -511,25 +511,45 @@ class DDTraceReleaseNotesDirective(rst.Directive):
         """Return a list of refs for the given commit sha"""
         return [ref for ref in self._repo.refs.keys() if self._repo.refs[ref] == commit_sha]
 
-    def _get_report_max_version(self):
-        # type: () -> Optional[Version]
-        """Determine the max cutoff version to report for HEAD"""
-        for entry in self._repo.get_walker():
+    def _get_report_max_version(self, max_commits=50):
+        # type: (int) -> Optional[Version]
+        """Determine the max cutoff version to report for HEAD
+
+        :param max_commits: Max number of commits to traverse looking for the latest origin/tag ref
+        """
+        for i, entry in enumerate(self._repo.get_walker()):
+            # If we have reached the max number of commits we want to look at without finding anything, return
+            # DEV: We should be able to find a proper ref within the first few, but if we do not then
+            #      it is better to return `None` and generate the notes for all versions, than to keep going backwards
+            #      looking for any ref that matches
+            if i >= max_commits:
+                return None
+
             refs = self._get_commit_refs(entry.commit.id)
             if not refs:
                 continue
 
-            for ref in refs:
-                if not ref.startswith(b"refs/remotes/origin/"):
-                    continue
+            origins = [ref[20:].decode() for ref in refs if ref.startswith(b"refs/remotes/origin/")]  # type: list[str]
+            tags = [Version(ref[10:].decode()) for ref in refs if ref.startswith(b"refs/tags/v")]  # type: list[Version]
 
-                ref_str = ref[20:].decode()
-                if self._release_branch_pattern.match(ref_str):
-                    v = Version(ref_str)
-                    return Version("{}.{}".format(v.major, v.minor + 1))
-                elif self._dev_branch_pattern.match(ref_str):
-                    major, _, _ = ref_str.partition(".")
-                    return Version("{}.0.0".format(int(major) + 1))
+            versions = set()  # set[Version]
+
+            # For release branches we want to set the max to the next minor, e.g. 1.2 -> 1.3.0
+            # For dev branches we want to set the max to the next major, e.g. 1.x -> 2.0.0
+            for origin in origins:
+                if self._release_branch_pattern.match(origin):
+                    v = Version(origin)
+                    versions.add(Version("{}.{}".format(v.major, v.minor + 1)))
+                elif self._dev_branch_pattern.match(origin):
+                    major, _, _ = origin.partition(".")
+                    versions.add(Version("{}.0.0".format(int(major) + 1)))
+
+            # For all tags we want to set the max to the next minor, e.g. v1.2.0rc3 -> 1.3.0, v1.2.1 -> 1.3.0
+            for tag in tags:
+                versions.add(Version("{}.{}.0".format(tag.major, tag.minor + 1)))
+
+            if versions:
+                return max(versions)
         return None
 
     def run(self):


### PR DESCRIPTION
## Description

Since we created the v1.2.0 tag on a commit that wasn't the HEAD of the 1.2 branch
we were never able to find a refs/remote/origin/1.2 associated with the commmit.
This caused us to keep going back in the history until we grabbed v0.27 as the max version,
which is too old for automated release notes, and we ended up with empty release notes.

With this change, we will consider refs/tags/vx.y.z[rc#] as well refs/remote/origin/
when looking for the current version to determine what versions to generate notes for.

As before, for dev branches (1.x) we will use the next major as the cutoff. For release branches
(1.2) or any tags (v1.2.0, v1.2.1rc1, etc) we will use the next minor version.


## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Relevant issue(s)

Fixes #3820

## Testing strategy
I have verified that running this locally properly generates the correct release notes for the `v1.2.0` tag.

From read the docs logs:

```
reading sources... [ 73%] release_notes
capping max report version to <Version('0.27')>
skipping 1.2 >= 0.27
skipping 1.1 >= 0.27
skipping 1.0 >= 0.27
```

Locally:

```
capping max report version to <Version('1.3.0')>
scanning /Users/brett.langdon/datadog/dd-trace-py/releasenotes/notes for origin/1.2 release notes, stopping at v1.2.0
unable to find release notes file associated with unique id '93288688036f669f', skipping
unable to find release notes file associated with unique id '59eedcbbcf065204', skipping
got versions ['v1.2.1rc1', 'v1.2.0']
scanning /Users/brett.langdon/datadog/dd-trace-py/releasenotes/notes for origin/1.1 release notes, stopping at v1.1.0
unable to find release notes file associated with unique id '59eedcbbcf065204', skipping
got versions ['v1.1.4', 'v1.1.3', 'v1.1.2', 'v1.1.1', 'v1.1.0']
```

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
