### PR TITLE
chore(ci/dogpile): move tests to riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -678,8 +678,8 @@ jobs:
   dogpile_cache:
     <<: *contrib_job
     steps:
-      - run_tox_scenario:
-          pattern: '^dogpile_contrib-'
+      - run_test:
+          pattern: 'dogpile_cache'
 
   elasticsearch:
     <<: *machine_executor

--- a/riotfile.py
+++ b/riotfile.py
@@ -2177,5 +2177,48 @@ venv = Venv(
             command="pytest {cmdargs} tests/contrib/dbapi",
             pys=select_pys(),
         ),
+        Venv(
+            name="dogpile_cache",
+            command="pytest {cmdargs} tests/contrib/dogpile_cache",
+            venvs=[
+                Venv(
+                    pys=select_pys(max_version="3.5"),
+                    pkgs={
+                        "dogpile.cache": [
+                            "==0.6.*",
+                            "==0.7.*",
+                            "==0.8.*",
+                            "==0.9.*",
+                        ],
+                        "decorator": "<5",
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version="3.6", max_version="3.10"),
+                    pkgs={
+                        "dogpile.cache": [
+                            "==0.6.*",
+                            "==0.7.*",
+                            "==0.8.*",
+                            "==0.9.*",
+                            "==1.0.*",
+                            latest,
+                        ],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version="3.11"),
+                    pkgs={
+                        "dogpile.cache": [
+                            "==0.8.*",
+                            "==0.9.*",
+                            "==1.0.*",
+                            "==1.1.*",
+                            latest,
+                        ],
+                    },
+                ),
+            ],
+        ),
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,6 @@ envlist =
     bottle_contrib{,_autopatch}-py{27,35,36,37,38,39}-bottle{11,12,}-webtest
     bottle_contrib{,_autopatch}-py{310,311}-bottle-webtest
     consul_contrib-py{27,35,36,37,38,39,310,311}-consul{07,10,11,}
-    dogpile_contrib-py{27,35}-dogpilecache{06,07,08,09}
-    dogpile_contrib-py{36,37,38,39,310}-dogpilecache{06,07,08,09,10,}
-    dogpile_contrib-py{311}-dogpilecache{08,09,10,11,}
     gevent_contrib-py27-gevent{11,12,13}-greenlet1-sslmodules
     gevent_contrib-py{35,36}-gevent{11,12,13}-greenlet1-sslmodules3-sslmodules
     gevent_contrib-py{37,38}-gevent{13,14}-greenlet1-sslmodules3-sslmodules
@@ -156,15 +153,6 @@ deps =
     consul07: python-consul>=0.7,<1.0
     consul10: python-consul>=1.0,<1.1
     consul11: python-consul>=1.1,<1.2
-# decorator 5 dropped support for Python 2
-    dogpile_contrib-py27: decorator<5
-    dogpilecache: dogpile.cache
-    dogpilecache06: dogpile.cache==0.6.*
-    dogpilecache07: dogpile.cache==0.7.*
-    dogpilecache08: dogpile.cache==0.8.*
-    dogpilecache09: dogpile.cache==0.9.*
-    dogpilecache10: dogpile.cache==1.0.*
-    dogpilecache11: dogpile.cache==1.1.*
     futures: futures
     futures30: futures>=3.0,<3.1
     futures31: futures>=3.1,<3.2
@@ -262,7 +250,6 @@ commands =
     bottle_contrib: python -m pytest {posargs} --ignore="tests/contrib/bottle/test_autopatch.py" tests/contrib/bottle/
     bottle_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/bottle/test_autopatch.py
     consul_contrib: python -m pytest {posargs} tests/contrib/consul
-    dogpile_contrib: python -m pytest {posargs} tests/contrib/dogpile_cache
     gevent_contrib: python -m pytest {posargs} tests/contrib/gevent
     molten_contrib: python -m pytest {posargs} tests/contrib/molten
     mysql_contrib: python -m pytest {posargs} tests/contrib/mysql


### PR DESCRIPTION
This should reduce the runtime of the futures CI substantially.

[18m5s](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/23937/workflows/a9e38bc6-0ce3-428e-b9a2-96b24e6ff338/jobs/1625894) -> [2m4s](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/23940/workflows/efddfb5f-81e1-44f3-b3db-43c7b0deb17c/jobs/1626091)

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
