### PR TITLE
ci(starlette/fastapi): pin SQLAlchemy to fix framework tests

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -170,6 +170,9 @@ jobs:
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: flit install --symlink
+      - name: Pin SQLAlchemy
+        # https://github.com/encode/databases/issues/512
+        run: pip install "SQLAlchemy==1.4.41"
       - name: Inject ddtrace
         run: pip install ../ddtrace
       - name: Test

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -309,6 +309,9 @@ jobs:
         run: pip install ../ddtrace
       - name: Install dependencies
         run: scripts/install
+      - name: Pin SQLAlchemy
+        # https://github.com/encode/databases/issues/512
+        run: pip install "SQLAlchemy==1.4.41"
       #Parameters for keyword expression skip 3 failing tests that are expected due to asserting on headers. The errors are because our context propagation headers are being added
       #test_staticfiles_with_invalid_dir_permissions_returns_401 fails with and without ddtrace enabled
       - name: Run tests


### PR DESCRIPTION
## Description

Pin SQLAlchemy to 1.4.41.
Issue: https://github.com/encode/databases/issues/512
Failing Fastapi Test: https://github.com/DataDog/dd-trace-py/actions/runs/3339686051/jobs/5528937301
Failing Starlette Test: https://github.com/DataDog/dd-trace-py/actions/runs/3340052660/jobs/5529727716

An alternative to pinning sqlachemy is to skip the failing test.

## Checklist
- [ n/a ] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
