### PR TITLE
chore(ci): move bottle tests to riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -629,8 +629,8 @@ jobs:
   bottle:
     <<: *contrib_job
     steps:
-      - run_tox_scenario:
-          pattern: '^bottle_contrib\(_autopatch\)\?-'
+      - run_test:
+          pattern: 'bottle'
 
   cassandra:
     <<: *contrib_job

--- a/riotfile.py
+++ b/riotfile.py
@@ -480,6 +480,39 @@ venv = Venv(
             ],
         ),
         Venv(
+            name="bottle",
+            pkgs={"WebTest": latest},
+            venvs=[
+                Venv(
+                    command="pytest {cmdargs} --ignore='tests/contrib/bottle/test_autopatch.py' tests/contrib/bottle/",
+                    venvs=[
+                        Venv(
+                            pys=select_pys(max_version="3.9"),
+                            pkgs={"bottle": [">=0.11,<0.12", ">=0.12,<0.13", latest]},
+                        ),
+                        Venv(
+                            pys=select_pys(min_version="3.10"),
+                            pkgs={"bottle": latest},
+                        ),
+                    ],
+                ),
+                Venv(
+                    command="python tests/ddtrace_run.py pytest {cmdargs} tests/contrib/bottle/test_autopatch.py",
+                    env={"DD_SERVICE": "bottle-app"},
+                    venvs=[
+                        Venv(
+                            pys=select_pys(max_version="3.9"),
+                            pkgs={"bottle": [">=0.11,<0.12", ">=0.12,<0.13", latest]},
+                        ),
+                        Venv(
+                            pys=select_pys(min_version="3.10"),
+                            pkgs={"bottle": latest},
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        Venv(
             name="celery",
             command="pytest {cmdargs} tests/contrib/celery",
             pkgs={"more_itertools": "<8.11.0"},

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,6 @@ envlist =
     py{27,35,36,37,38,39,310,311}-tracer_test_http
 # Integrations environments
     algoliasearch_contrib-py{27,35,36,37,38,39,310,311}-algoliasearch{1,2,}
-    bottle_contrib{,_autopatch}-py{27,35,36,37,38,39}-bottle{11,12,}-webtest
-    bottle_contrib{,_autopatch}-py{310,311}-bottle-webtest
     kombu_contrib-py{27,35,36}-kombu{40,41,42,43,44,45,46,}
 # Kombu >= 4.2 only supports Python 3.7+
     kombu_contrib-py{37,38,39}-kombu{42,43,44,45,46,}
@@ -67,7 +65,6 @@ setenv =
     DD_TESTING_RAISE=1
     DD_REMOTE_CONFIGURATION_ENABLED=false
     profile-gevent: DD_PROFILE_TEST_GEVENT=1
-    bottle_contrib_autopatch: DD_SERVICE=bottle-app
 
 extras =
   profile: profiling
@@ -117,9 +114,6 @@ deps =
     algoliasearch1: algoliasearch>=1.2,<2
     algoliasearch2: algoliasearch>=2,<3
     blinker: blinker
-    bottle: bottle
-    bottle11: bottle>=0.11,<0.12
-    bottle12: bottle>=0.12,<0.13
     futures: futures
     futures30: futures>=3.0,<3.1
     futures31: futures>=3.1,<3.2
@@ -194,8 +188,6 @@ commands =
     py3{5,6,7,8,9,10}-profile: python -m tests.profiling.run pytest --no-cov --capture=no --verbosity=2 --benchmark-disable {posargs} tests/profiling
 # Contribs
     algoliasearch_contrib: python -m pytest {posargs} tests/contrib/algoliasearch
-    bottle_contrib: python -m pytest {posargs} --ignore="tests/contrib/bottle/test_autopatch.py" tests/contrib/bottle/
-    bottle_contrib_autopatch: python tests/ddtrace_run.py pytest {posargs} tests/contrib/bottle/test_autopatch.py
     molten_contrib: python -m pytest {posargs} tests/contrib/molten
     mysql_contrib: python -m pytest {posargs} tests/contrib/mysql
     mysqldb_contrib: python -m pytest {posargs} tests/contrib/mysqldb


### PR DESCRIPTION
## Description
The bottle tests with tox are currently one of the longer running jobs on CI. By moving to riot, the goal is to further decrease the time spent running tests on CI.

Update: moving tornado from tox to riot decreased the test duration from >18 min to 3 minutes.


<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
