### PR TITLE
chore(ci/profiling): skip flaky test on windows

### DIFF
--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 import collections
 import os
+import sys
 import threading
 import time
 import timeit
@@ -129,6 +130,7 @@ def test_collect_once_with_class():
         assert SomeClass.sleep_class()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="FIXME: this test is flaky on Windows")
 def test_collect_once_with_class_not_right_type():
     # type: (...) -> None
     r = recorder.Recorder()


### PR DESCRIPTION
The test_collect_once_with_class_not_right_type test is very flaky on Windows and is causing noise in our CI. Disable it for now.

eg. https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/24036/workflows/226be696-d0a0-4e80-a6b8-e617dc2faf4f/jobs/1632376


## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
