### PR TITLE
fix(pytest-bdd): support for version 6

### DIFF
--- a/ddtrace/contrib/pytest_bdd/plugin.py
+++ b/ddtrace/contrib/pytest_bdd/plugin.py
@@ -72,23 +72,31 @@ class _PytestBddPlugin:
             span.set_tag(test.FRAMEWORK_VERSION, self.framework_version)
 
             # store parsed step arguments
-            parser = getattr(step_func, "parser", None)
-            if parser is not None:
-                converters = getattr(step_func, "converters", {})
-                parameters = {}
+            try:
+                parsers = [step_func.parser]
+            except AttributeError:
                 try:
-                    for arg, value in parser.parse_arguments(step.name).items():
-                        try:
-                            if arg in converters:
-                                value = converters[arg](value)
-                        except Exception:
-                            # Ignore invalid converters
-                            pass
-                        parameters[arg] = value
-                except Exception:
-                    pass
-                if parameters:
-                    span.set_tag(test.PARAMETERS, json.dumps(parameters))
+                    # pytest-bdd >= 6.0.0
+                    parsers = step_func._pytest_bdd_parsers
+                except AttributeError:
+                    parsers = []
+            for parser in parsers:
+                if parser is not None:
+                    converters = getattr(step_func, "converters", {})
+                    parameters = {}
+                    try:
+                        for arg, value in parser.parse_arguments(step.name).items():
+                            try:
+                                if arg in converters:
+                                    value = converters[arg](value)
+                            except Exception:
+                                # Ignore invalid converters
+                                pass
+                            parameters[arg] = value
+                    except Exception:
+                        pass
+                    if parameters:
+                        span.set_tag(test.PARAMETERS, json.dumps(parameters))
 
             location = os.path.relpath(step_func.__code__.co_filename, str(request.config.rootdir))
             span.set_tag(test.FILE, location)

--- a/releasenotes/notes/fix-pytest-bdd-6-88421928af50dc42.yaml
+++ b/releasenotes/notes/fix-pytest-bdd-6-88421928af50dc42.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed support for pytest-bdd 6.

--- a/riotfile.py
+++ b/riotfile.py
@@ -1275,32 +1275,42 @@ venv = Venv(
         Venv(
             name="pytest-bdd",
             command="pytest {cmdargs} tests/contrib/pytest_bdd/",
+            pkgs={"msgpack": latest},
             venvs=[
                 Venv(
                     pys=["2.7"],
                     # pytest-bdd==3.4 is last to support python 2.7
-                    pkgs={"pytest-bdd": ">=3.0,<3.5", "msgpack": latest},
+                    pkgs={"pytest-bdd": ">=3.0,<3.5"},
                 ),
                 Venv(
-                    pys=select_pys(min_version="3.6", max_version="3.9"),
                     pkgs={
-                        "pytest-bdd": [
-                            ">=4.0,<5.0",
-                        ],
-                        "msgpack": latest,
                         "more_itertools": "<8.11.0",
                     },
-                ),
-                Venv(
-                    pys=select_pys(min_version="3.10"),
-                    pkgs={
-                        "pytest-bdd": [
-                            ">=4.0,<5.0",
-                            latest,
-                        ],
-                        "msgpack": latest,
-                        "more_itertools": "<8.11.0",
-                    },
+                    venvs=[
+                        Venv(
+                            pys=["3.6"],
+                            pkgs={"pytest-bdd": [">=4.0,<5.0"]},
+                        ),
+                        Venv(
+                            pys=select_pys(min_version="3.7", max_version="3.9"),
+                            pkgs={
+                                "pytest-bdd": [
+                                    ">=4.0,<5.0",
+                                    ">=6.0,<7.0",
+                                ]
+                            },
+                        ),
+                        Venv(
+                            pys=select_pys(min_version="3.10"),
+                            pkgs={
+                                "pytest-bdd": [
+                                    ">=4.0,<5.0",
+                                    ">=6.0,<7.0",
+                                    latest,
+                                ]
+                            },
+                        ),
+                    ],
                 ),
             ],
         ),


### PR DESCRIPTION
## Description

This change fixes the support for the latest release of pytest-bdd v6. The issue was caused by some changes in the internal interface. With the right handling in place, the existing tests pass.

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Relevant issue(s)

This issue was caught in CI

## Testing strategy

The existing tests are still good.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] PR cannot be broken up into smaller PRs.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
