### PR TITLE
fix(tracing): fix usage of mapped_service when creating a new span (backport #4782)

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -632,7 +632,8 @@ class Tracer(object):
             else:
                 service = config.service
 
-        mapped_service = config.service_mapping.get(service, service)
+        # Update the service name based on any mapping
+        service = config.service_mapping.get(service, service)
 
         if trace_id:
             # child_of a non-empty context, so either a local child span or from a remote context
@@ -641,7 +642,7 @@ class Tracer(object):
                 context=context,
                 trace_id=trace_id,
                 parent_id=parent_id,
-                service=mapped_service,
+                service=service,
                 resource=resource,
                 span_type=span_type,
                 on_finish=[self._on_span_finish],
@@ -660,7 +661,7 @@ class Tracer(object):
             span = Span(
                 name=name,
                 context=context,
-                service=mapped_service,
+                service=service,
                 resource=resource,
                 span_type=span_type,
                 on_finish=[self._on_span_finish],

--- a/releasenotes/notes/fix-use-mapped-service-name-dc107848fd53a51e.yaml
+++ b/releasenotes/notes/fix-use-mapped-service-name-dc107848fd53a51e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    tracing: This fix resolves an issue where the ``DD_SERVICE_MAPPING`` mapped service names were not used
+    when updating span metadata with the ``DD_VERSION`` set version string.

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -473,6 +473,17 @@ class TracerTestCases(TracerTestCase):
                 pass
         assert self.tracer._services == set(["one", "two"])
 
+    @run_in_subprocess(env_overrides=dict(DD_SERVICE_MAPPING="two:three"))
+    def test_adding_mapped_services(self):
+        assert self.tracer._services == set()
+        with self.start_span("root", service="one") as root:
+            assert self.tracer._services == set(["one"])
+
+            # service "two" gets remapped to "three"
+            with self.start_span("child", service="two", child_of=root):
+                pass
+        assert self.tracer._services == set(["one", "three"])
+
     def test_configure_dogstatsd_url_host_port(self):
         tracer = Tracer()
         tracer.configure(dogstatsd_url="foo:1234")
@@ -900,6 +911,32 @@ class EnvTracerTestCase(TracerTestCase):
                 with self.trace("") as child2:
                     assert child2.service == "mysql"
                     assert VERSION_KEY not in child2.get_tags()
+
+    @run_in_subprocess(env_overrides=dict(DD_SERVICE="django", DD_VERSION="0.1.2", DD_SERVICE_MAPPING="mysql:django"))
+    def test_version_service_mapping(self):
+        """When using DD_SERVICE_MAPPING we properly add version tag to appropriate spans"""
+
+        # Our app is called django, we provide DD_SERVICE=django and DD_VERSION=0.1.2
+        # mysql spans will get remapped to django via DD_SERVICE_MAPPING=mysql:django
+
+        with self.trace("django.request") as root:
+            # Root span should be tagged
+            assert root.service == "django"
+            assert VERSION_KEY in root.get_tags() and root.get_tag(VERSION_KEY) == "0.1.2"
+
+            # Child spans should be tagged
+            with self.trace("") as child1:
+                assert child1.service == "django"
+                assert VERSION_KEY in child1.get_tags() and child1.get_tag(VERSION_KEY) == "0.1.2"
+
+            # Service name gets remapped to django and we get version tag applied
+            with self.trace("mysql.query", service="mysql") as span:
+                assert span.service == "django"
+                assert VERSION_KEY in span.get_tags() and span.get_tag(VERSION_KEY) == "0.1.2"
+                # Child should also have a version
+                with self.trace("") as child2:
+                    assert child2.service == "django"
+                    assert VERSION_KEY in child2.get_tags() and child2.get_tag(VERSION_KEY) == "0.1.2"
 
     @run_in_subprocess(env_overrides=dict(AWS_LAMBDA_FUNCTION_NAME="my-func"))
     def test_detect_agentless_env_with_lambda(self):


### PR DESCRIPTION
Backport of #4782 

## Description

After getting the remapped service name we were not using it to determine if the `DD_VERSION` tag should be set, or when keeping track of all the service names seen by the tracer

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy

Added two tests to validate that when setting `DD_SERVICE_MAPPING` we get the expected results for `version` tag and the collected list of services seen by the tracer.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.