### PR TITLE
chore(logging): fix noisy rq patching log

### DIFF
--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -110,6 +110,7 @@ _PATCH_ON_IMPORT = {
         "elasticsearch7",
     ),
     "pynamodb": ("pynamodb",),
+    "rq": ("rq",),
 }
 
 IAST_PATCH = {


### PR DESCRIPTION
The patching logs generated a scary looking message for rq:

```
DEBUG:ddtrace._monkey:failed to patch rq
Traceback (most recent call last):
  File "/Users/kverhoog/dev/dd-trace-py/ddtrace/_monkey.py", line 249, in _patch_module
    return _attempt_patch_module(module, patch_modules_prefix=patch_modules_prefix)
  File "/Users/kverhoog/dev/dd-trace-py/ddtrace/_monkey.py", line 304, in _attempt_patch_module
    imported_module.patch()
  File "/Users/kverhoog/dev/dd-trace-py/ddtrace/contrib/rq/__init__.py", line 207, in patch
    import rq
ModuleNotFoundError: No module named 'rq'
```

because the rq integration imports the `rq` module on `patch()` and doesn't declare required_modules. Nor does it dynamically expose the patch and unpatch methods.

By making the rq integration a patch-on-import integration the issue is avoided. This can be done because the rq integration was written to be patch-on-import compatible (no top-level imports of the library).


## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
