### PR TITLE
feat(span): add finish_with_ancestors method

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -485,6 +485,18 @@ class Span(object):
             self._context = Context(trace_id=self.trace_id, span_id=self.span_id)
         return self._context
 
+    def finish_with_ancestors(self):
+        # type: () -> None
+        """Finish this span along with all (accessible) ancestors of this span.
+
+        This method is useful if a sudden program shutdown is required and finishing
+        the trace is desired.
+        """
+        span = self  # type: Optional[Span]
+        while span is not None:
+            span.finish()
+            span = span._parent
+
     def __enter__(self):
         return self
 

--- a/releasenotes/notes/span_finish_with_ancestors-da848c160c0af08c.yaml
+++ b/releasenotes/notes/span_finish_with_ancestors-da848c160c0af08c.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    tracer/span: Add ``Span.finish_with_ancestors`` method to enable the abrupt
+      finishing of a trace in cases where the trace or application must be
+      immediately terminated.

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1887,6 +1887,22 @@ def test_top_level(tracer):
             assert _is_top_level(child_span2)
 
 
+def test_finish_span_with_ancestors(tracer):
+    # single span case
+    span1 = tracer.trace("span1")
+    span1.finish_with_ancestors()
+    assert span1.finished
+
+    # multi ancestor case
+    span1 = tracer.trace("span1")
+    span2 = tracer.trace("span2")
+    span3 = tracer.trace("span2")
+    span3.finish_with_ancestors()
+    assert span1.finished
+    assert span2.finished
+    assert span3.finished
+
+
 def test_ctx_api():
     from ddtrace.internal import _context
 


### PR DESCRIPTION
To support use cases where a span lineage needs to be finished abruptly (eg. AWS Lambda timeouts), a method `Span.finish_with_ancestors` is introduced.

This is a bit of a workaround for the fact that spans cannot be sent unfinished to the backend. Currently, in cases like AWS Lambda functions, the trace will never be sent because the spans are unfinished. This API at least enables traces to be sent with the drawback of not being totally accurate.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
