### PR TITLE
fix(profiling): rename code hotspots

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -126,7 +126,7 @@ class _ProfilerInstance(service.Service):
         factory=lambda: formats.asbool(os.environ.get("DD_PROFILING_MEMORY_ENABLED", "True")), type=bool
     )
     enable_code_provenance = attr.ib(
-        factory=attr_utils.from_env("DD_PROFILING_ENABLE_CODE_PROVENANCE", True, formats.asbool),
+        factory=attr_utils.from_env("DD_PROFILING_CODEHOTSPOTS_ENABLED", True, formats.asbool),
         type=bool,
     )
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -328,10 +328,10 @@ below:
      default: 64
      description: The maximum number of frames to capture in stack execution tracing.
 
-   DD_PROFILING_ENABLE_CODE_PROVENANCE:
+   DD_PROFILING_CODEHOTSPOTS_ENABLED:
      type: Boolean
      default: True
-     description: Whether to enable code provenance.
+     description: Whether to enable Code Hotspots.
      version_added:
        v1.7.0:
 

--- a/releasenotes/notes/profiling-enable-code-provenance-3d9663e0cd742fcd.yaml
+++ b/releasenotes/notes/profiling-enable-code-provenance-3d9663e0cd742fcd.yaml
@@ -1,4 +1,7 @@
 ---
 features:
   - |
-      profiling: Enables code provenance by default. To keep the feature disabled use ``DD_PROFILING_ENABLE_CODE_PROVENANCE=false``.
+      profiling: Enables Code Hotspots by default. To keep the feature disabled, set the environment variable ``DD_PROFILING_CODEHOTSPOTS_ENABLED=false``.
+updates:
+  - |
+      profiling: The environment variable for enabling Code Hotspots (formerly known as Code Provenance Reporting) is renamed to ``DD_PROFILING_CODEHOTSPOTS_ENABLED`` from ``DD_PROFILING_ENABLE_CODE_PROVENANCE`` and the former will no longer be supported.


### PR DESCRIPTION
The product name used for this feature is Code Hotspots. The environment variable is renamed.  