### PR TITLE
chore(span): remove unused method _remove_exc_info

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -453,13 +453,6 @@ class Span(object):
         self._meta[ERROR_TYPE] = exc_type_str
         self._meta[ERROR_STACK] = tb
 
-    def _remove_exc_info(self):
-        # type: () -> None
-        """Remove all exception related information from the span."""
-        self.error = 0
-        self._remove_tag(ERROR_MSG)
-        self._remove_tag(ERROR_TYPE)
-        self._remove_tag(ERROR_STACK)
 
     def _pprint(self):
         # type: () -> str

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -453,7 +453,6 @@ class Span(object):
         self._meta[ERROR_TYPE] = exc_type_str
         self._meta[ERROR_STACK] = tb
 
-
     def _pprint(self):
         # type: () -> str
         """Return a human readable version of the span."""


### PR DESCRIPTION
## Description
We don't use _remove_exc_info anywhere since a separate PR removed its usage, and it's a private method.

## Checklist
- [x] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
