### PR TITLE
ci: update github action runner image to ubuntu-latest

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -21,9 +21,9 @@ jobs:
     strategy:
       matrix:
         include:
-         - os: ubuntu-22.04
+         - os: ubuntu-latest
            archs: x86_64 i686
-         - os: ubuntu-22.04
+         - os: ubuntu-latest
            archs: aarch64
          - os: windows-latest
            archs: AMD64 x86
@@ -71,9 +71,9 @@ jobs:
     strategy:
       matrix:
         include:
-         - os: ubuntu-22.04
+         - os: ubuntu-latest
            archs: x86_64 i686
-         - os: ubuntu-22.04
+         - os: ubuntu-latest
            archs: aarch64
          - os: windows-latest
            archs: AMD64 x86

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -21,9 +21,9 @@ jobs:
     strategy:
       matrix:
         include:
-         - os: ubuntu-18.04
+         - os: ubuntu-22.04
            archs: x86_64 i686
-         - os: ubuntu-18.04
+         - os: ubuntu-22.04
            archs: aarch64
          - os: windows-latest
            archs: AMD64 x86
@@ -71,9 +71,9 @@ jobs:
     strategy:
       matrix:
         include:
-         - os: ubuntu-18.04
+         - os: ubuntu-22.04
            archs: x86_64 i686
-         - os: ubuntu-18.04
+         - os: ubuntu-22.04
            archs: aarch64
          - os: windows-latest
            archs: AMD64 x86


### PR DESCRIPTION
On v1.4.0 release, the build failed with:

```
[Build and test wheels on ubuntu-18.04 (aarch64)](https://github.com/DataDog/dd-trace-py/runs/7951686050?check_suite_focus=true)
This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on December 1st, 2022. For more details, see https://github.com/actions/runner-images/issues/6002
```

Failing build: https://github.com/DataDog/dd-trace-py/actions/runs/2903881861

https://github.com/actions/runner-images/issues/6002