### PR TITLE
fix: display a more helpful error message when cython imports fail

### DIFF
--- a/releasenotes/notes/cython-import-fix-a5b86512a7a59017.yaml
+++ b/releasenotes/notes/cython-import-fix-a5b86512a7a59017.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    This fix improves a cryptic error message encountered during some ``pip install ddtrace`` runs under old pip versions.
+    This fix improves a cryptic error message encountered during some ``pip install ddtrace`` runs under pip versions <18.

--- a/releasenotes/notes/cython-import-fix-a5b86512a7a59017.yaml
+++ b/releasenotes/notes/cython-import-fix-a5b86512a7a59017.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    This fix improves a cryptic error message encountered during some `pip install ddtrace` runs under old pip versions.

--- a/releasenotes/notes/cython-import-fix-a5b86512a7a59017.yaml
+++ b/releasenotes/notes/cython-import-fix-a5b86512a7a59017.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    This fix improves a cryptic error message encountered during some `pip install ddtrace` runs under old pip versions.
+    This fix improves a cryptic error message encountered during some ``pip install ddtrace`` runs under old pip versions.

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,11 @@ try:
     from Cython.Build import cythonize  # noqa: I100
     import Cython.Distutils
 except ImportError:
-    raise ImportError("Failed to import Cython modules. This can happen under versions of pip older than 18 that don't "
-                      "support installing build requirements during setup. If you're using pip, make sure it's a "
-                      "version >=18.")
+    raise ImportError(
+        "Failed to import Cython modules. This can happen under versions of pip older than 18 that don't "
+        "support installing build requirements during setup. If you're using pip, make sure it's a "
+        "version >=18."
+    )
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ except ImportError:
     raise ImportError(
         "Failed to import Cython modules. This can happen under versions of pip older than 18 that don't "
         "support installing build requirements during setup. If you're using pip, make sure it's a "
-        "version >=18."
+        "version >=18.\nSee the quickstart documentation for more information:\n"
+        "https://ddtrace.readthedocs.io/en/stable/installation_quickstart.html"
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,15 @@ from setuptools import setup, find_packages, Extension
 from setuptools.command.test import test as TestCommand
 from setuptools.command.build_ext import build_ext as BuildExtCommand
 
-# ORDER MATTERS
-# Import this after setuptools or it will fail
-from Cython.Build import cythonize  # noqa: I100
-import Cython.Distutils
+try:
+    # ORDER MATTERS
+    # Import this after setuptools or it will fail
+    from Cython.Build import cythonize  # noqa: I100
+    import Cython.Distutils
+except ImportError:
+    raise ImportError("Failed to import Cython modules. This can happen under versions of pip older than 18 that don't "
+                      "support installing build requirements during setup. If you're using pip, make sure it's a "
+                      "version >=18.")
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Description

This PR makes an error message from `pip install ddtrace` more helpful. The specific error happens when attempting to `import Cython.*` under pip versions older than 18.

I tested this with `pip install -e /path/to/local/repo` and `pip install --upgrade pip==9.0.3`. Because it's only a change to outputted text on install I don't think it's necessary to add unit testing.

## Checklist
- [x] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [x] Add additional sections for `feat` and `fix` pull requests.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
