### PR TITLE
chore(tracer): add tracer events

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -3,7 +3,6 @@ import pprint
 import sys
 import traceback
 from typing import Any
-from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -74,7 +73,6 @@ class Span(object):
         "_local_root",
         "_parent",
         "_ignored_exceptions",
-        "_on_finish_callbacks",
         "__weakref__",
     ]
 
@@ -89,7 +87,6 @@ class Span(object):
         parent_id=None,  # type: Optional[int]
         start=None,  # type: Optional[int]
         context=None,  # type: Optional[Context]
-        on_finish=None,  # type: Optional[List[Callable[[Span], None]]]
     ):
         # type: (...) -> None
         """
@@ -111,7 +108,6 @@ class Span(object):
 
         :param int start: the start time of request as a unix epoch in seconds
         :param object context: the Context of the span.
-        :param on_finish: list of functions called when the span finishes.
         """
         # pre-conditions
         if not (span_id is None or isinstance(span_id, six.integer_types)):
@@ -140,7 +136,6 @@ class Span(object):
         self.trace_id = trace_id or _rand.rand64bits()  # type: int
         self.span_id = span_id or _rand.rand64bits()  # type: int
         self.parent_id = parent_id  # type: Optional[int]
-        self._on_finish_callbacks = [] if on_finish is None else on_finish
 
         # sampling
         self.sampled = True  # type: bool
@@ -240,9 +235,6 @@ class Span(object):
         ft = time_ns() if finish_time is None else int(finish_time * 1e9)
         # be defensive so we don't die if start isn't set
         self.duration_ns = ft - (self.start_ns or ft)
-
-        for cb in self._on_finish_callbacks:
-            cb(self)
 
     def set_tag(self, key, value=None):
         # type: (_TagNameType, Any) -> None

--- a/tests/tracer/test_memory_leak.py
+++ b/tests/tracer/test_memory_leak.py
@@ -30,9 +30,9 @@ def trace(weakdict, tracer, *args, **kwargs):
     Note: ensure to delete the returned reference from this function to ensure
     no additional references are kept to the span.
     """
-    s = tracer.trace(*args, **kwargs)
-    weakdict[s.span_id] = s
-    return s
+    with tracer.trace(*args, **kwargs) as s:
+        weakdict[s.span_id] = s
+        return s
 
 
 def test_leak(tracer):

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -72,9 +72,8 @@ def assert_sampling_decision_tags(
 
 def create_span(tracer=None, name="test.span", service=""):
     tracer = tracer or DummyTracer()
-    span = tracer.trace(name=name, service=service)
-    span.finish()
-    return span
+    with tracer.trace(name=name, service=service) as span:
+        return span
 
 
 class RateSamplerTest(unittest.TestCase):


### PR DESCRIPTION
This change add a pub-sub functionality to the tracer to allow subscribing for tracer events, such as span finish events. These can be used, for example, to notify other products that a span has just been finished, and any potential exceptions attached to it can be notified and further analysed.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
