### PR TITLE
fix(ci): pin greenlet version to < 2.0.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -141,6 +141,10 @@ deps =
     py{310}-profile-minreqs-gevent: gevent==21.8.0
     py{310}-profile-minreqs-gevent: greenlet==1.1.0
     py{37,38,39,310}-profile-protobuf319: protobuf<3.19
+
+    gevent_contrib-py{27,35,36,39}-gevent{11,12,13,209}-sslmodules: greenlet<2.0.0
+    py39-opentracer_gevent-gevent{209,2012,211}: greenlet<2.0.0
+
 # backports
     py27: enum34
 # integrations


### PR DESCRIPTION
## Description
Fix CI errors due to the release of greenlet 2.0.0

## Checklist
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
