### PR TITLE
chore(refactor): memoize get header tag name

### DIFF
--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -7,11 +7,13 @@ from typing import Optional
 from typing import Union
 
 from ddtrace.internal import compat
+from ddtrace.internal.utils.cache import cached
 
 
 Connector = Callable[[], ContextManager[compat.httplib.HTTPConnection]]
 
 
+@cached()
 def normalize_header_name(header_name):
     # type: (Optional[str]) -> Optional[str]
     """

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -281,6 +281,7 @@ class Config(object):
         """
         return self.http.header_is_traced(header_name)
 
+    @cachedmethod()
     def _header_tag_name(self, header_name):
         # type: (str) -> Optional[str]
         return self.http._header_tag_name(header_name)

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -4,8 +4,8 @@ from typing import Tuple
 
 from .._hooks import Hooks
 from ..internal.utils.attrdict import AttrDict
+from ..internal.utils.cache import cachedmethod
 from ..internal.utils.formats import asbool
-from ..vendor.psutil._common import memoize
 from .http import HttpConfig
 
 
@@ -103,7 +103,7 @@ class IntegrationConfig(AttrDict):
         """
         return self._header_tag_name(header_name) is not None
 
-    @memoize
+    @cachedmethod()
     def _header_tag_name(self, header_name):
         # type: (str) -> Optional[str]
         tag_name = self.http._header_tag_name(header_name)

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -5,6 +5,7 @@ from typing import Tuple
 from .._hooks import Hooks
 from ..internal.utils.attrdict import AttrDict
 from ..internal.utils.formats import asbool
+from ..vendor.psutil._common import memoize
 from .http import HttpConfig
 
 
@@ -102,6 +103,7 @@ class IntegrationConfig(AttrDict):
         """
         return self._header_tag_name(header_name) is not None
 
+    @memoize
     def _header_tag_name(self, header_name):
         # type: (str) -> Optional[str]
         tag_name = self.http._header_tag_name(header_name)

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -4,7 +4,6 @@ from typing import Tuple
 
 from .._hooks import Hooks
 from ..internal.utils.attrdict import AttrDict
-from ..internal.utils.cache import cachedmethod
 from ..internal.utils.formats import asbool
 from .http import HttpConfig
 
@@ -103,7 +102,6 @@ class IntegrationConfig(AttrDict):
         """
         return self._header_tag_name(header_name) is not None
 
-    @cachedmethod()
     def _header_tag_name(self, header_name):
         # type: (str) -> Optional[str]
         tag_name = self.http._header_tag_name(header_name)


### PR DESCRIPTION
## Description
Cache get header tag name.

Benchmark:
```
+-----------------------------------------------------+---------+-----------------------+
| Benchmark                                           | /1.x    | /artifacts/eb22eac5-98|
+=====================================================+=========+=======================+
| sethttpmeta-no-useragentvariant                     | 29.0 us | 22.6 us: 1.29x faster |
+-----------------------------------------------------+---------+-----------------------+
| sethttpmeta-all-disabled                            | 9.20 us | 7.98 us: 1.15x faster |
+-----------------------------------------------------+---------+-----------------------+
| sethttpmeta-useragentvariant_exists_1               | 23.3 us | 24.1 us: 1.03x slower |
+-----------------------------------------------------+---------+-----------------------+
| sethttpmeta-useragentvariant_exists_2               | 25.1 us | 25.7 us: 1.02x slower |
+-----------------------------------------------------+---------+-----------------------+
| sethttpmeta-useragentvariant_exists_3               | 23.2 us | 24.0 us: 1.03x slower |
+-----------------------------------------------------+---------+-----------------------+
| sethttpmeta-useragentvariant_not_exists_1           | 22.4 us | 22.7 us: 1.01x slower |
+-----------------------------------------------------+---------+-----------------------+
| sethttpmeta-useragentvariant_not_exists_2           | 22.1 us | 23.2 us: 1.05x slower |
+-----------------------------------------------------+---------+-----------------------+
| sethttpmeta-obfuscation-worst-case-implicit-query   | 21.6 us | 22.7 us: 1.05x slower |
+-----------------------------------------------------+---------+-----------------------+
| sethttpmeta-obfuscation-worst-case-explicit-query   | 21.6 us | 23.4 us: 1.08x slower |
+-----------------------------------------------------+---------+-----------------------+
| sethttpmeta-obfuscation-regular-case-implicit-query | 22.4 us | 23.3 us: 1.04x slower |
+-----------------------------------------------------+---------+-----------------------+
| sethttpmeta-obfuscation-regular-case-explicit-query | 22.4 us | 23.0 us: 1.03x slower |
+-----------------------------------------------------+---------+-----------------------+
| sethttpmeta-obfuscation-no-query                    | 22.5 us | 22.9 us: 1.02x slower |
+-----------------------------------------------------+---------+-----------------------+
| sethttpmeta-obfuscation-send-querystring-disabled   | 22.1 us | 23.3 us: 1.05x slower |
+-----------------------------------------------------+---------+-----------------------+
| Geometric mean                                      | (ref)   | 1.00x slower          |
+-----------------------------------------------------+---------+-----------------------+
```
## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
