### PR TITLE
chore(mergifyio): use consistent conflict label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -42,11 +42,11 @@ pull_request_rules:
         message: "@{{author}} this pull request is now in conflict 😩"
       label:
         add:
-          - conflict
+          - conflicts
   - name: remove conflict label if not needed
     conditions:
       - -conflict
     actions:
       label:
         remove:
-          - conflict
+          - conflicts


### PR DESCRIPTION
Mergifyio applies the "conflicts" label whereas we apply the "conflict" label.

Example: https://github.com/DataDog/dd-trace-py/pull/4138