### PR TITLE
chore(rq): wait for snapshot traces in flaky rq test

### DIFF
--- a/tests/contrib/rq/test_rq.py
+++ b/tests/contrib/rq/test_rq.py
@@ -134,7 +134,8 @@ def test_enqueue(queue, distributed_tracing_enabled, worker_service_name):
         distributed_tracing_enabled,
         worker_service_name,
     )
-    with snapshot_context(token, ignores=snapshot_ignores):
+    num_traces_expected = 2 if distributed_tracing_enabled is False else 1
+    with snapshot_context(token, ignores=snapshot_ignores, wait_for_num_traces=num_traces_expected):
         env = os.environ.copy()
         env["DD_TRACE_REDIS_ENABLED"] = "false"
         if distributed_tracing_enabled is not None:

--- a/tests/contrib/rq/test_rq.py
+++ b/tests/contrib/rq/test_rq.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 import time
 
 import pytest
@@ -134,7 +135,9 @@ def test_enqueue(queue, distributed_tracing_enabled, worker_service_name):
         distributed_tracing_enabled,
         worker_service_name,
     )
-    num_traces_expected = 2 if distributed_tracing_enabled is False else 1
+    num_traces_expected = None
+    if sys.version_info.major == 3 and sys.version_info.minor != 5:
+        num_traces_expected = 2 if distributed_tracing_enabled is False else 1
     with snapshot_context(token, ignores=snapshot_ignores, wait_for_num_traces=num_traces_expected):
         env = os.environ.copy()
         env["DD_TRACE_REDIS_ENABLED"] = "false"

--- a/tests/contrib/rq/test_rq.py
+++ b/tests/contrib/rq/test_rq.py
@@ -136,7 +136,7 @@ def test_enqueue(queue, distributed_tracing_enabled, worker_service_name):
         worker_service_name,
     )
     num_traces_expected = None
-    if sys.version_info.major == 3 and sys.version_info.minor != 5:
+    if not (sys.version_info.major == 3 and sys.version_info.minor == 5):
         num_traces_expected = 2 if distributed_tracing_enabled is False else 1
     with snapshot_context(token, ignores=snapshot_ignores, wait_for_num_traces=num_traces_expected):
         env = os.environ.copy()


### PR DESCRIPTION
## Description
The rq test `test_enqueue()` has been found to be flaky in CI runs (example [run](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/27434/workflows/9c729ac6-9ee7-4c25-a9ac-b90fba66f419/jobs/1873546)), with traces not immediately being found. The solution is to use the snapshot function's `wait_for_num_traces` option to make the test retry fetching traces from the testagent for a few seconds.

Note: this workaround is avoided in Python 3.5 as for some reason the snapshot function's `wait_for_num_traces` retry mechanism does not work in 3.5.


## Checklist
- [ ] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [ ] Add additional sections for `feat` and `fix` pull requests.
- [ ] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Change contains telemetry where appropriate (logs, metrics, etc.).
- [x] Telemetry is meaningful, actionable and does not have the potential to leak sensitive data.
