### PR TITLE
chore(lib-injection): use non-root user in image

### DIFF
--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -2,7 +2,9 @@
 # and auto instrument Python applications in containerized environments.
 FROM busybox
 
+RUN addgroup -g 1000 -S datadog && \
+    adduser -u 1000 -S datadog -G datadog
+USER datadog
 WORKDIR /datadog-init
-
 ADD sitecustomize.py /datadog-init/sitecustomize.py
 ADD copy-lib.sh /datadog-init/copy-lib.sh

--- a/releasenotes/notes/lib-injection-user-19a5b5516c060d8b.yaml
+++ b/releasenotes/notes/lib-injection-user-19a5b5516c060d8b.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Kubernetes library injection: run commands as non-root user.


### PR DESCRIPTION
Containers using the root user can be blocked in Kubernetes which makes our lib injection image incompatible with certain Kubernetes configurations.

The solution is to simply add and use a non-root user in the image.

Follows the suggested user configuration mentioned here:

https://github.com/mhart/alpine-node/issues/48#issuecomment-370171836 and supported by [this](https://medium.com/@mccode/processes-in-containers-should-not-run-as-root-2feae3f0df3b
) write up.

Resolves #4476

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
