### PR TITLE
chore(telemetry): avoid starting the telemetry after a process forks

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -241,7 +241,6 @@ class TelemetryWriter(PeriodicService):
         # Avoid sending duplicate events.
         # Queued events should be sent in the main process.
         self._reset_queues()
-        self.start()
 
     def disable(self):
         # type: () -> None

--- a/tests/tracer/telemetry/test_telemetry.py
+++ b/tests/tracer/telemetry/test_telemetry.py
@@ -63,3 +63,21 @@ def test_fork():
         assert telemetry.telemetry_writer.status == ServiceStatus.RUNNING
         # Kill the process so it doesn't continue running the rest of the test suite
         os._exit(0)
+
+
+def test_logs_after_fork(ddtrace_run_python_code_in_subprocess):
+    # Regression test: telemetry writer should not log an error when a process forks
+    _, err, status, _ = ddtrace_run_python_code_in_subprocess(
+        """
+import ddtrace
+import logging
+import os
+
+logging.basicConfig() # required for python 2.7
+ddtrace.internal.telemetry.telemetry_writer.enable()
+os.fork()
+""",
+    )
+
+    assert status == 0, err
+    assert err == b""


### PR DESCRIPTION
## Description

The telemetry writer is still running after a fork. Calling `writer.start()` on a live periodic service logs the following error: 

```
Exception ignored in forksafe hook <bound method TelemetryWriter._fork_writer of TelemetryWriter(status=<ServiceStatus.RUNNING: 'running'>, _interval=60.0)>
Traceback (most recent call last):
  File "/Users/munir.abdinur/Documents/ApmPython/dd-trace-py/ddtrace/internal/forksafe.py", line 33, in ddtrace_after_in_child
    hook()
  File "/Users/munir.abdinur/Documents/ApmPython/dd-trace-py/ddtrace/internal/telemetry/writer.py", line 244, in _fork_writer
    self.start()
  File "/Users/munir.abdinur/Documents/ApmPython/dd-trace-py/ddtrace/internal/service.py", line 57, in start
    raise ServiceStatusError(self.__class__, self.status)
ddtrace.internal.service.ServiceStatusError: TelemetryWriter is already in status running
``` 

Reproduction:

```python
import ddtrace 
import os

ddtrace.internal.telemetry.telemetry_writer.enable()
os.fork()
```

<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [x] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
