### PR TITLE
fix(tracing/jinja2): ensure template name is a string

### DIFF
--- a/ddtrace/contrib/jinja2/patch.py
+++ b/ddtrace/contrib/jinja2/patch.py
@@ -7,6 +7,7 @@ from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanTypes
+from ...internal.compat import stringify
 from ...internal.utils import ArgumentError
 from ...internal.utils import get_argument_value
 from ...pin import Pin
@@ -54,7 +55,7 @@ def _wrap_render(wrapped, instance, args, kwargs):
     if not pin or not pin.enabled():
         return wrapped(*args, **kwargs)
 
-    template_name = instance.name or DEFAULT_TEMPLATE_NAME
+    template_name = stringify(instance.name or DEFAULT_TEMPLATE_NAME)
     with pin.tracer.trace("jinja2.render", pin.service, span_type=SpanTypes.TEMPLATE) as span:
         span.set_tag(SPAN_MEASURED_KEY)
         try:

--- a/releasenotes/notes/fix-jinja2-non-str-template-name-4cb2aa7cda15828a.yaml
+++ b/releasenotes/notes/fix-jinja2-non-str-template-name-4cb2aa7cda15828a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    jinja2: fixes handling of template name which are not strings.

--- a/releasenotes/notes/fix-jinja2-non-str-template-name-4cb2aa7cda15828a.yaml
+++ b/releasenotes/notes/fix-jinja2-non-str-template-name-4cb2aa7cda15828a.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    jinja2: fixes handling of template names which are not strings.
+    jinja2: fix handling of template names which are not strings.

--- a/releasenotes/notes/fix-jinja2-non-str-template-name-4cb2aa7cda15828a.yaml
+++ b/releasenotes/notes/fix-jinja2-non-str-template-name-4cb2aa7cda15828a.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    jinja2: fixes handling of template name which are not strings.
+    jinja2: fixes handling of template names which are not strings.


### PR DESCRIPTION
## Description

We assume that `Template.name` is going to be a string, but
this is not enforced by Jinja2 so we must be prepared for when
it isn't.

This is not an issue for setting the template name as a tag
since `Span.set_tag` will coerce the value, but it causes
an issue for `Span.resource` for the `jinja2.render` span.


## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Relevant issue(s)

Fixes #4008

## Testing strategy

Added a new test case for our Jinja2 integration to verify when custom template names are used of various types (str, unicode, int) that we properly coerce them into a string.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
