### PR TITLE
chore(ci): fix dry run parameter for prune workflows

### DIFF
--- a/.github/workflows/prune_workflow.yml
+++ b/.github/workflows/prune_workflow.yml
@@ -57,4 +57,4 @@ jobs:
           delete_workflow_pattern: ${{ inputs.delete_workflow_pattern }}
           delete_workflow_by_state_pattern: ${{ inputs.delete_workflow_by_state_pattern || 'All' }}
           delete_run_by_conclusion_pattern: ${{ inputs.delete_run_by_conclusion_pattern || 'All' }}
-          dry_run: ${{ inputs.dry_run || false }}
+          dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
If the `dry_run` input is set, regardless of value, the deletion is not performed.