### PR TITLE
fix(profiler): revert code provenance enabled by default

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -120,7 +120,7 @@ class _ProfilerInstance(service.Service):
         factory=lambda: formats.asbool(os.environ.get("DD_PROFILING_MEMORY_ENABLED", "True")), type=bool
     )
     enable_code_provenance = attr.ib(
-        factory=attr_utils.from_env("DD_PROFILING_ENABLE_CODE_PROVENANCE", True, formats.asbool),
+        factory=attr_utils.from_env("DD_PROFILING_ENABLE_CODE_PROVENANCE", False, formats.asbool),
         type=bool,
     )
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -360,10 +360,8 @@ below:
 
    DD_PROFILING_ENABLE_CODE_PROVENANCE:
      type: Boolean
-     default: True
+     default: False
      description: Whether to enable code provenance.
-     version_added:
-       v1.7.0:
 
    DD_PROFILING_MEMORY_ENABLED:
      type: Boolean

--- a/releasenotes/notes/profiler-code-provenance-issue-a912ea575a43ed07.yaml
+++ b/releasenotes/notes/profiler-code-provenance-issue-a912ea575a43ed07.yaml
@@ -1,0 +1,6 @@
+---
+issues:
+  - |
+    profiling: There is currently a known performance regression issue with the profiler's code provenance feature. 
+    Note that this feature is disabled by default and will only be enabled if 
+    ``DD_PROFILING_ENABLE_CODE_PROVENANCE`` is set to true.

--- a/releasenotes/notes/profiling-enable-code-provenance-3d9663e0cd742fcd.yaml
+++ b/releasenotes/notes/profiling-enable-code-provenance-3d9663e0cd742fcd.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-      profiling: Enables code provenance by default. To keep the feature disabled use ``DD_PROFILING_ENABLE_CODE_PROVENANCE=false``.


### PR DESCRIPTION
## Description
Reverts #4519 as this was causing a performance regression. Added release note acknowledging known performance regression. Note that code provenance is still disabled by default.

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
