### PR TITLE
fix(ci/lib-injection): add missing runs_on value [backport #5039 to 1.7]

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -1,0 +1,41 @@
+name: Build and publish image
+
+on:
+  workflow_call:
+    inputs:
+      tags:
+        required: true
+        type: string
+      platforms:
+        required: true
+        type: string
+      build-args:
+        required: true
+        type: string
+      context:
+        required: true
+        type: string
+    secrets:
+      token:
+        required: true
+
+jobs:
+  build_push:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Login to Docker
+      run: docker login -u publisher -p ${{ secrets.token }} ghcr.io
+    - name: Docker Build
+      uses: docker/build-push-action@v3
+      with:
+        push: true
+        tags: ${{ inputs.tags }}
+        platforms: ${{ inputs.platforms }}
+        build-args: ${{ inputs.build-args }}
+        context: ${{ inputs.context }}

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -203,22 +203,14 @@ jobs:
           skip_existing: true
 
   build-and-publish-init-image:
+    needs: [upload_pypi]
     # We have to wait for the PyPI job since the image that we publish depends on installing
     # the package from PyPI.
-    needs: [upload_pypi]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to Docker
-        run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-      - name: Docker Build
-        uses: docker/build-push-action@v3
-        with:
-          tags: ghcr.io/datadog/dd-trace-py/dd-lib-python-init:${{ github.ref_name }}
-          platforms: 'linux/amd64,linux/arm64/v8'
-          build-args: "DDTRACE_PYTHON_VERSION=${{ github.ref_name }}"
-          context: ./lib-injection
-          push: true
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      tags: ghcr.io/datadog/dd-trace-py/dd-lib-python-init:${{ github.ref_name }}
+      platforms: 'linux/amd64,linux/arm64/v8'
+      build-args: "DDTRACE_PYTHON_VERSION=${{ github.ref_name }}"
+      context: ./lib-injection
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -5,25 +5,14 @@ on:
 
 jobs:
   build-and-publish-test-image:
-    # Check build_deploy.yml for the publishing of the prod image.
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v2
-    - name: Login to Docker
-      run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-    - name: Docker Build
-      uses: docker/build-push-action@v3
-      with:
-        push: true
-        tags: ghcr.io/datadog/dd-trace-py/dd-lib-python-init:${{ github.sha }}
-        platforms: 'linux/amd64,linux/arm64/v8'
-        build-args: "DDTRACE_PYTHON_VERSION=git+https://github.com/Datadog/dd-trace-py@${{ github.sha }}"
-        context: ./lib-injection
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      tags: 'ghcr.io/datadog/dd-trace-py/dd-lib-python-init:${{ github.sha }}'
+      platforms: 'linux/amd64,linux/arm64/v8'
+      build-args: 'DDTRACE_PYTHON_VERSION=git+https://github.com/Datadog/dd-trace-py@${{ github.sha }}'
+      context: ./lib-injection
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     needs:


### PR DESCRIPTION
The `runs_on` field was missing which caused the 1.7.4 release workflow to fail.  To avoid this problem, or problems like this from happening again, the shared logic is pulled into a reusable workflow[0]. Now the build and push logic is shared between the test and publish jobs which will give us a better idea if the publish one works.

[0] https://docs.github.com/en/actions/using-workflows/reusing-workflows

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).


## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
