### PR TITLE
chore(ci): pin sanic and sanic-testing version

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -1833,9 +1833,9 @@ venv = Venv(
                         "sanic": [
                             "~=21.9.0",
                             "~=21.12.0",
-                            latest,
+                            "==22.6.2",
                         ],
-                        "sanic-testing": latest,
+                        "sanic-testing": ["<=22.6.0"],
                     },
                 ),
             ],


### PR DESCRIPTION
## Description
Pin sanic and sanic-testing versions to fix tests in CI

The tests for sanic integration are failing for the following new versions: sanic==[22.9.0](https://github.com/sanic-org/sanic/releases/tag/v22.9.0)  and sanic-testing==[22.9.0](https://github.com/sanic-org/sanic-testing/releases/tag/v22.9.0), with the following error:
```
self = <tests.contrib.sanic.test_sanic.client.<locals>.TestClient object at 0x7f4e4c78b0a0>
method = 'GET', url = '/hello', gather_request = True, args = ()
kwargs = {'auth': <httpx._client.UseClientDefault object at 0x7f4e4cfdd550>, 'cookies': None, 'extensions': None, 'follow_redirects': <httpx._client.UseClientDefault object at 0x7f4e4cfdd550>, ...}
route = <Route: name=sanic.hello path=hello>

    async def request(  # type: ignore
        self, method, url, gather_request=True, *args, **kwargs
    ) -> typing.Tuple[
        typing.Optional[Request], typing.Optional[TestingResponse]
    ]:
        self.sanic_app.router.reset()
        self.sanic_app.signal_router.reset()
        await self.sanic_app._startup()  # type: ignore
        await self.sanic_app._server_event("init", "before")
        await self.sanic_app._server_event("init", "after")
        for route in self.sanic_app.router.routes:
>           if self._collect_request not in route.extra.request_middleware:
E           AttributeError: 'Route' object has no attribute 'extra'
```

The failing tests are:
```
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[default-default] - A...
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[default-disable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[default-enable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[service_override-default]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[service_override-disable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[service_override-enable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[disable_analytics-default]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[disable_analytics-disable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[disable_analytics-enable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[enable_analytics_default_sample_rate-default]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[enable_analytics_default_sample_rate-disable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[enable_analytics_default_sample_rate-enable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[enable_analytics_custom_sample_rate-default]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[enable_analytics_custom_sample_rate-disable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[enable_analytics_custom_sample_rate-enable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[disable_analytics_custom_sample_rate-default]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[disable_analytics_custom_sample_rate-disable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[disable_analytics_custom_sample_rate-enable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[disable_distributed_tracing-default]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[disable_distributed_tracing-disable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_basic_app[disable_distributed_tracing-enable trace query string]
FAILED tests/contrib/sanic/test_sanic.py::test_resource_name[/hello/foo-expected_json0-GET /hello/<first_name>]
FAILED tests/contrib/sanic/test_sanic.py::test_resource_name[/hello/foo/bar-expected_json1-GET /hello/<first_name>/<surname>]
FAILED tests/contrib/sanic/test_sanic.py::test_streaming_response - Attribute...
FAILED tests/contrib/sanic/test_sanic.py::test_error_app[400-/error400-Something bad with the request]
FAILED tests/contrib/sanic/test_sanic.py::test_error_app[404-/nonexistent-not found]
FAILED tests/contrib/sanic/test_sanic.py::test_exception - AttributeError: 'R...
FAILED tests/contrib/sanic/test_sanic.py::test_multiple_requests - AttributeE...
FAILED tests/contrib/sanic/test_sanic.py::test_invalid_response_type_str - At...
FAILED tests/contrib/sanic/test_sanic.py::test_invalid_response_type_empty - ...
FAILED tests/contrib/sanic/test_sanic.py::test_http_request_header_tracing - ...
FAILED tests/contrib/sanic/test_sanic.py::test_endpoint_with_numeric_arg - At...
```

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
