### PR TITLE
chore(dbm): disable propagation for dbapi fetch methods

### DIFF
--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -104,7 +104,7 @@ class TracedCursor(wrapt.ObjectProxy):
             if dbm_operation:
                 # If the traced operation executes a database query (ex: cursor.execute(..) or cursor.executemany(..))
                 # then attempt to add DBM tags to the query.
-                args, kwargs = _propagate_dbm_comment(s, args, kwargs)
+                args, kwargs = _propagate_dbm_context(s, args, kwargs)
 
             try:
                 return method(*args, **kwargs)
@@ -313,7 +313,7 @@ def _get_module_name(conn):
     return conn.__class__.__module__.split(".")[0]
 
 
-def _propagate_dbm_comment(dbspan, args, kwargs):
+def _propagate_dbm_context(dbspan, args, kwargs):
     # type: (...) -> Tuple[Tuple[Any, ...], Dict[str, Any]]
     dbm_comment = _database_monitoring._get_dbm_comment(dbspan)
     if dbm_comment is None:

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -61,12 +61,16 @@ def unpatch():
 class Psycopg2TracedCursor(dbapi.TracedCursor):
     """TracedCursor for psycopg2"""
 
-    def _trace_method(self, method, name, resource, extra_tags, *args, **kwargs):
+    def _trace_method(self, method, name, resource, extra_tags, dbm_operation, *args, **kwargs):
         # treat psycopg2.sql.Composable resource objects as strings
         if isinstance(resource, Composable):
             resource = resource.as_string(self.__wrapped__)
+            # DBM context propagation is only supported for query args with the following type: string
+            dbm_operation = False
 
-        return super(Psycopg2TracedCursor, self)._trace_method(method, name, resource, extra_tags, *args, **kwargs)
+        return super(Psycopg2TracedCursor, self)._trace_method(
+            method, name, resource, extra_tags, dbm_operation, *args, **kwargs
+        )
 
 
 class Psycopg2FetchTracedCursor(Psycopg2TracedCursor, dbapi.FetchTracedCursor):

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -33,7 +33,7 @@ class TestTracedCursor(TracerTestCase):
 
     @TracerTestCase.run_in_subprocess(
         env_overrides=dict(
-            DD_TRACE_SQL_COMMENT_INJECTION_MODE="full",
+            DD_TRACE_SQL_COMMENT_INJECTION_MODE="service",
             DD_SERVICE="orders-app",
             DD_ENV="staging",
             DD_VERSION="v7343437-d7ac743",
@@ -41,13 +41,23 @@ class TestTracedCursor(TracerTestCase):
     )
     def test_curser_execute_with_dbm_injection(self):
         cursor = self.cursor
-        traced_cursor = TracedCursor(cursor, Pin("pin_name", tracer=self.tracer), {})
-        query = "SELECT * FROM db;"
-        traced_cursor.execute(query)
+        traced_cursor = TracedCursor(cursor, Pin(service="orders-db", tracer=self.tracer), {})
+
+        # The following operations should not generate DBM comments
+        traced_cursor.callproc("proc")
+        cursor.callproc.assert_called_once_with("proc")
         spans = self.tracer.pop()
         assert len(spans) == 1
-        dbm_comment = _database_monitoring._get_dbm_comment(spans[0])
-        cursor.execute.assert_called_once_with(dbm_comment + query)
+
+        # The following operations should generates DBM comments
+        traced_cursor.execute("SELECT * FROM db;")
+        traced_cursor.executemany("SELECT * FROM db;", ())
+
+        spans = self.tracer.pop()
+        assert len(spans) == 2
+        dbm_comment = " /*dddbs='orders-db',dde='staging',ddps='orders-app',ddpv='v7343437-d7ac743'*/"
+        cursor.execute.assert_called_once_with(dbm_comment + "SELECT * FROM db;")
+        cursor.executemany.assert_called_once_with(dbm_comment + "SELECT * FROM db;", ())
 
     def test_executemany_wrapped_is_called_and_returned(self):
         cursor = self.cursor
@@ -161,7 +171,7 @@ class TestTracedCursor(TracerTestCase):
         def method():
             pass
 
-        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"})
+        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
         span = tracer.pop()[0]  # type: Span
         # Only measure if the name passed matches the default name (e.g. `sql.query` and not `sql.query.fetchall`)
         assert_is_not_measured(span)
@@ -186,7 +196,7 @@ class TestTracedCursor(TracerTestCase):
         def method():
             pass
 
-        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"})
+        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
         span = tracer.pop()[0]  # type: Span
         assert span.service == "cfg-service"
 
@@ -201,7 +211,7 @@ class TestTracedCursor(TracerTestCase):
         def method():
             pass
 
-        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"})
+        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
         span = tracer.pop()[0]  # type: Span
         assert span.service == "db"
 
@@ -216,7 +226,7 @@ class TestTracedCursor(TracerTestCase):
         def method():
             pass
 
-        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"})
+        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
         span = tracer.pop()[0]  # type: Span
         assert span.service == "default-svc"
 
@@ -231,7 +241,7 @@ class TestTracedCursor(TracerTestCase):
         def method():
             pass
 
-        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"})
+        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
         span = tracer.pop()[0]  # type: Span
         assert span.service == "pin-svc"
 
@@ -249,7 +259,7 @@ class TestTracedCursor(TracerTestCase):
         def method():
             pass
 
-        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"})
+        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
         span = tracer.pop()[0]  # type: Span
         # Row count
         assert span.get_metric("db.rowcount") == 123, "Row count is set as a metric"
@@ -396,7 +406,7 @@ class TestFetchTracedCursor(TracerTestCase):
         def method():
             pass
 
-        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"})
+        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
         span = tracer.pop()[0]  # type: Span
         assert span.get_tag("pin1") == "value_pin1", "Pin tags are preserved"
         assert span.get_tag("extra1") == "value_extra1", "Extra tags are merged into pin tags"
@@ -421,7 +431,7 @@ class TestFetchTracedCursor(TracerTestCase):
         def method():
             pass
 
-        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"})
+        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
         span = tracer.pop()[0]  # type: Span
         # Row count
         assert span.get_metric("db.rowcount") == 123, "Row count is set as a metric"
@@ -473,7 +483,7 @@ class TestFetchTracedCursor(TracerTestCase):
         def method():
             pass
 
-        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"})
+        traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
         span = tracer.pop()[0]  # type: Span
         assert span.get_metric("db.rowcount") is None
         assert span.get_metric("sql.rows") is None
@@ -499,6 +509,42 @@ class TestFetchTracedCursor(TracerTestCase):
         spans = self.tracer.pop()
         assert len(spans) == 1
         self.reset()
+
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(
+            DD_TRACE_SQL_COMMENT_INJECTION_MODE="full",
+            DD_SERVICE="orders-app",
+            DD_ENV="staging",
+            DD_VERSION="v7343437-d7ac743",
+        )
+    )
+    def test_curser_execute_with_dbm_injection(self):
+        cursor = self.cursor
+        traced_cursor = FetchTracedCursor(cursor, Pin("pin_name", tracer=self.tracer), {})
+
+        # The following operations should not generate DBM comments
+        traced_cursor.callproc("proc")
+        traced_cursor.fetchone()
+        traced_cursor.fetchall()
+        traced_cursor.fetchmany(1)
+        cursor.callproc.assert_called_once_with("proc")
+        cursor.fetchone.assert_called_once_with()
+        cursor.fetchall.assert_called_once_with()
+        cursor.fetchmany.assert_called_once_with(1)
+
+        spans = self.tracer.pop()
+        assert len(spans) == 4
+
+        # The following operations should generates DBM comments
+        traced_cursor.execute("SELECT * FROM db;")
+        traced_cursor.executemany("SELECT * FROM db;", ())
+
+        spans = self.tracer.pop()
+        assert len(spans) == 2
+        dbm_comment_exc = _database_monitoring._get_dbm_comment(spans[0])
+        dbm_comment_excmany = _database_monitoring._get_dbm_comment(spans[1])
+        cursor.execute.assert_called_once_with(dbm_comment_exc + "SELECT * FROM db;")
+        cursor.executemany.assert_called_once_with(dbm_comment_excmany + "SELECT * FROM db;", ())
 
 
 class TestTracedConnection(TracerTestCase):

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -508,7 +508,7 @@ class TestFetchTracedCursor(TracerTestCase):
 
     @TracerTestCase.run_in_subprocess(
         env_overrides=dict(
-            DD_TRACE_SQL_COMMENT_INJECTION_MODE="full",
+            DD_DBM_PROPAGATION_MODE="full",
             DD_SERVICE="orders-app",
             DD_ENV="staging",
             DD_VERSION="v7343437-d7ac743",

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -43,21 +43,17 @@ class TestTracedCursor(TracerTestCase):
         cursor = self.cursor
         traced_cursor = TracedCursor(cursor, Pin(service="orders-db", tracer=self.tracer), {})
 
-        # The following operations should not generate DBM comments
-        traced_cursor.callproc("proc")
-        cursor.callproc.assert_called_once_with("proc")
-        spans = self.tracer.pop()
-        assert len(spans) == 1
-
         # The following operations should generate DBM comments
         traced_cursor.execute("SELECT * FROM db;")
         traced_cursor.executemany("SELECT * FROM db;", ())
+        traced_cursor.callproc("procedure_named_moon")
 
         spans = self.tracer.pop()
-        assert len(spans) == 2
+        assert len(spans) == 3
         dbm_comment = " /*dddbs='orders-db',dde='staging',ddps='orders-app',ddpv='v7343437-d7ac743'*/"
         cursor.execute.assert_called_once_with(dbm_comment + "SELECT * FROM db;")
         cursor.executemany.assert_called_once_with(dbm_comment + "SELECT * FROM db;", ())
+        cursor.callproc.assert_called_once_with(dbm_comment + "procedure_named_moon")
 
     def test_executemany_wrapped_is_called_and_returned(self):
         cursor = self.cursor
@@ -523,28 +519,29 @@ class TestFetchTracedCursor(TracerTestCase):
         traced_cursor = FetchTracedCursor(cursor, Pin("pin_name", tracer=self.tracer), {})
 
         # The following operations should not generate DBM comments
-        traced_cursor.callproc("proc")
         traced_cursor.fetchone()
         traced_cursor.fetchall()
         traced_cursor.fetchmany(1)
-        cursor.callproc.assert_called_once_with("proc")
         cursor.fetchone.assert_called_once_with()
         cursor.fetchall.assert_called_once_with()
         cursor.fetchmany.assert_called_once_with(1)
 
         spans = self.tracer.pop()
-        assert len(spans) == 4
+        assert len(spans) == 3
 
         # The following operations should generates DBM comments
         traced_cursor.execute("SELECT * FROM db;")
         traced_cursor.executemany("SELECT * FROM db;", ())
+        traced_cursor.callproc("proc")
 
         spans = self.tracer.pop()
-        assert len(spans) == 2
+        assert len(spans) == 3
         dbm_comment_exc = _database_monitoring._get_dbm_comment(spans[0])
-        dbm_comment_excmany = _database_monitoring._get_dbm_comment(spans[1])
         cursor.execute.assert_called_once_with(dbm_comment_exc + "SELECT * FROM db;")
+        dbm_comment_excmany = _database_monitoring._get_dbm_comment(spans[1])
         cursor.executemany.assert_called_once_with(dbm_comment_excmany + "SELECT * FROM db;", ())
+        dbm_comment_proc = _database_monitoring._get_dbm_comment(spans[2])
+        cursor.callproc.assert_called_once_with(dbm_comment_proc + "proc")
 
 
 class TestTracedConnection(TracerTestCase):

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -49,7 +49,7 @@ class TestTracedCursor(TracerTestCase):
         spans = self.tracer.pop()
         assert len(spans) == 1
 
-        # The following operations should generates DBM comments
+        # The following operations should generate DBM comments
         traced_cursor.execute("SELECT * FROM db;")
         traced_cursor.executemany("SELECT * FROM db;", ())
 


### PR DESCRIPTION
## Description

We recently added support for context propagation to database queries that are instrumented using `ddtrace.contrib.dbapi`. However, this change breaks the instrumentation for fetch methods (`fetchone`, `fetchmany`, and `fetchall`). We can safely disable propagation for these methods.

## Motivation

This PR ensure only `callproc()`, `execute()` and `executemany()` operations are used in DBM propagation. 

The following [dbapi operations](https://peps.python.org/pep-0249/#id20) do not execute queries and should not attempt to link APM Spans to Database Operations:
- Cusor.fetchone()
- Cusor.fetchmany()
- Cusor.fetchall()

## Checklist
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
