### PR TITLE
chore(test): avoid ValueErorr when `@` not in netloc

### DIFF
--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -291,6 +291,11 @@ def _sanitized_url(url):
     if "@" in url:
         parsed = parse.urlparse(url)
         netloc = parsed.netloc
+
+        if "@" not in netloc:
+            # Safe url, `@` not in netloc
+            return url
+
         netloc = netloc[netloc.index("@") + 1 :]
         return parse.urlunparse(
             (


### PR DESCRIPTION
## Description
Fix missing case where the `@` symbol is in the url but not in the netloc.

Testing: This is tested in some framework tests (fastapi at least), that are failing at the moment, this should fix them

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
