### PR TITLE
ci(tox): avoid running ddtrace with tox v4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
   setup_tox:
     description: "Install tox"
     steps:
-      - run: pip install -U tox
+      - run: pip install -U "tox<4"
 
   setup_riot:
     description: "Install riot"


### PR DESCRIPTION
## Description

Pins tox version to unblock ci. [Tox v4.0](https://tox.wiki/en/latest/changelog.html#v4-0-0-2022-12-07) is not compatible with ddtrace test suite. Sample Failure: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/25228/workflows/bc45adf5-0b42-4747-8932-289ae6cc7771/jobs/1710555.

Since we plan to migrate all ddtrace tests from tox to riot in the coming weeks this mitigation should be sufficient.  

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
