### PR TITLE
chore(ci): update mergifyio update rule

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -31,6 +31,7 @@ pull_request_rules:
   - name: update approved PRs
     conditions:
       - label!=manual merge
+      - check-success=test
       - "#approved-reviews-by>=2"
     actions:
       update: {}


### PR DESCRIPTION
With the CI improvements we should see CI pass consistently which means that mergifyio should only keep branches that are passing up to date (else there is an issue with the PR).

This will save resources resulting in faster CI runs and less money wasted on keeping broken PRs up to date.


## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
