### PR TITLE
chore(coverage): exclude TYPE_CHECKING from coverage

### DIFF
--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -33,7 +33,7 @@ from ddtrace.internal.processor import SpanProcessor
 from ddtrace.internal.rate_limiter import RateLimiter
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Dict
 
     from ddtrace.span import Span

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -13,7 +13,7 @@ from .internal.compat import PY2
 from .internal.logger import get_logger
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .span import Span
     from .span import _MetaDictType
     from .span import _MetricDictType

--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -13,7 +13,7 @@ from ...internal.logger import get_logger
 from .utils import guarantee_single_callable
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Any
     from typing import Mapping
     from typing import Optional

--- a/ddtrace/contrib/asyncpg/patch.py
+++ b/ddtrace/contrib/asyncpg/patch.py
@@ -16,7 +16,7 @@ from ..trace_utils import wrap
 from ..trace_utils_async import with_traced_module
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from types import ModuleType
     from typing import Dict
     from typing import Union

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -32,7 +32,7 @@ from ...propagation.http import HTTPPropagator
 from ..trace_utils import unwrap
 
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     from ddtrace import Span
 
 # Original botocore client class

--- a/ddtrace/contrib/flask_cache/tracers.py
+++ b/ddtrace/contrib/flask_cache/tracers.py
@@ -15,7 +15,7 @@ from .utils import _extract_conn_tags
 from .utils import _resource_from_cache_prefix
 
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     from ddtrace import Span
 
 

--- a/ddtrace/contrib/graphql/patch.py
+++ b/ddtrace/contrib/graphql/patch.py
@@ -4,7 +4,7 @@ import sys
 from typing import TYPE_CHECKING
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Callable
     from typing import Dict
     from typing import Iterable

--- a/ddtrace/contrib/httpx/patch.py
+++ b/ddtrace/contrib/httpx/patch.py
@@ -20,7 +20,7 @@ from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     from ddtrace import Span
     from ddtrace.vendor.wrapt import BoundFunctionWrapper
 

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -35,7 +35,7 @@ from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.vendor import wrapt
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ddtrace import Span
     from ddtrace import Tracer
     from ddtrace.settings import IntegrationConfig

--- a/ddtrace/contrib/wsgi/wsgi.py
+++ b/ddtrace/contrib/wsgi/wsgi.py
@@ -2,7 +2,7 @@ import functools
 from typing import TYPE_CHECKING
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Any
     from typing import Callable
     from typing import Dict

--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -56,7 +56,7 @@ from ddtrace.internal.service import Service
 from ddtrace.internal.wrapping import Wrapper
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ddtrace.tracer import Tracer
 
 

--- a/ddtrace/debugging/_encoding.py
+++ b/ddtrace/debugging/_encoding.py
@@ -39,7 +39,7 @@ from ddtrace.internal.safety import get_slots
 from ddtrace.internal.utils.cache import cached
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ddtrace.internal.compat import Collection
 
 

--- a/ddtrace/ext/aws.py
+++ b/ddtrace/ext/aws.py
@@ -7,7 +7,7 @@ from typing import Tuple
 from ddtrace.contrib.trace_utils import set_flattened_tags
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ddtrace.span import Span
 
 

--- a/ddtrace/filters.py
+++ b/ddtrace/filters.py
@@ -12,7 +12,7 @@ from ddtrace.internal.processor.trace import TraceProcessor
 from .ext import http
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ddtrace import Span
 
 

--- a/ddtrace/internal/_context.py
+++ b/ddtrace/internal/_context.py
@@ -4,7 +4,7 @@ from ddtrace.provider import _DD_CONTEXTVAR
 from ddtrace.span import Span
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Any
     from typing import Dict
     from typing import List

--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -17,7 +17,7 @@ from ddtrace.sampler import DatadogSampler
 from .logger import get_logger
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ddtrace import Tracer
 
 

--- a/ddtrace/internal/encoding.py
+++ b/ddtrace/internal/encoding.py
@@ -17,7 +17,7 @@ from .logger import get_logger
 __all__ = ["MsgpackEncoderV03", "MsgpackEncoderV05", "ListStringTable", "MSGPACK_ENCODERS"]
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ..span import Span
 
 

--- a/ddtrace/internal/processor/stats.py
+++ b/ddtrace/internal/processor/stats.py
@@ -25,7 +25,7 @@ from ..periodic import PeriodicService
 from ..writer import _human_size
 
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     from typing import DefaultDict
     from typing import Dict
     from typing import List

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -23,7 +23,7 @@ from ddtrace.internal import runtime
 from ddtrace.internal.utils.time import parse_isoformat
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Callable
     from typing import Dict
     from typing import MutableMapping

--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -6,7 +6,7 @@ from typing import Set
 from typing import TYPE_CHECKING
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ddtrace import Span
 
 import attr

--- a/ddtrace/internal/sampling.py
+++ b/ddtrace/internal/sampling.py
@@ -31,7 +31,7 @@ except ImportError:
     # handling python 2.X import error
     JSONDecodeError = ValueError  # type: ignore
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Any
     from typing import Dict
     from typing import List

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -39,7 +39,7 @@ from .runtime import container
 from .sma import SimpleMovingAverage
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ddtrace import Span
 
     from .agent import ConnectionType

--- a/ddtrace/opentracer/helpers.py
+++ b/ddtrace/opentracer/helpers.py
@@ -5,7 +5,7 @@ import opentracing
 import ddtrace
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ddtrace.opentracer import Tracer
 
 

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -20,7 +20,7 @@ from .span_context import SpanContext
 from .tags import Tags
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .tracer import Tracer
 
 

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -9,7 +9,7 @@ from .internal.logger import get_logger
 from .vendor import wrapt
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .tracer import Tracer
 
 

--- a/ddtrace/profiling/exporter/__init__.py
+++ b/ddtrace/profiling/exporter/__init__.py
@@ -3,7 +3,7 @@ import typing
 import attr
 
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     from .. import recorder
 
 

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -38,7 +38,7 @@ except ImportError:
     # handling python 2.X import error
     JSONDecodeError = ValueError  # type: ignore
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .span import Span
 
 

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -20,7 +20,7 @@ from tests.utils import assert_is_measured
 from tests.utils import assert_is_not_measured
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Generator
 
 

--- a/tests/tracer/test_memory_leak.py
+++ b/tests/tracer/test_memory_leak.py
@@ -12,7 +12,7 @@ import pytest
 from ddtrace import Tracer
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ddtrace.span import Span
 
 


### PR DESCRIPTION
## Description
Exclude TYPE_CHECKING from coverage.

`if TYPE_CHECKING:` block works only with `mypy`. Coverage reports never enter in these blocks and if we exclude these, we could have more accurate coverage reports.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
