### PR TITLE
fix(ci): add wait for redis asyncio snapshots

### DIFF
--- a/tests/contrib/redis/test_redis_asyncio.py
+++ b/tests/contrib/redis/test_redis_asyncio.py
@@ -208,16 +208,16 @@ async def test_two_traced_pipelines(redis_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.snapshot
-async def test_parenting(redis_client):
-    with tracer.trace("web-request", service="test"):
-        await redis_client.set("blah", "boo")
-        await redis_client.get("blah")
+async def test_parenting(redis_client, snapshot_context):
+    with snapshot_context(wait_for_num_traces=1):
+        with tracer.trace("web-request", service="test"):
+            await redis_client.set("blah", "boo")
+            await redis_client.get("blah")
 
 
 @pytest.mark.asyncio
-@pytest.mark.snapshot
-async def test_client_name():
-    with tracer.trace("web-request", service="test"):
-        redis_client = get_redis_instance(10, client_name="testing-client-name")
-        await redis_client.get("blah")
+async def test_client_name(snapshot_context):
+    with snapshot_context(wait_for_num_traces=1):
+        with tracer.trace("web-request", service="test"):
+            redis_client = get_redis_instance(10, client_name="testing-client-name")
+            await redis_client.get("blah")


### PR DESCRIPTION
## Description

The redis job are flaky on snapshot tests that use asyncio. We can use the work introduced in #4374 to mitigate the flaky tests.

Sample log from a [failing job](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/22753/workflows/a86bbe94-d82e-4f32-b8a7-2096f218d3aa/jobs/1547812):

```
At request <Request GET /test/session/snapshot >:
   At snapshot (token='tests.contrib.redis.test_redis_asyncio.test_parenting'):
    - Directory: /snapshots
    - CI mode: 1
    - Trace File: /snapshots/tests.contrib.redis.test_redis_asyncio.test_parenting.json
    - Stats File: /snapshots/tests.contrib.redis.test_redis_asyncio.test_parenting_tracestats.json
    At compare of 1 expected trace(s) to 0 received trace(s):
Did not receive expected traces: 'web-request'
```

## Checklist
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
