### PR TITLE
test(debugging): mark flaky poller test on Python 2

### DIFF
--- a/tests/debugging/probe/test_poller.py
+++ b/tests/debugging/probe/test_poller.py
@@ -8,6 +8,7 @@ from ddtrace.debugging._probe.model import Probe
 from ddtrace.debugging._probe.poller import ProbePoller
 from ddtrace.debugging._probe.poller import ProbePollerEvent
 from ddtrace.debugging._remoteconfig import _filter_by_env_and_version
+from ddtrace.internal.compat import PY2
 from tests.utils import override_global_config
 
 
@@ -86,6 +87,7 @@ def test_poller_env_version(env, version, expected):
         assert set(_.probe_id for _ in probes) == expected
 
 
+@pytest.mark.xfail(PY2, reason="occasionally fails on Python 2")
 def test_poller_events():
     events = set()
 


### PR DESCRIPTION
## Description

For unknown reasons, the poller event test occasionally fails on Python 2 because a modified probe is handled as a pair of "deleted" and "new" events. Therefore, we mark the test with xfail on Python 2 for now.

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
