### PR TITLE
chore(utils): make cache utils `callonce()` compatible with py 3.11

### DIFF
--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -88,14 +88,14 @@ else:
 try:
     from inspect import getargspec as getfullargspec
 
-    def args_provided(f, argspec):
+    def is_not_void_function(f, argspec):
         return argspec.args or argspec.varargs or argspec.keywords or argspec.defaults or isgeneratorfunction(f)
 
 
 except ImportError:
     from inspect import getfullargspec  # type: ignore[misc]  # noqa: F401
 
-    def args_provided(f, argspec):
+    def is_not_void_function(f, argspec):
         return (
             argspec.args
             or argspec.varargs

--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -1,3 +1,4 @@
+from inspect import isgeneratorfunction
 import platform
 import random
 import re
@@ -83,6 +84,27 @@ if PYTHON_VERSION_INFO >= (3, 7):
     pattern_type = re.Pattern
 else:
     pattern_type = re._pattern_type  # type: ignore[misc,attr-defined]
+
+try:
+    from inspect import getargspec as getfullargspec
+
+    def args_provided(f, argspec):
+        return argspec.args or argspec.varargs or argspec.keywords or argspec.defaults or isgeneratorfunction(f)
+
+
+except ImportError:
+    from inspect import getfullargspec  # type: ignore[misc]  # noqa: F401
+
+    def args_provided(f, argspec):
+        return (
+            argspec.args
+            or argspec.varargs
+            or argspec.varkw
+            or argspec.defaults
+            or argspec.kwonlyargs
+            or argspec.kwonlydefaults
+            or isgeneratorfunction(f)
+        )
 
 
 def is_integer(obj):

--- a/ddtrace/internal/utils/cache.py
+++ b/ddtrace/internal/utils/cache.py
@@ -1,17 +1,12 @@
-from ddtrace.internal.compat import PY2
-
-
-if PY2:
-    from inspect import getargspec
-else:
-    from inspect import getfullargspec
-from inspect import isgeneratorfunction
 from threading import RLock
 from typing import Any
 from typing import Callable
 from typing import Optional
 from typing import Type
 from typing import TypeVar
+
+from ddtrace.internal.compat import args_provided
+from ddtrace.internal.compat import getfullargspec
 
 
 miss = object()
@@ -113,22 +108,9 @@ def cachedmethod(maxsize=256):
 def callonce(f):
     # type: (Callable[[], Any]) -> Callable[[], Any]
     """Decorator for executing a function only the first time."""
-    if PY2:
-        argspec = getargspec(f)
-        if argspec.args or argspec.varargs or argspec.keywords or argspec.defaults or isgeneratorfunction(f):
-            raise ValueError("The callonce decorator can only be applied to functions with no arguments")
-    else:
-        argspec = getfullargspec(f)
-        if (
-            argspec.args
-            or argspec.varargs
-            or argspec.varkw
-            or argspec.defaults
-            or argspec.kwonlyargs
-            or argspec.kwonlydefaults
-            or isgeneratorfunction(f)
-        ):
-            raise ValueError("The callonce decorator can only be applied to functions with no arguments")
+    argspec = getfullargspec(f)
+    if args_provided(f, argspec):
+        raise ValueError("The callonce decorator can only be applied to functions with no arguments")
 
     def _():
         # type: () -> Any

--- a/ddtrace/internal/utils/cache.py
+++ b/ddtrace/internal/utils/cache.py
@@ -5,8 +5,8 @@ from typing import Optional
 from typing import Type
 from typing import TypeVar
 
-from ddtrace.internal.compat import args_provided
 from ddtrace.internal.compat import getfullargspec
+from ddtrace.internal.compat import is_not_void_function
 
 
 miss = object()
@@ -109,7 +109,7 @@ def callonce(f):
     # type: (Callable[[], Any]) -> Callable[[], Any]
     """Decorator for executing a function only the first time."""
     argspec = getfullargspec(f)
-    if args_provided(f, argspec):
+    if is_not_void_function(f, argspec):
         raise ValueError("The callonce decorator can only be applied to functions with no arguments")
 
     def _():

--- a/ddtrace/internal/utils/cache.py
+++ b/ddtrace/internal/utils/cache.py
@@ -1,4 +1,10 @@
-from inspect import getargspec
+from ddtrace.internal.compat import PY2
+
+
+if PY2:
+    from inspect import getargspec
+else:
+    from inspect import getfullargspec
 from inspect import isgeneratorfunction
 from threading import RLock
 from typing import Any
@@ -107,10 +113,22 @@ def cachedmethod(maxsize=256):
 def callonce(f):
     # type: (Callable[[], Any]) -> Callable[[], Any]
     """Decorator for executing a function only the first time."""
-
-    argspec = getargspec(f)
-    if argspec.args or argspec.varargs or argspec.keywords or argspec.defaults or isgeneratorfunction(f):
-        raise ValueError("The callonce decorator can only be applied to functions with no arguments")
+    if PY2:
+        argspec = getargspec(f)
+        if argspec.args or argspec.varargs or argspec.keywords or argspec.defaults or isgeneratorfunction(f):
+            raise ValueError("The callonce decorator can only be applied to functions with no arguments")
+    else:
+        argspec = getfullargspec(f)
+        if (
+            argspec.args
+            or argspec.varargs
+            or argspec.varkw
+            or argspec.defaults
+            or argspec.kwonlyargs
+            or argspec.kwonlydefaults
+            or isgeneratorfunction(f)
+        ):
+            raise ValueError("The callonce decorator can only be applied to functions with no arguments")
 
     def _():
         # type: () -> Any


### PR DESCRIPTION
## Description
#4302 added a `callonce()` decorator as a cache utility function. However, this imported `inspect.getargspec()` was removed as of Python 3.11. This was fixed by importing `inspect.getfullargspec()`, which is the recommended replacement for `getargspec()`. Note that `getargspec()` is still used in Python 2.

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
