### PR TITLE
chore(w3c): update tracestate tag regex

### DIFF
--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -171,7 +171,7 @@ def w3c_get_dd_list_member(context):
     for k, v in context._meta.items():
         if (
             isinstance(k, six.string_types)
-            and k.startswith("_dd.p")
+            and k.startswith("_dd.p.")
             # we've already added sampling decision and user id
             and k not in [SAMPLING_DECISION_TRACE_TAG_KEY, USER_ID_KEY]
         ):

--- a/tests/tracer/test_utils.py
+++ b/tests/tracer/test_utils.py
@@ -424,6 +424,19 @@ def test_callonce_signature():
                 sampling_priority=2,
                 dd_origin="synthetics",
                 meta={
+                    # we should not propagate _dd.propagation_error, since it does not start with _dd.p.
+                    "_dd.propagation_error": "-4",
+                    "_dd.p.unknown": "baz64",
+                },
+            ),
+            ["s:2", "o:synthetics", "t.unknown:baz64"],
+        ), 
+        (
+            Context(
+                trace_id=1234,
+                sampling_priority=2,
+                dd_origin="synthetics",
+                meta={
                     "_dd.p.unk": "-4",
                     "_dd.p.unknown": "baz64",
                     "no_add": "is_not_added",
@@ -473,6 +486,7 @@ def test_callonce_signature():
     ],
     ids=[
         "basic",
+        "does_not_add_propagation_error",
         "does_not_add_non_prefixed_tags",
         "does_not_add_more_than_256_char",
         "char_replacement",

--- a/tests/tracer/test_utils.py
+++ b/tests/tracer/test_utils.py
@@ -430,7 +430,7 @@ def test_callonce_signature():
                 },
             ),
             ["s:2", "o:synthetics", "t.unknown:baz64"],
-        ), 
+        ),
         (
             Context(
                 trace_id=1234,


### PR DESCRIPTION
## Description
Right now `_dd.propagation_error`  (and any internal tag that starts with p) will get set as a tracestate tag. With this change, we make sure to only add `_dd.p.*` tags.

## Checklist
- [x] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
