### PR TITLE
chore(ci): add missing dependency in wait-for-service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ commands:
                   - setup_tox
                   - run:
                       name: "Waiting for << parameters.wait >>"
-                      command: tox -e 'wait' << parameters.wait >>
+                      command: riot -v run 'wait' << parameters.wait >>
             - setup_riot
             - run:
                 command: "riot list -i '<<parameters.pattern>>' | circleci tests split | xargs -I PY riot -v run --python=PY --exitfirst --pass-env -s '<< parameters.pattern >>'"
@@ -203,7 +203,7 @@ commands:
           steps:
             - run:
                 name: "Waiting for << parameters.wait >>"
-                command: tox -e 'wait' << parameters.wait >>
+                command: riot -v run 'wait' << parameters.wait >>
       - start_docker_services:
           env: SNAPSHOT_CI=1
           services: memcached redis testagent
@@ -235,7 +235,7 @@ commands:
           steps:
             - run:
                 name: "Waiting for << parameters.wait >>"
-                command: tox -e 'wait' << parameters.wait >>
+                command: riot -v run 'wait' << parameters.wait >>
       - run:
           name: "Run scripts/run-tox-scenario"
           command: scripts/run-tox-scenario '<< parameters.pattern >>'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,15 +164,15 @@ commands:
           condition:
               << parameters.snapshot >>
           steps:
+            - setup_riot
             - when:
                 condition:
                   << parameters.wait >>
                 steps:
-                  - setup_tox
                   - run:
                       name: "Waiting for << parameters.wait >>"
                       command: riot -v run 'wait' << parameters.wait >>
-            - setup_riot
+
             - run:
                 command: "riot list -i '<<parameters.pattern>>' | circleci tests split | xargs -I PY riot -v run --python=PY --exitfirst --pass-env -s '<< parameters.pattern >>'"
       - save_pip_cache
@@ -201,6 +201,7 @@ commands:
           condition:
             << parameters.wait >>
           steps:
+            - setup_riot
             - run:
                 name: "Waiting for << parameters.wait >>"
                 command: riot -v run 'wait' << parameters.wait >>
@@ -233,6 +234,7 @@ commands:
           condition:
             << parameters.wait >>
           steps:
+            - setup_riot
             - run:
                 name: "Waiting for << parameters.wait >>"
                 command: riot -v run 'wait' << parameters.wait >>

--- a/riotfile.py
+++ b/riotfile.py
@@ -435,7 +435,7 @@ venv = Venv(
             pys="3.9",
             pkgs={
                 "cassandra-driver": latest,
-                "psycopg2": latest,
+                "psycopg2-binary": latest,
                 "mysql-connector-python": "!=8.0.18",
                 "vertica-python": ">=0.6.0,<0.7.0",
                 "kombu": ">=4.2.0,<4.3.0",

--- a/riotfile.py
+++ b/riotfile.py
@@ -432,6 +432,7 @@ venv = Venv(
         Venv(
             name="wait",
             command="python tests/wait-for-services.py {cmdargs}",
+            # Default Python 3 (3.10) collections package breaks with kombu/vertica, so specify Python 3.9 instead.
             pys="3.9",
             pkgs={
                 "cassandra-driver": latest,

--- a/riotfile.py
+++ b/riotfile.py
@@ -430,6 +430,18 @@ venv = Venv(
             },
         ),
         Venv(
+            name="wait",
+            command="python tests/wait-for-services.py {cmdargs}",
+            pys="3.9",
+            pkgs={
+                "cassandra-driver": latest,
+                "psycopg2": latest,
+                "mysql-connector-python": "!=8.0.18",
+                "vertica-python": ">=0.6.0,<0.7.0",
+                "kombu": ">=4.2.0,<4.3.0",
+            },
+        ),
+        Venv(
             name="httplib",
             command="pytest {cmdargs} tests/contrib/httplib",
             pys=select_pys(),

--- a/tox.ini
+++ b/tox.ini
@@ -202,17 +202,3 @@ commands =
     kombu_contrib: python -m pytest {posargs} tests/contrib/kombu
     tornado_contrib: python -m pytest {posargs} tests/contrib/tornado
     vertica_contrib: python -m pytest {posargs} tests/contrib/vertica/
-
-[testenv:wait]
-skip_install=true
-commands=python tests/wait-for-services.py {posargs}
-basepython=python3.9
-deps=
-    cassandra-driver
-    psycopg2
-    mysql-connector-python!=8.0.18
-    vertica-python>=0.6.0,<0.7.0
-    kombu>=4.2.0,<4.3.0
-
-# this is somewhat flaky (can fail and still be up) so try the tests anyway
-ignore_outcome=true

--- a/tox.ini
+++ b/tox.ini
@@ -208,6 +208,7 @@ skip_install=true
 commands=python tests/wait-for-services.py {posargs}
 basepython=python
 deps=
+    cassandra-driver
     psycopg2
     mysql-connector-python!=8.0.18
     vertica-python>=0.6.0,<0.7.0

--- a/tox.ini
+++ b/tox.ini
@@ -206,7 +206,7 @@ commands =
 [testenv:wait]
 skip_install=true
 commands=python tests/wait-for-services.py {posargs}
-basepython=python
+basepython=python3.9
 deps=
     cassandra-driver
     psycopg2


### PR DESCRIPTION
## Description
The `wait-for-services` job has been silently failing on CI since cassandra was moved from tox to riot and the cassandra dependency removed from the `wait-for-services` job. This has potentially caused kombu/cassandra/psycopg/mysql/vertica test suites to be flaky.

I've moved this `wait-for-service` job to riot, and also set the python runner for this job to Python 3.9, as cassandra is incompatible with Python 3.10 onward.

<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
