### PR TITLE
perf(debugging): reduce shutdown overhead

### DIFF
--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -189,8 +189,10 @@ class Debugger(Service):
 
         log.debug("%s enabled", cls.__name__)
 
+    # DEV: Joining in short-lived processes can cause latency spikes (e.g.
+    # gevent workers). We avoid joining by default in all cases.
     @classmethod
-    def disable(cls, join=True):
+    def disable(cls, join=False):
         # type: (bool) -> None
         """Disable dynamic instrumentation.
 
@@ -634,7 +636,9 @@ class Debugger(Service):
 
     def _stop_service(self, join=True):
         # type: (bool) -> None
-        self._function_store.restore_all()
+        # DEV: Skip restoring functions as this adds overhead on process
+        # shutdown for no benefit.
+        # self._function_store.restore_all()
         for service in self._services:
             service.stop()
             if join:

--- a/tests/debugging/mocking.py
+++ b/tests/debugging/mocking.py
@@ -82,6 +82,12 @@ class TestDebugger(Debugger):
         # type: (Probe) -> None
         self._on_configuration(ProbePollerEvent.DELETED_PROBES, probes)
 
+    @classmethod
+    def disable(cls):
+        if cls._instance is not None:
+            cls._instance._function_store.restore_all()
+        super(TestDebugger, cls).disable(join=True)
+
     @property
     def test_queue(self):
         return self._collector.test_queue


### PR DESCRIPTION
This change reduces shutdown overheads caused by the dynamic instrumentation services by skipping the join and the function code reset. Since the application is shutting down, there is no reason to restore code objects to their original form, since at the point when the dynamic instrumentation exit hook is invoked, no more user code will be executed. The positive impact of this change would be noticeable in multiprocess applications that spawn short-lived worker processes (e.g. gunicorn with gevent workers).

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- ~~Change is maintainable (easy to change, telemetry, documentation).~~
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
