### PR TITLE
fix(aioredis): handle all BaseException, not Exception in _finish_span

### DIFF
--- a/ddtrace/contrib/aioredis/patch.py
+++ b/ddtrace/contrib/aioredis/patch.py
@@ -140,10 +140,11 @@ def traced_13_execute_command(func, instance, args, kwargs):
     def _finish_span(future):
         try:
             # Accessing the result will raise an exception if:
-            #   - The future was cancelled
+            #   - The future was cancelled (CancelledError)
             #   - There was an error executing the future (`future.exception()`)
             #   - The future is in an invalid state
             future.result()
+        # CancelledError exceptions extend from BaseException as of Python 3.8, instead of usual Exception
         except BaseException:
             span.set_exc_info(*sys.exc_info())
         finally:

--- a/ddtrace/contrib/aioredis/patch.py
+++ b/ddtrace/contrib/aioredis/patch.py
@@ -144,7 +144,7 @@ def traced_13_execute_command(func, instance, args, kwargs):
             #   - There was an error executing the future (`future.exception()`)
             #   - The future is in an invalid state
             future.result()
-        except Exception:
+        except BaseException:
             span.set_exc_info(*sys.exc_info())
         finally:
             span.finish()

--- a/releasenotes/notes/fix-aioredis-catch-cancellederror-223e8bb3d1aea94f.yaml
+++ b/releasenotes/notes/fix-aioredis-catch-cancellederror-223e8bb3d1aea94f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    aioredis: Added exception handling for `CancelledError` in the aioredis integration as they 
+    now extend `BaseException` and not `Exception`. The aioredis integration now catches all
+    exceptions that extend from `BaseException`. 

--- a/releasenotes/notes/fix-aioredis-catch-cancellederror-223e8bb3d1aea94f.yaml
+++ b/releasenotes/notes/fix-aioredis-catch-cancellederror-223e8bb3d1aea94f.yaml
@@ -1,6 +1,4 @@
 ---
 fixes:
   - |
-    aioredis: Added exception handling for `CancelledError` in the aioredis integration as they 
-    now extend `BaseException` and not `Exception`. The aioredis integration now catches all
-    exceptions that extend from `BaseException`. 
+    aioredis: added exception handling for `CancelledError` in the aioredis integration.


### PR DESCRIPTION
## Description
This fixes the aioredis integration from raising `CancelledError`. As of Python 3.8 ([Docs link](https://docs.python.org/3/library/asyncio-exceptions.html#asyncio.CancelledError)), `CancelledError` now extends from `BaseException` and not `Exception`, and is currently being raised by the aioredis integration instead of being handled. The aioredis integration now catches all errors extending from `BaseException` in aioredis futures (i.e. the `_finish_span()` callback added to each future).

This should resolve #3253.