### PR TITLE
chore(w3c): replace ~ with _ and = with ~

### DIFF
--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -158,11 +158,9 @@ def w3c_get_dd_list_member(context):
         tags.append("{}:{}".format(W3C_TRACESTATE_SAMPLING_PRIORITY_KEY, context.sampling_priority))
     if context.dd_origin:
         # the origin value has specific values that are allowed.
-        tags.append(
-            "{}:{}".format(
-                W3C_TRACESTATE_ORIGIN_KEY, re.sub(r",|;|~|[^\x20-\x7E]+", "_", context.dd_origin).replace("=", "~")
-            )
-        )
+        tag_val = re.sub(r",|;|~|[^\x20-\x7E]+", "_", context.dd_origin)
+        tag_val = w3c_encode_equals(tag_val)
+        tags.append("{}:{}".format(W3C_TRACESTATE_ORIGIN_KEY, tag_val))
 
     sampling_decision = context._meta.get(SAMPLING_DECISION_TRACE_TAG_KEY)
     if sampling_decision:
@@ -183,10 +181,9 @@ def w3c_get_dd_list_member(context):
             # for key replace ",", "=", and characters outside the ASCII range 0x20 to 0x7E
             # for value replace ",", ";", "~" and characters outside the ASCII range 0x20 to 0x7E
             # for value also replace = with ~
-            next_tag = "{}:{}".format(
-                re.sub("_dd.p.", "t.", re.sub(r",| |=|[^\x20-\x7E]+", "_", k)),
-                re.sub(r",|;|~|[^\x20-\x7E]+", "_", v).replace("=", "~"),
-            )
+            tag_val = re.sub(r",|;|~|[^\x20-\x7E]+", "_", v)
+            tag_val = w3c_encode_equals(tag_val)
+            next_tag = "{}:{}".format(re.sub("_dd.p.", "t.", re.sub(r",| |=|[^\x20-\x7E]+", "_", k)), tag_val)
             # we need to keep the total length under 256 char
             potential_current_tags_len = current_tags_len + len(next_tag)
             if not potential_current_tags_len > 256:
@@ -196,3 +193,8 @@ def w3c_get_dd_list_member(context):
                 log.debug("tracestate would exceed 256 char limit with tag: %s. Tag will not be added.", next_tag)
 
     return ";".join(tags)
+
+
+def w3c_encode_equals(tag_value):
+    # type: (str) -> str
+    return tag_value.replace("=", "~")

--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -180,8 +180,9 @@ def w3c_get_dd_list_member(context):
         ):
             # for key replace ",", "=", and characters outside the ASCII range 0x20 to 0x7E
             # for value replace ",", ";", "~" and characters outside the ASCII range 0x20 to 0x7E
+            k = k.replace("_dd.p.", "t.")
             next_tag = "{}:{}".format(
-                w3c_encode_tag("_dd.p.", "t.", w3c_encode_tag(r",| |=|[^\x20-\x7E]+", "_", k)),
+                w3c_encode_tag(r",| |=|[^\x20-\x7E]+", "_", k),
                 w3c_encode_tag(r",|;|~|[^\x20-\x7E]+", "_", v),
             )
             # we need to keep the total length under 256 char

--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -6,6 +6,7 @@ from typing import Callable
 from typing import ContextManager
 from typing import Generator
 from typing import Optional
+from typing import Pattern
 from typing import Tuple
 from typing import Union
 
@@ -203,7 +204,7 @@ def w3c_get_dd_list_member(context):
 
 @cached()
 def w3c_encode_tag(args):
-    # type: (Tuple[str, str, str]) -> str
+    # type: (Tuple[Pattern, str, str]) -> str
     pattern, replacement, tag_val = args
     tag_val = pattern.sub(replacement, tag_val)
     # replace = with ~ if it wasn't already replaced by the regex

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -561,6 +561,11 @@ class _TraceContext:
     """
 
     @staticmethod
+    def decode_tag_val(tag_val):
+        # type str -> str
+        return tag_val.replace("~", "=")
+
+    @staticmethod
     def _get_traceparent_values(tp):
         # type: (str) -> Tuple[int, int, int]
         """If there is no traceparent, or if the traceparent value is invalid raise a ValueError.
@@ -630,10 +635,10 @@ class _TraceContext:
             origin = dd.get("o")
             if origin:
                 # we encode "=" as "~" in tracestate so need to decode here
-                origin = origin.replace("~", "=")
+                origin = _TraceContext.decode_tag_val(origin)
             # need to convert from t. to _dd.p.
             other_propagated_tags = {
-                "_dd.p.%s" % k[2:]: v.replace("~", "=") for (k, v) in dd.items() if (k.startswith("t."))
+                "_dd.p.%s" % k[2:]: _TraceContext.decode_tag_val(v) for (k, v) in dd.items() if (k.startswith("t."))
             }
 
             return sampling_priority_ts_int, other_propagated_tags, origin

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -638,7 +638,7 @@ class _TraceContext:
                 origin = _TraceContext.decode_tag_val(origin)
             # need to convert from t. to _dd.p.
             other_propagated_tags = {
-                "_dd.p.%s" % k[2:]: _TraceContext.decode_tag_val(v) for (k, v) in dd.items() if (k.startswith("t."))
+                "_dd.p.%s" % k[2:]: _TraceContext.decode_tag_val(v) for (k, v) in dd.items() if k.startswith("t.")
             }
 
             return sampling_priority_ts_int, other_propagated_tags, origin

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -627,8 +627,13 @@ class _TraceContext:
                 sampling_priority_ts_int = None
 
             origin = dd.get("o")
+            if origin:
+                # we encode "=" as "~" in tracestate so need to decode here
+                origin = origin.replace("~", "=")
             # need to convert from t. to _dd.p.
-            other_propagated_tags = {"_dd.p.%s" % k[2:]: v for (k, v) in dd.items() if (k.startswith("t."))}
+            other_propagated_tags = {
+                "_dd.p.%s" % k[2:]: v.replace("~", "=") for (k, v) in dd.items() if (k.startswith("t."))
+            }
 
             return sampling_priority_ts_int, other_propagated_tags, origin
         else:

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -616,7 +616,8 @@ class _TraceContext:
             if list_mem.startswith("dd="):
                 # cut out dd= before turning into dict
                 list_mem = list_mem[3:]
-                dd = dict(item.split(":") for item in list_mem.split(";"))
+                # since tags can have a value with a :, we need to only split on the first instance of :
+                dd = dict(item.split(":", 1) for item in list_mem.split(";"))
 
         # parse out values
         if dd:

--- a/tests/tracer/test_context.py
+++ b/tests/tracer/test_context.py
@@ -267,14 +267,14 @@ def test_traceparent(context, expected_traceparent):
             Context(),
             "",
         ),
-        (  # for value replace ",", ";", ":" and characters outside the ASCII range 0x20 to 0x7E with _
+        (  # for value replace ",", ";" and characters outside the ASCII range 0x20 to 0x7E with _
             Context(
                 trace_id=11803532876627986230,
                 span_id=67667974448284343,
                 sampling_priority=1,
                 meta={
                     "tracestate": "dd=s:1;o:rum;t.dm:-4;t.usr.id:baz64",
-                    "_dd.p.dm": ";5:",
+                    "_dd.p.dm": ";5;",
                     "_dd.p.usr.id": "b,z64,",
                     "_dd.p.unk": ";2",
                 },
@@ -307,7 +307,8 @@ def test_traceparent(context, expected_traceparent):
                 },
                 dd_origin=";r,um=",
             ),
-            "dd=s:1;o:_r_um_",
+            # = is encoded as ~
+            "dd=s:1;o:_r_um~",
         ),
     ],
     ids=[

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -650,9 +650,9 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
             ["received invalid dd header value in tracestate: 'dd=invalid,congo=123'"],
             ValueError,
         ),
-        (
+        (  # "ts_string,expected_tuple,expected_logging,expected_exception",
             "dd=foo|bar:hi|l¢¢¢¢¢¢:",
-            None,
+            (None, {}, None),
             ["received invalid tracestate header: 'dd=foo|bar:hi|l¢¢¢¢¢¢:"],
             ValueError,
         ),
@@ -664,6 +664,20 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
                 {
                     "_dd.p.dm": "-4",
                     "_dd.p.usr.id": "baz6===4",
+                },
+                "rum",
+            ),
+            None,
+            None,
+        ),
+        (
+            "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz:64",
+            # sampling_priority_ts, other_propagated_tags, origin
+            (
+                2,
+                {
+                    "_dd.p.dm": "-4",
+                    "_dd.p.usr.id": "baz6:4",
                 },
                 "rum",
             ),
@@ -684,6 +698,7 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
         "tracestate_invalid_dd_list_member",
         "tracestate_invalid_tracestate_char_outside_ascii_range_20-70",
         "tracestate_tilda_replaced_with_equals",
+        "tracestate_colon_acceptable_char_in_value",
     ],
 )
 def test_extract_tracestate(caplog, ts_string, expected_tuple, expected_logging, expected_exception):

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -653,8 +653,8 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
         (  # "ts_string,expected_tuple,expected_logging,expected_exception",
             "dd=foo|bar:hi|l¢¢¢¢¢¢:",
             (None, {}, None),
-            ["received invalid tracestate header: 'dd=foo|bar:hi|l¢¢¢¢¢¢:"],
-            ValueError,
+            None,
+            None,
         ),
         (
             "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz6~~~4",
@@ -671,13 +671,13 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
             None,
         ),
         (
-            "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz:64",
+            "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz:6:4",
             # sampling_priority_ts, other_propagated_tags, origin
             (
                 2,
                 {
                     "_dd.p.dm": "-4",
-                    "_dd.p.usr.id": "baz6:4",
+                    "_dd.p.usr.id": "baz:6:4",
                 },
                 "rum",
             ),

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -656,6 +656,20 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
             ["received invalid tracestate header: 'dd=foo|bar:hi|l¢¢¢¢¢¢:"],
             ValueError,
         ),
+        (
+            "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz6~~~4",
+            # sampling_priority_ts, other_propagated_tags, origin
+            (
+                2,
+                {
+                    "_dd.p.dm": "-4",
+                    "_dd.p.usr.id": "baz6===4",
+                },
+                "rum",
+            ),
+            None,
+            None,
+        ),
     ],
     ids=[
         "tracestate_with_additional_list_members",
@@ -669,6 +683,7 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
         "tracestate_no_origin",
         "tracestate_invalid_dd_list_member",
         "tracestate_invalid_tracestate_char_outside_ascii_range_20-70",
+        "tracestate_tilda_replaced_with_equals",
     ],
 )
 def test_extract_tracestate(caplog, ts_string, expected_tuple, expected_logging, expected_exception):

--- a/tests/tracer/test_utils.py
+++ b/tests/tracer/test_utils.py
@@ -478,10 +478,10 @@ def test_callonce_signature():
                 dd_origin="syn=",
                 meta={
                     "_dd.p.unk": "-4~",
-                    "_dd.p.unknow:n": "baz64",
+                    "_dd.p.unknown": "baz64",
                 },
             ),
-            ["s:2", "o:syn~", "t.unk:-4_", "t.unknow:n:baz64"],
+            ["s:2", "o:syn~", "t.unk:-4_", "t.unknown:baz64"],
         ),
     ],
     ids=[


### PR DESCRIPTION
## Description
Upon review we found that `:` should be allowed in the tags value: https://docs.datadoghq.com/getting_started/tagging/#define-tags  

We were using `:` as a way to represent an "encoded" = in the propagated trace tag values, so we decided to change the "encoded" value of the `=` to `~`.

Therefore, we should allow `=` in tag values. In order to do this in tracestate, we need to encode it. Therefore we encode `~`s in the value as `_` first, and then encode `=` as `~`.

## Checklist
- [x] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->



## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
