### PR TITLE
chore(debugger): use new reference operators in JSON DSL

### DIFF
--- a/ddtrace/debugging/_encoding.py
+++ b/ddtrace/debugging/_encoding.py
@@ -185,6 +185,16 @@ def _safe_getattr(obj, name):
         return e
 
 
+def _safe_getitem(obj, index):
+    if isinstance(obj, list):
+        return list.__getitem__(obj, index)
+    elif isinstance(obj, dict):
+        return dict.__getitem__(obj, index)
+    elif isinstance(obj, tuple):
+        return tuple.__getitem__(obj, index)
+    raise TypeError("Type is not indexable collection " + str(type(obj)))
+
+
 @cached()
 def _has_safe_dict(_type):
     # type: (Type) -> bool

--- a/ddtrace/debugging/_expressions.py
+++ b/ddtrace/debugging/_expressions.py
@@ -9,12 +9,9 @@ Full grammar:
     predicate               =>  <direct_predicate> | <arg_predicate> | <value_source>
     direct_predicate        =>  {"<direct_predicate_type>": <predicate>}
     direct_predicate_type   =>  not | isEmpty | isUndefined
-    value_source            =>  <literal> | <value_reference> | <operation>
+    value_source            =>  <literal> | <operation>
     literal                 =>  <number> | true | false | "string"
     number                  =>  0 | ([1-9][0-9]*\.[0-9]+)
-    value_reference         =>  "<reference_prefix><reference_path>"
-    reference_prefix        =>  @ | ^ | # | .
-    reference_path          =>  identifier(.identifier)*
     identifier              =>  [a-zA-Z][a-zA-Z0-9_]*
     arg_predicate           =>  {"<arg_predicate_type>": [<argument_list>]}
     arg_predicate_type      =>  eq | ne | gt | ge | lt | le | any | all | and | or
@@ -22,10 +19,11 @@ Full grammar:
     argument_list           =>  <predicate>(,<predicate>)+
     operation               =>  <direct_operation> | <arg_operation>
     direct_opearation       =>  {"<direct_op_type>": <value_source>}
-    direct_op_type          =>  len | count
+    direct_op_type          =>  len | count | ref
     arg_operation           =>  {"<arg_op_type>": [<argument_list>]}
-    arg_op_type             =>  filter | substring
+    arg_op_type             =>  filter | substring | getmember | index
 """  # noqa
+from itertools import chain
 import re
 from types import FunctionType
 from typing import Any
@@ -40,6 +38,7 @@ from bytecode import Bytecode
 from bytecode import Compare
 from bytecode import Instr
 
+from ddtrace.debugging._encoding import _safe_getitem
 from ddtrace.internal.compat import PYTHON_VERSION_INFO as PY
 
 
@@ -137,14 +136,11 @@ def _compile_arg_predicate(ast):
         if ca is None:
             raise ValueError("Invalid argument: %r" % a)
 
-        return (
-            [Instr("LOAD_CONST", lambda i, c, _locals: f(c(_, _locals) for _ in i))]
-            + ca
-            + [
-                Instr("LOAD_CONST", fb),
-                Instr("LOAD_FAST", "_locals"),
-                Instr("CALL_FUNCTION", 3),
-            ]
+        return _call_function(
+            lambda i, c, _locals: f(c(_, _locals) for _ in i),
+            ca,
+            [Instr("LOAD_CONST", fb)],
+            [Instr("LOAD_FAST", "_locals")],
         )
 
     if _type in {"startsWith", "endsWith"}:
@@ -154,7 +150,7 @@ def _compile_arg_predicate(ast):
             raise ValueError("Invalid argument: %r" % a)
         if cb is None:
             raise ValueError("Invalid argument: %r" % b)
-        return [Instr("LOAD_CONST", getattr(str, _type.lower()))] + ca + cb + [Instr("CALL_FUNCTION", 2)]
+        return _call_function(getattr(str, _type.lower()), ca, cb)
 
     if _type == "matches":
         a, b = args
@@ -163,7 +159,7 @@ def _compile_arg_predicate(ast):
             raise ValueError("Invalid argument: %r" % a)
         if cb is None:
             raise ValueError("Invalid argument: %r" % b)
-        return [Instr("LOAD_CONST", lambda p, s: re.match(p, s) is not None)] + cb + ca + [Instr("CALL_FUNCTION", 2)]
+        return _call_function(lambda p, s: re.match(p, s) is not None, cb, ca)
 
     return None
 
@@ -171,7 +167,7 @@ def _compile_arg_predicate(ast):
 def _compile_direct_operation(ast):
     # type: (DDASTType) -> Optional[List[Instr]]
     # direct_opearation  =>  {"<direct_op_type>": <value_source>}
-    # direct_op_type     =>  len | count
+    # direct_op_type     =>  len | count | ref
     if not isinstance(ast, dict):
         return None
 
@@ -181,9 +177,26 @@ def _compile_direct_operation(ast):
         value = _compile_value_source(arg)
         if value is None:
             raise ValueError("Invalid argument: %r" % arg)
-        return [Instr("LOAD_CONST", len)] + value + [Instr("CALL_FUNCTION", 1)]
+        return _call_function(len, value)
+
+    if _type == "ref":
+        if not isinstance(arg, str):
+            return None
+
+        if arg == "@it":
+            return [Instr("LOAD_FAST", "_dd_it")]
+
+        return [
+            Instr("LOAD_FAST", "_locals"),
+            Instr("LOAD_CONST", arg),
+            Instr("BINARY_SUBSCR"),
+        ]
 
     return None
+
+
+def _call_function(func, *args):
+    return [Instr("LOAD_CONST", func)] + list(chain(*args)) + [Instr("CALL_FUNCTION", len(args))]
 
 
 def _compile_arg_operation(ast):
@@ -195,7 +208,7 @@ def _compile_arg_operation(ast):
 
     _type, args = next(iter(ast.items()))
 
-    if _type not in {"filter", "substring"}:
+    if _type not in {"filter", "substring", "getmember", "index"}:
         return None
 
     if _type == "substring":
@@ -216,15 +229,32 @@ def _compile_arg_operation(ast):
         if ca is None:
             raise ValueError("Invalid argument: %r" % a)
 
-        return (
-            [Instr("LOAD_CONST", lambda i, c, _locals: type(i)(_ for _ in i if c(_, _locals)))]
-            + ca
-            + [
-                Instr("LOAD_CONST", fb),
-                Instr("LOAD_FAST", "_locals"),
-                Instr("CALL_FUNCTION", 3),
-            ]
+        return _call_function(
+            lambda i, c, _locals: type(i)(_ for _ in i if c(_, _locals)),
+            ca,
+            [Instr("LOAD_CONST", fb)],
+            [Instr("LOAD_FAST", "_locals")],
         )
+
+    if _type == "getmember":
+        v, atr = args
+        cv = _compile_predicate(v)
+        if not cv:
+            return None
+        if not isinstance(atr, str) or not IDENT_RE.match(atr):
+            return None
+
+        return _call_function(object.__getattribute__, cv, [Instr("LOAD_CONST", atr)])
+
+    if _type == "index":
+        v, i = args
+        cv = _compile_predicate(v)
+        if not cv:
+            return None
+        ci = _compile_predicate(i)
+        if not ci:
+            return None
+        return _call_function(_safe_getitem, cv, ci)
 
     return None
 
@@ -233,80 +263,6 @@ def _compile_operation(ast):
     # type: (DDASTType) -> Optional[List[Instr]]
     # operation  =>  <direct_operation> | <arg_operation>
     return _compile_direct_operation(ast) or _compile_arg_operation(ast)
-
-
-def _compile_identifier(ast):
-    # type: (DDASTType) -> Optional[List[Instr]]
-    # identifier  =>  [a-zA-Z][a-zA-Z0-9_]*
-    if not isinstance(ast, str) or not IDENT_RE.match(ast):
-        return None
-
-    return [Instr("LOAD_ATTR", ast)]
-
-
-def _compile_reference_path(ast):
-    # type: (DDASTType) -> Optional[List[Instr]]
-    # reference_path  =>  identifier(.identifier)*
-    if not isinstance(ast, str):
-        return None
-
-    if not ast:
-        return []
-
-    head, _, tail = ast.partition(".")
-
-    this = _compile_identifier(head)
-    if this is None:
-        raise ValueError("Invalid identifier: %s" % head)
-    rest = _compile_reference_path(tail)
-    if rest is None:
-        raise ValueError("Invalid reference: %s" % ast)
-    return this + rest
-
-
-def _compile_value_reference(ast):
-    # type: (DDASTType) -> Optional[List[Instr]]
-    # value_reference   =>  "<reference_prefix><reference_path>"
-    # reference_prefix  =>  @ | ^ | # | .
-    if not isinstance(ast, str) or not ast:
-        return None
-
-    ref_ident = ast[0]
-
-    if ref_ident not in {"#", "^", "@", "."}:
-        return None
-
-    head, _, tail = ast[1:].partition(".")
-    if not IDENT_RE.match(head):
-        raise ValueError("Invalid identifier: %s" % head)
-
-    if ref_ident in {"#", "^"}:  # Locals and arguments (including self)
-        path = _compile_reference_path(tail)
-        if path is None:
-            raise ValueError("Invalid reference: %s" % ast)
-        return [
-            Instr("LOAD_FAST", "_locals"),
-            Instr("LOAD_CONST", head),
-            Instr("BINARY_SUBSCR"),
-        ] + path
-
-    if ref_ident == ".":  # Attributes
-        path = _compile_reference_path(ast[1:])
-        if path is None:
-            raise ValueError("Invalid reference: %s" % ast)
-        return [
-            Instr("LOAD_FAST", "_locals"),
-            Instr("LOAD_CONST", "self"),
-            Instr("BINARY_SUBSCR"),
-        ] + path
-
-    if ref_ident == "@" and head == "it":
-        path = _compile_reference_path(tail)
-        if path is None:
-            raise ValueError("Invalid reference: %s" % ast)
-        return [Instr("LOAD_FAST", "_dd_it")] + path
-
-    return None
 
 
 def _compile_literal(ast):
@@ -320,8 +276,8 @@ def _compile_literal(ast):
 
 def _compile_value_source(ast):
     # type: (DDASTType) -> Optional[List[Instr]]
-    # value_source  =>  <literal> | <value_reference> | <operation>
-    return _compile_operation(ast) or _compile_value_reference(ast) or _compile_literal(ast)
+    # value_source  =>  <literal> | <operation>
+    return _compile_operation(ast) or _compile_literal(ast)
 
 
 def _compile_predicate(ast):

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -503,7 +503,7 @@ def test_debugger_metric_probe_simple_count(mock_metrics):
 
 def test_debugger_metric_probe_count_value(mock_metrics):
     with debugger() as d:
-        d.add_probes(create_line_metric_probe(MetricProbeKind.COUNTER, dd_compile("#bar")))
+        d.add_probes(create_line_metric_probe(MetricProbeKind.COUNTER, dd_compile({"ref": "bar"})))
         sleep(0.5)
         Stuff().instancestuff(40)
         assert call("probe.test.counter", 40.0, ["foo:bar"]) in mock_metrics.increment.mock_calls
@@ -511,7 +511,7 @@ def test_debugger_metric_probe_count_value(mock_metrics):
 
 def test_debugger_metric_probe_guage_value(mock_metrics):
     with debugger() as d:
-        d.add_probes(create_line_metric_probe(MetricProbeKind.GAUGE, dd_compile("#bar")))
+        d.add_probes(create_line_metric_probe(MetricProbeKind.GAUGE, dd_compile({"ref": "bar"})))
         sleep(0.5)
         Stuff().instancestuff(41)
         assert call("probe.test.counter", 41.0, ["foo:bar"]) in mock_metrics.gauge.mock_calls
@@ -519,7 +519,7 @@ def test_debugger_metric_probe_guage_value(mock_metrics):
 
 def test_debugger_metric_probe_histogram_value(mock_metrics):
     with debugger() as d:
-        d.add_probes(create_line_metric_probe(MetricProbeKind.HISTOGRAM, dd_compile("#bar")))
+        d.add_probes(create_line_metric_probe(MetricProbeKind.HISTOGRAM, dd_compile({"ref": "bar"})))
         sleep(0.5)
         Stuff().instancestuff(42)
         assert call("probe.test.counter", 42.0, ["foo:bar"]) in mock_metrics.histogram.mock_calls
@@ -527,7 +527,7 @@ def test_debugger_metric_probe_histogram_value(mock_metrics):
 
 def test_debugger_metric_probe_distribution_value(mock_metrics):
     with debugger() as d:
-        d.add_probes(create_line_metric_probe(MetricProbeKind.DISTRIBUTION, dd_compile("#bar")))
+        d.add_probes(create_line_metric_probe(MetricProbeKind.DISTRIBUTION, dd_compile({"ref": "bar"})))
         sleep(0.5)
         Stuff().instancestuff(43)
         assert call("probe.test.counter", 43.0, ["foo:bar"]) in mock_metrics.distribution.mock_calls
@@ -743,7 +743,7 @@ def test_debugger_condition_eval_then_rate_limit():
                 probe_id="foo",
                 source_file="tests/submod/stuff.py",
                 line=36,
-                condition=dd_compile({"eq": ["#bar", 42]}),
+                condition=dd_compile({"eq": [{"ref": "bar"}, 42]}),
             ),
         )
 
@@ -770,7 +770,7 @@ def test_debugger_function_probe_eval_on_exit():
                 probe_id="duration-probe",
                 module="tests.submod.stuff",
                 func_qname="mutator",
-                condition=dd_compile({"contains": ["#arg", 42]}),
+                condition=dd_compile({"contains": [{"ref": "arg"}, 42]}),
             )
         )
 
@@ -794,7 +794,9 @@ def test_debugger_lambda_fuction_access_locals():
                 probe_id="duration-probe",
                 module="tests.submod.stuff",
                 func_qname="age_checker",
-                condition=dd_compile({"any": ["#people", {"eq": ["#name", "@it.name"]}]}),
+                condition=dd_compile(
+                    {"any": [{"ref": "people"}, {"eq": [{"ref": "name"}, {"getmember": [{"ref": "@it"}, "name"]}]}]}
+                ),
             )
         )
 

--- a/tests/debugging/test_expressions.py
+++ b/tests/debugging/test_expressions.py
@@ -21,33 +21,80 @@ class CustomObject(object):
         raise SideEffect("contains")
 
 
+class CustomAttr(object):
+    def __init__(self):
+        self.field = "x"
+
+    def __getattribute__(self, prop):
+        return object.__getattribute__(self, prop) + "custom"
+
+
+class CustomList(list):
+    def __getitem__(self, index):
+
+        return str(list.__getitem__(self, index)) + "custom"
+
+
+class CustomDict(dict):
+    def __getitem__(self, name):
+        return dict.__getitem__(self, name) + "custom"
+
+
 @pytest.mark.parametrize(
     "ast, _locals, value",
     [
         # Test references with operations
-        ({"len": "#payload"}, {"payload": "hello"}, 5),
-        ({"len": ".collectionField"}, {"self": CustomObject("expr")}, 10),
-        ({"len": ".bogusField"}, {"self": CustomObject("expr")}, AttributeError),
-        ({"len": "^payload"}, {"payload": "hello"}, 5),
-        ({"len": "^payload"}, {}, KeyError),
+        ({"len": {"ref": "payload"}}, {"payload": "hello"}, 5),
+        ({"len": {"getmember": [{"ref": "self"}, "collectionField"]}}, {"self": CustomObject("expr")}, 10),
+        ({"len": {"getmember": [{"ref": "self"}, "bogusField"]}}, {"self": CustomObject("expr")}, AttributeError),
+        ({"len": {"ref": "payload"}}, {}, KeyError),
         # Test plain references
-        (".name", {"self": CustomObject("test-me")}, "test-me"),
-        ("#hits", {"hits": 42}, 42),
-        ("^hits", {"hits": 42}, 42),
+        ({"ref": "hits"}, {"hits": 42}, 42),
+        ({"getmember": [{"ref": "self"}, "name"]}, {"self": CustomObject("test-me")}, "test-me"),
+        (
+            {"getmember": [{"getmember": [{"ref": "self"}, "field1"]}, "name"]},
+            {"self": CustomObject("test-me")},
+            "field1",
+        ),
+        # Test index reference
+        ({"index": [{"ref": "arr"}, 1]}, {"arr": ["hello", "world"]}, "world"),
+        ({"index": [{"ref": "arr"}, 100]}, {"arr": ["hello", "world"]}, IndexError),
+        ({"index": [{"ref": "dict"}, "world"]}, {"dict": {"hello": "hi", "world": "space"}}, "space"),
+        ({"index": [{"ref": "dict"}, "bogus_index"]}, {"dict": {"hello": "hi", "world": "space"}}, KeyError),
+        # Test getmember and index have no sideeffects
+        ({"getmember": [{"ref": "obj"}, "field"]}, {"obj": CustomAttr()}, "x"),
+        ({"index": [{"ref": "arr"}, 1]}, {"arr": CustomList(["hello", "world"])}, "world"),
+        ({"index": [{"ref": "dict"}, "world"]}, {"dict": CustomDict({"hello": "hi", "world": "space"})}, "space"),
         # Test argument predicates and operations
-        ({"contains": ["#payload", "hello"]}, {"payload": "hello world"}, True),
-        ({"eq": ["#hits", True]}, {"hits": True}, True),
-        ({"substring": ["#payload", 4, 7]}, {"payload": "hello world"}, "hello world"[4:7]),
-        ({"any": ["#collection", {"isEmpty": "@it"}]}, {"collection": ["foo", "bar", ""]}, True),
-        ({"startsWith": ["#local_string", "hello"]}, {"local_string": "hello world!"}, True),
-        ({"startsWith": ["#local_string", "world"]}, {"local_string": "hello world!"}, False),
-        ({"filter": ["#collection", {"not": {"isEmpty": "@it"}}]}, {"collection": ["foo", "bar", ""]}, ["foo", "bar"]),
-        ({"filter": ["#collection", {"not": {"isEmpty": "@it"}}]}, {"collection": ("foo", "bar", "")}, ("foo", "bar")),
-        ({"filter": ["#collection", {"not": {"isEmpty": "@it"}}]}, {"collection": {"foo", "bar", ""}}, {"foo", "bar"}),
-        ({"contains": ["#payload", "hello"]}, {"payload": CustomObject("contains")}, SideEffect),
-        ({"contains": ["#payload", "hello"]}, {"payload": SafeObjectProxy.safe(CustomObject("contains"))}, False),
-        ({"contains": ["#payload", "name"]}, {"payload": SafeObjectProxy.safe(CustomObject("contains"))}, True),
-        ({"matches": ["#payload", "[0-9]+"]}, {"payload": "42"}, True),
+        ({"contains": [{"ref": "payload"}, "hello"]}, {"payload": "hello world"}, True),
+        ({"eq": [{"ref": "hits"}, True]}, {"hits": True}, True),
+        ({"substring": [{"ref": "payload"}, 4, 7]}, {"payload": "hello world"}, "hello world"[4:7]),
+        ({"any": [{"ref": "collection"}, {"isEmpty": {"ref": "@it"}}]}, {"collection": ["foo", "bar", ""]}, True),
+        ({"startsWith": [{"ref": "local_string"}, "hello"]}, {"local_string": "hello world!"}, True),
+        ({"startsWith": [{"ref": "local_string"}, "world"]}, {"local_string": "hello world!"}, False),
+        (
+            {"filter": [{"ref": "collection"}, {"not": {"isEmpty": {"ref": "@it"}}}]},
+            {"collection": ["foo", "bar", ""]},
+            ["foo", "bar"],
+        ),
+        (
+            {"filter": [{"ref": "collection"}, {"not": {"isEmpty": {"ref": "@it"}}}]},
+            {"collection": ("foo", "bar", "")},
+            ("foo", "bar"),
+        ),
+        (
+            {"filter": [{"ref": "collection"}, {"not": {"isEmpty": {"ref": "@it"}}}]},
+            {"collection": {"foo", "bar", ""}},
+            {"foo", "bar"},
+        ),
+        ({"contains": [{"ref": "payload"}, "hello"]}, {"payload": CustomObject("contains")}, SideEffect),
+        (
+            {"contains": [{"ref": "payload"}, "hello"]},
+            {"payload": SafeObjectProxy.safe(CustomObject("contains"))},
+            False,
+        ),
+        ({"contains": [{"ref": "payload"}, "name"]}, {"payload": SafeObjectProxy.safe(CustomObject("contains"))}, True),
+        ({"matches": [{"ref": "payload"}, "[0-9]+"]}, {"payload": "42"}, True),
         # Test literal values
         (42, {}, 42),
         (True, {}, True),
@@ -61,3 +108,12 @@ def test_parse_expressions(ast, _locals, value):
             compiled(_locals)
     else:
         assert compiled(_locals) == value
+
+
+def test_side_effects():
+    a = CustomList([1, 2])
+    assert a[0] == "1custom"
+    b = CustomDict({"hello": "world"})
+    assert b["hello"] == "worldcustom"
+    c = CustomAttr()
+    assert c.field == "xcustom"


### PR DESCRIPTION
## Description

Update expression parser to match with the updated debugger backend expression json format. This change replaces the old syntax for field references with the new reference operators `ref`, `getmember` and `index`.

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

