### PR TITLE
chore(kombu): move kombu tests to riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1073,6 +1073,7 @@ jobs:
       - image: *rabbitmq_image
     steps:
       - run_test:
+          wait: rabbitmq
           pattern: 'kombu'
 
   benchmarks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1072,9 +1072,8 @@ jobs:
       - image: *ddtrace_dev_image
       - image: *rabbitmq_image
     steps:
-      - run_tox_scenario:
-          wait: rabbitmq
-          pattern: '^kombu_contrib-'
+      - run_test:
+          pattern: 'kombu'
 
   benchmarks:
     <<: *contrib_job

--- a/riotfile.py
+++ b/riotfile.py
@@ -2380,5 +2380,55 @@ venv = Venv(
                 ),
             ],
         ),
+        Venv(
+            name="kombu",
+            command="pytest {cmdargs} tests/contrib/kombu",
+            venvs=[
+                Venv(
+                    pys=select_pys(max_version="3.6"),
+                    pkgs={
+                        "kombu": [
+                            ">=4.0,<4.1",
+                            ">=4.1,<4.2",
+                            ">=4.2,<4.3",
+                            ">=4.3,<4.4",
+                            ">=4.4,<4.5",
+                            ">=4.5,<4.6",
+                            ">=4.6,<4.7",
+                            latest,
+                        ],
+                        # kombu using deprecated shims removed in importlib-metadata 5.0 pre-Python 3.8
+                        "importlib_metadata": "<5.0",
+                    },
+                ),
+                # Kombu>=4.2 only supports Python 3.7+
+                Venv(
+                    pys="3.7",
+                    pkgs={
+                        "kombu": [">=4.2,<4.3", ">=4.3,<4.4", ">=4.4,<4.5", ">=4.5,<4.6", ">=4.6,<4.7", latest],
+                        # kombu using deprecated shims removed in importlib-metadata 5.0 pre-Python 3.8
+                        "importlib_metadata": "<5.0",
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version="3.8", max_version="3.9"),
+                    pkgs={
+                        "kombu": [">=4.2,<4.3", ">=4.3,<4.4", ">=4.4,<4.5", ">=4.5,<4.6", ">=4.6,<4.7", latest],
+                    },
+                ),
+                Venv(
+                    pys="3.10",
+                    pkgs={
+                        "kombu": [">=4.3,<4.4", ">=4.4,<4.5", ">=4.5,<4.6", ">=4.6,<4.7", latest],
+                    },
+                ),
+                Venv(
+                    pys="3.11",
+                    pkgs={
+                        "kombu": [">=5.0,<5.1", ">=5.1,<5.2", latest],
+                    },
+                ),
+            ],
+        ),
     ],
 )

--- a/tests/wait-for-services.py
+++ b/tests/wait-for-services.py
@@ -6,7 +6,9 @@ from cassandra.cluster import NoHostAvailable
 from contrib.config import CASSANDRA_CONFIG
 from contrib.config import MYSQL_CONFIG
 from contrib.config import POSTGRES_CONFIG
+from contrib.config import RABBITMQ_CONFIG
 from contrib.config import VERTICA_CONFIG
+import kombu
 import mysql.connector
 from psycopg2 import OperationalError
 from psycopg2 import connect
@@ -73,12 +75,23 @@ def check_vertica():
         conn.close()
 
 
+@try_until_timeout(Exception)
+def check_rabbitmq():
+    url = "amqp://{user}:{password}@{host}:{port}//".format(**RABBITMQ_CONFIG)
+    conn = kombu.Connection(url)
+    try:
+        conn.connect()
+    finally:
+        conn.release()
+
+
 if __name__ == "__main__":
     check_functions = {
         "cassandra": check_cassandra,
         "postgres": check_postgres,
         "mysql": check_mysql,
         "vertica": check_vertica,
+        "rabbitmq": check_rabbitmq,
     }
     if len(sys.argv) >= 2:
         for service in sys.argv[1:]:

--- a/tests/wait-for-services.py
+++ b/tests/wait-for-services.py
@@ -6,9 +6,7 @@ from cassandra.cluster import NoHostAvailable
 from contrib.config import CASSANDRA_CONFIG
 from contrib.config import MYSQL_CONFIG
 from contrib.config import POSTGRES_CONFIG
-from contrib.config import RABBITMQ_CONFIG
 from contrib.config import VERTICA_CONFIG
-import kombu
 import mysql.connector
 from psycopg2 import OperationalError
 from psycopg2 import connect
@@ -75,23 +73,12 @@ def check_vertica():
         conn.close()
 
 
-@try_until_timeout(Exception)
-def check_rabbitmq():
-    url = "amqp://{user}:{password}@{host}:{port}//".format(**RABBITMQ_CONFIG)
-    conn = kombu.Connection(url)
-    try:
-        conn.connect()
-    finally:
-        conn.release()
-
-
 if __name__ == "__main__":
     check_functions = {
         "cassandra": check_cassandra,
         "postgres": check_postgres,
         "mysql": check_mysql,
         "vertica": check_vertica,
-        "rabbitmq": check_rabbitmq,
     }
     if len(sys.argv) >= 2:
         for service in sys.argv[1:]:

--- a/tox.ini
+++ b/tox.ini
@@ -193,6 +193,7 @@ deps=
     psycopg2
     mysql-connector-python!=8.0.18
     vertica-python>=0.6.0,<0.7.0
+    kombu>=4.2.0,<4.3.0
 
 # this is somewhat flaky (can fail and still be up) so try the tests anyway
 ignore_outcome=true

--- a/tox.ini
+++ b/tox.ini
@@ -28,11 +28,6 @@ envlist =
     algoliasearch_contrib-py{27,35,36,37,38,39,310,311}-algoliasearch{1,2,}
     bottle_contrib{,_autopatch}-py{27,35,36,37,38,39}-bottle{11,12,}-webtest
     bottle_contrib{,_autopatch}-py{310,311}-bottle-webtest
-    kombu_contrib-py{27,35,36}-kombu{40,41,42,43,44,45,46,}
-# Kombu >= 4.2 only supports Python 3.7+
-    kombu_contrib-py{37,38,39}-kombu{42,43,44,45,46,}
-    kombu_contrib-py{310}-kombu{43,44,45,46,}
-    kombu_contrib-py{311}-kombu{50,51,}
     molten_contrib-py{36,37,38,39,310,311}-molten{06,07,10,}
     mysqldb_contrib-py{27,35,36,37,38,39}-mysqlclient{13,14,}
     mysqldb_contrib-py{310,311}-mysqlclient{14,}
@@ -136,18 +131,6 @@ deps =
     # Note -  gevent<20.12 does not set a maximum supported version.
     # To test with gevent<20.12 we need to manually install greenlet<2.
     greenlet1: greenlet>=1,<2
-    # kombu using deprecated shims removed in importlib-metadata 5.0
-    kombu{40,41,42,43,44,45,46,}: importlib_metadata<5.0; python_version<'3.8'
-    kombu: kombu
-    kombu40: kombu>=4.0,<4.1
-    kombu41: kombu>=4.1,<4.2
-    kombu42: kombu>=4.2,<4.3
-    kombu43: kombu>=4.3,<4.4
-    kombu44: kombu>=4.4,<4.5
-    kombu45: kombu>=4.5,<4.6
-    kombu46: kombu>=4.6,<4.7
-    kombu50: kombu>=5.0,<5.1
-    kombu51: kombu>=5.1,<5.2
     memcached: python-memcached
     moto: moto
     moto1: moto>=1,<2
@@ -199,7 +182,6 @@ commands =
     molten_contrib: python -m pytest {posargs} tests/contrib/molten
     mysql_contrib: python -m pytest {posargs} tests/contrib/mysql
     mysqldb_contrib: python -m pytest {posargs} tests/contrib/mysqldb
-    kombu_contrib: python -m pytest {posargs} tests/contrib/kombu
     tornado_contrib: python -m pytest {posargs} tests/contrib/tornado
     vertica_contrib: python -m pytest {posargs} tests/contrib/vertica/
 
@@ -211,7 +193,6 @@ deps=
     psycopg2
     mysql-connector-python!=8.0.18
     vertica-python>=0.6.0,<0.7.0
-    kombu>=4.2.0,<4.3.0
 
 # this is somewhat flaky (can fail and still be up) so try the tests anyway
 ignore_outcome=true


### PR DESCRIPTION
## Description
The kombu tests with tox are currently one of the longer running jobs on CI. By moving to riot, the goal is to further decrease the time spent running tests on CI.

Update: moving kombu from tox to riot decreased the test duration from >13 min to 2 minutes.

Also worth noting that the `wait-for-services.py` job on CI has not been properly running for quite some time now with import errors, but they've been silently failing. ~I've removed the kombu-relevant job for now.~ This is fixed in #4639.

<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
