### PR TITLE
fix(profiling): fix potential StackCollector deadlock 

### DIFF
--- a/ddtrace/internal/nogevent.py
+++ b/ddtrace/internal/nogevent.py
@@ -37,6 +37,7 @@ start_new_thread = get_original(six.moves._thread.__name__, "start_new_thread")
 thread_get_ident = get_original(six.moves._thread.__name__, "get_ident")
 Thread = get_original("threading", "Thread")
 Lock = get_original("threading", "Lock")
+RLock = get_original("threading", "RLock")
 
 is_threading_patched = is_module_patched("threading")
 

--- a/ddtrace/profiling/_threading.pyx
+++ b/ddtrace/profiling/_threading.pyx
@@ -69,7 +69,9 @@ class _ThreadLink(_thread_link_base):
     # Key is a thread_id
     # Value is a weakref to an object
     _thread_id_to_object = attr.ib(factory=dict, repr=False, init=False, type=typing.Dict[int, _weakref_type])
-    _lock = attr.ib(factory=nogevent.Lock, repr=False, init=False, type=nogevent.Lock)
+    # Note that this lock has to be reentrant as spans can be activated unexpectedly in the same thread
+    # ex. during a gc weakref finalize callback
+    _lock = attr.ib(factory=nogevent.RLock, repr=False, init=False, type=nogevent.RLock)
 
     def link_object(
             self,

--- a/releasenotes/notes/profiling-threadlink-lock-27df798c36ed64e6.yaml
+++ b/releasenotes/notes/profiling-threadlink-lock-27df798c36ed64e6.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    profiling: fix a possible deadlock due to spans being activated unexpectedly.


### PR DESCRIPTION
It is possible that while the profiling StackCollector is handling the
on_span_activate event that a gc occurs which could result in a weakref
finalize callback being called which then could activate a new span.
This sequence of events results in a deadlock as the lock the
StackCollector uses is not reentrant.

A regression test would be great but we cannot think of a tractable test
case which wouldn't be flaky.


Here's an example stacktrace of this happening:

```
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/contrib/dbapi/__init__.py", line 91, in _trace_method
[18:50:46 UTC]   [pytest:unit]                     		s.set_tag(sql.ROWS, row_count)
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/span.py", line 497, in __exit__
[18:50:46 UTC]   [pytest:unit]                     		self.finish()
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/span.py", line 239, in finish
[18:50:46 UTC]   [pytest:unit]                     		cb(self)
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/tracer.py", line 703, in _on_span_finish
[18:50:46 UTC]   [pytest:unit]                     		active = self.current_span()
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/tracer.py", line 813, in current_span
[18:50:46 UTC]   [pytest:unit]                     		active = self.context_provider.active()
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/contrib/gevent/provider.py", line 41, in active
[18:50:46 UTC]   [pytest:unit]                     		return self._update_active(ctx)
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/provider.py", line 103, in _update_active
[18:50:46 UTC]   [pytest:unit]                     		self.activate(new_active)
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/contrib/gevent/provider.py", line 34, in activate
[18:50:46 UTC]   [pytest:unit]                     		super(GeventContextProvider, self).activate(context)
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/provider.py", line 45, in activate
[18:50:46 UTC]   [pytest:unit]                     		self._hooks.emit(self.activate, ctx)
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/_hooks.py", line 131, in emit
[18:50:46 UTC]   [pytest:unit]                     		func(*args, **kwargs)
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/sqlalchemy/pool/base.py", line 503, in <lambda>
[18:50:46 UTC]   [pytest:unit]                     		and _finalize_fairy(None, rec, pool, ref, echo),
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/sqlalchemy/pool/base.py", line 680, in _finalize_fairy
[18:50:46 UTC]   [pytest:unit]                     		fairy._reset(pool)
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/sqlalchemy/pool/base.py", line 867, in _reset
[18:50:46 UTC]   [pytest:unit]                     		pool._dialect.do_rollback(self)
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 500, in do_rollback
[18:50:46 UTC]   [pytest:unit]                     		dbapi_connection.rollback()
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/contrib/dbapi/__init__.py", line 261, in rollback
[18:50:46 UTC]   [pytest:unit]                     		return self._trace_method(self.__wrapped__.rollback, span_name, {}, *args, **kwargs)
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/contrib/dbapi/__init__.py", line 242, in _trace_method
[18:50:46 UTC]   [pytest:unit]                     		with pin.tracer.trace(name, service=ext_service(pin, self._self_config)) as s:
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/tracer.py", line 782, in trace
[18:50:46 UTC]   [pytest:unit]                     		activate=True,
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/tracer.py", line 685, in _start_span
[18:50:46 UTC]   [pytest:unit]                     		self.context_provider.activate(span)
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/contrib/gevent/provider.py", line 34, in activate
[18:50:46 UTC]   [pytest:unit]                     		super(GeventContextProvider, self).activate(context)
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/provider.py", line 45, in activate
[18:50:46 UTC]   [pytest:unit]                     		self._hooks.emit(self.activate, ctx)
[18:50:46 UTC]   [pytest:unit]                     	File "/opt/dogweb/lib/python2.7/site-packages/ddtrace/_hooks.py", line 131, in emit
[18:50:46 UTC]   [pytest:unit]                     		func(*args, **kwargs)
```