### PR TITLE
feat(tornado): support config.http_server.error_ranges

### DIFF
--- a/ddtrace/contrib/tornado/handlers.py
+++ b/ddtrace/contrib/tornado/handlers.py
@@ -104,8 +104,7 @@ def log_exception(func, handler, args, kwargs):
         # is not a 2xx. In this case we want to check the status code to be sure that
         # only 5xx are traced as errors, while any other HTTPError exception is handled as
         # usual.
-        # if config.http_server.is_error_code(value.status_code):
-        if 500 <= value.status_code <= 599:
+        if config.http_server.is_error_code(value.status_code):
             current_span.set_exc_info(*args)
     else:
         # any other uncaught exception should be reported as error

--- a/ddtrace/contrib/tornado/handlers.py
+++ b/ddtrace/contrib/tornado/handlers.py
@@ -104,6 +104,7 @@ def log_exception(func, handler, args, kwargs):
         # is not a 2xx. In this case we want to check the status code to be sure that
         # only 5xx are traced as errors, while any other HTTPError exception is handled as
         # usual.
+        # if config.http_server.is_error_code(value.status_code):
         if 500 <= value.status_code <= 599:
             current_span.set_exc_info(*args)
     else:

--- a/releasenotes/notes/tornado_error_code_http_server-d1532491cb89563c.yaml
+++ b/releasenotes/notes/tornado_error_code_http_server-d1532491cb89563c.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    tornado: Support custom error codes: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#custom-error-codes.

--- a/tests/contrib/tornado/test_tornado_web.py
+++ b/tests/contrib/tornado/test_tornado_web.py
@@ -176,6 +176,28 @@ class TestTornadoWeb(TornadoTestCase):
         assert "HTTP 500: Server Error (server error)" == request_span.get_tag(ERROR_MSG)
         assert "HTTP 500: Server Error (server error)" in request_span.get_tag("error.stack")
 
+    def test_http_exception_500_handler_ignored_exception(self):
+        # it should trace a handler that raises a Tornado HTTPError
+        # The exception should NOT be set on the span
+        prev_error_statuses = config.http_server.error_statuses
+        try:
+            config.http_server.error_statuses = "501-599"
+            response = self.fetch("/http_exception_500/")
+            assert 500 == response.code
+        finally:
+            config.http_server.error_statuses = prev_error_statuses
+
+        traces = self.pop_traces()
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+        request_span = traces[0][0]
+        assert "tornado.request" == request_span.name
+
+        assert_span_http_status_code(request_span, 500)
+        assert request_span.error == 0
+        assert request_span.get_tag(ERROR_MSG) is None
+        assert request_span.get_tag("error.stack") is None
+
     def test_sync_success_handler(self):
         # it should trace a synchronous handler that returns 200
         response = self.fetch("/sync_success/")


### PR DESCRIPTION
## Description

Use `config.http_server.error_ranges` to determine whether   `tornado.request` spans should be marked as error spans.

Resolve: https://github.com/DataDog/dd-trace-py/issues/4838

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
