### PR TITLE
chore(benchmarks): remove outdated decorator in threading scenario

### DIFF
--- a/benchmarks/threading/scenario.py
+++ b/benchmarks/threading/scenario.py
@@ -30,7 +30,6 @@ class NoopWriter(TraceWriter):
         pass
 
 
-@bm.register
 class Threading(bm.Scenario):
     nthreads = bm.var(type=int)
     ntraces = bm.var(type=int)


### PR DESCRIPTION
#2791 auto-registered any subclasses of `bm.Scenario`, meaning that the decorator `@bm.register` was no longer necessary (and was also removed in that PR). However, #2789 added a new threading benchmark scenario which still had that decorator, meaning that this scenario no longer works. This PR updates that scenario by removing the `@bm.register` decorator.

Unblocks #5040.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).


## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
