### PR TITLE
chore(docs): reformat configuration page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -673,7 +673,52 @@ class DDTraceReleaseNotesDirective(rst.Directive):
         return node.children
 
 
+class DDTraceConfigurationOptionsDirective(rst.Directive):
+    r"""
+    Directive class to handle ``.. ddtrace-configuration-options::`` directive.
+
+    For example::
+
+        .. ddtrace-configuration-options::
+    """
+
+    has_content = True
+
+    def run(self):
+        options = yaml.load("\n".join(self.content), Loader=yaml.CLoader)
+
+        results = statemachine.ViewList()
+        for var_name, value in options.items():
+            skip_label = value.get("skip_label") == True
+            var_label = var_name.lower().replace("_", "-")
+            var_description = value["description"]
+            var_type = value.get("type") or "String"
+            var_default = value.get("default") or "(no value)"
+
+            if not skip_label:
+                results.append(".. _`{}`:".format(var_label), "", 0)
+                results.append("", "", 0)
+            results.append(".. py:data:: {}".format(var_name), "", 0)
+            results.append("", "", 0)
+            for line in var_description.splitlines():
+                results.append("    " + line.lstrip(), "", 0)
+
+            results.append("", "", 0)
+            results.append("    **Type**: {}".format(var_type), "", 0)
+            results.append("", "", 0)
+            results.append("    **Default**: {}".format(var_default), "", 0)
+            results.append("", "", 0)
+
+        # Generate the RST nodes to return for rendering
+        node = nodes.section()
+        node.document = self.state.document
+        self.state.nested_parse(results, 0, node)
+        # nested_parse_with_titles(self.state, results, node)
+        return node.children
+
+
 def setup(app):
     app.add_directive("ddtrace-release-notes", DDTraceReleaseNotesDirective)
+    app.add_directive("ddtrace-configuration-options", DDTraceConfigurationOptionsDirective)
     metadata_dict = {"version": "1.0.0", "parallel_read_safe": True}
     return metadata_dict

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -694,6 +694,7 @@ class DDTraceConfigurationOptionsDirective(rst.Directive):
             var_description = value["description"]
             var_type = value.get("type") or "String"
             var_default = value.get("default") or "(no value)"
+            var_version_added = value.get("version_added")
 
             if not skip_label:
                 results.append(".. _`{}`:".format(var_label), "", 0)
@@ -708,6 +709,14 @@ class DDTraceConfigurationOptionsDirective(rst.Directive):
             results.append("", "", 0)
             results.append("    **Default**: {}".format(var_default), "", 0)
             results.append("", "", 0)
+
+            if var_version_added:
+                for version, note in var_version_added.items():
+                    if note:
+                        results.append("    *Changed in version {}*: {}".format(version, note), "", 0)
+                    else:
+                        results.append("    *New in version {}.*".format(version), "", 0)
+                    results.append("", "", 0)
 
         # Generate the RST nodes to return for rendering
         node = nodes.section()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -722,7 +722,6 @@ class DDTraceConfigurationOptionsDirective(rst.Directive):
         node = nodes.section()
         node.document = self.state.document
         self.state.nested_parse(results, 0, node)
-        # nested_parse_with_titles(self.state, results, node)
         return node.children
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -689,7 +689,7 @@ class DDTraceConfigurationOptionsDirective(rst.Directive):
 
         results = statemachine.ViewList()
         for var_name, value in options.items():
-            skip_label = value.get("skip_label") == True
+            skip_label = value.get("skip_label") == "true"
             var_label = var_name.lower().replace("_", "-")
             var_description = value["description"]
             var_type = value.get("type") or "String"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -7,380 +7,343 @@
 `ddtrace` can be configured using environment variables. They are listed
 below:
 
-.. list-table::
-   :widths: 3 1 1 4
-   :header-rows: 1
 
-   * - Variable Name
-     - Type
-     - Default value
-     - Description
+.. ddtrace-configuration-options::
+   DD_ENV:
+     description: |
+         Set an application's environment e.g. ``prod``, ``pre-prod``, ``staging``. Added in ``v0.36.0``. See `Unified Service Tagging`_ for more information.
 
-       .. _dd-env:
-   * - ``DD_ENV``
-     - String
-     -
-     - Set an application's environment e.g. ``prod``, ``pre-prod``, ``staging``. Added in ``v0.36.0``. See `Unified Service Tagging`_ for more information.
+   DD_SERVICE:
+     default: (autodetected)
+     description: |
+         Set the service name to be used for this application. A default is
+         provided for these integrations: :ref:`bottle`, :ref:`flask`, :ref:`grpc`,
+         :ref:`pyramid`, :ref:`pylons`, :ref:`tornado`, :ref:`celery`, :ref:`django` and
+         :ref:`falcon`. Added in ``v0.36.0``. See `Unified Service Tagging`_ for more information.
 
-       .. _dd-service:
-   * - ``DD_SERVICE``
-     - String
-     - (autodetected)
-     - Set the service name to be used for this application. A default is
-       provided for these integrations: :ref:`bottle`, :ref:`flask`, :ref:`grpc`,
-       :ref:`pyramid`, :ref:`pylons`, :ref:`tornado`, :ref:`celery`, :ref:`django` and
-       :ref:`falcon`. Added in ``v0.36.0``. See `Unified Service Tagging`_ for more information.
+   DD_SERVICE_MAPPING:
+     description: |
+         Define service name mappings to allow renaming services in traces, e.g. ``postgres:postgresql,defaultdb:postgresql``.
 
-       .. _dd-service-mapping:
-   * - ``DD_SERVICE_MAPPING``
-     - String
-     -
-     - Define service name mappings to allow renaming services in traces, e.g. ``postgres:postgresql,defaultdb:postgresql``.
+   DD_TAGS:
+     description: |
+         Set global tags to be attached to every span. Value must be either comma or space separated. e.g. ``key1:value1,key2,value2`` or ``key1:value key2:value2``.
+         Comma separated support added in ``v0.38.0`` and space separated support added in ``v0.48.0``.
 
-       .. _dd-tags:
-   * - ``DD_TAGS``
-     - String
-     -
-     - Set global tags to be attached to every span. Value must be either comma or space separated. e.g. ``key1:value1,key2,value2`` or ``key1:value key2:value2``. Comma separated support added in ``v0.38.0`` and space separated support added in ``v0.48.0``.
+   DD_VERSION:
+     description: |
+         Set an application's version in traces and logs e.g. ``1.2.3``,
+         ``6c44da20``, ``2020.02.13``. Generally set along with ``DD_SERVICE``. Added in ``v0.36.0``. See `Unified Service Tagging`_ for more information.
 
-       .. _dd-version:
-   * - ``DD_VERSION``
-     - String
-     -
-     - Set an application's version in traces and logs e.g. ``1.2.3``,
-       ``6c44da20``, ``2020.02.13``. Generally set along with ``DD_SERVICE``. Added in ``v0.36.0``. See `Unified Service Tagging`_ for more information.
+   DD_SITE:
+     default: datadoghq.com
+     description: |
+         Specify which site to use for uploading profiles. Set to
+         ``datadoghq.eu`` to use EU site.
 
-       .. _dd-site:
-   * - ``DD_SITE``
-     - String
-     - datadoghq.com
-     - Specify which site to use for uploading profiles. Set to
-       ``datadoghq.eu`` to use EU site.
+   DD_TRACE_ENABLED:
+     type: Boolean
+     default: True
+     description: |
+         Enable sending of spans to the Agent. Note that instrumentation will still be installed and spans will be
+         generated. Added in ``v0.41.0`` (formerly named ``DATADOG_TRACE_ENABLED``).
 
-       .. _dd-trace-enabled:
-   * - ``DD_TRACE_ENABLED``
-     - Boolean
-     - True
-     - Enable sending of spans to the Agent. Note that instrumentation will still be installed and spans will be
-       generated. Added in ``v0.41.0`` (formerly named ``DATADOG_TRACE_ENABLED``).
+   DD_INSTRUMENTATION_TELEMETRY_ENABLED:
+     type: Boolean
+     default: True
+     description: |
+         Enables sending :ref:`telemetry <Instrumentation Telemetry>` events to the agent.
 
-       .. _dd-instrumentation-telemetry-enabled:
-   * - ``DD_INSTRUMENTATION_TELEMETRY_ENABLED``
-     - Boolean
-     - True
-     - Enables sending :ref:`telemetry <Instrumentation Telemetry>` events to the agent.
+   DD_TRACE_DEBUG:
+     type: Boolean
+     default: False
+     description: |
+         Enables debug logging in the tracer. Setting this flag will cause the library to create a root logging handler if one does not already exist.
+         Added in ``v0.41.0`` (formerly named ``DATADOG_TRACE_DEBUG``). Can be used with `DD_TRACE_LOG_FILE` to route logs to a file.
 
-       .. _dd-trace-debug:
-   * - ``DD_TRACE_DEBUG``
-     - Boolean
-     - False
-     - Enables debug logging in the tracer. Setting this flag will cause the library to create a root logging handler if one does not already exist. Added in ``v0.41.0`` (formerly named ``DATADOG_TRACE_DEBUG``). Can be used with `DD_TRACE_LOG_FILE` to route logs to a file.
+   DD_TRACE_LOG_FILE_LEVEL:
+     default: DEBUG
+     description: |
+         Configures the ``RotatingFileHandler`` used by the `ddtrace` logger to write logs to a file based on the level specified.
+         Defaults to `DEBUG`, but will accept the values found in the standard **logging** library, such as WARNING, ERROR, and INFO,
+         if further customization is needed. Files are not written to unless ``DD_TRACE_LOG_FILE`` has been defined.
 
-       .. _dd-trace-log-file-level:
-   * - ``DD_TRACE_LOG_FILE_LEVEL``
-     - String
-     - DEBUG
-     - Configures the ``RotatingFileHandler`` used by the `ddtrace` logger to write logs to a file based on the level specified. Defaults to `DEBUG`, but will accept the values found in the standard **logging** library, such as WARNING, ERROR, and INFO, if further customization is needed. Files are not written to unless ``DD_TRACE_LOG_FILE`` has been defined.
+   DD_TRACE_LOG_FILE:
+     description: |
+         Directs `ddtrace` logs to a specific file. Note: The default backup count is 1. For larger logs, use with ``DD_TRACE_LOG_FILE_SIZE_BYTES``.
+         To fine tune the logging level, use with ``DD_TRACE_LOG_FILE_LEVEL``.
 
-       .. _dd-trace-log-file:
-   * - ``DD_TRACE_LOG_FILE``
-     - String
-     - None
-     - Directs `ddtrace` logs to a specific file. Note: The default backup count is 1. For larger logs, use with ``DD_TRACE_LOG_FILE_SIZE_BYTES``. To fine tune the logging level, use with ``DD_TRACE_LOG_FILE_LEVEL``.
+   DD_TRACE_LOG_FILE_SIZE_BYTES:
+     type: Int
+     default: 15728640
+     description: |
+         Max size for a file when used with `DD_TRACE_LOG_FILE`. When a log has exceeded this size, there will be one backup log file created.
+         In total, the files will store ``2 * DD_TRACE_LOG_FILE_SIZE_BYTES`` worth of logs.
 
-       .. _dd-trace-log-file-size-bytes:
-   * - ``DD_TRACE_LOG_FILE_SIZE_BYTES``
-     - Int
-     - 15728640
-     - Max size for a file when used with `DD_TRACE_LOG_FILE`. When a log has exceeded this size, there will be one backup log file created. In total, the files will store ``2 * DD_TRACE_LOG_FILE_SIZE_BYTES`` worth of logs.
+   DD_TRACE_<INTEGRATION>_ENABLED:
+     type: Boolean
+     default: True
+     description: |
+         Enables <INTEGRATION> to be patched. For example, ``DD_TRACE_DJANGO_ENABLED=false`` will disable the Django
+         integration from being installed. Added in ``v0.41.0``.
 
-       .. _dd-trace-integration-enabled:
-   * - ``DD_TRACE_<INTEGRATION>_ENABLED``
-     - Boolean
-     - True
-     - Enables <INTEGRATION> to be patched. For example, ``DD_TRACE_DJANGO_ENABLED=false`` will disable the Django
-       integration from being installed. Added in ``v0.41.0``.
+   DD_PATCH_MODULES:
+     description: |
+         Override the modules patched for this execution of the program. Must be
+         a list in the ``module1:boolean,module2:boolean`` format. For example,
+         ``boto:true,redis:false``. Added in ``v0.55.0`` (formerly named ``DATADOG_PATCH_MODULES``).
 
-       .. _dd-patch-modules:
-   * - ``DD_PATCH_MODULES``
-     - String
-     -
-     - Override the modules patched for this execution of the program. Must be
-       a list in the ``module1:boolean,module2:boolean`` format. For example,
-       ``boto:true,redis:false``. Added in ``v0.55.0`` (formerly named ``DATADOG_PATCH_MODULES``).
+   DD_LOGS_INJECTION:
+     type: Boolean
+     default: False
+     description: Enables :ref:`Logs Injection`.
 
-       .. _dd-logs-injection:
-   * - ``DD_LOGS_INJECTION``
-     - Boolean
-     - False
-     - Enables :ref:`Logs Injection`.
+   DD_CALL_BASIC_CONFIG:
+     type: Boolean
+     default: False
+     description: Controls whether ``logging.basicConfig`` is called in ``ddtrace-run`` or when debug mode is enabled.
 
-       .. _dd-call-basic-config:
-   * - ``DD_CALL_BASIC_CONFIG``
-     - Boolean
-     - False
-     - Controls whether ``logging.basicConfig`` is called in ``ddtrace-run`` or when debug mode is enabled.
+   DD_TRACE_AGENT_URL:
+     type: URL
+     default: |
+         ``unix:///var/run/datadog/apm.socket`` if available
+         otherwise ``http://localhost:8126``
+     description: |
+           The URL to use to connect the Datadog agent for traces. The url can start with
+           ``http://`` to connect using HTTP or with ``unix://`` to use a Unix
+           Domain Socket.
 
-       .. _dd-trace-agent-url:
-   * - ``DD_TRACE_AGENT_URL``
-     - URL
-     - ``unix:///var/run/datadog/apm.socket`` if available 
-       otherwise ``http://localhost:8126``
-     - The URL to use to connect the Datadog agent for traces. The url can start with
-       ``http://`` to connect using HTTP or with ``unix://`` to use a Unix
-       Domain Socket.   
-       Example for http url: ``DD_TRACE_AGENT_URL=http://localhost:8126``
-       Example for UDS: ``DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket``
+           Example for http url: ``DD_TRACE_AGENT_URL=http://localhost:8126``
 
-       .. _dd-dogstatsd-url:
-   * - ``DD_DOGSTATSD_URL``
-     - URL
-     - ``unix:///var/run/datadog/dsd.socket`` if available 
-       otherwise ``udp://localhost:8125``
-     - The URL to use to connect the Datadog agent for Dogstatsd metrics. The url can start with
-       ``udp://`` to connect using UDP or with ``unix://`` to use a Unix
-       Domain Socket.   
-       Example for UDP url: ``DD_TRACE_AGENT_URL=udp://localhost:8125``
-       Example for UDS: ``DD_TRACE_AGENT_URL=unix:///var/run/datadog/dsd.socket``
+           Example for UDS: ``DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket``
 
-       .. _dd-trace-agent-timeout-seconds:
-   * - ``DD_TRACE_AGENT_TIMEOUT_SECONDS``
-     - Float
-     - 2.0
-     - The timeout in float to use to connect to the Datadog agent.
+   DD_DOGSTATSD_URL:
+     type: URL
+     default: |
+         ``unix:///var/run/datadog/dsd.socket`` if available
+         otherwise ``udp://localhost:8125``
+     description: |
+         The URL to use to connect the Datadog agent for Dogstatsd metrics. The url can start with
+         ``udp://`` to connect using UDP or with ``unix://`` to use a Unix
+         Domain Socket.
 
-       .. _dd-trace-writer-buffer-size-bytes:
-   * - ``DD_TRACE_WRITER_BUFFER_SIZE_BYTES``
-     - Int
-     - 8388608
-     - The max size in bytes of traces to buffer between flushes to the agent.
+         Example for UDP url: ``DD_TRACE_AGENT_URL=udp://localhost:8125``
 
-       .. _dd-trace-writer-max-payload-size-bytes:
-   * - ``DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES``
-     - Int
-     - 8388608
-     - The max size in bytes of each payload item sent to the trace agent. If the max payload size is greater than buffer size, then max size of each payload item will be the buffer size.
+         Example for UDS: ``DD_TRACE_AGENT_URL=unix:///var/run/datadog/dsd.socket``
 
-       .. _dd-trace-writer-interval-seconds:
-   * - ``DD_TRACE_WRITER_INTERVAL_SECONDS``
-     - Float
-     - 1.0
-     - The time between each flush of traces to the trace agent.
+   DD_TRACE_AGENT_TIMEOUT_SECONDS:
+     type: Float
+     default: 2.0
+     description: The timeout in float to use to connect to the Datadog agent.
 
-       .. _dd-trace-startup-logs:
-   * - ``DD_TRACE_STARTUP_LOGS``
-     - Boolean
-     - False
-     - Enable or disable start up diagnostic logging.
+   DD_TRACE_WRITER_BUFFER_SIZE_BYTES:
+     type: Int
+     default: 8388608
+     description: The max size in bytes of traces to buffer between flushes to the agent.
 
-       .. _dd-trace-sample-rate:
-   * - ``DD_TRACE_SAMPLE_RATE``
-     - Float
-     - 1.0
-     - A float, f, 0.0 <= f <= 1.0. f*100% of traces will be sampled.
+   DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES:
+     type: Int
+     default: 8388608
+     description: |
+         The max size in bytes of each payload item sent to the trace agent. If the max payload size is greater than buffer size,
+         then max size of each payload item will be the buffer size.
+
+   DD_TRACE_WRITER_INTERVAL_SECONDS:
+     type: Float
+     default: 1.0
+     description: The time between each flush of traces to the trace agent.
+
+   DD_TRACE_STARTUP_LOGS:
+     type: Boolean
+     default: False
+     description: Enable or disable start up diagnostic logging.
+
+   DD_TRACE_SAMPLE_RATE:
+     type: Float
+     default: 1.0
+     description: A float, f, 0.0 <= f <= 1.0. f*100% of traces will be sampled.
    
-   * - ``DD_TRACE_SAMPLING_RULES``
-     - JSON array
-     -
-     - A JSON array of objects. Each object must have a “sample_rate”, and the “name” and “service” fields are optional. The “sample_rate” value must be between 0.0 and 1.0 (inclusive). 
-       **Example:** ``DD_TRACE_SAMPLING_RULES='[{"sample_rate":0.5,"service":"my-service"}]'``
-       **Note** that the JSON object must be included in single quotes (') to avoid problems with escaping of the double quote (") character.
+   DD_TRACE_SAMPLING_RULES:
+     type: JSON array
+     description: |
+         A JSON array of objects. Each object must have a “sample_rate”, and the “name” and “service” fields are optional. The “sample_rate” value must be between 0.0 and 1.0 (inclusive).
 
-       .. _dd-trace-header-tags:
-   * - ``DD_TRACE_HEADER_TAGS``
-     - String
-     -
-     - A map of case-insensitive header keys to tag names. Automatically applies matching header values as tags on root spans.
-       For example, ``User-Agent:http.useragent,content-type:http.content_type``.
+         **Example:** ``DD_TRACE_SAMPLING_RULES='[{"sample_rate":0.5,"service":"my-service"}]'``
 
-       .. _dd-trace-api-version:
-   * - ``DD_TRACE_API_VERSION``
-     - String
-     - ``v0.4`` if priority sampling is enabled, else ``v0.3``
-     - The trace API version to use when sending traces to the Datadog agent.
-       Currently, the supported versions are: ``v0.3``, ``v0.4`` and ``v0.5``.
+         **Note** that the JSON object must be included in single quotes (') to avoid problems with escaping of the double quote (") character.
 
-       .. _dd-trace-obfuscation-query-string-pattern:
-   * - ``DD_TRACE_OBFUSCATION_QUERY_STRING_PATTERN``
-     - String
-     - ``(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\s|%20)*(?:=|%3D)[^&]+|(?:"|%22)(?:\s|%20)*(?::|%3A)(?:\s|%20)*(?:"|%22)(?:%2[^2]|%[^2]|[^"%])+(?:"|%22))|bearer(?:\s|%20)+[a-z0-9\._\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\w=-]|%3D)+\.ey[I-L](?:[\w=-]|%3D)+(?:\.(?:[\w.+\/=-]|%3D|%2F|%2B)+)?|[\-]{5}BEGIN(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY[\-]{5}[^\-]+[\-]{5}END(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY|ssh-rsa(?:\s|%20)*(?:[a-z0-9\/\.+]|%2F|%5C|%2B){100,}.``
-     - A regexp to redact sensitive query strings. Obfuscation disabled if set to empty string
+   DD_TRACE_HEADER_TAGS:
+     description: |
+         A map of case-insensitive header keys to tag names. Automatically applies matching header values as tags on root spans.
 
-       .. _dd-trace-propagation-style-extract:
-   * - ``DD_TRACE_PROPAGATION_STYLE_EXTRACT``
-     - String
-     - ``datadog``
-     - Comma separated list of propagation styles used for extracting trace context from inbound request headers.
+         For example, ``User-Agent:http.useragent,content-type:http.content_type``.
 
-       The supported values are ``datadog``, ``b3``, and ``b3 single header``.
+   DD_TRACE_API_VERSION:
+     default: |
+         ``v0.4`` if priority sampling is enabled, else ``v0.3``
+     description: |
+         The trace API version to use when sending traces to the Datadog agent.
 
-       When checking inbound request headers we will take the first valid trace context in the order ``datadog``, ``b3``,
-       then ``b3 single header``.
+         Currently, the supported versions are: ``v0.3``, ``v0.4`` and ``v0.5``.
 
-       Example: ``DD_TRACE_PROPAGATION_STYLE_EXTRACT="datadog,b3"`` to check for both ``x-datadog-*`` and ``x-b3-*``
-       headers when parsing incoming request headers for a trace context.
+   DD_TRACE_OBFUSCATION_QUERY_STRING_PATTERN:
+     default: |
+         ``(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\s|%20)*(?:=|%3D)[^&]+|(?:"|%22)(?:\s|%20)*(?::|%3A)(?:\s|%20)*(?:"|%22)(?:%2[^2]|%[^2]|[^"%])+(?:"|%22))|bearer(?:\s|%20)+[a-z0-9\._\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\w=-]|%3D)+\.ey[I-L](?:[\w=-]|%3D)+(?:\.(?:[\w.+\/=-]|%3D|%2F|%2B)+)?|[\-]{5}BEGIN(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY[\-]{5}[^\-]+[\-]{5}END(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY|ssh-rsa(?:\s|%20)*(?:[a-z0-9\/\.+]|%2F|%5C|%2B){100,}.``
+     description: A regexp to redact sensitive query strings. Obfuscation disabled if set to empty string
 
-       .. _dd-trace-propagation-style-inject:
-   * - ``DD_TRACE_PROPAGATION_STYLE_INJECT``
-     - String
-     - ``datadog``
-     - Comma separated list of propagation styles used for injecting trace context into outbound request headers.
+   DD_TRACE_PROPAGATION_STYLE_EXTRACT:
+     default: |
+         ``datadog``
+     description: |
+         Comma separated list of propagation styles used for extracting trace context from inbound request headers.
 
-       The supported values are ``datadog``, ``b3``, and ``b3 single header``.
+         The supported values are ``datadog``, ``b3``, and ``b3 single header``.
 
-       All provided styles are injected into the headers of outbound requests.
+         When checking inbound request headers we will take the first valid trace context in the order ``datadog``, ``b3``,
+         then ``b3 single header``.
 
-       Example: ``DD_TRACE_PROPAGATION_STYLE_INJECT="datadog,b3"`` to inject both ``x-datadog-*`` and ``x-b3-*``
-       headers into outbound requests.
+         Example: ``DD_TRACE_PROPAGATION_STYLE_EXTRACT="datadog,b3"`` to check for both ``x-datadog-*`` and ``x-b3-*``
+         headers when parsing incoming request headers for a trace context.
 
-       .. _dd-trace-x-datadog-tags-max-length:
-   * - ``DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH``
-     - Integer
-     - 512
-     - The maximum length of ``x-datadog-tags`` header allowed in the Datadog propagation style. Must be a value between 0 to 512. If 0, propagation of ``x-datadog-tags`` is disabled.
+   DD_TRACE_PROPAGATION_STYLE_INJECT:
+     default: |
+         ``datadog``
+     description: |
+         Comma separated list of propagation styles used for injecting trace context into outbound request headers.
 
-       .. _dd-trace-partial-flush-enabled:
-   * - ``DD_TRACE_PARTIAL_FLUSH_ENABLED``
-     - Boolean
-     - True
-     - Prevents large payloads being sent to APM.
+         The supported values are ``datadog``, ``b3``, and ``b3 single header``.
 
-       .. _dd-profiling-enabled:
-   * - ``DD_PROFILING_ENABLED``
-     - Boolean
-     - False
-     - Enable Datadog profiling when using ``ddtrace-run``.
+         All provided styles are injected into the headers of outbound requests.
 
-       .. _dd-profiling-api-timeout:
-   * - ``DD_PROFILING_API_TIMEOUT``
-     - Float
-     - 10
-     - The timeout in seconds before dropping events if the HTTP API does not
-       reply.
+         Example: ``DD_TRACE_PROPAGATION_STYLE_INJECT="datadog,b3"`` to inject both ``x-datadog-*`` and ``x-b3-*``
+         headers into outbound requests.
 
-       .. _dd-profiling-max-time-usage-pct:
-   * - ``DD_PROFILING_MAX_TIME_USAGE_PCT``
-     - Float
-     - 1
-     - The percentage of maximum time the stack profiler can use when computing
-       statistics. Must be greater than 0 and lesser or equal to 100.
+   DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH:
+     type: Integer
+     default: 512
+     description: |
+         The maximum length of ``x-datadog-tags`` header allowed in the Datadog propagation style.
+         Must be a value between 0 to 512. If 0, propagation of ``x-datadog-tags`` is disabled.
 
-       .. _dd-profiling-max-frames:
-   * - ``DD_PROFILING_MAX_FRAMES``
-     - Integer
-     - 64
-     - The maximum number of frames to capture in stack execution tracing.
+   DD_TRACE_PARTIAL_FLUSH_ENABLED:
+     type: Boolean
+     default: True
+     description: Prevents large payloads being sent to APM.
 
-       .. _dd-profiling-code-provenance:
-   * - ``DD_PROFILING_ENABLE_CODE_PROVENANCE``
-     - Boolean
-     - False
-     - Whether to enable code provenance.
+   DD_PROFILING_ENABLED:
+     type: Boolean
+     default: False
+     description: Enable Datadog profiling when using ``ddtrace-run``.
 
-       .. _dd-profiling-memory-enabled:
-   * - ``DD_PROFILING_MEMORY_ENABLED``
-     - Boolean
-     - True
-     - Whether to enable the memory profiler.
+   DD_PROFILING_API_TIMEOUT:
+     type: Float
+     default: 10
+     description: The timeout in seconds before dropping events if the HTTP API does not reply.
 
-       .. _dd-profiling-heap-enabled:
-   * - ``DD_PROFILING_HEAP_ENABLED``
-     - Boolean
-     - True
-     - Whether to enable the heap memory profiler.
+   DD_PROFILING_MAX_TIME_USAGE_PCT:
+     type: Float
+     default: 1
+     description: |
+         The percentage of maximum time the stack profiler can use when computing
+         statistics. Must be greater than 0 and lesser or equal to 100.
 
-       .. _dd-profiling-capture-pct:
-   * - ``DD_PROFILING_CAPTURE_PCT``
-     - Float
-     - 1
-     - The percentage of events that should be captured (e.g. memory
-       allocation). Greater values reduce the program execution speed. Must be
-       greater than 0 lesser or equal to 100.
+   DD_PROFILING_MAX_FRAMES:
+     type: Integer
+     default: 64
+     description: The maximum number of frames to capture in stack execution tracing.
 
-       .. _dd-profiling-upload-interval:
-   * - ``DD_PROFILING_UPLOAD_INTERVAL``
-     - Float
-     - 60
-     - The interval in seconds to wait before flushing out recorded events.
+   DD_PROFILING_ENABLE_CODE_PROVENANCE:
+     type: Boolean
+     default: False
+     description: Whether to enable code provenance.
 
-       .. _dd-profiling-ignore-profiler:
-   * - ``DD_PROFILING_IGNORE_PROFILER``
-     - Boolean
-     - False
-     - **Deprecated**: whether to ignore the profiler in the generated data.
+   DD_PROFILING_MEMORY_ENABLED:
+     type: Boolean
+     default: True
+     description: Whether to enable the memory profiler.
 
-       .. _dd-profiling-tags:
-   * - ``DD_PROFILING_TAGS``
-     - String
-     -
-     - The tags to apply to uploaded profile. Must be a list in the
-       ``key1:value,key2:value2`` format.
+   DD_PROFILING_HEAP_ENABLED:
+     type: Boolean
+     default: True
+     description: Whether to enable the heap memory profiler.
 
-       .. _dd-profiling-endpoing-collection-enabled:
-   * - ``DD_PROFILING_ENDPOINT_COLLECTION_ENABLED``
-     - Boolean
-     - True
-     - Whether to enable the endpoint data collection in profiles.
+   DD_PROFILING_CAPTURE_PCT:
+     type: Float
+     default: 1
+     description: |
+         The percentage of events that should be captured (e.g. memory
+         allocation). Greater values reduce the program execution speed. Must be
+         greater than 0 lesser or equal to 100.
 
-       .. _dd-appsec-enabled:
-   * - ``DD_APPSEC_ENABLED``
-     - Boolean
-     - False
-     - Whether to enable AppSec monitoring.
+   DD_PROFILING_UPLOAD_INTERVAL:
+     type: Float
+     default: 60
+     description: The interval in seconds to wait before flushing out recorded events.
 
-       .. _dd-appsec-rules:
-   * - ``DD_APPSEC_RULES``
-     - String
-     -
-     - Path to a json file containing AppSec rules.
+   DD_PROFILING_IGNORE_PROFILER:
+     type: Boolean
+     default: False
+     description: |
+       **Deprecated**: whether to ignore the profiler in the generated data.
 
-       .. _dd-compile-debug:
-   * - ``DD_COMPILE_DEBUG``
-     - Boolean
-     - False
-     - Compile Cython extensions in RelWithDebInfo mode (with debug info, but no debug code or asserts)
+   DD_PROFILING_TAGS:
+     description: |
+         The tags to apply to uploaded profile. Must be a list in the
+         ``key1:value,key2:value2`` format.
 
-       .. _dd-appsec-obfuscation-parameter-key-regexp:
-   * - ``DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP``
-     - String
-     - ``(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization``
-     - Sensitive parameter key regexp for obfuscation.
+   DD_PROFILING_ENDPOINT_COLLECTION_ENABLED:
+     type: Boolean
+     default: True
+     description: Whether to enable the endpoint data collection in profiles.
 
-       .. _dd-appsec-obfuscation-parameter-value-regexp:
-   * - ``DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP``
-     - String
-     - ``(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}``
-     - Sensitive parameter value regexp for obfuscation.
+   DD_APPSEC_ENABLED:
+     type: Boolean
+     default: False
+     description: Whether to enable AppSec monitoring.
 
-       .. _dd-http-client-tag-query-string:
-   * - ``DD_HTTP_CLIENT_TAG_QUERY_STRING``
-     - Boolean
-     - True
-     - Send query strings in http.url tag in http client integrations.
+   DD_APPSEC_RULES:
+     type: String
+     description: Path to a json file containing AppSec rules.
 
-       .. _dd-http-server-tag-query-string:
-   * - ``DD_HTTP_SERVER_TAG_QUERY_STRING``
-     - Boolean
-     - True
-     - Send query strings in http.url tag in http server integrations.
+   DD_COMPILE_DEBUG:
+     type: Boolean
+     default: False
+     description: Compile Cython extensions in RelWithDebInfo mode (with debug info, but no debug code or asserts)
 
-       .. _dd-iast-enabled:
-   * - ``DD_IAST_ENABLED``
-     - Boolean
-     - False
-     - Whether to enable IAST.
+   DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP:
+     default: |
+       ``(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization``
+     description: Sensitive parameter key regexp for obfuscation.
 
-       .. _dd-iast-max-concurrent-requests:
-   * - ``DD_IAST_MAX_CONCURRENT_REQUESTS``
-     - Integer
-     - 2
-     - Number of requests analyzed at the same time.
+   DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP:
+     default: |
+         ``(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}``
+     description: Sensitive parameter value regexp for obfuscation.
 
-       .. _dd-iast-vulnerability-per-request:
-   * - ``DD_IAST_VULNERABILITIES_PER_REQUEST``
-     - Integer
-     - 2
-     - Number of vulnerabilities reported in each request.
+   DD_HTTP_CLIENT_TAG_QUERY_STRING:
+     type: Boolean
+     default: True
+     description: Send query strings in http.url tag in http client integrations.
+
+   DD_HTTP_SERVER_TAG_QUERY_STRING:
+     type: Boolean
+     default: True
+     description: Send query strings in http.url tag in http server integrations.
+
+   DD_IAST_ENABLED:
+     type: Boolean
+     default: False
+     description: Whether to enable IAST.
+
+   DD_IAST_MAX_CONCURRENT_REQUESTS:
+     type: Integer
+     default: 2
+     description: Number of requests analyzed at the same time.
+
+   DD_IAST_VULNERABILITIES_PER_REQUEST:
+     type: Integer
+     default: 2
+     description: Number of vulnerabilities reported in each request.
 
 .. _Unified Service Tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -28,12 +28,18 @@ below:
    DD_TAGS:
      description: |
          Set global tags to be attached to every span. Value must be either comma or space separated. e.g. ``key1:value1,key2,value2`` or ``key1:value key2:value2``.
-         Comma separated support added in ``v0.38.0`` and space separated support added in ``v0.48.0``.
+     version_added:
+       v0.38.0: Comma separated support added
+       v0.48.0: Space separated support added
 
    DD_VERSION:
      description: |
          Set an application's version in traces and logs e.g. ``1.2.3``,
-         ``6c44da20``, ``2020.02.13``. Generally set along with ``DD_SERVICE``. Added in ``v0.36.0``. See `Unified Service Tagging`_ for more information.
+         ``6c44da20``, ``2020.02.13``. Generally set along with ``DD_SERVICE``.
+
+         See `Unified Service Tagging`_ for more information.
+     version_added:
+       v0.36.0:
 
    DD_SITE:
      default: datadoghq.com
@@ -46,7 +52,10 @@ below:
      default: True
      description: |
          Enable sending of spans to the Agent. Note that instrumentation will still be installed and spans will be
-         generated. Added in ``v0.41.0`` (formerly named ``DATADOG_TRACE_ENABLED``).
+         generated.
+     version_added:
+       v0.41.0: |
+           Formerly named ``DATADOG_TRACE_ENABLED``
 
    DD_INSTRUMENTATION_TELEMETRY_ENABLED:
      type: Boolean
@@ -59,7 +68,11 @@ below:
      default: False
      description: |
          Enables debug logging in the tracer. Setting this flag will cause the library to create a root logging handler if one does not already exist.
-         Added in ``v0.41.0`` (formerly named ``DATADOG_TRACE_DEBUG``). Can be used with `DD_TRACE_LOG_FILE` to route logs to a file.
+
+         Can be used with `DD_TRACE_LOG_FILE` to route logs to a file.
+     version_added:
+       v0.41.0: |
+           Formerly named ``DATADOG_TRACE_DEBUG``
 
    DD_TRACE_LOG_FILE_LEVEL:
      default: DEBUG
@@ -85,13 +98,18 @@ below:
      default: True
      description: |
          Enables <INTEGRATION> to be patched. For example, ``DD_TRACE_DJANGO_ENABLED=false`` will disable the Django
-         integration from being installed. Added in ``v0.41.0``.
+         integration from being installed.
+     version_added:
+       v0.41.0:
 
    DD_PATCH_MODULES:
      description: |
          Override the modules patched for this execution of the program. Must be
          a list in the ``module1:boolean,module2:boolean`` format. For example,
-         ``boto:true,redis:false``. Added in ``v0.55.0`` (formerly named ``DATADOG_PATCH_MODULES``).
+         ``boto:true,redis:false``.
+     version_added:
+       v0.55.0: |
+           Formerly named ``DATADOG_PATCH_MODULES``
 
    DD_LOGS_INJECTION:
      type: Boolean
@@ -162,7 +180,7 @@ below:
      type: Float
      default: 1.0
      description: A float, f, 0.0 <= f <= 1.0. f*100% of traces will be sampled.
-   
+
    DD_TRACE_SAMPLING_RULES:
      type: JSON array
      description: |


### PR DESCRIPTION
## Description
This change introduces a helper directive `.. ddtrace-configuration-options::` that will provide a consistent formatting from a list of configuration options. The reason we went with custom directive approach is the formatting of the configuration options can be changed at any time without needing to reformat each option individually.

## Motivation

The large table didn't handle large descriptions or default values very well. Especially if the values were code blocks since they do not overflow.

## Design 

The input to the directive is a YAML format of:

```yaml
OPTION_NAME:
    type: <type>
    default: <default>
    description: <description>
    version_added:
        vX.Y.Z:
```

If `type`is not provided then `String` is used.

If `default` is not provided then `(no value)` is used.

`description` **must** be provided.

`version_added` is a an optional mapping of versions to a message about what was changed. If no message is added then that is used as the version the configuration option was added, if there is a message then it it will render as a change.

Example usage of `version_added`:

```yaml
ENV_NAME:
    description: An env variable to use to set an option
    version_added:
        v1.2.3:
        v1.3.4: The value now can now contain ampersand.
        v2.0.0: |
            The option has been renamed from ``MY_ENV_NAME`` to ``ENV_NAME``.
```

`v1.2.3` is when the option was added for the first time, and it was updated in `v1.3.4`, and `v2.0.0`.

If the value of `default`, `description`, or `version_added` contains any special characters then a multi-line YAML block must be used.

```yaml
description: |
    ``inline code block``
```

The values of `type`, `default`, `version_added`, and `description` may contain rST formatted text.

## Relevant issue(s)

Fixes #4396 

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
