### PR TITLE
test(profiling): disable test_fork on Python 2

### DIFF
--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -1,8 +1,10 @@
+# -*- encoding: utf-8 -*-
 import multiprocessing
 import os
 import sys
 
 import pytest
+import six
 
 from tests.utils import call_program
 
@@ -45,6 +47,7 @@ def test_call_script_pprof_output(tmp_path, monkeypatch):
     return filename, pid
 
 
+@pytest.mark.skipif(six.PY2, reason="This test deadlocks randomly on Python 2")
 def test_fork(tmp_path, monkeypatch):
     filename = str(tmp_path / "pprof")
     monkeypatch.setenv("DD_PROFILING_API_TIMEOUT", "0.1")


### PR DESCRIPTION
This test often fails and deadlocks, but only in Python 2 as far as we've seen.
Since this might likely be a bug and a race condition in Python 2, let's
disable it there altogether.