### PR TITLE
chore(internal): remove side-effects from origin

### DIFF
--- a/ddtrace/internal/module.py
+++ b/ddtrace/internal/module.py
@@ -90,12 +90,14 @@ def origin(module):
     # type: (ModuleType) -> str
     """Get the origin source file of the module."""
     try:
-        orig = abspath(module.__file__)  # type: ignore[type-var]
+        # DEV: Use object.__getattribute__ to avoid potential side-effects.
+        orig = abspath(object.__getattribute__(module, "__file__"))
     except (AttributeError, TypeError):
         # Module is probably only partially initialised, so we look at its
         # spec instead
         try:
-            orig = abspath(module.__spec__.origin)  # type: ignore
+            # DEV: Use object.__getattribute__ to avoid potential side-effects.
+            orig = abspath(object.__getattribute__(module, "__spec__").origin)
         except (AttributeError, ValueError, TypeError):
             orig = None
 

--- a/tests/internal/test_module.py
+++ b/tests/internal/test_module.py
@@ -281,7 +281,7 @@ def test_post_run_module_hook():
 
 
 def test_get_by_origin(module_watchdog):
-    assert module_watchdog.get_by_origin(__file__) is sys.modules[__name__]
+    assert module_watchdog.get_by_origin(__file__.replace(".pyc", ".py")) is sys.modules[__name__]
 
 
 @pytest.mark.subprocess


### PR DESCRIPTION
## Description

Accessing attributes from a module object in Python 2 seems to cause potential side-effects, like loading more modules. To prevent them, we ensure that we access attributes using the object type getter to bypass any potential methods that might trigger said side-effects.


```
>   self._origin_map = {origin(module): module for module in sys.modules.values()}
E   RuntimeError: dictionary changed size during iteration

ddtrace/internal/module.py:212: RuntimeError
```

## Checklist
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
