### PR TITLE
chore[ci]: Fix typing with upgraded mypy

### DIFF
--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -596,14 +596,14 @@ class Debugger(Service):
         else:
             raise ValueError("Unknown probe poller event %r" % event)
 
-    def _stop_service(self):  # type: ignore[override]
+    def _stop_service(self):
         # type: () -> None
         self._function_store.restore_all()
         for service in self._services:
             service.stop()
             service.join()
 
-    def _start_service(self):  # type: ignore[override]
+    def _start_service(self):
         # type: () -> None
         for service in self._services:
             service.start()

--- a/ddtrace/internal/atexit.py
+++ b/ddtrace/internal/atexit.py
@@ -45,7 +45,7 @@ else:
         return func
 
     def unregister(func):
-        # type: (typing.Callable[..., None]) -> None
+        # type: (typing.Callable[..., typing.Any]) -> None
         """
         Unregister an exit function which was previously registered using
         atexit.register.

--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -148,7 +148,7 @@ class RuntimeWorker(periodic.PeriodicService):
                 log.debug("Writing metric %s:%s", key, value)
                 self._dogstatsd_client.distribution(key, value)
 
-    def _stop_service(self):  # type: ignore[override]
+    def _stop_service(self):
         # type: (...) -> None
         # De-register span hook
         super(RuntimeWorker, self)._stop_service()

--- a/ddtrace/internal/utils/attr.py
+++ b/ddtrace/internal/utils/attr.py
@@ -1,6 +1,5 @@
 import os
 from typing import Callable
-from typing import Type
 from typing import TypeVar
 from typing import Union
 
@@ -9,7 +8,7 @@ T = TypeVar("T")
 
 
 def from_env(name, default, value_type):
-    # type: (str, T, Union[Callable[[Union[str, T, None]], T], Type[T]]) -> Callable[[], T]
+    # type: (str, T, Union[Callable[[Union[str, T, None]], T], type(T)]) -> Callable[[], T]
     def _():
         return value_type(os.environ.get(name, default))
 

--- a/ddtrace/internal/utils/cache.py
+++ b/ddtrace/internal/utils/cache.py
@@ -29,7 +29,7 @@ class LFUCache(dict):
         self.lock = RLock()
 
     def get(self, key, f):  # type: ignore[override]
-        # type: (T, F) -> S
+        # type: (T, Callable[[T], S]) -> S
         """Get a value from the cache.
 
         If the value with the given key is not in the cache, the expensive
@@ -69,7 +69,7 @@ def cached(maxsize=256):
         cache = LFUCache(maxsize)
 
         def cached_f(key):
-            # type: (T) -> S
+            # type: (Callable[[T], S]) -> S
             return cache.get(key, f)
 
         cached_f.invalidate = cache.clear  # type: ignore[attr-defined]

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -587,7 +587,7 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
     def periodic(self):
         self.flush_queue(raise_exc=False)
 
-    def _stop_service(  # type: ignore[override]
+    def _stop_service(
         self,
         timeout=None,  # type: Optional[float]
     ):

--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -203,13 +203,13 @@ class LockCollector(collector.CaptureSamplerCollector):
         # type: (...) -> None
         pass
 
-    def _start_service(self):  # type: ignore[override]
+    def _start_service(self):
         # type: (...) -> None
         """Start collecting lock usage."""
         self.patch()
         super(LockCollector, self)._start_service()
 
-    def _stop_service(self):  # type: ignore[override]
+    def _stop_service(self):
         # type: (...) -> None
         """Stop collecting lock usage."""
         super(LockCollector, self)._stop_service()

--- a/ddtrace/profiling/collector/asyncio.py
+++ b/ddtrace/profiling/collector/asyncio.py
@@ -29,7 +29,7 @@ class AsyncioLockCollector(_lock.LockCollector):
 
     PROFILED_LOCK_CLASS = _ProfiledAsyncioLock
 
-    def _start_service(self):  # type: ignore[override]
+    def _start_service(self):
         # type: (...) -> None
         """Start collecting lock usage."""
         try:

--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -93,7 +93,7 @@ class MemoryCollector(collector.PeriodicCollector):
     heap_sample_size = attr.ib(type=int, factory=_get_default_heap_sample_size)
     ignore_profiler = attr.ib(factory=attr_utils.from_env("DD_PROFILING_IGNORE_PROFILER", False, formats.asbool))
 
-    def _start_service(self):  # type: ignore[override]
+    def _start_service(self):
         # type: (...) -> None
         """Start collecting memory profiles."""
         if _memalloc is None:
@@ -103,7 +103,7 @@ class MemoryCollector(collector.PeriodicCollector):
 
         super(MemoryCollector, self)._start_service()
 
-    def _stop_service(self):  # type: ignore[override]
+    def _stop_service(self):
         # type: (...) -> None
         super(MemoryCollector, self)._stop_service()
 

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -252,7 +252,7 @@ class _ProfilerInstance(service.Service):
             }
         )
 
-    def _start_service(self):  # type: ignore[override]
+    def _start_service(self):
         # type: (...) -> None
         """Start the profiler."""
         collectors = []
@@ -270,7 +270,7 @@ class _ProfilerInstance(service.Service):
         if self._scheduler is not None:
             self._scheduler.start()
 
-    def _stop_service(  # type: ignore[override]
+    def _stop_service(
         self, flush=True  # type: bool
     ):
         # type: (...) -> None

--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -28,7 +28,7 @@ class Scheduler(periodic.PeriodicService):
         # Copy the value to use it later since we're going to adjust the real interval
         self._configured_interval = self.interval
 
-    def _start_service(self):  # type: ignore[override]
+    def _start_service(self):
         # type: (...) -> None
         """Start the scheduler."""
         LOG.debug("Starting scheduler")


### PR DESCRIPTION
## Description
The latest 0.981 release of mypy which our CI checks and commit hooks are dependent on resulted in previously uncaught errors. This new release of mypy includes new specifications and rules for TypeVars and abstract classes, which has been addressed in this PR.