### PR TITLE
chore(docs): clarify django in-code docs

### DIFF
--- a/ddtrace/contrib/django/__init__.py
+++ b/ddtrace/contrib/django/__init__.py
@@ -29,6 +29,13 @@ To have Django capture the tracer logs, ensure the ``LOGGING`` variable in
 
 Configuration
 ~~~~~~~~~~~~~
+
+.. important::
+
+    Note that the in-code configuration must be run before Django is instrumented. This means that in-code configuration
+    will not work with ``ddtrace-run`` and before a call to ``patch`` or ``patch_all``.
+
+
 .. py:data:: ddtrace.config.django['distributed_tracing_enabled']
 
    Whether or not to parse distributed tracing headers from requests received by your Django app.


### PR DESCRIPTION
In-code configuration for Django only works prior to Django patching occurring for many of the options which leads to confusion like what was
reported here: https://github.com/DataDog/dd-trace-py/issues/3816.

Resolves #3816