### PR TITLE
fix(ci): add quotes for branch patterns

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -3,8 +3,8 @@ name: Build
 on:
   push:
     branches:
-      - [0-9].[0-9]*
-      - [0-9].x
+      - '[0-9].[0-9]*'
+      - '[0-9].x'
   pull_request:
     paths:
       - "setup.py"


### PR DESCRIPTION
#4431 added a pattern for branches to skip building wheels but the patterns must be quoted.