### PR TITLE
fix: parse datetime isoformat in python2

### DIFF
--- a/ddtrace/internal/utils/time.py
+++ b/ddtrace/internal/utils/time.py
@@ -13,7 +13,7 @@ log = get_logger(__name__)
 
 def fromisoformat_py2(t):
     # type: (str) -> datetime
-    """Alternative function to datetime.fromisoformat that not exists in python2. This function parses dates with
+    """Alternative function to datetime.fromisoformat that does not exist in python 2. This function parses dates with
     this format: 2022-09-01T01:00:00+02:00
     """
     ret = datetime.strptime(t[:19], "%Y-%m-%dT%H:%M:%S")

--- a/ddtrace/internal/utils/time.py
+++ b/ddtrace/internal/utils/time.py
@@ -16,7 +16,7 @@ def fromisoformat_py2(t):
     """Alternative function to datetime.fromisoformat that not exists in python2. This function parses dates with
     this format: 2022-09-01T01:00:00+02:00
     """
-    ret = datetime.strptime(t[0:19], "%Y-%m-%dT%H:%M:%S")
+    ret = datetime.strptime(t[:19], "%Y-%m-%dT%H:%M:%S")
     if t[19] == "+":
         ret -= timedelta(hours=int(t[20:22]), minutes=int(t[23:]))
     elif t[19] == "-":

--- a/ddtrace/internal/utils/time.py
+++ b/ddtrace/internal/utils/time.py
@@ -13,6 +13,9 @@ log = get_logger(__name__)
 
 def fromisoformat_py2(t):
     # type: (str) -> datetime
+    """Alternative function to datetime.fromisoformat that not exists in python2. This function parses dates with
+    this format: 2022-09-01T01:00:00+02:00
+    """
     ret = datetime.strptime(t[0:19], "%Y-%m-%dT%H:%M:%S")
     if t[19] == "+":
         ret -= timedelta(hours=int(t[20:22]), minutes=int(t[23:]))

--- a/tests/internal/test_utils_time.py
+++ b/tests/internal/test_utils_time.py
@@ -14,6 +14,8 @@ from ddtrace.internal.utils.time import parse_isoformat
         ("2022-07-31T22:00:00", None),
         ("2022-07-31", None),
         ("2022-07-3122:00:00", None),
+        ("", None),
+        ("aa", None),
     ],
 )
 def test_parse_isoformat_py2(date_str, expected):
@@ -29,6 +31,8 @@ def test_parse_isoformat_py2(date_str, expected):
         ("2022-07-31T22:00:00", datetime.datetime(2022, 7, 31, 22, 0)),
         ("2022-07-31", datetime.datetime(2022, 7, 31, 0, 0)),
         ("2022-07-3122:00:00", None),
+        ("", None),
+        ("aa", None),
     ],
 )
 @pytest.mark.skipif(sys.version_info < (3, 0, 0), reason="Python 3 tests")

--- a/tests/internal/test_utils_time.py
+++ b/tests/internal/test_utils_time.py
@@ -1,0 +1,45 @@
+import datetime
+import sys
+
+import pytest
+
+from ddtrace.internal.utils.time import parse_isoformat
+
+
+@pytest.mark.parametrize(
+    "date_str,expected",
+    [
+        ("2022-09-01T01:00:00+02:00", datetime.datetime(2022, 8, 31, 23, 0)),
+        ("2022-07-31T22:00:00Z", datetime.datetime(2022, 7, 31, 22, 0)),
+        ("2022-07-31T22:00:00", None),
+        ("2022-07-31", None),
+        ("2022-07-3122:00:00", None),
+    ],
+)
+def test_parse_isoformat_py2(date_str, expected):
+    # type: (str, datetime.datetime) -> None
+    result = parse_isoformat(date_str)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "date_str,expected",
+    [
+        ("2022-07-31T22:00:00Z", datetime.datetime(2022, 7, 31, 22, 0)),
+        ("2022-07-31T22:00:00", datetime.datetime(2022, 7, 31, 22, 0)),
+        ("2022-07-31", datetime.datetime(2022, 7, 31, 0, 0)),
+        ("2022-07-3122:00:00", None),
+    ],
+)
+@pytest.mark.skipif(sys.version_info < (3, 0, 0), reason="Python 3 tests")
+def test_parse_isoformat_py3(date_str, expected):
+    # type: (str, datetime.datetime) -> None
+    result = parse_isoformat(date_str)
+    assert result == expected
+
+
+@pytest.mark.skipif(sys.version_info < (3, 0, 0), reason="Python 3 tests")
+def test_parse_isoformat_py3_with_timezone():
+    # type: () -> None
+    result = parse_isoformat("2022-09-01T01:00:00+02:00")
+    assert result == datetime.datetime(2022, 9, 1, 1, 0, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200)))

--- a/tests/internal/test_utils_time.py
+++ b/tests/internal/test_utils_time.py
@@ -18,10 +18,36 @@ from ddtrace.internal.utils.time import parse_isoformat
         ("aa", None),
     ],
 )
+@pytest.mark.skipif(sys.version_info > (3, 0, 0), reason="Python 2 tests")
 def test_parse_isoformat_py2(date_str, expected):
     # type: (str, datetime.datetime) -> None
     result = parse_isoformat(date_str)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "date_str,expected",
+    [
+        ("2022-07-31T22:00:00Z", datetime.datetime(2022, 7, 31, 22, 0)),
+        ("2022-07-31T22:00:00", None),
+        ("2022-07-31", None),
+        ("2022-07-3122:00:00", None),
+        ("", None),
+        ("aa", None),
+    ],
+)
+@pytest.mark.skipif(sys.version_info < (3, 5, 0) or sys.version_info >= (3, 7, 0), reason="Python 3.5 and 3.6 tests")
+def test_parse_isoformat_py36(date_str, expected):
+    # type: (str, datetime.datetime) -> None
+    result = parse_isoformat(date_str)
+    assert result == expected
+
+
+@pytest.mark.skipif(sys.version_info < (3, 5, 0) or sys.version_info >= (3, 7, 0), reason="Python 3.5 and 3.6 tests")
+def test_parse_isoformat_py36_with_timezone():
+    # type: () -> None
+    result = parse_isoformat("2022-09-01T01:00:00+02:00")
+    assert result == datetime.datetime(2022, 8, 31, 23, 0)
 
 
 @pytest.mark.parametrize(
@@ -35,14 +61,14 @@ def test_parse_isoformat_py2(date_str, expected):
         ("aa", None),
     ],
 )
-@pytest.mark.skipif(sys.version_info < (3, 0, 0), reason="Python 3 tests")
+@pytest.mark.skipif(sys.version_info < (3, 7, 0), reason="Python 3 tests")
 def test_parse_isoformat_py3(date_str, expected):
     # type: (str, datetime.datetime) -> None
     result = parse_isoformat(date_str)
     assert result == expected
 
 
-@pytest.mark.skipif(sys.version_info < (3, 0, 0), reason="Python 3 tests")
+@pytest.mark.skipif(sys.version_info < (3, 7, 0), reason="Python 3 tests")
 def test_parse_isoformat_py3_with_timezone():
     # type: () -> None
     result = parse_isoformat("2022-09-01T01:00:00+02:00")


### PR DESCRIPTION
## Description
Fix error in `parse_isoformat` function with Python 2 retrieving information from Remote Configuration

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
