### PR TITLE
ci: testing python lib injection [backport #4545 to 1.7] 

### DIFF
--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -25,67 +25,53 @@ jobs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v2
+   
+    - name: lib-injection-tags
+      id: lib-injection-tags
+      uses: DataDog/system-tests/lib-injection/docker-tags@main
+      with:
+        init-image-name: 'dd-lib-python-init'
+        main-branch-name: '1.x'
 
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
-
-    - name: Set Docker Image Tag
-      id: set_names
-      run: |
-        DOCKER_IMAGE_TAG=${{ github.sha }}
-        DOCKER_IMAGE_NAME=dd-lib-python-init
-        DOCKER_IMAGE_NAME=$(echo ghcr.io/${GITHUB_REPOSITORY}/${DOCKER_IMAGE_NAME} | tr '[:upper:]' '[:lower:]')
-        DOCKER_IMAGE_NAME_WITH_TAG=$(echo ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} | tr '[:upper:]' '[:lower:]')
-        echo "Using image name '$DOCKER_IMAGE_NAME_WITH_TAG'"
-        echo "image_name=$DOCKER_IMAGE_NAME_WITH_TAG" >> $GITHUB_OUTPUT
     - name: Login to Docker
       run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+
     - name: Docker Build
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: ${{ steps.set_names.outputs.image_name }}
-        platforms: "linux/amd64,linux/arm64/v8"
+        tags: ${{ steps.lib-injection-tags.outputs.tag-names }}
+        platforms: 'linux/amd64,linux/arm64/v8'
         build-args: "DDTRACE_PYTHON_VERSION=${{ steps.get_version.outputs.library_version }}"
         context: ./lib-injection
 
-  build-and-publish-sample-app-images:
+  test:
+    needs:
+      - build-and-publish-init-image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
-        image-name: [
-          "dd-lib-python-init-test-django",
-          "dd-lib-python-init-test-django-gunicorn",
-          "dd-lib-python-init-test-django-uvicorn",
-        ]
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
-
-      - name: Set Docker Image Tag
-        id: set_names
-        run: |
-          DOCKER_IMAGE_TAG=${{ github.sha }}
-          DOCKER_IMAGE_NAME=${{ matrix.image-name }}
-          DOCKER_IMAGE_NAME=$(echo ghcr.io/${GITHUB_REPOSITORY}/${DOCKER_IMAGE_NAME} | tr '[:upper:]' '[:lower:]')
-          DOCKER_IMAGE_NAME_WITH_TAG=$(echo ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} | tr '[:upper:]' '[:lower:]')
-          echo "Using image name '$DOCKER_IMAGE_NAME_WITH_TAG'"
-          echo "image_name=$DOCKER_IMAGE_NAME_WITH_TAG" >> $GITHUB_OUTPUT
-      - name: Login to Docker
-        run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-      - name: Docker Build
-        uses: docker/build-push-action@v3
+        lib-injection-connection: ['network','uds']
+        lib-injection-use-admission-controller: ['', 'use-admission-controller']
+        weblog-variant: ['dd-lib-python-init-test-django','dd-lib-python-init-test-django-gunicorn','dd-lib-python-init-test-django-uvicorn']
+      fail-fast: false
+    env:
+      TEST_LIBRARY: python
+      WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
+      LIBRARY_INJECTION_CONNECTION: ${{ matrix.lib-injection-connection }}
+      LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ matrix.lib-injection-use-admission-controller }}
+      DOCKER_REGISTRY_IMAGES_PATH: ghcr.io/datadog
+      DOCKER_IMAGE_TAG: ${{ github.sha }}
+      BUILDX_PLATFORMS: linux/amd64
+    steps:    
+    
+      - name: lib-injection test runner
+        id: lib-injection-test-runner
+        uses: DataDog/system-tests/lib-injection/runner@main
         with:
-          push: true
-          tags: ${{ steps.set_names.outputs.image_name }}
-          platforms: "linux/amd64"
-          context: ./tests/lib-injection/${{ matrix.image-name }}
+          docker-registry: ghcr.io
+          docker-registry-username: ${{ github.repository_owner }}
+          docker-registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -50,34 +50,6 @@ jobs:
           name: logs_${{ matrix.weblog-variant }}
           path: artifact.tar.gz
 
-  lib-injection:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        lib-injection-connection: ['uds', 'network']
-        lib-injection-use-admission-controller: ['', 'use-admission-controller']
-        lib-injection-test-app: ['dd-lib-python-init-test-django', 'dd-lib-python-init-test-django-gunicorn', 'dd-lib-python-init-test-django-uvicorn']
-      fail-fast: false
-    env:
-      TEST_LIBRARY: python
-      WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
-      DD_API_KEY: ${{ secrets.DD_API_KEY }}
-      LIBRARY_INJECTION_CONNECTION: ${{ matrix.lib-injection-connection }}
-      LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ matrix.lib-injection-admission-controller }}
-      LIBRARY_INJECTION_INIT_IMAGE: ghcr.io/datadog/dd-trace-py/dd-lib-python-init:${{ github.sha }}
-      LIBRARY_INJECTION_TEST_APP_IMAGE: ghcr.io/datadog/dd-trace-py/${{ matrix.lib-injection-test-app }}:${{ github.sha }}
-    steps:
-      - name: Checkout system tests
-        uses: actions/checkout@v3
-        with:
-          repository: 'DataDog/system-tests'
-
-      - name: Build
-        run: ./lib-injection/build.sh
-
-      - name: Run
-        run: ./lib-injection/run-lib-injection.sh
-
   parametric:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Description
Backport of #4545

Move whole lib injection tests to system-tests.
Launch these tests for every PR.
