### PR TITLE
chore(asm): keep waf context during request

### DIFF
--- a/ddtrace/appsec/ddwaf/__init__.py
+++ b/ddtrace/appsec/ddwaf/__init__.py
@@ -140,9 +140,11 @@ if _DDWAF_LOADED:
             start = time.time()
 
             if self._ctx == 0:
+                LOGGER.warning("DDWaf failsafe to create the context")
                 self._ctx = ddwaf_context_init(self._handle)
 
             if self._ctx == 0:
+                LOGGER.error("DDWaf failure: no context created")
                 return DDWaf_result(None, [], 0, (time.time() - start) * 1e6)
 
             result = ddwaf_result()

--- a/ddtrace/appsec/ddwaf/__init__.py
+++ b/ddtrace/appsec/ddwaf/__init__.py
@@ -167,6 +167,7 @@ if _DDWAF_LOADED:
         # type: () -> text_type
         return ddwaf_get_version().decode("UTF-8")
 
+
 else:
     # Mockup of the DDWaf class doing nothing
     class DDWaf(object):  # type: ignore

--- a/ddtrace/appsec/ddwaf/__init__.py
+++ b/ddtrace/appsec/ddwaf/__init__.py
@@ -140,6 +140,9 @@ if _DDWAF_LOADED:
             start = time.time()
 
             if self._ctx == 0:
+                self._ctx = ddwaf_context_init(self._handle)
+
+            if self._ctx == 0:
                 return DDWaf_result(None, [], 0, (time.time() - start) * 1e6)
 
             result = ddwaf_result()

--- a/ddtrace/appsec/ddwaf/__init__.py
+++ b/ddtrace/appsec/ddwaf/__init__.py
@@ -84,6 +84,7 @@ if _DDWAF_LOADED:
             self._info = ddwaf_ruleset_info()
             self._ruleset_map = ddwaf_object.create_without_limits(ruleset_map)
             self._handle = ddwaf_init(self._ruleset_map, ctypes.byref(config), ctypes.byref(self._info))
+            self._ctx = 0
             if not self._handle or self._info.failed:
                 LOGGER.error(
                     "DDWAF.__init__: invalid rules\n ruleset: %s\nloaded:%s\nerrors:%s\n",
@@ -118,6 +119,18 @@ if _DDWAF_LOADED:
                 self._handle = result
                 return False
 
+        def _at_request_start(self):
+            if self._ctx:
+                ddwaf_context_destroy(self._ctx)
+            self._ctx = ddwaf_context_init(self._handle)
+            if self._ctx == 0:
+                LOGGER.error("DDWaf failure to create the context")
+
+        def _at_request_end(self):
+            if self._ctx:
+                ddwaf_context_destroy(self._ctx)
+                self._ctx = 0
+
         def run(
             self,  # type: DDWaf
             data,  # type: DDWafRulesType
@@ -126,38 +139,33 @@ if _DDWAF_LOADED:
             # type: (...) -> DDWaf_result
             start = time.time()
 
-            ctx = ddwaf_context_init(self._handle)
-            if ctx == 0:
-                LOGGER.error("DDWaf failure to create the context")
+            if self._ctx == 0:
                 return DDWaf_result(None, [], 0, (time.time() - start) * 1e6)
 
+            result = ddwaf_result()
+            wrapper = ddwaf_object(data)
+            error = ddwaf_run(self._ctx, wrapper, ctypes.byref(result), timeout_ms * 1000)
+            if error < 0:
+                LOGGER.warning("run DDWAF error: %d\ninput %s\nerror %s", error, wrapper.struct, self.info.errors)
             try:
-                result = ddwaf_result()
-                wrapper = ddwaf_object(data)
-                error = ddwaf_run(ctx, wrapper, ctypes.byref(result), timeout_ms * 1000)
-                if error < 0:
-                    LOGGER.warning("run DDWAF error: %d\ninput %s\nerror %s", error, wrapper.struct, self.info.errors)
-                try:
-                    return DDWaf_result(
-                        result.data.decode("UTF-8", errors="ignore")
-                        if hasattr(result, "data") and result.data
-                        else None,
-                        [result.actions.array[i].decode("UTF-8", errors="ignore") for i in range(result.actions.size)],
-                        result.total_runtime / 1e3,
-                        (time.time() - start) * 1e6,
-                    )
-                finally:
-                    ddwaf_result_free(ctypes.byref(result))
+                return DDWaf_result(
+                    result.data.decode("UTF-8", errors="ignore") if hasattr(result, "data") and result.data else None,
+                    [result.actions.array[i].decode("UTF-8", errors="ignore") for i in range(result.actions.size)],
+                    result.total_runtime / 1e3,
+                    (time.time() - start) * 1e6,
+                )
             finally:
-                ddwaf_context_destroy(ctx)
+                ddwaf_result_free(ctypes.byref(result))
 
         def __dealloc__(self):
-            ddwaf_destroy(self._handle)
+            if self._ctx:
+                ddwaf_context_destroy(self._ctx)
+            if self._handle:
+                ddwaf_destroy(self._handle)
 
     def version():
         # type: () -> text_type
         return ddwaf_get_version().decode("UTF-8")
-
 
 else:
     # Mockup of the DDWaf class doing nothing

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -195,7 +195,7 @@ class AppSecSpanProcessor(SpanProcessor):
 
         if span.span_type != SpanTypes.WEB:
             return
-        self._ddwaf._at_request_end()
+        self._ddwaf._at_request_start()
 
         peer_ip = _asm_request_context.get_ip()
         headers = _asm_request_context.get_headers()

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -195,6 +195,7 @@ class AppSecSpanProcessor(SpanProcessor):
 
         if span.span_type != SpanTypes.WEB:
             return
+        self._ddwaf._at_request_end()
 
         peer_ip = _asm_request_context.get_ip()
         headers = _asm_request_context.get_headers()
@@ -359,3 +360,4 @@ class AppSecSpanProcessor(SpanProcessor):
         if span.get_tag(APPSEC.JSON) is None:
             log.debug("metrics waf call")
             self._waf_action(span)
+        self._ddwaf._at_request_end()


### PR DESCRIPTION
To avoid performance issues, this PR defines a way to keep the same WAF context for all calls to the WAF during a single request.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
