### PR TITLE
chore(profiler): remove resolved known issue for profiler on Python 3.11 [backport #5153 to 1.8]

### DIFF
--- a/releasenotes/notes/prof-3-11-traceback-issue-20e06214d4a3879b.yaml
+++ b/releasenotes/notes/prof-3-11-traceback-issue-20e06214d4a3879b.yaml
@@ -1,6 +1,0 @@
----
-issues:
-  - |
-    profiling: There is currently a known Python 3.11 compatibility issue where the stack collector does not properly 
-    access ``PyFrameObject`` member values, as ``PyFrameObject`` is now created and computed lazily in Python 3.11.
-    Until this is fixed, we advise against enabling the profiler while using Python 3.11.


### PR DESCRIPTION
  Backport of #5153 to 1.8

  This PR removes the known issue release note for the profiler on Python 3.11 relating to `PyFrameObjects`, which was mitigated by #5019.
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
