### PR TITLE
fix(profiling): fix potential crash in frame converter

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_tb.c
+++ b/ddtrace/profiling/collector/_memalloc_tb.c
@@ -78,10 +78,6 @@ memalloc_convert_frame(PyFrameObject* pyframe, frame_t* frame)
         name = code->co_name;
     }
 
-#ifdef _PY39_AND_LATER
-    Py_DECREF(code);
-#endif
-
     if (name)
         frame->name = name;
     else
@@ -95,6 +91,10 @@ memalloc_convert_frame(PyFrameObject* pyframe, frame_t* frame)
         frame->filename = unknown_name;
 
     Py_INCREF(frame->filename);
+
+#ifdef _PY39_AND_LATER
+    Py_XDECREF(code);
+#endif
 }
 
 static traceback_t*


### PR DESCRIPTION
On Python 3.9 and later, PyFrame_GetCode returns a new reference that should be
decremented after the function finishes.

The current code calls Py_DECREF without checking that code is not NULL, while
there is a check doing that for safety. The DECREF is also done a little too
soon (in theory, in practice it does not have a real impact).

This switches to XDECREF to make sure that `code` is not NULL and does this at
the end of the function to be sure we have inc-referenced code items that we
cared about.