### PR TITLE
chore(test): avoid ValueErorr when `@` not in netloc [backport #4914 to 1.7]

### DIFF
--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -289,6 +289,11 @@ def _sanitized_url(url):
     if "@" in url:
         parsed = parse.urlparse(url)
         netloc = parsed.netloc
+
+        if "@" not in netloc:
+            # Safe url, `@` not in netloc
+            return url
+
         netloc = netloc[netloc.index("@") + 1 :]
         return parse.urlunparse(
             (

--- a/releasenotes/notes/fix-verify-url-7d0dd6b0ab53306f.yaml
+++ b/releasenotes/notes/fix-verify-url-7d0dd6b0ab53306f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix for ValueError when ``@`` is not present in network location but other part of the url.

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -339,6 +339,8 @@ def test_ext_service(int_config, pin, config_val, default, expected):
         ("GET", "http://user:pass@localhost/", 0, None, None, None, None, None, None, None),
         ("GET", "http://user@localhost/", 0, None, None, None, None, None, None, None),
         ("GET", "http://user:pass@localhost/api?q=test", 0, None, None, None, None, None, None, None),
+        ("GET", "http://localhost/api@test", 0, None, None, None, None, None, None, None),
+        ("GET", "http://localhost/?api@test", 0, None, None, None, None, None, None, None),
     ],
 )
 def test_set_http_meta(


### PR DESCRIPTION
Backport #4914 and #4915 

Fix missing case where the `@` symbol is in the url but not in the netloc.

Testing: This is tested in some framework tests (fastapi at least), that are failing at the moment, this should fix them

- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation
site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.