### PR TITLE
chore(sanic): ensure sanic tests ignore the http.userganet tag in snapshots

### DIFF
--- a/tests/contrib/sanic/test_sanic_server.py
+++ b/tests/contrib/sanic/test_sanic_server.py
@@ -40,6 +40,7 @@ def sanic_client():
 
 
 @pytest.mark.snapshot(
+    ignores=["meta.http.useragent"],
     variants={
         "": sanic_version >= (21, 9, 0),
         "pre_21.9": sanic_version < (21, 9, 0),
@@ -56,7 +57,7 @@ def test_multiple_requests_sanic_http(sanic_client):
 
 
 @pytest.mark.snapshot(
-    ignores=["meta.error.stack"],
+    ignores=["meta.error.stack", "meta.http.useragent"],
     variants={
         "": sanic_version >= (21, 9, 0),
         "pre_21.9": sanic_version < (21, 9, 0),


### PR DESCRIPTION
## Description
The user agent used in testing may change as the version of `requests` being used changes.

This change ensure that we do not consider the `http.useragent` tag value in the snapshots for the sanic tests.

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
