### PR TITLE
feat(graphql): add support for python 3.11

### DIFF
--- a/releasenotes/notes/graphql-support-py311-9c1398a0846bda87.yaml
+++ b/releasenotes/notes/graphql-support-py311-9c1398a0846bda87.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    graphql: Adds support for python 3.11

--- a/riotfile.py
+++ b/riotfile.py
@@ -1790,7 +1790,7 @@ venv = Venv(
                     },
                 ),
                 Venv(
-                    pys=select_pys(min_version="3.6", max_version="3.10"),
+                    pys=select_pys(min_version="3.6", max_version="3.11"),
                     # FIXME[bytecode-3.11]: depends on bytecode module which doesn't yet support Python 3.11
                     pkgs={
                         "graphene": ["~=2.1.9", "~=3.0.0", latest],
@@ -1811,8 +1811,7 @@ venv = Venv(
                     },
                 ),
                 Venv(
-                    pys=select_pys(min_version="3.6", max_version="3.10"),
-                    # FIXME[bytecode-3.11]: depends on bytecode module which doesn't yet support Python 3.11
+                    pys=select_pys(min_version="3.6", max_version="3.11"),
                     pkgs={
                         "graphql-core": ["~=2.2.0", "~=2.3.0", "~=3.0.0", "~=3.1.0", "~=3.2.0", latest],
                     },


### PR DESCRIPTION
The graphql integration is the only tracing integration which uses byte code instrumentation to trace function calls. https://github.com/DataDog/dd-trace-py/pull/4854 introduced python 3.11 support for bytecode instrumentation.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).


## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
