### PR TITLE
chore(debugging): remove encoding test flakiness

### DIFF
--- a/ddtrace/debugging/_encoding.py
+++ b/ddtrace/debugging/_encoding.py
@@ -65,7 +65,7 @@ class JsonBuffer(object):
             raise BufferFull(self.size, size)
 
         if self.size > 2:
-            size += 1
+            self.size += 1
             self._buffer += b","
         self._buffer += item
         self.size += size

--- a/tests/debugging/test_encoding.py
+++ b/tests/debugging/test_encoding.py
@@ -250,14 +250,15 @@ def test_batch_flush_reencode():
     )
 
     encoder = BatchJsonEncoder({Snapshot: SnapshotJsonEncoder(None)})
-    snapshot_size = encoder.put(s)
-    encoder.put(s)
-    assert encoder.count == 2
-    assert len(encoder.encode()) + 1 >= snapshot_size * 2
 
-    assert abs(encoder.put(s) - encoder.put(s)) < 1024
+    snapshot_total_size = sum(encoder.put(s) for _ in range(2))
     assert encoder.count == 2
-    assert len(encoder.encode()) + 1 >= snapshot_size * 2
+    assert len(encoder.encode()) == snapshot_total_size + 3
+
+    a, b = encoder.put(s), encoder.put(s)
+    assert abs(a - b) < 1024
+    assert encoder.count == 2
+    assert len(encoder.encode()) == a + b + 3
 
 
 # ---- Side effects ----


### PR DESCRIPTION
## Description

The debugger encoding tests displayed a certain degree of flakiness. This was due to the same snapshot getting encoded with just a 1-byte length difference (quite likely due to different encoding timings). This change makes the item encoder report the size of the encoded item alone which allows for simpler and more reliable testing logic.

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
