### PR TITLE
chore(ci/rq): wait for traces in snapshot

### DIFF
--- a/tests/contrib/rq/test_rq.py
+++ b/tests/contrib/rq/test_rq.py
@@ -134,7 +134,7 @@ def test_enqueue(queue, distributed_tracing_enabled, worker_service_name):
         distributed_tracing_enabled,
         worker_service_name,
     )
-    with snapshot_context(token, ignores=snapshot_ignores):
+    with snapshot_context(token, ignores=snapshot_ignores, wait_for_num_traces=1):
         env = os.environ.copy()
         env["DD_TRACE_REDIS_ENABLED"] = "false"
         if distributed_tracing_enabled is not None:


### PR DESCRIPTION
Fix the flaky test_enqueue test by waiting for traces to be received by the test agent before snapshotting them.

eg: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/24006/workflows/7fb0c8e6-a6b0-4ada-aa44-440c35a442fe/jobs/1630208

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
