### PR TITLE
fix(django): django asgi support (when using debug mode)

### DIFF
--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -292,6 +292,10 @@ def _after_request_tags(pin, span, request, response):
             # Note: getattr calls to user / user_is_authenticated may result in ImproperlyConfigured exceptions from
             # Django's get_user_model():
             # https://github.com/django/django/blob/a464ead29db8bf6a27a5291cad9eb3f0f3f0472b/django/contrib/auth/__init__.py
+            #
+            # FIXME: getattr calls to user fail in async contexts.
+            # Sample Error: django.core.exceptions.SynchronousOnlyOperation: You cannot call this from an async context
+            # - use a thread or sync_to_async.
             try:
                 if hasattr(user, "is_authenticated"):
                     span.set_tag_str("django.user.is_authenticated", str(user_is_authenticated(user)))
@@ -305,7 +309,7 @@ def _after_request_tags(pin, span, request, response):
                     if username:
                         span.set_tag_str("django.user.name", username)
             except Exception:
-                log.debug("Error retrieving authentication information for user %r", user, exc_info=True)
+                log.debug("Error retrieving authentication information for user", exc_info=True)
 
         if response:
             status = response.status_code

--- a/releasenotes/notes/fix-cors-errors-0fa947a1a583ad0c.yaml
+++ b/releasenotes/notes/fix-cors-errors-0fa947a1a583ad0c.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    django: fix django asgi support when running ddtrace in debug mode
+    django: avoid ``SynchronousOnlyOperation`` when failing to retrieve user information.

--- a/releasenotes/notes/fix-cors-errors-0fa947a1a583ad0c.yaml
+++ b/releasenotes/notes/fix-cors-errors-0fa947a1a583ad0c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    django: fix django asgi support when running ddtrace in debug mode


### PR DESCRIPTION
## Description
This PR mitigates the following issue: https://github.com/DataDog/dd-trace-py/issues/4305. Accessing ‘request.user’ is not supported in django async context.  

Support for ddtrace user tags in Django ASGI should be added in a follow up PR.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
