### PR TITLE
chore(docs): remove unnecessary checklist items

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,7 @@
 <!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->
 
 ## Checklist
-- [ ] Title must conform to [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).
 - [ ] Add additional sections for `feat` and `fix` pull requests.
-- [ ] Ensure tests are passing for affected code.
 - [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.
 
 <!-- Copy and paste the relevant snippet based on the type of pull request -->
@@ -38,7 +36,6 @@
 - [ ] Title is accurate.
 - [ ] Description motivates each change.
 - [ ] No unnecessary changes were introduced in this PR.
-- [ ] PR cannot be broken up into smaller PRs.
 - [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
 - [ ] Tests provided or description of manual testing performed is included in the code or PR.
 - [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.


### PR DESCRIPTION
## Description

Help make our PR template a little bit less work to fill out


<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
- [x] Add to milestone.
