### PR TITLE
fix(ci): set DD_HOSTNAME in the agent container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
     ddagent:
         image: datadog/agent:latest
         environment:
+            - DD_HOSTNAME=github-actions-worker
             - DD_BIND_HOST=0.0.0.0
             - DD_API_KEY=${DD_API_KEY-invalid_but_this_is_fine}
             - DD_APM_RECEIVER_SOCKET=/tmp/ddagent/trace.sock


### PR DESCRIPTION
Agent version v7.40.0 introduced a breaking change which will cause the agent to fail to start if DD_HOSTNAME is not set and the agent cannot deduce a hostname for the container.

https://github.com/DataDog/datadog-agent/releases/tag/7.40.0 (see the "Other Notes" section)


## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
