### PR TITLE
chore(ci): pin PasteDeploy<3 in pyramid tests

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -1236,14 +1236,30 @@ venv = Venv(
         ),
         Venv(
             name="pyramid",
+            command="pytest {cmdargs} tests/contrib/pyramid/test_pyramid.py",
+            pkgs={
+                "requests": [latest],
+                "webtest": [latest],
+                "tests/contrib/pyramid/pserve_app": [latest],
+            },
             venvs=[
                 Venv(
-                    command="pytest {cmdargs} tests/contrib/pyramid/test_pyramid.py",
-                    pys=select_pys(),
+                    # pserve_app has PasteDeploy dependency, but PasteDeploy>=3.0 is incompatible with Python 2.7
+                    # pyramid>=2.0 no longer supports Python 2.7 and 3.5
+                    pys=select_pys(max_version="3.5"),
                     pkgs={
-                        "requests": [latest],
-                        "webtest": [latest],
-                        "tests/contrib/pyramid/pserve_app": [latest],
+                        "pastedeploy": "<3.0",
+                        "pyramid": [
+                            "~=1.7",
+                            "~=1.8",
+                            "~=1.9",
+                            "~=1.10",
+                        ],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version="3.6"),
+                    pkgs={
                         "pyramid": [
                             "~=1.7",
                             "~=1.8",


### PR DESCRIPTION
## Description
Pyramid has a `plaster_pastedeploy` dependency, which itself is a plugin based on PasteDeploy, and is dependent on PasteDeploy. However, PasteDeploy>=3.0 is now incompatible with Python 2.7, so we'll need to pin PasteDeploy in our riot test suite for pyramid.

## Checklist
- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] Ensure tests are passing for affected code.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
