### PR TITLE
fix(docs): fix configuration options overflowing the sidebar

### DIFF
--- a/docs/_static/css/ddtrace.css
+++ b/docs/_static/css/ddtrace.css
@@ -1,0 +1,10 @@
+@import '../alabaster.css';
+
+/*
+  Clip any text in the sidebar.
+
+  Originally added to avoid configuration names overflowing into the page content.
+*/
+.sphinxsidebarwrapper {
+    overflow: auto;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -205,7 +205,11 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ["_static"]
+
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+html_css_files = ["css/ddtrace.css"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
## Description
**Before:**
![image](https://user-images.githubusercontent.com/1320353/200608953-d0096069-7940-469b-a51e-d113a57e95c8.png)

**After:**
![image](https://user-images.githubusercontent.com/1320353/200608910-0c1e03d7-e892-47a5-9e72-30a0581f2c72.png)

We will not be able to see this locally or from the artifacts in CircleCI since RTD is using a newer version of Sphinx (RTD: 5.3.0 Us: ~=4.3.2) which is what is causing these options to show up in the sidebar and overflow.

I made an attempt to upgrade Sphinx, but it is non-trivial. This fix should mitigate the issue for now until we can revisit and reconcile the differences between RTD and CircleCI builds.

This approach allows us to use our own CSS file inherited from the base Alabaster CSS file with whatever overrides we want.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
