### PR TITLE
fix(internal): support URLs in DD_TAGS variable

### DIFF
--- a/releasenotes/notes/fix-dd-tags-0763e940d889b8da.yaml
+++ b/releasenotes/notes/fix-dd-tags-0763e940d889b8da.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix parsing of the ``DD_TAGS`` environment variable value to include
+    support for values with colons (e.g. URLs). Also fixed the parsing of
+    invalid tags that begin with a space (e.g. ``DD_TAGS=" key:val"`` will now
+    produce a tag with label ``key``, instead of `` key``, and value ``val``).

--- a/tests/tracer/test_utils.py
+++ b/tests/tracer/test_utils.py
@@ -53,26 +53,15 @@ _LOG_ERROR_FAIL_SEPARATOR = (
         ("key: val", dict(key=" val"), None),
         ("key key: val", {"key key": " val"}, None),
         ("key: val,key2:val2", dict(key=" val", key2="val2"), None),
-        (" key: val,key2:val2", {" key": " val", "key2": "val2"}, None),
+        (" key: val,key2:val2", {"key": " val", "key2": "val2"}, None),
         ("key key2:val1", {"key key2": "val1"}, None),
-        (
-            "key:val key2:val:2",
-            dict(),
-            [mock.call(_LOG_ERROR_MALFORMED_TAG_STRING, "key:val key2:val:2")],
-        ),
+        ("key:val key2:val:2", {"key": "val", "key2": "val:2"}, None),
         (
             "key:val,key2:val2 key3:1234.23",
             dict(),
             [mock.call(_LOG_ERROR_FAIL_SEPARATOR, "key:val,key2:val2 key3:1234.23")],
         ),
-        (
-            "key:val key2:val2 key3: ",
-            dict(key="val", key2="val2"),
-            [
-                mock.call(_LOG_ERROR_MALFORMED_TAG, "key3:", "key:val key2:val2 key3: "),
-                mock.call(_LOG_ERROR_MALFORMED_TAG, "", "key:val key2:val2 key3: "),
-            ],
-        ),
+        ("key:val key2:val2 key3: ", dict(key="val", key2="val2", key3=""), None),
         (
             "key:val key2:val 2",
             dict(key="val", key2="val"),
@@ -80,51 +69,17 @@ _LOG_ERROR_FAIL_SEPARATOR = (
         ),
         (
             "key: val key2:val2 key3:val3",
-            {"key2": "val2", "key3": "val3"},
-            [
-                mock.call(_LOG_ERROR_MALFORMED_TAG, "key:", "key: val key2:val2 key3:val3"),
-                mock.call(_LOG_ERROR_MALFORMED_TAG, "val", "key: val key2:val2 key3:val3"),
-            ],
+            {"key": "", "key2": "val2", "key3": "val3"},
+            [mock.call(_LOG_ERROR_MALFORMED_TAG, "val", "key: val key2:val2 key3:val3")],
         ),
-        (
-            "key:,key3:val1,",
-            dict(key3="val1"),
-            [
-                mock.call(_LOG_ERROR_MALFORMED_TAG, "key:", "key:,key3:val1,"),
-                mock.call(_LOG_ERROR_MALFORMED_TAG, "", "key:,key3:val1,"),
-            ],
-        ),
-        (
-            ",",
-            dict(),
-            [
-                mock.call(_LOG_ERROR_MALFORMED_TAG, "", ","),
-                mock.call(_LOG_ERROR_MALFORMED_TAG, "", ","),
-            ],
-        ),
-        (
-            ":,:",
-            dict(),
-            [
-                mock.call(_LOG_ERROR_MALFORMED_TAG, ":", ":,:"),
-                mock.call(_LOG_ERROR_MALFORMED_TAG, ":", ":,:"),
-            ],
-        ),
-        (
-            "key,key2:val1",
-            dict(key2="val1"),
-            [mock.call(_LOG_ERROR_MALFORMED_TAG, "key", "key,key2:val1")],
-        ),
-        ("key2:val1:", dict(), [mock.call(_LOG_ERROR_MALFORMED_TAG_STRING, "key2:val1:")]),
-        (
-            "key,key2,key3",
-            dict(),
-            [
-                mock.call(_LOG_ERROR_MALFORMED_TAG, "key", "key,key2,key3"),
-                mock.call(_LOG_ERROR_MALFORMED_TAG, "key2", "key,key2,key3"),
-                mock.call(_LOG_ERROR_MALFORMED_TAG, "key3", "key,key2,key3"),
-            ],
-        ),
+        ("key:,key3:val1,", dict(key3="val1", key=""), None),
+        (",", dict(), [mock.call(_LOG_ERROR_FAIL_SEPARATOR, "")]),
+        (":,:", dict(), [mock.call(_LOG_ERROR_FAIL_SEPARATOR, ":,:")]),
+        ("key,key2:val1", {"key2": "val1"}, [mock.call(_LOG_ERROR_MALFORMED_TAG, "key", "key,key2:val1")]),
+        ("key2:val1:", {"key2": "val1:"}, None),
+        ("key,key2,key3", dict(), [mock.call(_LOG_ERROR_FAIL_SEPARATOR, "key,key2,key3")]),
+        ("foo:bar,foo:baz", dict(foo="baz"), None),
+        ("hash:asd url:https://github.com/foo/bar", dict(hash="asd", url="https://github.com/foo/bar"), None),
     ],
 )
 def test_parse_env_tags(tag_str, expected_tags, error_calls):
@@ -132,10 +87,10 @@ def test_parse_env_tags(tag_str, expected_tags, error_calls):
         tags = parse_tags_str(tag_str)
         assert tags == expected_tags
         if error_calls:
-            assert log.error.call_count == len(error_calls)
+            assert log.error.call_count == len(error_calls), log.error.call_args_list
             log.error.assert_has_calls(error_calls)
         else:
-            assert log.error.call_count == 0
+            assert log.error.call_count == 0, log.error.call_args_list
 
 
 def test_no_states():


### PR DESCRIPTION
## Description

This change allows for URLs to be passed as values to tag labels via the ``DD_TAGS`` environment variable.

**NOTE** This might constitute a slight breaking change, as configuration that was valid before might no longer work with the new logic.

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- START fix -->

## Testing strategy

The test suite included a test case that covered the URL case (a tag with a value containing the `:` character).

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
