### PR TITLE
fix(ci): correctly extract commit message from AppVeyor

### DIFF
--- a/ddtrace/ext/ci.py
+++ b/ddtrace/ext/ci.py
@@ -140,6 +140,12 @@ def extract_appveyor(env):
     else:
         repository = commit = branch = tag = None
 
+    commit_message = env.get("APPVEYOR_REPO_COMMIT_MESSAGE")
+    if commit_message:
+        extended = env.get("APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED")
+        if extended:
+            commit_message += "\n" + extended
+
     return {
         PROVIDER_NAME: "appveyor",
         git.REPOSITORY_URL: repository,
@@ -152,7 +158,7 @@ def extract_appveyor(env):
         JOB_URL: url,
         git.BRANCH: branch,
         git.TAG: tag,
-        git.COMMIT_MESSAGE: env.get("APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED"),
+        git.COMMIT_MESSAGE: commit_message,
         git.COMMIT_AUTHOR_NAME: env.get("APPVEYOR_REPO_COMMIT_AUTHOR"),
         git.COMMIT_AUTHOR_EMAIL: env.get("APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL"),
     }

--- a/releasenotes/notes/fix-appveyor-commit-message-752b38ce564f5be6.yaml
+++ b/releasenotes/notes/fix-appveyor-commit-message-752b38ce564f5be6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    CI Visibility: fixed AppVeyor integration not extracting the full commit
+    message.

--- a/tests/tracer/fixtures/ci/appveyor.json
+++ b/tests/tracer/fixtures/ci/appveyor.json
@@ -9,7 +9,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -24,7 +25,7 @@
       "git.branch": "master",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -39,7 +40,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -69,7 +70,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -99,7 +100,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -129,7 +130,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github",
       "HOME": "/not-my-home",
@@ -161,7 +162,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -191,7 +192,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github",
       "HOME": "/not-my-home",
@@ -223,7 +224,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name"
     },
     {
@@ -249,7 +250,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -279,7 +280,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -309,7 +310,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -340,7 +341,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -371,7 +372,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -401,7 +402,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github",
       "APPVEYOR_REPO_TAG_NAME": "origin/tags/0.1.0"
@@ -432,7 +433,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github",
       "APPVEYOR_REPO_TAG_NAME": "refs/heads/tags/0.1.0"
@@ -461,7 +462,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "DD_GIT_BRANCH": "user-supplied-branch",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
@@ -501,7 +502,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
       "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",

--- a/tests/tracer/test_ci.py
+++ b/tests/tracer/test_ci.py
@@ -161,7 +161,7 @@ def test_extract_git_user_provided_metadata_overwrites_ci(git_repo):
         "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
         "APPVEYOR_REPO_NAME": "appveyor-repo-name",
         "APPVEYOR_REPO_PROVIDER": "github",
-        "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "this is the correct commit message",
+        "APPVEYOR_REPO_COMMIT_MESSAGE": "this is the correct commit message",
         "APPVEYOR_REPO_COMMIT_AUTHOR": "John Jack",
         "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "john@jack.com",
     }
@@ -204,7 +204,7 @@ def test_ci_provider_tags_not_overwritten_by_git_executable(git_repo):
         "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
         "APPVEYOR_REPO_NAME": "appveyor-repo-name",
         "APPVEYOR_REPO_PROVIDER": "github",
-        "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "this is the correct commit message",
+        "APPVEYOR_REPO_COMMIT_MESSAGE": "this is the correct commit message",
         "APPVEYOR_REPO_COMMIT_AUTHOR": "John Jack",
         "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "john@jack.com",
     }
@@ -228,7 +228,7 @@ def test_falsey_ci_provider_values_overwritten_by_git_executable(git_repo):
         "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
         "APPVEYOR_REPO_NAME": "appveyor-repo-name",
         "APPVEYOR_REPO_PROVIDER": "not-github",
-        "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": None,
+        "APPVEYOR_REPO_COMMIT_MESSAGE": None,
         "APPVEYOR_REPO_COMMIT_AUTHOR": "",
     }
 


### PR DESCRIPTION
## Description
Fixes getting the full commit message when running on the AppVeyor CI.
Previously we were only checking `APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED` which, [as per the docs](https://www.appveyor.com/docs/environment-variables/) only contains the "rest" of the commit message. The first line of the commit message is in `APPVEYOR_REPO_COMMIT_MESSAGE`.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START fix -->

## Relevant issue(s)
N/A

## Testing strategy
Updated appveyor fixture.

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
