### PR TITLE
ci: add testrunner container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Set Docker Image Tag
+        id: set_names
+        run: |
+          DOCKER_IMAGE_TAG=${{ github.sha }}
+          DOCKER_IMAGE_NAME=$(echo ghcr.io/${GITHUB_REPOSITORY}/testrunner | tr '[:upper:]' '[:lower:]')
+          DOCKER_IMAGE_NAME_WITH_TAG=$(echo ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} | tr '[:upper:]' '[:lower:]')
+          echo "Using image name '$DOCKER_IMAGE_NAME_WITH_TAG'"
+          echo "image_name=$DOCKER_IMAGE_NAME_WITH_TAG" >> $GITHUB_OUTPUT
+
       - name: Login to the GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -31,4 +40,4 @@ jobs:
           file: docker/Dockerfile.buster
           platforms: "linux/amd64,linux/arm64"
           push: true
-          tags: datadog/dd-trace-py/testrunner:latest
+          tags: ${{ steps.set_names.outputs.image_name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,34 @@
+name: Build and publish Docker images
+
+on:
+  push:
+    branches:
+      - '1.x'
+
+jobs:
+  testrunner:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to the GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: publisher
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: docker
+          file: docker/Dockerfile.buster
+          platforms: "linux/amd64,linux/arm64"
+          push: true
+          tags: datadog/dd-trace-py/testrunner:latest


### PR DESCRIPTION
The `Datadog/dd-trace-py` image published on Docker Hub only supports linux/amd64 platform. This change adds a `ghcr.io/datadog/dd-trace-py/testrunner` container image for both linux/amd64 and linux/arm64. 