### PR TITLE
chore(debugging): add logs uploader

### DIFF
--- a/ddtrace/debugging/_config.py
+++ b/ddtrace/debugging/_config.py
@@ -19,6 +19,8 @@ DEFAULT_PROBE_API_URL = DEFAULT_SNAPSHOT_INTAKE_URL = get_trace_url()
 DEFAULT_MAX_PROBES = 100
 DEFAULT_METRICS = True
 DEFAULT_GLOBAL_RATE_LIMIT = 100.0
+DEFAULT_UPLOAD_TIMEOUT = 30  # seconds
+DEFAULT_UPLOAD_FLUSH_INTERVAL = 1.0  # seconds
 
 
 class DebuggerConfig(object):
@@ -30,6 +32,8 @@ class DebuggerConfig(object):
     max_probes = DEFAULT_MAX_PROBES
     metrics = DEFAULT_METRICS
     global_rate_limit = DEFAULT_GLOBAL_RATE_LIMIT
+    upload_timeout = DEFAULT_UPLOAD_TIMEOUT
+    upload_flush_interval = DEFAULT_UPLOAD_FLUSH_INTERVAL
     tags = None  # type: Optional[str]
     _tags = {}  # type: Dict[str, str]
     _tags_in_qs = True
@@ -45,6 +49,10 @@ class DebuggerConfig(object):
             self._snapshot_intake_endpoint = "/debugger" + self._snapshot_intake_endpoint
 
         self.probe_api_url = os.getenv("DD_DEBUGGER_PROBE_API_URL", DEFAULT_PROBE_API_URL)
+        self.upload_timeout = int(os.getenv("DD_DEBUGGER_UPLOAD_TIMEOUT", DEFAULT_UPLOAD_TIMEOUT))
+        self.upload_flush_interval = float(
+            os.getenv("DD_DEBUGGER_UPLOAD_FLUSH_INTERVAL", DEFAULT_UPLOAD_FLUSH_INTERVAL)
+        )
 
         self._tags["env"] = tracer_config.env
         self._tags["version"] = tracer_config.version

--- a/ddtrace/debugging/_uploader.py
+++ b/ddtrace/debugging/_uploader.py
@@ -1,0 +1,89 @@
+import tenacity
+
+from ddtrace.debugging._config import config
+from ddtrace.debugging._encoding import BufferedEncoder
+from ddtrace.debugging._metrics import metrics
+from ddtrace.internal import compat
+from ddtrace.internal.logger import get_logger
+from ddtrace.internal.periodic import AwakeablePeriodicService
+from ddtrace.internal.utils.http import connector
+
+
+log = get_logger(__name__)
+meter = metrics.get_meter("snapshot.uploader")
+
+
+class LogsIntakeUploader(AwakeablePeriodicService):
+    ENDPOINT = config._snapshot_intake_endpoint
+
+    RETRY_ATTEMPTS = 3
+
+    def __init__(self, api_key, encoder, interval=1.0):
+        # type: (str, BufferedEncoder, float) -> None
+        super(LogsIntakeUploader, self).__init__(interval or config.upload_flush_interval)
+        self._api_key = api_key
+        self._encoder = encoder
+        self._headers = {
+            "Content-type": "application/json; charset=utf-8",
+            "Accept": "text/plain",
+            "DD-API-KEY": api_key,
+        }
+        if config._tags_in_qs and config.tags:
+            self.ENDPOINT += "?ddtags=" + config.tags
+        self._connect = connector(config.snapshot_intake_url, timeout=config.upload_timeout)
+        self._retry_upload = tenacity.Retrying(
+            # Retry RETRY_ATTEMPTS times within the first half of the processing
+            # interval, using a Fibonacci policy with jitter
+            wait=tenacity.wait_random_exponential(
+                multiplier=0.618 * self.interval / (1.618 ** self.RETRY_ATTEMPTS) / 2, exp_base=1.618
+            ),
+            stop=tenacity.stop_after_attempt(self.RETRY_ATTEMPTS),
+        )
+
+        log.debug(
+            "Logs intake uploader initialized (url: %s, endpoint: %s, interval: %f)",
+            config.snapshot_intake_url,
+            self.ENDPOINT,
+            self.interval,
+        )
+
+    def _write(self, payload):
+        # type: (str) -> None
+        try:
+            with self._connect() as conn:
+                conn.request(
+                    "POST",
+                    self.ENDPOINT,
+                    payload,
+                    headers=self._headers,
+                )
+                resp = compat.get_connection_response(conn)
+                if resp.status != 200:
+                    log.error("Failed to upload snapshot: [%d] %r", resp.status, resp.read())
+                    meter.increment("upload.error", tags={"status": str(resp.status)})
+                else:
+                    meter.increment("upload.success")
+                    meter.distribution("upload.size", len(payload))
+                    log.debug("Snapshot uploaded: %s", payload)
+        except Exception:
+            log.error("Failed to write payload", exc_info=True)
+            meter.increment("error")
+
+    def upload(self):
+        # type: () -> None
+        """Upload request."""
+        self.awake()
+
+    def periodic(self):
+        # type: () -> None
+        """Upload the buffer content to the logs intake."""
+        count = self._encoder.count
+        if count:
+            payload = self._encoder.encode()
+            try:
+                self._retry_upload(self._write, payload)
+                meter.distribution("batch.cardinality", count)
+            except Exception:
+                log.debug("Cannot write to sink", exc_info=True)
+
+    on_shutdown = periodic

--- a/tests/debugging/test_uploader.py
+++ b/tests/debugging/test_uploader.py
@@ -1,0 +1,61 @@
+import json
+from time import sleep
+
+import pytest
+
+from ddtrace.debugging._encoding import BatchJsonEncoder
+from ddtrace.debugging._encoding import BufferFull
+from ddtrace.debugging._uploader import LogsIntakeUploader
+
+
+class MockLogsIntakeUploader(LogsIntakeUploader):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("interval", 0.1)
+        super(MockLogsIntakeUploader, self).__init__(*args, **kwargs)
+        self.queue = []
+
+    def _write(self, payload):
+        self.queue.append(payload.decode())
+
+    @property
+    def payloads(self):
+        return [json.loads(data) for data in self.queue]
+
+
+class ActiveBatchJsonEncoder(MockLogsIntakeUploader):
+    def __init__(self, size=1 << 10, interval=0.1):
+        super(ActiveBatchJsonEncoder, self).__init__(
+            None, BatchJsonEncoder({str: str}, size, self.on_full), interval=interval
+        )
+
+    def on_full(self, item, encoded):
+        self.upload()
+
+
+def test_uploader_batching():
+    with ActiveBatchJsonEncoder() as uploader:
+        for _ in range(5):
+            uploader._encoder.put("hello")
+            uploader._encoder.put("world")
+            sleep(0.11)
+        assert uploader.queue == ["[hello,world]"] * 5
+
+
+def test_uploader_full_buffer():
+    size = 1 << 8
+    with ActiveBatchJsonEncoder(size=size) as uploader:
+        item = "hello" * 10
+        n = size // len(item)
+        assert n
+        for _ in range(n):
+            uploader._encoder.put(item)
+
+        with pytest.raises(BufferFull):
+            uploader._encoder.put(item)
+
+        # The full buffer forces a flush
+        sleep(0.01)
+        assert len(uploader.queue) == 1
+
+        sleep(0.15)
+        assert len(uploader.queue) == 1


### PR DESCRIPTION
## Description

This change adds the uploader service thread that is responsible for
flushing the logs message queue to the agent. We use an awakeable
service to ensure that we can manually trigger a flush when the queue is
full, and on regular time intervals.

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
