### PR TITLE
test(debugging): slow down test uploader to allow buffer to fill

### DIFF
--- a/tests/debugging/test_uploader.py
+++ b/tests/debugging/test_uploader.py
@@ -22,7 +22,7 @@ class MockLogsIntakeUploaderV1(LogsIntakeUploaderV1):
 
 
 class ActiveBatchJsonEncoder(MockLogsIntakeUploaderV1):
-    def __init__(self, size=1 << 10, interval=0.1):
+    def __init__(self, size=1 << 10, interval=1):
         super(ActiveBatchJsonEncoder, self).__init__(
             BatchJsonEncoder({str: str}, size, self.on_full), interval=interval
         )
@@ -32,17 +32,17 @@ class ActiveBatchJsonEncoder(MockLogsIntakeUploaderV1):
 
 
 def test_uploader_batching():
-    with ActiveBatchJsonEncoder() as uploader:
+    with ActiveBatchJsonEncoder(interval=0.1) as uploader:
         for _ in range(5):
             uploader._encoder.put("hello")
             uploader._encoder.put("world")
-            sleep(0.11)
+            sleep(0.15)
         assert uploader.queue == ["[hello,world]"] * 5
 
 
 def test_uploader_full_buffer():
     size = 1 << 8
-    with ActiveBatchJsonEncoder(size=size) as uploader:
+    with ActiveBatchJsonEncoder(size=size, interval=0.5) as uploader:
         item = "hello" * 10
         n = size // len(item)
         assert n
@@ -59,5 +59,5 @@ def test_uploader_full_buffer():
         sleep(0.01)
         assert len(uploader.queue) == 1
 
-        sleep(0.15)
+        sleep(0.55)
         assert len(uploader.queue) == 1


### PR DESCRIPTION
## Description

This change slows down the test uploader to ensure that the buffer has a good chance to fill up during a full buffer test, before it is flushed by the underlying periodic worker.

This should resolve a flaky test observed in CI with Python 2.7.

## Checklist
- [x] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
