### PR TITLE
fix(rcm): error in capabilities

### DIFF
--- a/ddtrace/appsec/utils.py
+++ b/ddtrace/appsec/utils.py
@@ -39,17 +39,20 @@ def _appsec_rc_capabilities():
     256         -> 100000000        -> b'\x01\x00'          -> b'AQA='
     """
     value = 0b0
+    result = ""
+    if asbool(os.environ.get("DD_REMOTE_CONFIGURATION_ENABLED", "true")) or asbool(os.environ.get(APPSEC_ENV)):
+        if _appsec_rc_features_is_enabled():
+            value |= 1 << 1  # Enable ASM_ACTIVATION
+        value |= 1 << 2  # Enable ASM_IP_BLOCKING
+        value |= 1 << 3  # Enable ASM_DD_RULES
+        value |= 1 << 4  # Enable ASM_EXCLUSIONS
 
-    if _appsec_rc_features_is_enabled():
-        value |= 1 << 1
-        value |= 1 << 2
-
-    if sys.version_info.major < 3:
-        bytes_res = to_bytes_py2(value, (value.bit_length() + 7) // 8, "big")
-        # "type: ignore" because mypy does not notice this is for Python2 b64encode
-        result = str(base64.b64encode(bytes_res))  # type: ignore
-    else:
-        result = str(base64.b64encode(value.to_bytes((value.bit_length() + 7) // 8, "big")), encoding="utf-8")
+        if sys.version_info.major < 3:
+            bytes_res = to_bytes_py2(value, (value.bit_length() + 7) // 8, "big")
+            # "type: ignore" because mypy does not notice this is for Python2 b64encode
+            result = str(base64.b64encode(bytes_res))  # type: ignore
+        else:
+            result = str(base64.b64encode(value.to_bytes((value.bit_length() + 7) // 8, "big")), encoding="utf-8")
 
     return result
 

--- a/tests/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/test_remoteconfiguration.py
@@ -104,14 +104,21 @@ def test_rc_activation_states_off(tracer, appsec_enabled, rc_value, remote_confi
 
 
 @pytest.mark.parametrize(
-    "rc_enabled, capability",
+    "rc_enabled, appsec_enabled, capability",
     [
-        ("true", "Bg=="),
-        ("false", ""),
+        ("true", "true", "HA=="),
+        ("false", "true", "HA=="),
+        ("true", "false", "HA=="),
+        ("false", "false", ""),
+        ("true", "", "Hg=="),
+        ("false", "", ""),
     ],
 )
-def test_rc_capabilities(rc_enabled, capability):
-    with override_env({"DD_REMOTE_CONFIGURATION_ENABLED": rc_enabled}):
+def test_rc_capabilities(rc_enabled, appsec_enabled, capability):
+    env = {"DD_REMOTE_CONFIGURATION_ENABLED": rc_enabled}
+    if appsec_enabled:
+        env[APPSEC_ENV] = appsec_enabled
+    with override_env(env):
         assert _appsec_rc_capabilities() == capability
 
 


### PR DESCRIPTION
## Checklist
Error in capabilities. If we set DD_APPSEC_ENABLED env var, we don't report capabilities in RC requests


- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
