### PR TITLE
fix(graphql): rename service entry span

### DIFF
--- a/ddtrace/contrib/graphql/patch.py
+++ b/ddtrace/contrib/graphql/patch.py
@@ -182,7 +182,7 @@ def _traced_query(func, args, kwargs):
     resource = _get_source_str(source)
 
     with pin.tracer.trace(
-        name="graphql.graphql",
+        name="graphql.request",
         resource=resource,
         service=trace_utils.int_service(pin, config.graphql),
         span_type=SpanTypes.GRAPHQL,

--- a/ddtrace/contrib/graphql/patch.py
+++ b/ddtrace/contrib/graphql/patch.py
@@ -182,7 +182,7 @@ def _traced_query(func, args, kwargs):
     resource = _get_source_str(source)
 
     with pin.tracer.trace(
-        name="graphql.query",
+        name="graphql.graphql",
         resource=resource,
         service=trace_utils.int_service(pin, config.graphql),
         span_type=SpanTypes.GRAPHQL,

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "graphql.graphql",
+    "name": "graphql.request",
     "service": "graphql",
     "resource": "query HELLO { hello }",
     "trace_id": 0,

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "graphql.query",
+    "name": "graphql.graphql",
     "service": "graphql",
     "resource": "query HELLO { hello }",
     "trace_id": 0,

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_error.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_error.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "graphql.query",
+    "name": "graphql.graphql",
     "service": "graphql",
     "resource": "{ invalid_schema }",
     "trace_id": 0,

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_error.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_error.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "graphql.graphql",
+    "name": "graphql.request",
     "service": "graphql",
     "resource": "{ invalid_schema }",
     "trace_id": 0,

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_v2_with_document.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_v2_with_document.json
@@ -24,7 +24,7 @@
   }],
 [
   {
-    "name": "graphql.graphql",
+    "name": "graphql.request",
     "service": "graphql",
     "resource": "query HELLO { hello }",
     "trace_id": 1,

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_v2_with_document.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_v2_with_document.json
@@ -24,7 +24,7 @@
   }],
 [
   {
-    "name": "graphql.query",
+    "name": "graphql.graphql",
     "service": "graphql",
     "resource": "query HELLO { hello }",
     "trace_id": 1,

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_traced_resolver.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_traced_resolver.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "graphql.graphql",
+    "name": "graphql.request",
     "service": "graphql",
     "resource": "query HELLO { hello }",
     "trace_id": 0,

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_traced_resolver.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_traced_resolver.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "graphql.query",
+    "name": "graphql.graphql",
     "service": "graphql",
     "resource": "query HELLO { hello }",
     "trace_id": 0,


### PR DESCRIPTION
## Description

The graphql top level span is currently named `graphql.query`. This span wraps the execution of the `graphql.graphql()`. The current span name can be misleading since `graphql.graphql()` can execute graphql queries, graphql mutations or graphql subscriptions. This fix proposes setting the span name to `graphql.request` instead. 

An alternative fix would be to set the span name to  `graphql.query`, `graphql.mutation` or `graphql.subscription` depending on the operation name. However getting the operation name would require parsing the query and this can be expensive. 

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
