### PR TITLE
fix(tests/tox): updated gevent in tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,9 +72,9 @@ isolated_build = true
 
 requires = virtualenv<=20.2.1
 
-[testenv:gevent_contrib-py39-gevent{209,2012,211}-sslmodules3-sslmodules]
+[testenv:gevent_contrib-py{37,38}-gevent{13,14}-sslmodules3-sslmodules]
 # Wheels for gevent segfault pretty easily
-install_command=python -m pip install --no-binary=:all: {opts} {packages}
+install_command=python -m pip install --no-binary=gevent {opts} {packages}
 usedevelop = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ requires = virtualenv<=20.2.1
 
 [testenv]
 # Wheels for gevent segfault pretty easily
-install_command=python -m pip install {opts} {packages}
+install_command=python -m pip install --no-binary gevent<21.12.0 {opts} {packages}
 usedevelop = true
 
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -124,7 +124,8 @@ deps =
     profile-!minreqs-gevent: gevent
     py27-profile-minreqs-gevent: gevent==1.1.0
     py{35,36,37,38}-profile-minreqs-gevent: gevent==1.4.0
-    py39-profile-minreqs-gevent: gevent==20.6.1
+    py39-profile-minreqs-gevent: gevent==20.6.1; sys_platform != 'win32'
+    py39-profile-minreqs-gevent: gevent==21.1.2; sys_platform == 'win32'
     py39-profile-minreqs-gevent: greenlet==0.4.16
     py310-profile-minreqs-gevent: gevent==21.8.0
     py310-profile-minreqs-gevent: greenlet==1.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ requires = virtualenv<=20.2.1
 
 [testenv]
 # Wheels for gevent segfault pretty easily
-install_command=python -m pip install --no-binary gevent==21.12.0 {opts} {packages}
+install_command=python -m pip install --no-binary=:all: {opts} {packages}
 usedevelop = true
 
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,16 @@ requires = virtualenv<=20.2.1
 install_command=python -m pip install --no-binary=gevent {opts} {packages}
 usedevelop = true
 
+[testenv:py{37,38}-opentracer_gevent-gevent{13,14}]
+# Wheels for gevent segfault pretty easily
+install_command=python -m pip install --no-binary=gevent {opts} {packages}
+usedevelop = true
+
+[testenv:py{37,38}-profile-minreqs-gevent]
+# Wheels for gevent segfault pretty easily
+install_command=python -m pip install --no-binary=gevent {opts} {packages}
+usedevelop = true
+
 [testenv]
 install_command=python -m pip install {opts} {packages}
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ requires = virtualenv<=20.2.1
 
 [testenv]
 # Wheels for gevent segfault pretty easily
-install_command=python -m pip install --no-binary gevent {opts} {packages}
+install_command=python -m pip install Cython {opts} {packages}
 usedevelop = true
 
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -72,9 +72,13 @@ isolated_build = true
 
 requires = virtualenv<=20.2.1
 
-[testenv]
+[testenv:gevent_contrib-py39-gevent{209,2012,211}-sslmodules3-sslmodules]
 # Wheels for gevent segfault pretty easily
 install_command=python -m pip install --no-binary=:all: {opts} {packages}
+usedevelop = true
+
+[testenv]
+install_command=python -m pip install {opts} {packages}
 usedevelop = true
 
 setenv =
@@ -86,7 +90,7 @@ extras =
   profile: profiling
 
 deps =
-    cython
+    cython<=0.29.32
     cmake
     ninja
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ requires = virtualenv<=20.2.1
 
 [testenv]
 # Wheels for gevent segfault pretty easily
-install_command=python -m pip install Cython {opts} {packages}
+install_command=python -m pip install {opts} {packages}
 usedevelop = true
 
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -87,10 +87,6 @@ usedevelop = true
 install_command=python -m pip install --no-binary=gevent {opts} {packages}
 usedevelop = true
 
-[testenv:py39-profile-minreqs-gevent]
-# Wheels for gevent segfault pretty easily
-install_command=python -m pip install --only-binary=gevent {opts} {packages}
-
 
 [testenv]
 install_command=python -m pip install {opts} {packages}
@@ -126,7 +122,8 @@ deps =
     py{35,36,37,38}-profile-minreqs-gevent: gevent==1.4.0
     py39-profile-minreqs-gevent: gevent==20.6.1; sys_platform != 'win32'
     py39-profile-minreqs-gevent: gevent==21.1.2; sys_platform == 'win32'
-    py39-profile-minreqs-gevent: greenlet==0.4.16
+    py39-profile-minreqs-gevent: greenlet==0.4.16; sys_platform != 'win32'
+    py39-profile-minreqs-gevent: greenlet==0.4.17; sys_platform == 'win32'
     py310-profile-minreqs-gevent: gevent==21.8.0
     py310-profile-minreqs-gevent: greenlet==1.1.0
     py{37,38,39,310}-profile-protobuf319: protobuf<3.19

--- a/tox.ini
+++ b/tox.ini
@@ -87,6 +87,11 @@ usedevelop = true
 install_command=python -m pip install --no-binary=gevent {opts} {packages}
 usedevelop = true
 
+[testenv:py39-profile-minreqs-gevent]
+# Wheels for gevent segfault pretty easily
+install_command=python -m pip install --only-binary=gevent {opts} {packages}
+
+
 [testenv]
 install_command=python -m pip install {opts} {packages}
 usedevelop = true
@@ -119,7 +124,7 @@ deps =
     profile-!minreqs-gevent: gevent
     py27-profile-minreqs-gevent: gevent==1.1.0
     py{35,36,37,38}-profile-minreqs-gevent: gevent==1.4.0
-    py39-profile-minreqs-gevent: gevent==20.6.0
+    py39-profile-minreqs-gevent: gevent==20.6.1
     py39-profile-minreqs-gevent: greenlet==0.4.16
     py310-profile-minreqs-gevent: gevent==21.8.0
     py310-profile-minreqs-gevent: greenlet==1.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ requires = virtualenv<=20.2.1
 
 [testenv]
 # Wheels for gevent segfault pretty easily
-install_command=python -m pip install --no-binary gevent<21.12.0 {opts} {packages}
+install_command=python -m pip install --no-binary gevent==21.12.0 {opts} {packages}
 usedevelop = true
 
 setenv =


### PR DESCRIPTION
## Description
Fixed gevent error in tox tests:
```
Collecting gevent<20.10,>=20.9
  Using cached gevent-20.9.0.tar.gz (5.8 MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [60 lines of output]
      warning: src/gevent/resolver/cares.pyx:38:0: The 'DEF' statement is deprecated and will be removed in a future Cython version. Consider using global variables, constants, and in-place literals instead. See https://github.com/cython/cython/issues/4310
      warning: src/gevent/resolver/cares.pyx:40:0: The 'DEF' statement is deprecated and will be removed in a future Cython version. Consider using global variables, constants, and in-place literals instead. See https://github.com/cython/cython/issues/4310
      warning: src/gevent/resolver/cares.pyx:41:0: The 'DEF' statement is deprecated and will be removed in a future Cython version. Consider using global variables, constants, and in-place literals instead. See https://github.com/cython/cython/issues/4310
      Compiling src/gevent/resolver/cares.pyx because it changed.
      [1/1] Cythonizing src/gevent/resolver/cares.pyx
      warning: src/gevent/libev/corecext.pyx:325:0: The 'DEF' statement is deprecated and will be removed in a future Cython version. Consider using global variables, constants, and in-place literals instead. See https://github.com/cython/cython/issues/4310
      warning: src/gevent/libev/corecext.pyx:783:0: The 'DEF' statement is deprecated and will be removed in a future Cython version. Consider using global variables, constants, and in-place literals instead. See https://github.com/cython/cython/issues/4310
      warning: src/gevent/libev/corecext.pyx:785:0: The 'DEF' statement is deprecated and will be removed in a future Cython version. Consider using global variables, constants, and in-place literals instead. See https://github.com/cython/cython/issues/4310
      warning: src/gevent/libev/corecext.pyx:787:0: The 'DEF' statement is deprecated and will be removed in a future Cython version. Consider using global variables, constants, and in-place literals instead. See https://github.com/cython/cython/issues/4310
      warning: src/gevent/libev/corecext.pyx:791:0: The 'DEF' statement is deprecated and will be removed in a future Cython version. Consider using global variables, constants, and in-place literals instead. See https://github.com/cython/cython/issues/4310
      Compiling src/gevent/libev/corecext.pyx because it changed.
      [1/1] Cythonizing src/gevent/libev/corecext.pyx
      Compiling src/gevent/_greenlet_primitives.py because it changed.
      [1/1] Cythonizing src/gevent/_greenlet_primitives.py
      Compiling src/gevent/_hub_primitives.py because it changed.
      [1/1] Cythonizing src/gevent/_hub_primitives.py
      Compiling src/gevent/_hub_local.py because it changed.
      [1/1] Cythonizing src/gevent/_hub_local.py
      Compiling src/gevent/_waiter.py because it changed.
      [1/1] Cythonizing src/gevent/_waiter.py
      warning: src/gevent/_gevent_cgreenlet.pxd:112:33: Declarations should not be declared inline.
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      cdef load_traceback
      cdef Waiter
      cdef wait
      cdef iwait
      cdef reraise
      cpdef GEVENT_CONFIG
            ^
      ------------------------------------------------------------
      
      src/gevent/_gevent_cgreenlet.pxd:181:6: Variables cannot be declared with 'cpdef'. Use 'cdef' instead.
      Compiling src/gevent/greenlet.py because it changed.
      [1/1] Cythonizing src/gevent/greenlet.py
      Traceback (most recent call last):
```

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
