### PR TITLE
ci: re-enable slotscheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,7 +283,7 @@ jobs:
           command: riot run -s flake8
       - run:
           name: "Slots check"
-          command: riot run -s slotscheck
+          command: riot run slotscheck
       - run:
           name: "Mypy check"
           command: riot run -s mypy

--- a/hooks/scripts/run-slotscheck.sh
+++ b/hooks/scripts/run-slotscheck.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.py$')
 if [ -n "$staged_files" ]; then
-    riot -v run -s slotscheck $staged_files
+    riot -v run slotscheck $staged_files
 else
     echo 'Run slotscheck skipped: No Python files were found in git diff --staged'
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ exclude-modules = '''
   | ddtrace.profiling.auto
   # protobuf file fails to import
   | ddtrace.profiling.exporter.pprof_pre312_pb2
+  | ddtrace.profiling.exporter.pprof_pre319_pb2
   # TODO: resolve slot inheritance issues with profiling
   | ddtrace.profiling.collector
 )

--- a/riotfile.py
+++ b/riotfile.py
@@ -192,7 +192,7 @@ venv = Venv(
             venvs=[
                 Venv(
                     name="slotscheck",
-                    command="python -m slotscheck -v {cmdargs}",
+                    command="python -m slotscheck -v ddtrace/",
                 ),
             ],
         ),


### PR DESCRIPTION
#3527 seemed to have inadvertently removed the file argument in the slotscheck job in CI. We can re-enable the CI job with the minor update to the exclude list.