### PR TITLE
chore(ci): move tornado tests to riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -623,8 +623,8 @@ jobs:
   tornado:
     <<: *contrib_job
     steps:
-      - run_tox_scenario:
-          pattern: '^tornado_contrib-'
+      - run_test:
+          pattern: 'tornado'
 
   bottle:
     <<: *contrib_job

--- a/riotfile.py
+++ b/riotfile.py
@@ -2380,5 +2380,33 @@ venv = Venv(
                 ),
             ],
         ),
+        Venv(
+            name="tornado",
+            command="python -m pytest {cmdargs} tests/contrib/tornado",
+            venvs=[
+                Venv(
+                    pys="2.7",
+                    pkgs={"tornado": [">=4.4,<4.5", ">=4.5,<4.6"], "futures": ["~=3.0", "~=3.1", "~=3.2", latest]},
+                ),
+                Venv(
+                    pys=select_pys(max_version="3.9"),
+                    pkgs={
+                        "tornado": [">=4.4,<4.5", ">=4.5,<4.6"],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version="3.7", max_version="3.9"),
+                    pkgs={
+                        "tornado": [">=5.0,<5.1", ">=5.1,<5.2", ">=6.0,<6.1", latest],
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version="3.10", max_version="3.11"),
+                    pkgs={
+                        "tornado": [">=6.0,<6.1", latest],
+                    },
+                ),
+            ],
+        ),
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -42,10 +42,6 @@ envlist =
     pymongo_contrib-py{38,39,310,311}-pymongo{30,31,32,33,35,36,37,38,39,310,}-mongoengine
     pynamodb_contrib-py{27,35,36,37,38,39,310,311}-pynamodb{40,41,42,43,}-moto1
     pyodbc_contrib-py{27,35,36,37,38,39}-pyodbc{3,4}
-    tornado_contrib-py{27,35,36,37,38,39}-tornado{44,45}
-    tornado_contrib-py{37,38,39}-tornado{50,51,60,}
-    tornado_contrib-py{310,311}-tornado{60,}
-    tornado_contrib-py27-tornado{44,45}-futures{30,31,32,}
     vertica_contrib-py{27,35,36,37,38,39}-vertica{060,070}
 
 isolated_build = true
@@ -164,12 +160,6 @@ deps =
     redis: redis
     redis210: redis>=2.10,<2.11
     sqlalchemy: sqlalchemy
-    tornado: tornado
-    tornado44: tornado>=4.4,<4.5
-    tornado45: tornado>=4.5,<4.6
-    tornado50: tornado>=5.0,<5.1
-    tornado51: tornado>=5.1,<5.2
-    tornado60: tornado>=6.0,<6.1
     vertica060: vertica-python>=0.6.0,<0.7.0
     vertica070: vertica-python>=0.7.0,<0.8.0
     webtest: WebTest
@@ -200,7 +190,6 @@ commands =
     mysql_contrib: python -m pytest {posargs} tests/contrib/mysql
     mysqldb_contrib: python -m pytest {posargs} tests/contrib/mysqldb
     kombu_contrib: python -m pytest {posargs} tests/contrib/kombu
-    tornado_contrib: python -m pytest {posargs} tests/contrib/tornado
     vertica_contrib: python -m pytest {posargs} tests/contrib/vertica/
 
 [testenv:wait]


### PR DESCRIPTION
## Description
The tornado tests with tox are currently one of the longer running jobs on CI. By moving to riot, the goal is to further decrease the time spent running tests on CI.

Update: moving tornado from tox to riot decreased the test duration from >18 min to 3 minutes.


<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
