### PR TITLE
ci: move riot tests to precheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,8 +311,14 @@ jobs:
           name: "Codespell check"
           command: riot run -s codespell
       - run:
+          name: "Run riotfile.py tests"
+          command: riot run -s riot-helpers
+      - run:
           name: "Test agent snapshot check"
           command: riot run -s snapshot-fmt && git diff --exit-code
+      - run:
+          name: "Run scripts/*.py tests"
+          command: riot run -s scripts
 
   ccheck:
     executor: cimg_base
@@ -364,12 +370,6 @@ jobs:
     steps:
       - checkout
       - setup_riot
-      - run:
-          name: "Run riotfile.py tests"
-          command: riot run -s riot-helpers
-      - run:
-          name: "Run scripts/*.py tests"
-          command: riot run -s scripts
       - run:
           name: "Generate base virtual environments."
           # DEV: riot list -i tracer lists all supported Python versions


### PR DESCRIPTION
These were running for each base venv build, taking 1 min each.

This should save 1min of CI time.


## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
