### PR TITLE
ci(profiling): bump parallelism on profiler tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,7 +529,7 @@ jobs:
   profile:
     <<: *contrib_job
     resource_class: large
-    parallelism: 15
+    parallelism: 18
     steps:
       - run_tox_scenario:
           store_coverage: false


### PR DESCRIPTION
## Description

The profiling test runner has a parallelism of 15 but the jobs are not evenly distributed. The first 14 runners tests 2 tox variants while the 15th runner tests 9 tox variants ([example](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/25804/workflows/ec7b6bb7-990d-4919-9436-71b4038c5750/jobs/1760827/parallel-runs/14?filterBy=ALL)). This occurred after enabling profiling tests for python 3.11 (test duration when from ~10min to ~30mins). Bumping the number of runners from 15 to 18 should address this bottleneck.
  - 37 tests variants split across 15 runners -> 37/14 = 2 remainder 9
  - 37 tests variants split across 18 runners -> 37/17 = 2 remainder 3 
 
Note: this "fix" is brittle and this issue could be reintroduced easily. However since we plan to migrate the profiling tests from tox to riot this fix should be good enough. 

### Alternative
Currently the tox run script divides the number of tox variants by the parallelism (in this case 15). Runners `0` to `parallelism -1` run the same number of tox variants while the last runner tests the remainder. This this case the remainder is much larger than the quotient and it acts as a bottleneck in our test suite.

tldr: Update this script to evenly distribute tests: https://github.com/DataDog/dd-trace-py/blob/v1.6.3/scripts/run-tox-scenario#L15

## Checklist
- [x] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
