### PR TITLE
chore(asm): bump libddwaf to 1.6.1 with sha256 checksums

### DIFF
--- a/releasenotes/notes/asm-upgrade-libddwaf-cbebe158731bf7d9.yaml
+++ b/releasenotes/notes/asm-upgrade-libddwaf-cbebe158731bf7d9.yaml
@@ -1,4 +1,4 @@
 ---
 upgrade:
   - |
-    ASM: libddwaf upgraded to version 1.6.0 using a new library loading mechanism
+    ASM: libddwaf upgraded to version 1.6.1 using a new library loading mechanism

--- a/setup.py
+++ b/setup.py
@@ -48,12 +48,20 @@ CURRENT_OS = platform.system()
 LIBDDWAF_VERSION = "1.6.1"
 
 
-def verify_libddwaf_checksum(sha256_filename, filename):
+def verify_libddwaf_checksum(sha256_filename, filename, current_os):
     # sha256 File format is ``checksum`` followed by two whitespaces, then ``filename`` then ``\n``
+    # except for Windows, where the format is completely different, the filename is not even there
     checksum_file_contents = list(filter(None, open(sha256_filename, "r").read().strip().split(" ")))
-    expected_checksum = checksum_file_contents[0]
-    expected_filename = checksum_file_contents[-1]
     actual_checksum = hashlib.sha256(open(filename, "rb").read()).hexdigest()
+
+    if current_os == "Windows":
+        expected_checksum = checksum_file_contents[-2]
+        expected_filename = ""
+        actual_checksum = actual_checksum.upper()
+    else:
+        expected_checksum = checksum_file_contents[0]
+        expected_filename = checksum_file_contents[-1]
+
     try:
         assert filename.endswith(expected_filename)
         assert expected_checksum == actual_checksum
@@ -168,7 +176,7 @@ class LibDDWaf_Download(BuildPyCommand):
                 raise e
 
             # Verify checksum of downloaded file
-            verify_libddwaf_checksum(sha256_filename, filename)
+            verify_libddwaf_checksum(sha256_filename, filename, CURRENT_OS)
 
             # Open the tarfile first to get the files needed.
             # This could be solved with "r:gz" mode, that allows random access

--- a/setup.py
+++ b/setup.py
@@ -50,20 +50,10 @@ LIBDDWAF_VERSION = "1.6.1"
 
 def verify_libddwaf_checksum(sha256_filename, filename, current_os):
     # sha256 File format is ``checksum`` followed by two whitespaces, then ``filename`` then ``\n``
-    # except for Windows, where the format is completely different, the filename is not even there
-    checksum_file_contents = list(filter(None, open(sha256_filename, "r").read().strip().split(" ")))
+    expected_checksum, expected_filename = list(filter(None, open(sha256_filename, "r").read().strip().split(" ")))
     actual_checksum = hashlib.sha256(open(filename, "rb").read()).hexdigest()
-
-    if current_os == "Windows":
-        expected_checksum = checksum_file_contents[-2]
-        expected_filename = ""
-        actual_checksum = actual_checksum.upper()
-    else:
-        expected_checksum = checksum_file_contents[0]
-        expected_filename = checksum_file_contents[-1]
-
     try:
-        assert filename.endswith(expected_filename)
+        assert expected_filename.endswith(filename)
         assert expected_checksum == actual_checksum
     except AssertionError:
         print("Checksum verification error: Checksum and/or filename don't match:")

--- a/setup.py
+++ b/setup.py
@@ -45,21 +45,15 @@ LIBDDWAF_DOWNLOAD_DIR = os.path.join(HERE, os.path.join("ddtrace", "appsec", "dd
 
 CURRENT_OS = platform.system()
 
-LIBDDWAF_VERSION = "1.6.0"
-
-LIBDDWAF_CHECKSUMS = {
-    "darwin-arm64": "fe8773dbc8ffe5a44517719b9b7db62c",
-    "darwin-x86_64": "6c9ae9294058811add0bcf356acd1946",
-    "linux-aarch64": "7acd4cc79d582d84e5e0c83f360e6b37",
-    "linux-x86_64": "6b913003301dfc6bb4ff0ec6fc64037b",
-    "windows-win32": "26adb5896fc89c2edb4507f55ed2b6de",
-    "windows-x64": "63a67011bc70220f38099adee105bfe6",
-}
+LIBDDWAF_VERSION = "1.6.1"
 
 
-def verify_libddwaf_checksum(os_architecture, filename):
-    expected_checksum = LIBDDWAF_CHECKSUMS[os_architecture]
-    assert expected_checksum == hashlib.md5(open(filename, "rb").read()).hexdigest()
+def verify_libddwaf_checksum(sha256_filename, filename):
+    # sha256 File format is ``checksum`` followed by two whitespaces, then ``filename`` then ``\n``
+    # so the ``filter`` is used to remove an empty string in the middle of the resulting list
+    expected_checksum, expected_filename = filter(None, open(sha256_filename, "r").read().strip().split(" "))
+    assert filename.endswith(expected_filename)
+    assert expected_checksum == hashlib.sha256(open(filename, "rb").read()).hexdigest()
 
 
 def load_module_from_project_file(mod_name, fname):
@@ -154,15 +148,17 @@ class LibDDWaf_Download(BuildPyCommand):
                 LIBDDWAF_VERSION,
                 ddwaf_archive_name,
             )
+            ddwaf_sha256_address = ddwaf_download_address + ".sha256"
 
             try:
                 filename, http_response = urlretrieve(ddwaf_download_address, ddwaf_archive_name)
+                sha256_filename, http_response = urlretrieve(ddwaf_sha256_address, ddwaf_archive_name + ".sha256")
             except HTTPError as e:
                 print("No archive found for dynamic library ddwaf : " + ddwaf_archive_dir)
                 raise e
 
             # Verify checksum of downloaded file
-            verify_libddwaf_checksum("-".join((CURRENT_OS.lower(), arch)), filename)
+            verify_libddwaf_checksum(sha256_filename, filename)
 
             # Open the tarfile first to get the files needed.
             # This could be solved with "r:gz" mode, that allows random access

--- a/setup.py
+++ b/setup.py
@@ -53,12 +53,17 @@ def verify_libddwaf_checksum(sha256_filename, filename):
     checksum_file_contents = list(filter(None, open(sha256_filename, "r").read().strip().split(" ")))
     expected_checksum = checksum_file_contents[0]
     expected_filename = checksum_file_contents[-1]
+    actual_checksum = hashlib.sha256(open(filename, "rb").read()).hexdigest()
     try:
         assert filename.endswith(expected_filename)
-        assert expected_checksum == hashlib.sha256(open(filename, "rb").read()).hexdigest()
-    except AssertionError as e:
-        print("Checksum verification error: Checksum and/or filename don't match")
-        raise e
+        assert expected_checksum == actual_checksum
+    except AssertionError:
+        print("Checksum verification error: Checksum and/or filename don't match:")
+        print("expected checksum: %s" % expected_checksum)
+        print("actual checksum: %s" % actual_checksum)
+        print("expected filename: %s" % expected_filename)
+        print("actual filename: %s" % filename)
+        sys.exit(1)
 
 
 def load_module_from_project_file(mod_name, fname):

--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,15 @@ LIBDDWAF_VERSION = "1.6.1"
 
 def verify_libddwaf_checksum(sha256_filename, filename):
     # sha256 File format is ``checksum`` followed by two whitespaces, then ``filename`` then ``\n``
-    # so the ``filter`` is used to remove an empty string in the middle of the resulting list
-    expected_checksum, expected_filename = filter(None, open(sha256_filename, "r").read().strip().split(" "))
-    assert filename.endswith(expected_filename)
-    assert expected_checksum == hashlib.sha256(open(filename, "rb").read()).hexdigest()
+    checksum_file_contents = open(sha256_filename, "r").read().strip().split(" ")
+    expected_checksum = checksum_file_contents[0]
+    expected_filename = checksum_file_contents[-1]
+    try:
+        assert filename.endswith(expected_filename)
+        assert expected_checksum + "x" == hashlib.sha256(open(filename, "rb").read()).hexdigest()
+    except AssertionError as e:
+        print("Checksum verification error: Checksum and/or filename don't match")
+        raise e
 
 
 def load_module_from_project_file(mod_name, fname):

--- a/setup.py
+++ b/setup.py
@@ -50,12 +50,12 @@ LIBDDWAF_VERSION = "1.6.1"
 
 def verify_libddwaf_checksum(sha256_filename, filename):
     # sha256 File format is ``checksum`` followed by two whitespaces, then ``filename`` then ``\n``
-    checksum_file_contents = open(sha256_filename, "r").read().strip().split(" ")
+    checksum_file_contents = list(filter(None, open(sha256_filename, "r").read().strip().split(" ")))
     expected_checksum = checksum_file_contents[0]
     expected_filename = checksum_file_contents[-1]
     try:
         assert filename.endswith(expected_filename)
-        assert expected_checksum + "x" == hashlib.sha256(open(filename, "rb").read()).hexdigest()
+        assert expected_checksum == hashlib.sha256(open(filename, "rb").read()).hexdigest()
     except AssertionError as e:
         print("Checksum verification error: Checksum and/or filename don't match")
         raise e

--- a/tests/snapshots/tests.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
@@ -10,7 +10,7 @@
     "meta": {
       "_dd.appsec.event_rules.version": "1.4.2",
       "_dd.appsec.json": "{\"triggers\":[{\"rule\":{\"id\":\"nfd-000-006\",\"name\":\"Detect failed attempt to fetch sensitive files\",\"tags\":{\"type\":\"security_scanner\",\"category\":\"attack_attempt\"}},\"rule_matches\":[{\"operator\":\"match_regex\",\"operator_value\":\"^404$\",\"parameters\":[{\"address\":\"server.response.status\",\"key_path\":[],\"value\":\"404\",\"highlight\":[\"404\"]}]},{\"operator\":\"match_regex\",\"operator_value\":\"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\"parameters\":[{\"address\":\"server.request.uri.raw\",\"key_path\":[],\"value\":\"http://example.com/.git\",\"highlight\":[\".git\"]}]}]}]}",
-      "_dd.appsec.waf.version": "1.6.0",
+      "_dd.appsec.waf.version": "1.6.1",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-4",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
@@ -10,7 +10,7 @@
     "meta": {
       "_dd.appsec.event_rules.version": "1.4.2",
       "_dd.appsec.json": "{\"triggers\":[{\"rule\":{\"id\":\"nfd-000-006\",\"name\":\"Detect failed attempt to fetch sensitive files\",\"tags\":{\"type\":\"security_scanner\",\"category\":\"attack_attempt\"}},\"rule_matches\":[{\"operator\":\"match_regex\",\"operator_value\":\"^404$\",\"parameters\":[{\"address\":\"server.response.status\",\"key_path\":[],\"value\":\"404\",\"highlight\":[\"404\"]}]},{\"operator\":\"match_regex\",\"operator_value\":\"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\"parameters\":[{\"address\":\"server.request.uri.raw\",\"key_path\":[],\"value\":\"http://example.com/.git\",\"highlight\":[\".git\"]}]}]}]}",
-      "_dd.appsec.waf.version": "1.6.0",
+      "_dd.appsec.waf.version": "1.6.1",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-4",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.appsec.test_processor.test_appsec_span_tags_snapshot.json
+++ b/tests/snapshots/tests.appsec.test_processor.test_appsec_span_tags_snapshot.json
@@ -10,7 +10,7 @@
     "meta": {
       "_dd.appsec.event_rules.version": "1.4.2",
       "_dd.appsec.json": "{\"triggers\":[{\"rule\":{\"id\":\"nfd-000-006\",\"name\":\"Detect failed attempt to fetch sensitive files\",\"tags\":{\"type\":\"security_scanner\",\"category\":\"attack_attempt\"}},\"rule_matches\":[{\"operator\":\"match_regex\",\"operator_value\":\"^404$\",\"parameters\":[{\"address\":\"server.response.status\",\"key_path\":[],\"value\":\"404\",\"highlight\":[\"404\"]}]},{\"operator\":\"match_regex\",\"operator_value\":\"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\"parameters\":[{\"address\":\"server.request.uri.raw\",\"key_path\":[],\"value\":\"http://example.com/.git\",\"highlight\":[\".git\"]}]}]}]}",
-      "_dd.appsec.waf.version": "1.6.0",
+      "_dd.appsec.waf.version": "1.6.1",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-4",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
+++ b/tests/snapshots/tests.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
@@ -10,7 +10,7 @@
     "meta": {
       "_dd.appsec.event_rules.errors": "{\"missing key 'conditions'\": [\"crs-913-110\"], \"missing key 'tags'\": [\"crs-942-100\"]}",
       "_dd.appsec.event_rules.version": "5.5.5",
-      "_dd.appsec.waf.version": "1.6.0",
+      "_dd.appsec.waf.version": "1.6.1",
       "_dd.p.dm": "-0",
       "_dd.runtime_family": "python",
       "http.status_code": "404",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_appsec_enabled.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_appsec_enabled.json
@@ -10,7 +10,7 @@
     "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "1.4.2",
-      "_dd.appsec.waf.version": "1.6.0",
+      "_dd.appsec.waf.version": "1.6.1",
       "_dd.p.dm": "-0",
       "_dd.runtime_family": "python",
       "asgi.version": "3.0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_appsec_enabled_attack.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_appsec_enabled_attack.json
@@ -11,7 +11,7 @@
     "meta": {
       "_dd.appsec.event_rules.version": "1.4.2",
       "_dd.appsec.json": "{\"triggers\":[{\"rule\":{\"id\":\"nfd-000-006\",\"name\":\"Detect failed attempt to fetch sensitive files\",\"tags\":{\"type\":\"security_scanner\",\"category\":\"attack_attempt\"}},\"rule_matches\":[{\"operator\":\"match_regex\",\"operator_value\":\"^404$\",\"parameters\":[{\"address\":\"server.response.status\",\"key_path\":[],\"value\":\"404\",\"highlight\":[\"404\"]}]},{\"operator\":\"match_regex\",\"operator_value\":\"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\"parameters\":[{\"address\":\"server.request.uri.raw\",\"key_path\":[],\"value\":\"http://localhost:8000/.git\",\"highlight\":[\".git\"]}]}]}]}",
-      "_dd.appsec.waf.version": "1.6.0",
+      "_dd.appsec.waf.version": "1.6.1",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-4",
       "_dd.runtime_family": "python",


### PR DESCRIPTION
## Description
Bump libddwaf dependency to 1.6.1 and use the sha256 checksums they provide now.

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Change contains telemetry where appropriate (logs, metrics, etc.).
- [ ] Telemetry is meaningful, actionable and does not have the potential to leak sensitive data.
