### PR TITLE
chore(encoders): update package tool before installing packages

### DIFF
--- a/scripts/profiles/encoders/setup.sh
+++ b/scripts/profiles/encoders/setup.sh
@@ -20,6 +20,7 @@ pip install pip --upgrade
 
 # Install austin
 pushd ${PREFIX}
+    sudo apt update
     sudo apt-get -y install libunwind-dev binutils-dev libiberty-dev
     git clone --depth=1 https://github.com/p403n1x87/austin.git -b devel
     pushd austin


### PR DESCRIPTION
## Description

Ensure Ubuntu package information is update before attempting to install. 

This fixes failing encoders-profiler framework test: [example](https://github.com/DataDog/dd-trace-py/actions/runs/3640431431/jobs/6147151806)

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
