### PR TITLE
chore(ci): pin mariadb container to 10.7 image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         ports:
             - "127.0.0.1:5432:5432"
     mariadb:
-        image: mariadb
+        image: mariadb:10.7
         environment:
             - MYSQL_ROOT_PASSWORD=example
             - MYSQL_DATABASE=test


### PR DESCRIPTION
## Description
MariaDB `latest` only works on newer versions of Docker (see https://github.com/MariaDB/mariadb-docker/issues/434).

So we are pinning to `mariadb:10.7` for now to ensure consistent startup of the container in CircleCI.

https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/18717/workflows/de909835-3fae-4a51-b620-5e94da79d81b/jobs/1267024

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [x] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] PR cannot be broken up into smaller PRs.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
