### PR TITLE
fix(ci): pin mypy for v1.3.0 release

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -134,7 +134,7 @@ venv = Venv(
             command="mypy {cmdargs}",
             create=True,
             pkgs={
-                "mypy": latest,
+                "mypy": "<0.971",
                 "types-attrs": latest,
                 "types-docutils": latest,
                 "types-protobuf": latest,


### PR DESCRIPTION
CI is failing on the 1.3 branch after the release of mypy 0.971. This is not an issue on 1.x because of #3919, which is not released in v1.3.0. For now we can pin mypy, backport it, then safely unpin on 1.x.