### PR TITLE
chore(debugging): add probe configuration poller

### DIFF
--- a/ddtrace/debugging/_config.py
+++ b/ddtrace/debugging/_config.py
@@ -22,6 +22,7 @@ DEFAULT_MAX_PAYLOAD_SIZE = 1 << 20  # 1 MB
 DEFAULT_CONFIG_TIMEOUT = 30  # s
 DEFAULT_UPLOAD_TIMEOUT = 30  # seconds
 DEFAULT_UPLOAD_FLUSH_INTERVAL = 1.0  # seconds
+DEFAULT_PROBE_POLL_INTERVAL = 1.0  # seconds
 DEFAULT_DIAGNOSTIC_INTERVAL = 3600  # 1 hour
 
 
@@ -38,6 +39,7 @@ class DebuggerConfig(object):
     config_timeout = DEFAULT_CONFIG_TIMEOUT
     upload_timeout = DEFAULT_UPLOAD_TIMEOUT
     upload_flush_interval = DEFAULT_UPLOAD_FLUSH_INTERVAL
+    poll_interval = DEFAULT_PROBE_POLL_INTERVAL
     diagnostic_interval = DEFAULT_DIAGNOSTIC_INTERVAL
     tags = None  # type: Optional[str]
     _tags = {}  # type: Dict[str, str]
@@ -72,6 +74,7 @@ class DebuggerConfig(object):
         self.max_payload_size = int(os.getenv("DD_DEBUGGER_MAX_PAYLOAD_SIZE", DEFAULT_MAX_PAYLOAD_SIZE))
 
         self.config_timeout = int(os.getenv("DD_DEBUGGER_CONFIG_TIMEOUT", DEFAULT_CONFIG_TIMEOUT))
+        self.poll_interval = int(os.getenv("DD_DEBUGGER_POLL_INTERVAL", DEFAULT_PROBE_POLL_INTERVAL))
         self.diagnostic_interval = int(os.getenv("DD_DEBUGGER_DIAGNOSTIC_INTERVAL", DEFAULT_DIAGNOSTIC_INTERVAL))
 
         log.debug(

--- a/ddtrace/debugging/_probe/poller.py
+++ b/ddtrace/debugging/_probe/poller.py
@@ -17,11 +17,14 @@ DEFAULT_PROBE_POLLER_INTERVAL = 5
 DEFAULT_PROBE_STATUS_UPDATE_INTERVAL = 45 * 60  # 45 minutes
 
 
-class ProbePollerEvent(Enum):
+class ProbePollerEvent(object):
     NEW_PROBES = 0
     DELETED_PROBES = 1
     MODIFIED_PROBES = 2
     STATUS_UPDATE = 3
+
+
+ProbePollerEventType = int
 
 
 class ProbePoller(PeriodicService):
@@ -34,7 +37,7 @@ class ProbePoller(PeriodicService):
     """
 
     def __init__(self, remoteconfig, callback, interval=None):
-        # type: (DebuggingRCV07, Callable[[ProbePollerEvent, Any], None], Optional[float]) -> None
+        # type: (DebuggingRCV07, Callable[[ProbePollerEventType, Any], None], Optional[float]) -> None
         super(ProbePoller, self).__init__(interval if interval is not None else DEFAULT_PROBE_POLLER_INTERVAL)
 
         self._rc = remoteconfig

--- a/ddtrace/debugging/_probe/poller.py
+++ b/ddtrace/debugging/_probe/poller.py
@@ -1,0 +1,81 @@
+from enum import Enum
+import time
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Optional
+
+from ddtrace.debugging._probe.model import Probe
+from ddtrace.debugging._remoteconfig import DebuggingRCV07
+from ddtrace.internal.logger import get_logger
+from ddtrace.internal.periodic import PeriodicService
+
+
+log = get_logger(__name__)
+
+DEFAULT_PROBE_POLLER_INTERVAL = 5
+DEFAULT_PROBE_STATUS_UPDATE_INTERVAL = 45 * 60  # 45 minutes
+
+
+class ProbePollerEvent(Enum):
+    NEW_PROBES = 0
+    DELETED_PROBES = 1
+    MODIFIED_PROBES = 2
+    STATUS_UPDATE = 3
+
+
+class ProbePoller(PeriodicService):
+    """Poll RCM for new probe configurations.
+
+    This also keeps tracks of all seen probes to determine whether they are new,
+    deleted or modified. The corresponding events are then emitted to the
+    callback. Furthermore, probe status updates are emitted periodically to save
+    on having to create a dedicated thread.
+    """
+
+    def __init__(self, remoteconfig, callback, interval=None):
+        # type: (DebuggingRCV07, Callable[[ProbePollerEvent, Any], None], Optional[float]) -> None
+        super(ProbePoller, self).__init__(interval if interval is not None else DEFAULT_PROBE_POLLER_INTERVAL)
+
+        self._rc = remoteconfig
+        self._callback = callback
+        self._probes = {}  # type: Dict[str, Probe]
+
+        self._next_status_update_timestamp()
+
+        log.debug("Probe poller service initialized (interval: %d)", self._interval)
+
+    def _next_status_update_timestamp(self):
+        self._status_timestamp = time.time() + DEFAULT_PROBE_STATUS_UPDATE_INTERVAL
+
+    def periodic(self):
+        # type: () -> None
+
+        # DEV: We emit a status update event here to avoid having to spawn a
+        # separate thread for this.
+        if time.time() > self._status_timestamp:
+            self._callback(ProbePollerEvent.STATUS_UPDATE, self._probes)
+            self._next_status_update_timestamp()
+
+        probes = self._rc.get_probes()
+        if probes is None:
+            return
+
+        current_probes = {_.probe_id: _ for _ in probes}
+
+        new_probes = [current_probes[_] for _ in current_probes if _ not in self._probes]
+        deleted_probes = [self._probes[_] for _ in self._probes if _ not in current_probes]
+        # DEV: Probes are immutable modulo the active state. Hence we expect
+        # probes with the same ID to differ up to this property.
+        modified_probes = [
+            current_probes[_] for _ in current_probes if _ in self._probes and current_probes[_] != self._probes[_]
+        ]
+
+        if deleted_probes:
+            self._callback(ProbePollerEvent.DELETED_PROBES, deleted_probes)
+        if modified_probes:
+            self._callback(ProbePollerEvent.MODIFIED_PROBES, modified_probes)
+        if new_probes:
+            self._callback(ProbePollerEvent.NEW_PROBES, new_probes)
+
+        self._probes = current_probes

--- a/ddtrace/debugging/_probe/poller.py
+++ b/ddtrace/debugging/_probe/poller.py
@@ -1,10 +1,10 @@
-from enum import Enum
 import time
 from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Optional
 
+from ddtrace.debugging._config import config
 from ddtrace.debugging._probe.model import Probe
 from ddtrace.debugging._remoteconfig import DebuggingRCV07
 from ddtrace.internal.logger import get_logger
@@ -12,9 +12,6 @@ from ddtrace.internal.periodic import PeriodicService
 
 
 log = get_logger(__name__)
-
-DEFAULT_PROBE_POLLER_INTERVAL = 5
-DEFAULT_PROBE_STATUS_UPDATE_INTERVAL = 45 * 60  # 45 minutes
 
 
 class ProbePollerEvent(object):
@@ -38,7 +35,7 @@ class ProbePoller(PeriodicService):
 
     def __init__(self, remoteconfig, callback, interval=None):
         # type: (DebuggingRCV07, Callable[[ProbePollerEventType, Any], None], Optional[float]) -> None
-        super(ProbePoller, self).__init__(interval if interval is not None else DEFAULT_PROBE_POLLER_INTERVAL)
+        super(ProbePoller, self).__init__(interval if interval is not None else config.poll_interval)
 
         self._rc = remoteconfig
         self._callback = callback
@@ -49,7 +46,7 @@ class ProbePoller(PeriodicService):
         log.debug("Probe poller service initialized (interval: %d)", self._interval)
 
     def _next_status_update_timestamp(self):
-        self._status_timestamp = time.time() + DEFAULT_PROBE_STATUS_UPDATE_INTERVAL
+        self._status_timestamp = time.time() + config.diagnostic_interval
 
     def periodic(self):
         # type: () -> None

--- a/ddtrace/debugging/_probe/poller.py
+++ b/ddtrace/debugging/_probe/poller.py
@@ -24,6 +24,13 @@ class ProbePollerEvent(object):
 ProbePollerEventType = int
 
 
+def probe_modified(reference, probe):
+    # type: (Probe, Probe) -> bool
+    # DEV: Probes are immutable modulo the active state. Hence we expect
+    # probes with the same ID to differ up to this property for now.
+    return probe.active != reference.active
+
+
 class ProbePoller(PeriodicService):
     """Poll RCM for new probe configurations.
 
@@ -65,10 +72,10 @@ class ProbePoller(PeriodicService):
 
         new_probes = [current_probes[_] for _ in current_probes if _ not in self._probes]
         deleted_probes = [self._probes[_] for _ in self._probes if _ not in current_probes]
-        # DEV: Probes are immutable modulo the active state. Hence we expect
-        # probes with the same ID to differ up to this property.
         modified_probes = [
-            current_probes[_] for _ in current_probes if _ in self._probes and current_probes[_] != self._probes[_]
+            current_probes[_]
+            for _ in current_probes
+            if _ in self._probes and probe_modified(current_probes[_], self._probes[_])
         ]
 
         if deleted_probes:

--- a/tests/debugging/probe/test_poller.py
+++ b/tests/debugging/probe/test_poller.py
@@ -1,0 +1,158 @@
+from time import sleep
+
+import pytest
+
+from ddtrace.debugging._probe.model import LineProbe
+from ddtrace.debugging._probe.poller import ProbePoller
+from ddtrace.debugging._probe.poller import ProbePollerEvent
+from ddtrace.debugging._remoteconfig import _filter_by_env_and_version
+from tests.utils import override_global_config
+
+
+class MockDebuggerRC(object):
+    def __init__(self, *args, **kwargs):
+        self.probes = {}
+
+    @_filter_by_env_and_version
+    def get_probes(self):
+        return list(self.probes.values())
+
+    def add_probes(self, probes):
+        for probe in probes:
+            self.probes[probe.probe_id] = probe
+
+    def remove_probes(self, *probe_ids):
+        for probe_id in probe_ids:
+            try:
+                del self.probes[probe_id]
+            except KeyError:
+                pass
+
+
+@pytest.mark.parametrize(
+    "env,version,expected",
+    [
+        (None, None, set(["probe4"])),
+        (None, "dev", set(["probe3", "probe4"])),
+        ("prod", None, set(["probe2", "probe4"])),
+        ("prod", "dev", set(["probe1", "probe2", "probe3", "probe4"])),
+    ],
+)
+def test_poller_env_version(env, version, expected):
+    probes = []
+
+    def cb(e, ps):
+        probes.extend(ps)
+
+    with override_global_config(dict(env=env, version=version)):
+        api = MockDebuggerRC()
+        api.add_probes(
+            [
+                LineProbe(
+                    probe_id="probe1",
+                    source_file="tests/debugger/submod/stuff.py",
+                    line=36,
+                    condition=None,
+                    tags={"env": "prod", "version": "dev"},
+                ),
+                LineProbe(
+                    probe_id="probe2",
+                    source_file="tests/debugger/submod/stuff.py",
+                    line=36,
+                    condition=None,
+                    tags={"env": "prod"},
+                ),
+                LineProbe(
+                    probe_id="probe3",
+                    source_file="tests/debugger/submod/stuff.py",
+                    line=36,
+                    condition=None,
+                    tags={"version": "dev"},
+                ),
+                LineProbe(
+                    probe_id="probe4",
+                    source_file="tests/debugger/submod/stuff.py",
+                    line=36,
+                    condition=None,
+                ),
+            ]
+        )
+        poller = ProbePoller(api, cb, interval=0.1)
+        poller.start()
+        sleep(0.2)
+        poller.stop()
+        assert set(_.probe_id for _ in probes) == expected
+
+
+def test_poller_events():
+    events = set()
+    status_update_events = set()
+
+    def cb(e, ps):
+        if e is ProbePollerEvent.STATUS_UPDATE:
+            status_update_events.add(ps)
+        else:
+            events.add((e, frozenset([p.probe_id for p in ps])))
+
+    api = MockDebuggerRC()
+    api.add_probes(
+        [
+            LineProbe(
+                probe_id="probe1",
+                source_file="tests/debugger/submod/stuff.py",
+                line=36,
+                condition=None,
+            ),
+            LineProbe(
+                probe_id="probe2",
+                source_file="tests/debugger/submod/stuff.py",
+                line=36,
+                condition=None,
+            ),
+            LineProbe(
+                probe_id="probe3",
+                source_file="tests/debugger/submod/stuff.py",
+                line=36,
+                condition=None,
+            ),
+            LineProbe(
+                probe_id="probe4",
+                source_file="tests/debugger/submod/stuff.py",
+                line=36,
+                condition=None,
+            ),
+        ]
+    )
+    poller = ProbePoller(api, cb, interval=0.1)
+    poller.start()
+    sleep(0.2)
+    api.remove_probes("probe1", "probe2")
+    api.add_probes(
+        [
+            # Modified
+            LineProbe(
+                probe_id="probe2",
+                source_file="tests/debugger/submod/stuff.py",
+                line=36,
+                condition=None,
+                active=False,
+            ),
+            # New
+            LineProbe(
+                probe_id="probe5",
+                source_file="tests/debugger/submod/stuff.py",
+                line=36,
+                condition=None,
+                active=False,
+            ),
+        ]
+    )
+    sleep(0.2)
+    poller.stop()
+
+    assert events == {
+        (ProbePollerEvent.NEW_PROBES, frozenset(["probe4", "probe1", "probe2", "probe3"])),
+        (ProbePollerEvent.DELETED_PROBES, frozenset(["probe1"])),
+        (ProbePollerEvent.MODIFIED_PROBES, frozenset(["probe2"])),
+        (ProbePollerEvent.NEW_PROBES, frozenset(["probe5"])),
+    }

--- a/tests/debugging/probe/test_poller.py
+++ b/tests/debugging/probe/test_poller.py
@@ -4,6 +4,7 @@ import pytest
 
 from ddtrace.debugging._config import config
 from ddtrace.debugging._probe.model import LineProbe
+from ddtrace.debugging._probe.model import Probe
 from ddtrace.debugging._probe.poller import ProbePoller
 from ddtrace.debugging._probe.poller import ProbePollerEvent
 from ddtrace.debugging._remoteconfig import _filter_by_env_and_version
@@ -89,7 +90,7 @@ def test_poller_events():
     events = set()
 
     def cb(e, ps):
-        events.add((e, frozenset([p.probe_id for p in ps])))
+        events.add((e, frozenset([p.probe_id if isinstance(p, Probe) else p for p in ps])))
 
     api = MockDebuggerRC()
     api.add_probes(


### PR DESCRIPTION

## Description

This change introduces the probe configuration poller that allows "listening" for probe events, e.g. new, deleted or modified probes. To avoid having to create a dedicated thread that would only increase contention on the GIL, probe status updates are also emitted by the poller.

NOTE: The interfacing with the RCM in this implementation is not super sleek, but it will be changed soon.

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] PR cannot be broken up into smaller PRs.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
