### PR TITLE
fix(profiling): don't use AsyncioLockCollector unless asyncio available

### DIFF
--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -16,8 +16,10 @@ except ImportError:
         # type: (...) -> None
         pass
 
+    asyncio_available = False
 
 else:
+    asyncio_available = True
     DefaultEventLoopPolicy = asyncio.DefaultEventLoopPolicy  # type: ignore[misc]
 
     get_event_loop_policy = asyncio.get_event_loop_policy  # type: ignore[assignment]

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -199,8 +199,9 @@ class _ProfilerInstance(service.Service):
         self._collectors = [
             stack.StackCollector(r, tracer=self.tracer),  # type: ignore[call-arg]
             threading.ThreadingLockCollector(r, tracer=self.tracer),
-            asyncio.AsyncioLockCollector(r, tracer=self.tracer),
         ]
+        if _asyncio.asyncio_available:
+            self._collectors.append(asyncio.AsyncioLockCollector(r, tracer=self.tracer))
 
         if self._memory_collector_enabled:
             self._collectors.append(memalloc.MemoryCollector(r))

--- a/releasenotes/notes/profiler-asyncio-py2-5049a2c3fd02c842.yaml
+++ b/releasenotes/notes/profiler-asyncio-py2-5049a2c3fd02c842.yaml
@@ -1,6 +1,6 @@
 ---
 other:
   - |
-    profiler: don't initialize the AsyncioLockCollector unless asyncio is
+    profiler: don't initialize the ``AsyncioLockCollector`` unless asyncio is
       available. This prevents noisy logs messages from being emitted in Python
       2.

--- a/releasenotes/notes/profiler-asyncio-py2-5049a2c3fd02c842.yaml
+++ b/releasenotes/notes/profiler-asyncio-py2-5049a2c3fd02c842.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    profiler: don't initialize the AsyncioLockCollector unless asyncio is
+      available. This prevents noisy logs messages from being emitted in Python
+      2.


### PR DESCRIPTION
## Description

When used in Python 2, the profiler emits these error logs

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/ddtrace/profiling/profiler.py", line 242, in _start_service
    col.start()
  File "/usr/local/lib/python2.7/site-packages/ddtrace/internal/service.py", line 58, in start
    self._start_service(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/ddtrace/profiling/collector/asyncio.py", line 40, in _start_service
    return super(AsyncioLockCollector, self)._start_service()
  File "/usr/local/lib/python2.7/site-packages/ddtrace/profiling/collector/_lock.py", line 209, in _start_service
    self.patch()
  File "/usr/local/lib/python2.7/site-packages/ddtrace/profiling/collector/_lock.py", line 223, in patch
    self.original = self._get_original()
  File "/usr/local/lib/python2.7/site-packages/ddtrace/profiling/collector/asyncio.py", line 44, in _get_original
    return self._asyncio_module.Lock
AttributeError: 'module' object has no attribute 'Lock'
```

solution is to only use the AsyncioLockCollector if asyncio is available.

Will add a test if people think this is a good approach.

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
