### PR TITLE
fix: parse datetime isoformat in python2 [backport #4874 to 1.7]

### DIFF
--- a/ddtrace/internal/utils/time.py
+++ b/ddtrace/internal/utils/time.py
@@ -1,20 +1,44 @@
 from datetime import datetime
+from datetime import timedelta
 from types import TracebackType
 from typing import Optional
 from typing import Type
 
 from ddtrace.internal import compat
+from ddtrace.internal.logger import get_logger
+
+
+log = get_logger(__name__)
+
+
+def fromisoformat_py2(t):
+    # type: (str) -> datetime
+    """Alternative function to datetime.fromisoformat that does not exist in python 2. This function parses dates with
+    this format: 2022-09-01T01:00:00+02:00
+    """
+    ret = datetime.strptime(t[:19], "%Y-%m-%dT%H:%M:%S")
+    if t[19] == "+":
+        ret -= timedelta(hours=int(t[20:22]), minutes=int(t[23:]))
+    elif t[19] == "-":
+        ret += timedelta(hours=int(t[20:22]), minutes=int(t[23:]))
+    return ret
 
 
 def parse_isoformat(date):
+    # type: (str) -> Optional[datetime]
     if date.endswith("Z"):
         try:
             return datetime.strptime(date, "%Y-%m-%dT%H:%M:%S.%fZ")
         except ValueError:
             return datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ")
-    elif hasattr(datetime, "fromisoformat"):
-        return datetime.fromisoformat(date)
-    raise ValueError("unsupported isoformat")
+    try:
+        if hasattr(datetime, "fromisoformat"):
+            return datetime.fromisoformat(date)
+        else:
+            return fromisoformat_py2(date)
+    except (ValueError, IndexError):
+        log.debug("unsupported isoformat: %s", date)
+    return None
 
 
 class StopWatch(object):

--- a/tests/internal/test_utils_time.py
+++ b/tests/internal/test_utils_time.py
@@ -1,0 +1,75 @@
+import datetime
+import sys
+
+import pytest
+
+from ddtrace.internal.utils.time import parse_isoformat
+
+
+@pytest.mark.parametrize(
+    "date_str,expected",
+    [
+        ("2022-09-01T01:00:00+02:00", datetime.datetime(2022, 8, 31, 23, 0)),
+        ("2022-07-31T22:00:00Z", datetime.datetime(2022, 7, 31, 22, 0)),
+        ("2022-07-31T22:00:00", None),
+        ("2022-07-31", None),
+        ("2022-07-3122:00:00", None),
+        ("", None),
+        ("aa", None),
+    ],
+)
+@pytest.mark.skipif(sys.version_info > (3, 0, 0), reason="Python 2 tests")
+def test_parse_isoformat_py2(date_str, expected):
+    # type: (str, datetime.datetime) -> None
+    result = parse_isoformat(date_str)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "date_str,expected",
+    [
+        ("2022-07-31T22:00:00Z", datetime.datetime(2022, 7, 31, 22, 0)),
+        ("2022-07-31T22:00:00", None),
+        ("2022-07-31", None),
+        ("2022-07-3122:00:00", None),
+        ("", None),
+        ("aa", None),
+    ],
+)
+@pytest.mark.skipif(sys.version_info < (3, 5, 0) or sys.version_info >= (3, 7, 0), reason="Python 3.5 and 3.6 tests")
+def test_parse_isoformat_py36(date_str, expected):
+    # type: (str, datetime.datetime) -> None
+    result = parse_isoformat(date_str)
+    assert result == expected
+
+
+@pytest.mark.skipif(sys.version_info < (3, 5, 0) or sys.version_info >= (3, 7, 0), reason="Python 3.5 and 3.6 tests")
+def test_parse_isoformat_py36_with_timezone():
+    # type: () -> None
+    result = parse_isoformat("2022-09-01T01:00:00+02:00")
+    assert result == datetime.datetime(2022, 8, 31, 23, 0)
+
+
+@pytest.mark.parametrize(
+    "date_str,expected",
+    [
+        ("2022-07-31T22:00:00Z", datetime.datetime(2022, 7, 31, 22, 0)),
+        ("2022-07-31T22:00:00", datetime.datetime(2022, 7, 31, 22, 0)),
+        ("2022-07-31", datetime.datetime(2022, 7, 31, 0, 0)),
+        ("2022-07-3122:00:00", None),
+        ("", None),
+        ("aa", None),
+    ],
+)
+@pytest.mark.skipif(sys.version_info < (3, 7, 0), reason="Python 3 tests")
+def test_parse_isoformat_py3(date_str, expected):
+    # type: (str, datetime.datetime) -> None
+    result = parse_isoformat(date_str)
+    assert result == expected
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7, 0), reason="Python 3 tests")
+def test_parse_isoformat_py3_with_timezone():
+    # type: () -> None
+    result = parse_isoformat("2022-09-01T01:00:00+02:00")
+    assert result == datetime.datetime(2022, 9, 1, 1, 0, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200)))


### PR DESCRIPTION
Backport #4874