### PR TITLE
chore(framework tests): add uwsgi framework test suite

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -484,6 +484,8 @@ jobs:
           PYTHON_VERSION=python${PYTHON_VERSION//.}
           /usr/bin/python3 -V
           /usr/bin/python3 uwsgiconfig.py --plugin plugins/python base $PYTHON_VERSION
-      - name: Run tests
+      - name: Run Python tests
         run: |
           ddtrace-run ./tests/gh-python.sh python39
+      - name: Run deadlock tests
+          ddtrace-run ./tests/gh-deadlocks.sh python39

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -450,6 +450,7 @@ jobs:
     runs-on: "ubuntu-18.04"
     env:
       DD_TESTING_RAISE: true
+      DD_PROFILING_ENABLED: true
       PYTHONPATH: ../ddtrace/tests/debugging/exploration/
     defaults:
       run:
@@ -464,7 +465,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: unbit/uwsgi
-          ref: master
+          ref: 2.0.21
           path: uwsgi
       - name: Install dependencies
         run: |
@@ -480,12 +481,9 @@ jobs:
         run: make
       - name: Build Python plugin
         run: |
-          PYTHON_VERSION=3.9
-          PYTHON_VERSION=python${PYTHON_VERSION//.}
-          /usr/bin/python3 -V
-          /usr/bin/python3 uwsgiconfig.py --plugin plugins/python base $PYTHON_VERSION
+          python -V
+          python uwsgiconfig.py --plugin plugins/python base python39
       - name: Run Python tests
-        run: |
-          ddtrace-run ./tests/gh-python.sh python39
+        run: ddtrace-run ./tests/gh-python.sh python39
       - name: Run deadlock tests
-          ddtrace-run ./tests/gh-deadlocks.sh python39
+        run: ddtrace-run ./tests/gh-deadlocks.sh python39

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -444,3 +444,46 @@ jobs:
           
           pip install -e .
           pytest -p no:warnings -k "not test_import" tests/
+
+  uwsgi-testsuite-2_0_21:
+    name: uwsgi 2.0.21
+    runs-on: "ubuntu-18.04"
+    env:
+      DD_TESTING_RAISE: true
+      PYTHONPATH: ../ddtrace/tests/debugging/exploration/
+    defaults:
+      run:
+        working-directory: uwsgi
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - uses: actions/checkout@v2
+        with:
+          path: ddtrace
+      - uses: actions/checkout@v2
+        with:
+          repository: unbit/uwsgi
+          ref: master
+          path: uwsgi
+      - name: Install dependencies
+        run: |
+          sudo apt update -qq
+          sudo apt install --no-install-recommends -qqyf python3-dev \
+            libpcre3-dev libjansson-dev libcap2-dev \
+            curl check
+      - name: Install distutils
+        run: sudo apt install --no-install-recommends -qqyf python3-distutils
+      - name: Install ddtrace
+        run: pip install ../ddtrace
+      - name: Build uwsgi binary
+        run: make
+      - name: Build Python plugin
+        run: |
+          PYTHON_VERSION=3.9
+          PYTHON_VERSION=python${PYTHON_VERSION//.}
+          /usr/bin/python3 -V
+          /usr/bin/python3 uwsgiconfig.py --plugin plugins/python base $PYTHON_VERSION
+      - name: Run tests
+        run: |
+          ddtrace-run ./tests/gh-python.sh python39


### PR DESCRIPTION
## Description
Adding the uwsgi test suite to the framework tests in CI to have better test support for gevent.

<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
