### PR TITLE
chore(ci/django): bump parallelism, run less tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -684,7 +684,7 @@ jobs:
 
   django:
     <<: *machine_executor
-    parallelism: 6
+    parallelism: 8
     steps:
       - run_test:
           pattern: 'django$'

--- a/riotfile.py
+++ b/riotfile.py
@@ -729,7 +729,6 @@ venv = Venv(
                         "django": [
                             "~=3.0",
                             "~=3.0.0",
-                            "~=3.1.0",
                             "~=3.2.0",
                         ],
                         "channels": ["~=3.0", latest],
@@ -742,7 +741,7 @@ venv = Venv(
                             "~=4.0.0",
                             latest,
                         ],
-                        "channels": ["~=3.0", latest],
+                        "channels": [latest],
                     },
                 ),
                 Venv(
@@ -752,7 +751,7 @@ venv = Venv(
                             "~=4.1.0",
                             latest,
                         ],
-                        "channels": ["~=3.0", latest],
+                        "channels": [latest],
                     },
                 ),
             ],


### PR DESCRIPTION
Django takes ~15m to run, bump the parallelism to get this under 10m.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
