### PR TITLE
fix(opentracing): don't raise on no trace context

### DIFF
--- a/ddtrace/opentracer/propagation/http.py
+++ b/ddtrace/opentracer/propagation/http.py
@@ -1,7 +1,6 @@
 from typing import Dict
 
 from opentracing import InvalidCarrierException
-from opentracing import SpanContextCorruptedException
 
 from ddtrace.propagation.http import HTTPPropagator as DDHTTPPropagator
 
@@ -67,13 +66,6 @@ class HTTPPropagator(Propagator):
             raise InvalidCarrierException("propagator expects carrier to be a dict")
 
         ddspan_ctx = DDHTTPPropagator.extract(carrier)
-
-        # if the dd propagator fails then it will return a new empty span
-        # context (with trace_id=None), we however want to raise an exception
-        # if this occurs.
-        if not ddspan_ctx.trace_id:
-            raise SpanContextCorruptedException("failed to extract span context")
-
         baggage = {}
         for key in carrier:
             if key.startswith(HTTP_BAGGAGE_PREFIX):

--- a/releasenotes/notes/fix-ot-extract-5faf0276c75d033f.yaml
+++ b/releasenotes/notes/fix-ot-extract-5faf0276c75d033f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    opentracing: don't raise an exception when distributed tracing headers are
+    not present when attempting to extract.

--- a/tests/opentracer/core/test_tracer.py
+++ b/tests/opentracer/core/test_tracer.py
@@ -4,7 +4,6 @@ import mock
 import opentracing
 from opentracing import Format
 from opentracing import InvalidCarrierException
-from opentracing import SpanContextCorruptedException
 from opentracing import UnsupportedFormatException
 from opentracing import child_of
 import pytest
@@ -500,12 +499,11 @@ class TestTracerSpanContextPropagation(object):
         assert ext_span_ctx.baggage == span_ctx.baggage
 
     def test_empty_propagated_context(self, ot_tracer):
-        """An empty propagated context should raise a
+        """An empty propagated context should not raise a
         SpanContextCorruptedException when extracted.
         """
         carrier = {}
-        with pytest.raises(SpanContextCorruptedException):
-            ot_tracer.extract(Format.HTTP_HEADERS, carrier)
+        ot_tracer.extract(Format.HTTP_HEADERS, carrier)
 
     def test_text(self, ot_tracer):
         """extract should undo inject for http headers"""
@@ -533,8 +531,7 @@ class TestTracerSpanContextPropagation(object):
         corrupted_key = HTTP_HEADER_TRACE_ID[2:]
         carrier[corrupted_key] = 123
 
-        with pytest.raises(SpanContextCorruptedException):
-            ot_tracer.extract(Format.TEXT_MAP, carrier)
+        ot_tracer.extract(Format.TEXT_MAP, carrier)
 
     def test_immutable_span_context(self, ot_tracer):
         """Span contexts should be immutable."""


### PR DESCRIPTION
Extract should not raise an exception if there are no distributed tracing headers present. There is no way to distinguish in the ddtrace api between a failed parse and a successful one (errors are just logged and an empty context returned).

https://opentracing-python.readthedocs.io/en/1.3.0/api.html#opentracing.InvalidCarrierException

(finally) Fixes #2030