### PR TITLE
chore(tracing): readability improvements to sampler and propagation tests

### DIFF
--- a/tests/integration/test_propagation.py
+++ b/tests/integration/test_propagation.py
@@ -70,14 +70,19 @@ def downstream_tracer():
 
 @pytest.mark.snapshot()
 def test_sampling_decision_downstream(downstream_tracer):
-    headers = {
+    """
+    Ensures that set_tag(MANUAL_DROP_KEY) on a span causes the sampling decision meta and sampling priority metric
+    to be set appropriately indicating rejection
+
+    """
+    headers_indicating_kept_trace = {
         "x-datadog-trace-id": "1234",
         "x-datadog-parent-id": "5678",
         "x-datadog-sampling-priority": "1",
         "x-datadog-tags": "_dd.p.dm=-1",
     }
-    context = HTTPPropagator.extract(headers)
-    downstream_tracer.context_provider.activate(context)
+    kept_trace_context = HTTPPropagator.extract(headers_indicating_kept_trace)
+    downstream_tracer.context_provider.activate(kept_trace_context)
 
-    with downstream_tracer.trace("p", service="downstream") as span:
-        span.set_tag(MANUAL_DROP_KEY)
+    with downstream_tracer.trace("p", service="downstream") as span_to_reject:
+        span_to_reject.set_tag(MANUAL_DROP_KEY)

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -190,8 +190,7 @@ class RateByServiceSamplerTest(unittest.TestCase):
                 assert_sampling_decision_tags(
                     sample,
                     agent=sample_rate,
-                    # sampling decision made by agent
-                    trace_tag="-1",
+                    trace_tag="-{}".format(SamplingMechanism.AGENT_RATE),
                 )
             # We must have at least 1 sample, check that it has its sample rate properly assigned
             assert samples[0].get_metric(SAMPLE_RATE_METRIC_KEY) is None
@@ -731,8 +730,7 @@ def test_datadog_sampler_sample_no_rules(mock_sample, dummy_tracer):
         limit=None,
         rule=None,
         sampling_priority=AUTO_KEEP,
-        # default sampling decision
-        trace_tag="-0",
+        trace_tag="-{}".format(SamplingMechanism.DEFAULT),
     )
 
     # Default RateByServiceSampler() is applied
@@ -902,8 +900,7 @@ def test_datadog_sampler_tracer(dummy_tracer):
         rule=1.0,
         limit=None,
         sampling_priority=USER_KEEP,
-        # sampling decision from user sampling rule
-        trace_tag="-3",
+        trace_tag="-{}".format(SamplingMechanism.TRACE_SAMPLING_RULE),
     )
 
 
@@ -952,7 +949,7 @@ def test_datadog_sampler_tracer_child(dummy_tracer):
         limit=None,
         sampling_priority=USER_KEEP,
         # sampling decision from user sampling rule
-        trace_tag="-3",
+        trace_tag="-{}".format(SamplingMechanism.TRACE_SAMPLING_RULE),
     )
     assert_sampling_decision_tags(
         spans[1],
@@ -960,7 +957,7 @@ def test_datadog_sampler_tracer_child(dummy_tracer):
         rule=None,
         limit=None,
         # DEV: the trace tag check is on the context which is shared between parent and child
-        trace_tag="-3",
+        trace_tag="-{}".format(SamplingMechanism.TRACE_SAMPLING_RULE),
     )
 
 
@@ -981,7 +978,7 @@ def test_datadog_sampler_tracer_start_span(dummy_tracer):
         limit=None,
         sampling_priority=USER_KEEP,
         # sampling decision from user sampling rule
-        trace_tag="-3",
+        trace_tag="-{}".format(SamplingMechanism.TRACE_SAMPLING_RULE),
     )
 
 


### PR DESCRIPTION
A few small readability refactors to tests I came across in my first week working on this repo.

I messed up https://github.com/DataDog/dd-trace-py/pull/4995 trying to sign an old unsigned commit, so this PR replaces it. Same diff, all commits signed.