### PR TITLE
fix(profiler): handle non-frame objects while stack-unwinding [backport #5019 to 1.7]

### DIFF
--- a/ddtrace/profiling/collector/_traceback.pyx
+++ b/ddtrace/profiling/collector/_traceback.pyx
@@ -1,3 +1,12 @@
+from types import CodeType
+from types import FrameType
+
+from ddtrace.internal.logger import get_logger
+
+
+log = get_logger(__name__)
+
+
 cpdef _extract_class_name(frame):
     # type: (...) -> str
     """Extract class name from a frame, if possible.
@@ -47,13 +56,39 @@ cpdef pyframe_to_frames(frame, max_nframes):
     :param frame: The frame object to serialize.
     :param max_nframes: The maximum number of frames to return.
     :return: The serialized frames and the number of frames present in the original traceback."""
+    # DEV: There are reports that Python 3.11 returns non-frame objects when
+    # retrieving frame objects and doing stack unwinding. If we detect a
+    # non-frame object we log a warning and return an empty stack, to avoid
+    # reporting potentially incomplete and/or inaccurate data. This until we can
+    # come to the bottom of the issue.
+    if not isinstance(frame, FrameType):
+        log.warning(
+            "Got object of type '%s' instead of a frame object for the top frame of a thread", type(frame).__name__
+        )
+        return [], 0
+
     frames = []
     nframes = 0
+
     while frame is not None:
-        nframes += 1
-        if len(frames) < max_nframes:
+        IF PY_MAJOR_VERSION > 3 or (PY_MAJOR_VERSION == 3 and PY_MINOR_VERSION >= 11):
+            if not isinstance(frame, FrameType):
+                log.warning(
+                    "Got object of type '%s' instead of a frame object during stack unwinding", type(frame).__name__
+                )
+                return [], 0
+        
+        if nframes < max_nframes:
             code = frame.f_code
+            IF PY_MAJOR_VERSION > 3 or (PY_MAJOR_VERSION == 3 and PY_MINOR_VERSION >= 11):
+                if not isinstance(code, CodeType):
+                    log.warning(
+                        "Got object of type '%s' instead of a code object during stack unwinding", type(code).__name__
+                    )
+                    return [], 0
+
             lineno = 0 if frame.f_lineno is None else frame.f_lineno
             frames.append((code.co_filename, lineno, code.co_name, _extract_class_name(frame)))
+        nframes += 1
         frame = frame.f_back
     return frames, nframes

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -336,38 +336,36 @@ cdef stack_collect(ignore_profiler, thread_time, max_nframes, interval, wall_tim
                 continue
 
             frames, nframes = _traceback.pyframe_to_frames(task_pyframes, max_nframes)
+            if nframes:
+                stack_events.append(
+                    stack_event.StackSampleEvent(
+                        thread_id=thread_id,
+                        thread_native_id=thread_native_id,
+                        thread_name=thread_name,
+                        task_id=task_id,
+                        task_name=task_name,
+                        nframes=nframes, frames=frames,
+                        wall_time_ns=wall_time,
+                        sampling_period=int(interval * 1e9),
+                    )
+                )
 
+        frames, nframes = _traceback.pyframe_to_frames(thread_pyframes, max_nframes)
+        if nframes:
             event = stack_event.StackSampleEvent(
                 thread_id=thread_id,
                 thread_native_id=thread_native_id,
                 thread_name=thread_name,
-                task_id=task_id,
-                task_name=task_name,
-                nframes=nframes, frames=frames,
+                task_id=thread_task_id,
+                task_name=thread_task_name,
+                nframes=nframes,
+                frames=frames,
                 wall_time_ns=wall_time,
+                cpu_time_ns=cpu_time,
                 sampling_period=int(interval * 1e9),
             )
-
+            event.set_trace_info(span, collect_endpoint)
             stack_events.append(event)
-
-        frames, nframes = _traceback.pyframe_to_frames(thread_pyframes, max_nframes)
-
-        event = stack_event.StackSampleEvent(
-            thread_id=thread_id,
-            thread_native_id=thread_native_id,
-            thread_name=thread_name,
-            task_id=thread_task_id,
-            task_name=thread_task_name,
-            nframes=nframes,
-            frames=frames,
-            wall_time_ns=wall_time,
-            cpu_time_ns=cpu_time,
-            sampling_period=int(interval * 1e9),
-        )
-
-        event.set_trace_info(span, collect_endpoint)
-
-        stack_events.append(event)
 
         if exception is not None:
             exc_type, exc_traceback = exception

--- a/releasenotes/notes/profiler-py311-alien-frame-objects-a7eca2f7dd3270c1.yaml
+++ b/releasenotes/notes/profiler-py311-alien-frame-objects-a7eca2f7dd3270c1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    profiler: Handles potential ``AttributeErrors`` which would arise while collecting frames during stack unwinding in Python 3.11.


### PR DESCRIPTION
  Backport of #5019 to 1.7

  Following reports of Python 3.11 returning non-frame objects while unwinding the stack of a running thread, this change adds handling code that prevents exceptions from being raised.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).


## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
