### PR TITLE
ci(mariadb): add missing snapshot tests

### DIFF
--- a/tests/contrib/mariadb/test_mariadb.py
+++ b/tests/contrib/mariadb/test_mariadb.py
@@ -130,7 +130,7 @@ def test_analytics_default(connection, tracer):
 
 
 @pytest.mark.subprocess(env=dict(DD_SERVICE="mysvc"))
-@snapshot(async_mode=False, variants=SNAPSHOT_VARIANTS)
+@pytest.mark.snapshot(variants=SNAPSHOT_VARIANTS)
 def test_user_specified_dd_service_snapshot():
     """
     When a user specifies a service for the app
@@ -138,9 +138,7 @@ def test_user_specified_dd_service_snapshot():
     """
     import mariadb
 
-    from ddtrace import config  # noqa
     from ddtrace import patch
-    from ddtrace import tracer
 
     patch(mariadb=True)
     from tests.contrib.config import MARIADB_CONFIG
@@ -150,11 +148,10 @@ def test_user_specified_dd_service_snapshot():
     cursor.execute("SELECT 1")
     rows = cursor.fetchall()
     assert len(rows) == 1
-    tracer.shutdown()
 
 
 @pytest.mark.subprocess(env=dict(DD_MARIADB_SERVICE="mysvc"))
-@snapshot(async_mode=False, variants=SNAPSHOT_VARIANTS)
+@pytest.mark.snapshot(variants=SNAPSHOT_VARIANTS)
 def test_user_specified_dd_mariadb_service_snapshot():
     """
     When a user specifies a service for the app
@@ -162,9 +159,7 @@ def test_user_specified_dd_mariadb_service_snapshot():
     """
     import mariadb
 
-    from ddtrace import config  # noqa
     from ddtrace import patch
-    from ddtrace import tracer
 
     patch(mariadb=True)
     from tests.contrib.config import MARIADB_CONFIG
@@ -174,7 +169,6 @@ def test_user_specified_dd_mariadb_service_snapshot():
     cursor.execute("SELECT 1")
     rows = cursor.fetchall()
     assert len(rows) == 1
-    tracer.shutdown()
 
 
 @snapshot(include_tracer=True, variants=SNAPSHOT_VARIANTS)

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_post_1_1.json
@@ -1,0 +1,30 @@
+[[
+  {
+    "name": "mariadb.query",
+    "service": "mysvc",
+    "resource": "SELECT 1",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "meta": {
+      "_dd.p.dm": "-0",
+      "db.name": "test",
+      "db.user": "test",
+      "out.host": "127.0.0.1",
+      "runtime-id": "4bf7d992405a49ec8cef450e74e9f121"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "db.rowcount": 1,
+      "out.port": 3306,
+      "sql.rows": 1,
+      "system.pid": 2209
+    },
+    "duration": 2895542,
+    "start": 1666907272534186839
+  }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_pre_1_1.json
@@ -1,0 +1,30 @@
+[[
+  {
+    "name": "mariadb.query",
+    "service": "mysvc",
+    "resource": "SELECT 1",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "meta": {
+      "_dd.p.dm": "-0",
+      "db.name": "test",
+      "db.user": "test",
+      "out.host": "127.0.0.1",
+      "runtime-id": "568b391eb6c9436d8115636d6346bdb6"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "db.rowcount": 0,
+      "out.port": 3306,
+      "sql.rows": 0,
+      "system.pid": 2187
+    },
+    "duration": 2572959,
+    "start": 1666907195155263470
+  }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_service_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_service_snapshot_post_1_1.json
@@ -1,0 +1,30 @@
+[[
+  {
+    "name": "mariadb.query",
+    "service": "mariadb",
+    "resource": "SELECT 1",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "meta": {
+      "_dd.p.dm": "-0",
+      "db.name": "test",
+      "db.user": "test",
+      "out.host": "127.0.0.1",
+      "runtime-id": "76924267a57b44f48c9c3c90527a8cff"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "db.rowcount": 1,
+      "out.port": 3306,
+      "sql.rows": 1,
+      "system.pid": 2201
+    },
+    "duration": 2602916,
+    "start": 1666907268511224421
+  }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_service_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_service_snapshot_pre_1_1.json
@@ -1,0 +1,30 @@
+[[
+  {
+    "name": "mariadb.query",
+    "service": "mariadb",
+    "resource": "SELECT 1",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "meta": {
+      "_dd.p.dm": "-0",
+      "db.name": "test",
+      "db.user": "test",
+      "out.host": "127.0.0.1",
+      "runtime-id": "460f0ba847f14dd2ae661cb4a5511f5c"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "db.rowcount": 0,
+      "out.port": 3306,
+      "sql.rows": 0,
+      "system.pid": 2179
+    },
+    "duration": 2502750,
+    "start": 1666907192496273844
+  }]]


### PR DESCRIPTION
## Description

Snapshots are not generated when a test is annotated with `@tests.utils.snapshot()` and `@pytest.mark.subprocess()`. This change updates mariadb tests to use the `@pytest.mark.snapshot()`. 

0.61 uses `run_python_code_in_subprocess fixture` to run mariadb snapshot tests so it does not experience this issue: https://github.com/DataDog/dd-trace-py/blob/0.61/tests/contrib/mariadb/test_mariadb.py#L157. We do not need to backport this change to 0.61. 

## Checklist
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
