### PR TITLE
chore(ci): update fastapi framework test suite to latest version 0.92.0

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Run tests
         run: ddtrace-run pytest graphene
 
-  fastapi-testsuite-0_75:
+  fastapi-testsuite-0_92:
     runs-on: ubuntu-latest
     env:
       DD_TESTING_RAISE: true
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: tiangolo/fastapi
-          ref: 0.75.0
+          ref: 0.92.0
           path: fastapi
       - uses: actions/cache@v3.2.5
         id: cache

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -176,14 +176,9 @@ jobs:
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-python-${{ env.pythonLocation }}-fastapi
-      #This step installs Flit, a way to put Python packages and modules on PyPI (More info at https://flit.readthedocs.io/en/latest/)
-      - name: Install Flit
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install flit
-      #Installs all dependencies needed for FastAPI
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: flit install --symlink
+        run: pip install -e .[all,dev,doc,test]
       - name: Inject ddtrace
         run: pip install ../ddtrace
       - name: Test


### PR DESCRIPTION
The framework test suite started failing with the follow 2 errors:

- The job was hanging due to an issue with Flint.
- There was a failing test that is not related to a change in dd-trace-py:
```
        if context.result_column_struct:
>           (
                result_columns,
                cols_are_ordered,
                textual_ordered,
                ad_hoc_textual,
                loose_column_name_matching,
            ) = context.result_column_struct
E           ValueError: not enough values to unpack (expected 5, got 4)
```

Instead of trying to debug the cause of this specific error we have updated the framework test suite to use the latest version of FastAPI (0.92.0), and moving from `flint` to `pip` for installing dependencies. This has resolved the issue.

**Risks:** This was likely caused because a dependency was updated. We are still susceptible to updated dependencies breaking things. We should consider if we should introduce lock files or something to ensure better consistency here.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
