### PR TITLE
chore(benchmarks): update set_http_meta benchmark config

### DIFF
--- a/benchmarks/set_http_meta/config.yaml
+++ b/benchmarks/set_http_meta/config.yaml
@@ -4,7 +4,7 @@ all-enabled: &all-enabled
   send_querystring_enabled: false
   obfuscation_disabled: false
   ip_header: ""
-  ip_disabled: true
+  ip_enabled: false
   querystring: ''
   url: 'http://localhost:8888/index'
 no-useragentvariant:
@@ -13,7 +13,7 @@ no-useragentvariant:
 all-disabled:
   <<: *all-enabled
   allenabled: false
-  ip_disabled: true
+  ip_enabled: false
 useragentvariant_exists_1:
   <<: *all-enabled
   useragentvariant: "HTTP_USER_AGENT"
@@ -32,10 +32,10 @@ useragentvariant_not_exists_2:
 no-collectipvariant:
   <<: *all-enabled
   ip_header: ""
-  ip_disabled: true
+  ip_enabled: false
 collectipvariant_exists:
   <<: *all-enabled
-  ip_disabled: false
+  ip_enabled: true
   ip_header: "x-forwarded-for"
 obfuscation-worst-case-implicit-query:
   <<: *all-enabled


### PR DESCRIPTION
#4967 removed an env variable `DD_TRACE_CLIENT_IP_HEADER_DISABLED`, but did not replace it (referenced by `ip_disabled`) in the benchmark tests for `set_http_meta` scenario. This PR replaces the `ip_disabled` with `ip_enabled` as was added in #4967.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).


## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
