### PR TITLE
chore(internal): prevent deadlock in awakeable services

### DIFF
--- a/ddtrace/internal/periodic.py
+++ b/ddtrace/internal/periodic.py
@@ -96,13 +96,6 @@ class AwakeablePeriodicThread(PeriodicThread):
         self.served = forksafe.Event()
         self.awake_lock = forksafe.Lock()
 
-    def stop(self):
-        """Stop the thread."""
-        super(AwakeablePeriodicThread, self).stop()
-
-        if self.is_alive():
-            self.awake()
-
     def awake(self):
         """Awake the thread."""
         with self.awake_lock:


### PR DESCRIPTION
## Description

Trying to awake the awakeable thread on stop might cause deadlocks during shutdowns. The call to on_shutdown should be enough to handle stop events on this kind of services.

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
