### PR TITLE
chore(celery): replace set_tag usage with set_tag_str

### DIFF
--- a/ddtrace/contrib/celery/signals.py
+++ b/ddtrace/contrib/celery/signals.py
@@ -69,7 +69,7 @@ def trace_postrun(*args, **kwargs):
         return
     else:
         # request context tags
-        span.set_tag(c.TASK_TAG_KEY, c.TASK_RUN)
+        span.set_tag_str(c.TASK_TAG_KEY, c.TASK_RUN)
         set_tags_from_context(span, kwargs)
         set_tags_from_context(span, task.request.__dict__)
         span.finish()
@@ -105,8 +105,8 @@ def trace_before_publish(*args, **kwargs):
         span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, rate)
 
     span.set_tag(SPAN_MEASURED_KEY)
-    span.set_tag(c.TASK_TAG_KEY, c.TASK_APPLY_ASYNC)
-    span.set_tag("celery.id", task_id)
+    span.set_tag_str(c.TASK_TAG_KEY, c.TASK_APPLY_ASYNC)
+    span.set_tag_str("celery.id", task_id)
     set_tags_from_context(span, kwargs)
 
     # Note: adding tags from `traceback` or `state` calls will make an
@@ -190,4 +190,4 @@ def trace_retry(*args, **kwargs):
 
     # Add retry reason metadata to span
     # DEV: Use `str(reason)` instead of `reason.message` in case we get something that isn't an `Exception`
-    span.set_tag(c.TASK_RETRY_REASON_KEY, str(reason))
+    span.set_tag_str(c.TASK_RETRY_REASON_KEY, str(reason))


### PR DESCRIPTION
## Description
Replacing usages of set_tag() that are known to work only with text arguments to set_tag_str() in our celery integration. This should provide a performance benefit as set_tag_str() bypasses the unnecessary type checking that occurs in set_tag().


<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
