### PR TITLE
chore(ci): update tested versions of rq

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -1702,8 +1702,6 @@ venv = Venv(
                     pkgs={
                         "rq": [
                             "~=1.0.0",
-                            "~=1.1.0",
-                            "~=1.2.0",
                             "~=1.3.0",
                         ],
                     },
@@ -1713,16 +1711,19 @@ venv = Venv(
                     pkgs={
                         "rq": [
                             "~=1.0.0",
-                            "~=1.1.0",
-                            "~=1.2.0",
-                            "~=1.3.0",
-                            "~=1.4.0",
-                            "~=1.5.0",
-                            "~=1.6.0",
-                            "~=1.7.0",
-                            "~=1.8.0",
-                            "~=1.9.0",
-                            "~=1.10.0",
+                            "~=1.11.0",
+                            # 1.12.0 removed support for Python 3.5
+                        ],
+                        # https://github.com/rq/rq/issues/1469 rq [1.0,1.8] is incompatible with click 8.0+
+                        "click": "==7.1.2",
+                    },
+                ),
+                Venv(
+                    pys=select_pys(min_version="3.6"),
+                    pkgs={
+                        "rq": [
+                            "~=1.0.0",
+                            "~=1.11.0",
                             latest,
                         ],
                         # https://github.com/rq/rq/issues/1469 rq [1.0,1.8] is incompatible with click 8.0+


### PR DESCRIPTION
## Description

`rq` released 1.12.0 which dropped support for Python 3.5, but did not update the `python_requires` in `setup.py` to reflect this. This means it is possible to install 1.12.0 on Python 3.5, which will not work.

https://github.com/rq/rq/issues/1755

I also updated the overall tested versions of `rq` since the current pattern is fairly (unnecessarily?) verbose.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Backports are identified and tagged with Mergifyio.
