### PR TITLE
chore(ci/celery): test less celery

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -437,22 +437,6 @@ venv = Venv(
                         "redis": "~=2.10.6",
                     },
                 ),
-                # 4.x celery bumps kombu to 4.4+, which requires redis 3.2 or later, this tests against
-                # older redis with an older kombu, and newer kombu/newer redis.
-                # https://github.com/celery/kombu/blob/3e60e6503a77b9b1a987cf7954659929abac9bac/Changelog#L35
-                Venv(
-                    pys=select_pys(max_version="3.6"),
-                    pkgs={
-                        "pytest": "~=3.10",
-                        "celery": [
-                            "~=4.0.2",
-                            "~=4.1.1",
-                        ],
-                        "redis": "~=2.10.6",
-                        "kombu": "~=4.3.0",
-                        "importlib_metadata": "<5.0",  # kombu using deprecated shims removed in importlib-metadata>=5.0
-                    },
-                ),
                 # Celery 4.2 is now limited to Kombu 4.3
                 # https://github.com/celery/celery/commit/1571d414461f01ae55be63a03e2adaa94dbcb15d
                 Venv(
@@ -472,8 +456,6 @@ venv = Venv(
                     pkgs={
                         "pytest": "~=3.10",
                         "celery": [
-                            "~=4.3.1",
-                            "~=4.4.7",
                             "~=4.4",  # most recent 4.x
                         ],
                         "redis": "~=3.5",
@@ -486,8 +468,6 @@ venv = Venv(
                     pkgs={
                         "pytest": "~=3.10",
                         "celery": [
-                            "~=4.3.1",
-                            "~=4.4.7",
                             "~=4.4",  # most recent 4.x
                         ],
                         "redis": "~=3.5",
@@ -522,7 +502,6 @@ venv = Venv(
                     },
                     pkgs={
                         "celery": [
-                            "~=5.0.5",
                             "~=5.0",  # most recent 5.x
                             latest,
                         ],


### PR DESCRIPTION
The celery integration only instruments using the public API of celery which should be stable under semver. There is not much value gained in testing so many versions and the integration library support guidelines state to only test the major version when only the public API is instrumented:
https://ddtrace.readthedocs.io/en/stable/contributing.html#library-support


[20m36s](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/23929/workflows/2b116026-96a4-4f8c-9561-6f203c93724a/jobs/1625413/parallel-runs/3?filterBy=ALL) -> [12m55s](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/23935/workflows/2aa6419b-dca9-41a6-abaa-556fc79886f0/jobs/1625664/parallel-runs/3?filterBy=ALL)

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
