### PR TITLE
ci(profiling): disable Python 3.8 and 3.9 on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,25 +469,27 @@ jobs:
   #         store_coverage: false
   #         pattern: '^py37-profile'
 
-  profile-windows-38:
-    executor:
-      name: win/default
-      shell: bash.exe
-    steps:
-      - run: choco install -y python --version=3.8.10 --side-by-side
-      - run_tox_scenario:
-          store_coverage: false
-          pattern: '^py38-profile'
+  # This requires the machine to reboot :(
+  # profile-windows-38:
+  #   executor:
+  #     name: win/default
+  #     shell: bash.exe
+  #   steps:
+  #     - run: choco install -y python --version=3.8.10 --side-by-side
+  #     - run_tox_scenario:
+  #         store_coverage: false
+  #         pattern: '^py38-profile'
 
-  profile-windows-39:
-    executor:
-      name: win/default
-      shell: bash.exe
-    steps:
-      - run: choco install -y python --version=3.9.12 --side-by-side
-      - run_tox_scenario:
-          store_coverage: false
-          pattern: '^py39-profile'
+  # This requires the machine to reboot :(
+  # profile-windows-39:
+  #   executor:
+  #     name: win/default
+  #     shell: bash.exe
+  #   steps:
+  #     - run: choco install -y python --version=3.9.12 --side-by-side
+  #     - run_tox_scenario:
+  #         store_coverage: false
+  #         pattern: '^py39-profile'
 
   profile-windows-310:
     executor:
@@ -1225,8 +1227,8 @@ requires_tests: &requires_tests
     - profile-windows-35
     - profile-windows-36
     # - profile-windows-37
-    - profile-windows-38
-    - profile-windows-39
+    # - profile-windows-38
+    # - profile-windows-39
     - profile-windows-310
 
 workflows:
@@ -1327,8 +1329,8 @@ workflows:
       - profile-windows-35: *requires_pre_check
       - profile-windows-36: *requires_pre_check
       # - profile-windows-37: *requires_pre_check
-      - profile-windows-38: *requires_pre_check
-      - profile-windows-39: *requires_pre_check
+      # - profile-windows-38: *requires_pre_check
+      # - profile-windows-39: *requires_pre_check
       - profile-windows-310: *requires_pre_check
       # Final reports
       - coverage_report: *requires_tests


### PR DESCRIPTION
The installation of Python on Windows require a reboot, which is impossible to
do in the CI:

  Packages requiring reboot:
   - vcredist140 (exit code 3010)

  The recent package changes indicate a reboot is necessary.
   Please reboot at your earliest convenience.

  Exited with code exit status 194