### PR TITLE
fix(logging): account for placeholder in get_logger

### DIFF
--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -36,7 +36,7 @@ def get_logger(name):
     # DEV: `Manager.loggerDict` is a dict mapping logger name to logger
     # DEV: This is a simplified version of `logging.Manager.getLogger`
     #   https://github.com/python/cpython/blob/48769a28ad6ef4183508951fa6a378531ace26a4/Lib/logging/__init__.py#L1221-L1253  # noqa
-     # DEV: _fixupParents could be adding a placeholder, we want to replace it if that's the case
+    # DEV: _fixupParents could be adding a placeholder, we want to replace it if that's the case
     if name not in manager.loggerDict or isinstance(manager.loggerDict[name], logging.PlaceHolder):
         manager.loggerDict[name] = DDLogger(name=name)
 

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -36,7 +36,8 @@ def get_logger(name):
     # DEV: `Manager.loggerDict` is a dict mapping logger name to logger
     # DEV: This is a simplified version of `logging.Manager.getLogger`
     #   https://github.com/python/cpython/blob/48769a28ad6ef4183508951fa6a378531ace26a4/Lib/logging/__init__.py#L1221-L1253  # noqa
-    if name not in manager.loggerDict:
+     # DEV: _fixupParents could be adding a placeholder, we want to replace it if that's the case
+    if name not in manager.loggerDict or isinstance(manager.loggerDict[name], logging.PlaceHolder):
         manager.loggerDict[name] = DDLogger(name=name)
 
     # Get our logger

--- a/tests/tracer/test_logger.py
+++ b/tests/tracer/test_logger.py
@@ -94,7 +94,7 @@ class DDLoggerTestCase(BaseTestCase):
 
         # If a PlaceHolder is in place of the logger
         # We should return the DDLogger
-        placeholder = logging.PlaceHolder()
+        placeholder = logging.PlaceHolder("test")
         self.manager.loggerDict["test.name.logger"] = placeholder
         log = get_logger("test.name.logger")
         self.assertEqual(log.name, "test.name.logger")

--- a/tests/tracer/test_logger.py
+++ b/tests/tracer/test_logger.py
@@ -65,6 +65,8 @@ class DDLoggerTestCase(BaseTestCase):
                 We return the expected logger
             When a different logger is requested
                 We return a new DDLogger
+            When a Placeholder exists
+                We return DDLogger
         """
         # Assert the logger doesn't already exist
         self.assertNotIn("test.logger", self.manager.loggerDict)
@@ -89,6 +91,14 @@ class DDLoggerTestCase(BaseTestCase):
         new_log = get_logger("new.test.logger")
         # Make sure we didn't get the same one
         self.assertNotEqual(log, new_log)
+
+        # If a PlaceHolder is in place of the logger
+        # We should return the DDLogger
+        placeholder = logging.PlaceHolder()
+        self.manager.loggerDict["test.name.logger"] = placeholder
+        log = get_logger("test.name.logger")
+        self.assertEqual(log.name, "test.name.logger")
+        self.assertIsInstance(log, DDLogger)
 
     def test_get_logger_parents(self):
         """


### PR DESCRIPTION
## Description
Before we wouldn't replace a PlaceHolder added by _fixUpParents which would be incorrect since we'd want to get rid of the PlaceHolder and replace it with our DDLogger.

From Gab: 
This was causing issues with some tests that I was running as part of a change I’m working on. With that line the problem goes away.

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.



## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
