### PR TITLE
fix: fix the backport GitHub Action's labels_template lodash template

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,5 +27,5 @@ jobs:
           body_template: "Backport <%= mergeCommitSha %> from #<%= number %> to <%= base %>.\n\n<%= body %>"
           label_pattern: "^backport (?<base>([0-9]+\\.[0-9]+))$"
           # Include the original labels from the merged PR (minus any matching label_pattern)
-          labels_template: "[<%= labels %>]"
+          labels_template: "<% print(JSON.stringify(labels)) %>"
           title_template: "<%= title %> [backport <%= base %>]"


### PR DESCRIPTION
I still haven't figured out the best way to test this, but I dug into lodash's documentation further, and they have a REPL in their docs to try executing code.

This seems to produce what we want:

```js
var compiled = _.template('<% print(JSON.stringify(labels)) %>');
var res = compiled({ 'labels': ['profiling', 'changelog/no-changelog'] });
JSON.parse(res)
```

This is the closest to a test I could figure out.

If this doesn't work, then I'll just remove the `labels_template`. I'd really like to figure out how to make this work so original labels like `changelog/no-changelog` get copied to the backport PR.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).


## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
