### PR TITLE
fix(internal): catch possible OSError when calling platform.libc_ver() (backport #4828)

### DIFF
--- a/ddtrace/internal/telemetry/data.py
+++ b/ddtrace/internal/telemetry/data.py
@@ -33,11 +33,28 @@ def _get_container_id():
 def _get_os_version():
     # type: () -> str
     """Returns the os version for applications running on Unix, Mac or Windows 32-bit"""
-    mver, _, _ = platform.mac_ver()
-    _, wver, _, _ = platform.win32_ver()
-    _, lver = platform.libc_ver()
+    try:
+        mver, _, _ = platform.mac_ver()
+        if mver:
+            return mver
 
-    return mver or wver or lver or ""
+        _, wver, _, _ = platform.win32_ver()
+        if wver:
+            return wver
+
+        # This is the call which is more likely to fail
+        #
+        # https://docs.python.org/3/library/platform.html#unix-platforms
+        #   Note that this function has intimate knowledge of how different libc versions add symbols
+        #   to the executable is probably only usable for executables compiled using gcc.
+        _, lver = platform.libc_ver()
+        if lver:
+            return lver
+    except OSError:
+        # We were unable to lookup the proper version
+        pass
+
+    return ""
 
 
 @cached()

--- a/releasenotes/notes/fix-telemetry-platform-libc-ver-call-8872bde91bcc8765.yaml
+++ b/releasenotes/notes/fix-telemetry-platform-libc-ver-call-8872bde91bcc8765.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    telemetry: This fix resolves an issue when we try to fetch ``platform.libc_ver()`` on an unsupported system.


### PR DESCRIPTION
## Description

Backport #4828 to 1.7

When calling `platform.libc_ver()` on an unsupported system it can raise an `OSError`.

This change adds exception handling for `OSError` and regression test.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.