### PR TITLE
chore(kombu): replace set_tag usages with set_tag_str

### DIFF
--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -97,10 +97,10 @@ def traced_receive(func, instance, args, kwargs):
         # run the command
         exchange = message.delivery_info["exchange"]
         s.resource = exchange
-        s.set_tag(kombux.EXCHANGE, exchange)
+        s.set_tag_str(kombux.EXCHANGE, exchange)
 
         s.set_tags(extract_conn_tags(message.channel.connection))
-        s.set_tag(kombux.ROUTING_KEY, message.delivery_info["routing_key"])
+        s.set_tag_str(kombux.ROUTING_KEY, message.delivery_info["routing_key"])
         # set analytics sample rate
         s.set_tag(ANALYTICS_SAMPLE_RATE_KEY, config.kombu.get_analytics_sample_rate())
         return func(*args, **kwargs)
@@ -115,10 +115,10 @@ def traced_publish(func, instance, args, kwargs):
         s.set_tag(SPAN_MEASURED_KEY)
         exchange_name = get_exchange_from_args(args)
         s.resource = exchange_name
-        s.set_tag(kombux.EXCHANGE, exchange_name)
+        s.set_tag_str(kombux.EXCHANGE, exchange_name)
         if pin.tags:
             s.set_tags(pin.tags)
-        s.set_tag(kombux.ROUTING_KEY, get_routing_key_from_args(args))
+        s.set_tag_str(kombux.ROUTING_KEY, get_routing_key_from_args(args))
         s.set_tags(extract_conn_tags(instance.channel.connection))
         s.set_metric(kombux.BODY_LEN, get_body_length_from_args(args))
         # set analytics sample rate


### PR DESCRIPTION
## Description
Replacing usages of set_tag() that are known to work only with text arguments to set_tag_str() in the kombu integration. This should provide a performance benefit as set_tag_str() bypasses the unnecessary type checking that occurs in set_tag().


<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
