### PR TITLE
ci(pytest-bdd): pin pytest-bdd<6.1

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -1531,7 +1531,8 @@ venv = Venv(
                             pkgs={
                                 "pytest-bdd": [
                                     ">=4.0,<5.0",
-                                    ">=6.0,<7.0",
+                                    # FIXME: add support for v6.1
+                                    ">=6.0,<6.1",
                                 ]
                             },
                         ),
@@ -1540,8 +1541,8 @@ venv = Venv(
                             pkgs={
                                 "pytest-bdd": [
                                     ">=4.0,<5.0",
-                                    ">=6.0,<7.0",
-                                    latest,
+                                    # FIXME: add support for v6.1
+                                    ">=6.0,<6.1",
                                 ]
                             },
                         ),


### PR DESCRIPTION
## Description

Pin pytest-bdd in riot to to unblock CI. Sample failure: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/23362/workflows/3297c2f8-6425-4d32-adc3-b8f9a6afec3d/jobs/1590764.

Cause of failure: pytest_bdd.__version__ attribute was removed: https://github.com/pytest-dev/pytest-bdd/commit/6f95c5cacdafc954b8d60d6fcf93227230f2623a.

This PR will fix the underlying issue: https://github.com/DataDog/dd-trace-py/pull/4485

## Checklist
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
