### PR TITLE
commit just the regression test from #5088

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -347,20 +347,31 @@ venv = Venv(
         Venv(
             name="internal",
             command="pytest {cmdargs} tests/internal/",
-            pkgs={
-                "httpretty": "==0.9.7",
-                "gevent": latest,
-            },
+            pkgs={"httpretty": "==0.9.7", "gevent": latest, "requests": latest},
             venvs=[
                 Venv(pys="2.7", pkgs={"packaging": ["==17.1", latest]}),
                 Venv(
                     pys=select_pys(min_version="3.5", max_version="3.6"),
-                    pkgs={"pytest-asyncio": latest, "packaging": ["==17.1", latest]},
+                    pkgs={
+                        "httpretty": "==0.9.7",
+                        "requests": latest,
+                        "pytest-asyncio": latest,
+                        "gunicorn": latest,
+                        "flask": latest,
+                        "packaging": ["==17.1", latest],
+                    },
                 ),
                 # FIXME[bytecode-3.11]: internal depends on bytecode, which is not python 3.11 compatible.
                 Venv(
                     pys=select_pys(min_version="3.7"),
-                    pkgs={"pytest-asyncio": latest, "packaging": ["==17.1", "==22.0", latest]},
+                    pkgs={
+                        "httpretty": "==0.9.7",
+                        "requests": latest,
+                        "pytest-asyncio": latest,
+                        "gunicorn": latest,
+                        "flask": latest,
+                        "packaging": ["==17.1", "==22.0", latest],
+                    },
                 ),
             ],
         ),

--- a/tests/internal/remoteconfig/stuck_test_app.py
+++ b/tests/internal/remoteconfig/stuck_test_app.py
@@ -1,0 +1,28 @@
+import os
+import time
+
+from flask import Flask
+
+
+app = Flask(__name__)
+app.config["PROPAGATE_EXCEPTIONS"] = True
+
+
+def start():
+    pid1 = os.fork()
+    if pid1 == 0:
+        os.setsid()
+        time.sleep(0.2)
+    else:
+        os.waitpid(pid1, 0)
+
+
+@app.route("/")
+def index_view():
+    start()
+    return "OK"
+
+
+@app.route("/start")
+def start_view():
+    return "start"

--- a/tests/internal/remoteconfig/test_remoteconfig.py
+++ b/tests/internal/remoteconfig/test_remoteconfig.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import base64
 import datetime
-import getpass
 import hashlib
 import json
 import os

--- a/tests/internal/remoteconfig/test_remoteconfig.py
+++ b/tests/internal/remoteconfig/test_remoteconfig.py
@@ -263,6 +263,7 @@ def test_gevent_no_stuck_processes():  # type: () -> None
             # Avoid noisy database spans being output on app startup/teardown.
             "DD_TRACE_SQLITE3_ENABLED": "0",
             "DD_GEVENT_PATCH_ALL": "true",
+            "DD_REMOTE_CONFIGURATION_ENABLED": "true",
         }
     )
 

--- a/tests/internal/remoteconfig/test_remoteconfig.py
+++ b/tests/internal/remoteconfig/test_remoteconfig.py
@@ -263,6 +263,7 @@ def test_gevent_no_stuck_processes():  # type: () -> None
             "DD_TRACE_SQLITE3_ENABLED": "0",
             "DD_GEVENT_PATCH_ALL": "true",
             "DD_REMOTE_CONFIGURATION_ENABLED": "false",
+            "DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE": "1",
         }
     )
 

--- a/tests/internal/remoteconfig/test_remoteconfig.py
+++ b/tests/internal/remoteconfig/test_remoteconfig.py
@@ -262,7 +262,7 @@ def test_gevent_no_stuck_processes():  # type: () -> None
             # Avoid noisy database spans being output on app startup/teardown.
             "DD_TRACE_SQLITE3_ENABLED": "0",
             "DD_GEVENT_PATCH_ALL": "true",
-            "DD_REMOTE_CONFIGURATION_ENABLED": "true",
+            "DD_REMOTE_CONFIGURATION_ENABLED": "false",
         }
     )
 

--- a/tests/internal/remoteconfig/test_remoteconfig.py
+++ b/tests/internal/remoteconfig/test_remoteconfig.py
@@ -1,13 +1,20 @@
 # -*- coding: utf-8 -*-
 import base64
 import datetime
+import getpass
 import hashlib
 import json
+import os
+import signal
+import subprocess
+import sys
+import time
 from time import sleep
 import warnings
 
 import mock
 import pytest
+import tenacity
 
 from ddtrace.internal.compat import PY2
 from ddtrace.internal.remoteconfig import RemoteConfig
@@ -15,8 +22,11 @@ from ddtrace.internal.remoteconfig.client import RemoteConfigClient
 from ddtrace.internal.remoteconfig.constants import ASM_FEATURES_PRODUCT
 from ddtrace.internal.remoteconfig.constants import REMOTE_CONFIG_AGENT_ENDPOINT
 from ddtrace.internal.remoteconfig.worker import get_poll_interval_seconds
+from ddtrace.vendor import psutil
+from ddtrace.vendor.psutil import NoSuchProcess
 from tests.internal.test_utils_version import _assert_and_get_version_agent_format
 from tests.utils import override_env
+from tests.webclient import Client
 
 
 def to_bytes(string):
@@ -227,3 +237,80 @@ def test_remoteconfig_semver():
 def test_remote_configuration_check_remote_config_enable_in_agent_errors(mock_healthcheck, result, expected):
     mock_healthcheck.return_value = result
     assert RemoteConfig._check_remote_config_enable_in_agent() is expected
+
+
+def _count_running_processes(canary_str):
+    found = 0
+    for proc in psutil.process_iter():
+        if "python" in proc.name():
+            try:
+                if canary_str in " ".join(proc.cmdline()):
+                    found += 1
+            except psutil.AccessDenied:
+                continue
+
+    return found
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6, 0), reason="Python versions below 3.6 sort dictionaries differently")
+def test_gevent_no_stuck_processes():  # type: () -> None
+    port = 8000
+    flask_app = "tests.internal.remoteconfig.stuck_test_app:app"
+    gunicorn_cmd = "ddtrace-run gunicorn -b 0.0.0.0:%s -w 3 -k gevent %s" % (port, flask_app)
+    flask_env = os.environ.copy()
+    flask_env.update(
+        {
+            # Avoid noisy database spans being output on app startup/teardown.
+            "DD_TRACE_SQLITE3_ENABLED": "0",
+            "DD_GEVENT_PATCH_ALL": "true",
+        }
+    )
+
+    proc = subprocess.Popen(
+        gunicorn_cmd.split(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True,
+        env=flask_env,
+        preexec_fn=os.setsid,
+    )
+
+    try:
+        client = Client("http://0.0.0.0:%s" % port)
+        # Wait for the server to start up
+        try:
+            client.wait(max_tries=5, path="/start", delay=0.2)
+            client.wait(max_tries=5, delay=0.1)
+        except tenacity.RetryError:
+            # if proc.returncode is not None: process failed
+            stdout = proc.stdout.read()
+            stderr = proc.stderr.read()
+            raise TimeoutError(
+                "Server failed to start\n======STDOUT=====%s\n\n======STDERR=====%s\n" % (stdout, stderr)
+            )
+
+        # Do a bunch of requests and check that the number of processes doesn't increase
+        for i in range(20):
+            client.get("/")
+
+        time.sleep(5)
+        try:
+            nprocesses = _count_running_processes(flask_app)
+            assert nprocesses == 4
+
+            client.get_ignored("/shutdown")
+        except Exception as e:  # noqa
+            stdout = proc.stdout.read()
+            stderr = proc.stderr.read()
+            print("Server failed to start\n======STDOUT=====%s\n\n======STDERR=====%s\n" % (stdout, stderr))
+            raise
+
+    finally:
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait()
+
+    try:
+        nprocesses = _count_running_processes(flask_app)
+        assert nprocesses == 0
+    except NoSuchProcess:
+        print("Process is finished")

--- a/tests/internal/remoteconfig/test_remoteconfig.py
+++ b/tests/internal/remoteconfig/test_remoteconfig.py
@@ -241,7 +241,7 @@ def test_remote_configuration_check_remote_config_enable_in_agent_errors(mock_he
 def _count_running_processes(canary_str):
     found = 0
     for proc in psutil.process_iter():
-        if "python" in proc.name():
+        if "python" in proc.name() or "gunicorn" in proc.name():
             try:
                 if canary_str in " ".join(proc.cmdline()):
                     found += 1
@@ -262,8 +262,6 @@ def test_gevent_no_stuck_processes():  # type: () -> None
             # Avoid noisy database spans being output on app startup/teardown.
             "DD_TRACE_SQLITE3_ENABLED": "0",
             "DD_GEVENT_PATCH_ALL": "true",
-            "DD_REMOTE_CONFIGURATION_ENABLED": "false",
-            "DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE": "1",
         }
     )
 
@@ -280,7 +278,7 @@ def test_gevent_no_stuck_processes():  # type: () -> None
         client = Client("http://0.0.0.0:%s" % port)
         # Wait for the server to start up
         try:
-            client.wait(max_tries=5, path="/start", delay=0.2)
+            client.wait(max_tries=5, path="/start", delay=0.5)
             client.wait(max_tries=5, delay=0.1)
         except tenacity.RetryError:
             # if proc.returncode is not None: process failed


### PR DESCRIPTION
This pull request contains only the regression test from https://github.com/DataDog/dd-trace-py/pull/5088. The purpose of setting this up is to verify whether or not that test actually replicates an issue on 1.x and solves it in #5088.

You can run this test locally with `riot -v run -s -p 3.10 internal -- -k "test_gevent_no_stuck_processes" -s`