### PR TITLE
chore(tests): remove agent v5 testing support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -510,19 +510,6 @@ jobs:
           store_coverage: false
           pattern: '^py.\+-profile'
 
-  integration_agent5:
-    <<: *machine_executor
-    steps:
-      - attach_workspace:
-          at: .
-      - checkout
-      - start_docker_services:
-          services: ddagent5
-      - run:
-          command: |
-            mv .riot .ddriot
-            ./scripts/ddtest riot -v run --pass-env -s 'integration-v5'
-
   integration_agent:
     <<: *machine_executor
     steps:
@@ -1163,7 +1150,6 @@ requires_tests: &requires_tests
     - grpc
     - httplib
     - httpx
-    - integration_agent5
     - integration_agent
     - integration_testagent
     - vendor
@@ -1262,7 +1248,6 @@ workflows:
       - grpc: *requires_base_venvs
       - httplib: *requires_base_venvs
       - httpx: *requires_base_venvs
-      - integration_agent5: *requires_base_venvs
       - integration_agent: *requires_base_venvs
       - integration_testagent: *requires_base_venvs
       - internal: *requires_base_venvs

--- a/releasenotes/notes/old-agent-8193550a76b21357.yaml
+++ b/releasenotes/notes/old-agent-8193550a76b21357.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    tracer: support for Datadog Agent v5 has been dropped. Datadog Agent v5 is
+    no longer supported since ddtrace==1.0.0. See
+    https://ddtrace.readthedocs.io/en/v1.0.0/versioning.html#release-support
+    for the version support.

--- a/riotfile.py
+++ b/riotfile.py
@@ -293,12 +293,6 @@ venv = Venv(
             pkgs={"msgpack": [latest]},
             venvs=[
                 Venv(
-                    name="integration-v5",
-                    env={
-                        "AGENT_VERSION": "v5",
-                    },
-                ),
-                Venv(
                     name="integration-latest",
                     env={
                         "AGENT_VERSION": "latest",


### PR DESCRIPTION
The minimum supported Datadog Agent version of ddtrace is 7.28[^0] as of
ddtrace v1.0 which means we can drop testing support for it.

With this, support for the v0.3 traces endpoint could also be dropped
but maintaining it is little burden due to its overlap with v0.4.

[^0]: https://ddtrace.readthedocs.io/en/v1.0.0/versioning.html#release-support


## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
