### PR TITLE
feat(asm): add new ASM context manager

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -6,6 +6,13 @@ from typing import Optional
 from ddtrace.vendor import contextvars
 
 
+"""
+Stopgap module for providing ASM context for the blocking features wrapping some
+contextvars. When using this, note that context vars are always thread-local so each
+thread will have a different context.
+"""
+
+
 # FIXME: remove these and use the new context API once implemented and allowing
 # contexts without spans
 

--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -1,0 +1,68 @@
+import contextlib
+from typing import Any
+from typing import Generator
+from typing import Optional
+
+from ddtrace.vendor import contextvars
+
+
+# FIXME: remove these and use the new context API once implemented and allowing
+# contexts without spans
+
+_DD_EARLY_IP_CONTEXTVAR = contextvars.ContextVar("datadog_early_ip_contextvar", default=None)
+_DD_EARLY_HEADERS_CONTEXTVAR = contextvars.ContextVar("datadog_early_headers_contextvar", default=None)
+_DD_EARLY_HEADERS_CASE_SENSITIVE_CONTEXTVAR = contextvars.ContextVar(
+    "datadog_early_headers_casesensitive_contextvar", default=False
+)
+
+
+def reset():  # type: () -> None
+    _DD_EARLY_IP_CONTEXTVAR.set(None)
+    _DD_EARLY_HEADERS_CONTEXTVAR.set(None)
+    _DD_EARLY_HEADERS_CASE_SENSITIVE_CONTEXTVAR.set(False)
+
+
+def set_ip(ip):  # type: (Optional[str]) -> None
+    _DD_EARLY_IP_CONTEXTVAR.set(ip)
+
+
+def get_ip():  # type: () -> Optional[str]
+    return _DD_EARLY_IP_CONTEXTVAR.get()
+
+
+# Note: get/set headers use Any since we just carry the headers here without changing or using them
+# and different frameworks use different types that we don't want to force it into a Mapping at the
+# early point set_headers is usually called
+
+
+def set_headers(headers):  # type: (Any) -> None
+    _DD_EARLY_HEADERS_CONTEXTVAR.set(headers)
+
+
+def get_headers():  # type: () -> Optional[Any]
+    return _DD_EARLY_HEADERS_CONTEXTVAR.get()
+
+
+def set_headers_case_sensitive(case_sensitive):  # type: (bool) -> None
+    _DD_EARLY_HEADERS_CASE_SENSITIVE_CONTEXTVAR.set(case_sensitive)
+
+
+def get_headers_case_sensitive():  # type: () -> bool
+    return _DD_EARLY_HEADERS_CASE_SENSITIVE_CONTEXTVAR.get()
+
+
+def asm_request_context_set(remote_ip=None, headers=None, headers_case_sensitive=False):
+    # type: (Optional[str], Any, bool) -> None
+    set_ip(remote_ip)
+    set_headers(headers)
+    set_headers_case_sensitive(headers_case_sensitive)
+
+
+@contextlib.contextmanager
+def asm_request_context_manager(remote_ip=None, headers=None, headers_case_sensitive=False):
+    # type: (Optional[str], Any, bool) -> Generator[None, None, None]
+    asm_request_context_set(remote_ip, headers, headers_case_sensitive)
+    try:
+        yield
+    finally:
+        reset()

--- a/tests/appsec/test_asm_request_context.py
+++ b/tests/appsec/test_asm_request_context.py
@@ -1,0 +1,57 @@
+import pytest
+
+from ddtrace.appsec import _asm_request_context
+
+
+@pytest.fixture(autouse=True)
+def reset_test_asm_context():
+    _asm_request_context.reset()
+    yield
+    _asm_request_context.reset()
+
+
+_TEST_IP = "1.2.3.4"
+_TEST_HEADERS = {"foo": "bar"}
+
+
+def test_context_set_and_reset():
+    _asm_request_context.asm_request_context_set(_TEST_IP, _TEST_HEADERS, True)
+    assert _asm_request_context.get_ip() == _TEST_IP
+    assert _asm_request_context.get_headers() == _TEST_HEADERS
+    assert _asm_request_context.get_headers_case_sensitive()
+    _asm_request_context.reset()
+    assert _asm_request_context.get_ip() is None
+    assert _asm_request_context.get_headers() is None
+    assert not _asm_request_context.get_headers_case_sensitive()
+    _asm_request_context.asm_request_context_set(_TEST_IP, _TEST_HEADERS)
+    assert not _asm_request_context.get_headers_case_sensitive()
+
+
+def test_set_get_ip():
+    _asm_request_context.set_ip(_TEST_IP)
+    assert _asm_request_context.get_ip() == _TEST_IP
+
+
+def test_set_get_headers():
+    _asm_request_context.set_headers(_TEST_HEADERS)
+    assert _asm_request_context.get_headers() == _TEST_HEADERS
+
+
+def test_set_get_headers_case_sensitive():
+    # default reset value should be False
+    assert not _asm_request_context.get_headers_case_sensitive()
+    _asm_request_context.set_headers_case_sensitive(True)
+    assert _asm_request_context.get_headers_case_sensitive()
+    _asm_request_context.set_headers_case_sensitive(False)
+    assert not _asm_request_context.get_headers_case_sensitive()
+
+
+def test_asm_request_context_manager():
+    with _asm_request_context.asm_request_context_manager(_TEST_IP, _TEST_HEADERS, True):
+        assert _asm_request_context.get_ip() == _TEST_IP
+        assert _asm_request_context.get_headers() == _TEST_HEADERS
+        assert _asm_request_context.get_headers_case_sensitive()
+
+    assert _asm_request_context.get_ip() is None
+    assert _asm_request_context.get_headers() is None
+    assert not _asm_request_context.get_headers_case_sensitive()


### PR DESCRIPTION
# Description

Add a ASM context manager. Didn't include a release note since it's an internal private API.

# Motivation

The new blocking features of ASM, specially IP blocking, require that we store some values, mostly headers and the IP, even before the span is created. This is a stopgap measure until the new tracer context API is created.

# Design

This is a simple implementation using `contextvars.ContextVars` and some ad-hoc functions to get or set the values, plus a shortcut function to set some values and a context manager.

# Testing Strategy

This includes some basic unittests.  The PRs to add Flask and Django IP Blocking will also add more tests regarding this for checking that the context is correctly reset on each request cycle.

# Risk

This is an internal module that only new features will use so there is no risk of breakage.

Signed-off-by: Juanjo Alvarez <juanjo.alvarezmartinez@datadoghq.com>

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
