### PR TITLE
fix(tracing): ensure Context is serializable

### DIFF
--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -4,7 +4,6 @@ from typing import Any
 from typing import Optional
 from typing import TYPE_CHECKING
 from typing import Text
-from typing import Tuple
 
 from .constants import ORIGIN_KEY
 from .constants import SAMPLING_PRIORITY_KEY
@@ -15,6 +14,8 @@ from .internal.logger import get_logger
 
 
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import Tuple
+
     from .span import Span
     from .span import _MetaDictType
     from .span import _MetricDictType

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -4,6 +4,7 @@ from typing import Any
 from typing import Optional
 from typing import TYPE_CHECKING
 from typing import Text
+from typing import Tuple
 
 from .constants import ORIGIN_KEY
 from .constants import SAMPLING_PRIORITY_KEY
@@ -17,6 +18,14 @@ if TYPE_CHECKING:  # pragma: no cover
     from .span import Span
     from .span import _MetaDictType
     from .span import _MetricDictType
+
+    _ContextState = Tuple[
+        Optional[int],  # trace_id
+        Optional[int],  # span_id
+        _MetaDictType,  # _meta
+        _MetricDictType,  # _metrics
+    ]
+
 
 log = get_logger(__name__)
 
@@ -62,6 +71,22 @@ class Context(object):
             # are recreated by the tracer after fork
             # https://github.com/DataDog/dd-trace-py/blob/a1932e8ddb704d259ea8a3188d30bf542f59fd8d/ddtrace/tracer.py#L489-L508
             self._lock = threading.RLock()
+
+    def __getstate__(self):
+        # type: () -> _ContextState
+        return (
+            self.trace_id,
+            self.span_id,
+            self._meta,
+            self._metrics,
+            # Note: self._lock is not serializable
+        )
+
+    def __setstate__(self, state):
+        # type: (_ContextState) -> None
+        self.trace_id, self.span_id, self._meta, self._metrics = state
+        # We cannot serialize and lock, so we must recreate it unless we already have one
+        self._lock = threading.RLock()
 
     def _with_span(self, span):
         # type: (Span) -> Context

--- a/releasenotes/notes/fix-context-serializable-2c9768cbe4738b73.yaml
+++ b/releasenotes/notes/fix-context-serializable-2c9768cbe4738b73.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    tracing: fix manual tracing across processes, make ``ddtrace.context.Context`` serializable.
+    tracing: make ``ddtrace.context.Context`` serializable which fixes distributed tracing across processes.

--- a/releasenotes/notes/fix-context-serializable-2c9768cbe4738b73.yaml
+++ b/releasenotes/notes/fix-context-serializable-2c9768cbe4738b73.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    tracing: fix manual tracing across processes, make``ddtrace.context.Context`` pickable.
+    tracing: fix manual tracing across processes, make ``ddtrace.context.Context`` pickable.

--- a/releasenotes/notes/fix-context-serializable-2c9768cbe4738b73.yaml
+++ b/releasenotes/notes/fix-context-serializable-2c9768cbe4738b73.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: fix ``ddtrace.context.Context`` class not being serializable by ``pickle`` for passing context across processes.

--- a/releasenotes/notes/fix-context-serializable-2c9768cbe4738b73.yaml
+++ b/releasenotes/notes/fix-context-serializable-2c9768cbe4738b73.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    tracing: fix manual tracing across processes, make ``ddtrace.context.Context`` pickable.
+    tracing: fix manual tracing across processes, make ``ddtrace.context.Context`` serializable.

--- a/releasenotes/notes/fix-context-serializable-2c9768cbe4738b73.yaml
+++ b/releasenotes/notes/fix-context-serializable-2c9768cbe4738b73.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    tracing: fix ``ddtrace.context.Context`` class not being serializable by ``pickle`` for passing context across processes.
+    tracing: fix manual tracing across processes, make``ddtrace.context.Context`` pickable.

--- a/tests/integration/test_context_snapshots.py
+++ b/tests/integration/test_context_snapshots.py
@@ -1,0 +1,44 @@
+import pytest
+
+from tests.utils import snapshot
+
+from .test_integration import AGENT_VERSION
+
+
+pytestmark = pytest.mark.skipif(AGENT_VERSION != "testagent", reason="Tests only compatible with a testagent")
+
+
+@snapshot()
+def test_context_multiprocess(run_python_code_in_subprocess):
+    # Testing example from our docs:
+    # https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#tracing-across-processes
+    code = """
+from multiprocessing import Process
+import time
+
+from ddtrace import tracer
+
+
+def _target(ctx):
+    tracer.context_provider.activate(ctx)
+    with tracer.trace("proc"):
+        time.sleep(0.1)
+    tracer.shutdown()
+
+
+def main():
+    with tracer.trace("work"):
+        proc = Process(target=_target, args=(tracer.current_trace_context(), ))
+        proc.start()
+        time.sleep(0.25)
+        proc.join()
+
+
+if __name__ == "__main__":
+    main()
+    """
+
+    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code)
+    assert status == 0, (stdout, stderr)
+    assert stdout == b"", stderr
+    assert stderr == b"", stdout

--- a/tests/snapshots/tests.integration.test_context_snapshots.test_context_multiprocess.json
+++ b/tests/snapshots/tests.integration.test_context_snapshots.test_context_multiprocess.json
@@ -1,0 +1,42 @@
+[[
+  {
+    "name": "work",
+    "service": null,
+    "resource": "work",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "runtime-id": "f706b29e0e8049178c7f1e0ac8d01ab7"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 25193
+    },
+    "duration": 259538000,
+    "start": 1667237294717521000
+  },
+     {
+       "name": "proc",
+       "service": null,
+       "resource": "proc",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "meta": {
+         "_dd.p.dm": "-0",
+         "runtime-id": "38ca0ac0547f4097b2e030ebff1064c7"
+       },
+       "metrics": {
+         "_dd.top_level": 1,
+         "_dd.tracer_kr": 1.0,
+         "_sampling_priority_v1": 1,
+         "system.pid": 25194
+       },
+       "duration": 100317000,
+       "start": 1667237294727339000
+     }]]

--- a/tests/tracer/test_context.py
+++ b/tests/tracer/test_context.py
@@ -1,3 +1,5 @@
+import pickle
+
 import pytest
 
 from ddtrace.context import Context
@@ -75,3 +77,19 @@ def test_traceparent():
     span = Span("span_c")
     span.context.sampling_priority = 1
     validate_traceparent(span.context, "01")
+
+
+@pytest.mark.parametrize(
+    "context",
+    [
+        Context(),
+        Context(trace_id=123, span_id=321),
+        Context(trace_id=123, span_id=321, dd_origin="synthetics", sampling_priority=2),
+        Context(trace_id=123, span_id=321, meta={"meta": "value"}, metrics={"metric": 4.556}),
+    ],
+)
+def test_context_serializable(context):
+    # type: (Context) -> None
+    state = pickle.dumps(context)
+    restored = pickle.loads(state)
+    assert context == restored


### PR DESCRIPTION
## Description
`ddtrace.context.Context` object is not serializable, meaning it cannot be pickled/shared between processes.

This breaks the example usage we have in our documentation for passing context through to other threads.

e.g. `Process(target=_target, args=(ctx, ))`

This fix added `__getstate__` and `__setstate__` methods to `Context` class to have pickle ignore the RLock which cannot be serialized.

## Checklist
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Relevant issue(s)

Fixes #4434

## Testing strategy

Test cases added for pickling/unpickling `Context` instances, as well as a snapshot test added for the multiprocessing strategy outlined in our documentation.

https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#tracing-across-processes

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
