### PR TITLE
fix[pytest]: Ensure pytest plugin does not accidentally reactivate global tracer

### DIFF
--- a/ddtrace/contrib/pytest/__init__.py
+++ b/ddtrace/contrib/pytest/__init__.py
@@ -23,8 +23,8 @@ alongside ``--ddtrace`` or by adding this to your configuration::
    The ddtrace plugin for pytest has the side effect of importing the ddtrace
    package and starting a global tracer.
 
-   While you can avoid this by setting ``DD_TRACE_ENABLED=False``, if this is still causing issues for your pytest
-   runs where traced execution of tests is not enabled, you can deactivate the pytest plugin entirely::
+   Generating traces can be avoided by setting ``DD_TRACE_ENABLED=False``.
+   If other issues occur then the pytest plugin can be disabled entirely::
 
      [pytest]
      addopts = -p no:ddtrace

--- a/ddtrace/contrib/pytest/__init__.py
+++ b/ddtrace/contrib/pytest/__init__.py
@@ -23,7 +23,7 @@ alongside ``--ddtrace`` or by adding this to your configuration::
    The ddtrace plugin for pytest has the side effect of importing the ddtrace
    package and starting a global tracer.
 
-   While you can avoid this by setting ``DD_TRACE_ENABLED=False``, if this is causing issues for your pytest
+   While you can avoid this by setting ``DD_TRACE_ENABLED=False``, if this is still causing issues for your pytest
    runs where traced execution of tests is not enabled, you can deactivate the pytest plugin entirely::
 
      [pytest]

--- a/ddtrace/contrib/pytest/__init__.py
+++ b/ddtrace/contrib/pytest/__init__.py
@@ -23,8 +23,8 @@ alongside ``--ddtrace`` or by adding this to your configuration::
    The ddtrace plugin for pytest has the side effect of importing the ddtrace
    package and starting a global tracer.
 
-   If this is causing issues for your pytest runs where traced execution of
-   tests is not enabled, you can deactivate the plugin::
+   While you can avoid this by setting ``DD_TRACE_ENABLED=False``, if this is causing issues for your pytest
+   runs where traced execution of tests is not enabled, you can deactivate the pytest plugin entirely::
 
      [pytest]
      addopts = -p no:ddtrace
@@ -68,5 +68,6 @@ config._add(
     dict(
         _default_service="pytest",
         operation_name=os.getenv("DD_PYTEST_OPERATION_NAME", default="pytest.test"),
+        trace_enabled=os.getenv("DD_TRACE_ENABLED", default=None),
     ),
 )

--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -110,7 +110,7 @@ def pytest_sessionstart(session):
         tracer_filters = pin.tracer._filters
         if not any(isinstance(tracer_filter, TraceCiVisibilityFilter) for tracer_filter in tracer_filters):
             tracer_filters += [TraceCiVisibilityFilter()]
-            pin.tracer.configure(settings={"FILTERS": tracer_filters})
+            pin.tracer.configure(settings={"FILTERS": tracer_filters}, enabled=ddtrace.config.pytest.trace_enabled)
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/ddtrace/contrib/pytest_bdd/__init__.py
+++ b/ddtrace/contrib/pytest_bdd/__init__.py
@@ -10,11 +10,12 @@ Please follow the instructions for enabling `pytest` integration.
    The ddtrace.pytest_bdd plugin for pytest-bdd has the side effect of importing
    the ddtrace package and starting a global tracer.
 
-   If this is causing issues for your pytest-bdd runs where traced execution of
-   tests is not enabled, you can deactivate the plugin::
+   While you can avoid this by setting ``DD_TRACE_ENABLED=False``, if this is still causing issues
+   for your pytest-bdd runs where traced execution of tests is not enabled,
+   you can deactivate the pytest plugins entirely::
 
      [pytest]
-     addopts = -p no:ddtrace.pytest_bdd
+     addopts = -p no:ddtrace -p no:ddtrace.pytest_bdd
 
    See the `pytest documentation
    <https://docs.pytest.org/en/7.1.x/how-to/plugins.html#deactivating-unregistering-a-plugin-by-name>`_

--- a/ddtrace/contrib/pytest_bdd/__init__.py
+++ b/ddtrace/contrib/pytest_bdd/__init__.py
@@ -10,9 +10,8 @@ Please follow the instructions for enabling `pytest` integration.
    The ddtrace.pytest_bdd plugin for pytest-bdd has the side effect of importing
    the ddtrace package and starting a global tracer.
 
-   While you can avoid this by setting ``DD_TRACE_ENABLED=False``, if this is still causing issues
-   for your pytest-bdd runs where traced execution of tests is not enabled,
-   you can deactivate the pytest plugins entirely::
+   Generating traces can be avoided by setting ``DD_TRACE_ENABLED=False``.
+   If other issues occur then the pytest-bdd plugin can be disabled entirely::
 
      [pytest]
      addopts = -p no:ddtrace -p no:ddtrace.pytest_bdd


### PR DESCRIPTION
## Description
#3674 added docs to explicitly disable the pytest plugin if users did not want tracing activated, as the pytest plugin indirectly reactivated the global tracer in the process of importing `ddtrace`. This was not an ideal solution as users have found it unclear why and how to avoid seeing traces in their pytest tests when they had set the environment variable `DD_TRACE_ENABLED=false` (see #4179). 

While I can't reproduce the original issue, the proposed solution is to have the pytest plugin check the value of the environment variable `DD_TRACE_ENABLED` and use that value when it configures the global tracer before the start of every test run. This way, the tracer's enabled status will always reflect the provided environment variable.
