### PR TITLE
chore(internal): remove gevent hub reinit hack

### DIFF
--- a/ddtrace/internal/forksafe.py
+++ b/ddtrace/internal/forksafe.py
@@ -7,8 +7,6 @@ import threading
 import typing
 import weakref
 
-from ddtrace.internal.module import ModuleWatchdog
-from ddtrace.internal.utils.formats import asbool
 from ddtrace.vendor import wrapt
 
 
@@ -22,26 +20,6 @@ _registry = []  # type: typing.List[typing.Callable[[], None]]
 # like SIGSEGV will occur. Setting this to True will cause the after-fork hooks
 # to be executed after the actual fork, which seems to prevent the issue.
 _soft = True
-
-
-def patch_gevent_hub_reinit(module):
-    # The gevent hub is re-initialized *after* the after-in-child fork hooks are
-    # called, so we patch the gevent.hub.reinit function to ensure that the
-    # fork hooks run again after this further re-initialisation, if it is ever
-    # called.
-    from ddtrace.internal.wrapping import wrap
-
-    def wrapped_reinit(f, args, kwargs):
-        try:
-            return f(*args, **kwargs)
-        finally:
-            ddtrace_after_in_child()
-
-    wrap(module.reinit, wrapped_reinit)
-
-
-if asbool(os.getenv("_DD_TRACE_GEVENT_HUB_PATCHED", default=False)):
-    ModuleWatchdog.register_module_hook("gevent.hub", patch_gevent_hub_reinit)
 
 
 def ddtrace_after_in_child():


### PR DESCRIPTION
This pull request contains changes pulled out of https://github.com/DataDog/dd-trace-py/pull/4863. Specifically, it removes the import hook causing the gevent hub to be reinitialized, because the changes in #4863 will make it obsolete. 

Blocked by #5109

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
