### PR TITLE
fix(ci): pin moto<4.0.3 for botocore tests

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -1118,7 +1118,9 @@ venv = Venv(
             command="pytest {cmdargs} tests/contrib/botocore",
             pkgs={"botocore": latest},
             venvs=[
-                Venv(pys=select_pys(min_version="3.5"), pkgs={"moto[all]": latest}),
+                # moto release v4.0.3 enforces api limits causing error in boto integration tests
+                # https://github.com/spulec/moto/issues/5249
+                Venv(pys=select_pys(min_version="3.5"), pkgs={"moto[all]": "<4.0.3"}),
                 Venv(pys=["2.7"], pkgs={"moto": ["~=1.0"], "rsa": ["<4.7.1"]}),
             ],
         ),


### PR DESCRIPTION
The botocore tests make a call to an API that as of v4.0.3 of moto raises an exception.

https://github.com/DataDog/dd-trace-py/blob/fde91fd2571f6d9de1a3b32ab136281041a3bc69/tests/contrib/botocore/test.py#L1676

See https://github.com/spulec/moto/issues/5249 for more details on the change in moto.