### PR TITLE
feat(celery): flatten context `delivery_info` tags (backport #4772)

### DIFF
--- a/releasenotes/notes/celery-flatten-context-dicts-bc5c33b72bd72ac2.yaml
+++ b/releasenotes/notes/celery-flatten-context-dicts-bc5c33b72bd72ac2.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    celery: Enhances context tags containing dictionaries so that their contents are sent as individual tags (issue #4771).

--- a/tests/contrib/celery/test_utils.py
+++ b/tests/contrib/celery/test_utils.py
@@ -19,7 +19,7 @@ class CeleryTagsTest(CeleryBaseTestCase):
         # it should extract only relevant keys
         context = {
             "correlation_id": "44b7f305",
-            "delivery_info": '{"eager": "True"}',
+            "delivery_info": {"eager": "True", "priority": "0", "int_zero": 0},
             "eta": "soon",
             "expires": "later",
             "hostname": "localhost",
@@ -36,7 +36,9 @@ class CeleryTagsTest(CeleryBaseTestCase):
         metrics = span.get_metrics()
         sentinel = object()
         assert metas["celery.correlation_id"] == "44b7f305"
-        assert metas["celery.delivery_info"] == '{"eager": "True"}'
+        assert metas["celery.delivery_info.eager"] == "True"
+        assert metas["celery.delivery_info.priority"] == "0"
+        assert metrics["celery.delivery_info.int_zero"] == 0
         assert metas["celery.eta"] == "soon"
         assert metas["celery.expires"] == "later"
         assert metas["celery.hostname"] == "localhost"


### PR DESCRIPTION
## Description
Tag data from celery is included as a raw string representation for `delivery_info`, which makes it impossible to use as a facet or measure in APM. The fix is necessary because routing info is valuable to have when understanding why delays happen between task creation and task execution. Issue #4771.

This is only breaking for the tag output format from celery spans, and should only break any cases currently modifying or depending on dicts to be represented as raw strings.

## Checklist
- [x] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation
site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START fix -->

## Relevant issue(s)
Fixes #4771 

## Testing strategy
Modified existing unit tests to expect the new tag structure. Manually tested on project that included celery to ensure expected dictionary (`delivery_info`) would be flattened as expected.

<!-- END fix -->

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.

Co-authored-by: Brett Langdon <brett.langdon@datadoghq.com>
Co-authored-by: Gabriele N. Tornetta <P403n1x87@users.noreply.github.com>
Co-authored-by: Kyle Verhoog <kyle@verhoog.ca>

## Description
<!-- Briefly describe the change and why it was required. -->

<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
