### PR TITLE
ci(gevent): pin greenlet for legacy gevent versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -134,8 +134,12 @@ deps =
     py{310}-profile-minreqs: protobuf==3.8.0
     profile-minreqs: tenacity==5.0.1
     profile-!minreqs-gevent: gevent
+    # gevent==1.1 requires greenlet<2
     py27-profile-minreqs-gevent: gevent==1.1.0
+    py27-profile-minreqs-gevent: greenlet<2
+    # gevent==1.4 requires greenlet<2
     py{35,36,37,38}-profile-minreqs-gevent: gevent==1.4.0
+    py{35,36,37,38}-profile-minreqs-gevent: greenlet<2
     py39-profile-minreqs-gevent: gevent==20.6.1; sys_platform != 'win32'
     py39-profile-minreqs-gevent: gevent==21.1.2; sys_platform == 'win32'
     py39-profile-minreqs-gevent: greenlet==0.4.16; sys_platform != 'win32'

--- a/tox.ini
+++ b/tox.ini
@@ -36,10 +36,11 @@ envlist =
     dogpile_contrib-py{311}-dogpilecache{08,09,10,11,}
     futures_contrib-py27-futures{30,31,32,}
     futures_contrib-py{35,36,37,38,39,310,311}
-    gevent_contrib-py27-gevent{11,12,13}-sslmodules
-    gevent_contrib-py{35,36}-gevent{11,12,13}-sslmodules3-sslmodules
-    gevent_contrib-py{37,38}-gevent{13,14}-sslmodules3-sslmodules
-    gevent_contrib-py{39}-gevent{209,2012,211}-sslmodules3-sslmodules
+    gevent_contrib-py27-gevent{11,12,13}-greenlet1-sslmodules
+    gevent_contrib-py{35,36}-gevent{11,12,13}-greenlet1-sslmodules3-sslmodules
+    gevent_contrib-py{37,38}-gevent{13,14}-greenlet1-sslmodules3-sslmodules
+    gevent_contrib-py{39}-gevent209-greenlet1-sslmodules3-sslmodules
+    gevent_contrib-py{39}-gevent{2012,211}-sslmodules3-sslmodules
     gevent_contrib-py{310}-gevent{218}-sslmodules3-sslmodules
     gevent_contrib-py{311}-gevent{228}-sslmodules3-sslmodules
     kombu_contrib-py{27,35,36}-kombu{40,41,42,43,44,45,46,}
@@ -69,16 +70,17 @@ envlist =
     py{27,35,36,37,38,39,310,311}-opentracer
     py{35,36,37,38,39,310,311}-opentracer_asyncio
     py{35,36,37,38,39,310,311}-opentracer_tornado-tornado{44,45,50,60,}
-    py{27,35,36}-opentracer_gevent-gevent{11,12}
-    py{37,38}-opentracer_gevent-gevent{13,14}
-    py{39}-opentracer_gevent-gevent{209,2012,211}
+    py{27,35,36}-opentracer_gevent-gevent{11,12}-greenlet1
+    py{37,38}-opentracer_gevent-gevent{13,14}-greenlet1
+    py{39}-opentracer_gevent-gevent209-greenlet1
+    py{39}-opentracer_gevent-gevent{2012,211}-greenlet1
     py{310,311}-opentracer_gevent-gevent{228}
 
 isolated_build = true
 
 requires = virtualenv<=20.2.1
 
-[testenv:gevent_contrib-py{37,38}-gevent{13,14}-sslmodules3-sslmodules]
+[testenv:gevent_contrib-py{37,38}-gevent{13,14}-greenlet1-sslmodules3-sslmodules]
 # Wheels for gevent segfault pretty easily
 install_command=python -m pip install --no-binary=gevent {opts} {packages}
 usedevelop = true
@@ -177,6 +179,9 @@ deps =
     gevent211: gevent>=21.1,<21.2
     gevent218: gevent>=21.8,<21.9
     gevent228: gevent>=22.8,<22.10
+    # Note -  gevent<20.12 does not set a maximum supported version.
+    # To test with gevent<20.12 we need to manually install greenlet<2.
+    greenlet1: greenlet>=1,<2
     # kombu using deprecated shims removed in importlib-metadata 5.0
     kombu{40,41,42,43,44,45,46,}: importlib_metadata<5.0; python_version<'3.8'
     kombu: kombu

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ requires = virtualenv<=20.2.1
 install_command=python -m pip install --no-binary=gevent {opts} {packages}
 usedevelop = true
 
-[testenv:py{37,38}-opentracer_gevent-gevent{13,14}]
+[testenv:py{37,38}-opentracer_gevent-gevent{13,14}-greenlet1]
 # Wheels for gevent segfault pretty easily
 install_command=python -m pip install --no-binary=gevent {opts} {packages}
 usedevelop = true


### PR DESCRIPTION
## Description

[Earlier versions of gevent](https://github.com/gevent/gevent/blob/20.9.0/setup.py#L196) (v1.1, v1.2, v1.3, v1.4, v20.9) only specify a minimum greenlet version. greenlet v2.0 updated its ABI to support py3.11 and is only compatible with [gevent>=22.10.2.](https://github.com/gevent/gevent/pull/1922).

This change updates gevent and opentracer tests to  install `greenlet<2` if `gevent<=20.9` is used.

## Checklist
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
