### PR TITLE
fix(django): CI erros with Django 4.1 new release

### DIFF
--- a/tests/contrib/django/django_app/settings.py
+++ b/tests/contrib/django/django_app/settings.py
@@ -50,11 +50,13 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.memcached.PyLibMCCache",
         "LOCATION": "127.0.0.1:11211",
     },
-    "python_memcached": {
+}
+
+if django.VERSION <= (4, 1, 0):
+    CACHES["python_memcached"] = {
         "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
         "LOCATION": "127.0.0.1:11211",
-    },
-}
+    }
 
 SITE_ID = 1
 SECRET_KEY = "not_very_secret_in_tests"


### PR DESCRIPTION
## Description
[Django new release](https://pypi.org/project/Django/#history) deprecates [django.core.cache.backends.memcached.MemcachedCache](https://docs.djangoproject.com/en/4.1/releases/4.1/)

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
