### PR TITLE
fix(wsgi): ensure correct resource and tags are set  on wsgi.request spans

### DIFF
--- a/ddtrace/contrib/wsgi/wsgi.py
+++ b/ddtrace/contrib/wsgi/wsgi.py
@@ -121,7 +121,6 @@ class DDWSGIMiddleware(object):
             # Note: The wsgi.response span will still have the error information included.
             span._ignore_exception(generatorExit)
 
-            # set wsgi.request resource and tags
             url = construct_url(environ)
             method = environ.get("REQUEST_METHOD")
             query_string = environ.get("QUERY_STRING")

--- a/ddtrace/contrib/wsgi/wsgi.py
+++ b/ddtrace/contrib/wsgi/wsgi.py
@@ -120,6 +120,18 @@ class DDWSGIMiddleware(object):
             # This can occur if a streaming response exits abruptly leading to a broken pipe.
             # Note: The wsgi.response span will still have the error information included.
             span._ignore_exception(generatorExit)
+
+            # set wsgi.request resource and tags
+            url = construct_url(environ)
+            method = environ.get("REQUEST_METHOD")
+            query_string = environ.get("QUERY_STRING")
+            request_headers = get_request_headers(environ)
+            trace_utils.set_http_meta(
+                span, config.wsgi, method=method, url=url, query=query_string, request_headers=request_headers
+            )
+            if self.span_modifier:
+                self.span_modifier(span, environ)
+
             with self.tracer.trace("wsgi.application"):
                 result = self.app(environ, intercept_start_response)
 
@@ -131,17 +143,6 @@ class DDWSGIMiddleware(object):
 
                 for chunk in result:
                     yield chunk
-
-            url = construct_url(environ)
-            method = environ.get("REQUEST_METHOD")
-            query_string = environ.get("QUERY_STRING")
-            request_headers = get_request_headers(environ)
-            trace_utils.set_http_meta(
-                span, config.wsgi, method=method, url=url, query=query_string, request_headers=request_headers
-            )
-
-            if self.span_modifier:
-                self.span_modifier(span, environ)
 
             if hasattr(result, "close"):
                 try:

--- a/releasenotes/notes/wsgi-move-request-modifer-code-809521ff9000ea64.yaml
+++ b/releasenotes/notes/wsgi-move-request-modifer-code-809521ff9000ea64.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    wsgi: ensures resource and http tags are always set on `wsgi.request` spans.

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py2.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py2.json
@@ -2,7 +2,7 @@
   {
     "name": "wsgi.request",
     "service": "wsgi",
-    "resource": "wsgi.request",
+    "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
@@ -13,6 +13,8 @@
       "error.msg": "Oops!",
       "error.stack": "Traceback (most recent call last):\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/ddtrace/contrib/wsgi/wsgi.py\", line 124, in __call__\n    result = self.app(environ, intercept_start_response)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/tests/contrib/wsgi/test_wsgi.py\", line 46, in application\n    raise Exception(\"Oops!\")\nException: Oops!\n",
       "error.type": "exceptions.Exception",
+      "http.method": "GET",
+      "http.url": "http://localhost:80/error",
       "runtime-id": "c8fcd5c1faf945f0ae5f194a3992723e"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py3.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py3.json
@@ -2,7 +2,7 @@
   {
     "name": "wsgi.request",
     "service": "wsgi",
-    "resource": "wsgi.request",
+    "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
@@ -13,6 +13,8 @@
       "error.msg": "Oops!",
       "error.stack": "Traceback (most recent call last):\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/ddtrace/contrib/wsgi/wsgi.py\", line 124, in __call__\n    result = self.app(environ, intercept_start_response)\n  File \"/Users/kyle.verhoog/dev/dd-trace-py/tests/contrib/wsgi/test_wsgi.py\", line 46, in application\n    raise Exception(\"Oops!\")\nException: Oops!\n",
       "error.type": "builtins.Exception",
+      "http.method": "GET",
+      "http.url": "http://localhost:80/error",
       "runtime-id": "95c79fa6df0d4378985caf03beebf928"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_in_top_level_span_snapshot_py2.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_in_top_level_span_snapshot_py2.json
@@ -2,15 +2,17 @@
   {
     "name": "wsgi.request",
     "service": "wsgi",
-    "resource": "wsgi.request",
+    "resource": "GET /generatorError",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "http.method": "GET",
       "http.status_code": "200",
       "http.status_msg": "OK",
+      "http.url": "http://localhost:80/generatorError",
       "runtime-id": "c8fcd5c1faf945f0ae5f194a3992723e"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_in_top_level_span_snapshot_py3.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_in_top_level_span_snapshot_py3.json
@@ -2,15 +2,17 @@
   {
     "name": "wsgi.request",
     "service": "wsgi",
-    "resource": "wsgi.request",
+    "resource": "GET /generatorError",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "http.method": "GET",
       "http.status_code": "200",
       "http.status_msg": "OK",
+      "http.url": "http://localhost:80/generatorError",
       "runtime-id": "95c79fa6df0d4378985caf03beebf928"
     },
     "metrics": {


### PR DESCRIPTION
## Description

Ensures resource and http tags are always set on `wsgi.request` spans.

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Motivation

The resource name and tags on a `wsgi.request` span is set [after the response is streamed](https://github.com/DataDog/dd-trace-py/blob/v1.2.2/ddtrace/contrib/wsgi/wsgi.py#L135-L144.). If an exception is raised [when the wsgi_app is called](https://github.com/DataDog/dd-trace-py/blob/v1.2.2/ddtrace/contrib/wsgi/wsgi.py#L133) or [during streaming the response](https://github.com/DataDog/dd-trace-py/blob/v1.2.2/ddtrace/contrib/wsgi/wsgi.py#L124) then the resource name and span tags will not be set.

## Design 

Modify the request span before calling the wsgi app.

## Testing strategy

Ensure the http_method tag and resource name is set in all wsgi snapshot tests.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] PR cannot be broken up into smaller PRs.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
