### PR TITLE
test: improve stream checks for subprocess tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,21 @@ class FunctionDefFinder(ast.NodeVisitor):
             return t
 
 
+def is_stream_ok(stream, expected):
+    if expected is None:
+        return True
+
+    if isinstance(expected, str):
+        ex = expected.encode("utf-8")
+    elif isinstance(expected, bytes):
+        ex = expected
+    else:
+        # Assume it's a callable condition
+        return expected(stream.decode("utf-8"))
+
+    return stream == ex
+
+
 def run_function_from_file(item, params=None):
     file, _, func = item.location
     marker = item.get_closest_marker("subprocess")
@@ -188,14 +203,8 @@ def run_function_from_file(item, params=None):
         env.update(params)
 
     expected_status = marker.kwargs.get("status", 0)
-
     expected_out = marker.kwargs.get("out", "")
-    if expected_out is not None:
-        expected_out = expected_out.encode("utf-8")
-
     expected_err = marker.kwargs.get("err", "")
-    if expected_err is not None:
-        expected_err = expected_err.encode("utf-8")
 
     with NamedTemporaryFile(mode="wb", suffix=".pyc") as fp:
         dump_code_to_file(compile(FunctionDefFinder(func).find(file), file, "exec"), fp.file)
@@ -222,9 +231,11 @@ def run_function_from_file(item, params=None):
                     "\n=== Captured STDERR ===\n%s=== End of captured STDERR ==="
                     % (expected_status, status, out.decode("utf-8"), err.decode("utf-8"))
                 )
-            elif expected_out is not None and out != expected_out:
+
+            if not is_stream_ok(out, expected_out):
                 raise AssertionError("STDOUT: Expected [%s] got [%s]" % (expected_out, out))
-            elif expected_err is not None and err != expected_err:
+
+            if not is_stream_ok(err, expected_err):
                 raise AssertionError("STDERR: Expected [%s] got [%s]" % (expected_err, err))
 
         return TestReport.from_item_and_call(item, CallInfo.from_call(_subprocess_wrapper, "call"))


### PR DESCRIPTION
This change allows passing in callables for performing more complex checks against the standard streams captured during a test run in a subprocess.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
