### PR TITLE
fix(rcm): disable ASM if it is disabled in the dashboard

### DIFF
--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -45,9 +45,9 @@ def appsec_rc_reload_features(tracer):
         ```
         """
 
-        if features:
-            log.debug("Reloading tracer features. %r", features)
-            rc_appsec_enabled = features.get("asm", {}).get("enabled")
+        if features is not None:
+            log.debug("Reloading appsec rc: %s", features)
+            rc_appsec_enabled = features.get("asm", {}).get("enabled") if features is not False else False
 
             _appsec_enabled = True
 

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -322,7 +322,8 @@ class RemoteConfigClient(object):
         if last_targets_version is None or targets is None:
             log.debug("No targets in configuration payload")
             for callback in self._products.values():
-                callback(None, None)
+                if callback:
+                    callback(None, None)
             return
 
         client_configs = {k: v for k, v in targets.items() if k in payload.client_configs}

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Tuple
     from typing import Union
 
-    ProductCallback = Callable[[Optional["ConfigMetadata"], Optional[Mapping[str, Any], bool]], None]
+    ProductCallback = Optional[Callable[[Optional["ConfigMetadata"], Union[Mapping[str, Any], bool, None]], None]]
 
 
 log = logging.getLogger(__name__)
@@ -226,7 +226,7 @@ class RemoteConfigClient(object):
         self._backend_state = None  # type: Optional[str]
 
     def register_product(self, product_name, func=None):
-        # type: (str, Optional[ProductCallback]) -> None
+        # type: (str, ProductCallback) -> None
         if func is not None:
             self._products[product_name] = func
         else:

--- a/releasenotes/notes/rcm-fix-disable-product-06e4343ba60a89cd.yaml
+++ b/releasenotes/notes/rcm-fix-disable-product-06e4343ba60a89cd.yaml
@@ -1,5 +1,4 @@
 ---
 fixes:
   - |
-    Fix error in 1-click Remote Configuration. When an user disabled ASM in a dashboard, it was an error in the
-    Agent response payload.
+    Fix error in the agent response payload when the user disabled ASM in a dashboard using 1-click Remote Configuration.

--- a/releasenotes/notes/rcm-fix-disable-product-06e4343ba60a89cd.yaml
+++ b/releasenotes/notes/rcm-fix-disable-product-06e4343ba60a89cd.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix error in 1-click Remote Configuration. When an user disabled ASM in a dashboard, it was an error in the
+    Agent response payload.


### PR DESCRIPTION
## Description
Fix error in 1-click Remote Configuration. When an user disabled ASM in a dashboard, it was an error in the Agent response payload.

If ASM is disabled in the dashboard, the Agent returns empty (`{}`) instead of return a boolean. Update the code with the new behavior


## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
