### PR TITLE
chore(ci): move molten test suite to riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -798,8 +798,8 @@ jobs:
   molten:
     <<: *contrib_job
     steps:
-      - run_tox_scenario:
-          pattern: '^molten_contrib-'
+      - run_test:
+          pattern: 'molten'
 
   mysqlconnector:
     <<: *contrib_job

--- a/riotfile.py
+++ b/riotfile.py
@@ -2522,5 +2522,13 @@ venv = Venv(
                 ),
             ],
         ),
+        Venv(
+            name="molten",
+            command="pytest {cmdargs} tests/contrib/molten",
+            pys=select_pys(min_version="3.6"),
+            pkgs={
+                "molten": [">=0.6,<0.7", ">=0.7,<0.8", ">=1.0,<1.1", latest],
+            },
+        ),
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ envlist =
     py{27,35,36,37,38,39,310,311}-tracer_test_http
 # Integrations environments
     algoliasearch_contrib-py{27,35,36,37,38,39,310,311}-algoliasearch{1,2,}
-    molten_contrib-py{36,37,38,39,310,311}-molten{06,07,10,}
     pymongo_contrib-py{27,35,36,37}-pymongo{30,31,32,33,34,35,36,37,38,39,310,}-mongoengine
 # pymongo does not yet support Python 3.8: https://github.com/pymssql/pymssql/issues/586
 # but these tests still work.
@@ -122,10 +121,6 @@ deps =
     memcached: python-memcached
     moto: moto
     moto1: moto>=1,<2
-    molten: molten
-    molten06: molten>=0.6,<0.7
-    molten07: molten>=0.7,<0.8
-    molten10: molten>=1.0,<1.1
     mongoengine: mongoengine
     pytest: pytest>=3
     pytest3: pytest>=3.0,<4.0
@@ -156,5 +151,4 @@ commands =
     py3{5,6,7,8,9,10}-profile: python -m tests.profiling.run pytest --no-cov --capture=no --verbosity=2 --benchmark-disable {posargs} tests/profiling
 # Contribs
     algoliasearch_contrib: python -m pytest {posargs} tests/contrib/algoliasearch
-    molten_contrib: python -m pytest {posargs} tests/contrib/molten
     vertica_contrib: python -m pytest {posargs} tests/contrib/vertica/


### PR DESCRIPTION
## Description
The molten tests are currently one of the longer running jobs on CI. By moving the test suite to riot from tox, the goal is to further decrease the time spent running tests on CI.

Update: moving molten to riot decreased the test duration from >10 min to 3 minutes.

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
