### PR TITLE
fix(appsec): add recommended compiler flag for windows builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -302,7 +302,7 @@ if sys.version_info[:2] >= (3, 4) and not IS_PYSTON:
                         recursive=True,
                     )
                 ),
-                extra_compile_args=debug_compile_args + ["-std=c++17"],
+                extra_compile_args=extra_compile_args + debug_compile_args + ["-std=c++17"],
             )
         )
 else:

--- a/setup.py
+++ b/setup.py
@@ -246,7 +246,7 @@ else:
 
 if CURRENT_OS == "Windows":
     encoding_libraries = ["ws2_32"]
-    extra_compile_args = ["-std=c++17"]
+    extra_compile_args = ["/std:c++17"]
     debug_compile_args = []
 else:
     linux = CURRENT_OS == "Linux"

--- a/setup.py
+++ b/setup.py
@@ -246,7 +246,7 @@ else:
 
 if CURRENT_OS == "Windows":
     encoding_libraries = ["ws2_32"]
-    extra_compile_args = []
+    extra_compile_args = ["-std=c++17"]
     debug_compile_args = []
 else:
     linux = CURRENT_OS == "Linux"

--- a/setup.py
+++ b/setup.py
@@ -246,7 +246,7 @@ else:
 
 if CURRENT_OS == "Windows":
     encoding_libraries = ["ws2_32"]
-    extra_compile_args = ["/std:c++17"]
+    extra_compile_args = []
     debug_compile_args = []
 else:
     linux = CURRENT_OS == "Linux"
@@ -302,7 +302,8 @@ if sys.version_info[:2] >= (3, 4) and not IS_PYSTON:
                         recursive=True,
                     )
                 ),
-                extra_compile_args=extra_compile_args + debug_compile_args + ["-std=c++17"],
+                extra_compile_args=debug_compile_args
+                + ["/std:c++17" if platform.system() == "Windows" else "-std=c++17"],
             )
         )
 else:


### PR DESCRIPTION
This change fixes windows wheel build failures related to recent changes to the Application Security product. Here's an [example](https://github.com/DataDog/dd-trace-py/actions/runs/4244490342/jobs/7380404486) of one such failure.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
