### PR TITLE
fix(span): ignored exceptions should not bubble up to parent spans

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -497,6 +497,13 @@ class Span(object):
             self.finish()
         except Exception:
             log.exception("error closing trace")
+        finally:
+            # prevent ignored exceptions from being propagated to the parent span
+            return (
+                exc_type
+                and self._ignored_exceptions
+                and any([issubclass(exc_type, e) for e in self._ignored_exceptions])
+            )
 
     def __repr__(self):
         return "<Span(id=%s,trace_id=%s,parent_id=%s,name=%s)>" % (

--- a/releasenotes/notes/span-fix-ignored-exceptions-366013ac956d5752.yaml
+++ b/releasenotes/notes/span-fix-ignored-exceptions-366013ac956d5752.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    span: prevent ignored exceptions from being propagated to the parent span

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -517,6 +517,26 @@ def test_span_ignored_exception_multi():
     assert s.get_tag(ERROR_STACK) is None
 
 
+def test_span_ignored_parent(tracer):
+    try:
+        with tracer.trace("parent") as parent:
+            with tracer.trace("child") as child:
+                child._ignore_exception(ValueError)
+                raise ValueError()
+    except ValueError:
+        pass
+
+    assert child.error == 0
+    assert child.get_tag(ERROR_MSG) is None
+    assert child.get_tag(ERROR_TYPE) is None
+    assert child.get_tag(ERROR_STACK) is None
+
+    assert parent.error == 0
+    assert parent.get_tag(ERROR_MSG) is None
+    assert parent.get_tag(ERROR_TYPE) is None
+    assert parent.get_tag(ERROR_STACK) is None
+
+
 def test_span_ignored_exception_subclass():
     s = Span(None)
     s._ignore_exception(Exception)

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -471,10 +471,9 @@ def test_span_nonstring_set_str_tag_warning(span_log):
 def test_span_ignored_exceptions():
     s = Span(None)
     s._ignore_exception(ValueError)
-
-    with pytest.raises(ValueError):
-        with s:
-            raise ValueError()
+    
+    with s:
+        raise ValueError()
 
     assert s.error == 0
     assert s.get_tag(ERROR_MSG) is None

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -471,7 +471,7 @@ def test_span_nonstring_set_str_tag_warning(span_log):
 def test_span_ignored_exceptions():
     s = Span(None)
     s._ignore_exception(ValueError)
-    
+
     with s:
         raise ValueError()
 
@@ -483,9 +483,8 @@ def test_span_ignored_exceptions():
     s = Span(None)
     s._ignore_exception(ValueError)
 
-    with pytest.raises(ValueError):
-        with s:
-            raise ValueError()
+    with s:
+        raise ValueError()
 
     with pytest.raises(RuntimeError):
         with s:
@@ -502,13 +501,11 @@ def test_span_ignored_exception_multi():
     s._ignore_exception(ValueError)
     s._ignore_exception(RuntimeError)
 
-    with pytest.raises(ValueError):
-        with s:
-            raise ValueError()
+    with s:
+        raise ValueError()
 
-    with pytest.raises(RuntimeError):
-        with s:
-            raise RuntimeError()
+    with s:
+        raise RuntimeError()
 
     assert s.error == 0
     assert s.get_tag(ERROR_MSG) is None
@@ -540,13 +537,11 @@ def test_span_ignored_exception_subclass():
     s = Span(None)
     s._ignore_exception(Exception)
 
-    with pytest.raises(ValueError):
-        with s:
-            raise ValueError()
+    with s:
+        raise ValueError()
 
-    with pytest.raises(RuntimeError):
-        with s:
-            raise RuntimeError()
+    with s:
+        raise RuntimeError()
 
     assert s.error == 0
     assert s.get_tag(ERROR_MSG) is None


### PR DESCRIPTION
## Description

Prevent ignored exceptions from being propagated to the parent span. 

If `Span.__exit__()` returns `True` the exception will be suppressed.


## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
