### PR TITLE
chore(packaging): support version parsing in packaging v22 [backport #4752 to 1.6]

### DIFF
--- a/ddtrace/internal/utils/version.py
+++ b/ddtrace/internal/utils/version.py
@@ -27,7 +27,12 @@ def parse_version(version):
 
     # version() will not raise an exception, if the version if malformed instead
     # we will end up with a LegacyVersion
-    parsed = packaging.version.parse(version)
+
+    try:
+        parsed = packaging.version.parse(version)
+    except packaging.version.InvalidVersion:
+        # packaging>=22.0 raises an InvalidVersion instead of returning a LegacyVersion
+        return (0, 0, 0)
 
     # LegacyVersion.release will always be `None`
     if not parsed.release:

--- a/riotfile.py
+++ b/riotfile.py
@@ -324,11 +324,15 @@ venv = Venv(
                 "DD_REMOTE_CONFIGURATION_ENABLED": "false",
             },
             venvs=[
-                Venv(pys="2.7"),
+                Venv(pys="2.7", pkgs={"packaging": ["==17.1", latest]}),
                 Venv(
-                    # FIXME[bytecode-3.11]: internal depends on bytecode, which is not python 3.11 compatible.
-                    pys=select_pys(min_version="3.5"),
-                    pkgs={"pytest-asyncio": latest},
+                    pys=select_pys(min_version="3.5", max_version="3.6"),
+                    pkgs={"pytest-asyncio": latest, "packaging": ["==17.1", latest]},
+                ),
+                # FIXME[bytecode-3.11]: internal depends on bytecode, which is not python 3.11 compatible.
+                Venv(
+                    pys=select_pys(min_version="3.7"),
+                    pkgs={"pytest-asyncio": latest, "packaging": ["==17.1", "==22.0", latest]},
                 ),
             ],
         ),


### PR DESCRIPTION
## Description

Backport https://github.com/DataDog/dd-trace-py/pull/4752

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
