### PR TITLE
chore(asm): revert enable remote config by default [backport to 1.7] Revert #4835

### DIFF
--- a/ddtrace/appsec/utils.py
+++ b/ddtrace/appsec/utils.py
@@ -6,7 +6,7 @@ from ddtrace.internal.utils.formats import asbool
 
 def _appsec_rc_features_is_enabled():
     # type: () -> bool
-    if asbool(os.environ.get("DD_REMOTE_CONFIGURATION_ENABLED", "true")):
+    if asbool(os.environ.get("DD_REMOTE_CONFIGURATION_ENABLED", "false")):
         return APPSEC_ENV not in os.environ
     return False
 

--- a/releasenotes/notes/asm-1-click-activation-with-RCM-by-default-92233ac7f60292e0.yaml
+++ b/releasenotes/notes/asm-1-click-activation-with-RCM-by-default-92233ac7f60292e0.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    ASM: One click activation enabled by default using Remote Configuration Management (RCM). Set ``DD_REMOTE_CONFIGURATION_ENABLED=false`` to disable this feature.

--- a/tests/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/test_remoteconfiguration.py
@@ -26,7 +26,7 @@ def _set_and_get_appsec_tags(tracer):
 def test_rc_enabled_by_default(tracer):
     result = _set_and_get_appsec_tags(tracer)
     assert result is None
-    assert _appsec_rc_features_is_enabled()
+    assert not _appsec_rc_features_is_enabled()
 
 
 def test_rc_activate_is_active_and_get_processor_tags(tracer):


### PR DESCRIPTION
## Description

Revert: https://github.com/DataDog/dd-trace-py/pull/4835