### PR TITLE
fix(ci): add py as a dependency

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -219,6 +219,7 @@ venv = Venv(
             pkgs={
                 "pytest-benchmark": latest,
                 "msgpack": latest,
+                # TODO: remove py dependency once https://github.com/ionelmc/pytest-benchmark/pull/227 is released
                 "py": latest,
             },
             venvs=[

--- a/riotfile.py
+++ b/riotfile.py
@@ -216,7 +216,11 @@ venv = Venv(
         ),
         Venv(
             pys=select_pys(),
-            pkgs={"pytest-benchmark": latest, "msgpack": latest},
+            pkgs={
+                "pytest-benchmark": latest,
+                "msgpack": latest,
+                "py": latest,
+            },
             venvs=[
                 Venv(
                     name="benchmarks",

--- a/tox.ini
+++ b/tox.ini
@@ -112,6 +112,7 @@ deps =
     hypothesis
 # used to test our custom msgpack encoder
     profile: pytest-benchmark
+    # TODO: remove py dependency once https://github.com/ionelmc/pytest-benchmark/pull/227 is released
     profile: py
     py{35,36,37,38,39,310}-profile: pytest-asyncio
     py{27,35,36,37,38,39}-profile: uwsgi; sys_platform != 'win32'

--- a/tox.ini
+++ b/tox.ini
@@ -112,6 +112,7 @@ deps =
     hypothesis
 # used to test our custom msgpack encoder
     profile: pytest-benchmark
+    profile: py
     py{35,36,37,38,39,310}-profile: pytest-asyncio
     py{27,35,36,37,38,39}-profile: uwsgi; sys_platform != 'win32'
     py{27,35,36,37,38,39,310}-profile: gunicorn; sys_platform != 'win32'


### PR DESCRIPTION
## Description
`pytest` recently vendored specific portions of the `py` library and removed it as a requirement. This broke our `benchmarks` and `profile` test suites in CI as they use the `py.io` module. Specifically, `pytest-benchmark` is the dependency that uses `py.io` and have addressed the issue (https://github.com/ionelmc/pytest-benchmark/issues/226) but haven't yet released a new hotfix. Until they do, we can just add `py` as a dependency in our riot test suites.

<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
