### PR TITLE
feat: Add possibility to start trace on application startup

### DIFF
--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -47,7 +47,10 @@ class IntegrationConfig(AttrDict):
             "DD_%s_SERVICE" % name.upper(),
             default=os.getenv(
                 "DD_%s_SERVICE_NAME" % name.upper(),
-                default=None,
+                default=os.getenv(
+                    "DD_SERVICE",
+                    default=None,
+                ),
             ),
         )
         self.setdefault("service", service)


### PR DESCRIPTION
## Description
I have jobs running in a kubernetes cluster which I would like to trace. To enable tracing them without manually editing every job and adding a start trace I added the possiblity to start a trace on application startup (and end it on close) into `ddtrace-run`.
Additionally these jobs have subprocesses that are started via `subprocess.Popen` to enable forwarding the trace context I added environment variables for trace_id and span_id.

If you think this change could make it into the main branch I will write tests and documentation for it. Otherwise there is  maybe already a better way?

edit: I have also added DD_SERVICE as the standard fallback service for integrations as described in this issue: https://github.com/DataDog/dd-trace-py/issues/2065

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
