### PR TITLE
fix(ci): fix WSGI tests that did not reset traced headers

### DIFF
--- a/ddtrace/settings/http.py
+++ b/ddtrace/settings/http.py
@@ -24,6 +24,10 @@ class HttpConfig(object):
         self._header_tags = {normalize_header_name(k): v for k, v in header_tags.items()} if header_tags else {}
         self.trace_query_string = None
 
+    def _reset(self):
+        self._header_tags = {}
+        self._header_tag_name.invalidate()
+
     @cachedmethod()
     def _header_tag_name(self, header_name):
         # type: (str) -> Optional[str]

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -142,25 +142,31 @@ def test_query_string_tracing(tracer, test_spans):
 
 def test_http_request_header_tracing(tracer, test_spans):
     config.wsgi.http.trace_headers(["my-header"])
-    app = TestApp(wsgi.DDWSGIMiddleware(application, tracer=tracer))
-    resp = app.get("/", headers={"my-header": "test_value"})
+    try:
+        app = TestApp(wsgi.DDWSGIMiddleware(application, tracer=tracer))
+        resp = app.get("/", headers={"my-header": "test_value"})
 
-    assert resp.status == "200 OK"
-    assert resp.status_int == 200
-    spans = test_spans.pop()
-    assert spans[0].get_tag("http.request.headers.my-header") == "test_value"
+        assert resp.status == "200 OK"
+        assert resp.status_int == 200
+        spans = test_spans.pop()
+        assert spans[0].get_tag("http.request.headers.my-header") == "test_value"
+    finally:
+        config.wsgi.http._reset()
 
 
 def test_http_response_header_tracing(tracer, test_spans):
     config.wsgi.http.trace_headers(["my-response-header"])
-    app = TestApp(wsgi.DDWSGIMiddleware(application, tracer=tracer))
-    resp = app.get("/", headers={"my-header": "test_value"})
+    try:
+        app = TestApp(wsgi.DDWSGIMiddleware(application, tracer=tracer))
+        resp = app.get("/", headers={"my-header": "test_value"})
 
-    assert resp.status == "200 OK"
-    assert resp.status_int == 200
+        assert resp.status == "200 OK"
+        assert resp.status_int == 200
 
-    spans = test_spans.pop()
-    assert spans[0].get_tag("http.response.headers.my-response-header") == "test_response_value"
+        spans = test_spans.pop()
+        assert spans[0].get_tag("http.response.headers.my-response-header") == "test_response_value"
+    finally:
+        config.wsgi.http._reset()
 
 
 def test_service_name_can_be_overriden(tracer, test_spans):

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_200.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_200.json
@@ -10,7 +10,6 @@
     "meta": {
       "_dd.p.dm": "-0",
       "http.method": "GET",
-      "http.response.headers.my-response-header": "test_response_value",
       "http.status_code": "200",
       "http.status_msg": "OK",
       "http.url": "http://localhost:80/",


### PR DESCRIPTION
## Description
The tests we had do did not reset the activation of traced headers so the configuration was leaking over to other tests.

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] PR cannot be broken up into smaller PRs.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
