### PR TITLE
fix(telemetry): debug field should be set to a boolean

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -171,7 +171,7 @@ class TelemetryWriter(PeriodicService):
                 "runtime_id": get_runtime_id(),
                 "api_version": "v1",
                 "seq_id": next(self._sequence),
-                "debug": str(self._debug).lower(),
+                "debug": self._debug,
                 "application": get_application(config.service, config.version, config.env),
                 "host": get_host_info(),
                 "payload": payload,

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -37,7 +37,7 @@ def test_add_event(telemetry_writer, test_agent_session):
     assert requests[0]["headers"]["Content-Type"] == "application/json"
     assert requests[0]["headers"]["DD-Telemetry-Request-Type"] == payload_type
     assert requests[0]["headers"]["DD-Telemetry-API-Version"] == "v1"
-    assert requests[0]["headers"]["DD-Telemetry-Debug-Enabled"] == "false"
+    assert requests[0]["headers"]["DD-Telemetry-Debug-Enabled"] == "False"
     assert requests[0]["body"] == _get_request_body(payload, payload_type)
 
 
@@ -235,7 +235,7 @@ def _get_request_body(payload, payload_type, seq_id=1):
         "runtime_id": get_runtime_id(),
         "api_version": "v1",
         "seq_id": seq_id,
-        "debug": "false",
+        "debug": False,
         "application": get_application(config.service, config.version, config.env),
         "host": get_host_info(),
         "payload": payload,


### PR DESCRIPTION
`TelemetryWriter._debug` field and `"DD-Telemetry-Debug-Enabled"` request header should be set to a boolean (True/False), not a lower case string ("true"/"false"). 

This bug was introduced by the following [commit](https://github.com/DataDog/dd-trace-py/commit/76294ea33dcad52f40bd40b5b7001f34152afba2) and is set to be released in v1.9.0. Since this bug is not released, a release note is not required.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
