### PR TITLE
perf(profiling): remove more unnecessary sorting

### DIFF
--- a/ddtrace/profiling/exporter/pprof.pyx
+++ b/ddtrace/profiling/exporter/pprof.pyx
@@ -463,7 +463,7 @@ class _PprofConverter(object):
                     "name": lib.name,
                     "kind": "library",
                     "version": lib.version,
-                    "paths": sorted(lib_and_filename[1] for lib_and_filename in libs_and_filenames),
+                    "paths": [lib_and_filename[1] for lib_and_filename in libs_and_filenames],
                 }
             )
             for lib, libs_and_filenames in groupby(
@@ -496,7 +496,7 @@ class _PprofConverter(object):
                 value=[values.get(sample_type_name, 0) for sample_type_name, unit in sample_types],
                 label=[pprof_pb2.Label(key=self._str(key), str=self._str(s)) for key, s in labels],
             )
-            for (locations, labels), values in sorted(six.iteritems(self._location_values), key=_ITEMGETTER_ZERO)
+            for (locations, labels), values in six.iteritems(self._location_values)
         ]
 
         period_type = pprof_pb2.ValueType(type=self._str("time"), unit=self._str("nanoseconds"))
@@ -512,9 +512,8 @@ class _PprofConverter(object):
                     filename=self._str(program_name),
                 ),
             ],
-            # Sort location and function by id so the output is reproducible
-            location=sorted(self._locations.values(), key=_ATTRGETTER_ID),
-            function=sorted(self._functions.values(), key=_ATTRGETTER_ID),
+            location=self._locations.values(),
+            function=self._functions.values(),
             string_table=list(self._string_table),
             time_nanos=start_time_ns,
             duration_nanos=duration_ns,

--- a/releasenotes/notes/perf-profiler-lower-overhead-f2c2e7c12c337196.yaml
+++ b/releasenotes/notes/perf-profiler-lower-overhead-f2c2e7c12c337196.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    profiler: CPU overhead reduction.

--- a/tests/profiling/exporter/test_pprof.py
+++ b/tests/profiling/exporter/test_pprof.py
@@ -758,7 +758,7 @@ def test_pprof_exporter_libs(gan):
         ]
     }
 
-    exports, libs = exp.export(TEST_EVENTS, 1, 7)
+    _, libs = exp.export(TEST_EVENTS, 1, 7)
 
     # Version does not match between pip and __version__ for ddtrace; ignore
     for lib in libs:
@@ -772,8 +772,8 @@ def test_pprof_exporter_libs(gan):
             del lib["paths"]
 
     expected_libs = [
-        {"name": "ddtrace", "kind": "library", "paths": [memalloc.__file__, __file__]},
-        {"name": "six", "kind": "library", "version": six.__version__, "paths": [six.__file__]},
+        {"name": "ddtrace", "kind": "library", "paths": {__file__, memalloc.__file__}},
+        {"name": "six", "kind": "library", "version": six.__version__, "paths": {six.__file__}},
         {"kind": "standard library", "name": "stdlib", "version": platform.python_version()},
         {
             "kind": "library",
@@ -794,6 +794,8 @@ def test_pprof_exporter_libs(gan):
     # - we end up with an empty expected_libs
     # This is equivalent to checking that the two lists are equal.
     for _ in libs:
+        if "paths" in _:
+            _["paths"] = set(_["paths"])
         expected_libs.remove(_)
 
     assert not expected_libs


### PR DESCRIPTION
## Description

This change removes more unnecessary sorting operations that were added to ensure that the data was reproducible. This was only beneficial for tests, and as such only constituted an extra burden on CPU that just added overhead to the profiler.

## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] Description motivates each change.
- [ ] No unnecessary changes were introduced in this PR.
- [ ] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Tests provided or description of manual testing performed is included in the code or PR.
- [ ] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [ ] All relevant GitHub issues are correctly linked.
- [ ] Change contains telemetry where appropriate (logs, metrics, etc.).
- [ ] Telemetry is meaningful, actionable and does not have the potential to leak sensitive data.
