### PR TITLE
feat: :adhesive_bandage: run linux/amd64 containers on M1 Macs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ version: "3"
 services:
     elasticsearch:
         image: elasticsearch:2.4-alpine
+        platform: linux/amd64
         ports:
             - "127.0.0.1:9200:9200"
     cassandra:
@@ -36,6 +37,7 @@ services:
             - "127.0.0.1:3306:3306"
     mysql:
         image: mysql:5.7
+        platform: linux/amd64
         environment:
             - MYSQL_ROOT_PASSWORD=admin
             - MYSQL_PASSWORD=test


### PR DESCRIPTION
## Description
Allow docker-compose to work seamlessly on M1 Macs for containers where arm64 images don't exist.

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Motivation
Allow the same containers to be run on amd64 and arm64 platforms for testing purposes.

## Design 
The alternative would be to find other images that have amd64 and arm64 support, but they would be different than current ones.

## Testing strategy
- [x] Test that this change enables running the containers on arm64 platforms
- [x] Test that this change has no impact on amd64 platforms

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] PR cannot be broken up into smaller PRs.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
