### PR TITLE
fix(releasenotes): add prelude for ASM one click feature

### DIFF
--- a/releasenotes/notes/asm-1-click-activation-with-RCM-6a2431949768b73b.yaml
+++ b/releasenotes/notes/asm-1-click-activation-with-RCM-6a2431949768b73b.yaml
@@ -1,6 +1,11 @@
 ---
+prelude: >
+  Application Security Management (ASM) has added support for preventing attacks by blocking malicious IPs using one click within Datadog.
+  
+  .. note::
+    One click activation for ASM is currently in beta.
+
 features:
   - |
-    ASM: 1-click activation ability through Remote Configuration Management. 
-    Set ``DD_REMOTE_CONFIGURATION_ENABLED`` to true to enable 1-click activation for ASM. 
-    Note that this feature is currently in beta.
+    ASM: One click activation ability through Remote Configuration Management (RCM). 
+    Set ``DD_REMOTE_CONFIGURATION_ENABLED=true`` to enable this feature.

--- a/releasenotes/notes/asm-1-click-activation-with-RCM-6a2431949768b73b.yaml
+++ b/releasenotes/notes/asm-1-click-activation-with-RCM-6a2431949768b73b.yaml
@@ -1,11 +1,12 @@
 ---
 prelude: >
   Application Security Management (ASM) has added support for preventing attacks by blocking malicious IPs using one click within Datadog.
-  
+
+
   .. note::
     One click activation for ASM is currently in beta.
 
+
 features:
   - |
-    ASM: One click activation ability through Remote Configuration Management (RCM). 
-    Set ``DD_REMOTE_CONFIGURATION_ENABLED=true`` to enable this feature.
+    ASM: Added support for one click activation using Remote Configuration Management (RCM). Set ``DD_REMOTE_CONFIGURATION_ENABLED=true`` to enable this feature.

--- a/releasenotes/notes/asm-1-click-activation-with-RCM-6a2431949768b73b.yaml
+++ b/releasenotes/notes/asm-1-click-activation-with-RCM-6a2431949768b73b.yaml
@@ -9,4 +9,4 @@ prelude: >
 
 features:
   - |
-    ASM: Added support for one click activation using Remote Configuration Management (RCM). Set ``DD_REMOTE_CONFIGURATION_ENABLED=true`` to enable this feature.
+    ASM: add support for one click activation using Remote Configuration Management (RCM). Set ``DD_REMOTE_CONFIGURATION_ENABLED=true`` to enable this feature.


### PR DESCRIPTION
This should clarify for library users the new functionality and its support level.

https://www.datadoghq.com/blog/dash-2022-new-feature-roundup/#application-security-management-protection

> We’re excited to announce that we’ve expanded Datadog ASM to include native protection capabilities. You can now prevent attacks by blocking malicious IPs directly from Datadog and in one click. 

**Current**

<img width="692" alt="image" src="https://user-images.githubusercontent.com/155673/198388481-32792cd4-aeeb-4787-85f1-f8e164041d44.png">

**Preview**

<img width="703" alt="image" src="https://user-images.githubusercontent.com/155673/198387208-84fc753f-5556-49b4-a4b8-dd2ea4127d1d.png">

<img width="721" alt="image" src="https://user-images.githubusercontent.com/155673/198388308-f47771c1-9a1c-4594-8202-27a091de65cc.png">
