### PR TITLE
fix(sanic/tests): replace usage of response.stream

### DIFF
--- a/tests/contrib/sanic/test_sanic.py
+++ b/tests/contrib/sanic/test_sanic.py
@@ -9,7 +9,6 @@ from sanic.config import DEFAULT_CONFIG
 from sanic.exceptions import InvalidUsage
 from sanic.exceptions import ServerError
 from sanic.response import json
-from sanic.response import stream
 from sanic.response import text
 from sanic.server import HttpProtocol
 
@@ -26,6 +25,18 @@ from tests.utils import override_http_config
 # Helpers for handling response objects across sanic versions
 
 sanic_version = tuple(map(int, sanic_version.split(".")))
+
+
+try:
+    from sanic.response import ResponseStream
+
+    def stream(*args, **kwargs):
+        return ResponseStream(*args, **kwargs)
+
+
+except ImportError:
+    # stream was removed in sanic v22.6.0
+    from sanic.response import stream
 
 
 def _response_status(response):


### PR DESCRIPTION


## Description
This function was removed in sanic [v22.6.0](https://github.com/sanic-org/sanic/pull/2487).

We can just use ResponseStream directly.
## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->
## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] PR cannot be broken up into smaller PRs.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
