### PR TITLE
docs(profiler): add release note for profiler lock removal

### DIFF
--- a/releasenotes/notes/profiler-threadlink-nolock-200ffbc2d0400d2d.yaml
+++ b/releasenotes/notes/profiler-threadlink-nolock-200ffbc2d0400d2d.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    profiler: Remove lock for data structure linking threads to spans to avoid deadlocks with trade-off of correctness of spans linked to threads by stack profiler at a given point in time.
+    profiler: Remove lock for data structure linking threads to spans to avoid deadlocks with the trade-off of correctness of spans linked to threads by stack profiler at a given point in time.

--- a/releasenotes/notes/profiler-threadlink-nolock-200ffbc2d0400d2d.yaml
+++ b/releasenotes/notes/profiler-threadlink-nolock-200ffbc2d0400d2d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    profiler: Remove lock for data structure linking threads to spans to avoid deadlocks with trade-off of correctness of spans linked to threads by stack profiler at a given point in time.


### PR DESCRIPTION
Add release note for change made in #4147 as it fixes a known issue with gevent deadlocks in the profiler under certain conditions.