### PR TITLE
fix(internal): fix exception raised for invalid trace tag length

### DIFF
--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -200,7 +200,7 @@ class Config(object):
                 (
                     "Invalid value {!r} provided for DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH, "
                     "only non-negative values less than or equal to 512 allowed"
-                ).format(self._propagation_datadog_tags_max_length)
+                ).format(x_datadog_tags_max_length)
             )
         self._x_datadog_tags_max_length = x_datadog_tags_max_length
         self._x_datadog_tags_enabled = x_datadog_tags_max_length > 0

--- a/releasenotes/notes/fix-trace-tag-config-e1bc9c83f066eb51.yaml
+++ b/releasenotes/notes/fix-trace-tag-config-e1bc9c83f066eb51.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    internal: fix exception raised for invalid values of ``DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH``.


### PR DESCRIPTION
## Description

Fix a typo in the exception message when an invalid value is provided for `DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH`.

The existing test case did not check the message. Once the test was updated, it fails with the following:

```
>               assert expected[1] in exc.value.args[0]
E               AssertionError: assert 'Invalid value 513' in 'Invalid value ddtrace.settings.integration.IntegrationConfig(analytics_enabled, analytics_sample_rate, service, service_name) provided for DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH, only non-negative values less than
 or equal to 512 allowed'
```

## Checklist
- [X] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [X] Add additional sections for `feat` and `fix` pull requests.
- [x] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Testing strategy

Test cases updated.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
