### PR TITLE
feat(lib-injection): add image deploy jobs

### DIFF
--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -1,11 +1,6 @@
 name: "Library Injection"
 on:
   push:
-    branches:
-     - 1.x
-  pull_request:
-    branches:
-      - 1.x
 
 jobs:
   build-and-publish-init-image:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,3 +40,39 @@ trigger_microbenchmarking_platform:
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
     UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
+
+deploy_to_docker_registries:
+  stage: deploy
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+      when: on_success
+    - when: manual
+      allow_failure: true
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: ghcr.io/datadog/dd-trace-py/dd-lib-python-init:$CI_COMMIT_SHA
+    IMG_DESTINATIONS: dd-lib-python-init:$CI_COMMIT_TAG
+    IMG_SIGNING: "false"
+
+deploy_latest_tag_to_docker_registries:
+  stage: deploy
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+      when: on_success
+    - when: manual
+      allow_failure: true
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: ghcr.io/datadog/dd-trace-py/dd-lib-python-init:$CI_COMMIT_SHA
+    IMG_DESTINATIONS: dd-lib-python-init:latest
+    IMG_SIGNING: "false"


### PR DESCRIPTION
Deploy the images to the official registries that will be used by the cluster agent. We only do this when a new tag is pushed (matching `v.*`) in which we publish the corresponding version tag for the image and also the `latest` tag.


https://github.com/DataDog/datadog-agent/blob/024346a5c57fa91501b8df25a84601d01b78131e/pkg/clusteragent/admission/mutate/auto_instrumentation.go#L85-L101