### PR TITLE
chore(lib-injection): update system-tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -15,10 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        weblog-variant: ['']
-        lib-injection-enabled: ['lib-injection-enabled']
-        lib-injection-connection: ['uds', 'network']
-        lib-injection-use-admission-controller: ['', 'use-admission-controller']
         include:
           - weblog-variant: flask-poc
           - weblog-variant: uwsgi-poc
@@ -28,17 +24,11 @@ jobs:
       TEST_LIBRARY: python
       WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
-      LIBRARY_INJECTION_ENABLED: ${{ matrix.lib-injection-enabled }}
-      LIBRARY_INJECTION_CONNECTION: ${{ matrix.lib-injection-connection }}
-      LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ matrix.lib-injection-admission-controller }}
-      LIBRARY_INJECTION_INIT_IMAGE: ghcr.io/datadog/dd-trace-py/dd-lib-python-init:${{ github.sha }}
-      LIBRARY_INJECTION_TEST_APP_IMAGE: ghcr.io/datadog/dd-trace-py/dd-lib-python-init-test-app:${{ github.sha }}
     steps:
       - name: Checkout system tests
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
-          ref: 'injection-tests'  # TODO: update when merged
 
       - name: Checkout dd-trace-py
         uses: actions/checkout@v3
@@ -55,7 +45,7 @@ jobs:
       # The compress step speed up a lot the upload artifact process
       - name: Compress artifact
         if: ${{ always() }}  
-        run: tar -czvf artifact.tar.gz $(ls | grep logs) || true
+        run: tar -czvf artifact.tar.gz $(ls | grep logs)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -63,3 +53,31 @@ jobs:
         with:
           name: logs_${{ matrix.weblog-variant }}
           path: artifact.tar.gz
+
+  lib-injection:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lib-injection-connection: ['uds', 'network']
+        lib-injection-use-admission-controller: ['', 'use-admission-controller']
+      fail-fast: false
+    env:
+      TEST_LIBRARY: python
+      WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      LIBRARY_INJECTION_CONNECTION: ${{ matrix.lib-injection-connection }}
+      LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ matrix.lib-injection-admission-controller }}
+      LIBRARY_INJECTION_INIT_IMAGE: ghcr.io/datadog/dd-trace-py/dd-lib-python-init:${{ github.sha }}
+      LIBRARY_INJECTION_TEST_APP_IMAGE: ghcr.io/datadog/dd-trace-py/dd-lib-python-init-test-app:${{ github.sha }}
+    steps:
+      - name: Checkout system tests
+        uses: actions/checkout@v3
+        with:
+          repository: 'DataDog/system-tests'
+          ref: 'injection-tests'  # TODO: update when merged
+
+      - name: Build
+        run: ./lib-injection/build.sh
+
+      - name: Run
+        run: ./lib-injection/run-lib-injection.sh


### PR DESCRIPTION
We opted to not use the same build/run scripts as normal system tests, so create a new job to run the library injection tests.