### PR TITLE
test(lib-injection): fix the version of tests used [backport to 1.6]

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -71,12 +71,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
+          ref: b3ca75b6ce109a349f7390a9f111e6b3ef3c97ef
 
       - name: Build
         run: ./lib-injection/build.sh
 
       - name: Run
-        run: ./lib-injection/run-lib-injection.sh
+        run: ./lib-injection/run-manual-lib-injection.sh
 
   parametric:
     runs-on: ubuntu-latest

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -77,7 +77,7 @@ jobs:
         run: ./lib-injection/build.sh
 
       - name: Run
-        run: ./lib-injection/run-manual-lib-injection.sh
+        run: ./lib-injection/run-lib-injection.sh
 
   parametric:
     runs-on: ubuntu-latest

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
-          ref: 852bc2874e76edd078198c51727731ad7d1d0704
+          ref: 5aa8c4fea01ea6a929acb9b78b2b70403fe6c961
 
       - name: Build
         run: ./lib-injection/build.sh

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
-          ref: 8673a616565c3b9c0e867d169bdf60925f55d748
+          ref: 4cd01c3ac62ca61e489b6e0cd1679052ae531777
 
       - name: Build
         run: ./lib-injection/build.sh

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
-          ref: 34267134f72c6b7d615a42a807fd47c47e020e96
+          ref: 53c7b5c1b1c4e65807df7552d4e0a6bda314b67f
 
       - name: Build
         run: ./lib-injection/build.sh

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -40,7 +40,7 @@ jobs:
       # even on failures, we want to have artifact to be able to investigate
       # The compress step speed up a lot the upload artifact process
       - name: Compress artifact
-        if: ${{ always() }}  
+        if: ${{ always() }}
         run: tar -czvf artifact.tar.gz $(ls | grep logs)
 
       - name: Upload artifact
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
-          ref: b3ca75b6ce109a349f7390a9f111e6b3ef3c97ef
+          ref: 8673a616565c3b9c0e867d169bdf60925f55d748
 
       - name: Build
         run: ./lib-injection/build.sh

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
-          ref: 53c7b5c1b1c4e65807df7552d4e0a6bda314b67f
+          ref: 852bc2874e76edd078198c51727731ad7d1d0704
 
       - name: Build
         run: ./lib-injection/build.sh

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
-          ref: 4cd01c3ac62ca61e489b6e0cd1679052ae531777
+          ref: 34267134f72c6b7d615a42a807fd47c47e020e96
 
       - name: Build
         run: ./lib-injection/build.sh


### PR DESCRIPTION
We've been changing the tests quite a bit lately which has led to CI breakage. It makes sense, since we backport so much, to fix the version so that CI remains stable.

This particular change, changed the scripts used to run the tests.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).


## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
