### PR TITLE
revert: "chore(mako): replace set_tag usages with set_tag_str"

### DIFF
--- a/ddtrace/contrib/mako/patch.py
+++ b/ddtrace/contrib/mako/patch.py
@@ -56,4 +56,4 @@ def _wrap_render(wrapped, instance, args, kwargs):
             return wrapped(*args, **kwargs)
         finally:
             span.resource = template_name
-            span.set_tag_str("mako.template_name", template_name)
+            span.set_tag("mako.template_name", template_name)


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#4697

The framework tests caught an issue with using set_tag_str (which might have always existed using `set_tag` but just failed silently)

cc @Yun-Kim