### PR TITLE
fix(tests): pin attrs<22.2.0 for Python 3.6 in integration tests

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -333,7 +333,6 @@ venv = Venv(
         ),
         Venv(
             name="integration",
-            pys=select_pys(),
             command="pytest --no-cov {cmdargs} tests/integration/",
             pkgs={"msgpack": [latest]},
             venvs=[
@@ -342,6 +341,14 @@ venv = Venv(
                     env={
                         "AGENT_VERSION": "latest",
                     },
+                    venvs=[
+                        Venv(pys=select_pys(max_version="3.5")),
+                        # DEV: attrs marked Python 3.6 as deprecated in 22.2.0,
+                        #      this logs a warning and causes these tests to fail
+                        # https://www.attrs.org/en/22.2.0/changelog.html#id1
+                        Venv(pys=["3.6"], pkgs={"attrs": "<22.2.0"}),
+                        Venv(pys=select_pys(min_version="3.7")),
+                    ],
                 ),
                 Venv(
                     name="integration-snapshot",
@@ -349,6 +356,14 @@ venv = Venv(
                         "DD_TRACE_AGENT_URL": "http://localhost:9126",
                         "AGENT_VERSION": "testagent",
                     },
+                    venvs=[
+                        Venv(pys=select_pys(max_version="3.5")),
+                        # DEV: attrs marked Python 3.6 as deprecated in 22.2.0,
+                        #      this logs a warning and causes these tests to fail
+                        # https://www.attrs.org/en/22.2.0/changelog.html#id1
+                        Venv(pys=["3.6"], pkgs={"attrs": "<22.2.0"}),
+                        Venv(pys=select_pys(min_version="3.7")),
+                    ],
                 ),
             ],
         ),

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -56,9 +56,12 @@ def test_debug_mode():
     assert p.stdout.read() == b""
     assert b"DEBUG:ddtrace" not in p.stderr.read()
 
+    env = os.environ.copy()
+    env.update({"DD_TRACE_DEBUG": "true", "DD_CALL_BASIC_CONFIG": "true"})
+
     p = subprocess.Popen(
         [sys.executable, "-c", "import ddtrace"],
-        env=dict(DD_TRACE_DEBUG="true", DD_CALL_BASIC_CONFIG="true"),
+        env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
@@ -670,16 +673,18 @@ s2.finish()
 """.lstrip()
         % str(patch_logging)
     )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "DD_TRACE_LOGS_INJECTION": str(logs_injection).lower(),
+            "DD_TRACE_DEBUG": str(debug_mode).lower(),
+            "DD_CALL_BASIC_CONFIG": "true",
+        }
+    )
+
     p = subprocess.Popen(
-        [sys.executable, "test.py"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        cwd=str(tmpdir),
-        env=dict(
-            DD_TRACE_LOGS_INJECTION=str(logs_injection).lower(),
-            DD_TRACE_DEBUG=str(debug_mode).lower(),
-            DD_CALL_BASIC_CONFIG="true",
-        ),
+        [sys.executable, "test.py"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=str(tmpdir), env=env
     )
     try:
         p.wait(timeout=2)


### PR DESCRIPTION
## Description
`attrs==22.2.0` removed support for Python 3.5 and made Python 3.6 support deprecated.

This causes deprecation warnings to be logged and causes our integration tests to fail.

This change makes sure we install a version of `attrs<22.2.0` only for these failing integration tests.

https://www.attrs.org/en/22.2.0/changelog.html#id1

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
