### PR TITLE
feat(elasticsearch): support elasticsearch 8

### DIFF
--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -50,6 +50,7 @@ def _determine_transport_module(elasticsearch):
     transport_module = getattr(elasticsearch, "transport", False)
     if not transport_module:
         import elastic_transport
+
         transport_module = getattr(elastic_transport, "_transport")
 
     return transport_module

--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -54,6 +54,8 @@ except ImportError:
 
 httplib = six.moves.http_client
 urlencode = six.moves.urllib.parse.urlencode
+urldecode = six.moves.urllib.parse.unquote
+urlparse = six.moves.urllib.parse.urlparse
 parse = six.moves.urllib.parse
 Queue = six.moves.queue.Queue
 iteritems = six.iteritems

--- a/riotfile.py
+++ b/riotfile.py
@@ -730,6 +730,7 @@ venv = Venv(
                             "~=7.8.0",
                             "~=7.10.0",
                             "~=8.4.0",
+                            latest,
                         ]
                     },
                 ),
@@ -753,7 +754,6 @@ venv = Venv(
                         "elasticsearch5": [latest],
                         "elasticsearch6": [latest],
                         "elasticsearch7": ["<7.14.0"],
-                        "elasticsearch8": ["~=8.4.0"],
                     },
                 ),
             ],

--- a/riotfile.py
+++ b/riotfile.py
@@ -729,9 +729,7 @@ venv = Venv(
                             "~=7.6.0",
                             "~=7.8.0",
                             "~=7.10.0",
-                            # FIXME: Elasticsearch introduced a breaking change in 7.14
-                            # which makes it incompatible with previous major versions.
-                            # latest,
+                            "~=8.4.0",
                         ]
                     },
                 ),
@@ -740,6 +738,7 @@ venv = Venv(
                 Venv(pys=select_pys(), pkgs={"elasticsearch5": ["~=5.5.0"]}),
                 Venv(pys=select_pys(), pkgs={"elasticsearch6": ["~=6.4.0", "~=6.8.0", latest]}),
                 Venv(pys=select_pys(), pkgs={"elasticsearch7": ["~=7.6.0", "~=7.8.0", "~=7.10.0"]}),
+                Venv(pys=select_pys(), pkgs={"elasticsearch8": ["~=8.4.0"]}),
             ],
         ),
         Venv(
@@ -754,6 +753,7 @@ venv = Venv(
                         "elasticsearch5": [latest],
                         "elasticsearch6": [latest],
                         "elasticsearch7": ["<7.14.0"],
+                        "elasticsearch8": ["~=8.4.0"],
                     },
                 ),
             ],

--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -19,6 +19,7 @@ module_names = (
     "elasticsearch5",
     "elasticsearch6",
     "elasticsearch7",
+    "elasticsearch8",
 )
 
 for module_name in module_names:


### PR DESCRIPTION
## Description
This change is required because newer versions of elasticsearch have the Transport class in a different location.

Fixes https://github.com/DataDog/dd-trace-py/issues/3482

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation

Since newer versions of elasticsearch contain the `Transport` class on `elastic_transport._transport`, the patching mechanism needs to use this new location instead of the older versions location. 

## Design 

This change is backwards compatible and I don't see a major drawback.

## Testing strategy
The riot testing suite has been expanded with new versions of elasticsearch.

<!-- END feat -->


## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
