### PR TITLE
refactor(profiling): remove lock from _ThreadLink

### DIFF
--- a/ddtrace/profiling/_threading.pyx
+++ b/ddtrace/profiling/_threading.pyx
@@ -89,7 +89,7 @@ class _ThreadLink(_thread_link_base):
         """
         # This code clears the thread/object mapping by clearing a copy and swapping it in an atomic operation This is
         # needed to be able to have this whole class lock-free and avoid concurrency issues.
-        # The fact that is is lock free means we might lose some accuracy, but it's worth the trade-off for speed and simplicity.
+        # The fact that it is lock free means we might lose some accuracy, but it's worth the trade-off for speed and simplicity.
         new_thread_id_to_object_mapping = self._thread_id_to_object.copy()
         # Iterate over a copy of the list of keys since it's mutated during our iteration.
         for thread_id in list(new_thread_id_to_object_mapping):


### PR DESCRIPTION
The _ThreadLink data structure historically used a lock to make sure there was
no threads overlapping each other. For example, this could happen:

1. Main thread from the application starts a trace and `link_object` is being
   called
2. Stack profiler would run and clear the thread list or get an spans from the
   list

Removing the lock makes it possible that, while the stack profiler thread
clears the mapping, a user's thread links a thread to a span.

That's a trade-off we are willing to accept for performance and safeness
reason.