### PR TITLE
feat(propagation):  DD_TRACE_PROPAGATION_STYLE_EXTRACT order matters

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -544,19 +544,22 @@ class HTTPPropagator(object):
         try:
             normalized_headers = {name.lower(): v for name, v in headers.items()}
             # Check all styles until we find the first valid match
-            # DEV: We want to check them in this specific priority order
-            if PROPAGATION_STYLE_DATADOG in config._propagation_style_extract:
-                context = _DatadogMultiHeader._extract(normalized_headers)
-                if context is not None:
-                    return context
-            if PROPAGATION_STYLE_B3 in config._propagation_style_extract:
-                context = _B3MultiHeader._extract(normalized_headers)
-                if context is not None:
-                    return context
-            if PROPAGATION_STYLE_B3_SINGLE_HEADER in config._propagation_style_extract:
-                context = _B3SingleHeader._extract(normalized_headers)
-                if context is not None:
-                    return context
+            # DEV: We want to check them in the order that they're specified.
+            for style in config._propagation_style_extract:
+                if style == PROPAGATION_STYLE_DATADOG:
+                    context = _DatadogMultiHeader._extract(normalized_headers)
+                    if context is not None:
+                        return context
+
+                if style == PROPAGATION_STYLE_B3:
+                    context = _B3MultiHeader._extract(normalized_headers)
+                    if context is not None:
+                        return context
+
+                if style == PROPAGATION_STYLE_B3_SINGLE_HEADER:
+                    context = _B3SingleHeader._extract(normalized_headers)
+                    if context is not None:
+                        return context
         except Exception:
             log.debug("error while extracting context propagation headers", exc_info=True)
         return Context()

--- a/releasenotes/notes/trace-propagation-style-extract-order-eb41c6f3c2f70d73.yaml
+++ b/releasenotes/notes/trace-propagation-style-extract-order-eb41c6f3c2f70d73.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The propagation style values provided in ``DD_TRACE_PROPAGATION_STYLE_EXTRACT`` are evaluated in the order that they are provided. Previously the order was hardcoded.


### PR DESCRIPTION
## Description
Going forward, we want the order of the propagation styles specified with `DD_TRACE_PROPAGATION_STYLE_EXTRACT` to matter. Previously we had hardcoded order. This gives users greater control over propagation.

## Example
Before this change, the order was hardcoded, so if we had `DD_TRACE_PROPAGATION_STYLE_EXTRACT=b3,datadog` then datadog extraction would be attempted first. Now if someone puts `DD_TRACE_PROPAGATION_STYLE_EXTRACT=b3,datadog` b3 will be evaluated first.

## Testing strategy
There is already a test that has all of the propagation styles, with datadog as the first value. Therefore I didn't think it was necessary to add further tests.


## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
