### PR TITLE
fix(deps): Python 3.6 is now deprecated in attrs==22.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -261,6 +261,7 @@ setup(
         "tenacity>=5",
         "attrs>=20; python_version>'2.7'",
         "attrs>=20,<22; python_version=='2.7'",
+        "attrs>=22,<22.2; python_version=='3.6'",
         "contextlib2<1.0; python_version=='2.7'",
         "cattrs",
         "six>=1.12.0",


### PR DESCRIPTION
## Description
`attrs==22.2.0` removed support for Python 3.5, and then made Python 3.6 deprecated.

https://www.attrs.org/en/stable/changelog.html#backwards-incompatible-changes

We are having an issue with our testing since these deprecation warnings are causing errors.

This change ensures we do not try to install `attrs>=22.2.0` if we have Python 3.6

The downside to this approach is that Python 3.6 support is only deprecated and not fully removed by `attrs==22.2.0` which means we might have a customer who _wants_ to use this version of attrs on Python 3.6. This change would mean they cannot make this change and update to this version.


## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
