### PR TITLE
chore(w3c): support byte strings in tracestate

### DIFF
--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -175,6 +175,16 @@ def w3c_get_dd_list_member(context):
             # we've already added sampling decision and user id
             and k not in [SAMPLING_DECISION_TRACE_TAG_KEY, USER_ID_KEY]
         ):
+            # Hack: convert byte string to unicode to use the regex below.
+            # 1. decodes byte string to ascii (unsupported characters are converted to `?`)
+            # 2. Converts `?` to `_` to align with DBM spec
+            if isinstance(k, bytes):
+                k = k.decode("ascii", "replace")
+                k = k.replace("?", "_")
+            if isinstance(v, bytes):
+                v = v.decode("ascii", "replace")
+                v = v.replace("?", "_")
+
             # for key replace ",", "=", and characters outside the ASCII range 0x20 to 0x7E
             # for value replace ",", ";", "~" and characters outside the ASCII range 0x20 to 0x7E
             next_tag = "{}~{}".format(

--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -13,6 +13,7 @@ import six
 
 from ddtrace.constants import USER_ID_KEY
 from ddtrace.internal import compat
+from ddtrace.internal.compat import ensure_str
 from ddtrace.internal.constants import W3C_TRACESTATE_ORIGIN_KEY
 from ddtrace.internal.constants import W3C_TRACESTATE_SAMPLING_PRIORITY_KEY
 from ddtrace.internal.sampling import SAMPLING_DECISION_TRACE_TAG_KEY
@@ -175,15 +176,9 @@ def w3c_get_dd_list_member(context):
             # we've already added sampling decision and user id
             and k not in [SAMPLING_DECISION_TRACE_TAG_KEY, USER_ID_KEY]
         ):
-            # Hack: convert byte string to unicode to use the regex below.
-            # 1. decodes byte string to ascii (unsupported characters are converted to `?`)
-            # 2. Converts `?` to `_` to align with DBM spec
-            if isinstance(k, bytes):
-                k = k.decode("ascii", "replace")
-                k = k.replace("?", "_")
-            if isinstance(v, bytes):
-                v = v.decode("ascii", "replace")
-                v = v.replace("?", "_")
+            # key/values must be unicode to use the regex below.
+            k = ensure_str(k, errors="ignore")
+            v = ensure_str(v, errors="ignore")
 
             # for key replace ",", "=", and characters outside the ASCII range 0x20 to 0x7E
             # for value replace ",", ";", "~" and characters outside the ASCII range 0x20 to 0x7E

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -69,7 +69,9 @@ def test_inject_tags_unicode(tracer):
 def test_inject_tags_bytes(tracer):
     """We properly encode when the meta key as long as it is just ascii characters"""
     # Context._meta allows str and bytes for keys
-    with override_global_config({"_propagation_style_extract": PROPAGATION_STYLE_ALL}):
+    with override_global_config(
+        {"_propagation_style_extract": PROPAGATION_STYLE_ALL, "_propagation_style_inject": PROPAGATION_STYLE_ALL}
+    ):
         meta = {u"_dd.p.test": b"bytes"}
         ctx = Context(trace_id=1234, sampling_priority=2, dd_origin="synthetics", meta=meta)
         tracer.context_provider.activate(ctx)


### PR DESCRIPTION
## Description

The W3C tracecontext propagator uses a unicode regex to generate a tracestate. The regex breaks if the key/value pairs passed to tracestate formatter is a byte string. To address this issue this change  uses `ensure_str` to decode tracestate values from bytes to unicode. 

Sample Failure: 
```
ddtrace/propagation/http.py:760: in inject
    _TraceContext._inject(span_context, headers)
ddtrace/propagation/http.py:696: in _inject
    ts = span_context._tracestate
ddtrace/context.py:149: in _tracestate
    dd_list_member = _w3c_get_dd_list_member(self)
ddtrace/internal/utils/http.py:182: in w3c_get_dd_list_member
    re.sub(_W3C_TRACESTATE_INVALID_CHARS_REGEX, "_", v),
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

pattern = ',|;|~|[^\\x20-\\x7E]+', repl = '_', string = b'bytes', count = 0
flags = 0

    def sub(pattern, repl, string, count=0, flags=0):
        """Return the string obtained by replacing the leftmost
        non-overlapping occurrences of the pattern in string by the
        replacement repl.  repl can be either a string or a callable;
        if a string, backslash escapes in it are processed.  If it is
        a callable, it's passed the Match object and must return
        a replacement string to be used."""
>       return _compile(pattern, flags).sub(repl, string, count)
E       TypeError: cannot use a string pattern on a bytes-like object

../.pyenv/versions/3.10.3/lib/python3.10/re.py:209: TypeError
```
https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/25524/workflows/5a16c5e0-0159-431c-82a2-ae905460d71e/jobs/1730388

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
