### PR TITLE
ci(algoliasearch): move algoliasearch tests to riot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1101,8 +1101,8 @@ jobs:
   algoliasearch:
     <<: *contrib_job
     steps:
-      - run_tox_scenario:
-          pattern: '^algoliasearch_contrib-'
+      - run_test:
+          pattern: 'algoliasearch'
 
   build_docs:
     # build documentation and store as an artifact

--- a/riotfile.py
+++ b/riotfile.py
@@ -1861,6 +1861,14 @@ venv = Venv(
             command="pytest {cmdargs} tests/contrib/cassandra",
         ),
         Venv(
+            name="algoliasearch",
+            pys=select_pys(),
+            command="pytest {cmdargs} tests/contrib/algoliasearch",
+            pkgs={
+                "algoliasearch": [">=1.2,<2", ">=2,<3", latest],
+            },
+        ),
+        Venv(
             name="aiopg",
             venvs=[
                 Venv(

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ envlist =
     # We'll skip the test_http.py tests in riot and run them separately here through tox in CI.
     py{27,35,36,37,38,39,310,311}-tracer_test_http
 # Integrations environments
-    algoliasearch_contrib-py{27,35,36,37,38,39,310,311}-algoliasearch{1,2,}
     molten_contrib-py{36,37,38,39,310,311}-molten{06,07,10,}
     pymongo_contrib-py{27,35,36,37}-pymongo{30,31,32,33,34,35,36,37,38,39,310,}-mongoengine
 # pymongo does not yet support Python 3.8: https://github.com/pymssql/pymssql/issues/586
@@ -99,9 +98,6 @@ deps =
 # backports
     py27: enum34
 # integrations
-    algoliasearch: algoliasearch
-    algoliasearch1: algoliasearch>=1.2,<2
-    algoliasearch2: algoliasearch>=2,<3
     blinker: blinker
     futures: futures
     futures30: futures>=3.0,<3.1
@@ -155,6 +151,5 @@ commands =
     # Coverage is excluded from profile because of an issue with Python 3.5.
     py3{5,6,7,8,9,10}-profile: python -m tests.profiling.run pytest --no-cov --capture=no --verbosity=2 --benchmark-disable {posargs} tests/profiling
 # Contribs
-    algoliasearch_contrib: python -m pytest {posargs} tests/contrib/algoliasearch
     molten_contrib: python -m pytest {posargs} tests/contrib/molten
     vertica_contrib: python -m pytest {posargs} tests/contrib/vertica/


### PR DESCRIPTION
## Description
The algoliasearch tests are currently one of the longer running jobs on CI. By moving the test suite to riot from tox, the goal is to further decrease the time spent running tests on CI.

Update: moving algoliasearch to riot decreased the test duration from >13 min to 5 minutes.


## Checklist
- [x] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
