### PR TITLE
feat(asm): configure ddwaf data obfuscator

### DIFF
--- a/ddtrace/appsec/CMakeLists.txt
+++ b/ddtrace/appsec/CMakeLists.txt
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libddwaf
     GIT_REPOSITORY https://github.com/DataDog/libddwaf.git
-    GIT_TAG e8997be4c9ba1f54c8f95c48a560a2a5253b5956
+    GIT_TAG af96a851bd765290d6b4f5cbbba07f4256717b57
     INSTALL_DIR ${CMAKE_SOURCE_DIR}
     CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/ddtrace/appsec/CMakeLists.txt
+++ b/ddtrace/appsec/CMakeLists.txt
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libddwaf
     GIT_REPOSITORY https://github.com/DataDog/libddwaf.git
-    GIT_TAG 627d8958d72440eb020e55ecb8772503796a73af
+    GIT_TAG e8997be4c9ba1f54c8f95c48a560a2a5253b5956
     INSTALL_DIR ${CMAKE_SOURCE_DIR}
     CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/ddtrace/appsec/_ddwaf.pyx
+++ b/ddtrace/appsec/_ddwaf.pyx
@@ -13,6 +13,7 @@ else:
 
 from _libddwaf cimport DDWAF_LOG_LEVEL
 from _libddwaf cimport DDWAF_OBJ_TYPE
+from _libddwaf cimport ddwaf_config
 from _libddwaf cimport ddwaf_context
 from _libddwaf cimport ddwaf_context_destroy
 from _libddwaf cimport ddwaf_context_init
@@ -224,11 +225,26 @@ cdef class DDWaf(object):
     cdef ddwaf_handle _handle
     cdef object _rules
 
-    def __init__(self, rules):
+    def __init__(self, rules, obfuscation_parameter_key_regexp, obfuscation_parameter_value_regexp):
         cdef ddwaf_object* rule_objects
+        cdef ddwaf_config config
+
+        config = {
+            # Default limits
+            'limits': {
+                "max_container_size": 0,
+                "max_container_depth": 0,
+                "max_string_length": 0
+            },
+            'obfuscator': {
+                "key_regex": obfuscation_parameter_key_regexp,
+                "value_regex": obfuscation_parameter_value_regexp
+            },
+        }
+
         self._rules = _Wrapper(rules, max_objects=None)
         rule_objects = (<_Wrapper?>self._rules)._ptr;
-        self._handle = ddwaf_init(rule_objects, NULL, NULL)
+        self._handle = ddwaf_init(rule_objects, &config, NULL)
         if <void *> self._handle == NULL:
             raise ValueError("invalid rules")
 

--- a/ddtrace/appsec/_libddwaf.pxd
+++ b/ddtrace/appsec/_libddwaf.pxd
@@ -4,6 +4,15 @@ from libc.stdint cimport uint32_t
 from libc.stdint cimport uint64_t
 from libcpp cimport bool
 
+cdef extern from "include/ddwaf.h" namespace "_ddwaf_config":
+    ctypedef struct _ddwaf_config_limits:
+        uint32_t max_container_size
+        uint32_t max_container_depth
+        uint32_t max_string_length
+
+    ctypedef struct _ddwaf_config_obfuscator:
+        const char *key_regex
+        const char *value_regex
 
 cdef extern from "include/ddwaf.h":
     ctypedef struct ddwaf_version:
@@ -33,10 +42,11 @@ cdef extern from "include/ddwaf.h":
         ddwaf_object errors
         const char *version
 
-    ctypedef struct ddwaf_handle:
-        pass
-
     ctypedef struct ddwaf_config:
+        _ddwaf_config_limits limits
+        _ddwaf_config_obfuscator obfuscator
+
+    ctypedef struct ddwaf_handle:
         pass
 
     ctypedef struct ddwaf_context:

--- a/ddtrace/appsec/_libddwaf.pxd
+++ b/ddtrace/appsec/_libddwaf.pxd
@@ -4,6 +4,7 @@ from libc.stdint cimport uint32_t
 from libc.stdint cimport uint64_t
 from libcpp cimport bool
 
+
 cdef extern from "include/ddwaf.h" namespace "_ddwaf_config":
     ctypedef struct _ddwaf_config_limits:
         uint32_t max_container_size
@@ -13,6 +14,7 @@ cdef extern from "include/ddwaf.h" namespace "_ddwaf_config":
     ctypedef struct _ddwaf_config_obfuscator:
         const char *key_regex
         const char *value_regex
+
 
 cdef extern from "include/ddwaf.h":
     ctypedef struct ddwaf_version:

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -32,15 +32,15 @@ DEFAULT_RULES = os.path.join(ROOT_DIR, "rules.json")
 DEFAULT_TRACE_RATE_LIMIT = 100
 DEFAULT_WAF_TIMEOUT = 20  # ms
 DEFAULT_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = (
-    rb"(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?"
-    rb"(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization"
+    r"(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?"
+    r"(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization"
 )
 DEFAULT_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = (
-    rb"(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)"
-    rb"key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)"
-    rb'(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}'
-    rb"|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]"
-    rb"{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}"
+    r"(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)"
+    r"key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)"
+    r'(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}'
+    r"|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]"
+    r"{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}"
 )
 
 

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -44,14 +44,6 @@ DEFAULT_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = (
 )
 
 
-APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = ensure_binary(
-    os.getenv("DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP", DEFAULT_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP)
-)
-APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = ensure_binary(
-    os.getenv("DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP", DEFAULT_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP)
-)
-
-
 log = get_logger(__name__)
 
 
@@ -77,6 +69,20 @@ def _transform_headers(data):
 def get_rules():
     # type: () -> str
     return os.getenv("DD_APPSEC_RULES", default=DEFAULT_RULES)
+
+
+def get_appsec_obfuscation_parameter_key_regexp():
+    # type: () -> bytes
+    return ensure_binary(
+        os.getenv("DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP", DEFAULT_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP)
+    )
+
+
+def get_appsec_obfuscation_parameter_value_regexp():
+    # type: () -> bytes
+    return ensure_binary(
+        os.getenv("DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP", DEFAULT_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP)
+    )
 
 
 class _Addresses(object):
@@ -137,8 +143,8 @@ def _get_waf_timeout():
 class AppSecSpanProcessor(SpanProcessor):
 
     rules = attr.ib(type=str, factory=get_rules)
-    obfuscation_parameter_key_regexp = attr.ib(type=bytes, default=APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP)
-    obfuscation_parameter_value_regexp = attr.ib(type=bytes, default=APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP)
+    obfuscation_parameter_key_regexp = attr.ib(type=bytes, factory=get_appsec_obfuscation_parameter_key_regexp)
+    obfuscation_parameter_value_regexp = attr.ib(type=bytes, factory=get_appsec_obfuscation_parameter_value_regexp)
     _ddwaf = attr.ib(type=DDWaf, default=None)
     _addresses_to_keep = attr.ib(type=Set[str], factory=set)
     _rate_limiter = attr.ib(type=RateLimiter, factory=_get_rate_limiter)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -304,4 +304,16 @@ below:
      - True
      - Whether to enable the endpoint data collection in profiles.
 
+       .. _dd-appsec-obfuscation-parameter-key-regexp:
+   * - ``DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP``
+     - String
+     - ``(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization``
+     - Sensitive parameter key regexp for obfuscation.
+
+       .. _dd-appsec-obfuscation-parameter-value-regexp:
+   * - ``DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP``
+     - String
+     - ``(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}``
+     - Sensitive parameter value regexp for obfuscation.
+
 .. _Unified Service Tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -304,6 +304,24 @@ below:
      - True
      - Whether to enable the endpoint data collection in profiles.
 
+       .. _dd-appsec-enabled:
+   * - ``DD_APPSEC_ENABLED``
+     - Boolean
+     - False
+     - Whether to enable AppSec monitoring.
+
+       .. _dd-appsec-rules:
+   * - ``DD_APPSEC_RULES``
+     - String
+     -
+     - Path to a json file containing AppSec rules.
+
+       .. _dd-compile-debug:
+   * - ``DD_COMPILE_DEBUG``
+     - Boolean
+     - False
+     - Compile Cython extensions in RelWithDebInfo mode (with debug info, but no debug code or asserts)
+
        .. _dd-appsec-obfuscation-parameter-key-regexp:
    * - ``DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP``
      - String

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -116,6 +116,7 @@ mysql
 mysqlclient
 mysqldb
 namespace
+obfuscator
 opentracer
 opentracing
 parameterized

--- a/releasenotes/notes/asm-configure-sensitive-data-obfuscator-4bf70dcccb9f6350.yaml
+++ b/releasenotes/notes/asm-configure-sensitive-data-obfuscator-4bf70dcccb9f6350.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    ASM: configure the sensitive data obfuscator.

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -2,6 +2,7 @@ import json
 import os.path
 
 import pytest
+from six import ensure_binary
 
 from ddtrace.appsec._ddwaf import DDWaf
 from ddtrace.appsec.processor import AppSecSpanProcessor
@@ -207,6 +208,52 @@ def test_ddwaf_not_raises_exception():
         rules_json = json.loads(rules.read())
         DDWaf(
             rules_json,
-            DEFAULT_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP,
-            DEFAULT_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP,
+            ensure_binary(DEFAULT_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP),
+            ensure_binary(DEFAULT_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP),
         )
+
+
+def test_obfuscation_parameter_key_empty():
+    with override_env(dict(DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP="")):
+        processor = AppSecSpanProcessor()
+
+    assert processor.enabled
+
+
+def test_obfuscation_parameter_value_empty():
+    with override_env(dict(DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP="")):
+        processor = AppSecSpanProcessor()
+
+    assert processor.enabled
+
+
+def test_obfuscation_parameter_key_and_value_empty():
+    with override_env(
+        dict(DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP="", DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP="")
+    ):
+        processor = AppSecSpanProcessor()
+
+    assert processor.enabled
+
+
+def test_obfuscation_parameter_key_invalid_regex():
+    with override_env(dict(DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP="(")):
+        processor = AppSecSpanProcessor()
+
+    assert processor.enabled
+
+
+def test_obfuscation_parameter_invalid_regex():
+    with override_env(dict(DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP="(")):
+        processor = AppSecSpanProcessor()
+
+    assert processor.enabled
+
+
+def test_obfuscation_parameter_key_and_value_invalid_regex():
+    with override_env(
+        dict(DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP="(", DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP="(")
+    ):
+        processor = AppSecSpanProcessor()
+
+    assert processor.enabled

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -259,7 +259,7 @@ def test_obfuscation_parameter_key_and_value_invalid_regex():
     assert processor.enabled
 
 
-def test_obfuscation_parameter_unconfigured_value_not_matching(tracer):
+def test_obfuscation_parameter_value_unconfigured_not_matching(tracer):
     _enable_appsec(tracer)
 
     with tracer.trace("test", span_type=SpanTypes.WEB) as span:
@@ -272,7 +272,7 @@ def test_obfuscation_parameter_unconfigured_value_not_matching(tracer):
     assert "<Redacted>" not in span.get_tag("_dd.appsec.json")
 
 
-def test_obfuscation_parameter_unconfigured_key_matching(tracer):
+def test_obfuscation_parameter_value_unconfigured_matching(tracer):
     _enable_appsec(tracer)
 
     with tracer.trace("test", span_type=SpanTypes.WEB) as span:

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -5,6 +5,8 @@ import pytest
 
 from ddtrace.appsec._ddwaf import DDWaf
 from ddtrace.appsec.processor import AppSecSpanProcessor
+from ddtrace.appsec.processor import DEFAULT_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP
+from ddtrace.appsec.processor import DEFAULT_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP
 from ddtrace.appsec.processor import DEFAULT_RULES
 from ddtrace.appsec.processor import _transform_headers
 from ddtrace.constants import USER_KEEP
@@ -203,4 +205,8 @@ def test_appsec_span_rate_limit(tracer):
 def test_ddwaf_not_raises_exception():
     with open(DEFAULT_RULES) as rules:
         rules_json = json.loads(rules.read())
-        DDWaf(rules_json)
+        DDWaf(
+            rules_json,
+            DEFAULT_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP,
+            DEFAULT_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP,
+        )


### PR DESCRIPTION
## Description

Enable libddwaf data obfuscator by setting the config properly.
The configuration consists in two regexp that can be overriden by env vars.

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Motivation
ASM feature of sensitive data obfuscation


## Testing strategy
Unit tests and system tests

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
