### PR TITLE
ci: disable broken windows profiling jobs [backport 4579 to 1.5]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1219,12 +1219,12 @@ requires_tests: &requires_tests
     - vertica
     - wsgi
     # - profile-windows-27
-    - profile-windows-35
-    - profile-windows-36
+    # - profile-windows-35
+    # - profile-windows-36
     # - profile-windows-37
     # - profile-windows-38
     # - profile-windows-39
-    - profile-windows-310
+    # - profile-windows-310
 
 workflows:
   version: 2
@@ -1321,12 +1321,12 @@ workflows:
       - vertica: *requires_base_venvs
       - wsgi: *requires_base_venvs
       # - profile-windows-27: *requires_pre_check
-      - profile-windows-35: *requires_pre_check
-      - profile-windows-36: *requires_pre_check
+      # - profile-windows-35: *requires_pre_check
+      # - profile-windows-36: *requires_pre_check
       # - profile-windows-37: *requires_pre_check
       # - profile-windows-38: *requires_pre_check
       # - profile-windows-39: *requires_pre_check
-      - profile-windows-310: *requires_pre_check
+      # - profile-windows-310: *requires_pre_check
       # Final reports
       - coverage_report: *requires_tests
 


### PR DESCRIPTION
## Description

backport: https://github.com/DataDog/dd-trace-py/pull/4579

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
