### PR TITLE
fix(ci): wait for traces in grpc snapshots

### DIFF
--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -1,3 +1,4 @@
+import sys
 import threading
 import time
 
@@ -661,6 +662,7 @@ class _UnaryUnaryRpcHandler(grpc.GenericRpcHandler):
         return grpc.unary_unary_rpc_method_handler(self._handler)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="flaky on older python versions")
 @snapshot(ignores=["meta.grpc.port"])
 def test_method_service(patch_grpc):
     def handler(request, context):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -917,7 +917,7 @@ def snapshot_context(token, ignores=None, tracer=None, async_mode=True, variants
         # Wait for the traces to be available
         if wait_for_num_traces is not None:
             traces = []
-            for i in range(20):
+            for i in range(50):
                 try:
                     conn.request("GET", "/test/session/traces?test_session_token=%s" % token)
                     r = conn.getresponse()
@@ -950,7 +950,9 @@ def snapshot_context(token, ignores=None, tracer=None, async_mode=True, variants
         conn.close()
 
 
-def snapshot(ignores=None, include_tracer=False, variants=None, async_mode=True, token_override=None):
+def snapshot(
+    ignores=None, include_tracer=False, variants=None, async_mode=True, token_override=None, wait_for_num_traces=None
+):
     """Performs a snapshot integration test with the testing agent.
 
     All traces sent to the agent will be recorded and compared to a snapshot
@@ -986,7 +988,14 @@ def snapshot(ignores=None, include_tracer=False, variants=None, async_mode=True,
             else token_override
         )
 
-        with snapshot_context(token, ignores=ignores, tracer=tracer, async_mode=async_mode, variants=variants):
+        with snapshot_context(
+            token,
+            ignores=ignores,
+            tracer=tracer,
+            async_mode=async_mode,
+            variants=variants,
+            wait_for_num_traces=wait_for_num_traces,
+        ):
             # Run the test.
             if include_tracer:
                 kwargs["tracer"] = tracer


### PR DESCRIPTION
Example flaky job: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/23745/workflows/b4bee4b1-4f99-4c57-a259-4ed6f174781b/jobs/1612294


## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
