### PR TITLE
ci: add prune workflow runs action

### DIFF
--- a/.github/workflows/prune_workflow.yml
+++ b/.github/workflows/prune_workflow.yml
@@ -9,10 +9,6 @@ on:
         description: 'Number of days.'
         required: true
         default: 30
-      minimum_runs:
-        description: 'The minimum runs to keep for each workflow.'
-        required: true
-        default: 6
       delete_workflow_pattern:
         description: 'The name or filename of the workflow. if not set then it will target all workflows.'
         required: false

--- a/.github/workflows/prune_workflow.yml
+++ b/.github/workflows/prune_workflow.yml
@@ -53,7 +53,6 @@ jobs:
           token: ${{ github.token }}
           repository: ${{ github.repository }}
           retain_days: ${{ inputs.days || 30}}
-          keep_minimum_runs: ${{ inputs.minimum_runs || 6 }}
           delete_workflow_pattern: ${{ inputs.delete_workflow_pattern }}
           delete_workflow_by_state_pattern: ${{ inputs.delete_workflow_by_state_pattern || 'All' }}
           delete_run_by_conclusion_pattern: ${{ inputs.delete_run_by_conclusion_pattern || 'All' }}

--- a/.github/workflows/prune_workflow.yml
+++ b/.github/workflows/prune_workflow.yml
@@ -1,0 +1,62 @@
+name: Prune workflow runs
+on:
+  schedule:
+    # Run monthly, at 00:00 on the 1st day of month.
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Number of days.'
+        required: true
+        default: 30
+      minimum_runs:
+        description: 'The minimum runs to keep for each workflow.'
+        required: true
+        default: 6
+      delete_workflow_pattern:
+        description: 'The name or filename of the workflow. if not set then it will target all workflows.'
+        required: false
+      delete_workflow_by_state_pattern:
+        description: 'Remove workflow by state: active, deleted, disabled_fork, disabled_inactivity, disabled_manually'
+        required: true
+        default: "All"
+        type: choice
+        options:
+          - "All"
+          - active
+          - deleted
+          - disabled_inactivity
+          - disabled_manually
+      delete_run_by_conclusion_pattern:
+        description: 'Remove workflow by conclusion: action_required, cancelled, failure, skipped, success'
+        required: true
+        default: "All"
+        type: choice
+        options:
+          - "All"
+          - action_required
+          - cancelled
+          - failure
+          - skipped
+          - success
+      dry_run:
+        description: 'Only log actions, do not perform any delete operations.'
+        required: false
+
+jobs:
+  del_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: ${{ inputs.days || 30}}
+          keep_minimum_runs: ${{ inputs.minimum_runs || 6 }}
+          delete_workflow_pattern: ${{ inputs.delete_workflow_pattern }}
+          delete_workflow_by_state_pattern: ${{ inputs.delete_workflow_by_state_pattern || 'All' }}
+          delete_run_by_conclusion_pattern: ${{ inputs.delete_run_by_conclusion_pattern || 'All' }}
+          # FIXME: only allow dry run until tested
+          # dry_run: ${{ inputs.dry_run }}
+          dry_run: true


### PR DESCRIPTION
There is no method for delete workflow runs from GitHub for older workflow runs or workflows that are no longer run. The action added here is scheduled to perform regular deletion of older workflow runs. A manual trigger can also be used to specify the types of workflow runs to be deleted, which is useful for those workflows that have become inactive or have been disabled.