### PR TITLE
chore(debugging): fix ejection

### DIFF
--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -405,12 +405,12 @@ class Debugger(Service):
                     self._probe_registry.set_exc_info(probe, exc_info)
                 log.error("Cannot register probe injection hook on source '%s'", source, exc_info=True)
 
-    def _eject_probes(self, probes):
+    def _eject_probes(self, probes_to_eject):
         # type: (List[LineProbe]) -> None
         # TODO[perf]: Bulk-collect probes as for injection. This is lower
         # priority as probes are normally removed manually by users.
         unregistered_probes = []  # type: List[LineProbe]
-        for probe in probes:
+        for probe in probes_to_eject:
             if probe not in self._probe_registry:
                 log.error("Attempted to eject unregistered probe %r", probe)
                 continue
@@ -438,12 +438,12 @@ class Debugger(Service):
                     for function in (cast(FullyNamedWrappedFunction, _) for _ in functions):
                         probes_for_function[function].append(probe)
 
-                for function, probes in probes_for_function.items():
+                for function, ps in probes_for_function.items():
                     failed = self._function_store.eject_hooks(
                         cast(FunctionType, function),
-                        [(self._dd_debugger_hook, probe.line, probe) for probe in probes if probe.line is not None],
+                        [(self._dd_debugger_hook, probe.line, probe) for probe in ps if probe.line is not None],
                     )
-                    for probe in probes:
+                    for probe in ps:
                         if probe.probe_id in failed:
                             log.error("Failed to eject %r from %r", probe, function)
                         else:

--- a/ddtrace/internal/injection.py
+++ b/ddtrace/internal/injection.py
@@ -66,7 +66,7 @@ def _eject_hook(code, hook, line, arg):
             # hook and we also test for the expected opcode arguments
             if (
                 instr.lineno == line
-                and code[i].arg is hook
+                and code[i].arg == hook  # bound methods don't like identity comparisons
                 and code[i + 1].arg is arg
                 and [code[_].name for _ in range(i, i + 4)] == ["LOAD_CONST", "LOAD_CONST", "CALL_FUNCTION", "POP_TOP"]
             ):

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -98,6 +98,7 @@ def test_debugger_line_probe_on_imported_module_function():
                 probe_id="probe-instance-method",
                 module="tests.submod.stuff",
                 func_qname="Stuff.instancestuff",
+                rate=1000,
             ),
             lambda: getattr(Stuff(), "instancestuff")(42),
         ),
@@ -106,6 +107,7 @@ def test_debugger_line_probe_on_imported_module_function():
                 probe_id="probe-instance-method",
                 source_file="tests/submod/stuff.py",
                 line=36,
+                rate=1000,
             ),
             lambda: getattr(Stuff(), "instancestuff")(42),
         ),
@@ -149,7 +151,7 @@ def test_debugger_probe_new_delete(probe, trigger):
 
         assert d.uploader.queue
 
-        payload = d.uploader.payloads[-1]
+        (payload,) = d.uploader.payloads
         assert payload
 
         (snapshot,) = payload
@@ -165,6 +167,7 @@ def test_debugger_probe_new_delete(probe, trigger):
                 probe_id="probe-instance-method",
                 module="tests.submod.stuff",
                 func_qname="Stuff.instancestuff",
+                rate=1000.0,
             ),
             lambda: Stuff().instancestuff(42),
         ),
@@ -173,6 +176,7 @@ def test_debugger_probe_new_delete(probe, trigger):
                 probe_id="probe-instance-method",
                 source_file="tests/submod/stuff.py",
                 line=36,
+                rate=1000.0,
             ),
             lambda: Stuff().instancestuff(42),
         ),


### PR DESCRIPTION
## Description

Since identity comparison between bound methods does not work as expected, probe ejection with a bound method hook always fails. This change replaces the identity comparison with equality to fix the issue.

The problem was not caught in tests because of the default rate limiting on probes and a lax testing logic. The relevant test cases have been enhanced to be stricter and increase the rate on probes to avoid hitting the rate limit.

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
