### PR TITLE
chore(debugging): ignore functions with no __code__

### DIFF
--- a/ddtrace/debugging/_function/discovery.py
+++ b/ddtrace/debugging/_function/discovery.py
@@ -155,7 +155,9 @@ def _collect_functions(module):
         for k, o in c:
             if PY2 and _isinstance(o, UnboundMethodType):
                 o = o.__func__
-            if _isinstance(o, (FunctionType, FunctionWrapper)) and abspath(o.__code__.co_filename) == path:
+
+            code = getattr(o, "__code__", None) if _isinstance(o, (FunctionType, FunctionWrapper)) else None
+            if code is not None and abspath(code.co_filename) == path:
                 if o not in seen_functions:
                     seen_functions.add(o)
                     o = cast(FullyNamedFunction, o)


### PR DESCRIPTION
## Description

If the module discovery finds a function-like object with no `__code__` attribute, we ignore it instead of letting an AttributeError to be thrown. Cases where the problem could have happened are those where the function-like objects are builtin or native functions, which are implemented in native libraries and don't have a code object.

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
