### PR TITLE
chore(typing): update types to be compatible with mypy 0.990

### DIFF
--- a/ddtrace/debugging/_function/discovery.py
+++ b/ddtrace/debugging/_function/discovery.py
@@ -14,7 +14,7 @@ except ImportError:
 try:
     from typing import Protocol
 except ImportError:
-    from typing_extensions import Protocol  # type: ignore[misc]
+    from typing_extensions import Protocol  # type: ignore[assignment]
 
 from os.path import abspath
 from types import FunctionType

--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -93,7 +93,7 @@ try:
 
 
 except ImportError:
-    from inspect import getfullargspec  # type: ignore[misc]  # noqa: F401
+    from inspect import getfullargspec  # type: ignore[assignment]  # noqa: F401
 
     def is_not_void_function(f, argspec):
         return (

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -49,7 +49,7 @@ def get_logger(name):
     #   https://github.com/python/cpython/blob/7c7839329c2c66d051960ab1df096aed1cc9343e/Lib/logging/__init__.py#L1272-L1294  # noqa
     # DEV: `_fixupParents` has been around for awhile, but add the `hasattr` guard... just in case.
     if hasattr(manager, "_fixupParents"):
-        manager._fixupParents(logger)  # type: ignore[attr-defined]
+        manager._fixupParents(logger)
 
     # Return our logger
     return logger

--- a/ddtrace/internal/wrapping.py
+++ b/ddtrace/internal/wrapping.py
@@ -13,7 +13,7 @@ from six import PY3
 try:
     from typing import Protocol
 except ImportError:
-    from typing_extensions import Protocol  # type: ignore[misc]
+    from typing_extensions import Protocol  # type: ignore[assignment]
 
 from bytecode import Bytecode
 from bytecode import Compare

--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -28,7 +28,7 @@ else:
     if hasattr(asyncio, "current_task"):
         current_task = asyncio.current_task
     elif hasattr(asyncio.Task, "current_task"):
-        current_task = asyncio.Task.current_task  # type: ignore[attr-defined]
+        current_task = asyncio.Task.current_task
     else:
 
         def current_task(loop=None):
@@ -37,7 +37,7 @@ else:
     if hasattr(asyncio, "all_tasks"):
         all_tasks = asyncio.all_tasks
     elif hasattr(asyncio.Task, "all_tasks"):
-        all_tasks = asyncio.Task.all_tasks  # type: ignore[attr-defined]
+        all_tasks = asyncio.Task.all_tasks
     else:
 
         def all_tasks(loop=None):

--- a/ddtrace/profiling/exporter/pprof.pyx
+++ b/ddtrace/profiling/exporter/pprof.pyx
@@ -170,7 +170,7 @@ class pprof_ProfileType(object):
     string_table: typing.Dict[int, str]
     mapping: typing.List[pprof_Mapping]
 
-    def SerializeToString(self) -> bytes:
+    def SerializeToString(self) -> bytes:  # type: ignore[empty-body]
         ...
 
 


### PR DESCRIPTION
mypy 0.990 was released which breaks some of our type ignores. Some are no longer necessary, others require a different type of ignore.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
