### PR TITLE
feat(pytest_bdd): support v6.1

### DIFF
--- a/ddtrace/contrib/pytest_bdd/plugin.py
+++ b/ddtrace/contrib/pytest_bdd/plugin.py
@@ -9,6 +9,7 @@ from ddtrace.contrib.pytest_bdd.constants import FRAMEWORK
 from ddtrace.contrib.pytest_bdd.constants import STEP_KIND
 from ddtrace.ext import test
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.packages import get_distribution
 from ddtrace.pin import Pin
 
 
@@ -32,9 +33,7 @@ def pytest_sessionstart(session):
 
 class _PytestBddPlugin:
     def __init__(self):
-        import pytest_bdd
-
-        self.framework_version = pytest_bdd.__version__
+        self.framework_version = self._get_framework_version()
 
     @staticmethod
     @pytest.hookimpl(tryfirst=True)
@@ -129,3 +128,9 @@ class _PytestBddPlugin:
                 _, _, tb = sys.exc_info()
             span.set_exc_info(type(exception), exception, tb)
             span.finish()
+
+    def _get_framework_version(self):
+        dist = get_distribution("pytest-bdd")
+        if dist:
+            return dist.version
+        return ""

--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -32,3 +32,12 @@ def get_distributions():
 
     _DISTRIBUTIONS = pkgs
     return _DISTRIBUTIONS
+
+
+def get_distribution(name):
+    # type: (str) -> typing.Optional[Distribution]
+    dists = get_distributions()
+    for dist in dists:
+        if name == dist.name:
+            return dist
+    return None

--- a/releasenotes/notes/pytest_bdd-support-6-1-05b18776393a8ffa.yaml
+++ b/releasenotes/notes/pytest_bdd-support-6-1-05b18776393a8ffa.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    pytest: add support for ``pytest_bdd>=6.1``.

--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -1,5 +1,6 @@
 import os
 
+from ddtrace.internal.packages import get_distribution
 from ddtrace.internal.packages import get_distributions
 
 
@@ -27,3 +28,14 @@ def test_get_distributions():
 
     # assert that pkg_resources and importlib.metadata return the same packages
     assert pkg_resources_ws == importlib_pkgs
+
+
+def test_get_distribution():
+    """test retrieving a distribution by name"""
+    # Get a distribution that does not exist
+    moon_dist = get_distribution("moon_package")
+    assert moon_dist is None
+    # Get ddtrace
+    ddtrace_dist = get_distribution("ddtrace")
+    assert ddtrace_dist is not None
+    assert ddtrace_dist.name == "ddtrace"


### PR DESCRIPTION
## Description

pytest_bdd.__version__ was removed in `pytest_bdd>6.1`: https://github.com/pytest-dev/pytest-bdd/commit/6f95c5cacdafc954b8d60d6fcf93227230f2623a. imporlib_metdata should be used to get the package version.

Sample Error: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/23362/workflows/3297c2f8-6425-4d32-adc3-b8f9a6afec3d/jobs/1590764.

## Checklist
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


<!-- START fix -->

## Relevant issue(s)

Resolves: https://github.com/DataDog/dd-trace-py/issues/4492

## Testing strategy

Ensure pytestbdd tests pass with the latest release

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
