### PR TITLE
chore(debugging): add timestamp to probe status messages

### DIFF
--- a/ddtrace/debugging/_probe/status.py
+++ b/ddtrace/debugging/_probe/status.py
@@ -26,10 +26,11 @@ class ProbeStatusLogger(object):
         self._encoder = encoder
         self._retry_queue = deque()  # type: deque[Tuple[str, float]]
 
-    def _payload(self, probe, status, message, exc_info=None):
-        # type: (Probe, str, str, Optional[ExcInfoType]) -> str
+    def _payload(self, probe, status, message, timestamp, exc_info=None):
+        # type: (Probe, str, str, float, Optional[ExcInfoType]) -> str
         payload = {
             "service": self._service,
+            "timestamp": int(timestamp * 1e3),  # milliseconds
             "message": message,
             "ddsource": "dd_debugger",
             "debugger": {
@@ -76,7 +77,7 @@ class ProbeStatusLogger(object):
                     meter.increment("backlog.buffer_full")
                     return
 
-            payload = self._payload(probe, status, message, exc_info)
+            payload = self._payload(probe, status, message, now, exc_info)
 
             try:
                 self._encoder.put(payload)

--- a/tests/debugging/probe/test_registry.py
+++ b/tests/debugging/probe/test_registry.py
@@ -56,6 +56,8 @@ def test_registry_location_error():
     assert not registry.get_pending(__file__)
 
     # Check that we emitted the correct diagnostic error message
+    for e in status_logger.queue:
+        del e["timestamp"]
     assert status_logger.queue == [
         {
             "service": "test",

--- a/tests/debugging/probe/test_status.py
+++ b/tests/debugging/probe/test_status.py
@@ -1,5 +1,6 @@
 import json
 import sys
+import time
 
 from ddtrace.debugging._probe.model import LineProbe
 from ddtrace.debugging._probe.status import ProbeStatusLogger
@@ -10,8 +11,8 @@ class DummyProbeStatusLogger(ProbeStatusLogger):
         super(DummyProbeStatusLogger, self).__init__(*args, **kwargs)
         self.queue = []
 
-    def _write(self, *args, **kwargs):
-        payload = self._payload(*args, **kwargs)
+    def _write(self, probe, status, message, exc_info=None):
+        payload = self._payload(probe, status, message, int(time.time() * 1e3), exc_info)
         self.queue.append(json.loads(payload))
 
 


### PR DESCRIPTION
## Description

This change adds the timestamp field to the probe status messages so that they can be ordered in proper chronological order by the backend

## Checklist
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
