### PR TITLE
feat(asm): detect attacks on path Params

### DIFF
--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -526,5 +526,6 @@ def _set_request_tags(span):
                 # DEV: Do not use `_set_str_tag` here since view args can be string/int/float/path/uuid/etc
                 #      https://flask.palletsprojects.com/en/1.1.x/api/#url-route-registrations
                 span.set_tag(u".".join((FLASK_VIEW_ARGS, k)), v)
+            trace_utils.set_http_meta(span, config.flask, request_path_params=request.view_args)
     except Exception:
         log.debug('failed to set tags for "flask.request" span', exc_info=True)

--- a/releasenotes/notes/detect-attacks-on-path-params-d6d06c22573d22e8.yaml
+++ b/releasenotes/notes/detect-attacks-on-path-params-d6d06c22573d22e8.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    ASM: Detect attacks on path params

--- a/releasenotes/notes/detect-attacks-on-path-params-d6d06c22573d22e8.yaml
+++ b/releasenotes/notes/detect-attacks-on-path-params-d6d06c22573d22e8.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    ASM: Detect attacks on path params
+    AppSec: Detect attacks on path params

--- a/releasenotes/notes/detect-attacks-on-path-params-d6d06c22573d22e8.yaml
+++ b/releasenotes/notes/detect-attacks-on-path-params-d6d06c22573d22e8.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    AppSec: Detect attacks on path params
+    ASM: Detect attacks on path parameters

--- a/tests/appsec/rules-good.json
+++ b/tests/appsec/rules-good.json
@@ -66,6 +66,55 @@
       "transformers": [
         "removeNulls"
       ]
+    },
+    {
+      "id": "crs-913-120",
+      "name": "Known security scanner filename/argument",
+      "tags": {
+        "type": "security_scanner",
+        "crs_id": "913120",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "list": [
+              "/.adsensepostnottherenonobook",
+              "/<invalid>hello.html",
+              "/actsensepostnottherenonotive",
+              "/acunetix-wvs-test-for-some-inexistent-file",
+              "/antidisestablishmentarianism",
+              "/appscan_fingerprint/mac_address",
+              "/arachni-",
+              "/cybercop",
+              "/nessus_is_probing_you_",
+              "/nessustest",
+              "/netsparker-",
+              "/rfiinc.txt",
+              "/thereisnowaythat-you-canbethere",
+              "/w3af/remotefileinclude.html",
+              "appscan_fingerprint",
+              "w00tw00t.at.isc.sans.dfind",
+              "w00tw00t.at.blackhats.romanian.anti-sec"
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
     }
   ]
 }

--- a/tests/contrib/django/django1_app/urls.py
+++ b/tests/contrib/django/django1_app/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     url(r"^template-view/$", views.template_view, name="template-view"),
     url(r"^template-simple-view/$", views.template_simple_view, name="template-simple-view"),
     url(r"^template-list-view/$", views.template_list_view, name="template-list-view"),
+    url(r"^path-params/(?P<year>[0-9]{4})/(?P<month>\w+)/$", views.path_params_view, name="path-params-view"),
     # This must precede composed tests.
     url(r"some-static-view/", TemplateView.as_view(template_name="my-template.html")),
     url(r"^composed-template-view/$", views.ComposedTemplateView.as_view(), name="composed-template-view"),

--- a/tests/contrib/django/django_app/urls.py
+++ b/tests/contrib/django/django_app/urls.py
@@ -47,6 +47,10 @@ def shutdown(request):
     return HttpResponse(status=200)
 
 
+def path_params_view(request, year, month):
+    return HttpResponse(status=200)
+
+
 urlpatterns = [
     handler(r"^$", views.index),
     handler(r"^simple/$", views.BasicView.as_view()),
@@ -65,6 +69,7 @@ urlpatterns = [
     handler(r"^template-view/$", views.template_view, name="template-view"),
     handler(r"^template-simple-view/$", views.template_simple_view, name="template-simple-view"),
     handler(r"^template-list-view/$", views.template_list_view, name="template-list-view"),
+    path("path-params/<int:year>/<str:month>/", path_params_view, name="path-params-view"),
     re_path(r"re-path.*/", repath_view),
     path("path/", path_view),
     path("include/", include("tests.contrib.django.django_app.extra_urls")),

--- a/tests/contrib/django/django_app/urls.py
+++ b/tests/contrib/django/django_app/urls.py
@@ -47,10 +47,6 @@ def shutdown(request):
     return HttpResponse(status=200)
 
 
-def path_params_view(request, year, month):
-    return HttpResponse(status=200)
-
-
 urlpatterns = [
     handler(r"^$", views.index),
     handler(r"^simple/$", views.BasicView.as_view()),
@@ -69,7 +65,7 @@ urlpatterns = [
     handler(r"^template-view/$", views.template_view, name="template-view"),
     handler(r"^template-simple-view/$", views.template_simple_view, name="template-simple-view"),
     handler(r"^template-list-view/$", views.template_list_view, name="template-list-view"),
-    path("path-params/<int:year>/<str:month>/", path_params_view, name="path-params-view"),
+    path("path-params/<int:year>/<str:month>/", views.path_params_view, name="path-params-view"),
     re_path(r"re-path.*/", repath_view),
     path("path/", path_view),
     path("include/", include("tests.contrib.django.django_app.extra_urls")),

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -62,3 +62,14 @@ def test_django_request_cookies_attack(client, test_spans, tracer):
         query = dict(_context.get_item("http.request.cookies", span=root_span))
         assert "triggers" in json.loads(root_span.get_tag("_dd.appsec.json"))
         assert query == {"attack": "1' or '1' = '1'"}
+
+
+def test_django_path_params(client, test_spans, tracer):
+    tracer._appsec_enabled = True
+    # Hack: need to pass an argument to configure so that the processors are recreated
+    tracer.configure(api_version="v0.4")
+    client.get("/path-params/2022/july/")
+    root_span = test_spans.spans[0]
+    path_params = _context.get_item("http.request.path_params", span=root_span)
+
+    assert path_params == {"year": 2022, "month": "july"}

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -72,4 +72,6 @@ def test_django_path_params(client, test_spans, tracer):
     root_span = test_spans.spans[0]
     path_params = _context.get_item("http.request.path_params", span=root_span)
 
-    assert path_params == {"year": 2022, "month": "july"}
+    assert path_params["month"] == "july"
+    # django>=1.8,<1.9 returns string instead int
+    assert int(path_params["year"]) == 2022

--- a/tests/contrib/django/views.py
+++ b/tests/contrib/django/views.py
@@ -178,3 +178,7 @@ class ComposedView(TemplateView, CustomDispatchView):
 
 def not_found_view(request):
     raise Http404("DNE")
+
+
+def path_params_view(request, year, month):
+    return HttpResponse(status=200)

--- a/tests/contrib/flask/test_flask_appsec.py
+++ b/tests/contrib/flask/test_flask_appsec.py
@@ -36,10 +36,10 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         root_span = spans[0]
 
         flask_args = root_span.get_tag("flask.view_args.item")
-        path_params = _context.get_item("http.request.path_params", span=root_span)
-
-        assert path_params == {"item": "attack"}
         assert flask_args == "attack"
+
+        path_params = _context.get_item("http.request.path_params", span=root_span)
+        assert path_params == {"item": "attack"}
 
     def test_flask_path_params_attack(self):
         @self.app.route("/params/<item>")


### PR DESCRIPTION
## Description
Detect attacks on path params

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] Ensure tests are passing for affected code.

## Motivation
Expand Appsec features

## Testing strategy
Check:
* `tests/contrib/django/test_django_appsec.py`
* `tests/contrib/flask/test_flask_appsec.py`

### Manual testing
Run a Flask/Django application with dd-trace-py configured and appsec enabled. This app should hava a endpoint like:

```
@self.app.route("/path/<item>")
def dynamic_url(item):
    return item
```

Then, execute a curl command such as:

```
curl -v http://192.168.1.35:8081/path/w00tw00t.at.isc.sans.dfind
```

ddwaf should return:

```
`DEBUG:ddtrace.appsec.processor:[DDAS-011-00] AppSec In-App WAF returned: [{"rule":{"id":"crs-913-120","name":"Known security scanner filename/argument", ... ]}]`
```

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
