### PR TITLE
chore(ci): move internal version/packaging tests out of tracer test suite

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -262,7 +262,6 @@ venv = Venv(
                     pkgs={
                         "msgpack": latest,
                         "attrs": ["==20.1.0", latest],
-                        "packaging": ["==17.1", latest],
                         "structlog": latest,
                         # httpretty v1.0 drops python 2.7 support
                         "httpretty": "==0.9.7",
@@ -313,6 +312,7 @@ venv = Venv(
             pkgs={
                 "httpretty": "==0.9.7",
                 "gevent": latest,
+                "packaging": ["==17.1", latest],
             },
             env={
                 "DD_REMOTE_CONFIGURATION_ENABLED": "false",

--- a/tests/internal/test_utils_version.py
+++ b/tests/internal/test_utils_version.py
@@ -1,0 +1,29 @@
+import typing
+
+import pytest
+
+from ddtrace.internal.utils.version import parse_version
+
+
+@pytest.mark.parametrize(
+    "version_str,expected",
+    [
+        ("5", (5, 0, 0)),
+        ("0.5", (0, 5, 0)),
+        ("0.5.0", (0, 5, 0)),
+        ("1.0.0", (1, 0, 0)),
+        ("1.2.0", (1, 2, 0)),
+        ("1.2.8", (1, 2, 8)),
+        ("2.0.0rc1", (2, 0, 0)),
+        ("2.0.0-rc1", (2, 0, 0)),
+        ("2.0.0 here be dragons", (2, 0, 0)),
+        ("2020.6.19", (2020, 6, 19)),
+        ("beta 1.0.0", (0, 0, 0)),
+        ("no version found", (0, 0, 0)),
+        ("", (0, 0, 0)),
+    ],
+)
+def test_parse_version(version_str, expected):
+    # type: (str, typing.Tuple[int, int, int]) -> None
+    """Ensure parse_version helper properly parses versions"""
+    assert parse_version(version_str) == expected

--- a/tests/tracer/test_utils.py
+++ b/tests/tracer/test_utils.py
@@ -1,6 +1,5 @@
 from functools import partial
 import sys
-import typing
 import unittest
 
 import mock
@@ -16,7 +15,6 @@ from ddtrace.internal.utils.cache import callonce
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import parse_tags_str
 from ddtrace.internal.utils.importlib import func_name
-from ddtrace.internal.utils.version import parse_version
 
 
 class TestUtils(unittest.TestCase):
@@ -322,30 +320,6 @@ def test_cachedmethod():
             return expensive(key)
 
     cached_test_recipe(expensive, Foo().cheap, witness, cache_size)
-
-
-@pytest.mark.parametrize(
-    "version_str,expected",
-    [
-        ("5", (5, 0, 0)),
-        ("0.5", (0, 5, 0)),
-        ("0.5.0", (0, 5, 0)),
-        ("1.0.0", (1, 0, 0)),
-        ("1.2.0", (1, 2, 0)),
-        ("1.2.8", (1, 2, 8)),
-        ("2.0.0rc1", (2, 0, 0)),
-        ("2.0.0-rc1", (2, 0, 0)),
-        ("2.0.0 here be dragons", (2, 0, 0)),
-        ("2020.6.19", (2020, 6, 19)),
-        ("beta 1.0.0", (0, 0, 0)),
-        ("no version found", (0, 0, 0)),
-        ("", (0, 0, 0)),
-    ],
-)
-def test_parse_version(version_str, expected):
-    # type: (str, typing.Tuple[int, int, int]) -> None
-    """Ensure parse_version helper properly parses versions"""
-    assert parse_version(version_str) == expected
 
 
 i = 0


### PR DESCRIPTION
## Description
This PR moves the internal utils packaging tests out of the tracer test suite and into the internal test suite. This should speed up the tracer test suite by almost half, as this removes `packaging` from the riot tracer venvs.

UPDATE: this decreases the tracer test suite duration from `16 min 58s` to `9 min 16s`. It also increases the internal test suite duration from `3 min 10s` to `4 min 11s`, which is an acceptable tradeoff.

<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
