### PR TITLE
ci(graphql): reduce test runs from 16mins to 3mins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -746,6 +746,7 @@ jobs:
 
   graphql:
     <<: *machine_executor
+    parallelism: 8
     steps:
       - run_test:
           pattern: "graphql"


### PR DESCRIPTION
Graphql is our slowest testsuite. Currently test runs had a parallelism of 1 and take 16mins ([example](https://app.circleci.com/pipelines/gh/DataDog/dd-trace-py/29392/workflows/5d8d5aa6-0a9a-4162-bf1a-6f4d303270d1/jobs/1996793/steps)). With a parallelism of 8 tests should finish in 3-5mins.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
