### PR TITLE
fix(asm): change ipaddress backport library

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -33,6 +33,7 @@ autodetected
 autopatching
 backend
 backends
+backport
 bdd
 bikeshedding
 booleans

--- a/releasenotes/notes/asm-fix-ipaddress-backport-lib-4684ce71e63459e7.yaml
+++ b/releasenotes/notes/asm-fix-ipaddress-backport-lib-4684ce71e63459e7.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    ASM: fix a conflict with another backport of ipaddress by using the same lib. Add a test.

--- a/setup.py
+++ b/setup.py
@@ -258,7 +258,7 @@ setup(
         "pathlib2; python_version<'3.5'",
         "jsonschema",
         "xmltodict>=0.12",
-        "ipaddress; python_version=='2.7'",
+        "ipaddress",
         "envier",
     ]
     + bytecode,

--- a/setup.py
+++ b/setup.py
@@ -258,7 +258,7 @@ setup(
         "pathlib2; python_version<'3.5'",
         "jsonschema",
         "xmltodict>=0.12",
-        "backport_ipaddress; python_version=='2.7'",
+        "ipaddress; python_version=='2.7'",
         "envier",
     ]
     + bytecode,

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from ipaddress import ip_network
 import sys
 
 from hypothesis import given
@@ -21,6 +22,7 @@ from ddtrace.context import Context
 from ddtrace.contrib import trace_utils
 from ddtrace.ext import http
 from ddtrace.internal import _context
+from ddtrace.internal.compat import six
 from ddtrace.internal.compat import stringify
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
@@ -568,6 +570,16 @@ def test_set_http_meta_headers_ip(
             assert result_keys == expected_keys
             assert span.get_tag(http.CLIENT_IP) == expected
             mock_store_headers.assert_called()
+
+
+def test_ip_subnet_regression():
+    del_ip = "1.2.3.4/32"
+    req_ip = "10.2.3.4"
+
+    del_ip = six.ensure_text(del_ip)
+    req_ip = six.ensure_text(req_ip)
+
+    assert not ip_network(req_ip).subnet_of(ip_network(del_ip))
 
 
 @pytest.mark.skipif(sys.version_info < (3, 0, 0), reason="Python2 tests")


### PR DESCRIPTION
## Description

Fix a failing test in mcnulty by switching to the same backport ipaddress library they're using. 

Also adds a new test to avoid future regressions on the same failure point as their test.

<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->


## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
