### PR TITLE
fix(flask-caching): support v2.0

### DIFF
--- a/ddtrace/contrib/flask_cache/utils.py
+++ b/ddtrace/contrib/flask_cache/utils.py
@@ -17,14 +17,19 @@ def _resource_from_cache_prefix(resource, cache):
     return name.lower()
 
 
-def _extract_client(cache, write=False):
+def _extract_client(cache):
     """
     Get the client from the cache instance according to the current operation
     """
     client = getattr(cache, "_client", None)
     if client is None:
         # flask-caching has _read_clients & _write_client for the redis backend
-        client = getattr(cache, "_write_client" if write else "_read_clients", None)
+        # These use the same connection so just try to get a reference to one of them.
+        # flask-caching < 2.0.0 uses _read_clients so look for that one too.
+        for attr in ("_write_client", "_read_client", "_read_clients"):
+            client = getattr(cache, attr, None)
+            if client is not None:
+                break
     return client
 
 

--- a/releasenotes/notes/flask_caching-dc23b94171041b4f.yaml
+++ b/releasenotes/notes/flask_caching-dc23b94171041b4f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    flask_caching: fix redis tagging after the v2.0 release.

--- a/riotfile.py
+++ b/riotfile.py
@@ -897,7 +897,7 @@ venv = Venv(
                     pys=select_pys(min_version="3"),
                     pkgs={
                         "flask": ["~=1.0.0", "~=1.1.0", latest],
-                        "flask-caching": ["~=1.10.0", "<2.0.0"],
+                        "flask-caching": ["~=1.10.0", latest],
                         # https://github.com/pallets/itsdangerous/issues/290
                         # DEV: Breaking change made in 2.0 release
                         "itsdangerous": "<2.0",
@@ -910,7 +910,7 @@ venv = Venv(
                     pys=select_pys(min_version="3"),
                     pkgs={
                         "flask": [latest],
-                        "flask-caching": ["~=1.10.0", "<2.0.0"],
+                        "flask-caching": ["~=1.10.0", latest],
                     },
                 ),
             ],

--- a/riotfile.py
+++ b/riotfile.py
@@ -897,7 +897,7 @@ venv = Venv(
                     pys=select_pys(min_version="3"),
                     pkgs={
                         "flask": ["~=1.0.0", "~=1.1.0", latest],
-                        "flask-caching": ["~=1.10.0", latest],
+                        "flask-caching": ["~=1.10.0", "<2.0.0"],
                         # https://github.com/pallets/itsdangerous/issues/290
                         # DEV: Breaking change made in 2.0 release
                         "itsdangerous": "<2.0",
@@ -910,7 +910,7 @@ venv = Venv(
                     pys=select_pys(min_version="3"),
                     pkgs={
                         "flask": [latest],
-                        "flask-caching": ["~=1.10.0", latest],
+                        "flask-caching": ["~=1.10.0", "<2.0.0"],
                     },
                 ),
             ],


### PR DESCRIPTION
## Description

flask-caching released version 2.0 which moves the cache client to a new library
called [`cachelib`](https://github.com/pallets-eco/cachelib).

Diff here: https://github.com/pallets-eco/flask-caching/compare/v1.10.0...v2.0.0

This breaks our logic which collects tags for the redis client.

## Fix

It was noticed that both `_write_client` and `_read_client` use the same connection information
so we don't need to dynamically check for each.

Also [`_read_clients`](https://github.com/pallets-eco/flask-caching/blob/ac13e01baa11d65c68dcba64f99ccaafd9b5419c/src/flask_caching/backends/rediscache.py#L62) was moved to [`_read_client`](https://github.com/pallets-eco/cachelib/blob/13c8bf8db156dd06154f5e08e23bdd9e73480a5b/src/cachelib/redis.py#L29) when the logic was moved to `cachelib`.

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] PR cannot be broken up into smaller PRs.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
