### PR TITLE
chore(rcm): ensure semver in tracer version

### DIFF
--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -192,6 +192,11 @@ class RemoteConfigClient(object):
         self._client_tracer = dict(
             runtime_id=runtime.get_runtime_id(),
             language="python",
+            # The library uses a PEP 440-compliant versioning scheme, but the
+            # RCM spec requires that we use a SemVer-compliant version. We only
+            # expect that the first occurrence of "rc" in the version string to
+            # break the SemVer format, so we replace it with "-rc" for
+            # simplicity.
             tracer_version=ddtrace.__version__.replace("rc", "-rc", 1),
             service=ddtrace.config.service,
             env=ddtrace.config.env,

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -191,7 +191,7 @@ class RemoteConfigClient(object):
         self._client_tracer = dict(
             runtime_id=runtime.get_runtime_id(),
             language="python",
-            tracer_version=ddtrace.__version__,
+            tracer_version=ddtrace.__version__.replace("rc", "-rc", 1),
             service=ddtrace.config.service,
             env=ddtrace.config.env,
             app_version=ddtrace.config.version,

--- a/tests/internal/test_remoteconfig.py
+++ b/tests/internal/test_remoteconfig.py
@@ -132,3 +132,9 @@ def test_remote_configuration(mock_send_request):
         sleep(0.2)
         mock_send_request.assert_called_once()
         assert callback.features == {"asm": {"enabled": True}}
+
+
+def test_remoteconfig_semver():
+    version = RemoteConfigClient()._client_tracer["tracer_version"]
+    if "rc" in version:
+        assert "-rc" in version, version

--- a/tests/internal/test_remoteconfig.py
+++ b/tests/internal/test_remoteconfig.py
@@ -3,6 +3,7 @@ import base64
 import datetime
 import hashlib
 import json
+import re
 from time import sleep
 
 import mock
@@ -135,6 +136,7 @@ def test_remote_configuration(mock_send_request):
 
 
 def test_remoteconfig_semver():
-    version = RemoteConfigClient()._client_tracer["tracer_version"]
-    if "rc" in version:
-        assert "-rc" in version, version
+    assert re.match(
+        r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
+        RemoteConfigClient()._client_tracer["tracer_version"],
+    )


### PR DESCRIPTION
## Description

When producing dev builds, setuptools_scm produces a PEP 440-compliant version string, which is not a SemVer. Since we expect the version string for dev build to have rc following the patch component, we simply replace the first occurrence of "rc" with "-rc" to make the version string SemVer-compliant.

## Checklist
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
