### PR TITLE
chore(ci/profiling): increase profiling windows jobs parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,6 +432,7 @@ jobs:
   #   executor:
   #     name: win/default
   #     shell: bash.exe
+  #   parallelism: 15
   #   steps:
   #     - run: choco install python2
   #     - run_tox_scenario:
@@ -442,6 +443,7 @@ jobs:
     executor:
       name: win/default
       shell: bash.exe
+    parallelism: 15
     steps:
       - run: choco install -y python --version=3.5.4 --side-by-side
       - run_tox_scenario:
@@ -452,6 +454,7 @@ jobs:
     executor:
       name: win/default
       shell: bash.exe
+    parallelism: 15
     steps:
       - run: choco install -y python --version=3.6.8 --side-by-side
       - run_tox_scenario:
@@ -463,6 +466,7 @@ jobs:
   #   executor:
   #     name: win/default
   #     shell: bash.exe
+  #   parallelism: 15
   #   steps:
   #     - run: choco install python --version=3.7.9
   #     - run_tox_scenario:
@@ -474,6 +478,7 @@ jobs:
   #   executor:
   #     name: win/default
   #     shell: bash.exe
+  #   parallelism: 15
   #   steps:
   #     - run: choco install -y python --version=3.8.10 --side-by-side
   #     - run_tox_scenario:
@@ -485,6 +490,7 @@ jobs:
   #   executor:
   #     name: win/default
   #     shell: bash.exe
+  #   parallelism: 15
   #   steps:
   #     - run: choco install -y python --version=3.9.12 --side-by-side
   #     - run_tox_scenario:
@@ -495,6 +501,7 @@ jobs:
     executor:
       name: win/default
       shell: bash.exe
+    parallelism: 15
     steps:
       # circleci/windows@5.0 orb includes python 3.10.6
       - run_tox_scenario:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,7 +432,8 @@ jobs:
   #   executor:
   #     name: win/default
   #     shell: bash.exe
-  #   parallelism: 15
+  #   # This is the number of tox envs for this job
+  #   parallelism: 4
   #   steps:
   #     - run: choco install python2
   #     - run_tox_scenario:
@@ -443,7 +444,8 @@ jobs:
     executor:
       name: win/default
       shell: bash.exe
-    parallelism: 15
+    # This is the number of tox envs for this job
+    parallelism: 4
     steps:
       - run: choco install -y python --version=3.5.4 --side-by-side
       - run_tox_scenario:
@@ -454,7 +456,8 @@ jobs:
     executor:
       name: win/default
       shell: bash.exe
-    parallelism: 15
+    # This is the number of tox envs for this job
+    parallelism: 4
     steps:
       - run: choco install -y python --version=3.6.8 --side-by-side
       - run_tox_scenario:
@@ -466,7 +469,8 @@ jobs:
   #   executor:
   #     name: win/default
   #     shell: bash.exe
-  #   parallelism: 15
+  #   # This is the number of tox envs for this job
+  #   parallelism: 5
   #   steps:
   #     - run: choco install python --version=3.7.9
   #     - run_tox_scenario:
@@ -478,7 +482,8 @@ jobs:
   #   executor:
   #     name: win/default
   #     shell: bash.exe
-  #   parallelism: 15
+  #   # This is the number of tox envs for this job
+  #   parallelism: 5
   #   steps:
   #     - run: choco install -y python --version=3.8.10 --side-by-side
   #     - run_tox_scenario:
@@ -490,7 +495,8 @@ jobs:
   #   executor:
   #     name: win/default
   #     shell: bash.exe
-  #   parallelism: 15
+  #   # This is the number of tox envs for this job
+  #   parallelism: 5
   #   steps:
   #     - run: choco install -y python --version=3.9.12 --side-by-side
   #     - run_tox_scenario:
@@ -501,7 +507,8 @@ jobs:
     executor:
       name: win/default
       shell: bash.exe
-    parallelism: 15
+    # This is the number of tox envs for this job
+    parallelism: 5
     steps:
       # circleci/windows@5.0 orb includes python 3.10.6
       - run_tox_scenario:


### PR DESCRIPTION
## Description

This improves the runtime of the profiling windows jobs from 20+m each to around 6m each.

Each profiling windows job is broken up by python version, so we can only set the parallelism to the max number of tox environments for each. For older Python's this is 4, and newer this is 5. This means each tox env will run on it's own node.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
