### PR TITLE
chore(debugging): fix exploration debugger import

### DIFF
--- a/tests/debugging/exploration/debugger.py
+++ b/tests/debugging/exploration/debugger.py
@@ -13,7 +13,7 @@ from ddtrace.debugging._encoding import SnapshotJsonEncoder
 from ddtrace.debugging._function.discovery import FunctionDiscovery
 from ddtrace.debugging._probe.model import ConditionalProbe
 from ddtrace.debugging._probe.model import Probe
-from ddtrace.debugging._probe.poller import ProbePollerEvent
+from ddtrace.debugging._probe.remoteconfig import ProbePollerEvent
 from ddtrace.debugging._snapshot.collector import SnapshotCollector
 from ddtrace.debugging._snapshot.collector import SnapshotContext
 from ddtrace.debugging._snapshot.model import Snapshot
@@ -232,17 +232,17 @@ class ExplorationDebugger(Debugger):
     @classmethod
     def add_probe(cls, probe):
         # type: (Probe) -> None
-        cls._instance._on_poller_event(ProbePollerEvent.NEW_PROBES, [probe])
+        cls._instance._on_configuration(ProbePollerEvent.NEW_PROBES, [probe])
 
     @classmethod
     def add_probes(cls, probes):
         # type: (t.List[Probe]) -> None
-        cls._instance._on_poller_event(ProbePollerEvent.NEW_PROBES, probes)
+        cls._instance._on_configuration(ProbePollerEvent.NEW_PROBES, probes)
 
     @classmethod
     def delete_probe(cls, probe):
         # type: (Probe) -> None
-        cls._instance._on_poller_event(ProbePollerEvent.DELETED_PROBES, [probe])
+        cls._instance._on_configuration(ProbePollerEvent.DELETED_PROBES, [probe])
 
 
 if asbool(os.getenv("DD_DEBUGGER_EXPL_STATUS_MESSAGES", False)):

--- a/tests/debugging/exploration/test_bootstrap.py
+++ b/tests/debugging/exploration/test_bootstrap.py
@@ -1,0 +1,52 @@
+from os.path import dirname
+
+import pytest
+
+from ddtrace.internal.compat import PY2
+
+
+if PY2:
+    OUT = """Enabling debugging exploration testing
+========================== LineCoverage: probes stats ==========================
+
+Installed probes: 0/0
+
+================================ Line coverage =================================
+
+Source                                                       Lines Covered
+==========================================================================
+No lines found
+===================== DeterministicProfiler: probes stats ======================
+
+Installed probes: 0/0
+
+============================== Function coverage ===============================
+
+No functions called
+"""
+else:
+    OUT = """Enabling debugging exploration testing
+===================== DeterministicProfiler: probes stats ======================
+
+Installed probes: 0/0
+
+============================== Function coverage ===============================
+
+No functions called
+========================== LineCoverage: probes stats ==========================
+
+Installed probes: 0/0
+
+================================ Line coverage =================================
+
+Source                                                       Lines Covered
+==========================================================================
+No lines found
+"""
+
+
+@pytest.mark.subprocess(env={"PYTHONPATH": dirname(__file__)}, out=OUT)
+def test_exploration_bootstrap():
+    # We test that we get the expected output from the exploration debuggers
+    # and no errors when running the sitecustomize.py script.
+    pass


### PR DESCRIPTION
## Description

With the recent refactor that enabled RCM for the debugger, the content of the old probe poller module has been moved in the probe remoteconfig one. This change fixes an import that was still referecing the removed module and prevented the exploration debuggers from running.

A test has also been added to catch potential issues with the exploration debuggers in the future.

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
