### PR TITLE
chore(iast): remote config thread workaround for gevent [backport #4749 to 1.6]

### DIFF
--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -21,8 +21,11 @@ if TYPE_CHECKING:  # pragma: no cover
 log = get_logger(__name__)
 
 
-def enable_appsec_rc(tracer):
-    # type: (Tracer) -> None
+def enable_appsec_rc():
+    # type: () -> None
+    # Import tracer here to avoid a circular import
+    from ddtrace import tracer
+
     if _appsec_rc_features_is_enabled():
         RemoteConfig.register(ASM_FEATURES_PRODUCT, appsec_rc_reload_features(tracer))
 

--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -16,6 +16,7 @@ import six
 import tenacity
 
 import ddtrace
+from ddtrace.appsec._remoteconfiguration import enable_appsec_rc
 from ddtrace.vendor.dogstatsd import DogStatsd
 
 from . import agent
@@ -509,10 +510,14 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
             try:
                 if self.status != service.ServiceStatus.RUNNING:
                     self.start()
+
                     # instrumentation telemetry writer should be enabled/started after the global tracer and configs
                     # are initialized
                     if asbool(os.getenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", True)):
                         telemetry_writer.enable()
+                    # appsec remote config should be enabled/started after the global tracer and configs
+                    # are initialized
+                    enable_appsec_rc()
             except service.ServiceStatusError:
                 pass
 

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -16,7 +16,6 @@ from typing import TypeVar
 from typing import Union
 
 from ddtrace import config
-from ddtrace.appsec._remoteconfiguration import enable_appsec_rc
 from ddtrace.filters import TraceFilter
 from ddtrace.internal.sampling import SpanSamplingRule
 from ddtrace.internal.sampling import get_span_sampling_rules
@@ -238,7 +237,6 @@ class Tracer(object):
             self._single_span_sampling_rules,
             self._agent_url,
         )
-        enable_appsec_rc(self)
 
         self._hooks = _hooks.Hooks()
         atexit.register(self._atexit)
@@ -520,7 +518,6 @@ class Tracer(object):
             self._single_span_sampling_rules,
             self._agent_url,
         )
-        enable_appsec_rc(self)
 
         self._new_process = True
 


### PR DESCRIPTION
## Description
Workaround for remote config to work properly with gevent.

This PR ensures the Remote config worker thread is launched at the very end, not interrupting the gevent patching mechanism.

Without this PR, the gevent patching is interrupted so if gevent is used, it won't work as expected.

As a side effect, if gevent is used and Django is installed, our Django patching mechanism collides with gevent raising a Django ImproperlyConfigured error.

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation
site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
