### PR TITLE
ci(boto): remove test_kinesis_put_records_base64_exceeds_max_size

### DIFF
--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -1653,56 +1653,6 @@ class BotocoreTest(TracerTestCase):
 
         client.delete_stream(StreamName=stream_name)
 
-    @mock_kinesis
-    def test_kinesis_put_records_base64_exceeds_max_size(self):
-        client = self.session.create_client("kinesis", region_name="us-east-1")
-
-        stream_name = "test"
-        client.create_stream(StreamName=stream_name, ShardCount=1)
-        stream = client.describe_stream(StreamName=stream_name)["StreamDescription"]
-        shard_id = stream["Shards"][0]["ShardId"]
-
-        partition_key = "1234"
-        sample_string = json.dumps({"Hello": "x" * (1 << 20)})
-        sample_string_bytes = sample_string.encode("ascii")
-        base64_bytes = base64.b64encode(sample_string_bytes)
-        data_str = base64_bytes.decode("ascii")
-        data = [
-            {"Data": data_str, "PartitionKey": partition_key},
-            {"Data": data_str, "PartitionKey": partition_key},
-        ]
-
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(client)
-        client.put_records(StreamName=stream_name, Records=data)
-
-        # check if the appropriate span was generated
-        spans = self.get_spans()
-        assert spans
-        span = spans[0]
-        assert len(spans) == 1
-        assert span.get_tag("aws.region") == "us-east-1"
-        assert span.get_tag("aws.operation") == "PutRecords"
-        assert span.get_tag("params.MessageBody") is None
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        assert span.service == "test-botocore-tracing.kinesis"
-        assert span.resource == "kinesis.putrecords"
-        records = span.get_tag("params.Records")
-        assert records is None
-
-        resp = client.get_shard_iterator(StreamName=stream_name, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON")
-        shard_iterator = resp["ShardIterator"]
-
-        # ensure headers are not present in received message
-        resp = client.get_records(ShardIterator=shard_iterator)
-        assert len(resp["Records"]) == 2
-        records = resp["Records"]
-        for record in records:
-            headers = json.loads(base64.b64decode(record["Data"]).decode("ascii"))
-            assert "_datadog" not in headers
-
-        client.delete_stream(StreamName=stream_name)
-
     @unittest.skipIf(PY2, "Skipping for Python 2.7 since older moto doesn't support secretsmanager")
     def test_secretsmanager(self):
         from moto import mock_secretsmanager


### PR DESCRIPTION
## Description

With the latest [moto release](https://github.com/spulec/moto/issues/5249), adding a record which exceeds the max size constraint is not supported. Since this test validates unsupported behavior it was removed.

New [Boto Validation Error](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/21184/workflows/33375cfd-6f3f-446e-aae7-2e800994e9df/jobs/1440546):
```
def test_kinesis_put_records_base64_exceeds_max_size(self):
        client = self.session.create_client("kinesis", region_name="us-east-1")
    
        stream_name = "test"
        client.create_stream(StreamName=stream_name, ShardCount=1)
        stream = client.describe_stream(StreamName=stream_name)["StreamDescription"]
        shard_id = stream["Shards"][0]["ShardId"]

        partition_key = "1234"
        sample_string = json.dumps({"Hello": "x" * (1 << 20)})
        sample_string_bytes = sample_string.encode("ascii")
        base64_bytes = base64.b64encode(sample_string_bytes)
        data_str = base64_bytes.decode("ascii")
        data = [
            {"Data": data_str, "PartitionKey": partition_key},
            {"Data": data_str, "PartitionKey": partition_key},
        ]
    
        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(client)
>       client.put_records(StreamName=stream_name, Records=data)

tests/contrib/botocore/test.py:1676: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
        if http.status_code >= 300:
            error_code = parsed_response.get("Error", {}).get("Code")
            error_class = self.exceptions.from_code(error_code)
>           raise error_class(parsed_response, operation_name)
E           botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the PutRecords operation: 1 validation error detected: Value at 'records.1.member.data' failed to satisfy constraint: Member must have length less than or equal to 1048576

.riot/venv_py3615_moto[all]/lib/python3.6/site-packages/botocore/client.py:911: ValidationException
```

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
