### PR TITLE
chore(mypy): set python3.x version in riotfile

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -129,7 +129,7 @@ venv = Venv(
             ],
         ),
         Venv(
-            pys=["3"],
+            pys=["3.9"],
             name="mypy",
             command="mypy {cmdargs}",
             create=True,


### PR DESCRIPTION
## Description
CI set a specific python version to run the tests:

```
  steps:
    - &pyenv-set-global
      run:
        name: Set global pyenv
        command: |
          pyenv global 3.9.4
          
```

If we don't set a python3 version, riot assumes the default python version (3.6, 3.7...) of your environment and as we can see below, each version could throw errors when we try to commit a file and mypy hook raises

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Testing strategy
:heavy_check_mark:  Ok with py3.9
```
pyenv activate 3.9
riot -v run -r mypy
[14:56:04] INFO     Generating virtual environments for interpreters Interpreter(_hint='3')                                                                                                                                  riot.py:844
           INFO     Creating virtualenv 'dd-trace-py/.riot/venv_py391' with interpreter '/home/alberto.vara/.pyenv/shims/python3'.                                                     riot.py:172
[14:56:05] INFO     Installing dev package (edit mode) in dd-trace-py/.riot/venv_py391.                                                                                               riot.py:1055
[14:56:43] INFO     Running with Interpreter(_hint='3')                                                                                                                                                                      riot.py:665
           INFO     Running command 'mypy -V; mypy' in venv                                                                                                                                                                  riot.py:715
                    'dd-trace-py/.riot/venv_py391_mypy_types-attrs_types-docutils_types-protobuf_types-PyYAML_types-setuptools_types-six_types-requests_types-boto_types-redis_types-P            
                    yMySQL_mock_pytest700_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451' with environment:                                                                                                                 
                    DD_TESTING_RAISE=1                                                                                                                                                                                                  
                    RIOT=1                                                                                                                                                                                                              
                    RIOT_PYTHON_HINT=Interpreter(_hint='3')                                                                                                                                                                             
                    RIOT_PYTHON_VERSION=3.9.1                                                                                                                                                                                           
                    RIOT_VENV_HASH=7307995                                                                                                                                                                                              
                    RIOT_VENV_IDENT=mypy_types-attrs_types-docutils_types-protobuf_types-PyYAML_types-setuptools_types-six_types-requests_types-boto_types-redis_types-PyMySQL_mock_pytest700_pytest-mock_coverage_pytest-co            
                    v_opentracing_hypothesis6451                                                                                                                                                                                        
                    RIOT_VENV_NAME=mypy                                                                                                                                                                                                 
                    RIOT_VENV_PKGS='mypy' 'types-attrs' 'types-docutils' 'types-protobuf' 'types-PyYAML' 'types-setuptools' 'types-six' 'types-requests' 'types-boto' 'types-redis' 'types-PyMySQL' 'mock' 'pytest<7.0.0'               
                    'pytest-mock' 'coverage' 'pytest-cov' 'opentracing' 'hypothesis<6.45.1'                                                                                                                                             
                    RIOT_VENV_FULL_PKGS='mock' 'pytest<7.0.0' 'pytest-mock' 'coverage' 'pytest-cov' 'opentracing' 'hypothesis<6.45.1' 'mypy' 'types-attrs' 'types-docutils' 'types-protobuf' 'types-PyYAML'                             
                    'types-setuptools' 'types-six' 'types-requests' 'types-boto' 'types-redis' 'types-PyMySQL'                                                                                                                          
                    PYTHONPATH=:dd-trace-py.                                                                                                                                                      
mypy 0.961 (compiled: yes)
Success: no issues found in 398 source files
```
:x:  Error with py3.8
```
pyenv activate 3.8
riot -v run -r mypy
[14:57:19] INFO     Generating virtual environments for interpreters Interpreter(_hint='3')                                                                                                                                  riot.py:844
           INFO     Creating virtualenv 'dd-trace-py/.riot/venv_py3813' with interpreter '/home/alberto.vara/.pyenv/shims/python3'.                                                    riot.py:172
           INFO     Installing dev package (edit mode) in dd-trace-py/.riot/venv_py3813.                                                                                              riot.py:1055
[14:58:00] INFO     Running with Interpreter(_hint='3')                                                                                                                                                                      riot.py:665
           INFO     Running command 'mypy -V; mypy' in venv                                                                                                                                                                  riot.py:715
                    'dd-trace-py/.riot/venv_py3813_mypy_types-attrs_types-docutils_types-protobuf_types-PyYAML_types-setuptools_types-six_types-requests_types-boto_types-redis_types-            
                    PyMySQL_mock_pytest700_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451' with environment:                                                                                                                
                    DD_TESTING_RAISE=1                                                                                                                                                                                                  
                    RIOT=1                                                                                                                                                                                                              
                    RIOT_PYTHON_HINT=Interpreter(_hint='3')                                                                                                                                                                             
                    RIOT_PYTHON_VERSION=3.8.13                                                                                                                                                                                          
                    RIOT_VENV_HASH=7307995                                                                                                                                                                                              
                    RIOT_VENV_IDENT=mypy_types-attrs_types-docutils_types-protobuf_types-PyYAML_types-setuptools_types-six_types-requests_types-boto_types-redis_types-PyMySQL_mock_pytest700_pytest-mock_coverage_pytest-co            
                    v_opentracing_hypothesis6451                                                                                                                                                                                        
                    RIOT_VENV_NAME=mypy                                                                                                                                                                                                 
                    RIOT_VENV_PKGS='mypy' 'types-attrs' 'types-docutils' 'types-protobuf' 'types-PyYAML' 'types-setuptools' 'types-six' 'types-requests' 'types-boto' 'types-redis' 'types-PyMySQL' 'mock' 'pytest<7.0.0'               
                    'pytest-mock' 'coverage' 'pytest-cov' 'opentracing' 'hypothesis<6.45.1'                                                                                                                                             
                    RIOT_VENV_FULL_PKGS='mock' 'pytest<7.0.0' 'pytest-mock' 'coverage' 'pytest-cov' 'opentracing' 'hypothesis<6.45.1' 'mypy' 'types-attrs' 'types-docutils' 'types-protobuf' 'types-PyYAML'                             
                    'types-setuptools' 'types-six' 'types-requests' 'types-boto' 'types-redis' 'types-PyMySQL'                                                                                                                          
                    PYTHONPATH=:dd-trace-py.                                                                                                                                                      
mypy 0.961 (compiled: yes)
ddtrace/debugging/_function/discovery.py:12: error: Module "collections" has no attribute "Iterator"  [attr-defined]
ddtrace/debugging/_function/discovery.py:12: error: Name "Iterator" already defined (possibly by an import)  [no-redef]
Found 2 errors in 1 file (checked 398 source files)
Test failed with exit code 1
```

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
