### PR TITLE
chore(slotcheck): exclude contrib tests directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ exclude = [
 exclude-modules = '''
 (
   ^ddtrace.(contrib|vendor)
+  | ^tests.(contrib|vendor)
   # avoid sitecustomize modules as they start services
   | ddtrace.bootstrap.sitecustomize
   | ddtrace.profiling.bootstrap.sitecustomize


### PR DESCRIPTION
## Description
Exclude contrib tests directories from `slotcheck` validation as we exclude `ddtrace.contrib` directories

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Ensure tests are passing for affected code.

## Motivation
Avoid errors witch not exists in CI

## Testing strategy
Without these changes, If you run slotchecks you should got an error like:

```
riot run slotscheck -v 'ddtrace/appsec/processor.py' 'ddtrace/contrib/flask/patch.py' 'ddtrace/contrib/trace_utils.py' 'tests/appsec/test_processor.py' 'tests/contrib/django/test_django_appsec.py' 'tests/contrib/flask/test_flask_appsec.py'

tests/contrib/flask/test_flask_appsec.py'
ERROR: Couldn't inspect module 'tests.contrib.flask.test_flask_appsec' due to ImportError("Error while finding loader for 'tests.contrib.flask.test_flask_appsec' (<class 'ModuleNotFoundError'>: No module named 'flask')"). Run `import tests.contrib.flask.test_flask_appsec` to reproduce this error.
Test failed with exit code 1
```

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
