### PR TITLE
chore(ci/futures): move futures tests to riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -563,8 +563,8 @@ jobs:
   futures:
     <<: *contrib_job_small
     steps:
-      - run_tox_scenario:
-          pattern: '^futures_contrib-'
+      - run_test:
+          pattern: '^futures$'
 
   boto:
     <<: *machine_executor

--- a/riotfile.py
+++ b/riotfile.py
@@ -2177,5 +2177,16 @@ venv = Venv(
                 "pytest-asyncio": latest,
             },
         ),
+        Venv(
+            name="futures",
+            command="pytest {cmdargs} tests/contrib/futures",
+            venvs=[
+                # futures is backported for 2.7
+                Venv(pys=["2.7"], pkgs={"futures": ["~=3.0", "~=3.1", "~=3.2", "~=3.4"]}),
+                Venv(
+                    pys=select_pys(min_version="3.5"),
+                ),
+            ],
+        ),
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,6 @@ envlist =
     dogpile_contrib-py{27,35}-dogpilecache{06,07,08,09}
     dogpile_contrib-py{36,37,38,39,310}-dogpilecache{06,07,08,09,10,}
     dogpile_contrib-py{311}-dogpilecache{08,09,10,11,}
-    futures_contrib-py27-futures{30,31,32,}
-    futures_contrib-py{35,36,37,38,39,310,311}
     gevent_contrib-py27-gevent{11,12,13}-greenlet1-sslmodules
     gevent_contrib-py{35,36}-gevent{11,12,13}-greenlet1-sslmodules3-sslmodules
     gevent_contrib-py{37,38}-gevent{13,14}-greenlet1-sslmodules3-sslmodules
@@ -268,7 +266,6 @@ commands =
     consul_contrib: python -m pytest {posargs} tests/contrib/consul
     dbapi_contrib: python -m pytest {posargs} tests/contrib/dbapi
     dogpile_contrib: python -m pytest {posargs} tests/contrib/dogpile_cache
-    futures_contrib: python -m pytest {posargs} tests/contrib/futures
     gevent_contrib: python -m pytest {posargs} tests/contrib/gevent
     molten_contrib: python -m pytest {posargs} tests/contrib/molten
     mysql_contrib: python -m pytest {posargs} tests/contrib/mysql


### PR DESCRIPTION
This should reduce the runtime of the futures CI substantially.

Cut down to [2m44s](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/23925/workflows/60ff9e5c-2e07-42d6-9e72-db9cd33f72b1/jobs/1625150) (from [18m44s](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/23915/workflows/db215273-1772-4b1c-baa7-3bcf013c4a03/jobs/1624638)).
## Reviewer Checklist
- [x] Title is accurate.
- [ ] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
