### PR TITLE
fix(asm): skip compilation of _taint_tracking for Windows OS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -291,20 +291,20 @@ if sys.version_info[:2] >= (3, 4) and not IS_PYSTON:
                 extra_compile_args=debug_compile_args,
             )
         )
-    if sys.version_info >= (3, 6, 0):
-        ext_modules.append(
-            Extension(
-                "ddtrace.appsec.iast._taint_tracking",
-                # Sort source files for reproducibility
-                sources=sorted(
-                    glob.glob(
-                        os.path.join(HERE, "ddtrace", "appsec", "iast", "_taint_tracking", "**", "*.cpp"),
-                        recursive=True,
-                    )
-                ),
-                extra_compile_args=debug_compile_args + ["-std=c++17"],
+        if sys.version_info >= (3, 6, 0):
+            ext_modules.append(
+                Extension(
+                    "ddtrace.appsec.iast._taint_tracking",
+                    # Sort source files for reproducibility
+                    sources=sorted(
+                        glob.glob(
+                            os.path.join(HERE, "ddtrace", "appsec", "iast", "_taint_tracking", "**", "*.cpp"),
+                            recursive=True,
+                        )
+                    ),
+                    extra_compile_args=debug_compile_args + ["-std=c++17"],
+                )
             )
-        )
 else:
     ext_modules = []
 


### PR DESCRIPTION
This change skips compilation of this WIP feature under Windows, which is currently failing on 1.x

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
