### PR TITLE
fix(runtime): add support for PCF containers

### DIFF
--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -23,7 +23,9 @@ class CGroupInfo(object):
     controllers = attr.ib(default=None)
     pod_id = attr.ib(default=None)
 
-    UUID_SOURCE_PATTERN = r"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}"
+    # Second part is PCF/Garden regexp. We currently assume no suffix ($) to avoid matching pod UIDs
+    # similar to: https://github.com/DataDog/datadog-agent/blob/main/pkg/util/cgroups/reader.go#L50
+    UUID_SOURCE_PATTERN = r"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|([0-9a-f]{8}(-[0-9a-f]{4}){4}$)"
     CONTAINER_SOURCE_PATTERN = r"[0-9a-f]{64}"
     TASK_PATTERN = r"[0-9a-f]{32}-\d+"
 

--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -23,9 +23,11 @@ class CGroupInfo(object):
     controllers = attr.ib(default=None)
     pod_id = attr.ib(default=None)
 
-    # Second part is PCF/Garden regexp. We currently assume no suffix ($) to avoid matching pod UIDs
-    # similar to: https://github.com/DataDog/datadog-agent/blob/main/pkg/util/cgroups/reader.go#L50
-    UUID_SOURCE_PATTERN = r"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|([0-9a-f]{8}(-[0-9a-f]{4}){4}$)"
+    # The second part is the PCF/Garden regexp. We currently assume no suffix ($) to avoid matching pod UIDs
+    # See https://github.com/DataDog/datadog-agent/blob/7.40.x/pkg/util/cgroups/reader.go#L50
+    UUID_SOURCE_PATTERN = (
+        r"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|([0-9a-f]{8}(-[0-9a-f]{4}){4}$)"
+    )
     CONTAINER_SOURCE_PATTERN = r"[0-9a-f]{64}"
     TASK_PATTERN = r"[0-9a-f]{32}-\d+"
 

--- a/releasenotes/notes/PCF-container-UUID-0f65eed47e42f4ad.yaml
+++ b/releasenotes/notes/PCF-container-UUID-0f65eed47e42f4ad.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CGroup file parsing was fixed to correctly parse container UUID for PCF containers.

--- a/tests/tracer/runtime/test_container.py
+++ b/tests/tracer/runtime/test_container.py
@@ -70,6 +70,18 @@ def test_cgroup_info_init():
                 pod_id=None,
             ),
         ),
+        # Valid, PCF
+        (
+            "10:freezer:/garden/6f265890-5165-7fab-6b52-18d1",
+            CGroupInfo(
+                id="10",
+                groups="freezer",
+                controllers=["freezer"],
+                path="/garden/6f265890-5165-7fab-6b52-18d1",
+                container_id="6f265890-5165-7fab-6b52-18d1",
+                pod_id=None,
+            ),
+        ),
         # Invalid container_ids
         (
             # One character too short
@@ -239,6 +251,24 @@ def test_cgroup_info_from_line(line, expected_info):
 1:name=systemd:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890
             """,
             "34dc0b5e626f2c5c4c5170e34b10e765-1234567890",
+        ),
+        # PCF file
+        (
+            """
+12:rdma:/
+11:net_cls,net_prio:/garden/6f265890-5165-7fab-6b52-18d1
+10:freezer:/garden/6f265890-5165-7fab-6b52-18d1
+9:devices:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1
+8:blkio:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1
+7:pids:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1
+6:memory:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1
+5:cpuset:/garden/6f265890-5165-7fab-6b52-18d1
+4:cpu,cpuacct:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1
+3:perf_event:/garden/6f265890-5165-7fab-6b52-18d1
+2:hugetlb:/garden/6f265890-5165-7fab-6b52-18d1
+1:name=systemd:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1
+            """,
+            "6f265890-5165-7fab-6b52-18d1",
         ),
         # Linux non-containerized file
         (


### PR DESCRIPTION
## Description
Updates the container ID regex to support PCF container UUIDs

PCF container IDs are in a different format than the current assumption so the container IDs are currently not being recognized in PCF environments

## Checklist
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- START fix -->

## Relevant issue(s)
N/A
Note: this fix will be implemented on the other tracing libraries as well
## Testing strategy
- ~Write tests with real PCF containers~
- Test on PCF test env
<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
