### PR TITLE
chore(profile): track which memory domain allocated Python memory

### DIFF
--- a/ddtrace/profiling/collector/_memalloc.c
+++ b/ddtrace/profiling/collector/_memalloc.c
@@ -14,6 +14,8 @@
 typedef struct
 {
     PyMemAllocatorEx pymem_allocator_obj;
+    /* The domain we are tracking */
+    PyMemAllocatorDomain domain;
     /* The maximum number of events for allocation tracking */
     uint16_t max_events;
     /* The maximum number of frames collected in stack traces */
@@ -34,6 +36,9 @@ typedef struct
     /* Total number of allocations */
     uint64_t alloc_count;
 } alloc_tracker_t;
+
+/* A string containing "object" */
+static PyObject* object_string = NULL;
 
 #define ALLOC_TRACKER_MAX_COUNT UINT64_MAX
 
@@ -57,7 +62,7 @@ memalloc_add_event(memalloc_context_t* ctx, void* ptr, size_t size)
         /* set a barrier so we don't loop as getting a traceback allocates memory */
         memalloc_set_reentrant(true);
         /* Buffer is not full, fill it */
-        traceback_t* tb = memalloc_get_traceback(ctx->max_nframe, ptr, size);
+        traceback_t* tb = memalloc_get_traceback(ctx->max_nframe, ptr, size, ctx->domain);
         memalloc_set_reentrant(false);
         if (tb)
             traceback_array_append(&global_alloc_tracker->allocs, tb);
@@ -69,7 +74,8 @@ memalloc_add_event(memalloc_context_t* ctx, void* ptr, size_t size)
         if (r < ctx->max_events) {
             /* set a barrier so we don't loop as getting a traceback allocates memory */
             memalloc_set_reentrant(true);
-            traceback_t* tb = memalloc_get_traceback(ctx->max_nframe, ptr, size);
+            /* Replace a random traceback with this one */
+            traceback_t* tb = memalloc_get_traceback(ctx->max_nframe, ptr, size, ctx->domain);
             memalloc_set_reentrant(false);
             if (tb) {
                 traceback_free(global_alloc_tracker->allocs.tab[r]);
@@ -111,7 +117,7 @@ memalloc_alloc(int use_calloc, void* ctx, size_t nelem, size_t elsize)
 
     if (ptr) {
         memalloc_add_event(memalloc_ctx, ptr, nelem * elsize);
-        memalloc_heap_track(memalloc_ctx->max_nframe, ptr, nelem * elsize);
+        memalloc_heap_track(memalloc_ctx->max_nframe, ptr, nelem * elsize, memalloc_ctx->domain);
     }
 
     return ptr;
@@ -138,7 +144,7 @@ memalloc_realloc(void* ctx, void* ptr, size_t new_size)
     if (ptr2) {
         memalloc_add_event(memalloc_ctx, ptr2, new_size);
         memalloc_heap_untrack(ptr);
-        memalloc_heap_track(memalloc_ctx->max_nframe, ptr2, new_size);
+        memalloc_heap_track(memalloc_ctx->max_nframe, ptr2, new_size, memalloc_ctx->domain);
     }
 
     return ptr2;
@@ -207,6 +213,13 @@ memalloc_start(PyObject* Py_UNUSED(module), PyObject* args)
     if (memalloc_tb_init(global_memalloc_ctx.max_nframe) < 0)
         return NULL;
 
+    if (object_string == NULL) {
+        object_string = PyUnicode_FromString("object");
+        if (object_string == NULL)
+            return NULL;
+        PyUnicode_InternInPlace(&object_string);
+    }
+
     memalloc_heap_tracker_init((uint32_t)heap_sample_size);
 
     PyMemAllocatorEx alloc;
@@ -217,6 +230,8 @@ memalloc_start(PyObject* Py_UNUSED(module), PyObject* args)
     alloc.free = memalloc_free;
 
     alloc.ctx = &global_memalloc_ctx;
+
+    global_memalloc_ctx.domain = PYMEM_DOMAIN_OBJ;
 
     global_alloc_tracker = alloc_tracker_new();
 
@@ -322,11 +337,20 @@ iterevents_next(IterEventsState* iestate)
         traceback_t* tb = iestate->alloc_tracker->allocs.tab[iestate->seq_index];
         iestate->seq_index++;
 
-        PyObject* tb_and_size = PyTuple_New(2);
-        PyTuple_SET_ITEM(tb_and_size, 0, traceback_to_tuple(tb));
-        PyTuple_SET_ITEM(tb_and_size, 1, PyLong_FromSize_t(tb->size));
+        PyObject* tb_size_domain = PyTuple_New(3);
+        PyTuple_SET_ITEM(tb_size_domain, 0, traceback_to_tuple(tb));
+        PyTuple_SET_ITEM(tb_size_domain, 1, PyLong_FromSize_t(tb->size));
 
-        return tb_and_size;
+        /* Domain name */
+        if (tb->domain == PYMEM_DOMAIN_OBJ) {
+            PyTuple_SET_ITEM(tb_size_domain, 2, object_string);
+            Py_INCREF(object_string);
+        } else {
+            PyTuple_SET_ITEM(tb_size_domain, 2, Py_None);
+            Py_INCREF(Py_None);
+        }
+
+        return tb_size_domain;
     }
 
     /* Returning NULL in this case is enough. The next() builtin will raise the

--- a/ddtrace/profiling/collector/_memalloc_heap.c
+++ b/ddtrace/profiling/collector/_memalloc_heap.c
@@ -150,7 +150,7 @@ memalloc_heap_untrack(void* ptr)
 
    Returns true if the allocation was tracked, false otherwise. */
 bool
-memalloc_heap_track(uint16_t max_nframe, void* ptr, size_t size)
+memalloc_heap_track(uint16_t max_nframe, void* ptr, size_t size, PyMemAllocatorDomain domain)
 {
     /* Heap tracking is disabled */
     if (global_heap_tracker.sample_size == 0)
@@ -174,7 +174,7 @@ memalloc_heap_track(uint16_t max_nframe, void* ptr, size_t size)
         return false;
 
     memalloc_set_reentrant(true);
-    traceback_t* tb = memalloc_get_traceback(max_nframe, ptr, global_heap_tracker.allocated_memory);
+    traceback_t* tb = memalloc_get_traceback(max_nframe, ptr, global_heap_tracker.allocated_memory, domain);
     memalloc_set_reentrant(false);
 
     if (tb) {

--- a/ddtrace/profiling/collector/_memalloc_heap.h
+++ b/ddtrace/profiling/collector/_memalloc_heap.h
@@ -21,7 +21,7 @@ PyObject*
 memalloc_heap();
 
 bool
-memalloc_heap_track(uint16_t max_nframe, void* ptr, size_t size);
+memalloc_heap_track(uint16_t max_nframe, void* ptr, size_t size, PyMemAllocatorDomain domain);
 void
 memalloc_heap_untrack(void* ptr);
 

--- a/ddtrace/profiling/collector/_memalloc_tb.c
+++ b/ddtrace/profiling/collector/_memalloc_tb.c
@@ -140,7 +140,7 @@ memalloc_frame_to_traceback(PyFrameObject* pyframe, uint16_t max_nframe)
 }
 
 traceback_t*
-memalloc_get_traceback(uint16_t max_nframe, void* ptr, size_t size)
+memalloc_get_traceback(uint16_t max_nframe, void* ptr, size_t size, PyMemAllocatorDomain domain)
 {
     PyThreadState* tstate = PyThreadState_Get();
 
@@ -169,6 +169,8 @@ memalloc_get_traceback(uint16_t max_nframe, void* ptr, size_t size)
 #else
     traceback->thread_id = tstate->thread_id;
 #endif
+
+    traceback->domain = domain;
 
     return traceback;
 }

--- a/ddtrace/profiling/collector/_memalloc_tb.h
+++ b/ddtrace/profiling/collector/_memalloc_tb.h
@@ -32,6 +32,8 @@ typedef struct
     void* ptr;
     /* Memory size allocated in bytes */
     size_t size;
+    /* Domain allocated */
+    PyMemAllocatorDomain domain;
     /* Thread ID */
     unsigned long thread_id;
     /* List of frames, top frame first */
@@ -50,7 +52,7 @@ void
 traceback_free(traceback_t* tb);
 
 traceback_t*
-memalloc_get_traceback(uint16_t max_nframe, void* ptr, size_t size);
+memalloc_get_traceback(uint16_t max_nframe, void* ptr, size_t size, PyMemAllocatorDomain domain);
 
 PyObject*
 traceback_to_tuple(traceback_t* tb);

--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -166,7 +166,7 @@ class MemoryCollector(collector.PeriodicCollector):
                     capture_pct=capture_pct,
                     nevents=alloc_count,
                 )
-                for (stack, nframes, thread_id), size in events
+                for (stack, nframes, thread_id), size, domain in events
                 if not self.ignore_profiler or thread_id not in thread_id_ignore_set
             ),
         )

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -74,7 +74,8 @@ def test_iter_events():
     # Watchout: if we dropped samples the test will likely fail
 
     object_count = 0
-    for (stack, nframe, thread_id), size in events:
+    for (stack, nframe, thread_id), size, domain in events:
+        assert domain == "object"
         assert 0 < len(stack) <= max_nframe
         assert nframe >= len(stack)
         last_call = stack[0]
@@ -123,7 +124,8 @@ def test_iter_events_multi_thread():
 
     count_object = 0
     count_thread = 0
-    for (stack, nframe, thread_id), size in events:
+    for (stack, nframe, thread_id), size, domain in events:
+        assert domain == "object"
         assert 0 < len(stack) <= max_nframe
         assert nframe >= len(stack)
         last_call = stack[0]
@@ -165,7 +167,7 @@ def test_memory_collector():
             assert event.thread_name == "MainThread"
             count_object += 1
             assert event.frames[2][0] == __file__
-            assert event.frames[2][1] == 152
+            assert event.frames[2][1] == 154
             assert event.frames[2][2] == "test_memory_collector"
 
     assert count_object > 0


### PR DESCRIPTION
This adds tracking the memory domain that has been allocated for in memalloc.
This makes sure we can later use it in test to assert different kind of domain
tracking, and possibly export it to the users if we see value.