### PR TITLE
chore: add release note for changing system.pid to process_id

### DIFF
--- a/releasenotes/notes/system.pid-tag-change-d9e68052b1e5baaf.yaml
+++ b/releasenotes/notes/system.pid-tag-change-d9e68052b1e5baaf.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    tracing: The value of ``ddtrace.constants.PID`` has been changed from ``system.pid`` to ``process_id``. All spans will now use
+    the metric tag of ``process_id`` instead.

--- a/releasenotes/notes/tracing:-ddtrace.constants.PID-changed-from-system.pid-to-process_id-197409ef9b68bd73.yaml
+++ b/releasenotes/notes/tracing:-ddtrace.constants.PID-changed-from-system.pid-to-process_id-197409ef9b68bd73.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    tracing: ``ddtrace.constants.PID`` has been changed from ``system.pid`` to ``process_id``. All spans will now use
+    the metric tag of ``process_id`` instead.

--- a/releasenotes/notes/tracing:-ddtrace.constants.PID-changed-from-system.pid-to-process_id-197409ef9b68bd73.yaml
+++ b/releasenotes/notes/tracing:-ddtrace.constants.PID-changed-from-system.pid-to-process_id-197409ef9b68bd73.yaml
@@ -1,5 +1,0 @@
----
-other:
-  - |
-    tracing: ``ddtrace.constants.PID`` has been changed from ``system.pid`` to ``process_id``. All spans will now use
-    the metric tag of ``process_id`` instead.


### PR DESCRIPTION
## Description
Adds a release note stating the change of `system.pid` to `process_id` within the tracer.

## Checklist
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added for fixes and features, or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
