### PR TITLE
chore(releasenotes): ignore 1.6 changes in 1.7 release notes

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -19,6 +19,23 @@ Release Notes
 
 
 .. ddtrace-release-notes::
+    "1.7.0":
+      ignore_notes:
+        - "Fix-version-constraints-for-Py27-e3a0069f43a84c16.yaml"
+        - "PCF-container-UUID-0f65eed47e42f4ad.yaml"
+        - "asm-1-click-activation-with-RCM-6a2431949768b73b.yaml"
+        - "asm-add-http-route-for-flask-8b13c721e2f7543b.yaml"
+        - "asm-fix-ipaddress-backport-lib-4684ce71e63459e7.yaml"
+        - "asm-ipaddress-rfc-part-two-a546e8453cc8163a.yaml"
+        - "asm-tag-http-query-string-c7faba44b1402215.yaml"
+        - "feat-dynamic-instrumentation-4c46bb86482438c1.yaml"
+        - "fix-context-serializable-2c9768cbe4738b73.yaml"
+        - "fix-cors-errors-0fa947a1a583ad0c.yaml"
+        - "iast-weak-hash-2fe50c2c7da2289d.yaml"
+        - "ipaddress-dep-3.7-b2bf42719e5f99ec.yaml"
+        - "python311-tracer-a7077c0e461622d2.yaml"
+        - "remove-deprecated-flask-methods-8d7a4a3d32c3c69d.yaml"
+        - "wsgi-span-parenting-fix-22908787ac7ee6a6.yaml"
     "1.1.0":
       ignore_notes:
         # Ignore 1.0 release notes


### PR DESCRIPTION
## Description

This PR ensures old release notes are not included in v1.7.0. 1.7.0 release notes should NOT contain release notes published in `ddtrace<=1.6.0`. 


## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
