### PR TITLE
docs: update theme to prevent overlap on configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,6 +177,9 @@ html_theme = "alabaster"
 #
 html_theme_options = {
     "description": "Datadog's Python APM client",
+    # https://alabaster.readthedocs.io/en/latest/customization.html#basics
+    "page_width": "1200px",
+    "sidebar_width": "400px",
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
The Configuration page in particular gets messy with longer environment variable names in the sidebar, making it harder to read the docs.

Increasing the overall page width to 1200px (from the default of 940px) and increasing the sidebar size to 400px (from 220px) provides a more hospitable view.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [n/a] Testing strategy is described if automated tests are not included in the PR.
- [n/a] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [n/a] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
