### PR TITLE
refactor(tracer): wait for tracer to complete

### DIFF
--- a/ddtrace/internal/forksafe.py
+++ b/ddtrace/internal/forksafe.py
@@ -135,3 +135,36 @@ def RLock():
 def Event():
     # type: (...) -> ResetObject[threading.Event]
     return ResetObject(threading.Event)
+
+
+class REvent(object):
+    def __init__(self):
+        self._event = Event()
+        self._count = 0
+        self._count_lock = Lock()
+
+    def __enter__(self):
+        self.set()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.clear()
+
+    def set(self):
+        with self._count_lock:
+            self._count += 1
+            self._event.set()
+
+    def clear(self):
+        with self._count_lock:
+            if self._count == 0:
+                return
+            self._count -= 1
+            if self._count == 0:
+                self._event.clear()
+
+    def wait(self, timeout=None):
+        return self._event.wait(timeout)
+
+    def is_set(self):
+        return self._event.is_set()

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -228,6 +228,14 @@ class Tracer(object):
 
         self._new_process = False
 
+        self._tracing_event = forksafe.REvent()
+
+    def wait(self, timeout=None):
+        return self._tracing_event.wait(timeout)
+
+    def is_tracing(self):
+        return self._tracing_event.is_set()
+
     def _atexit(self):
         # type: () -> None
         key = "ctrl-break" if os.name == "nt" else "ctrl-c"
@@ -610,6 +618,7 @@ class Tracer(object):
                 span_type=span_type,
                 on_finish=[self._on_span_finish],
             )
+            span._tracer = self
 
             # Extra attributes when from a local parent
             if parent:
@@ -629,6 +638,7 @@ class Tracer(object):
                 span_type=span_type,
                 on_finish=[self._on_span_finish],
             )
+            span._tracer = self
             span._local_root = span
             if config.report_hostname:
                 span._set_str_tag(HOSTNAME_KEY, hostname.get_hostname())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -903,6 +903,7 @@ def snapshot_context(token, ignores=None, tracer=None, async_mode=True, variants
             )
         finally:
             # Force a flush so all traces are submitted.
+            tracer.wait()
             tracer._writer.flush_queue()
             if async_mode:
                 del tracer._writer._headers["X-Datadog-Test-Session-Token"]


### PR DESCRIPTION
## Description

This change adds the possibility of waiting for the tracer to finish with all the traces that are being created.

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
