### PR TITLE
chore(ci): add asyncpg test suite for Python 3.11

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -2146,7 +2146,6 @@ venv = Venv(
                     },
                 ),
                 Venv(
-                    # asyncpg does not yet support Python 3.11
                     pys=["3.10"],
                     pkgs={
                         "asyncpg": [
@@ -2154,6 +2153,10 @@ venv = Venv(
                             latest,
                         ],
                     },
+                ),
+                Venv(
+                    pys=["3.11"],
+                    pkgs={"asyncpg": latest},
                 ),
             ],
         ),


### PR DESCRIPTION
## Description
As of `asyncpg==0.27.0`, asyncpg [now supports ](https://github.com/MagicStack/asyncpg/releases/tag/v0.27.0)Python 3.11. The asyncpg test suites are now updated so that we now test with Python 3.11.

## Checklist
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
