### PR TITLE
fix(asm): fix unicode decode errors in pylons [backport #5029 to 1.8]

### DIFF
--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -107,11 +107,11 @@ class PylonsTraceMiddleware(object):
                         if hasattr(request, "json"):
                             req_body = request.json
                         else:
-                            req_body = json.loads(request.body.decode("UTF-8"))
+                            req_body = json.loads(request.body.decode(request.charset or "utf-8", errors="ignore"))
                     elif content_type in ("application/xml", "text/xml"):
-                        req_body = xmltodict.parse(request.body.decode("UTF-8"))
+                        req_body = xmltodict.parse(request.body.decode(request.charset or "utf-8", errors="ignore"))
                     else:  # text/plain, xml, others: take them as strings
-                        req_body = request.body.decode("UTF-8")
+                        req_body = request.body.decode(request.charset or "utf-8", errors="ignore")
 
                 except (
                     AttributeError,

--- a/releasenotes/notes/fix-unicode-decode-errors-pylons-52d28b22f82e184a.yaml
+++ b/releasenotes/notes/fix-unicode-decode-errors-pylons-52d28b22f82e184a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    pylons: This fix resolves an issue where ``str.decode`` could cause critical unicode decode errors when ASM is enabled. ASM is disabled by default.


### PR DESCRIPTION
Backports https://github.com/DataDog/dd-trace-py/pull/5029 to 1.8

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

This PR is related to a critical exception detected two days ago on https://app.datadoghq.com/logs

<img width="1352" alt="Pylons Unicode Error"
src="https://user-images.githubusercontent.com/114495376/216595049-a0fa6bb0-5c2b-4e5f-ac97-e83000c225eb.png">

Silently drop non translatable UTF-8 characters instead of raising critical exception in Pylons framework.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.