### PR TITLE
ci(codespell): ignore ddwaf header

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -150,7 +150,7 @@ venv = Venv(
             venvs=[
                 Venv(
                     name="codespell",
-                    command="codespell ddtrace/ tests/",
+                    command='codespell --skip="ddwaf.h" ddtrace/ tests/',
                 ),
                 Venv(
                     name="hook-codespell",


### PR DESCRIPTION
The codespell job is failing with the following errors:

```
ddtrace/appsec/include/ddwaf.h:194: emmitted ==> emitted
ddtrace/appsec/include/ddwaf.h:195: emmitted ==> emitted
ddtrace/appsec/include/ddwaf.h:461: calcualted ==> calculated
```

We can safely ignore the `ddwaf.h` included from this appsec dependency when checking spelling in code.