### PR TITLE
chore(tests): move gevent tests to riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -750,8 +750,8 @@ jobs:
     <<: *contrib_job
     parallelism: 8
     steps:
-      - run_tox_scenario:
-          pattern: '^gevent_contrib-'
+      - run_test:
+          pattern: 'gevent'
 
   graphene:
     <<: *machine_executor

--- a/riotfile.py
+++ b/riotfile.py
@@ -364,14 +364,12 @@ venv = Venv(
                         ),
                         Venv(
                             pys=select_pys(min_version="3.7", max_version="3.8"),
-                            # Wheels for gevent segfault pretty easily
-                            env={"PIP_NO_CACHE_DIR": "1"},
                             pkgs={
                                 "gevent": ["~=1.3.0", "~=1.4.0"],
-                                "greenlet": "~=1.0",
-                                "cython": "<=0.29.32",
-                                "cmake": latest,
-                                "ninja": latest,
+                                # greenlet>0.4.17 wheels are incompatible with gevent and python>3.7
+                                # This issue was fixed in gevent v20.9:
+                                # https://github.com/gevent/gevent/issues/1678#issuecomment-697995192
+                                "greenlet": "<0.4.17",
                             },
                         ),
                         Venv(
@@ -390,7 +388,7 @@ venv = Venv(
                         Venv(
                             pys="3.11",
                             pkgs={
-                                "gevent": ["~=22.8.0"],
+                                "gevent": ["~=22.8.0", latest],
                             },
                         ),
                     ],

--- a/riotfile.py
+++ b/riotfile.py
@@ -333,6 +333,71 @@ venv = Venv(
             ],
         ),
         Venv(
+            name="gevent",
+            command="pytest {cmdargs} tests/contrib/gevent",
+            pkgs={
+                "botocore": latest,
+                "requests": latest,
+                "elasticsearch": latest,
+                "pynamodb": latest,
+            },
+            venvs=[
+                Venv(
+                    pys="2.7",
+                    pkgs={
+                        "gevent": ["~=1.1.0", "~=1.2.0", "~=1.3.0"],
+                        "greenlet": "~=1.0",
+                    },
+                ),
+                Venv(
+                    pkgs={
+                        "aiobotocore": "<=2.3.1",
+                        "aiohttp": latest,
+                    },
+                    venvs=[
+                        Venv(
+                            pys=select_pys(min_version="3.5", max_version="3.6"),
+                            pkgs={
+                                "gevent": ["~=1.1.0", "~=1.2.0", "~=1.3.0"],
+                                "greenlet": "~=1.0",
+                            },
+                        ),
+                        Venv(
+                            pys=select_pys(min_version="3.7", max_version="3.8"),
+                            # Wheels for gevent segfault pretty easily
+                            env={"PIP_NO_CACHE_DIR": "1"},
+                            pkgs={
+                                "gevent": ["~=1.3.0", "~=1.4.0"],
+                                "greenlet": "~=1.0",
+                                "cython": "<=0.29.32",
+                                "cmake": latest,
+                                "ninja": latest,
+                            },
+                        ),
+                        Venv(
+                            pys="3.9",
+                            pkgs={
+                                "gevent": ["~=20.12.0", "~=21.1.0"],
+                                "greenlet": "~=1.0",
+                            },
+                        ),
+                        Venv(
+                            pys="3.10",
+                            pkgs={
+                                "gevent": ["~=21.8.0"],
+                            },
+                        ),
+                        Venv(
+                            pys="3.11",
+                            pkgs={
+                                "gevent": ["~=22.8.0"],
+                            },
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        Venv(
             name="runtime",
             command="pytest {cmdargs} tests/runtime/",
             venvs=[Venv(pys=select_pys(), pkgs={"msgpack": latest})],

--- a/tox.ini
+++ b/tox.ini
@@ -33,13 +33,6 @@ envlist =
     dogpile_contrib-py{27,35}-dogpilecache{06,07,08,09}
     dogpile_contrib-py{36,37,38,39,310}-dogpilecache{06,07,08,09,10,}
     dogpile_contrib-py{311}-dogpilecache{08,09,10,11,}
-    gevent_contrib-py27-gevent{11,12,13}-greenlet1-sslmodules
-    gevent_contrib-py{35,36}-gevent{11,12,13}-greenlet1-sslmodules3-sslmodules
-    gevent_contrib-py{37,38}-gevent{13,14}-greenlet1-sslmodules3-sslmodules
-    gevent_contrib-py{39}-gevent209-greenlet1-sslmodules3-sslmodules
-    gevent_contrib-py{39}-gevent{2012,211}-sslmodules3-sslmodules
-    gevent_contrib-py{310}-gevent{218}-sslmodules3-sslmodules
-    gevent_contrib-py{311}-gevent{228}-sslmodules3-sslmodules
     kombu_contrib-py{27,35,36}-kombu{40,41,42,43,44,45,46,}
 # Kombu >= 4.2 only supports Python 3.7+
     kombu_contrib-py{37,38,39}-kombu{42,43,44,45,46,}
@@ -77,10 +70,6 @@ isolated_build = true
 
 requires = virtualenv<=20.2.1
 
-[testenv:gevent_contrib-py{37,38}-gevent{13,14}-greenlet1-sslmodules3-sslmodules]
-# Wheels for gevent segfault pretty easily
-install_command=python -m pip install --no-binary=gevent {opts} {packages}
-usedevelop = true
 
 [testenv:py{37,38}-opentracer_gevent-gevent{13,14}-greenlet1]
 # Wheels for gevent segfault pretty easily
@@ -266,7 +255,6 @@ commands =
     consul_contrib: python -m pytest {posargs} tests/contrib/consul
     dbapi_contrib: python -m pytest {posargs} tests/contrib/dbapi
     dogpile_contrib: python -m pytest {posargs} tests/contrib/dogpile_cache
-    gevent_contrib: python -m pytest {posargs} tests/contrib/gevent
     molten_contrib: python -m pytest {posargs} tests/contrib/molten
     mysql_contrib: python -m pytest {posargs} tests/contrib/mysql
     mysqldb_contrib: python -m pytest {posargs} tests/contrib/mysqldb


### PR DESCRIPTION
## Description

Moves gevent tests from tox to riot. 
Pins greenlet in legacy gevent version to avoid segfaults

## Checklist
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
