### PR TITLE
chore(ci): install official MariaDB C headers in dev image

### DIFF
--- a/docker/Dockerfile.buster
+++ b/docker/Dockerfile.buster
@@ -33,8 +33,6 @@ RUN \
       libenchant-dev \
       libffi-dev \
       liblzma-dev \
-      libmariadb-dev \
-      libmariadb-dev-compat \
       libmemcached-dev \
       libmemcached-dev \
       libncurses5-dev \
@@ -51,7 +49,12 @@ RUN \
       unixodbc-dev \
       wget \
       zlib1g-dev \
-  && apt-get install -y --no-install-recommends libmariadb3 \
+  # Install Mariadb
+  && wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup \
+  && chmod +x mariadb_repo_setup \
+  && ./mariadb_repo_setup \
+  && apt-get install -y --no-install-recommends libmariadb-dev libmariadb-dev-compat \
+  && rm mariadb_repo_setup \
   # Cleaning up apt cache space
   && rm -rf /var/lib/apt/lists/* \
   # Install pyenv


### PR DESCRIPTION
## Description
The latest version of `mariadb` client library requires a newer version of the C library in order to build.

This PR updated our development docker image to install latest MariaDB C connector headers

#3883 is a follow-up PR to update the snapshot files / fix the MariaDB tests.

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] PR cannot be broken up into smaller PRs.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
- [x] Add to milestone.
