### PR TITLE
chore(flask): avoid using deprecated internals

### DIFF
--- a/ddtrace/contrib/flask/helpers.py
+++ b/ddtrace/contrib/flask/helpers.py
@@ -8,9 +8,11 @@ from .. import trace_utils
 
 def get_current_app():
     """Helper to get the flask.app.Flask from the current app context"""
-    appctx = flask._app_ctx_stack.top
-    if appctx:
-        return appctx.app
+    try:
+        return flask.current_app
+    except RuntimeError:
+        # raised if current_app is None: https://github.com/pallets/flask/blob/2.1.3/src/flask/globals.py#L40
+        pass
     return None
 
 

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -587,7 +587,9 @@ def traced_jsonify(wrapped, instance, args, kwargs):
 
 def _set_request_tags(span):
     try:
-        request = flask._request_ctx_stack.top.request
+        # raises RuntimeError if a request is not active:
+        # https://github.com/pallets/flask/blob/2.1.3/src/flask/globals.py#L40
+        request = flask.request
 
         # DEV: This name will include the blueprint name as well (e.g. `bp.index`)
         if not span.get_tag(FLASK_ENDPOINT) and request.endpoint:

--- a/releasenotes/notes/remove-deprecated-flask-methods-8d7a4a3d32c3c69d.yaml
+++ b/releasenotes/notes/remove-deprecated-flask-methods-8d7a4a3d32c3c69d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    flask: add support for flask v2.3. Remove the following deprecated attributes: ``flask._app_ctx_stack`` and ``flask._request_ctx_stack``.

--- a/releasenotes/notes/remove-deprecated-flask-methods-8d7a4a3d32c3c69d.yaml
+++ b/releasenotes/notes/remove-deprecated-flask-methods-8d7a4a3d32c3c69d.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    flask: add support for flask v2.3. Remove the following deprecated attributes: ``flask._app_ctx_stack`` and ``flask._request_ctx_stack``.
+    flask: add support for flask v2.3. Remove deprecated usages of ``flask._app_ctx_stack`` and ``flask._request_ctx_stack``.


### PR DESCRIPTION
## Description

The following flask attributes have been deprecated in flask v2.2.2 and will be removed in the next minor release:
- [flask. _app_ctx_stack](https://github.com/pallets/flask/blob/2a54cfa5cecf4dd9f17525bf3ebae4d33a155776/src/flask/__init__.py#L58) 
- [flask. _request_ctx_stack](https://github.com/pallets/flask/blob/2a54cfa5cecf4dd9f17525bf3ebae4d33a155776/src/flask/__init__.py#L69)

This change replaces deprecated methods with flask globals (flask.current_app and flask.request). 

Context: https://github.com/pallets/flask/pull/4682

## Checklist
- [x] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->


## Relevant issue(s)
Closes: https://github.com/DataDog/dd-trace-py/issues/4430

## Testing strategy
Ensure existing flask tests pass

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
