### PR TITLE
chore(ci): add require checklist action

### DIFF
--- a/.github/workflows/require-checklist.yaml
+++ b/.github/workflows/require-checklist.yaml
@@ -1,0 +1,12 @@
+name: Require Checklist
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+jobs:
+  require-checklist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/require-checklist-action@v2
+        with:
+          # require a checklist to be present in the PR description
+          requireChecklist: true


### PR DESCRIPTION
Use https://github.com/mheap/require-checklist-action to enforce that the checklist is completed. This should encourage authors and reviewers to manually verify things for which there is no automation yet.

## Checklist
- [x] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Change contains telemetry where appropriate (logs, metrics, etc.).
- [x] Telemetry is meaningful, actionable and does not have the potential to leak sensitive data.
