### PR TITLE
revert: "chore(dogpile_cache): replace set_tag usage with set_tag_str"

### DIFF
--- a/ddtrace/contrib/dogpile_cache/region.py
+++ b/ddtrace/contrib/dogpile_cache/region.py
@@ -15,9 +15,9 @@ def _wrap_get_create(func, instance, args, kwargs):
     key = get_argument_value(args, kwargs, 0, "key")
     with pin.tracer.trace("dogpile.cache", resource="get_or_create", span_type=SpanTypes.CACHE) as span:
         span.set_tag(SPAN_MEASURED_KEY)
-        span.set_tag_str("key", key)
-        span.set_tag_str("region", instance.name)
-        span.set_tag_str("backend", instance.actual_backend.__class__.__name__)
+        span.set_tag("key", key)
+        span.set_tag("region", instance.name)
+        span.set_tag("backend", instance.actual_backend.__class__.__name__)
         return func(*args, **kwargs)
 
 
@@ -29,7 +29,7 @@ def _wrap_get_create_multi(func, instance, args, kwargs):
     keys = get_argument_value(args, kwargs, 0, "keys")
     with pin.tracer.trace("dogpile.cache", resource="get_or_create_multi", span_type="cache") as span:
         span.set_tag(SPAN_MEASURED_KEY)
-        span.set_tag_str("keys", keys)
-        span.set_tag_str("region", instance.name)
-        span.set_tag_str("backend", instance.actual_backend.__class__.__name__)
+        span.set_tag("keys", keys)
+        span.set_tag("region", instance.name)
+        span.set_tag("backend", instance.actual_backend.__class__.__name__)
         return func(*args, **kwargs)


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#4731

Accidentally was merged with tests failing

cc @Yun-Kim 