### PR TITLE
chore(ci/debugger): increase range for flaky test

### DIFF
--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -698,7 +698,7 @@ def test_debugger_function_probe_duration(duration):
         durationstuff(duration)
 
         (snapshot,) = d.test_queue
-        assert 0.9 * duration <= snapshot.duration <= 2.5 * duration, snapshot
+        assert 0.9 * duration <= snapshot.duration <= 3.0 * duration, snapshot
 
 
 def test_debugger_condition_eval_then_rate_limit():

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -698,7 +698,7 @@ def test_debugger_function_probe_duration(duration):
         durationstuff(duration)
 
         (snapshot,) = d.test_queue
-        assert 0.9 * duration <= snapshot.duration <= 3.0 * duration, snapshot
+        assert 0.9 * duration <= snapshot.duration <= 10.0 * duration, snapshot
 
 
 def test_debugger_condition_eval_then_rate_limit():


### PR DESCRIPTION
This test run:

```
            (snapshot,) = d.test_queue
>           assert 0.9 * duration <= snapshot.duration <= 2.5 * duration, snapshot
E           AssertionError: Snapshot(probe=FunctionProbe(probe_id='duration-probe', tags={}, active=True, rate=1.0, condition=None, module='tests.... 'throwable': None}, duration=284068, timestamp=1668637423.0604956, snapshot_id='0b0bba8c-dfaf-4884-9233-3b3208bfbaa1')
E           assert 284068 <= (2.5 * 100000.0)
E            +  where 284068 = Snapshot(probe=FunctionProbe(probe_id='duration-probe', tags={}, active=True, rate=1.0, condition=None, module='tests.... 'throwable': None}, duration=284068, timestamp=1668637423.0604956, snapshot_id='0b0bba8c-dfaf-4884-9233-3b3208bfbaa1').duration
```
https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/24048/workflows/07d39bba-30fd-49d5-a5e8-ec85f58ad8c5/jobs/1633200

demonstrates that a factor of 2.5 is too narrow. Increase it to 10.0.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
