### PR TITLE
ci(tracer): move test_http from tox to riot

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -278,17 +278,21 @@ venv = Venv(
             venvs=[
                 Venv(
                     pys=select_pys(),
+                    create=True,
                     pkgs={
                         "msgpack": latest,
                         "attrs": ["==20.1.0", latest],
                         "structlog": latest,
                         # httpretty v1.0 drops python 2.7 support
                         "httpretty": "==0.9.7",
+                        "jsonschema": ">=1.0",
+                        "tenacity": ">=5.0",
+                        "cattrs": ">=1.0.0",
+                        "envier": "~=0.4.0",
+                        "ddsketch": "~=2.0",
+                        "ipaddress": "~=1.0",
                     },
-                    # Riot venvs break with Py 3.11 importlib, specifically with hypothesis (test_http.py).
-                    # We'll skip the test_http.py tests in riot and run them separately through tox in CI.
-                    # See linked riot issue: https://github.com/DataDog/riot/issues/192
-                    command="pytest {cmdargs} tests/tracer/ --ignore=tests/tracer/test_http.py",
+                    command="pytest {cmdargs} tests/tracer/",
                 ),
             ],
             env={

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,6 @@ envlist =
     py{27,35,36,37,38,39,310,311}-profile{,-gevent}
     py{27,35,36,37,38,39,310,311}-profile-minreqs{,-gevent}
     py{37,38,39,310,311}-profile-protobuf319
-    # FIXME[riot-3.11]: Riot venvs break with Py 3.11 importlib, specifically with hypothesis (test_http.py).
-    # We'll skip the test_http.py tests in riot and run them separately here through tox in CI.
-    py{27,35,36,37,38,39,310,311}-tracer_test_http
 
 isolated_build = true
 
@@ -118,7 +115,6 @@ passenv=
 
 commands =
 # run only essential tests related to the tracing client
-    tracer_test_http: python -m pytest {posargs} tests/tracer/test_http.py
     py27-profile: python -m tests.profiling.run pytest --capture=no --verbosity=2 --benchmark-disable --ignore-glob="*asyncio*" {posargs} tests/profiling
     # Coverage is excluded from profile because of an issue with Python 3.5.
     py3{5,6,7,8,9,10,11}-profile: python -m tests.profiling.run pytest --no-cov --capture=no --verbosity=2 --benchmark-disable {posargs} tests/profiling


### PR DESCRIPTION
## Description

Hypothesis' vendored text file is not found in riot py3.11 virtualenvs: [issue](https://github.com/DataDog/riot/issues/192). To work around this issue this change creates real virtual environments to run the tracer test suite.

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
