### PR TITLE
fix(dbapi): add iterable methods to object proxy

### DIFF
--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -9,6 +9,7 @@ from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanTypes
 from ...ext import sql
+from ...internal.compat import PY2
 from ...internal.logger import get_logger
 from ...internal.utils import ArgumentError
 from ...internal.utils import get_argument_value
@@ -46,6 +47,18 @@ class TracedCursor(wrapt.ObjectProxy):
         self._self_datadog_name = "{}.query".format(span_name_prefix)
         self._self_last_execute_operation = None
         self._self_config = cfg or config.dbapi2
+
+    def __iter__(self):
+        return self.__wrapped__.__iter__()
+
+    def __next__(self):
+        return self.__wrapped__.__next__()
+
+    if PY2:
+
+        # Python 2 iterators use `next`
+        def next(self):  # noqa: A001
+            return self.__wrapped__.next()
 
     def _trace_method(self, method, name, resource, extra_tags, *args, **kwargs):
         """

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -93,6 +93,7 @@ initializer
 integration
 integrations
 ip
+iterable
 JSON
 jinja
 js

--- a/releasenotes/notes/fix-dbapi-cursor-iter-3e8eb0fbed08e47f.yaml
+++ b/releasenotes/notes/fix-dbapi-cursor-iter-3e8eb0fbed08e47f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Add iterable methods on TracedCursor. Previously these were not present and would cause iterable usage of
+    cursors in DB API integrations to fail.


### PR DESCRIPTION
According to the [dbapi spec](https://peps.python.org/pep-0249/#iter)
cursors can be iterable. For some reason wrapt.ObjectProxy does not
proxy the `__iter__` or `__next__` methods. The solution is to simply
add them to the base TraceCursor class which is used in our dbapi
integrations.

Fixes #4143