### PR TITLE
chore(telemetry): replace warning logs with debug logs

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -115,14 +115,14 @@ class TelemetryWriter(PeriodicService):
             try:
                 resp = self._send_request(telemetry_request)
                 if resp.status >= 300:
-                    log.warning(
+                    log.debug(
                         "failed to send telemetry to the Datadog Agent at %s/%s. response: %s",
                         self._agent_url,
                         self.ENDPOINT,
                         resp.status,
                     )
             except Exception:
-                log.warning(
+                log.debug(
                     "failed to send telemetry to the Datadog Agent at %s/%s.",
                     self._agent_url,
                     self.ENDPOINT,

--- a/tests/tracer/telemetry/test_writer.py
+++ b/tests/tracer/telemetry/test_writer.py
@@ -213,23 +213,15 @@ def test_periodic(mock_send_request, telemetry_writer):
     # queue two integrations
     telemetry_writer.add_integration("integration-1", True)
     telemetry_writer.add_integration("integration-2", False)
-
-    with mock.patch("ddtrace.internal.telemetry.writer.log") as log:
-        # send all events to the agent proxy
-        telemetry_writer.periodic()
-        # assert no warning logs were generated while sending telemetry requests
-        log.warning.assert_not_called()
+    telemetry_writer.periodic()
     # ensure one app-started and one app-integrations-change event was sent
     assert len(httpretty.latest_requests()) == 2
 
     # queue 2 more integrations
     telemetry_writer.add_integration("integration-3", True)
     telemetry_writer.add_integration("integration-4", False)
-    with mock.patch("ddtrace.internal.telemetry.writer.log") as log:
-        # send both integrations to the agent proxy
-        telemetry_writer.periodic()
-        # assert no warning logs were generated while sending telemetry requests
-        log.warning.assert_not_called()
+    # send both integrations to the agent proxy
+    telemetry_writer.periodic()
     # ensure one more app-integrations-change events was sent
     # 2 requests were sent in the previous flush
     assert len(httpretty.latest_requests()) == 3
@@ -242,7 +234,7 @@ def test_send_failing_request(mock_status, mock_send_request, telemetry_writer):
         # sends failing app-closing event
         telemetry_writer.on_shutdown()
         # asserts unsuccessful status code was logged
-        log.warning.assert_called_with(
+        log.debug.assert_called_with(
             "failed to send telemetry to the Datadog Agent at %s/%s. response: %s",
             telemetry_writer._agent_url,
             telemetry_writer.ENDPOINT,
@@ -263,7 +255,7 @@ def test_send_request_exception():
         # sends failing app-closing event
         telemetry_writer.on_shutdown()
         # assert an exception was logged
-        log.warning.assert_called_with(
+        log.debug.assert_called_with(
             "failed to send telemetry to the Datadog Agent at %s/%s.",
             "http://hostthatdoesntexist:1234",
             telemetry_writer.ENDPOINT,


### PR DESCRIPTION
Do not log warnings in telemetry, generate debug logs instead. Unblocks https://github.com/DataDog/dd-trace-py/pull/3925

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation

Failing to send telemetry events should not log a warning in a customer's application.

## Design 

Replace log.warning with log.debug

## Testing strategy

Ensure existing telemetry tests pass. Replace `log.warning` mocks with `log.debug`

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] PR cannot be broken up into smaller PRs.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
- [x] Add to milestone.
