### PR TITLE
chore(rq): replace set_tag usages with set_tag_str

### DIFF
--- a/ddtrace/contrib/rq/__init__.py
+++ b/ddtrace/contrib/rq/__init__.py
@@ -131,7 +131,7 @@ def traced_queue_enqueue_job(rq, pin, func, instance, args, kwargs):
         span_type=SpanTypes.WORKER,
     ) as span:
         span.set_tag_str("queue.name", instance.name)
-        span.set_tag("job.id", job.get_id())
+        span.set_tag_str("job.id", job.get_id())
         span.set_tag_str("job.func_name", job.func_name)
 
         # If the queue is_async then add distributed tracing headers to the job
@@ -144,7 +144,7 @@ def traced_queue_enqueue_job(rq, pin, func, instance, args, kwargs):
 def traced_queue_fetch_job(rq, pin, func, instance, args, kwargs):
     with pin.tracer.trace("rq.queue.fetch_job", service=trace_utils.int_service(pin, config.rq)) as span:
         job_id = get_argument_value(args, kwargs, 0, "job_id")
-        span.set_tag("job.id", job_id)
+        span.set_tag_str("job.id", job_id)
         return func(*args, **kwargs)
 
 
@@ -166,12 +166,12 @@ def traced_perform_job(rq, pin, func, instance, args, kwargs):
             span_type=SpanTypes.WORKER,
             resource=job.func_name,
         ) as span:
-            span.set_tag("job.id", job.get_id())
+            span.set_tag_str("job.id", job.get_id())
             try:
                 return func(*args, **kwargs)
             finally:
-                span.set_tag("job.status", job.get_status())
-                span.set_tag("job.origin", job.origin)
+                span.set_tag_str("job.status", job.get_status())
+                span.set_tag_str("job.origin", job.origin)
                 if job.is_failed:
                     span.error = 1
     finally:


### PR DESCRIPTION
## Description
Replacing usages of set_tag() that are known to work only with text arguments to set_tag_str() in the rq integration. This should provide a performance benefit as set_tag_str() bypasses the unnecessary type checking that occurs in set_tag().


<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
