### PR TITLE
test(debugging): include-list and collect elusive modules in exploration tests

### DIFF
--- a/tests/debugging/exploration/_config.py
+++ b/tests/debugging/exploration/_config.py
@@ -1,0 +1,86 @@
+import os
+import typing as t
+from warnings import warn
+
+from envier import En
+
+
+def parse_venv(value):
+    # type: (str) -> t.Optional[str]
+    try:
+        return os.path.abspath(value) if value is not None else None
+    except TypeError:
+        warn(
+            "No virtual environment detected. Running without a virtual environment active might "
+            "cause exploration tests to instrument more than intended."
+        )
+
+
+class ExplorationConfig(En):
+    venv = En.v(
+        t.Optional[str],
+        "virtual_env",
+        parser=parse_venv,
+        default=None,
+    )
+
+    encode = En.v(
+        bool,
+        "dd.debugger.expl.encode",
+        default=True,
+        help="Whether to encode the snapshots",
+    )
+
+    status_messages = En.v(
+        bool,
+        "dd.debugger.expl.status_messages",
+        default=False,
+        help="Whether to print exploration debugger status messages",
+    )
+
+    include = En.v(
+        list,
+        "dd.debugger.expl.include",
+        parser=lambda v: [path.split(".") for path in v.split(",")],
+        default=[],
+        help="List of module paths to include in the exploration",
+    )
+
+    elusive = En.v(
+        bool,
+        "dd.debugger.expl.elusive",
+        default=False,
+        help="Whether to include elusive modules in the exploration",
+    )
+
+    class ProfilerConfig(En):
+        __item__ = "profiler"
+        __prefix__ = "dd.debugger.expl.profiler"
+
+        enabled = En.v(
+            bool,
+            "enabled",
+            default=True,
+            help="Whether to enable the exploration deterministic profiler",
+        )
+
+    class CoverageConfig(En):
+        __item__ = "coverage"
+        __prefix__ = "dd.debugger.expl.coverage"
+
+        enabled = En.v(
+            bool,
+            "enabled",
+            default=True,
+            help="Whether to enable the exploration line coverage",
+        )
+
+        delete_probes = En.v(
+            bool,
+            "delete_line_probes",
+            default=False,
+            help="Whether to delete line probes after they are triggered",
+        )
+
+
+config = ExplorationConfig()

--- a/tests/debugging/exploration/_coverage.py
+++ b/tests/debugging/exploration/_coverage.py
@@ -8,20 +8,17 @@ from debugger import COLS
 from debugger import CWD
 from debugger import ExplorationDebugger
 from debugger import ModuleCollector
+from debugger import config
 from debugger import status
 
 from ddtrace.debugging._function.discovery import FunctionDiscovery
 from ddtrace.debugging._probe.model import LineProbe
 from ddtrace.debugging._snapshot.model import Snapshot
 from ddtrace.internal.module import origin
-from ddtrace.internal.utils.formats import asbool
 
 
 # Track all the covered modules and its lines. Indexed by module origin.
 _tracked_modules = {}  # type: t.Dict[str, t.Tuple[ModuleType, t.Set[int]]]
-
-ENABLED = asbool(os.getenv("DD_DEBUGGER_EXPL_COVERAGE_ENABLED", True))
-DELETE_LINE_PROBE = asbool(os.getenv("DD_DEBUGGER_EXPL_DELETE_LINE_PROBE", False))
 
 
 class LineCollector(ModuleCollector):
@@ -92,9 +89,9 @@ class LineCoverage(ExplorationDebugger):
     @classmethod
     def on_snapshot(cls, snapshot):
         # type: (Snapshot) -> None
-        if DELETE_LINE_PROBE:
+        if config.coverage.delete_probes:
             cls.delete_probe(snapshot.probe)
 
 
-if ENABLED:
+if config.coverage.enabled:
     LineCoverage.enable()

--- a/tests/debugging/exploration/_profiler.py
+++ b/tests/debugging/exploration/_profiler.py
@@ -1,21 +1,17 @@
-import os
 import typing as t
 
 from debugger import COLS
 from debugger import ExplorationDebugger
 from debugger import ModuleCollector
+from debugger import config
 from debugger import status
 
 from ddtrace.debugging._function.discovery import FunctionDiscovery
 from ddtrace.debugging._probe.model import FunctionProbe
-from ddtrace.internal.utils.formats import asbool
 
 
 # Track all instrumented functions and their call count.
 _tracked_funcs = {}  # type: t.Dict[str, int]
-
-
-ENABLED = asbool(os.getenv("DD_DEBUGGER_EXPL_PROFILER_ENABLED", True))
 
 
 class FunctionCollector(ModuleCollector):
@@ -65,5 +61,5 @@ class DeterministicProfiler(ExplorationDebugger):
         cls.report_func_calls()
 
 
-if ENABLED:
+if config.profiler.enabled:
     DeterministicProfiler.enable()

--- a/tests/debugging/exploration/debugger.py
+++ b/tests/debugging/exploration/debugger.py
@@ -1,12 +1,14 @@
 import os
+import sys
 from threading import Thread
 from types import FrameType
 from types import ModuleType
 import typing as t
-from warnings import warn
+
+from _config import config
 
 from ddtrace.context import Context
-from ddtrace.debugging._config import config
+from ddtrace.debugging._config import config as debugger_config
 from ddtrace.debugging._debugger import Debugger
 from ddtrace.debugging._debugger import DebuggerModuleWatchdog
 from ddtrace.debugging._encoding import SnapshotJsonEncoder
@@ -18,8 +20,8 @@ from ddtrace.debugging._snapshot.collector import SnapshotCollector
 from ddtrace.debugging._snapshot.collector import SnapshotContext
 from ddtrace.debugging._snapshot.model import Snapshot
 from ddtrace.internal.compat import ExcInfoType
+from ddtrace.internal.compat import PY3
 from ddtrace.internal.module import origin
-from ddtrace.internal.utils.formats import asbool
 
 
 try:
@@ -28,37 +30,93 @@ except Exception:
     COLS = 80
 CWD = os.path.abspath(os.getcwd())
 TESTS = os.path.join(CWD, "test")
-try:
-    _ = os.getenv("VIRTUAL_ENV")
-    VENV = os.path.abspath(_) if _ is not None else None
-except TypeError:
-    warn(
-        "No virtual environment detected. Running without a virtual environment active might cause exploration tests "
-        "to instrument more than intended."
-    )
-    VENV = None
 
-ENCODE = asbool(os.getenv("DD_DEBUGGER_EXPL_ENCODE", True))
+
+def from_editable_install(module):
+    # type: (ModuleType) -> bool
+    o = origin(module)
+    return o.startswith(CWD) and not o.startswith(TESTS) and (config.venv is None or not o.startswith(config.venv))
+
+
+def is_included(module):
+    # type: (ModuleType) -> bool
+    segments = module.__name__.split(".")
+    for i in config.include:
+        if i == segments[: len(i)]:
+            return True
+    return False
+
+
+def is_ddtrace(module):
+    # type: (ModuleType) -> bool
+    name = module.__name__
+    return name == "ddtrace" or name.startswith("ddtrace.")
 
 
 class ModuleCollector(DebuggerModuleWatchdog):
     def __init__(self, *args, **kwargs):
         super(ModuleCollector, self).__init__(*args, **kwargs)
 
+        self._imported_modules = set()  # type: t.Set[str]
+
     def on_collect(self, discovery):
         # type: (FunctionDiscovery) -> None
         raise NotImplementedError()
 
+    def _on_new_module(self, module):
+        try:
+            if not is_ddtrace(module):
+                if config.include:
+                    if not is_included(module):
+                        return
+                elif not from_editable_install(module):
+                    # We want to instrument only the modules that belong to the
+                    # codebase and exclude the modules that belong to the tests
+                    # and the dependencies installed within the virtual env.
+                    return
+
+                try:
+                    return self.on_collect(FunctionDiscovery(module))
+                except Exception as e:
+                    status("Error collecting functions from %s: %s" % (module.__name__, e))
+                    raise e
+
+            status("Excluding module %s" % module.__name__)
+
+        except Exception as e:
+            status("Error after module import %s: %s" % (module.__name__, e))
+            raise e
+
     def after_import(self, module):
         # type: (ModuleType) -> None
-        o = origin(module)
-        if o.startswith(CWD) and not o.startswith(TESTS) and (VENV is None or not o.startswith(VENV)):
-            # We want to instrument only the modules that belong to the codebase
-            # and exclude the modules that belong to the tests and the
-            # dependencies installed within the virtual environment.
-            self.on_collect(FunctionDiscovery(module))
+        name = module.__name__
+        if name in self._imported_modules:
+            return
 
-        return super(ModuleCollector, self).after_import(module)
+        self._imported_modules.add(name)
+
+        self._on_new_module(module)
+
+        super(ModuleCollector, self).after_import(module)
+
+        if PY3 and config.elusive:
+            # Handle any new modules that have been imported since the last time
+            # and that have eluded the import hook.
+            for m in list(_ for _ in sys.modules.values() if _ is not None):
+                # In Python 3 we can check if a module has been fully
+                # initialised. At this stage we want to skip anything that is
+                # only partially initialised.
+                try:
+                    if m.__spec__._initializing:
+                        continue
+                except AttributeError:
+                    continue
+
+                name = m.__name__
+                if name not in self._imported_modules:
+                    self._imported_modules.add(name)
+                    self._on_new_module(m)
+                    super(ModuleCollector, self).after_import(m)
 
 
 class NoopDebuggerRC(object):
@@ -122,7 +180,7 @@ class NoopSnapshotJsonEncoder(SnapshotJsonEncoder):
 class ExplorationSnapshotCollector(SnapshotCollector):
     def __init__(self, *args, **kwargs):
         super(ExplorationSnapshotCollector, self).__init__(*args, **kwargs)
-        encoder_class = SnapshotJsonEncoder if ENCODE else NoopSnapshotJsonEncoder
+        encoder_class = SnapshotJsonEncoder if config.encode else NoopSnapshotJsonEncoder
         self._encoder = encoder_class("exploration")
         self._encoder._encoders = {Snapshot: self._encoder}
         self._snapshots = []
@@ -132,7 +190,7 @@ class ExplorationSnapshotCollector(SnapshotCollector):
 
     def _enqueue(self, snapshot):
         # type: (Snapshot) -> None
-        if ENCODE:
+        if config.encode:
             try:
                 self._snapshots.append(self._encoder.encode(snapshot))
             except Exception:
@@ -185,9 +243,9 @@ class ExplorationDebugger(Debugger):
     @classmethod
     def enable(cls):
         # type: () -> None
-        config.max_probes = float("inf")
-        config.global_rate_limit = float("inf")
-        config.metrics = False
+        debugger_config.max_probes = float("inf")
+        debugger_config.global_rate_limit = float("inf")
+        debugger_config.metrics = False
 
         super(ExplorationDebugger, cls).enable()
 
@@ -245,7 +303,7 @@ class ExplorationDebugger(Debugger):
         cls._instance._on_configuration(ProbePollerEvent.DELETED_PROBES, [probe])
 
 
-if asbool(os.getenv("DD_DEBUGGER_EXPL_STATUS_MESSAGES", False)):
+if config.status_messages:
 
     def status(msg):
         # type: (str) -> None


### PR DESCRIPTION
## Description

This change adds the option to specify a list of module paths to include during exploration test runs. By default, the exploration debuggers will instrument the modules of a package installed in editable mode, if any.

This change also adds checks to collect any modules that might have eluded the import machinery.

## Checklist
- [x] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] Ensure tests are passing for affected code.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
