### PR TITLE
chore(profiler): add known issue changelog for Python 3.11 PyFrameObject

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -141,6 +141,7 @@ profiler
 protobuf
 psycopg
 py
+PyFrameObject
 pylibmc
 pymemcache
 pymongo

--- a/releasenotes/notes/prof-3-11-traceback-issue-20e06214d4a3879b.yaml
+++ b/releasenotes/notes/prof-3-11-traceback-issue-20e06214d4a3879b.yaml
@@ -1,0 +1,5 @@
+---
+issues:
+  - |
+    profiling: There is currently a known Python 3.11 compatibility issue where the stack collector does not properly 
+    access ``PyFrameObject`` member values, as ``PyFrameObject`` is now created and computed lazily in Python 3.11.

--- a/releasenotes/notes/prof-3-11-traceback-issue-20e06214d4a3879b.yaml
+++ b/releasenotes/notes/prof-3-11-traceback-issue-20e06214d4a3879b.yaml
@@ -3,3 +3,4 @@ issues:
   - |
     profiling: There is currently a known Python 3.11 compatibility issue where the stack collector does not properly 
     access ``PyFrameObject`` member values, as ``PyFrameObject`` is now created and computed lazily in Python 3.11.
+    Until this is fixed, we advise against enabling the profiler while using Python 3.11.


### PR DESCRIPTION
## Description
As #4895 has not been merged yet and we don't want to block the 1.8 release any longer, this PR adds a release note entry publishing the known issue of the profiler running in Python 3.11 with the new `PyFrameObject` opaque struct changes.

<!-- If this is a breaking change, explain why it is necessary. Breaking changes must append `!` after the type/scope. See https://ddtrace.readthedocs.io/en/stable/contributing.html for more details. -->

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

<!-- Copy and paste the relevant snippet based on the type of pull request -->

<!-- START feat -->

## Motivation
<!-- Expand on why the change is required, include relevant context for reviewers -->

## Design 
<!-- Include benefits from the change as well as possible drawbacks and trade-offs -->

## Testing strategy
<!-- Describe the automated tests and/or the steps for manual testing.

<!-- END feat -->

<!-- START fix -->

## Relevant issue(s)
<!-- Link the pull request to any issues related to the fix. Use keywords for links to automate closing the issues once the pull request is merged. -->

## Testing strategy
<!-- Describe any added regression tests and/or the manual testing performed. -->

<!-- END fix -->

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Change contains telemetry where appropriate (logs, metrics, etc.).
- [ ] Telemetry is meaningful, actionable and does not have the potential to leak sensitive data.
