### PR TITLE
chore(w3c): allow colons in datadog tags propagated in tracestate

### DIFF
--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -19,7 +19,7 @@ from ddtrace.internal.sampling import SAMPLING_DECISION_TRACE_TAG_KEY
 from ddtrace.internal.utils.cache import cached
 
 
-_W3C_TRACESTATE_INVALID_CHARS_REGEX = r",|;|:|[^\x20-\x7E]+"
+_W3C_TRACESTATE_INVALID_CHARS_REGEX = r",|;|~|[^\x20-\x7E]+"
 
 
 Connector = Callable[[], ContextManager[compat.httplib.HTTPConnection]]
@@ -155,17 +155,17 @@ def w3c_get_dd_list_member(context):
     # Context -> str
     tags = []
     if context.sampling_priority is not None:
-        tags.append("{}:{}".format(W3C_TRACESTATE_SAMPLING_PRIORITY_KEY, context.sampling_priority))
+        tags.append("{}~{}".format(W3C_TRACESTATE_SAMPLING_PRIORITY_KEY, context.sampling_priority))
     if context.dd_origin:
         # the origin value has specific values that are allowed.
-        tags.append("{}:{}".format(W3C_TRACESTATE_ORIGIN_KEY, re.sub(r",|;|=|[^\x20-\x7E]+", "_", context.dd_origin)))
+        tags.append("{}~{}".format(W3C_TRACESTATE_ORIGIN_KEY, re.sub(r",|;|=|[^\x20-\x7E]+", "_", context.dd_origin)))
     sampling_decision = context._meta.get(SAMPLING_DECISION_TRACE_TAG_KEY)
     if sampling_decision:
-        tags.append("t.dm:{}".format(re.sub(_W3C_TRACESTATE_INVALID_CHARS_REGEX, "_", sampling_decision)))
+        tags.append("t.dm~{}".format(re.sub(_W3C_TRACESTATE_INVALID_CHARS_REGEX, "_", sampling_decision)))
     # since this can change, we need to grab the value off the current span
     usr_id_key = context._meta.get(USER_ID_KEY)
     if usr_id_key:
-        tags.append("t.usr.id:{}".format(re.sub(_W3C_TRACESTATE_INVALID_CHARS_REGEX, "_", usr_id_key)))
+        tags.append("t.usr.id~{}".format(re.sub(_W3C_TRACESTATE_INVALID_CHARS_REGEX, "_", usr_id_key)))
 
     current_tags_len = sum(len(i) for i in tags)
     for k, v in context._meta.items():
@@ -176,8 +176,8 @@ def w3c_get_dd_list_member(context):
             and k not in [SAMPLING_DECISION_TRACE_TAG_KEY, USER_ID_KEY]
         ):
             # for key replace ",", "=", and characters outside the ASCII range 0x20 to 0x7E
-            # for value replace ",", ";", ":" and characters outside the ASCII range 0x20 to 0x7E
-            next_tag = "{}:{}".format(
+            # for value replace ",", ";", "~" and characters outside the ASCII range 0x20 to 0x7E
+            next_tag = "{}~{}".format(
                 re.sub("_dd.p.", "t.", re.sub(r",| |=|[^\x20-\x7E]+", "_", k)),
                 re.sub(_W3C_TRACESTATE_INVALID_CHARS_REGEX, "_", v),
             )

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -582,14 +582,14 @@ class _TraceContext:
     def _get_tracestate_values(ts):
         # type: (str) -> Tuple[Optional[int], Dict[str, str], Optional[str]]
 
-        # tracestate parsing, example: dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE
+        # tracestate parsing, example: dd=s~2;o~rum;t.dm~-4;t.usr.id~baz64,congo=t61rcWkgMzE
         dd = None
         ts_l = ts.split(",")
         for list_mem in ts_l:
             if list_mem.startswith("dd="):
                 # cut out dd= before turning into dict
                 list_mem = list_mem[3:]
-                dd = dict(item.split(":") for item in list_mem.split(";"))
+                dd = dict(item.split("~") for item in list_mem.split(";"))
 
         # parse out values
         if dd:

--- a/tests/tracer/test_context.py
+++ b/tests/tracer/test_context.py
@@ -203,13 +203,13 @@ def test_traceparent(context, expected_traceparent):
                 span_id=67667974448284343,
                 sampling_priority=1,
                 meta={
-                    "tracestate": "dd=s:1;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
+                    "tracestate": "dd=s~1;o~rum;t.dm~-4;t.usr.id~baz64,congo=t61rcWkgMzE",
                     "_dd.p.dm": "-4",
                     "_dd.p.usr.id": "baz64",
                 },
                 dd_origin="rum",
             ),
-            "dd=s:1;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
+            "dd=s~1;o~rum;t.dm~-4;t.usr.id~baz64,congo=t61rcWkgMzE",
         ),
         (
             Context(
@@ -219,7 +219,7 @@ def test_traceparent(context, expected_traceparent):
                 dd_origin="rum",
                 meta={"tracestate": "congo=t61rcWkgMzE"},
             ),
-            "dd=s:1;o:rum,congo=t61rcWkgMzE",
+            "dd=s~1;o~rum,congo=t61rcWkgMzE",
         ),
         (
             Context(
@@ -227,13 +227,13 @@ def test_traceparent(context, expected_traceparent):
                 span_id=67667974448284343,
                 sampling_priority=2,
                 meta={
-                    "tracestate": "dd=s:1;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE,nr=ok,s=ink",
+                    "tracestate": "dd=s~1;o~rum;t.dm~-4;t.usr.id~baz64,congo=t61rcWkgMzE,nr=ok,s=ink",
                     "_dd.p.dm": "-4",
                     "_dd.p.usr.id": "baz64",
                 },
                 dd_origin="synthetics",
             ),
-            "dd=s:2;o:synthetics;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE,nr=ok,s=ink",
+            "dd=s~2;o~synthetics;t.dm~-4;t.usr.id~baz64,congo=t61rcWkgMzE,nr=ok,s=ink",
         ),
         (
             Context(
@@ -246,7 +246,7 @@ def test_traceparent(context, expected_traceparent):
                 },
                 dd_origin="synthetics",
             ),
-            "dd=s:-1;o:synthetics;t.dm:-4;t.usr.id:baz64",
+            "dd=s~-1;o~synthetics;t.dm~-4;t.usr.id~baz64",
         ),
         (
             Context(
@@ -254,33 +254,33 @@ def test_traceparent(context, expected_traceparent):
                 span_id=67667974448284343,
                 sampling_priority=1,
                 meta={
-                    "tracestate": "dd=s:1;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
+                    "tracestate": "dd=s~1;o~rum;t.dm~-4;t.usr.id~baz64,congo=t61rcWkgMzE",
                     "_dd.p.dm": "-4",
                     "_dd.p.usr.id": "baz64",
                     "_dd.p.unknown": "unk",
                 },
                 dd_origin="rum",
             ),
-            "dd=s:1;o:rum;t.dm:-4;t.usr.id:baz64;t.unknown:unk,congo=t61rcWkgMzE",
+            "dd=s~1;o~rum;t.dm~-4;t.usr.id~baz64;t.unknown~unk,congo=t61rcWkgMzE",
         ),
         (
             Context(),
             "",
         ),
-        (  # for value replace ",", ";", ":" and characters outside the ASCII range 0x20 to 0x7E with _
+        (  # for value replace ",", ";", "~" and characters outside the ASCII range 0x20 to 0x7E with _
             Context(
                 trace_id=11803532876627986230,
                 span_id=67667974448284343,
                 sampling_priority=1,
                 meta={
-                    "tracestate": "dd=s:1;o:rum;t.dm:-4;t.usr.id:baz64",
-                    "_dd.p.dm": ";5:",
+                    "tracestate": "dd=s~1;o~rum;t.dm~-4;t.usr.id~baz64",
+                    "_dd.p.dm": ";5~",
                     "_dd.p.usr.id": "b,z64,",
                     "_dd.p.unk": ";2",
                 },
                 dd_origin="rum",
             ),
-            "dd=s:1;o:rum;t.dm:_5_;t.usr.id:b_z64_;t.unk:_2",
+            "dd=s~1;o~rum;t.dm~_5_;t.usr.id~b_z64_;t.unk~_2",
         ),
         (  # for key replace ",", "=", and characters outside the ASCII range 0x20 to 0x7E with _
             Context(
@@ -288,14 +288,14 @@ def test_traceparent(context, expected_traceparent):
                 span_id=67667974448284343,
                 sampling_priority=1,
                 meta={
-                    "tracestate": "dd=s:1;o:rum;t.dm:-4;t.usr.id:baz64",
+                    "tracestate": "dd=s~1;o~rum;t.dm~-4;t.usr.id~baz64",
                     "_dd.p.dm": "5",
                     "_dd.p.usr.id": "bz64",
                     "_dd.p.unk¢": "2",
                 },
                 dd_origin="rum",
             ),
-            "dd=s:1;o:rum;t.dm:5;t.usr.id:bz64;t.unk_:2",
+            "dd=s~1;o~rum;t.dm~5;t.usr.id~bz64;t.unk_~2",
         ),
         (
             Context(
@@ -303,11 +303,11 @@ def test_traceparent(context, expected_traceparent):
                 span_id=67667974448284343,
                 sampling_priority=1,
                 meta={
-                    "tracestate": "dd=s:1;o:rum;t.dm:-4;t.usr.id:baz64",
+                    "tracestate": "dd=s~1;o~rum;t.dm~-4;t.usr.id~baz64",
                 },
                 dd_origin=";r,um=",
             ),
-            "dd=s:1;o:_r_um_",
+            "dd=s~1;o~_r_um_",
         ),
     ],
     ids=[

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -376,12 +376,12 @@ def test_get_wsgi_header(tracer):
 # for testing with other propagation styles
 TRACECONTEXT_HEADERS_VALID_BASIC = {
     _HTTP_HEADER_TRACEPARENT: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
-    _HTTP_HEADER_TRACESTATE: "dd=s:2;o:rum",
+    _HTTP_HEADER_TRACESTATE: "dd=s~2;o~rum",
 }
 
 TRACECONTEXT_HEADERS_VALID = {
     _HTTP_HEADER_TRACEPARENT: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
-    _HTTP_HEADER_TRACESTATE: "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
+    _HTTP_HEADER_TRACESTATE: "dd=s~2;o~rum;t.dm~-4;t.usr.id~baz64,congo=t61rcWkgMzE",
 }
 
 
@@ -497,7 +497,7 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
     "ts_string,expected_tuple,expected_logging,expected_exception",
     [
         (
-            "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE,mako=s:2;o:rum;",
+            "dd=s~2;o~rum;t.dm~-4;t.usr.id~baz64,congo=t61rcWkgMzE,mako=s~2;o~rum;",
             # sampling_priority_ts, other_propagated_tags, origin
             (
                 2,
@@ -511,7 +511,7 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
             None,
         ),
         (
-            "dd=s:0;o:rum;t.dm:-4;t.usr.id:baz64",
+            "dd=s~0;o~rum;t.dm~-4;t.usr.id~baz64",
             # sampling_priority_ts, other_propagated_tags, origin
             (
                 0,
@@ -525,7 +525,7 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
             None,
         ),
         (
-            "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64",
+            "dd=s~2;o~rum;t.dm~-4;t.usr.id~baz64",
             # sampling_priority_ts, other_propagated_tags, origin
             (
                 2,
@@ -539,7 +539,7 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
             None,
         ),
         (
-            "dd=o:rum;t.dm:-4;t.usr.id:baz64",
+            "dd=o~rum;t.dm~-4;t.usr.id~baz64",
             # sampling_priority_ts, other_propagated_tags, origin
             (
                 None,
@@ -553,7 +553,7 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
             None,
         ),
         (
-            "dd=s:-1;o:rum;t.dm:-4;t.usr.id:baz64",
+            "dd=s~-1;o~rum;t.dm~-4;t.usr.id~baz64",
             # sampling_priority_ts, other_propagated_tags, origin
             (
                 -1,
@@ -567,7 +567,7 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
             None,
         ),
         (
-            "dd=s:2;t.dm:-4;t.usr.id:baz64",
+            "dd=s~2;t.dm~-4;t.usr.id~baz64",
             # sampling_priority_ts, other_propagated_tags, origin
             (
                 2,
@@ -581,7 +581,7 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
             None,
         ),
         (
-            "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64;t.unk:unk,congo=t61rcWkgMzE,mako=s:2;o:rum;",
+            "dd=s~2;o~rum;t.dm~-4;t.usr.id~baz64;t.unk~unk,congo=t61rcWkgMzE,mako=s:2;o~rum;",
             # sampling_priority_ts, other_propagated_tags, origin
             (
                 2,
@@ -596,14 +596,14 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
             None,
         ),
         (
-            "congo=t61rcWkgMzE,mako=s:2;o:rum;",
+            "congo=t61rcWkgMzE,mako=s:2;o~rum;",
             # sampling_priority_ts, other_propagated_tags, origin
             (None, {}, None),
             None,
             None,
         ),
         (
-            "dd=s:2;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE,mako=s:2;o:rum;",
+            "dd=s~2;t.dm~-4;t.usr.id~baz64,congo=t61rcWkgMzE,mako=s~2;o~rum;",
             # sampling_priority_ts, other_propagated_tags, origin
             (
                 2,
@@ -666,7 +666,7 @@ def test_extract_tracestate(caplog, ts_string, expected_tuple, expected_logging,
                 "trace_id": 11803532876627986230,
                 "span_id": 67667974448284343,
                 "meta": {
-                    "tracestate": "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
+                    "tracestate": "dd=s~2;o~rum;t.dm~-4;t.usr.id~baz64,congo=t61rcWkgMzE",
                     "_dd.p.dm": "-4",
                     "_dd.p.usr.id": "baz64",
                     "_dd.origin": "rum",
@@ -681,7 +681,7 @@ def test_extract_tracestate(caplog, ts_string, expected_tuple, expected_logging,
                 "trace_id": 11803532876627986230,
                 "span_id": 67667974448284343,
                 "meta": {
-                    "tracestate": "dd=s:2;o:rum",
+                    "tracestate": "dd=s~2;o~rum",
                     "_dd.origin": "rum",
                     "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
                 },
@@ -691,7 +691,7 @@ def test_extract_tracestate(caplog, ts_string, expected_tuple, expected_logging,
         (
             {
                 _HTTP_HEADER_TRACEPARENT: "00-4bae0e4736-00f067aa0ba902b7-01",
-                _HTTP_HEADER_TRACESTATE: "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
+                _HTTP_HEADER_TRACESTATE: "dd=s~2;o~rum;t.dm~-4;t.usr.id~baz64,congo=t61rcWkgMzE",
             },
             {"trace_id": None, "span_id": None, "meta": {}, "metrics": {}},
         ),
@@ -710,7 +710,7 @@ def test_extract_tracestate(caplog, ts_string, expected_tuple, expected_logging,
         ),
         (
             {
-                _HTTP_HEADER_TRACESTATE: "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
+                _HTTP_HEADER_TRACESTATE: "dd=s~2;o~rum;t.dm~-4;t.usr.id~baz64,congo=t61rcWkgMzE",
             },
             {"trace_id": None, "span_id": None, "meta": {}, "metrics": {}},
         ),

--- a/tests/tracer/test_utils.py
+++ b/tests/tracer/test_utils.py
@@ -416,7 +416,7 @@ def test_callonce_signature():
                     "_dd.p.unknown": "baz64",
                 },
             ),
-            ["s:2", "o:synthetics", "t.unk:-4", "t.unknown:baz64"],
+            ["s~2", "o~synthetics", "t.unk~-4", "t.unknown~baz64"],
         ),
         (
             Context(
@@ -429,7 +429,7 @@ def test_callonce_signature():
                     "no_add": "is_not_added",
                 },
             ),
-            ["s:2", "o:synthetics", "t.unk:-4", "t.unknown:baz64"],
+            ["s~2", "o~synthetics", "t.unk~-4", "t.unknown~baz64"],
         ),
         (
             Context(
@@ -441,10 +441,10 @@ def test_callonce_signature():
                     "_dd.p.unknown": "baz64",
                 },
             ),
-            ["s:2", "o:synthetics", "t.unknown:baz64"],
+            ["s~2", "o~synthetics", "t.unknown~baz64"],
         ),
         (  # for key replace ",", "=", and characters outside the ASCII range 0x20 to 0x7E with _
-            # for value replace ",", ";", ":" and characters outside the ASCII range 0x20 to 0x7E with _
+            # for value replace ",", ";", "~" and characters outside the ASCII range 0x20 to 0x7E with _
             Context(
                 trace_id=1234,
                 sampling_priority=2,
@@ -453,10 +453,10 @@ def test_callonce_signature():
                     "_dd.p.unk": "-4",
                     "_dd.p.unknown": "baz64",
                     "_dd.p.¢": ";4",
-                    "_dd.p.u=,": "b:,¢a",
+                    "_dd.p.u=,": "b~,¢a",
                 },
             ),
-            ["s:2", "o:synthetics", "t.unk:-4", "t.unknown:baz64", "t._:_4", "t.u__:b___a"],
+            ["s~2", "o~synthetics", "t.unk~-4", "t.unknown~baz64", "t._~_4", "t.u__~b___a"],
         ),
         (
             Context(
@@ -468,7 +468,7 @@ def test_callonce_signature():
                     "_dd.p.unknown": "baz64",
                 },
             ),
-            ["s:0", "o:synthetics", "t.unk:-4", "t.unknown:baz64"],
+            ["s~0", "o~synthetics", "t.unk~-4", "t.unknown~baz64"],
         ),
     ],
     ids=[


### PR DESCRIPTION
## Description

Datadog tag values allows colon `:` (0x3A) which is not currently allowed in the W3C Trace Context propagation with `tracestate`. We update the propagation to allow `:` and not allow `~` (0x7E).

## Checklist
- [x] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
