### PR TITLE
chore(ci): remove test_nightly scheduled workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1327,14 +1327,3 @@ workflows:
       # - profile-windows-311: *requires_pre_check
       # Final reports
       - coverage_report: *requires_tests
-
-  test_nightly:
-    <<: *workflow_test
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - 0.x
-                - 1.x


### PR DESCRIPTION
## Description
We now have these configured as scheduled pipelines via the UI.

This method of scheduling jobs is deprecated.

Moving to scheduled pipelines means we can also inject pipeline parameters for the nightly jobs. This should help with #4627


https://circleci.com/docs/schedule-pipelines-with-multiple-workflows/#schedule-using-pipeline-parameters