### PR TITLE
chore(dogpile_cache): replace set_tag usage with set_tag_str

### DIFF
--- a/ddtrace/contrib/dogpile_cache/region.py
+++ b/ddtrace/contrib/dogpile_cache/region.py
@@ -15,9 +15,9 @@ def _wrap_get_create(func, instance, args, kwargs):
     key = get_argument_value(args, kwargs, 0, "key")
     with pin.tracer.trace("dogpile.cache", resource="get_or_create", span_type=SpanTypes.CACHE) as span:
         span.set_tag(SPAN_MEASURED_KEY)
-        span.set_tag("key", key)
-        span.set_tag("region", instance.name)
-        span.set_tag("backend", instance.actual_backend.__class__.__name__)
+        span.set_tag_str("key", key)
+        span.set_tag_str("region", instance.name)
+        span.set_tag_str("backend", instance.actual_backend.__class__.__name__)
         return func(*args, **kwargs)
 
 
@@ -29,7 +29,7 @@ def _wrap_get_create_multi(func, instance, args, kwargs):
     keys = get_argument_value(args, kwargs, 0, "keys")
     with pin.tracer.trace("dogpile.cache", resource="get_or_create_multi", span_type="cache") as span:
         span.set_tag(SPAN_MEASURED_KEY)
-        span.set_tag("keys", keys)
-        span.set_tag("region", instance.name)
-        span.set_tag("backend", instance.actual_backend.__class__.__name__)
+        span.set_tag_str("keys", keys)
+        span.set_tag_str("region", instance.name)
+        span.set_tag_str("backend", instance.actual_backend.__class__.__name__)
         return func(*args, **kwargs)


### PR DESCRIPTION
## Description
Replacing usages of set_tag() that are known to work only with text arguments to set_tag_str() in our dogpile_cache integration. This should provide a performance benefit as set_tag_str() bypasses the unnecessary type checking that occurs in set_tag().


<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
