### PR TITLE
docs: make docstring pin reflect general uses

### DIFF
--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -23,10 +23,13 @@ _DD_PIN_PROXY_NAME = "_self_" + _DD_PIN_NAME
 
 
 class Pin(object):
-    """Pin (a.k.a Patch INfo) is a small class which is used to
-    set tracing metadata on a particular traced connection.
-    This is useful if you wanted to, say, trace two different
-    database clusters.
+    """
+    Pin (a.k.a Patch INfo) is a small class which is used to control tracing of
+    execution contexts for a particular object instance of an instrumented class
+    or for a loaded module that is instrumented.
+
+    One use case is to configure span metadata for two different database
+    connections:
 
         >>> conn = sqlite.connect('/tmp/user.db')
         >>> # Override a pin for a specific connection


### PR DESCRIPTION
## Description

The library documentation currently explains `ddtrace.Pin` with relation to database connections but it is used more generally. This PR updates its docstring to reflect the more general usage of the class.

## Checklist
- [X] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
- [X] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] PR cannot be broken up into smaller PRs.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
- [ ] Add to milestone.
