### PR TITLE
ci: disable broken windows profiling jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1210,12 +1210,12 @@ requires_tests: &requires_tests
     - vertica
     - wsgi
     # - profile-windows-27
-    - profile-windows-35
-    - profile-windows-36
+    # - profile-windows-35
+    # - profile-windows-36
     # - profile-windows-37
     # - profile-windows-38
     # - profile-windows-39
-    - profile-windows-310
+    # - profile-windows-310
 
 workflows:
   version: 2
@@ -1310,12 +1310,12 @@ workflows:
       - vertica: *requires_base_venvs
       - wsgi: *requires_base_venvs
       # - profile-windows-27: *requires_pre_check
-      - profile-windows-35: *requires_pre_check
-      - profile-windows-36: *requires_pre_check
+      # - profile-windows-35: *requires_pre_check
+      # - profile-windows-36: *requires_pre_check
       # - profile-windows-37: *requires_pre_check
       # - profile-windows-38: *requires_pre_check
       # - profile-windows-39: *requires_pre_check
-      - profile-windows-310: *requires_pre_check
+      # - profile-windows-310: *requires_pre_check
       # Final reports
       - coverage_report: *requires_tests
 


### PR DESCRIPTION
These are breaking consistently:

```
        CMake Error at C:/Users/circleci.PACKER-633B1A5A/AppData/Local/Temp/pip-build-env-4_tkbtz5/overlay/Lib/site-packages/cmake/data/share/cmake-3.25/Modules/CMakeTestCXXCompiler.cmake:63 (message):
          The C++ compiler

            "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.33.31629/bin/Hostx64/x64/cl.exe"

          is not able to compile a simple test program.

          It fails with the following output:

            Change Dir: C:/Users/circleci.PACKER-633B1A5A/AppData/Local/Temp/tmpk0i77wqa/libddwaf-prefix/src/libddwaf-build/third_party/proj_rapidjson-prefix/src/proj_rapidjson-build/CMakeFiles/CMakeScratch/TryCompile-jypmkr

            Run Build Command(s):C:/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin/amd64/MSBuild.exe cmTC_ad5ed.vcxproj /p:Configuration=Debug /p:Platform=x64 /p:VisualStudioVersion=17.0 /v:m && MSBuild version 17.3.1+2badb37d1 for .NET Framework
    C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppBuild.targets(383,5): error MSB3491: Could not write lines to file "cmTC_ad5ed.dir\Debug\cmTC_ad5ed.tlog\cmTC_ad5ed.lastbuildstate". Path: cmTC_ad5ed.dir\Debug\cmTC_ad5ed.tlog\cmTC_ad5ed.lastbuildstate exceeds the OS max path limit. The fully qualified file name must be less than 260 characters. [C:\Users\circleci.PACKER-633B1A5A\AppData\Local\Temp\tmpk0i77wqa\libddwaf-prefix\src\libddwaf-build\third_party\proj_rapidjson-prefix\src\proj_rapidjson-build\CMakeFiles\CMakeScratch\TryCompile-jypmkr\cmTC_ad5ed.vcxproj] [C:\Users\circleci.PACKER-633B1A5A\AppData\Local\Temp\tmpk0i77wqa\libddwaf-prefix\src\libddwaf-build\third_party\proj_rapidjson.vcxproj] [C:\Users\circleci.PACKER-633B1A5A\AppData\Local\Temp\tmpk0i77wqa\libddwaf.vcxproj]
        -- Configuring incomplete, errors occurred!
        See also "C:/Users/circleci.PACKER-633B1A5A/AppData/Local/Temp/tmpk0i77wqa/libddwaf-prefix/src/libddwaf-build/third_party/proj_rapidjson-prefix/src/proj_rapidjson-build/CMakeFiles/CMakeOutput.log".
        See also "C:/Users/circleci.PACKER-633B1A5A/AppData/Local/Temp/tmpk0i77wqa/libddwaf-prefix/src/libddwaf-build/third_party/proj_rapidjson-prefix/src/proj_rapidjson-build/CMakeFiles/CMakeError.log".

          CMake will not be able to correctly generate this project.
        Call Stack (most recent call first):
          CMakeLists.txt:12 (PROJECT)
```

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
