### PR TITLE
feat(asm): collect http.client_ip

### DIFF
--- a/benchmarks/bm/utils.py
+++ b/benchmarks/bm/utils.py
@@ -1,5 +1,7 @@
+import contextlib
 from functools import partial
 import json
+import os
 import random
 import string
 
@@ -82,3 +84,24 @@ def random_w_n_digits(lmetrics):
 
 def rands(size=6, chars=string.ascii_uppercase + string.digits):
     return "".join(random.choice(chars) for _ in range(size))
+
+
+@contextlib.contextmanager
+def override_env(env):
+    """
+    Temporarily override ``os.environ`` with provided values::
+
+        >>> with self.override_env(dict(DD_TRACE_DEBUG=True)):
+            # Your test
+    """
+    # Copy the full original environment
+    original = dict(os.environ)
+
+    # Update based on the passed in arguments
+    os.environ.update(env)
+    try:
+        yield
+    finally:
+        # Full clear the environment out and reset back to the original
+        os.environ.clear()
+        os.environ.update(original)

--- a/benchmarks/set_http_meta/config.yaml
+++ b/benchmarks/set_http_meta/config.yaml
@@ -1,13 +1,19 @@
-no-useragentvariant: &all-enabled
+all-enabled: &all-enabled
   allenabled: true
-  useragentvariant: ""
+  useragentvariant: "user-agent"
   send_querystring_enabled: false
   obfuscation_disabled: false
+  ip_header: ""
+  ip_disabled: true
   querystring: ''
   url: 'http://localhost:8888/index'
+no-useragentvariant:
+  <<: *all-enabled
+  useragentvariant: ""
 all-disabled:
   <<: *all-enabled
   allenabled: false
+  ip_disabled: true
 useragentvariant_exists_1:
   <<: *all-enabled
   useragentvariant: "HTTP_USER_AGENT"
@@ -23,7 +29,14 @@ useragentvariant_not_exists_1:
 useragentvariant_not_exists_2:
   <<: *all-enabled
   useragentvariant: "UserAgent"
-
+no-collectipvariant:
+  <<: *all-enabled
+  ip_header: ""
+  ip_disabled: true
+collectipvariant_exists:
+  <<: *all-enabled
+  ip_disabled: false
+  ip_header: "x-forwarded-for"
 obfuscation-worst-case-implicit-query:
   <<: *all-enabled
   send_querystring_enabled: true

--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -20,6 +20,7 @@ SERVICE_VERSION_KEY = "service.version"
 SPAN_KIND = "span.kind"
 SPAN_MEASURED_KEY = "_dd.measured"
 KEEP_SPANS_RATE_KEY = "_dd.tracer_kr"
+MULTIPLE_IP_HEADERS = "_dd.multiple-ip-headers"
 
 APPSEC_ENABLED = "_dd.appsec.enabled"
 APPSEC_JSON = "_dd.appsec.json"

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -355,6 +355,8 @@ def _after_request_tags(pin, span, request, response):
             if raw_uri and request.META.get("QUERY_STRING"):
                 raw_uri += "?" + request.META["QUERY_STRING"]
 
+            client_addr = request.META.get("REMOTE_ADDR")
+
             trace_utils.set_http_meta(
                 span,
                 config.django,
@@ -369,6 +371,7 @@ def _after_request_tags(pin, span, request, response):
                 request_cookies=request.COOKIES,
                 request_path_params=request.resolver_match.kwargs if request.resolver_match is not None else None,
                 request_body=_extract_body(request),
+                peer_ip=client_addr,
             )
     finally:
         if span.resource == REQUEST_DEFAULT_RESOURCE:

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -5,6 +5,7 @@ from typing import List
 from typing import Text
 from typing import Union
 
+import django
 from django.http import RawPostDataException
 from django.http import UnreadablePostError
 from django.utils.functional import SimpleLazyObject
@@ -355,7 +356,7 @@ def _after_request_tags(pin, span, request, response):
             if raw_uri and request.META.get("QUERY_STRING"):
                 raw_uri += "?" + request.META["QUERY_STRING"]
 
-            client_addr = request.META.get("REMOTE_ADDR")
+            headers_case_sensitive = django.VERSION < (2, 2)
 
             trace_utils.set_http_meta(
                 span,
@@ -371,7 +372,8 @@ def _after_request_tags(pin, span, request, response):
                 request_cookies=request.COOKIES,
                 request_path_params=request.resolver_match.kwargs if request.resolver_match is not None else None,
                 request_body=_extract_body(request),
-                peer_ip=client_addr,
+                peer_ip=request.META.get("REMOTE_ADDR"),
+                headers_are_case_sensitive=headers_case_sensitive,
             )
     finally:
         if span.resource == REQUEST_DEFAULT_RESOURCE:

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -134,7 +134,6 @@ class _FlaskWSGIMiddleware(_DDWSGIMiddlewareBase):
         span._set_str_tag(FLASK_VERSION, flask_version_str)
 
         req_body = None
-        client_addr = request.remote_addr
         if config._appsec_enabled and request.method in _BODY_METHODS:
             content_type = request.content_type
             wsgi_input = environ.get("wsgi.input", "")
@@ -184,7 +183,7 @@ class _FlaskWSGIMiddleware(_DDWSGIMiddlewareBase):
             request_headers=request.headers,
             request_cookies=request.cookies,
             request_body=req_body,
-            peer_ip=client_addr,
+            peer_ip=request.remote_addr,
         )
 
 

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -134,6 +134,7 @@ class _FlaskWSGIMiddleware(_DDWSGIMiddlewareBase):
         span._set_str_tag(FLASK_VERSION, flask_version_str)
 
         req_body = None
+        client_addr = request.remote_addr
         if config._appsec_enabled and request.method in _BODY_METHODS:
             content_type = request.content_type
             wsgi_input = environ.get("wsgi.input", "")
@@ -183,6 +184,7 @@ class _FlaskWSGIMiddleware(_DDWSGIMiddlewareBase):
             request_headers=request.headers,
             request_cookies=request.cookies,
             request_body=req_body,
+            peer_ip=client_addr,
         )
 
 

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -121,6 +121,7 @@ class PylonsTraceMiddleware(object):
                 request_headers=dict(request.headers),
                 request_cookies=dict(request.cookies),
                 request_body=req_body,
+                headers_are_case_sensitive=True,
             )
 
             if not span.sampled:
@@ -140,6 +141,7 @@ class PylonsTraceMiddleware(object):
                     method=request.method,
                     status_code=http_code,
                     response_headers=response_headers,
+                    headers_are_case_sensitive=True,
                 )
                 return start_response(status, *args, **kwargs)
 

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -24,6 +24,7 @@ from ddtrace import constants
 from ddtrace.ext import http
 from ddtrace.ext import user
 from ddtrace.internal import _context
+from ddtrace.internal.compat import six
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.cache import cached
 from ddtrace.internal.utils.formats import asbool
@@ -181,7 +182,7 @@ def _get_request_header_client_ip(span, headers, peer_ip=None):
                 return ""
 
             try:
-                _ = ipaddress.ip_address(ip_header_value)
+                _ = ipaddress.ip_address(six.text_type(ip_header_value))
             except ValueError:
                 log.debug(
                     "Invalid IP address from configured %s header: %s", user_configured_ip_header, ip_header_value
@@ -217,7 +218,7 @@ def _get_request_header_client_ip(span, headers, peer_ip=None):
                 continue
 
             try:
-                ip_obj = ipaddress.ip_address(ip)
+                ip_obj = ipaddress.ip_address(six.text_type(ip))
             except ValueError:
                 continue
 
@@ -231,9 +232,9 @@ def _get_request_header_client_ip(span, headers, peer_ip=None):
     # return either the private_ip from the headers (if we have one) or the peer private ip
     if peer_ip:
         try:
-            peer_ip_obj = ipaddress.ip_address(peer_ip)
+            peer_ip_obj = ipaddress.ip_address(six.text_type(peer_ip))
             # "or" because if both are private we prefer the one from the headers
-            if peer_ip_obj.is_global or not private_ip:
+            if not peer_ip_obj.is_private or not private_ip:
                 return peer_ip
         except ValueError:
             pass

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -34,8 +34,6 @@ from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.vendor import wrapt
 
 
-# from ddtrace import constants
-
 if TYPE_CHECKING:
     from ddtrace import Span
     from ddtrace import Tracer
@@ -86,7 +84,7 @@ def _get_header_value_case_insensitive(headers, keyname):
     """
     # just in case we are lucky
     shortcut_value = headers.get(keyname)
-    if shortcut_value:
+    if shortcut_value is not None:
         return shortcut_value
 
     for key, value in six.iteritems(headers):
@@ -217,7 +215,6 @@ def _get_request_header_client_ip(span, headers, peer_ip=None, headers_are_case_
                     ip_header_value = tmp_ip_header_value
                     _USED_IP_HEADER = ip_header
                     break
-            # ip_header_value = ""
 
     # At this point, we have one IP header, check its value and retrieve the first public IP
     private_ip = ""

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -179,14 +179,14 @@ def _get_request_header_client_ip(span, headers, peer_ip=None, headers_are_case_
     # type: (Span, Mapping[str, str], Optional[str], bool) -> str
     global _USED_IP_HEADER
 
+    if asbool(os.getenv("DD_TRACE_CLIENT_IP_HEADER_DISABLED", default=False)):
+        return ""
+
     def get_header_value(key):  # type: (str) -> Optional[str]
         if not headers_are_case_sensitive:
             return headers.get(key)
 
         return _get_header_value_case_insensitive(headers, key)
-
-    if asbool(os.getenv("DD_TRACE_CLIENT_IP_HEADER_DISABLED", default=False)):
-        return ""
 
     ip_header_value = ""
     user_configured_ip_header = os.getenv("DD_TRACE_CLIENT_IP_HEADER", None)

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -157,7 +157,7 @@ def _find_normalized_header(headers, header):
     if norm_header in headers:
         return norm_header
 
-    for header_key in headers.keys():
+    for header_key in dict(headers).keys():
         if header_key.lower().replace("-", "_").strip() == norm_header:
             return header_key
 

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -57,7 +57,7 @@ RESPONSE = "response"
 NORMALIZE_PATTERN = re.compile(r"([^a-z0-9_\-:/]){1}")
 
 # Possible User Agent header.
-USER_AGENT_PATTERNS = ("http_user_agent", "user-agent")
+USER_AGENT_PATTERNS = ("http-user-agent", "user-agent")
 
 IP_PATTERNS = (
     "x-forwarded-for",
@@ -90,8 +90,7 @@ def _get_header_value_case_insensitive(headers, keyname):
         return shortcut_value
 
     for key, value in six.iteritems(headers):
-        key = key.lower()
-        if key == keyname:
+        if key.lower().replace("_", "-") == keyname:
             return value
 
     return None

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -193,7 +193,10 @@ def _get_request_header_client_ip(span, headers, peer_ip=None):
         used_ip_headers = []
         headers_count = 0
         for ip_header in IP_PATTERNS:
-            tmp_ip_header_value = headers.get(_find_normalized_header(headers, ip_header))
+            norm_header = _find_normalized_header(headers, ip_header)
+            if not norm_header:
+                continue
+            tmp_ip_header_value = headers.get(norm_header)
             if tmp_ip_header_value:
                 ip_header_value = tmp_ip_header_value
                 used_ip_headers.append(ip_header)

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -20,7 +20,6 @@ from typing import cast
 
 from ddtrace import Pin
 from ddtrace import config
-from ddtrace import constants
 from ddtrace.ext import http
 from ddtrace.ext import user
 from ddtrace.internal import _context
@@ -34,6 +33,8 @@ import ddtrace.internal.utils.wrappers
 from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.vendor import wrapt
 
+
+# from ddtrace import constants
 
 if TYPE_CHECKING:
     from ddtrace import Span
@@ -56,7 +57,7 @@ RESPONSE = "response"
 NORMALIZE_PATTERN = re.compile(r"([^a-z0-9_\-:/]){1}")
 
 # Possible User Agent header.
-USER_AGENT_PATTERNS = {"HTTP_USER_AGENT", "User-Agent", "user-agent", "Http-User-Agent"}
+USER_AGENT_PATTERNS = ("http_user_agent", "user-agent")
 
 IP_PATTERNS = (
     "x-forwarded-for",
@@ -75,6 +76,25 @@ IP_PATTERNS = (
 def _normalized_header_name(header_name):
     # type: (str) -> str
     return NORMALIZE_PATTERN.sub("_", normalize_header_name(header_name))
+
+
+def _get_header_value_case_insensitive(headers, keyname):
+    # type: (Mapping[str, str], str) -> Optional[str]
+    """
+    Get a header in a case insensitive way. This function is meant for frameworks
+    like Django < 2.2 that don't store the headers in a case insensitive mapping.
+    """
+    # just in case we are lucky
+    shortcut_value = headers.get(keyname)
+    if shortcut_value:
+        return shortcut_value
+
+    for key, value in six.iteritems(headers):
+        key = key.lower()
+        if key == keyname:
+            return value
+
+    return None
 
 
 def _normalize_tag_name(request_or_response, header_name):
@@ -132,41 +152,39 @@ def _store_headers(headers, span, integration_config, request_or_response):
         span.set_tag(tag_name or _normalize_tag_name(request_or_response, header_name), header_value)
 
 
-def _get_request_header_user_agent(headers):
-    # type: (Mapping[str, str]) -> str
+def _get_request_header_user_agent(headers, headers_are_case_sensitive=False):
+    # type: (Mapping[str, str], bool) -> str
     """Get user agent from request headers
     :param headers: A dict of http headers to be stored in the span
     :type headers: dict or list
     """
     for key_pattern in USER_AGENT_PATTERNS:
-        user_agent = headers.get(key_pattern)
+        if not headers_are_case_sensitive:
+            user_agent = headers.get(key_pattern)
+        else:
+            user_agent = _get_header_value_case_insensitive(headers, key_pattern)
+
         if user_agent:
             return user_agent
     return ""
 
 
-def _find_normalized_header(headers, header):
-    # type: (Mapping[str, str], str) -> Optional[str]
-    if not header or not headers:
-        return None
-
-    if header in headers:
-        return header
-
-    norm_header = header.lower().replace("-", "_").strip()
-
-    if norm_header in headers:
-        return norm_header
-
-    for header_key in dict(headers).keys():
-        if header_key.lower().replace("-", "_").strip() == norm_header:
-            return header_key
-
-    return None
+# Used to cache the last header used for the cache. From the same server/framework
+# usually the same header will be used on further requests, so we use this to check
+# only it.
+_USED_IP_HEADER = ""
 
 
-def _get_request_header_client_ip(span, headers, peer_ip=None):
-    # type: (Span, Mapping[str, str], Optional[str]) -> str
+def _get_request_header_client_ip(span, headers, peer_ip=None, headers_are_case_sensitive=False):
+    # type: (Span, Mapping[str, str], Optional[str], bool) -> str
+    global _USED_IP_HEADER
+
+    def get_header_value(key):  # type: (str) -> Optional[str]
+        if not headers_are_case_sensitive:
+            return headers.get(key)
+
+        return _get_header_value_case_insensitive(headers, key)
+
     if asbool(os.getenv("DD_TRACE_CLIENT_IP_HEADER_DISABLED", default=False)):
         return ""
 
@@ -174,38 +192,33 @@ def _get_request_header_client_ip(span, headers, peer_ip=None):
     user_configured_ip_header = os.getenv("DD_TRACE_CLIENT_IP_HEADER", None)
     if user_configured_ip_header:
         # Used selected the header to use to get the IP
-        ip_header = _find_normalized_header(headers, user_configured_ip_header)
-        if ip_header:
-            ip_header_value = headers.get(ip_header)
-            if not ip_header_value:
-                log.debug("DD_TRACE_CLIENT_IP_HEADER configured but '%s' header missing", ip_header)
-                return ""
+        ip_header_value = headers.get(user_configured_ip_header)
+        if not ip_header_value:
+            log.debug("DD_TRACE_CLIENT_IP_HEADER configured but '%s' header missing", user_configured_ip_header)
+            return ""
 
-            try:
-                _ = ipaddress.ip_address(six.text_type(ip_header_value))
-            except ValueError:
-                log.debug(
-                    "Invalid IP address from configured %s header: %s", user_configured_ip_header, ip_header_value
-                )
-                return ""
+        try:
+            _ = ipaddress.ip_address(six.text_type(ip_header_value))
+        except ValueError:
+            log.debug("Invalid IP address from configured %s header: %s", user_configured_ip_header, ip_header_value)
+            return ""
+
     else:
         # No configured IP header, go through the list defined in:
         # https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2118779066/Client+IP+addresses+resolution
-        used_ip_headers = []
-        headers_count = 0
-        for ip_header in IP_PATTERNS:
-            norm_header = _find_normalized_header(headers, ip_header)
-            if not norm_header:
-                continue
-            tmp_ip_header_value = headers.get(norm_header)
-            if tmp_ip_header_value:
-                ip_header_value = tmp_ip_header_value
-                used_ip_headers.append(ip_header)
-                headers_count += 1
-                if headers_count > 1:
-                    log.debug("Multiple IP headers found: %s", used_ip_headers)
-                    span._set_str_tag(constants.MULTIPLE_IP_HEADERS, ",".join(used_ip_headers))
-                    return ""
+        if _USED_IP_HEADER:
+            ip_header_value = get_header_value(_USED_IP_HEADER)
+
+        # For some reason request uses other header or the specified header is empty, do the
+        # search
+        if not ip_header_value:
+            for ip_header in IP_PATTERNS:
+                tmp_ip_header_value = get_header_value(ip_header)
+                if tmp_ip_header_value:
+                    ip_header_value = tmp_ip_header_value
+                    _USED_IP_HEADER = ip_header
+                    break
+            # ip_header_value = ""
 
     # At this point, we have one IP header, check its value and retrieve the first public IP
     private_ip = ""
@@ -233,20 +246,13 @@ def _get_request_header_client_ip(span, headers, peer_ip=None):
     if peer_ip:
         try:
             peer_ip_obj = ipaddress.ip_address(six.text_type(peer_ip))
-
-            if peer_ip_obj.is_loopback:
-                return private_ip
-
-            if not peer_ip_obj.is_private:
-                # peer is public and ip from headers is private or does not exists: return peer
+            if not peer_ip_obj.is_loopback:
+                # If we have a private_ip and the peer_ip is not public, prefer the one we have
+                if private_ip:
+                    if peer_ip_obj.is_loopback or peer_ip_obj.is_private:
+                        return private_ip
+                # peer_ip is public or we dont have a private_ip to we return the private peer_ip
                 return peer_ip
-            elif private_ip:
-                # peer is private and ip from headers exists and it's private: return headers ip
-                return private_ip
-            else:
-                # peer is private and we dont have a (private or public) ip from headers: peer
-                return peer_ip
-
         except ValueError:
             pass
 
@@ -394,6 +400,7 @@ def set_http_meta(
     request_path_params=None,  # type: Optional[Dict[str, str]]
     request_body=None,  # type: Optional[Union[str, Dict[str, List[str]]]]
     peer_ip=None,  # type: Optional[str]
+    headers_are_case_sensitive=False,  # type: bool
 ):
     # type: (...) -> None
     """
@@ -436,7 +443,7 @@ def set_http_meta(
 
     ip = None
     if request_headers:
-        user_agent = _get_request_header_user_agent(request_headers)
+        user_agent = _get_request_header_user_agent(request_headers, headers_are_case_sensitive)
         if user_agent:
             span.set_tag(http.USER_AGENT, user_agent)
 
@@ -445,7 +452,7 @@ def set_http_meta(
             is the DD standardized tag for user-agent"""
             _store_request_headers(dict(request_headers), span, integration_config)
 
-        ip = _get_request_header_client_ip(span, request_headers, peer_ip)
+        ip = _get_request_header_client_ip(span, request_headers, peer_ip, headers_are_case_sensitive)
         if ip:
             span.set_tag(http.CLIENT_IP, ip)
             if span._meta:

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -221,7 +221,7 @@ def _get_request_header_client_ip(span, headers, peer_ip=None):
             except ValueError:
                 continue
 
-            if ip_obj.is_global:
+            if not ip_obj.is_private:  # is_global is Python3+ only
                 return ip
             elif not private_ip and not ip_obj.is_loopback:
                 private_ip = ip

--- a/ddtrace/ext/http.py
+++ b/ddtrace/ext/http.py
@@ -15,6 +15,7 @@ STATUS_MSG = "http.status_msg"
 QUERY_STRING = "http.query.string"
 RETRIES_REMAIN = "http.retries_remain"
 VERSION = "http.version"
+CLIENT_IP = "http.client_ip"
 
 # template render span type
 TEMPLATE = "template"

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -92,6 +92,7 @@ ini
 initializer
 integration
 integrations
+ip
 JSON
 jinja
 js

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -43,7 +43,9 @@ cassandra
 cgroups
 cherrypy
 ciapp
+client_ip
 codepath
+collect
 committer
 compat
 composable

--- a/hooks/scripts/run-slotscheck.sh
+++ b/hooks/scripts/run-slotscheck.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.py$')
 if [ -n "$staged_files" ]; then
-    echo 'xxx disabled'
+    riot -v run -s slotscheck $staged_files
 else
     echo 'Run slotscheck skipped: No Python files were found in git diff --staged'
 fi

--- a/hooks/scripts/run-slotscheck.sh
+++ b/hooks/scripts/run-slotscheck.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.py$')
 if [ -n "$staged_files" ]; then
-    riot -v run -s slotscheck $staged_files
+    echo 'xxx disabled'
 else
     echo 'Run slotscheck skipped: No Python files were found in git diff --staged'
 fi

--- a/releasenotes/notes/asm-collect-header-ip-494f489b1778b6ed.yaml
+++ b/releasenotes/notes/asm-collect-header-ip-494f489b1778b6ed.yaml
@@ -1,3 +1,3 @@
 features:
   - |
-    ASM: collect http.client_ip
+    ASM: collect http client_ip

--- a/releasenotes/notes/asm-collect-header-ip-494f489b1778b6ed.yaml
+++ b/releasenotes/notes/asm-collect-header-ip-494f489b1778b6ed.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    ASM: Collect http.client_ip

--- a/releasenotes/notes/asm-collect-header-ip-494f489b1778b6ed.yaml
+++ b/releasenotes/notes/asm-collect-header-ip-494f489b1778b6ed.yaml
@@ -1,3 +1,3 @@
 features:
   - |
-    ASM: collect http client_ip
+    ASM: collect http client_ip.

--- a/releasenotes/notes/asm-collect-header-ip-494f489b1778b6ed.yaml
+++ b/releasenotes/notes/asm-collect-header-ip-494f489b1778b6ed.yaml
@@ -1,3 +1,3 @@
 features:
   - |
-    ASM: Collect http.client_ip
+    ASM: collect http.client_ip

--- a/setup.py
+++ b/setup.py
@@ -258,6 +258,7 @@ setup(
         "pathlib2; python_version<'3.5'",
         "jsonschema",
         "xmltodict>=0.12",
+        "backport_ipaddress; python_version=='2.7'",
     ]
     + bytecode,
     extras_require={

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -411,7 +411,11 @@ def test_ddwaf_info_with_2_errors():
         info = _ddwaf.info
         assert info["loaded"] == 1
         assert info["failed"] == 2
-        assert info["errors"] == {"missing key 'conditions'": ["crs-913-110"], "missing key 'tags'": ["crs-942-100"]}
+        # Compare dict contents insensitive to ordering
+        expected_dict = sorted(
+            {"missing key 'conditions'": ["crs-913-110"], "missing key 'tags'": ["crs-942-100"]}.items()
+        )
+        assert sorted(info["errors"].items()) == expected_dict
         assert info["version"] == "5.5.5"
 
 

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -1,7 +1,7 @@
+# -*- coding: utf-8 -*-
 import json
 import logging
 
-from ddtrace import constants
 from ddtrace.ext import http
 from ddtrace.internal import _context
 from ddtrace.internal.compat import urlencode
@@ -248,7 +248,7 @@ def test_django_client_ip_disabled(client, test_spans, tracer):
 
 
 def test_django_client_ip_header_set_by_env_var_empty(client, test_spans, tracer):
-    with override_env(dict(DD_TRACE_CLIENT_IP_HEADER="fooipheader")):
+    with override_env(dict(DD_TRACE_CLIENT_IP_HEADER="Fooipheader")):
         client.get("/?a=1&b&c=d", HTTP_FOOIPHEADER="", HTTP_X_REAL_IP="8.8.8.8")
         root_span = test_spans.spans[0]
         # X_REAL_IP should be ignored since the client provided a header
@@ -256,7 +256,7 @@ def test_django_client_ip_header_set_by_env_var_empty(client, test_spans, tracer
 
 
 def test_django_client_ip_header_set_by_env_var_invalid(client, test_spans, tracer):
-    with override_env(dict(DD_TRACE_CLIENT_IP_HEADER="fooipheader")):
+    with override_env(dict(DD_TRACE_CLIENT_IP_HEADER="Fooipheader")):
         client.get("/?a=1&b&c=d", HTTP_FOOIPHEADER="foobar", HTTP_X_REAL_IP="8.8.8.8")
         root_span = test_spans.spans[0]
         # X_REAL_IP should be ignored since the client provided a header
@@ -264,17 +264,10 @@ def test_django_client_ip_header_set_by_env_var_invalid(client, test_spans, trac
 
 
 def test_django_client_ip_header_set_by_env_var_valid(client, test_spans, tracer):
-    with override_env(dict(DD_TRACE_CLIENT_IP_HEADER="X-USE-THIS")):
+    with override_env(dict(DD_TRACE_CLIENT_IP_HEADER="X-Use-This")):
         client.get("/?a=1&b&c=d", HTTP_CLIENT_IP="8.8.8.8", HTTP_X_USE_THIS="4.4.4.4")
         root_span = test_spans.spans[0]
         assert root_span.get_tag(http.CLIENT_IP) == "4.4.4.4"
-
-
-def test_django_client_ip_headers_multiple_error(client, test_spans, tracer):
-    client.get("/?a=1&b&c=d", HTTP_CLIENT_IP="8.8.8.8", HTTP_X_FORWARDED_FOR="4.4.4.4")
-    root_span = test_spans.spans[0]
-    assert not root_span.get_tag(http.CLIENT_IP)
-    assert root_span.get_tag(constants.MULTIPLE_IP_HEADERS).lower() == "x-forwarded-for,client-ip"
 
 
 def test_django_client_ip_headers_priority(client, test_spans, tracer):
@@ -308,7 +301,7 @@ def test_django_client_ip_nothing(client, test_spans, tracer):
 
 
 def test_django_client_ip_header_set_by_env_var_invalid_2(client, test_spans, tracer):
-    with override_env(dict(DD_TRACE_CLIENT_IP_HEADER="fooipheader")):
+    with override_env(dict(DD_TRACE_CLIENT_IP_HEADER="Fooipheader")):
         result = client.get("/?a=1&b&c=d", HTTP_FOOIPHEADER="", HTTP_X_REAL_IP="アスダス")
         assert result.status_code == 200
         root_span = test_spans.spans[0]

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -305,3 +305,12 @@ def test_django_client_ip_nothing(client, test_spans, tracer):
     client.get("/?a=1&b&c=d")
     root_span = test_spans.spans[0]
     assert not root_span.get_tag(http.CLIENT_IP)
+
+
+def test_django_client_ip_header_set_by_env_var_invalid_2(client, test_spans, tracer):
+    with override_env(dict(DD_TRACE_CLIENT_IP_HEADER="fooipheader")):
+        result = client.get("/?a=1&b&c=d", HTTP_FOOIPHEADER="", HTTP_X_REAL_IP="アスダス")
+        assert result.status_code == 200
+        root_span = test_spans.spans[0]
+        # X_REAL_IP should be ignored since the client provided a header
+        assert not root_span.get_tag(http.CLIENT_IP)

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -305,6 +305,3 @@ def test_django_client_ip_nothing(client, test_spans, tracer):
     client.get("/?a=1&b&c=d")
     root_span = test_spans.spans[0]
     assert not root_span.get_tag(http.CLIENT_IP)
-
-
-# XXX add tests for peer ip

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -264,8 +264,8 @@ def test_django_client_ip_header_set_by_env_var_invalid(client, test_spans, trac
 
 
 def test_django_client_ip_header_set_by_env_var_valid(client, test_spans, tracer):
-    with override_env(dict(DD_TRACE_CLIENT_IP_HEADER="X-FOO")):
-        client.get("/?a=1&b&c=d", HTTP_X_FOO="use-this", HTTP_CLIENT_IP="8.8.8.8", HTTP_USE_THIS="4.4.4.4")
+    with override_env(dict(DD_TRACE_CLIENT_IP_HEADER="X-USE-THIS")):
+        client.get("/?a=1&b&c=d", HTTP_CLIENT_IP="8.8.8.8", HTTP_X_USE_THIS="4.4.4.4")
         root_span = test_spans.spans[0]
         assert root_span.get_tag(http.CLIENT_IP) == "4.4.4.4"
 

--- a/tests/contrib/flask/test_flask_appsec.py
+++ b/tests/contrib/flask/test_flask_appsec.py
@@ -137,6 +137,13 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         root_span = spans[0]
         assert root_span.get_tag(http.USER_AGENT) == "test/1.2.3"
 
+    def test_flask_client_ip_header_set_by_env_var_valid(self):
+        with override_env(dict(DD_TRACE_CLIENT_IP_HEADER="X-Use-This")):
+            self.client.get("/?a=1&b&c=d", headers={"HTTP_CLIENT_IP": "8.8.8.8", "X_USE_THIS": "4.4.4.4"})
+            spans = self.pop_spans()
+            root_span = spans[0]
+            assert root_span.get_tag(http.CLIENT_IP) == "4.4.4.4"
+
     def test_flask_body_urlencoded(self):
         @self.app.route("/body", methods=["GET", "POST", "DELETE"])
         def body():

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -489,16 +489,46 @@ def test_set_http_meta_headers_useragent(
 @pytest.mark.parametrize(
     "header_env_var,headers_dict,expected_keys,expected",
     [
-        ("", {"X-FORWARDED-FOR": "8.8.8.8"}, ["runtime-id", http.CLIENT_IP], "8.8.8.8"),
-        ("", {"X_FoRwArDeD-for": "8.8.8.8"}, ["runtime-id", http.CLIENT_IP], "8.8.8.8"),
-        ("", {"X-FORWARDED-FOR": "8.8.8.8,127.0.0.1"}, ["runtime-id", http.CLIENT_IP], "8.8.8.8"),
-        ("", {"X-FORWARDED-FOR": "192.168.1.14,8.8.8.8,127.0.0.1"}, ["runtime-id", http.CLIENT_IP], "8.8.8.8"),
-        ("", {"X-FORWARDED-FOR": "192.168.1.14,127.0.0.1"}, ["runtime-id", http.CLIENT_IP], "192.168.1.14"),
+        (
+            "",
+            {"X-FORWARDED-FOR": "8.8.8.8"},
+            ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"],
+            "8.8.8.8",
+        ),
+        (
+            "",
+            {"X_FoRwArDeD-for": "8.8.8.8"},
+            ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"],
+            "8.8.8.8",
+        ),
+        (
+            "",
+            {"X-FORWARDED-FOR": "8.8.8.8,127.0.0.1"},
+            ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"],
+            "8.8.8.8",
+        ),
+        (
+            "",
+            {"X-FORWARDED-FOR": "192.168.1.14,8.8.8.8,127.0.0.1"},
+            ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"],
+            "8.8.8.8",
+        ),
+        (
+            "",
+            {"X-FORWARDED-FOR": "192.168.1.14,127.0.0.1"},
+            ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"],
+            "192.168.1.14",
+        ),
         ("", {"X-FORWARDED-FOR": "foobar"}, ["runtime-id"], None),
         ("", {"X-FORWARDED-FOR": "4.4.4.4", "via": "8.8.8.8"}, ["runtime-id", constants.MULTIPLE_IP_HEADERS], None),
         ("via", {"X-FORWARDED-FOR": "4.4.4.4"}, ["runtime-id"], None),
-        ("via", {"VIA": "8.8.8.8"}, ["runtime-id", http.CLIENT_IP], "8.8.8.8"),
-        ("via", {"X-FORWARDED-FOR": "4.4.4.4", "Via": "8.8.8.8"}, ["runtime-id", http.CLIENT_IP], "8.8.8.8"),
+        ("via", {"VIA": "8.8.8.8"}, ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"], "8.8.8.8"),
+        (
+            "via",
+            {"X-FORWARDED-FOR": "4.4.4.4", "Via": "8.8.8.8"},
+            ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"],
+            "8.8.8.8",
+        ),
     ],
 )
 def test_set_http_meta_headers_ip(

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -17,7 +17,6 @@ from ddtrace import Pin
 from ddtrace import Span
 from ddtrace import Tracer
 from ddtrace import config
-from ddtrace import constants
 from ddtrace.context import Context
 from ddtrace.contrib import trace_utils
 from ddtrace.ext import http
@@ -456,16 +455,15 @@ def test_set_http_meta_no_headers(mock_store_headers, span, int_config):
 @pytest.mark.parametrize(
     "user_agent_key,user_agent_value,expected_keys,expected",
     [
-        ("HTTP_USER_AGENT", "dd-agent/1.0.0", ["runtime-id", http.USER_AGENT], "dd-agent/1.0.0"),
-        ("Http-User-Agent", "dd-agent/1.0.0", ["runtime-id", http.USER_AGENT], "dd-agent/1.0.0"),
-        ("HTTP_USER_AGENT", None, ["runtime-id"], None),
-        ("HTTP_USER_AGENT", 101234, ["runtime-id"], None),
-        ("UserAgent", True, ["runtime-id"], None),
-        ("HTTP_USER_AGENT", False, ["runtime-id"], None),
-        ("HTTP_USER_AGENT", [], ["runtime-id"], None),
-        ("HTTP_USER_AGENT", {}, ["runtime-id"], None),
-        ("User_Agent", ["test1", "test2"], ["runtime-id"], None),
-        ("User-Agent", {"test1": "key1"}, ["runtime-id", http.USER_AGENT], "{'test1': 'key1'}"),
+        ("http_user_agent", "dd-agent/1.0.0", ["runtime-id", http.USER_AGENT], "dd-agent/1.0.0"),
+        ("http_user_agent", None, ["runtime-id"], None),
+        ("http_user_agent", 101234, ["runtime-id"], None),
+        ("useragent", True, ["runtime-id"], None),
+        ("http_user_agent", False, ["runtime-id"], None),
+        ("http_user_agent", [], ["runtime-id"], None),
+        ("http_user_agent", {}, ["runtime-id"], None),
+        ("user_agent", ["test1", "test2"], ["runtime-id"], None),
+        ("user-agent", {"test1": "key1"}, ["runtime-id", http.USER_AGENT], "{'test1': 'key1'}"),
     ],
 )
 def test_set_http_meta_headers_useragent(
@@ -486,46 +484,65 @@ def test_set_http_meta_headers_useragent(
 
 
 @mock.patch("ddtrace.contrib.trace_utils._store_headers")
+def test_set_http_meta_case_sensitive_headers(mock_store_headers, span, int_config):
+    int_config.myint.http._header_tags = {"enabled": True}
+    trace_utils.set_http_meta(
+        span, int_config.myint, request_headers={"USER-AGENT": "dd-agent/1.0.0"}, headers_are_case_sensitive=True
+    )
+    result_keys = list(span.get_tags().keys())
+    result_keys.sort(reverse=True)
+    assert result_keys == ["runtime-id", http.USER_AGENT]
+    assert span.get_tag(http.USER_AGENT) == "dd-agent/1.0.0"
+    mock_store_headers.assert_called()
+
+
+@mock.patch("ddtrace.contrib.trace_utils._store_headers")
+def test_set_http_meta_case_sensitive_headers_notfound(mock_store_headers, span, int_config):
+    int_config.myint.http._header_tags = {"enabled": True}
+    trace_utils.set_http_meta(
+        span, int_config.myint, request_headers={"USER-AGENT": "dd-agent/1.0.0"}, headers_are_case_sensitive=False
+    )
+    result_keys = list(span.get_tags().keys())
+    result_keys.sort(reverse=True)
+    assert result_keys == ["runtime-id"]
+    assert not span.get_tag(http.USER_AGENT)
+    mock_store_headers.assert_called()
+
+
+@mock.patch("ddtrace.contrib.trace_utils._store_headers")
 @pytest.mark.parametrize(
     "header_env_var,headers_dict,expected_keys,expected",
     [
         (
             "",
-            {"X-FORWARDED-FOR": "8.8.8.8"},
+            {"x-forwarded-for": "8.8.8.8"},
             ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"],
             "8.8.8.8",
         ),
         (
             "",
-            {"X_FoRwArDeD-for": "8.8.8.8"},
+            {"x-forwarded-for": "8.8.8.8,127.0.0.1"},
             ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"],
             "8.8.8.8",
         ),
         (
             "",
-            {"X-FORWARDED-FOR": "8.8.8.8,127.0.0.1"},
+            {"x-forwarded-for": "192.168.1.14,8.8.8.8,127.0.0.1"},
             ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"],
             "8.8.8.8",
         ),
         (
             "",
-            {"X-FORWARDED-FOR": "192.168.1.14,8.8.8.8,127.0.0.1"},
-            ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"],
-            "8.8.8.8",
-        ),
-        (
-            "",
-            {"X-FORWARDED-FOR": "192.168.1.14,127.0.0.1"},
+            {"x-forwarded-for": "192.168.1.14,127.0.0.1"},
             ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"],
             "192.168.1.14",
         ),
-        ("", {"X-FORWARDED-FOR": "foobar"}, ["runtime-id"], None),
-        ("", {"X-FORWARDED-FOR": "4.4.4.4", "via": "8.8.8.8"}, ["runtime-id", constants.MULTIPLE_IP_HEADERS], None),
-        ("via", {"X-FORWARDED-FOR": "4.4.4.4"}, ["runtime-id"], None),
-        ("via", {"VIA": "8.8.8.8"}, ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"], "8.8.8.8"),
+        ("", {"x-forwarded-for": "foobar"}, ["runtime-id"], None),
+        ("via", {"x-forwarded-for": "4.4.4.4"}, ["runtime-id"], None),
+        ("via", {"via": "8.8.8.8"}, ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"], "8.8.8.8"),
         (
             "via",
-            {"X-FORWARDED-FOR": "4.4.4.4", "Via": "8.8.8.8"},
+            {"x-forwarded-for": "4.4.4.4", "via": "8.8.8.8"},
             ["runtime-id", "network.client.ip", http.CLIENT_IP, "actor.ip"],
             "8.8.8.8",
         ),

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -455,14 +455,14 @@ def test_set_http_meta_no_headers(mock_store_headers, span, int_config):
 @pytest.mark.parametrize(
     "user_agent_key,user_agent_value,expected_keys,expected",
     [
-        ("http_user_agent", "dd-agent/1.0.0", ["runtime-id", http.USER_AGENT], "dd-agent/1.0.0"),
-        ("http_user_agent", None, ["runtime-id"], None),
-        ("http_user_agent", 101234, ["runtime-id"], None),
+        ("http-user-agent", "dd-agent/1.0.0", ["runtime-id", http.USER_AGENT], "dd-agent/1.0.0"),
+        ("http-user-agent", None, ["runtime-id"], None),
+        ("http-user-agent", 101234, ["runtime-id"], None),
         ("useragent", True, ["runtime-id"], None),
-        ("http_user_agent", False, ["runtime-id"], None),
-        ("http_user_agent", [], ["runtime-id"], None),
-        ("http_user_agent", {}, ["runtime-id"], None),
-        ("user_agent", ["test1", "test2"], ["runtime-id"], None),
+        ("http-user-agent", False, ["runtime-id"], None),
+        ("http-user-agent", [], ["runtime-id"], None),
+        ("http-user-agent", {}, ["runtime-id"], None),
+        ("user-agent", ["test1", "test2"], ["runtime-id", http.USER_AGENT], "['test1', 'test2']"),
         ("user-agent", {"test1": "key1"}, ["runtime-id", http.USER_AGENT], "{'test1': 'key1'}"),
     ],
 )


### PR DESCRIPTION
```
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| Benchmark                                           | /artifacts/3240773f-677b-42b7-a71b-9989289b2247/set_http_meta/1.4.0rc2.dev70+ged05a17f//results.json | /artifacts/3240773f-677b-42b7-a71b-9989289b2247/set_http_meta/1.4.0rc2.dev84+g3730ae83//results.json |
+=====================================================+======================================================================================================+======================================================================================================+
| sethttpmeta-all-enabled                             | 24.3 us                                                                                              | 25.1 us: 1.03x slower                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-no-useragentvariant                     | 23.4 us                                                                                              | 24.2 us: 1.03x slower                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-all-disabled                            | 9.24 us                                                                                              | 10.6 us: 1.15x slower                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-useragentvariant_exists_1               | 25.8 us                                                                                              | 24.7 us: 1.04x faster                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-useragentvariant_exists_2               | 28.5 us                                                                                              | 26.8 us: 1.06x faster                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-useragentvariant_not_exists_2           | 25.6 us                                                                                              | 24.5 us: 1.05x faster                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-no-collectipvariant                     | 24.4 us                                                                                              | 25.6 us: 1.05x slower                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-collectipvariant_exists                 | 24.5 us                                                                                              | 37.0 us: 1.51x slower                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-obfuscation-worst-case-implicit-query   | 24.5 us                                                                                              | 25.8 us: 1.06x slower                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-obfuscation-worst-case-explicit-query   | 24.1 us                                                                                              | 26.4 us: 1.09x slower                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-obfuscation-regular-case-implicit-query | 24.3 us                                                                                              | 26.0 us: 1.07x slower                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-obfuscation-regular-case-explicit-query | 24.1 us                                                                                              | 25.7 us: 1.07x slower                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-obfuscation-no-query                    | 24.2 us                                                                                              | 26.4 us: 1.09x slower                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-obfuscation-send-querystring-disabled   | 23.8 us                                                                                              | 26.6 us: 1.12x slower                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| sethttpmeta-obfuscation-disabled                    | 23.9 us                                                                                              | 26.3 us: 1.10x slower                                                                                |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
| Geometric mean                                      | (ref)                                                                                                | 1.06x slower                                                                                         |
+-----------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+

```

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
