### PR TITLE
chore(ci): add style checks for release notes

### DIFF
--- a/.github/styles/Vocab/Python/accept.txt
+++ b/.github/styles/Vocab/Python/accept.txt
@@ -1,0 +1,2 @@
+wsgi
+middleware

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -35,6 +35,8 @@ jobs:
       - uses: errata-ai/vale-action@reviewdog
         with:
           reporter: github-pr-review
+          files: docs/_build/
+          filter_mode: nofilter
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -33,6 +33,8 @@ jobs:
           riot run reno report | tee docs/_build/release_notes.rst
 
       - uses: errata-ai/vale-action@reviewdog
+        with:
+          reporter: github-pr-review
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -1,0 +1,40 @@
+name: Documentation style
+on:
+  push:
+    branches:
+      - master
+      - 0.x
+      - 1.x
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
+jobs:
+  releasenotes:
+    name: Generate and check release notes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.8'
+
+      - name: Install Dependencies
+        run: pip install riot
+
+      - name: Lint release notes
+        run: riot run reno lint
+
+      - name: Generate release notes
+        run: |
+          mkdir -p docs/_build/
+          riot run reno report | tee docs/_build/release_notes.rst
+
+      - uses: errata-ai/vale-action@reviewdog
+
+      - name: Upload release_notes
+        uses: actions/upload-artifact@v3
+        with:
+          name: release_notes
+          path: |
+            docs/_build/release_notes.rst

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -33,6 +33,8 @@ jobs:
           riot run reno report | tee docs/_build/release_notes.rst
 
       - uses: errata-ai/vale-action@reviewdog
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Upload release_notes
         uses: actions/upload-artifact@v3

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -13,36 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # Fetch all branches and tags for reno release traversal
+          # FIXME: For testing, fetch all branches and tags for reno release traversal
           fetch-depth: 0
-
-      - uses: actions/setup-python@v4
-        name: Install Python
-        with:
-          python-version: '3.10'
-
-      - name: Install Dependencies
-        run: pip install riot
-
-      - name: Lint release notes
-        run: riot run -s reno lint
-
-      - name: Generate release notes
-        run: |
-          mkdir -p docs/_build/
-          riot run reno report | tee docs/_build/release_notes.rst
 
       - uses: errata-ai/vale-action@reviewdog
         with:
           reporter: github-pr-review
-          files: docs/_build/
+          files: releasenotes/notes
+          # FIXME: For testing, run over all notes
           filter_mode: nofilter
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Upload release_notes
-        uses: actions/upload-artifact@v3
-        with:
-          name: release_notes
-          path: |
-            docs/_build/release_notes.rst

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Fetch all branches and tags for reno release traversal
+          fetch-depth: 0
 
       - uses: actions/setup-python@v4
         name: Install Python

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -2,7 +2,6 @@ name: Documentation style
 on:
   push:
     branches:
-      - master
       - 0.x
       - 1.x
   pull_request:
@@ -17,13 +16,13 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Install Dependencies
         run: pip install riot
 
       - name: Lint release notes
-        run: riot run reno lint
+        run: riot run -s reno lint
 
       - name: Generate release notes
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ artifacts/
 
 # Vale
 .github/styles/*
+!.github/styles/Vocab

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ ddtrace/_version.py
 
 # Benchmarks
 artifacts/
+
+# Vale
+.github/styles/*

--- a/.vale.ini
+++ b/.vale.ini
@@ -6,6 +6,5 @@ Packages = RedHat, write-good
 
 Vocab = Python
 
-[docs/_build/*.rst]
+[releasenotes/notes/*.yaml]
 BasedOnStyles = RedHat, write-good
-TokenIgnores = (v\d+\.\d+\.\d(?:rc[0-9]+))

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,11 @@
+StylesPath = .github/styles
+
+MinAlertLevel = suggestion
+
+Packages = RedHat, write-good
+
+Vocab = Python
+
+[docs/_build/*.rst]
+BasedOnStyles = RedHat, write-good
+TokenIgnores = (v\d+\.\d+\.\d(?:rc[0-9]+))

--- a/releasenotes/notes/releasenotes-style-9580a13b9739009c.yaml
+++ b/releasenotes/notes/releasenotes-style-9580a13b9739009c.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    This release not is totally new and probably most likely has several language style issuess that would be worth our attention, no? 

--- a/scripts/reno2rst
+++ b/scripts/reno2rst
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+from argparse import ArgumentParser, FileType
+import io
+import sys
+import yaml
+
+
+def convert(src: io.TextIOWrapper, dest: io.TextIOWrapper) -> None:
+    content = yaml.safe_load(src.read())
+    output = []
+    for section_name, section_content in content.items():
+        output.append(section_name.capitalize())
+        output.append("-" * len(section_name))
+        output.append("")
+        if isinstance(section_content, str):
+            # content is a block of text rather than a list
+            output.append(section_content.strip())
+            output.append("")
+            continue
+        for c in section_content:
+            output.append(c.strip())
+            output.append("")
+
+    dest.write("\n".join(output))
+
+
+def main() -> None:
+    """Convert tool from a reno note yaml to reStructuredText markup"""
+    argp = ArgumentParser(
+        prog="reno2rst",
+        description=("Convert tool from a reno YAML file to reStructuredText markup"),
+    )
+    argp.add_argument("infile", nargs="?", type=FileType("r"), default=sys.stdin)
+    argp.add_argument("outfile", nargs="?", type=FileType("w"), default=sys.stdout)
+
+    args = argp.parse_args()
+
+    convert(args.infile, args.outfile)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Before this change, pull requests were merged without style guidelines for the content of release notes. After this change, pull requests will have a workflow that uses [vale](https://vale.sh) to check generated release notes.