### PR TITLE
fix(aws): limit api params as span tags

### DIFF
--- a/ddtrace/contrib/aiobotocore/__init__.py
+++ b/ddtrace/contrib/aiobotocore/__init__.py
@@ -1,22 +1,44 @@
 """
 The aiobotocore integration will trace all AWS calls made with the ``aiobotocore``
-library. This integration isn't enabled when applying the default patching.
-To enable it, you must run ``patch_all(aiobotocore=True)``
+library. This integration is not enabled by default.
 
-::
+Enabling
+~~~~~~~~
 
-    import aiobotocore.session
+The aiobotocore integration is not enabled by default. Use
+:func:`patch()<ddtrace.patch>` to enable the integration::
+
     from ddtrace import patch
-
-    # If not patched yet, you can patch botocore specifically
     patch(aiobotocore=True)
 
-    # This will report spans with the default instrumentation
-    aiobotocore.session.get_session()
-    lambda_client = session.create_client('lambda', region_name='us-east-1')
+Configuration
+~~~~~~~~~~~~~
 
-    # This query generates a trace
-    lambda_client.list_functions()
+.. py:data:: ddtrace.config.aiobotocore['tag_no_params']
+
+    This opts out of the default behavior of adding span tags for a narrow set of API parameters.
+
+    To not collect any API parameters, ``ddtrace.config.aiobotocore.tag_no_params = True`` or by setting the environment
+    variable ``DD_AWS_TAG_NO_PARAMS=true``.
+
+
+    Default: ``False``
+
+.. py:data:: ddtrace.config.aiobotocore['tag_all_params']
+
+    **Deprecated**: This retains the deprecated behavior of adding span tags for
+    all API parameters that are not explicitly excluded by the integration.
+    These deprecated span tags will be added along with the API parameters
+    enabled by default.
+
+    This configuration is ignored if ``tag_no_parms`` (``DD_AWS_TAG_NO_PARAMS``)
+    is set to ``True``.
+
+    To collect all API parameters, ``ddtrace.config.botocore.tag_all_params =
+    True`` or by setting the environment variable ``DD_AWS_TAG_ALL_PARAMS=true``.
+
+
+    Default: ``False``
 """
 from ...internal.utils.importlib import require_modules
 

--- a/ddtrace/contrib/aiobotocore/patch.py
+++ b/ddtrace/contrib/aiobotocore/patch.py
@@ -1,7 +1,10 @@
+import os
+
 import aiobotocore.client
 
 from ddtrace import config
 from ddtrace.internal.utils.version import parse_version
+from ddtrace.vendor import debtcollector
 from ddtrace.vendor import wrapt
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -12,6 +15,7 @@ from ...ext import http
 from ...internal.compat import PYTHON_VERSION_INFO
 from ...internal.utils import ArgumentError
 from ...internal.utils import get_argument_value
+from ...internal.utils.formats import asbool
 from ...internal.utils.formats import deep_getattr
 from ...pin import Pin
 from ..trace_utils import unwrap
@@ -29,6 +33,22 @@ elif AIOBOTOCORE_VERSION >= (0, 11, 0) and AIOBOTOCORE_VERSION < (2, 3, 0):
 
 ARGS_NAME = ("action", "params", "path", "verb")
 TRACED_ARGS = {"params", "path", "verb"}
+
+
+if os.getenv("DD_AWS_TAG_ALL_PARAMS") is not None:
+    debtcollector.deprecate(
+        "Using environment variable 'DD_AWS_TAG_ALL_PARAMS' is deprecated",
+        message="The aiobotocore integration no longer includes all API parameters by default.",
+        removal_version="2.0.0",
+    )
+
+config._add(
+    "aiobotocore",
+    {
+        "tag_no_params": asbool(os.getenv("DD_AWS_TAG_NO_PARAMS", default=False)),
+        "tag_all_params": asbool(os.getenv("DD_AWS_TAG_ALL_PARAMS", default=False)),
+    },
+)
 
 
 def patch():
@@ -94,13 +114,20 @@ async def _wrapped_api_call(original_func, instance, args, kwargs):
         span.set_tag(SPAN_MEASURED_KEY)
 
         try:
+
             operation = get_argument_value(args, kwargs, 0, "operation_name")
+            params = get_argument_value(args, kwargs, 1, "params")
+
             span.resource = "{}.{}".format(endpoint_name, operation.lower())
+
+            if params and not config.aiobotocore["tag_no_params"]:
+                aws._add_api_param_span_tags(span, endpoint_name, params)
         except ArgumentError:
             operation = None
             span.resource = endpoint_name
 
-        aws.add_span_arg_tags(span, endpoint_name, args, ARGS_NAME, TRACED_ARGS)
+        if not config.aiobotocore["tag_no_params"] and config.aiobotocore["tag_all_params"]:
+            aws.add_span_arg_tags(span, endpoint_name, args, ARGS_NAME, TRACED_ARGS)
 
         region_name = deep_getattr(instance, "meta.region_name")
 

--- a/ddtrace/contrib/boto/__init__.py
+++ b/ddtrace/contrib/boto/__init__.py
@@ -1,17 +1,47 @@
 """
 Boto integration will trace all AWS calls made via boto2.
-This integration is automatically patched when using ``patch_all()``::
 
-    import boto.ec2
+Enabling
+~~~~~~~~
+
+The boto integration is enabled automatically when using
+:ref:`ddtrace-run<ddtracerun>` or :func:`patch_all()<ddtrace.patch_all>`.
+
+Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
+
     from ddtrace import patch
-
-    # If not patched yet, you can patch boto specifically
     patch(boto=True)
 
-    # This will report spans with the default instrumentation
-    ec2 = boto.ec2.connect_to_region("us-west-2")
-    # Example of instrumented query
-    ec2.get_all_instances()
+Configuration
+~~~~~~~~~~~~~
+
+.. py:data:: ddtrace.config.boto['tag_no_params']
+
+    This opts out of the default behavior of collecting a narrow set of API
+    parameters as span tags.
+
+    To not collect any API parameters, ``ddtrace.config.boto.tag_no_params =
+    True`` or by setting the environment variable ``DD_AWS_TAG_NO_PARAMS=true``.
+
+
+    Default: ``False``
+
+.. py:data:: ddtrace.config.boto['tag_all_params']
+
+    **Deprecated**: This retains the deprecated behavior of adding span tags for
+    all API parameters that are not explicitly excluded by the integration.
+    These deprecated span tags will be added along with the API parameters
+    enabled by default.
+
+    This configuration is ignored if ``tag_no_parms`` (``DD_AWS_TAG_NO_PARAMS``)
+    is set to ``True``.
+
+    To collect all API parameters, ``ddtrace.config.botocore.tag_all_params =
+    True`` or by setting the environment variable ``DD_AWS_TAG_ALL_PARAMS=true``.
+
+
+    Default: ``False``
+
 """
 
 from ...internal.utils.importlib import require_modules

--- a/ddtrace/contrib/botocore/__init__.py
+++ b/ddtrace/contrib/botocore/__init__.py
@@ -52,6 +52,32 @@ Configuration
 
     See :ref:`HTTP - Custom Error Codes<http-custom-error>` documentation for more examples.
 
+.. py:data:: ddtrace.config.botocore['tag_no_params']
+
+    This opts out of the default behavior of collecting a narrow set of API parameters as span tags.
+
+    To not collect any API parameters, ``ddtrace.config.botocore.tag_no_params = True`` or by setting the environment
+    variable ``DD_AWS_TAG_NO_PARAMS=true``.
+
+
+    Default: ``False``
+
+.. py:data:: ddtrace.config.botocore['tag_all_params']
+
+    **Deprecated**: This retains the deprecated behavior of adding span tags for
+    all API parameters that are not explicitly excluded by the integration.
+    These deprecated span tags will be added along with the API parameters
+    enabled by default.
+
+    This configuration is ignored if ``tag_no_parms`` (``DD_AWS_TAG_NO_PARAMS``)
+    is set to ``True``.
+
+    To collect all API parameters, ``ddtrace.config.botocore.tag_all_params =
+    True`` or by setting the environment variable ``DD_AWS_TAG_ALL_PARAMS=true``.
+
+
+    Default: ``False``
+
 
 Example::
 

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -16,6 +16,7 @@ import botocore.exceptions
 
 from ddtrace import config
 from ddtrace.settings.config import Config
+from ddtrace.vendor import debtcollector
 from ddtrace.vendor import wrapt
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -47,6 +48,14 @@ MAX_EVENTBRIDGE_DETAIL_SIZE = 1 << 18  # 256KB
 log = get_logger(__name__)
 
 
+if os.getenv("DD_AWS_TAG_ALL_PARAMS") is not None:
+    debtcollector.deprecate(
+        "Using environment variable 'DD_AWS_TAG_ALL_PARAMS' is deprecated",
+        message="The botocore integration no longer includes all API parameters by default.",
+        removal_version="2.0.0",
+    )
+
+
 # Botocore default settings
 config._add(
     "botocore",
@@ -54,6 +63,8 @@ config._add(
         "distributed_tracing": asbool(os.getenv("DD_BOTOCORE_DISTRIBUTED_TRACING", default=True)),
         "invoke_with_legacy_context": asbool(os.getenv("DD_BOTOCORE_INVOKE_WITH_LEGACY_CONTEXT", default=False)),
         "operations": collections.defaultdict(Config._HTTPServerConfig),
+        "tag_no_params": asbool(os.getenv("DD_AWS_TAG_NO_PARAMS", default=False)),
+        "tag_all_params": asbool(os.getenv("DD_AWS_TAG_ALL_PARAMS", default=False)),
     },
 )
 
@@ -325,10 +336,14 @@ def patched_api_call(original_func, instance, args, kwargs):
                 except Exception:
                     log.warning("Unable to inject trace context", exc_info=True)
 
+            if params and not config.botocore["tag_no_params"]:
+                aws._add_api_param_span_tags(span, endpoint_name, params)
+
         else:
             span.resource = endpoint_name
 
-        aws.add_span_arg_tags(span, endpoint_name, args, ARGS_NAME, TRACED_ARGS)
+        if not config.botocore["tag_no_params"] and config.botocore["tag_all_params"]:
+            aws.add_span_arg_tags(span, endpoint_name, args, ARGS_NAME, TRACED_ARGS)
 
         region_name = deep_getattr(instance, "meta.region_name")
 

--- a/ddtrace/ext/aws.py
+++ b/ddtrace/ext/aws.py
@@ -1,4 +1,5 @@
 from typing import Any
+from typing import Dict
 from typing import FrozenSet
 from typing import Set
 from typing import TYPE_CHECKING
@@ -45,6 +46,38 @@ def add_span_arg_tags(
             exclude_policy=lambda tag: tag in exclude_set or tag.endswith("Body"),
             processor=truncate_arg_value,
         )
+
+
+def _add_api_param_span_tags(span, endpoint_name, params):
+    # type: (Span, str, Dict[str, Any]) -> None
+    if endpoint_name == "cloudwatch":
+        log_group_name = params.get("logGroupName")
+        if log_group_name:
+            span.set_tag_str("aws.cloudwatch.logs.log_group_name", log_group_name)
+    elif endpoint_name == "dynamodb":
+        table_name = params.get("TableName")
+        if table_name:
+            span.set_tag_str("aws.dynamodb.table_name", table_name)
+    elif endpoint_name == "kinesis":
+        stream_name = params.get("StreamName")
+        if stream_name:
+            span.set_tag_str("aws.kinesis.stream_name", stream_name)
+    elif endpoint_name == "redshift":
+        cluster_identifier = params.get("ClusterIdentifier")
+        if cluster_identifier:
+            span.set_tag_str("aws.redshift.cluster_identifier", cluster_identifier)
+    elif endpoint_name == "s3":
+        bucket_name = params.get("Bucket")
+        if bucket_name:
+            span.set_tag_str("aws.s3.bucket_name", bucket_name)
+    elif endpoint_name == "sns":
+        topic_arn = params.get("TopicArn")
+        if topic_arn:
+            span.set_tag_str("aws.sns.topic_arn", topic_arn)
+    elif endpoint_name == "sqs":
+        queue_name = params.get("QueueName") or params.get("QueueUrl")
+        if queue_name:
+            span.set_tag_str("aws.sqs.queue_name", queue_name)
 
 
 REGION = "aws.region"

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -32,6 +32,7 @@ asyncpg
 attrs
 autodetected
 autopatching
+aws
 backend
 backends
 backport

--- a/releasenotes/notes/fix-aws-tag-params-0e1488513a0ae5c7.yaml
+++ b/releasenotes/notes/fix-aws-tag-params-0e1488513a0ae5c7.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+    aws: The boto, botocore and aiobotocore integrations no longer include all API parameters by default. To retain the deprecated behavior, set the environment variable ``DD_AWS_TAG_ALL_PARAMS=1``. The deprecated behavior and environment variable will be removed in v2.0.0.
+fixes:
+  - |
+    aws: We are reducing the number of API parameters that the boto, botocore and aiobotocore integrations collect as span tags by default. This change limits span tags to a narrow set of parameters for specific AWS APIs using standard tag names. To opt out of the new default behavior and collect no API parameters, set the environment variable ``DD_AWS_TAG_NO_PARAMS=1``. To retain the deprecated behavior and collect all API parameters, set the environment variable ``DD_AWS_TAG_ALL_PARAMS=1``.

--- a/tests/contrib/aiobotocore/test.py
+++ b/tests/contrib/aiobotocore/test.py
@@ -6,7 +6,6 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.constants import ERROR_MSG
 from ddtrace.contrib.aiobotocore.patch import patch
 from ddtrace.contrib.aiobotocore.patch import unpatch
-from ddtrace.internal.compat import stringify
 from tests.utils import assert_is_measured
 from tests.utils import assert_span_http_status_code
 from tests.utils import override_config
@@ -76,8 +75,7 @@ async def test_s3_client(tracer):
     assert span.name == "s3.command"
 
 
-@pytest.mark.asyncio
-async def test_s3_put(tracer):
+async def _test_s3_put(tracer):
     params = dict(Key="foo", Bucket="mybucket", Body=b"bar")
 
     async with aiobotocore_client("s3", tracer) as s3:
@@ -97,9 +95,33 @@ async def test_s3_put(tracer):
     assert_is_measured(spans[1])
     assert spans[1].get_tag("aws.operation") == "PutObject"
     assert spans[1].resource == "s3.putobject"
-    assert spans[1].get_tag("params.Key") == stringify(params["Key"])
-    assert spans[1].get_tag("params.Bucket") == stringify(params["Bucket"])
-    assert spans[1].get_tag("params.Body") is None
+
+    return spans[1]
+
+
+@pytest.mark.asyncio
+async def test_s3_put(tracer):
+    span = await _test_s3_put(tracer)
+    assert span.get_tag("aws.s3.bucket_name") == "mybucket"
+
+
+@pytest.mark.asyncio
+async def test_s3_put_no_params(tracer):
+    with override_config("aiobotocore", dict(tag_no_params=True)):
+        span = await _test_s3_put(tracer)
+        assert span.get_tag("aws.s3.bucket_name") is None
+        assert span.get_tag("params.Key") is None
+        assert span.get_tag("params.Bucket") is None
+        assert span.get_tag("params.Body") is None
+
+
+@pytest.mark.asyncio
+async def test_s3_put_all_params(tracer):
+    with override_config("aiobotocore", dict(tag_all_params=True)):
+        span = await _test_s3_put(tracer)
+        assert span.get_tag("params.Key") == "foo"
+        assert span.get_tag("params.Bucket") == "mybucket"
+        assert span.get_tag("params.Body") is None
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/boto/test.py
+++ b/tests/contrib/boto/test.py
@@ -93,8 +93,8 @@ class BotoTest(TracerTestCase):
         span = spans[0]
         self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
 
-    @mock_s3
-    def test_s3_client(self):
+    def _test_s3_client(self):
+        # DEV: To test tag params check create bucket's span
         s3 = boto.s3.connect_to_region("us-east-1")
         Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(s3)
 
@@ -113,12 +113,11 @@ class BotoTest(TracerTestCase):
         spans = self.pop_spans()
         assert spans
         self.assertEqual(len(spans), 1)
-        span = spans[0]
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        self.assertEqual(span.get_tag(http.METHOD), "PUT")
-        self.assertEqual(span.get_tag("path"), "/")
-        self.assertEqual(span.get_tag("aws.operation"), "create_bucket")
+        create_span = spans[0]
+        assert_is_measured(create_span)
+        assert_span_http_status_code(create_span, 200)
+        self.assertEqual(create_span.get_tag(http.METHOD), "PUT")
+        self.assertEqual(create_span.get_tag("aws.operation"), "create_bucket")
 
         # Get the created bucket
         s3.get_bucket("cheese")
@@ -142,6 +141,34 @@ class BotoTest(TracerTestCase):
             assert spans
             span = spans[0]
             self.assertEqual(span.resource, "s3.head")
+
+        return create_span
+
+    @mock_s3
+    def test_s3_client(self):
+        span = self._test_s3_client()
+        # DEV: Not currently supported
+        self.assertIsNone(span.get_tag("aws.s3.bucket_name"))
+
+    @mock_s3
+    def test_s3_client_no_params(self):
+        with self.override_config("boto", dict(tag_no_params=True)):
+            span = self._test_s3_client()
+            self.assertIsNone(span.get_tag("aws.s3.bucket_name"))
+
+    @mock_s3
+    def test_s3_client_all_params(self):
+        with self.override_config("boto", dict(tag_all_params=True)):
+            span = self._test_s3_client()
+            self.assertEqual(span.get_tag("path"), "/")
+
+    @mock_s3
+    def test_s3_client_no_params_all_params(self):
+        # DEV: Test no params overrides all params
+        with self.override_config("boto", dict(tag_no_params=True, tag_all_params=True)):
+            span = self._test_s3_client()
+            self.assertIsNone(span.get_tag("aws.s3.bucket_name"))
+            self.assertIsNone(span.get_tag("path"))
 
     @mock_s3
     def test_s3_put(self):

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -33,7 +33,6 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.botocore.patch import patch
 from ddtrace.contrib.botocore.patch import unpatch
 from ddtrace.internal.compat import PY2
-from ddtrace.internal.compat import stringify
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
@@ -204,8 +203,7 @@ class BotocoreTest(TracerTestCase):
         for t in (ERROR_MSG, ERROR_STACK, ERROR_TYPE):
             assert head_object.get_tag(t) is not None
 
-    @mock_s3
-    def test_s3_put(self):
+    def _test_s3_put(self):
         s3 = self.session.create_client("s3", region_name="us-west-2")
         Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(s3)
         params = {
@@ -229,63 +227,113 @@ class BotocoreTest(TracerTestCase):
         assert span.resource == "s3.createbucket"
         assert spans[1].get_tag("aws.operation") == "PutObject"
         assert spans[1].resource == "s3.putobject"
-        assert spans[1].get_tag("params.Key") == stringify(params["Key"])
-        assert spans[1].get_tag("params.Bucket") == stringify(params["Bucket"])
-        # confirm blacklisted
-        assert spans[1].get_tag("params.Body") is None
+        return spans[1]
+
+    @mock_s3
+    def test_s3_put(self):
+        span = self._test_s3_put()
+        assert span.get_tag("aws.s3.bucket_name") == "mybucket"
+
+    @mock_s3
+    def test_s3_put_no_params(self):
+        with self.override_config("botocore", dict(tag_no_params=True)):
+            span = self._test_s3_put()
+            assert span.get_tag("aws.s3.bucket_name") is None
+            assert span.get_tag("params.Key") is None
+            assert span.get_tag("params.Bucket") is None
+            assert span.get_tag("params.Body") is None
+
+    @mock_s3
+    def test_s3_put_all_params(self):
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            span = self._test_s3_put()
+            assert span.get_tag("params.Key") == "foo"
+            assert span.get_tag("params.Bucket") == "mybucket"
+            # confirm blacklisted
+            assert span.get_tag("params.Body") is None
+
+    @mock_s3
+    def test_s3_put_no_params_all_params(self):
+        # DEV: Test no params overrides all params
+        with self.override_config("botocore", dict(tag_no_params=True, tag_all_params=True)):
+            span = self._test_s3_put()
+            assert span.get_tag("aws.s3.bucket_name") is None
+            assert span.get_tag("params.Key") is None
+            assert span.get_tag("params.Bucket") is None
+            assert span.get_tag("params.Body") is None
+
+    def _test_sqs_client(self):
+        sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
+        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sqs)
+
+        sqs.create_queue(QueueName="test")
+
+        spans = self.get_spans()
+        assert spans
+        span = spans[0]
+        assert len(spans) == 1
+        assert span.get_tag("aws.region") == "us-east-1"
+        assert span.get_tag("aws.operation") == "CreateQueue"
+        assert_is_measured(span)
+        assert_span_http_status_code(span, 200)
+        assert span.service == "test-botocore-tracing.sqs"
+        assert span.resource == "sqs.createqueue"
+        return span
 
     @mock_sqs
     def test_sqs_client(self):
-        sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sqs)
+        span = self._test_sqs_client()
+        assert span.get_tag("aws.sqs.queue_name") == "test"
 
-        sqs.list_queues()
+    @mock_sqs
+    def test_sqs_client_no_params(self):
+        with self.override_config("botocore", dict(tag_no_params=True)):
+            span = self._test_sqs_client()
+            assert span.get_tag("aws.sqs.queue_name") is None
+            assert span.get_tag("params.MessageBody") is None
 
-        spans = self.get_spans()
-        assert spans
-        span = spans[0]
-        assert len(spans) == 1
-        assert span.get_tag("aws.region") == "us-east-1"
-        assert span.get_tag("aws.operation") == "ListQueues"
-        assert span.get_tag("params.MessageBody") is None
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        assert span.service == "test-botocore-tracing.sqs"
-        assert span.resource == "sqs.listqueues"
+    @mock_sqs
+    def test_sqs_client_all_params(self):
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            span = self._test_sqs_client()
+            assert span.get_tag("params.MessageBody") is None
 
     @mock_sqs
     def test_sqs_send_message_trace_injection_with_no_message_attributes(self):
-        sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
-        queue = sqs.create_queue(QueueName="test")
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sqs)
+        # DEV: Only test deprecated behavior because this inspect span tags for MessageAttributes
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
+            queue = sqs.create_queue(QueueName="test")
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sqs)
 
-        sqs.send_message(QueueUrl=queue["QueueUrl"], MessageBody="world")
-        spans = self.get_spans()
-        assert spans
-        span = spans[0]
-        assert len(spans) == 1
-        assert span.get_tag("aws.region") == "us-east-1"
-        assert span.get_tag("aws.operation") == "SendMessage"
-        assert span.get_tag("params.MessageBody") is None
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        assert span.service == "test-botocore-tracing.sqs"
-        assert span.resource == "sqs.sendmessage"
-        trace_json = span.get_tag("params.MessageAttributes._datadog.StringValue")
-        trace_data_injected = json.loads(trace_json)
-        assert trace_data_injected[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        assert trace_data_injected[HTTP_HEADER_PARENT_ID] == str(span.span_id)
-        response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
-        assert len(response["Messages"]) == 1
-        trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
-        sqs.delete_queue(QueueUrl=queue["QueueUrl"])
-        trace_data_in_message = json.loads(trace_json_message)
-        assert trace_data_in_message[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        assert trace_data_in_message[HTTP_HEADER_PARENT_ID] == str(span.span_id)
+            sqs.send_message(QueueUrl=queue["QueueUrl"], MessageBody="world")
+            spans = self.get_spans()
+            assert spans
+            span = spans[0]
+            assert len(spans) == 1
+            assert span.get_tag("aws.region") == "us-east-1"
+            assert span.get_tag("aws.operation") == "SendMessage"
+            assert span.get_tag("params.MessageBody") is None
+            assert_is_measured(span)
+            assert_span_http_status_code(span, 200)
+            assert span.service == "test-botocore-tracing.sqs"
+            assert span.resource == "sqs.sendmessage"
+            trace_json = span.get_tag("params.MessageAttributes._datadog.StringValue")
+            trace_data_injected = json.loads(trace_json)
+            assert trace_data_injected[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
+            assert trace_data_injected[HTTP_HEADER_PARENT_ID] == str(span.span_id)
+            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+            assert len(response["Messages"]) == 1
+            trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
+            sqs.delete_queue(QueueUrl=queue["QueueUrl"])
+            trace_data_in_message = json.loads(trace_json_message)
+            assert trace_data_in_message[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
+            assert trace_data_in_message[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
     @mock_sqs
     def test_sqs_send_message_distributed_tracing_off(self):
-        with self.override_config("botocore", dict(distributed_tracing=False)):
+        # DEV: Only test deprecated behavior because this inspect span tags for MessageAttributes
+        with self.override_config("botocore", dict(distributed_tracing=False, tag_all_params=True)):
             sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
             queue = sqs.create_queue(QueueName="test")
             Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sqs)
@@ -312,154 +360,162 @@ class BotocoreTest(TracerTestCase):
 
     @mock_sqs
     def test_sqs_send_message_trace_injection_with_message_attributes(self):
-        sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
-        queue = sqs.create_queue(QueueName="test")
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sqs)
-        message_attributes = {
-            "one": {"DataType": "String", "StringValue": "one"},
-            "two": {"DataType": "String", "StringValue": "two"},
-            "three": {"DataType": "String", "StringValue": "three"},
-            "four": {"DataType": "String", "StringValue": "four"},
-            "five": {"DataType": "String", "StringValue": "five"},
-            "six": {"DataType": "String", "StringValue": "six"},
-            "seven": {"DataType": "String", "StringValue": "seven"},
-            "eight": {"DataType": "String", "StringValue": "eight"},
-            "nine": {"DataType": "String", "StringValue": "nine"},
-        }
-        sqs.send_message(QueueUrl=queue["QueueUrl"], MessageBody="world", MessageAttributes=message_attributes)
-        spans = self.get_spans()
-        assert spans
-        span = spans[0]
-        assert len(spans) == 1
-        assert span.get_tag("aws.region") == "us-east-1"
-        assert span.get_tag("aws.operation") == "SendMessage"
-        assert span.get_tag("params.MessageBody") is None
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        assert span.service == "test-botocore-tracing.sqs"
-        assert span.resource == "sqs.sendmessage"
-        trace_json = span.get_tag("params.MessageAttributes._datadog.StringValue")
-        trace_data_injected = json.loads(trace_json)
-        assert trace_data_injected[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        assert trace_data_injected[HTTP_HEADER_PARENT_ID] == str(span.span_id)
-        response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
-        assert len(response["Messages"]) == 1
-        trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
-        trace_data_in_message = json.loads(trace_json_message)
-        assert trace_data_in_message[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        assert trace_data_in_message[HTTP_HEADER_PARENT_ID] == str(span.span_id)
-        sqs.delete_queue(QueueUrl=queue["QueueUrl"])
+        # DEV: Only test deprecated behavior because this inspect span tags for MessageAttributes
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
+            queue = sqs.create_queue(QueueName="test")
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sqs)
+            message_attributes = {
+                "one": {"DataType": "String", "StringValue": "one"},
+                "two": {"DataType": "String", "StringValue": "two"},
+                "three": {"DataType": "String", "StringValue": "three"},
+                "four": {"DataType": "String", "StringValue": "four"},
+                "five": {"DataType": "String", "StringValue": "five"},
+                "six": {"DataType": "String", "StringValue": "six"},
+                "seven": {"DataType": "String", "StringValue": "seven"},
+                "eight": {"DataType": "String", "StringValue": "eight"},
+                "nine": {"DataType": "String", "StringValue": "nine"},
+            }
+            sqs.send_message(QueueUrl=queue["QueueUrl"], MessageBody="world", MessageAttributes=message_attributes)
+            spans = self.get_spans()
+            assert spans
+            span = spans[0]
+            assert len(spans) == 1
+            assert span.get_tag("aws.region") == "us-east-1"
+            assert span.get_tag("aws.operation") == "SendMessage"
+            assert span.get_tag("params.MessageBody") is None
+            assert_is_measured(span)
+            assert_span_http_status_code(span, 200)
+            assert span.service == "test-botocore-tracing.sqs"
+            assert span.resource == "sqs.sendmessage"
+            trace_json = span.get_tag("params.MessageAttributes._datadog.StringValue")
+            trace_data_injected = json.loads(trace_json)
+            assert trace_data_injected[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
+            assert trace_data_injected[HTTP_HEADER_PARENT_ID] == str(span.span_id)
+            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+            assert len(response["Messages"]) == 1
+            trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
+            trace_data_in_message = json.loads(trace_json_message)
+            assert trace_data_in_message[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
+            assert trace_data_in_message[HTTP_HEADER_PARENT_ID] == str(span.span_id)
+            sqs.delete_queue(QueueUrl=queue["QueueUrl"])
 
     @mock_sqs
     def test_sqs_send_message_trace_injection_with_max_message_attributes(self):
-        sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
-        queue = sqs.create_queue(QueueName="test")
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sqs)
-        message_attributes = {
-            "one": {"DataType": "String", "StringValue": "one"},
-            "two": {"DataType": "String", "StringValue": "two"},
-            "three": {"DataType": "String", "StringValue": "three"},
-            "four": {"DataType": "String", "StringValue": "four"},
-            "five": {"DataType": "String", "StringValue": "five"},
-            "six": {"DataType": "String", "StringValue": "six"},
-            "seven": {"DataType": "String", "StringValue": "seven"},
-            "eight": {"DataType": "String", "StringValue": "eight"},
-            "nine": {"DataType": "String", "StringValue": "nine"},
-            "ten": {"DataType": "String", "StringValue": "ten"},
-        }
-        sqs.send_message(QueueUrl=queue["QueueUrl"], MessageBody="world", MessageAttributes=message_attributes)
-        spans = self.get_spans()
-        assert spans
-        span = spans[0]
-        assert len(spans) == 1
-        assert span.get_tag("aws.region") == "us-east-1"
-        assert span.get_tag("aws.operation") == "SendMessage"
-        assert span.get_tag("params.MessageBody") is None
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        assert span.service == "test-botocore-tracing.sqs"
-        assert span.resource == "sqs.sendmessage"
-        trace_json = span.get_tag("params.MessageAttributes._datadog.StringValue")
-        assert trace_json is None
-        response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
-        assert len(response["Messages"]) == 1
-        trace_in_message = "MessageAttributes" in response["Messages"][0]
-        assert trace_in_message is False
-        sqs.delete_queue(QueueUrl=queue["QueueUrl"])
+        # DEV: Only test deprecated behavior where MessageBody would be excluded
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
+            queue = sqs.create_queue(QueueName="test")
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sqs)
+            message_attributes = {
+                "one": {"DataType": "String", "StringValue": "one"},
+                "two": {"DataType": "String", "StringValue": "two"},
+                "three": {"DataType": "String", "StringValue": "three"},
+                "four": {"DataType": "String", "StringValue": "four"},
+                "five": {"DataType": "String", "StringValue": "five"},
+                "six": {"DataType": "String", "StringValue": "six"},
+                "seven": {"DataType": "String", "StringValue": "seven"},
+                "eight": {"DataType": "String", "StringValue": "eight"},
+                "nine": {"DataType": "String", "StringValue": "nine"},
+                "ten": {"DataType": "String", "StringValue": "ten"},
+            }
+            sqs.send_message(QueueUrl=queue["QueueUrl"], MessageBody="world", MessageAttributes=message_attributes)
+            spans = self.get_spans()
+            assert spans
+            span = spans[0]
+            assert len(spans) == 1
+            assert span.get_tag("aws.region") == "us-east-1"
+            assert span.get_tag("aws.operation") == "SendMessage"
+            assert span.get_tag("params.MessageBody") is None
+            assert_is_measured(span)
+            assert_span_http_status_code(span, 200)
+            assert span.service == "test-botocore-tracing.sqs"
+            assert span.resource == "sqs.sendmessage"
+            trace_json = span.get_tag("params.MessageAttributes._datadog.StringValue")
+            assert trace_json is None
+            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+            assert len(response["Messages"]) == 1
+            trace_in_message = "MessageAttributes" in response["Messages"][0]
+            assert trace_in_message is False
+            sqs.delete_queue(QueueUrl=queue["QueueUrl"])
 
     @mock_sqs
     def test_sqs_send_message_batch_trace_injection_with_no_message_attributes(self):
-        sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
-        queue = sqs.create_queue(QueueName="test")
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sqs)
-        entries = [
-            {
-                "Id": "1",
-                "MessageBody": "ironmaiden",
-            }
-        ]
-        sqs.send_message_batch(QueueUrl=queue["QueueUrl"], Entries=entries)
-        spans = self.get_spans()
-        assert spans
-        span = spans[0]
-        assert len(spans) == 1
-        assert span.get_tag("aws.region") == "us-east-1"
-        assert span.get_tag("aws.operation") == "SendMessageBatch"
-        assert span.get_tag("params.MessageBody") is None
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        assert span.service == "test-botocore-tracing.sqs"
-        assert span.resource == "sqs.sendmessagebatch"
-        response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
-        assert len(response["Messages"]) == 1
-        trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
-        trace_data_in_message = json.loads(trace_json_message)
-        assert trace_data_in_message[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        assert trace_data_in_message[HTTP_HEADER_PARENT_ID] == str(span.span_id)
-        sqs.delete_queue(QueueUrl=queue["QueueUrl"])
+        # DEV: Only test deprecated behavior where MessageBody would be excluded
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
+            queue = sqs.create_queue(QueueName="test")
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sqs)
+            entries = [
+                {
+                    "Id": "1",
+                    "MessageBody": "ironmaiden",
+                }
+            ]
+            sqs.send_message_batch(QueueUrl=queue["QueueUrl"], Entries=entries)
+            spans = self.get_spans()
+            assert spans
+            span = spans[0]
+            assert len(spans) == 1
+            assert span.get_tag("aws.region") == "us-east-1"
+            assert span.get_tag("aws.operation") == "SendMessageBatch"
+            assert span.get_tag("params.MessageBody") is None
+            assert_is_measured(span)
+            assert_span_http_status_code(span, 200)
+            assert span.service == "test-botocore-tracing.sqs"
+            assert span.resource == "sqs.sendmessagebatch"
+            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+            assert len(response["Messages"]) == 1
+            trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
+            trace_data_in_message = json.loads(trace_json_message)
+            assert trace_data_in_message[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
+            assert trace_data_in_message[HTTP_HEADER_PARENT_ID] == str(span.span_id)
+            sqs.delete_queue(QueueUrl=queue["QueueUrl"])
 
     @mock_sqs
     def test_sqs_send_message_batch_trace_injection_with_message_attributes(self):
-        sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
-        queue = sqs.create_queue(QueueName="test")
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sqs)
-        entries = [
-            {
-                "Id": "1",
-                "MessageBody": "ironmaiden",
-                "MessageAttributes": {
-                    "one": {"DataType": "String", "StringValue": "one"},
-                    "two": {"DataType": "String", "StringValue": "two"},
-                    "three": {"DataType": "String", "StringValue": "three"},
-                    "four": {"DataType": "String", "StringValue": "four"},
-                    "five": {"DataType": "String", "StringValue": "five"},
-                    "six": {"DataType": "String", "StringValue": "six"},
-                    "seven": {"DataType": "String", "StringValue": "seven"},
-                    "eight": {"DataType": "String", "StringValue": "eight"},
-                    "nine": {"DataType": "String", "StringValue": "nine"},
-                },
-            }
-        ]
+        # DEV: Only test deprecated behavior where MessageBody would be excluded
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
+            queue = sqs.create_queue(QueueName="test")
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sqs)
+            entries = [
+                {
+                    "Id": "1",
+                    "MessageBody": "ironmaiden",
+                    "MessageAttributes": {
+                        "one": {"DataType": "String", "StringValue": "one"},
+                        "two": {"DataType": "String", "StringValue": "two"},
+                        "three": {"DataType": "String", "StringValue": "three"},
+                        "four": {"DataType": "String", "StringValue": "four"},
+                        "five": {"DataType": "String", "StringValue": "five"},
+                        "six": {"DataType": "String", "StringValue": "six"},
+                        "seven": {"DataType": "String", "StringValue": "seven"},
+                        "eight": {"DataType": "String", "StringValue": "eight"},
+                        "nine": {"DataType": "String", "StringValue": "nine"},
+                    },
+                }
+            ]
 
-        sqs.send_message_batch(QueueUrl=queue["QueueUrl"], Entries=entries)
-        spans = self.get_spans()
-        assert spans
-        span = spans[0]
-        assert len(spans) == 1
-        assert span.get_tag("aws.region") == "us-east-1"
-        assert span.get_tag("aws.operation") == "SendMessageBatch"
-        assert span.get_tag("params.MessageBody") is None
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        assert span.service == "test-botocore-tracing.sqs"
-        assert span.resource == "sqs.sendmessagebatch"
-        response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
-        assert len(response["Messages"]) == 1
-        trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
-        trace_data_in_message = json.loads(trace_json_message)
-        assert trace_data_in_message[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        assert trace_data_in_message[HTTP_HEADER_PARENT_ID] == str(span.span_id)
-        sqs.delete_queue(QueueUrl=queue["QueueUrl"])
+            sqs.send_message_batch(QueueUrl=queue["QueueUrl"], Entries=entries)
+            spans = self.get_spans()
+            assert spans
+            span = spans[0]
+            assert len(spans) == 1
+            assert span.get_tag("aws.region") == "us-east-1"
+            assert span.get_tag("aws.operation") == "SendMessageBatch"
+            assert span.get_tag("params.MessageBody") is None
+            assert_is_measured(span)
+            assert_span_http_status_code(span, 200)
+            assert span.service == "test-botocore-tracing.sqs"
+            assert span.resource == "sqs.sendmessagebatch"
+            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+            assert len(response["Messages"]) == 1
+            trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
+            trace_data_in_message = json.loads(trace_json_message)
+            assert trace_data_in_message[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
+            assert trace_data_in_message[HTTP_HEADER_PARENT_ID] == str(span.span_id)
+            sqs.delete_queue(QueueUrl=queue["QueueUrl"])
 
     @mock_sqs
     def test_sqs_send_message_batch_trace_injection_with_max_message_attributes(self):
@@ -503,23 +559,50 @@ class BotocoreTest(TracerTestCase):
         assert trace_in_message is False
         sqs.delete_queue(QueueUrl=queue["QueueUrl"])
 
-    @mock_kinesis
-    def test_kinesis_client(self):
-        kinesis = self.session.create_client("kinesis", region_name="us-east-1")
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(kinesis)
+    def _test_kinesis_client(self):
+        client = self.session.create_client("kinesis", region_name="us-east-1")
+        stream_name = "test"
+        client.create_stream(StreamName=stream_name, ShardCount=1)
 
-        kinesis.list_streams()
+        partition_key = "1234"
+        data = [
+            {"Data": json.dumps({"Hello": "World"}), "PartitionKey": partition_key},
+            {"Data": json.dumps({"foo": "bar"}), "PartitionKey": partition_key},
+        ]
+        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(client)
+        client.put_records(StreamName=stream_name, Records=data)
 
         spans = self.get_spans()
         assert spans
         span = spans[0]
         assert len(spans) == 1
         assert span.get_tag("aws.region") == "us-east-1"
-        assert span.get_tag("aws.operation") == "ListStreams"
+        assert span.get_tag("aws.operation") == "PutRecords"
         assert_is_measured(span)
         assert_span_http_status_code(span, 200)
         assert span.service == "test-botocore-tracing.kinesis"
-        assert span.resource == "kinesis.liststreams"
+        assert span.resource == "kinesis.putrecords"
+        return span
+
+    @mock_kinesis
+    def test_kinesis_client(self):
+        span = self._test_kinesis_client()
+        assert span.get_tag("aws.kinesis.stream_name") == "test"
+
+    @mock_kinesis
+    def test_kinesis_client_no_params(self):
+        with self.override_config("botocore", dict(tag_no_params=True)):
+            span = self._test_kinesis_client()
+            assert span.get_tag("aws.kinesis.stream_name") is None
+            assert span.get_tag("params.Records") is None
+
+    @mock_kinesis
+    def test_kinesis_client_all_params(self):
+        with self.override_config("botocore", dict(tag_no_params=True)):
+            span = self._test_kinesis_client()
+            assert span.get_tag("params.Records") is None
+            assert span.get_tag("params.Data") is None
+            assert span.get_tag("params.MessageBody") is None
 
     @mock_kinesis
     def test_unpatch(self):
@@ -548,6 +631,7 @@ class BotocoreTest(TracerTestCase):
 
     @mock_lambda
     def test_lambda_client(self):
+        # DEV: No lambda params tagged so we only check no ClientContext
         lamb = self.session.create_client("lambda", region_name="us-west-2")
         Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(lamb)
 
@@ -563,53 +647,57 @@ class BotocoreTest(TracerTestCase):
         assert_span_http_status_code(span, 200)
         assert span.service == "test-botocore-tracing.lambda"
         assert span.resource == "lambda.listfunctions"
+        assert span.get_tag("params.ClientContext") is None
 
     @mock_lambda
     def test_lambda_invoke_no_context_client(self):
-        lamb = self.session.create_client("lambda", region_name="us-west-2", endpoint_url="http://localhost:4566")
-        lamb.create_function(
-            FunctionName="ironmaiden",
-            Runtime="python3.7",
-            Role="test-iam-role",
-            Handler="lambda_function.lambda_handler",
-            Code={
-                "ZipFile": get_zip_lambda(),
-            },
-            Publish=True,
-            Timeout=30,
-            MemorySize=128,
-        )
+        # DEV: Test only deprecated behavior as we need to inspect span tags for ClientContext
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            lamb = self.session.create_client("lambda", region_name="us-west-2", endpoint_url="http://localhost:4566")
+            lamb.create_function(
+                FunctionName="ironmaiden",
+                Runtime="python3.7",
+                Role="test-iam-role",
+                Handler="lambda_function.lambda_handler",
+                Code={
+                    "ZipFile": get_zip_lambda(),
+                },
+                Publish=True,
+                Timeout=30,
+                MemorySize=128,
+            )
 
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(lamb)
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(lamb)
 
-        lamb.invoke(
-            FunctionName="ironmaiden",
-            Payload=json.dumps({}),
-        )
+            lamb.invoke(
+                FunctionName="ironmaiden",
+                Payload=json.dumps({}),
+            )
 
-        spans = self.get_spans()
-        assert spans
-        span = spans[0]
+            spans = self.get_spans()
+            assert spans
+            span = spans[0]
 
-        assert len(spans) == 1
-        assert span.get_tag("aws.region") == "us-west-2"
-        assert span.get_tag("aws.operation") == "Invoke"
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        assert span.service == "test-botocore-tracing.lambda"
-        assert span.resource == "lambda.invoke"
-        context_b64 = span.get_tag("params.ClientContext")
-        context_json = base64.b64decode(context_b64.encode()).decode()
-        context_obj = json.loads(context_json)
+            assert len(spans) == 1
+            assert span.get_tag("aws.region") == "us-west-2"
+            assert span.get_tag("aws.operation") == "Invoke"
+            assert_is_measured(span)
+            assert_span_http_status_code(span, 200)
+            assert span.service == "test-botocore-tracing.lambda"
+            assert span.resource == "lambda.invoke"
+            context_b64 = span.get_tag("params.ClientContext")
+            context_json = base64.b64decode(context_b64.encode()).decode()
+            context_obj = json.loads(context_json)
 
-        assert context_obj["custom"][HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        assert context_obj["custom"][HTTP_HEADER_PARENT_ID] == str(span.span_id)
+            assert context_obj["custom"][HTTP_HEADER_TRACE_ID] == str(span.trace_id)
+            assert context_obj["custom"][HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
-        lamb.delete_function(FunctionName="ironmaiden")
+            lamb.delete_function(FunctionName="ironmaiden")
 
     @mock_lambda
     def test_lambda_invoke_with_old_style_trace_propagation(self):
-        with self.override_config("botocore", dict(invoke_with_legacy_context=True)):
+        # DEV: Test only deprecated behavior as we need to inspect span tags for ClientContext
+        with self.override_config("botocore", dict(invoke_with_legacy_context=True, tag_all_params=True)):
             lamb = self.session.create_client("lambda", region_name="us-west-2", endpoint_url="http://localhost:4566")
             lamb.create_function(
                 FunctionName="ironmaiden",
@@ -653,7 +741,8 @@ class BotocoreTest(TracerTestCase):
 
     @mock_lambda
     def test_lambda_invoke_distributed_tracing_off(self):
-        with self.override_config("botocore", dict(distributed_tracing=False)):
+        # DEV: Test only deprecated behavior as we need to inspect span tags for ClientContext
+        with self.override_config("botocore", dict(distributed_tracing=False, tag_all_params=True)):
             lamb = self.session.create_client("lambda", region_name="us-west-2", endpoint_url="http://localhost:4566")
             lamb.create_function(
                 FunctionName="ironmaiden",
@@ -691,49 +780,51 @@ class BotocoreTest(TracerTestCase):
 
     @mock_lambda
     def test_lambda_invoke_with_context_client(self):
-        lamb = self.session.create_client("lambda", region_name="us-west-2", endpoint_url="http://localhost:4566")
-        lamb.create_function(
-            FunctionName="megadeth",
-            Runtime="python3.7",
-            Role="test-iam-role",
-            Handler="lambda_function.lambda_handler",
-            Code={
-                "ZipFile": get_zip_lambda(),
-            },
-            Publish=True,
-            Timeout=30,
-            MemorySize=128,
-        )
-        client_context = base64.b64encode(json.dumps({"custom": {"foo": "bar"}}).encode()).decode()
+        # DEV: Test only deprecated behavior as we need to inspect span tags for ClientContext
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            lamb = self.session.create_client("lambda", region_name="us-west-2", endpoint_url="http://localhost:4566")
+            lamb.create_function(
+                FunctionName="megadeth",
+                Runtime="python3.7",
+                Role="test-iam-role",
+                Handler="lambda_function.lambda_handler",
+                Code={
+                    "ZipFile": get_zip_lambda(),
+                },
+                Publish=True,
+                Timeout=30,
+                MemorySize=128,
+            )
+            client_context = base64.b64encode(json.dumps({"custom": {"foo": "bar"}}).encode()).decode()
 
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(lamb)
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(lamb)
 
-        lamb.invoke(
-            FunctionName="megadeth",
-            ClientContext=client_context,
-            Payload=json.dumps({}),
-        )
+            lamb.invoke(
+                FunctionName="megadeth",
+                ClientContext=client_context,
+                Payload=json.dumps({}),
+            )
 
-        spans = self.get_spans()
-        assert spans
-        span = spans[0]
+            spans = self.get_spans()
+            assert spans
+            span = spans[0]
 
-        assert len(spans) == 1
-        assert span.get_tag("aws.region") == "us-west-2"
-        assert span.get_tag("aws.operation") == "Invoke"
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        assert span.service == "test-botocore-tracing.lambda"
-        assert span.resource == "lambda.invoke"
-        context_b64 = span.get_tag("params.ClientContext")
-        context_json = base64.b64decode(context_b64.encode()).decode()
-        context_obj = json.loads(context_json)
+            assert len(spans) == 1
+            assert span.get_tag("aws.region") == "us-west-2"
+            assert span.get_tag("aws.operation") == "Invoke"
+            assert_is_measured(span)
+            assert_span_http_status_code(span, 200)
+            assert span.service == "test-botocore-tracing.lambda"
+            assert span.resource == "lambda.invoke"
+            context_b64 = span.get_tag("params.ClientContext")
+            context_json = base64.b64decode(context_b64.encode()).decode()
+            context_obj = json.loads(context_json)
 
-        assert context_obj["custom"]["foo"] == "bar"
-        assert context_obj["custom"][HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        assert context_obj["custom"][HTTP_HEADER_PARENT_ID] == str(span.span_id)
+            assert context_obj["custom"]["foo"] == "bar"
+            assert context_obj["custom"][HTTP_HEADER_TRACE_ID] == str(span.trace_id)
+            assert context_obj["custom"][HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
-        lamb.delete_function(FunctionName="megadeth")
+            lamb.delete_function(FunctionName="megadeth")
 
     @mock_lambda
     def test_lambda_invoke_bad_context_client(self):
@@ -770,152 +861,158 @@ class BotocoreTest(TracerTestCase):
 
     @mock_events
     def test_eventbridge_single_entry_trace_injection(self):
-        bridge = self.session.create_client("events", region_name="us-east-1", endpoint_url="http://localhost:4566")
-        bridge.create_event_bus(Name="a-test-bus")
+        # DEV: Only check deprecated all params behavior
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            bridge = self.session.create_client("events", region_name="us-east-1", endpoint_url="http://localhost:4566")
+            bridge.create_event_bus(Name="a-test-bus")
 
-        entries = [
-            {
-                "Source": "some-event-source",
-                "DetailType": "some-event-detail-type",
-                "Detail": json.dumps({"foo": "bar"}),
-                "EventBusName": "a-test-bus",
-            }
-        ]
-        bridge.put_rule(
-            Name="a-test-bus-rule",
-            EventBusName="a-test-bus",
-            EventPattern="""{"source": [{"prefix": ""}]}""",
-            State="ENABLED",
-        )
+            entries = [
+                {
+                    "Source": "some-event-source",
+                    "DetailType": "some-event-detail-type",
+                    "Detail": json.dumps({"foo": "bar"}),
+                    "EventBusName": "a-test-bus",
+                }
+            ]
+            bridge.put_rule(
+                Name="a-test-bus-rule",
+                EventBusName="a-test-bus",
+                EventPattern="""{"source": [{"prefix": ""}]}""",
+                State="ENABLED",
+            )
 
-        bridge.list_rules()
-        sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
-        queue = sqs.create_queue(QueueName="test")
-        queue_url = queue["QueueUrl"]
-        bridge.put_targets(
-            Rule="a-test-bus-rule",
-            Targets=[{"Id": "a-test-bus-rule-target", "Arn": "arn:aws:sqs:us-east-1:000000000000:test"}],
-        )
+            bridge.list_rules()
+            sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
+            queue = sqs.create_queue(QueueName="test")
+            queue_url = queue["QueueUrl"]
+            bridge.put_targets(
+                Rule="a-test-bus-rule",
+                Targets=[{"Id": "a-test-bus-rule-target", "Arn": "arn:aws:sqs:us-east-1:000000000000:test"}],
+            )
 
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(bridge)
-        bridge.put_events(Entries=entries)
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(bridge)
+            bridge.put_events(Entries=entries)
 
-        messages = sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=2)
+            messages = sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=2)
 
-        bridge.delete_event_bus(Name="a-test-bus")
-        sqs.delete_queue(QueueUrl=queue["QueueUrl"])
+            bridge.delete_event_bus(Name="a-test-bus")
+            sqs.delete_queue(QueueUrl=queue["QueueUrl"])
 
-        spans = self.get_spans()
-        assert spans
-        assert len(spans) == 2
-        span = spans[0]
-        str_entries = span.get_tag("params.Entries")
-        assert str_entries is None
+            spans = self.get_spans()
+            assert spans
+            assert len(spans) == 2
+            span = spans[0]
+            str_entries = span.get_tag("params.Entries")
+            assert str_entries is None
 
-        message = messages["Messages"][0]
-        body = message.get("Body")
-        assert body is not None
-        # body_obj = ast.literal_eval(body)
-        body_obj = json.loads(body)
-        detail = body_obj.get("detail")
-        headers = detail.get("_datadog")
-        assert headers is not None
-        assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
+            message = messages["Messages"][0]
+            body = message.get("Body")
+            assert body is not None
+            # body_obj = ast.literal_eval(body)
+            body_obj = json.loads(body)
+            detail = body_obj.get("detail")
+            headers = detail.get("_datadog")
+            assert headers is not None
+            assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
+            assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
     @mock_events
     def test_eventbridge_muliple_entries_trace_injection(self):
-        bridge = self.session.create_client("events", region_name="us-east-1", endpoint_url="http://localhost:4566")
-        bridge.create_event_bus(Name="a-test-bus")
+        # DEV: Only check deprecated all params behavior
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            bridge = self.session.create_client("events", region_name="us-east-1", endpoint_url="http://localhost:4566")
+            bridge.create_event_bus(Name="a-test-bus")
 
-        entries = [
-            {
-                "Source": "another-event-source",
-                "DetailType": "a-different-event-detail-type",
-                "Detail": json.dumps({"abc": "xyz"}),
-                "EventBusName": "a-test-bus",
-            },
-            {
-                "Source": "some-event-source",
-                "DetailType": "some-event-detail-type",
-                "Detail": json.dumps({"foo": "bar"}),
-                "EventBusName": "a-test-bus",
-            },
-        ]
-        bridge.put_rule(
-            Name="a-test-bus-rule",
-            EventBusName="a-test-bus",
-            EventPattern="""{"source": [{"prefix": ""}]}""",
-            State="ENABLED",
-        )
+            entries = [
+                {
+                    "Source": "another-event-source",
+                    "DetailType": "a-different-event-detail-type",
+                    "Detail": json.dumps({"abc": "xyz"}),
+                    "EventBusName": "a-test-bus",
+                },
+                {
+                    "Source": "some-event-source",
+                    "DetailType": "some-event-detail-type",
+                    "Detail": json.dumps({"foo": "bar"}),
+                    "EventBusName": "a-test-bus",
+                },
+            ]
+            bridge.put_rule(
+                Name="a-test-bus-rule",
+                EventBusName="a-test-bus",
+                EventPattern="""{"source": [{"prefix": ""}]}""",
+                State="ENABLED",
+            )
 
-        bridge.list_rules()
-        sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
-        queue = sqs.create_queue(QueueName="test")
-        queue_url = queue["QueueUrl"]
-        bridge.put_targets(
-            Rule="a-test-bus-rule",
-            Targets=[{"Id": "a-test-bus-rule-target", "Arn": "arn:aws:sqs:us-east-1:000000000000:test"}],
-        )
+            bridge.list_rules()
+            sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
+            queue = sqs.create_queue(QueueName="test")
+            queue_url = queue["QueueUrl"]
+            bridge.put_targets(
+                Rule="a-test-bus-rule",
+                Targets=[{"Id": "a-test-bus-rule-target", "Arn": "arn:aws:sqs:us-east-1:000000000000:test"}],
+            )
 
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(bridge)
-        bridge.put_events(Entries=entries)
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(bridge)
+            bridge.put_events(Entries=entries)
 
-        messages = sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=2)
+            messages = sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=2)
 
-        bridge.delete_event_bus(Name="a-test-bus")
-        sqs.delete_queue(QueueUrl=queue["QueueUrl"])
+            bridge.delete_event_bus(Name="a-test-bus")
+            sqs.delete_queue(QueueUrl=queue["QueueUrl"])
 
-        spans = self.get_spans()
-        assert spans
-        assert len(spans) == 2
-        span = spans[0]
-        str_entries = span.get_tag("params.Entries")
-        assert str_entries is None
+            spans = self.get_spans()
+            assert spans
+            assert len(spans) == 2
+            span = spans[0]
+            str_entries = span.get_tag("params.Entries")
+            assert str_entries is None
 
-        message = messages["Messages"][0]
-        body = message.get("Body")
-        assert body is not None
-        body_obj = json.loads(body)
-        detail = body_obj.get("detail")
-        headers = detail.get("_datadog")
-        assert headers is not None
-        assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
+            message = messages["Messages"][0]
+            body = message.get("Body")
+            assert body is not None
+            body_obj = json.loads(body)
+            detail = body_obj.get("detail")
+            headers = detail.get("_datadog")
+            assert headers is not None
+            assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
+            assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
-        # the following doesn't work due to an issue in moto/localstack where
-        # an SQS message is generated per put_events rather than per event sent
+            # the following doesn't work due to an issue in moto/localstack where
+            # an SQS message is generated per put_events rather than per event sent
 
-        # message = messages["Messages"][1]
-        # body = message.get("Body")
-        # assert body is not None
-        # body_obj = json.loads(body)
-        # detail = body_obj.get("detail")
-        # headers = detail.get("_datadog")
-        # assert headers is not None
-        # assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        # assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
+            # message = messages["Messages"][1]
+            # body = message.get("Body")
+            # assert body is not None
+            # body_obj = json.loads(body)
+            # detail = body_obj.get("detail")
+            # headers = detail.get("_datadog")
+            # assert headers is not None
+            # assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
+            # assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
     @mock_kms
     def test_kms_client(self):
-        kms = self.session.create_client("kms", region_name="us-east-1")
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(kms)
+        # DEV: We can ignore the params tags as none currently exists. Test all params for deprecated exclusion.
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            kms = self.session.create_client("kms", region_name="us-east-1")
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(kms)
 
-        kms.list_keys(Limit=21)
+            kms.list_keys(Limit=21)
 
-        spans = self.get_spans()
-        assert spans
-        span = spans[0]
-        assert len(spans) == 1
-        assert span.get_tag("aws.region") == "us-east-1"
-        assert span.get_tag("aws.operation") == "ListKeys"
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        assert span.service == "test-botocore-tracing.kms"
-        assert span.resource == "kms.listkeys"
+            spans = self.get_spans()
+            assert spans
+            span = spans[0]
+            assert len(spans) == 1
+            assert span.get_tag("aws.region") == "us-east-1"
+            assert span.get_tag("aws.operation") == "ListKeys"
+            assert_is_measured(span)
+            assert_span_http_status_code(span, 200)
+            assert span.service == "test-botocore-tracing.kms"
+            assert span.resource == "kms.listkeys"
 
-        # checking for protection on sts against security leak
-        assert span.get_tag("params") is None
+            # checking for protection on sts against security leak
+            assert span.get_tag("params") is None
 
     @mock_ec2
     def test_traced_client_ot(self):
@@ -967,48 +1064,50 @@ class BotocoreTest(TracerTestCase):
 
     @mock_firehose
     def test_firehose_no_records_arg(self):
-        firehose = self.session.create_client("firehose", region_name="us-west-2")
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(firehose)
+        # DEV: This test only applies for deprecated all params
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            firehose = self.session.create_client("firehose", region_name="us-west-2")
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(firehose)
 
-        stream_name = "test-stream"
-        account_id = "test-account"
+            stream_name = "test-stream"
+            account_id = "test-account"
 
-        firehose.create_delivery_stream(
-            DeliveryStreamName=stream_name,
-            RedshiftDestinationConfiguration={
-                "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(account_id),
-                "ClusterJDBCURL": "jdbc:redshift://host.amazonaws.com:5439/database",
-                "CopyCommand": {
-                    "DataTableName": "outputTable",
-                    "CopyOptions": "CSV DELIMITER ',' NULL '\\0'",
-                },
-                "Username": "username",
-                "Password": "password",
-                "S3Configuration": {
+            firehose.create_delivery_stream(
+                DeliveryStreamName=stream_name,
+                RedshiftDestinationConfiguration={
                     "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(account_id),
-                    "BucketARN": "arn:aws:s3:::kinesis-test",
-                    "Prefix": "myFolder/",
-                    "BufferingHints": {"SizeInMBs": 123, "IntervalInSeconds": 124},
-                    "CompressionFormat": "UNCOMPRESSED",
+                    "ClusterJDBCURL": "jdbc:redshift://host.amazonaws.com:5439/database",
+                    "CopyCommand": {
+                        "DataTableName": "outputTable",
+                        "CopyOptions": "CSV DELIMITER ',' NULL '\\0'",
+                    },
+                    "Username": "username",
+                    "Password": "password",
+                    "S3Configuration": {
+                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(account_id),
+                        "BucketARN": "arn:aws:s3:::kinesis-test",
+                        "Prefix": "myFolder/",
+                        "BufferingHints": {"SizeInMBs": 123, "IntervalInSeconds": 124},
+                        "CompressionFormat": "UNCOMPRESSED",
+                    },
                 },
-            },
-        )
+            )
 
-        firehose.put_record_batch(
-            DeliveryStreamName=stream_name,
-            Records=[{"Data": "some data"}],
-        )
+            firehose.put_record_batch(
+                DeliveryStreamName=stream_name,
+                Records=[{"Data": "some data"}],
+            )
 
-        spans = self.get_spans()
+            spans = self.get_spans()
 
-        assert spans
-        assert len(spans) == 2
-        assert all(span.name == "firehose.command" for span in spans)
+            assert spans
+            assert len(spans) == 2
+            assert all(span.name == "firehose.command" for span in spans)
 
-        delivery_stream_span, put_record_batch_span = spans
-        assert delivery_stream_span.get_tag("aws.operation") == "CreateDeliveryStream"
-        assert put_record_batch_span.get_tag("aws.operation") == "PutRecordBatch"
-        assert put_record_batch_span.get_tag("params.Records") is None
+            delivery_stream_span, put_record_batch_span = spans
+            assert delivery_stream_span.get_tag("aws.operation") == "CreateDeliveryStream"
+            assert put_record_batch_span.get_tag("aws.operation") == "PutRecordBatch"
+            assert put_record_batch_span.get_tag("params.Records") is None
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_BOTOCORE_DISTRIBUTED_TRACING="true"))
     def test_distributed_tracing_env_override(self):
@@ -1022,9 +1121,7 @@ class BotocoreTest(TracerTestCase):
     def test_invoke_legacy_context_env_override(self):
         assert config.botocore.invoke_with_legacy_context is True
 
-    @mock_sns
-    @mock_sqs
-    def test_sns_send_message_trace_injection_with_no_message_attributes(self):
+    def _test_sns(self):
         sns = self.session.create_client("sns", region_name="us-east-1", endpoint_url="http://localhost:4566")
         sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
 
@@ -1041,171 +1138,229 @@ class BotocoreTest(TracerTestCase):
         spans = self.get_spans()
 
         # get SNS messages via SQS
-        response = sqs.receive_message(QueueUrl=queue["QueueUrl"], WaitTimeSeconds=2)
+        _ = sqs.receive_message(QueueUrl=queue["QueueUrl"], WaitTimeSeconds=2)
 
         # clean up resources
         sqs.delete_queue(QueueUrl=sqs_url)
         sns.delete_topic(TopicArn=topic_arn)
 
         # check if the appropriate span was generated
-        assert spans
-        span = spans[0]
         assert len(spans) == 2
-        assert span.get_tag("aws.region") == "us-east-1"
-        assert span.get_tag("aws.operation") == "Publish"
-        assert span.get_tag("params.MessageBody") is None
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        assert span.service == "test-botocore-tracing.sns"
-        assert span.resource == "sns.publish"
-        trace_json = span.get_tag("params.MessageAttributes._datadog.StringValue")
-        assert trace_json is None
+        return spans[0]
 
-        # receive message using SQS and ensure headers are present
-        assert len(response["Messages"]) == 1
-        msg = response["Messages"][0]
-        assert msg is not None
-        msg_body = json.loads(msg["Body"])
-        msg_str = msg_body["Message"]
-        assert msg_str == "test"
-        msg_attr = msg_body["MessageAttributes"]
-        assert msg_attr.get("_datadog") is not None
-        assert msg_attr["_datadog"]["Type"] == "Binary"
-        datadog_value_decoded = base64.b64decode(msg_attr["_datadog"]["Value"])
-        headers = json.loads(datadog_value_decoded.decode())
-        assert headers is not None
-        assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
+    @mock_sns
+    @mock_sqs
+    def test_sns(self):
+        span = self._test_sns()
+        assert span.get_tag("aws.sns.topic_arn") == "arn:aws:sns:us-east-1:000000000000:testTopic"
+
+    @mock_sns
+    @mock_sqs
+    def test_sns_no_params(self):
+        with self.override_config("botocore", dict(tag_no_params=True)):
+            span = self._test_sns()
+            assert span.get_tag("aws.sns.topic_arn") is None
+
+    @mock_sns
+    @mock_sqs
+    def test_sns_all_params(self):
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            span = self._test_sns()
+            assert span.get_tag("params.MessageBody") is None
+
+    @mock_sns
+    @mock_sqs
+    def test_sns_send_message_trace_injection_with_no_message_attributes(self):
+        # DEV: This test expects MessageAttributes to be included as span tags which has been deprecated.
+        # TODO: Move away from inspecting MessageAttributes using span tag
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            sns = self.session.create_client("sns", region_name="us-east-1", endpoint_url="http://localhost:4566")
+            sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
+
+            topic = sns.create_topic(Name="testTopic")
+            queue = sqs.create_queue(QueueName="test")
+
+            topic_arn = topic["TopicArn"]
+            sqs_url = queue["QueueUrl"]
+            sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=sqs_url)
+
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sns)
+
+            sns.publish(TopicArn=topic_arn, Message="test")
+            spans = self.get_spans()
+
+            # get SNS messages via SQS
+            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], WaitTimeSeconds=2)
+
+            # clean up resources
+            sqs.delete_queue(QueueUrl=sqs_url)
+            sns.delete_topic(TopicArn=topic_arn)
+
+            # check if the appropriate span was generated
+            assert spans
+            span = spans[0]
+            assert len(spans) == 2
+            assert span.get_tag("aws.region") == "us-east-1"
+            assert span.get_tag("aws.operation") == "Publish"
+            assert span.get_tag("params.MessageBody") is None
+            assert_is_measured(span)
+            assert_span_http_status_code(span, 200)
+            assert span.service == "test-botocore-tracing.sns"
+            assert span.resource == "sns.publish"
+            trace_json = span.get_tag("params.MessageAttributes._datadog.StringValue")
+            assert trace_json is None
+
+            # receive message using SQS and ensure headers are present
+            assert len(response["Messages"]) == 1
+            msg = response["Messages"][0]
+            assert msg is not None
+            msg_body = json.loads(msg["Body"])
+            msg_str = msg_body["Message"]
+            assert msg_str == "test"
+            msg_attr = msg_body["MessageAttributes"]
+            assert msg_attr.get("_datadog") is not None
+            assert msg_attr["_datadog"]["Type"] == "Binary"
+            datadog_value_decoded = base64.b64decode(msg_attr["_datadog"]["Value"])
+            headers = json.loads(datadog_value_decoded.decode())
+            assert headers is not None
+            assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
+            assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
     @mock_sns
     @mock_sqs
     @pytest.mark.xfail(strict=False)  # FIXME: flaky test
     def test_sns_send_message_trace_injection_with_message_attributes(self):
-        sns = self.session.create_client("sns", region_name="us-east-1", endpoint_url="http://localhost:4566")
-        sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
+        # DEV: This test expects MessageAttributes to be included as span tags which has been deprecated.
+        # TODO: Move away from inspecting MessageAttributes using span tag
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            sns = self.session.create_client("sns", region_name="us-east-1", endpoint_url="http://localhost:4566")
+            sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
 
-        topic = sns.create_topic(Name="testTopic")
-        queue = sqs.create_queue(QueueName="test")
+            topic = sns.create_topic(Name="testTopic")
+            queue = sqs.create_queue(QueueName="test")
 
-        topic_arn = topic["TopicArn"]
-        sqs_url = queue["QueueUrl"]
-        sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=sqs_url)
+            topic_arn = topic["TopicArn"]
+            sqs_url = queue["QueueUrl"]
+            sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=sqs_url)
 
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sns)
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sns)
 
-        message_attributes = {
-            "one": {"DataType": "String", "StringValue": "one"},
-            "two": {"DataType": "String", "StringValue": "two"},
-            "three": {"DataType": "String", "StringValue": "three"},
-            "four": {"DataType": "String", "StringValue": "four"},
-            "five": {"DataType": "String", "StringValue": "five"},
-            "six": {"DataType": "String", "StringValue": "six"},
-            "seven": {"DataType": "String", "StringValue": "seven"},
-            "eight": {"DataType": "String", "StringValue": "eight"},
-            "nine": {"DataType": "String", "StringValue": "nine"},
-        }
+            message_attributes = {
+                "one": {"DataType": "String", "StringValue": "one"},
+                "two": {"DataType": "String", "StringValue": "two"},
+                "three": {"DataType": "String", "StringValue": "three"},
+                "four": {"DataType": "String", "StringValue": "four"},
+                "five": {"DataType": "String", "StringValue": "five"},
+                "six": {"DataType": "String", "StringValue": "six"},
+                "seven": {"DataType": "String", "StringValue": "seven"},
+                "eight": {"DataType": "String", "StringValue": "eight"},
+                "nine": {"DataType": "String", "StringValue": "nine"},
+            }
 
-        sns.publish(TopicArn=topic_arn, Message="test", MessageAttributes=message_attributes)
-        spans = self.get_spans()
+            sns.publish(TopicArn=topic_arn, Message="test", MessageAttributes=message_attributes)
+            spans = self.get_spans()
 
-        # get SNS messages via SQS
-        response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+            # get SNS messages via SQS
+            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
 
-        # clean up resources
-        sqs.delete_queue(QueueUrl=sqs_url)
-        sns.delete_topic(TopicArn=topic_arn)
+            # clean up resources
+            sqs.delete_queue(QueueUrl=sqs_url)
+            sns.delete_topic(TopicArn=topic_arn)
 
-        # check if the appropriate span was generated
-        assert spans
-        span = spans[0]
-        assert len(spans) == 2
-        assert span.get_tag("aws.region") == "us-east-1"
-        assert span.get_tag("aws.operation") == "Publish"
-        assert span.get_tag("params.MessageBody") is None
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        assert span.service == "test-botocore-tracing.sns"
-        assert span.resource == "sns.publish"
-        trace_json = span.get_tag("params.MessageAttributes._datadog.StringValue")
-        assert trace_json is None
+            # check if the appropriate span was generated
+            assert spans
+            span = spans[0]
+            assert len(spans) == 2
+            assert span.get_tag("aws.region") == "us-east-1"
+            assert span.get_tag("aws.operation") == "Publish"
+            assert span.get_tag("params.MessageBody") is None
+            assert_is_measured(span)
+            assert_span_http_status_code(span, 200)
+            assert span.service == "test-botocore-tracing.sns"
+            assert span.resource == "sns.publish"
+            trace_json = span.get_tag("params.MessageAttributes._datadog.StringValue")
+            assert trace_json is None
 
-        # receive message using SQS and ensure headers are present
-        assert len(response["Messages"]) == 1
-        msg = response["Messages"][0]
-        assert msg is not None
-        msg_body = json.loads(msg["Body"])
-        msg_str = msg_body["Message"]
-        assert msg_str == "test"
-        msg_attr = msg_body["MessageAttributes"]
-        assert msg_attr.get("_datadog") is not None
-        assert msg_attr["_datadog"]["Type"] == "Binary"
-        datadog_value_decoded = base64.b64decode(msg_attr["_datadog"]["Value"])
-        headers = json.loads(datadog_value_decoded.decode())
-        assert headers is not None
-        assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
-        assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
+            # receive message using SQS and ensure headers are present
+            assert len(response["Messages"]) == 1
+            msg = response["Messages"][0]
+            assert msg is not None
+            msg_body = json.loads(msg["Body"])
+            msg_str = msg_body["Message"]
+            assert msg_str == "test"
+            msg_attr = msg_body["MessageAttributes"]
+            assert msg_attr.get("_datadog") is not None
+            assert msg_attr["_datadog"]["Type"] == "Binary"
+            datadog_value_decoded = base64.b64decode(msg_attr["_datadog"]["Value"])
+            headers = json.loads(datadog_value_decoded.decode())
+            assert headers is not None
+            assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
+            assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
     @mock_sns
     @mock_sqs
     def test_sns_send_message_trace_injection_with_max_message_attributes(self):
-        sns = self.session.create_client("sns", region_name="us-east-1", endpoint_url="http://localhost:4566")
-        sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
+        # DEV: This test expects MessageAttributes to be included as span tags which has been deprecated.
+        # TODO: Move away from inspecting MessageAttributes using span tag
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            sns = self.session.create_client("sns", region_name="us-east-1", endpoint_url="http://localhost:4566")
+            sqs = self.session.create_client("sqs", region_name="us-east-1", endpoint_url="http://localhost:4566")
 
-        topic = sns.create_topic(Name="testTopic")
-        queue = sqs.create_queue(QueueName="test")
+            topic = sns.create_topic(Name="testTopic")
+            queue = sqs.create_queue(QueueName="test")
 
-        topic_arn = topic["TopicArn"]
-        sqs_url = queue["QueueUrl"]
-        sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=sqs_url)
+            topic_arn = topic["TopicArn"]
+            sqs_url = queue["QueueUrl"]
+            sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=sqs_url)
 
-        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sns)
+            Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(sns)
 
-        message_attributes = {
-            "one": {"DataType": "String", "StringValue": "one"},
-            "two": {"DataType": "String", "StringValue": "two"},
-            "three": {"DataType": "String", "StringValue": "three"},
-            "four": {"DataType": "String", "StringValue": "four"},
-            "five": {"DataType": "String", "StringValue": "five"},
-            "six": {"DataType": "String", "StringValue": "six"},
-            "seven": {"DataType": "String", "StringValue": "seven"},
-            "eight": {"DataType": "String", "StringValue": "eight"},
-            "nine": {"DataType": "String", "StringValue": "nine"},
-            "ten": {"DataType": "String", "StringValue": "ten"},
-        }
+            message_attributes = {
+                "one": {"DataType": "String", "StringValue": "one"},
+                "two": {"DataType": "String", "StringValue": "two"},
+                "three": {"DataType": "String", "StringValue": "three"},
+                "four": {"DataType": "String", "StringValue": "four"},
+                "five": {"DataType": "String", "StringValue": "five"},
+                "six": {"DataType": "String", "StringValue": "six"},
+                "seven": {"DataType": "String", "StringValue": "seven"},
+                "eight": {"DataType": "String", "StringValue": "eight"},
+                "nine": {"DataType": "String", "StringValue": "nine"},
+                "ten": {"DataType": "String", "StringValue": "ten"},
+            }
 
-        sns.publish(TopicArn=topic_arn, Message="test", MessageAttributes=message_attributes)
-        spans = self.get_spans()
+            sns.publish(TopicArn=topic_arn, Message="test", MessageAttributes=message_attributes)
+            spans = self.get_spans()
 
-        # get SNS messages via SQS
-        response = sqs.receive_message(QueueUrl=queue["QueueUrl"], WaitTimeSeconds=2)
+            # get SNS messages via SQS
+            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], WaitTimeSeconds=2)
 
-        # clean up resources
-        sqs.delete_queue(QueueUrl=sqs_url)
-        sns.delete_topic(TopicArn=topic_arn)
+            # clean up resources
+            sqs.delete_queue(QueueUrl=sqs_url)
+            sns.delete_topic(TopicArn=topic_arn)
 
-        # check if the appropriate span was generated
-        assert spans
-        span = spans[0]
-        assert len(spans) == 2
-        assert span.get_tag("aws.region") == "us-east-1"
-        assert span.get_tag("aws.operation") == "Publish"
-        assert span.get_tag("params.MessageBody") is None
-        assert_is_measured(span)
-        assert_span_http_status_code(span, 200)
-        assert span.service == "test-botocore-tracing.sns"
-        assert span.resource == "sns.publish"
-        trace_json = span.get_tag("params.MessageAttributes._datadog.StringValue")
-        assert trace_json is None
+            # check if the appropriate span was generated
+            assert spans
+            span = spans[0]
+            assert len(spans) == 2
+            assert span.get_tag("aws.region") == "us-east-1"
+            assert span.get_tag("aws.operation") == "Publish"
+            assert span.get_tag("params.MessageBody") is None
+            assert_is_measured(span)
+            assert_span_http_status_code(span, 200)
+            assert span.service == "test-botocore-tracing.sns"
+            assert span.resource == "sns.publish"
+            trace_json = span.get_tag("params.MessageAttributes._datadog.StringValue")
+            assert trace_json is None
 
-        # receive message using SQS and ensure headers are present
-        assert len(response["Messages"]) == 1
-        msg = response["Messages"][0]
-        assert msg is not None
-        msg_body = json.loads(msg["Body"])
-        msg_str = msg_body["Message"]
-        assert msg_str == "test"
-        msg_attr = msg_body["MessageAttributes"]
-        assert msg_attr.get("_datadog") is None
+            # receive message using SQS and ensure headers are present
+            assert len(response["Messages"]) == 1
+            msg = response["Messages"][0]
+            assert msg is not None
+            msg_body = json.loads(msg["Body"])
+            msg_str = msg_body["Message"]
+            assert msg_str == "test"
+            msg_attr = msg_body["MessageAttributes"]
+            assert msg_attr.get("_datadog") is None
 
     # NOTE: commenting out the tests below because localstack has a bug where messages
     # published to SNS via publish_batch and retrieved via SQS are missing MessageAttributes
@@ -1424,13 +1579,10 @@ class BotocoreTest(TracerTestCase):
         assert len(spans) == 1
         assert span.get_tag("aws.region") == "us-east-1"
         assert span.get_tag("aws.operation") == "PutRecord"
-        assert span.get_tag("params.MessageBody") is None
         assert_is_measured(span)
         assert_span_http_status_code(span, 200)
         assert span.service == "test-botocore-tracing.kinesis"
         assert span.resource == "kinesis.putrecord"
-        trace_json = span.get_tag("params.Data")
-        assert trace_json is None
 
         resp = client.get_shard_iterator(StreamName=stream_name, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON")
         shard_iterator = resp["ShardIterator"]
@@ -1474,13 +1626,10 @@ class BotocoreTest(TracerTestCase):
         assert len(spans) == 1
         assert span.get_tag("aws.region") == "us-east-1"
         assert span.get_tag("aws.operation") == "PutRecord"
-        assert span.get_tag("params.MessageBody") is None
         assert_is_measured(span)
         assert_span_http_status_code(span, 200)
         assert span.service == "test-botocore-tracing.kinesis"
         assert span.resource == "kinesis.putrecord"
-        trace_json = span.get_tag("params.Data")
-        assert trace_json is None
 
         resp = client.get_shard_iterator(StreamName=stream_name, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON")
         shard_iterator = resp["ShardIterator"]
@@ -1529,8 +1678,6 @@ class BotocoreTest(TracerTestCase):
         assert_span_http_status_code(span, 200)
         assert span.service == "test-botocore-tracing.kinesis"
         assert span.resource == "kinesis.putrecord"
-        trace_json = span.get_tag("params.Data")
-        assert trace_json is None
 
         resp = client.get_shard_iterator(StreamName=stream_name, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON")
         shard_iterator = resp["ShardIterator"]
@@ -1575,8 +1722,6 @@ class BotocoreTest(TracerTestCase):
         assert_span_http_status_code(span, 200)
         assert span.service == "test-botocore-tracing.kinesis"
         assert span.resource == "kinesis.putrecords"
-        records = span.get_tag("params.Records")
-        assert records is None
 
         resp = client.get_shard_iterator(StreamName=stream_name, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON")
         shard_iterator = resp["ShardIterator"]
@@ -1626,13 +1771,10 @@ class BotocoreTest(TracerTestCase):
         assert len(spans) == 1
         assert span.get_tag("aws.region") == "us-east-1"
         assert span.get_tag("aws.operation") == "PutRecords"
-        assert span.get_tag("params.MessageBody") is None
         assert_is_measured(span)
         assert_span_http_status_code(span, 200)
         assert span.service == "test-botocore-tracing.kinesis"
         assert span.resource == "kinesis.putrecords"
-        records = span.get_tag("params.Records")
-        assert records is None
 
         resp = client.get_shard_iterator(StreamName=stream_name, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON")
         shard_iterator = resp["ShardIterator"]
@@ -1670,13 +1812,39 @@ class BotocoreTest(TracerTestCase):
 
             assert span.name == "secretsmanager.command"
             assert span.resource == "secretsmanager.createsecret"
-            assert span.get_tag("params.Name") == "/my/secrets"
+            assert span.get_tag("params.Name") is None
             assert span.get_tag("aws.operation") == "CreateSecret"
             assert span.get_tag("aws.region") == "us-east-1"
             assert span.get_tag("aws.agent") == "botocore"
             assert span.get_tag("http.status_code") == "200"
             assert span.get_tag("params.SecretString") is None
             assert span.get_tag("params.SecretBinary") is None
+
+    @unittest.skipIf(PY2, "Skipping for Python 2.7 since older moto doesn't support secretsmanager")
+    def test_secretsmanager_all_params(self):
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            from moto import mock_secretsmanager
+
+            with mock_secretsmanager():
+                client = self.session.create_client("secretsmanager", region_name="us-east-1")
+                Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(client)
+
+                resp = client.create_secret(Name="/my/secrets", SecretString="supersecret-string")
+                assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+                spans = self.get_spans()
+                assert len(spans) == 1
+                span = spans[0]
+
+                assert span.name == "secretsmanager.command"
+                assert span.resource == "secretsmanager.createsecret"
+                assert span.get_tag("params.Name") == "/my/secrets"
+                assert span.get_tag("aws.operation") == "CreateSecret"
+                assert span.get_tag("aws.region") == "us-east-1"
+                assert span.get_tag("aws.agent") == "botocore"
+                assert span.get_tag("http.status_code") == "200"
+                assert span.get_tag("params.SecretString") is None
+                assert span.get_tag("params.SecretBinary") is None
 
     @unittest.skipIf(PY2, "Skipping for Python 2.7 since older moto doesn't support secretsmanager")
     def test_secretsmanager_binary(self):
@@ -1695,10 +1863,36 @@ class BotocoreTest(TracerTestCase):
 
             assert span.name == "secretsmanager.command"
             assert span.resource == "secretsmanager.createsecret"
-            assert span.get_tag("params.Name") == "/my/secrets"
+            assert span.get_tag("params.Name") is None
             assert span.get_tag("aws.operation") == "CreateSecret"
             assert span.get_tag("aws.region") == "us-east-1"
             assert span.get_tag("aws.agent") == "botocore"
             assert span.get_tag("http.status_code") == "200"
             assert span.get_tag("params.SecretString") is None
             assert span.get_tag("params.SecretBinary") is None
+
+    @unittest.skipIf(PY2, "Skipping for Python 2.7 since older moto doesn't support secretsmanager")
+    def test_secretsmanager_binary_all_params(self):
+        with self.override_config("botocore", dict(tag_all_params=True)):
+            from moto import mock_secretsmanager
+
+            with mock_secretsmanager():
+                client = self.session.create_client("secretsmanager", region_name="us-east-1")
+                Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(client)
+
+                resp = client.create_secret(Name="/my/secrets", SecretBinary=b"supersecret-binary")
+                assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+                spans = self.get_spans()
+                assert len(spans) == 1
+                span = spans[0]
+
+                assert span.name == "secretsmanager.command"
+                assert span.resource == "secretsmanager.createsecret"
+                assert span.get_tag("params.Name") == "/my/secrets"
+                assert span.get_tag("aws.operation") == "CreateSecret"
+                assert span.get_tag("aws.region") == "us-east-1"
+                assert span.get_tag("aws.agent") == "botocore"
+                assert span.get_tag("http.status_code") == "200"
+                assert span.get_tag("params.SecretString") is None
+                assert span.get_tag("params.SecretBinary") is None


### PR DESCRIPTION
## Description

We are reducing the number of API parameters that the boto, botocore and aiobotocore integrations collect as span tags by default. This change limits span tags to a narrow set of parameters for specific AWS APIs using standard tag names. Users can opt out and collect no parameters.

This is a functional breaking change. Users can configure the integrations to retain the existing deprecated behavior of collecting all parameters checked against an exclusion list.

## Checklist
- [X] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [X] Add additional sections for `feat` and `fix` pull requests.
- [X] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Relevant issue(s)

Discussed in #4710 

## Testing strategy

Test cases have been added for new behavior as well as for the deprecated behavior.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
