### PR TITLE
fix(tracing): disallow v0.5 api usage for windows machines

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -279,9 +279,26 @@ class AgentWriter(periodic.PeriodicService, TraceWriter):
         if headers:
             self._headers.update(headers)
         self._timeout = timeout
+
+        # Default to v0.4 if we are on Windows since there is a known compatibility issue
+        # https://github.com/DataDog/dd-trace-py/issues/4829
+        # DEV: sys.platform on windows should be `win32` or `cygwin`, but using `startswith`
+        #      as a safety precaution.
+        #      https://docs.python.org/3/library/sys.html#sys.platform
+        is_windows = sys.platform.startswith("win") or sys.platform.startswith("cygwin")
+        default_api_version = "v0.4" if is_windows else "v0.5"
+
         self._api_version = (
-            api_version or os.getenv("DD_TRACE_API_VERSION") or ("v0.5" if priority_sampler is not None else "v0.3")
+            api_version
+            or os.getenv("DD_TRACE_API_VERSION")
+            or (default_api_version if priority_sampler is not None else "v0.3")
         )
+        if is_windows and self._api_version == "v0.5":
+            raise RuntimeError(
+                "There is a known compatibiltiy issue with v0.5 API and Windows, "
+                "please see https://github.com/DataDog/dd-trace-py/issues/4829 for more details."
+            )
+
         try:
             Encoder = MSGPACK_ENCODERS[self._api_version]
         except KeyError:

--- a/releasenotes/notes/v05-encoding-eac70f23850a445e.yaml
+++ b/releasenotes/notes/v05-encoding-eac70f23850a445e.yaml
@@ -1,5 +1,8 @@
 ---
 upgrade:
   - |
-    tracing: upgrades the default trace API version to ``v0.5``. The ``v0.5`` trace API version generates 
+    tracing: upgrades the default trace API version to ``v0.5`` for non-Windows systems. The ``v0.5`` trace API version generates
     smaller payloads, thus increasing the throughput to the Datadog agent especially with larger traces.
+  - |
+    tracing: configuring the ``v0.5`` trace API version on Windows machines will raise a ``RuntimeError``
+    due to known compatibility issues. Please see https://github.com/DataDog/dd-trace-py/issues/4829 for more details.


### PR DESCRIPTION
## Description

Using the `v0.5` API endpoint on Windows can cause issues (see #4829 for details).

This PR makes it so we default to `v0.4` on Windows and will raise an exception if you try to use `v0.5` on a Windows machine.

## Relevant issue(s)
Fixes #4829 

## Testing strategy

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
