### PR TITLE
chore(internal): remove match fn from sample for single span sampling

### DIFF
--- a/ddtrace/internal/sampling.py
+++ b/ddtrace/internal/sampling.py
@@ -138,7 +138,7 @@ class SpanSamplingRule:
 
     def sample(self, span):
         # type: (Span) -> bool
-        if self.match(span) and self._sample(span):
+        if self._sample(span):
             if self._limiter.is_allowed(span.start_ns):
                 self.apply_span_sampling_tags(span)
                 return True

--- a/tests/tracer/test_single_span_sampling_rule.py
+++ b/tests/tracer/test_single_span_sampling_rule.py
@@ -17,7 +17,8 @@ def traced_function(rule, name="test_name", service="test_service"):
     tracer = DummyTracer()
     with tracer.trace(name) as span:
         span.service = service
-        rule.sample(span)
+        if rule.match(span):
+            rule.sample(span)
     return span
 
 


### PR DESCRIPTION
## Description
Refactoring out match from the sample function for easier and more understandable use in the span processor introduced here: https://github.com/DataDog/dd-trace-py/pull/3966

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
