### PR TITLE
chore(redis): replace set_tag usages with set_tag_str

### DIFF
--- a/ddtrace/contrib/redis/util.py
+++ b/ddtrace/contrib/redis/util.py
@@ -40,7 +40,7 @@ def _trace_redis_cmd(pin, config_integration, instance, args):
         span.set_tag(SPAN_MEASURED_KEY)
         query = stringify_cache_args(args)
         span.resource = query
-        span.set_tag(redisx.RAWCMD, query)
+        span.set_tag_str(redisx.RAWCMD, query)
         if pin.tags:
             span.set_tags(pin.tags)
         # some redis clients do not have a connection_pool attribute (ex. aioredis v1.3)
@@ -62,7 +62,7 @@ def _trace_redis_execute_pipeline(pin, config_integration, resource, instance):
         span_type=SpanTypes.REDIS,
     ) as span:
         span.set_tag(SPAN_MEASURED_KEY)
-        span.set_tag(redisx.RAWCMD, resource)
+        span.set_tag_str(redisx.RAWCMD, resource)
         span.set_tags(_extract_conn_tags(instance.connection_pool.connection_kwargs))
         span.set_metric(redisx.PIPELINE_LEN, len(instance.command_stack))
         # set analytics sample rate if enabled


### PR DESCRIPTION
## Description
Replacing usages of set_tag() that are known to work only with text arguments to set_tag_str() in the redis integration. This should provide a performance benefit as set_tag_str() bypasses the unnecessary type checking that occurs in set_tag().


<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
