### PR TITLE
chore: make issue template easier to triage

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,7 +14,6 @@ library.
 
 ### Which version of pip are you using?
 
-_ddtrace requires pip>=18 to install one of our pre-built wheels_
 
 ### Which libraries and their versions are you using?
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!--
 Thanks for taking the time for reporting an issue!
 
 Before reporting an issue on dd-trace-py, please be sure to provide all
@@ -5,6 +6,9 @@ necessary information.
 
 If you're hitting a bug, make sure that you're using the latest version of this
 library.
+-->
+
+### Summary of problem
 
 ### Which version of dd-trace-py are you using?
 
@@ -12,9 +16,12 @@ library.
 
 _ddtrace requires pip>=18 to install one of our pre-built wheels_
 
-### Which version of the libraries are you using?
+### Which supported libraries and their versions are you using?
 
-You can copy/paste the output of `pip freeze` here.
+<details>
+  <summary>`pip freeze`</summary>
+  <!-- Paste output of pip freeze here -->
+</details>
 
 ### How can we reproduce your problem?
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,7 +16,7 @@ library.
 
 _ddtrace requires pip>=18 to install one of our pre-built wheels_
 
-### Which supported libraries and their versions are you using?
+### Which libraries and their versions are you using?
 
 <details>
   <summary>`pip freeze`</summary>


### PR DESCRIPTION
I have found myself scrolling to the bottom of an issue to get a summary. Similarly, the output of pip freeze should be hidden by default.