### PR TITLE
fix(asm): fix another body read blocking problem on Flask

### DIFF
--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -362,13 +362,15 @@ def traced_wsgi_app(pin, wrapped, instance, args, kwargs):
             wsgi_input = environ.get("wsgi.input", "")
 
             # Copy wsgi input if not seekable
-            try:
-                seekable = wsgi_input.seekable()
-            except AttributeError:
-                seekable = False
-            if not seekable:
-                body = wsgi_input.read()
-                environ["wsgi.input"] = BytesIO(body)
+            if wsgi_input:
+                try:
+                    seekable = wsgi_input.seekable()
+                except AttributeError:
+                    seekable = False
+                if not seekable:
+                    content_length = int(environ.get("CONTENT_LENGTH", 0))
+                    body = wsgi_input.read(content_length) if content_length else wsgi_input.read()
+                    environ["wsgi.input"] = BytesIO(body)
 
             try:
                 if content_type == "application/json":
@@ -390,10 +392,11 @@ def traced_wsgi_app(pin, wrapped, instance, args, kwargs):
                 log.warning("Failed to parse werkzeug request body", exc_info=True)
             finally:
                 # Reset wsgi input to the beginning
-                if seekable:
-                    wsgi_input.seek(0)
-                else:
-                    environ["wsgi.input"] = BytesIO(body)
+                if wsgi_input:
+                    if seekable:
+                        wsgi_input.seek(0)
+                    else:
+                        environ["wsgi.input"] = BytesIO(body)
 
         trace_utils.set_http_meta(
             span,

--- a/releasenotes/notes/fix-another-flask-body-blocking-acd533aa3c1bd46e.yaml
+++ b/releasenotes/notes/fix-another-flask-body-blocking-acd533aa3c1bd46e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: fix a body read problem on some corner case where don't passing the content length makes wsgi.input.read() blocks.


### PR DESCRIPTION
Signed-off-by: Juanjo Alvarez <juanjo.alvarezmartinez@datadoghq.com>

## Description
Fixed another potencial block on wsgi.input.read() on Flask on POSTed data.

In some cases, a read without a length can block, see:

https://stackoverflow.com/questions/22894078/why-does-environwsgi-input-read-block-even-though-it-is-allowed-by-pep-333

## Checklist
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
