### PR TITLE
chore(asm): change default value for remote config env var [backport #4813 to 1.7]

### DIFF
--- a/ddtrace/appsec/utils.py
+++ b/ddtrace/appsec/utils.py
@@ -6,7 +6,7 @@ from ddtrace.internal.utils.formats import asbool
 
 def _appsec_rc_features_is_enabled():
     # type: () -> bool
-    if asbool(os.environ.get("DD_REMOTE_CONFIGURATION_ENABLED", "false")):
+    if asbool(os.environ.get("DD_REMOTE_CONFIGURATION_ENABLED", "true")):
         return APPSEC_ENV not in os.environ
     return False
 

--- a/releasenotes/notes/asm-1-click-activation-with-RCM-by-default-92233ac7f60292e0.yaml
+++ b/releasenotes/notes/asm-1-click-activation-with-RCM-by-default-92233ac7f60292e0.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    ASM: one click activation enabled by default using Remote Configuration Management (RCM). Set ``DD_REMOTE_CONFIGURATION_ENABLED=false`` to disable this feature.

--- a/releasenotes/notes/asm-1-click-activation-with-RCM-by-default-92233ac7f60292e0.yaml
+++ b/releasenotes/notes/asm-1-click-activation-with-RCM-by-default-92233ac7f60292e0.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    ASM: one click activation enabled by default using Remote Configuration Management (RCM). Set ``DD_REMOTE_CONFIGURATION_ENABLED=false`` to disable this feature.
+    ASM: One click activation enabled by default using Remote Configuration Management (RCM). Set ``DD_REMOTE_CONFIGURATION_ENABLED=false`` to disable this feature.

--- a/tests/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/test_remoteconfiguration.py
@@ -26,7 +26,7 @@ def _set_and_get_appsec_tags(tracer):
 def test_rc_enabled_by_default(tracer):
     result = _set_and_get_appsec_tags(tracer)
     assert result is None
-    assert not _appsec_rc_features_is_enabled()
+    assert _appsec_rc_features_is_enabled()
 
 
 def test_rc_activate_is_active_and_get_processor_tags(tracer):


### PR DESCRIPTION
## Description
Change the value for DD_REMOTE_CONFIGURATION_ENABLED to True by default, so AppSec 1-click-activation feature is enabled by default, unless this environment variable is disabled.

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation
site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
