### PR TITLE
ci(tox): avoid running ddtrace with tox v4.0 [backport #4751 to 1.5]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
   setup_tox:
     description: "Install tox"
     steps:
-      - run: pip install -U tox
+      - run: pip install -U "tox<4"
 
   setup_riot:
     description: "Install riot"


### PR DESCRIPTION
## Description

https://github.com/DataDog/dd-trace-py/pull/4751


## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
