### PR TITLE
chore(molten): replace set_tag usage with set_tag_str

### DIFF
--- a/ddtrace/contrib/molten/patch.py
+++ b/ddtrace/contrib/molten/patch.py
@@ -131,7 +131,7 @@ def patch_app_call(wrapped, instance, args, kwargs):
             span, config.molten, method=request.method, url=url, query=query, request_headers=request.headers
         )
 
-        span.set_tag("molten.version", molten.__version__)
+        span.set_tag_str("molten.version", molten.__version__)
         return wrapped(environ, start_response, **kwargs)
 
 


### PR DESCRIPTION
## Description
Replacing usages of set_tag() that are known to work only with text arguments to set_tag_str() in the molten integration. This should provide a performance benefit as set_tag_str() bypasses the unnecessary type checking that occurs in set_tag().


<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
