### PR TITLE
test(internal): check that ddtrace does not force-load lazy modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import time
 from _pytest.runner import CallInfo
 from _pytest.runner import TestReport
 from _pytest.runner import call_and_report
+from _pytest.runner import pytest_runtest_protocol as default_pytest_runtest_protocol
 import pytest
 from six import PY2
 
@@ -231,6 +232,13 @@ def run_function_from_file(item, params=None):
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_protocol(item):
+    if item.get_closest_marker("skip"):
+        return default_pytest_runtest_protocol(item, None)
+
+    skipif = item.get_closest_marker("skipif")
+    if skipif and skipif.args[0]:
+        return default_pytest_runtest_protocol(item, None)
+
     marker = item.get_closest_marker("subprocess")
     if marker:
         params = marker.kwargs.get("parametrize", None)

--- a/tests/internal/lazy.py
+++ b/tests/internal/lazy.py
@@ -1,0 +1,1 @@
+print("lazy loaded")


### PR DESCRIPTION
## Description

This change adds a test to ensure that the import of ddtrace does not cause lazy modules to be force-loaded when the ModuleWatchdog is installed on start-up.

## Checklist
- [x] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Backports are identified and tagged with Mergifyio.
