### PR TITLE
chore(ci): remove test_latest workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1314,7 +1314,3 @@ workflows:
       # - profile-windows-311: *requires_pre_check
       # Final reports
       - coverage_report: *requires_tests
-
-  test_latest:
-    <<: *workflow_test
-


### PR DESCRIPTION
## Description

Right now the `test_latest` workflow runs on every single PR. We only want to run this workflow either manually or via the nightly job.


I tried to get pipeline parameters working to inject the environment variable for `riotfile.py` but it did weird things where it would run a larger set of tests than were being asked for (e.g. running pymysql tests when we were in the bottle suite).

Instead of still trying to get that working, just disable entirely running `test_latest` until we can either implement a hold/manual approval to run or actually implement the pipeline parameter approach.


Doing this now saves us $$$ on CI costs, when we generally don't need these additional test runs.


## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
