### PR TITLE
fix(aiomysql): fix AttributeError: __aenter__ when using cursor as a context manager

### DIFF
--- a/releasenotes/notes/fix-aiomysql-async-with-usage-ac6510f48ed0e6fe.yaml
+++ b/releasenotes/notes/fix-aiomysql-async-with-usage-ac6510f48ed0e6fe.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    aiomysql: fix ``AttributeError: __aenter__`` when using cursors as context managers.

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_async_with_usage.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_async_with_usage.json
@@ -1,0 +1,30 @@
+[[
+  {
+    "name": "mysql.query",
+    "service": null,
+    "resource": "SELECT 1",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "meta": {
+      "db.name": "test",
+      "db.user": "test",
+      "out.host": "127.0.0.1",
+      "runtime-id": "f09816a4d96c4c51abaf8769c10b0a7a",
+      "sql.query": "SELECT 1"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "db.rowcount": 1,
+      "db.rownumber": 0,
+      "out.port": 3306,
+      "system.pid": 89502
+    },
+    "duration": 1370000,
+    "start": 1656453688953207000
+  }]]


### PR DESCRIPTION
## Description
The implementation of [Connection.cursor](https://github.com/aio-libs/aiomysql/blob/8a32f052a16dc3886af54b98f4d91d95862bfb8e/aiomysql/connection.py#L431-L461) is a sync function that returns a context manager around a coroutine. Our integration changed the `def cursor()` function into an `async def cursor():` function. This causes issues when using `async with conn.cursor():` as the result of our wrapped function would be a coroutine and not an async friendly context manager.

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Relevant issue(s)

Fixes #3877 

## Testing strategy

Tests added for different async/await/async with usage for aiomysql. All of them share the same snapshot file since the resulting span should be the same no matter what.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] PR cannot be broken up into smaller PRs.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
