### PR TITLE
perf(ddtrace): lazy load global tracer

### DIFF
--- a/benchmarks/startup/config.yaml
+++ b/benchmarks/startup/config.yaml
@@ -1,0 +1,5 @@
+baseline:
+  do_import: "false"
+
+import:
+  do_import: "true"

--- a/benchmarks/startup/scenario.py
+++ b/benchmarks/startup/scenario.py
@@ -1,0 +1,21 @@
+import os
+import subprocess
+import tempfile
+
+import bm
+
+
+class Startup(bm.Scenario):
+    do_import = bm.var_bool()
+
+    def run(self):
+        # setup subprocess environment variables
+        with tempfile.NamedTemporaryFile(delete=False) as code_file:
+            if self.do_import:
+                code_file.write(b"import ddtrace\n")
+
+        def _(loops):
+            for _ in range(loops):
+                subprocess.check_output(["python", code_file.name], env=os.environ.copy())
+
+        yield _

--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -1,3 +1,13 @@
+import importlib
+import sys
+import typing
+
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+    from typing import List
+    from typing import Optional
+
 from ddtrace.internal.module import ModuleWatchdog
 
 
@@ -14,15 +24,10 @@ from .internal.utils.deprecations import DDTraceDeprecationWarning  # noqa: E402
 from .pin import Pin  # noqa: E402
 from .settings import _config as config  # noqa: E402
 from .span import Span  # noqa: E402
-from .tracer import Tracer  # noqa: E402
 from .version import get_version  # noqa: E402
 
 
 __version__ = get_version()
-
-# a global tracer instance with integration settings
-tracer = Tracer()
-
 __all__ = [
     "patch",
     "patch_all",
@@ -33,3 +38,37 @@ __all__ = [
     "config",
     "DDTraceDeprecationWarning",
 ]
+
+if sys.version_info >= (3, 7):
+    _tracer = None  # type: Optional[Tracer]
+
+    def __getattr__(name):
+        # type: (str) -> Any
+        if name == "tracer":
+            global _tracer
+            if _tracer is None:
+                from .tracer import Tracer
+
+                _tracer = Tracer()
+            return _tracer
+        if name == "Tracer":
+            from .tracer import Tracer
+
+            return Tracer
+        if name in __all__:
+            return importlib.import_module("." + name, __name__)
+
+        raise AttributeError("module %r has no attribute %r" % (__name__, name))
+
+
+else:
+    from .tracer import Tracer
+
+    tracer = Tracer()
+
+
+def __dir__():
+    # type: () -> List[str]
+    return __all__ + [
+        "tracer",
+    ]

--- a/ddtrace/__init__.pyi
+++ b/ddtrace/__init__.pyi
@@ -1,0 +1,13 @@
+import ddtrace
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning as DDTraceDeprecationWarning
+from ddtrace.pin import Pin as Pin
+import ddtrace.settings.config
+from ddtrace.span import Span as Span
+from ddtrace.tracer import Tracer as Tracer
+
+def patch_all(**patch_modules: bool) -> None: ...
+def patch(raise_errors: bool = ..., patch_modules_prefix: str = ..., **patch_modules: bool) -> None: ...
+
+config: ddtrace.settings.config.Config
+tracer: Tracer
+__version__: str

--- a/releasenotes/notes/tracer-lazy-load-6a1607ed4ce1f82c.yaml
+++ b/releasenotes/notes/tracer-lazy-load-6a1607ed4ce1f82c.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    tracer: the global tracer (``ddtrace.tracer``) is now lazily initialized.


### PR DESCRIPTION
Creating a global tracer at module-load is expensive. If the global tracer is not being used (accessed) then it does not need to be initialized.

It is still desirable to have a global tracer so it makes sense to lazy load the tracer using module-level `__getattr__`.

Module-level `__getattr__` was added in Python 3.7 ([PEP 562](https://peps.python.org/pep-0562/))

```
+----------------+---------------+-----------------------+
| Benchmark      | lazy-import   | 1.x                   |
+================+===============+=======================+
| startup-import | 99.9 ms       | 82.1 ms: 1.22x faster |
+----------------+---------------------------------------+
```

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
