### PR TITLE
fix(botocore): fix inclusion of lambda params.ClientContext tag

### DIFF
--- a/ddtrace/ext/aws.py
+++ b/ddtrace/ext/aws.py
@@ -15,6 +15,7 @@ EXCLUDED_ENDPOINT = frozenset({"kms", "sts", "sns", "kinesis", "events"})
 EXCLUDED_ENDPOINT_TAGS = {
     "firehose": frozenset({"params.Records"}),
     "secretsmanager": frozenset({"params.SecretString", "params.SecretBinary"}),
+    "lambda": frozenset({"params.ClientContext"}),
 }
 
 

--- a/releasenotes/notes/exclude-lambda-client-context-param-30c361694f41d3b6.yaml
+++ b/releasenotes/notes/exclude-lambda-client-context-param-30c361694f41d3b6.yaml
@@ -1,29 +1,4 @@
 ---
-#instructions:
-#    The style guide below provides explanations, instructions, and templates to write your own release note.
-#    Once finished, all irrelevant sections (including this instruction section) should be removed,
-#    and the release note should be committed with the rest of the changes.
-#
-#    The main goal of a release note is to provide a brief overview of a change and provide actionable steps to the user.
-#    The release note should clearly communicate what the change is, why the change was made, and how a user can migrate their code.
-#
-#    The release note should also clearly distinguish between announcements and user instructions. Use:
-#    * Past tense for previous/existing behavior (ex: ``resulted, caused, failed``)
-#    * Third person present tense for the change itself (ex: ``adds, fixes, upgrades``)
-#    * Active present infinitive for user instructions (ex: ``set, use, add``)
-#
-#    Release notes should:
-#    * Use plain language
-#    * Be concise
-#    * Include actionable steps with the necessary code changes
-#    * Include relevant links (bug issues, upstream issues or release notes, documentation pages)
-#    * Use full sentences with sentence-casing and punctuation.
-#    * Before using Datadog specific acronyms/terminology, a release note must first introduce them with a definition.
-#
-#    Release notes should not:
-#    * Be vague. Example: ``fixes an issue in tracing``.
-#    * Use overly technical language
-#    * Use dynamic links (``stable/latest/1.x`` URLs). Instead, use static links (specific version, commit hash) whenever possible so that they don't break in the future.
 fixes:
   - |
     botocore: This fix will not longer include ``params.ClientContext`` tag for ``lambda`` endpoint calls.

--- a/releasenotes/notes/exclude-lambda-client-context-param-30c361694f41d3b6.yaml
+++ b/releasenotes/notes/exclude-lambda-client-context-param-30c361694f41d3b6.yaml
@@ -1,0 +1,29 @@
+---
+#instructions:
+#    The style guide below provides explanations, instructions, and templates to write your own release note.
+#    Once finished, all irrelevant sections (including this instruction section) should be removed,
+#    and the release note should be committed with the rest of the changes.
+#
+#    The main goal of a release note is to provide a brief overview of a change and provide actionable steps to the user.
+#    The release note should clearly communicate what the change is, why the change was made, and how a user can migrate their code.
+#
+#    The release note should also clearly distinguish between announcements and user instructions. Use:
+#    * Past tense for previous/existing behavior (ex: ``resulted, caused, failed``)
+#    * Third person present tense for the change itself (ex: ``adds, fixes, upgrades``)
+#    * Active present infinitive for user instructions (ex: ``set, use, add``)
+#
+#    Release notes should:
+#    * Use plain language
+#    * Be concise
+#    * Include actionable steps with the necessary code changes
+#    * Include relevant links (bug issues, upstream issues or release notes, documentation pages)
+#    * Use full sentences with sentence-casing and punctuation.
+#    * Before using Datadog specific acronyms/terminology, a release note must first introduce them with a definition.
+#
+#    Release notes should not:
+#    * Be vague. Example: ``fixes an issue in tracing``.
+#    * Use overly technical language
+#    * Use dynamic links (``stable/latest/1.x`` URLs). Instead, use static links (specific version, commit hash) whenever possible so that they don't break in the future.
+fixes:
+  - |
+    botocore: This fix will not longer include ``params.ClientContext`` tag for ``lambda`` endpoint calls.


### PR DESCRIPTION
## Description
`params.ClientContext` is being included by default for calls to Lambda Invoke command. This is potentially sensitive data and should not be included by default.

This change adds `params.ClientContext` to the exclusion list for `lambda` spans.

## Relevant issue(s)

N/A

## Testing strategy

TODO

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
