### PR TITLE
chore(asm): remove raw body extraction in django, flask and pylons

### DIFF
--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -154,7 +154,7 @@ def get_request_uri(request):
 
     # If any url part is a SimpleLazyObject, use its __class__ property to cast
     # str/bytes and allow for _setup() to execute
-    for (k, v) in urlparts.items():
+    for k, v in urlparts.items():
         if isinstance(v, SimpleLazyObject):
             if issubclass(v.__class__, str):
                 v = str(v)
@@ -272,8 +272,8 @@ def _extract_body(request):
                     if rest_framework
                     else xmltodict.parse(request.body.decode("UTF-8"))
                 )
-            else:  # text/plain, xml, others: take them as strings
-                req_body = request.data.decode("UTF-8") if rest_framework else request.body.decode("UTF-8")
+            else:  # text/plain, others: don't use them
+                req_body = None
         except (
             AttributeError,
             RawPostDataException,

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -174,7 +174,8 @@ class _FlaskWSGIMiddleware(_DDWSGIMiddlewareBase):
                 elif hasattr(request, "form"):
                     req_body = request.form.to_dict()
                 else:
-                    req_body = request.get_data()
+                    # no raw body
+                    req_body = None
             except (
                 AttributeError,
                 RuntimeError,

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -110,8 +110,8 @@ class PylonsTraceMiddleware(object):
                             req_body = json.loads(request.body.decode(request.charset or "utf-8", errors="ignore"))
                     elif content_type in ("application/xml", "text/xml"):
                         req_body = xmltodict.parse(request.body.decode(request.charset or "utf-8", errors="ignore"))
-                    else:  # text/plain, xml, others: take them as strings
-                        req_body = request.body.decode(request.charset or "utf-8", errors="ignore")
+                    else:  # text/plain, others: don't use them
+                        req_body = None
 
                 except (
                     AttributeError,

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -234,7 +234,7 @@ def test_django_request_body_plain_attack(client, test_spans, tracer):
 
         query = _context.get_item("http.request.body", span=root_span)
         str_json = root_span.get_tag(APPSEC_JSON)
-        assert str_json is not None, "no JSON tag in root span"
+        assert str_json is None, "JSON tag in root span"
         assert "triggers" in json.loads(str_json)
         assert query is None
 

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -225,7 +225,7 @@ def test_django_request_body_plain(client, test_spans, tracer):
         query = _context.get_item("http.request.body", span=root_span)
 
         assert root_span.get_tag(APPSEC_JSON) is None
-        assert query == "foo=bar"
+        assert query is None
 
 
 def test_django_request_body_plain_attack(client, test_spans, tracer):
@@ -236,7 +236,7 @@ def test_django_request_body_plain_attack(client, test_spans, tracer):
         str_json = root_span.get_tag(APPSEC_JSON)
         assert str_json is not None, "no JSON tag in root span"
         assert "triggers" in json.loads(str_json)
-        assert query == "1' or '1' = '1'"
+        assert query is None
 
 
 def test_django_request_body_json_bad(caplog, client, test_spans, tracer):

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -235,7 +235,6 @@ def test_django_request_body_plain_attack(client, test_spans, tracer):
         query = _context.get_item("http.request.body", span=root_span)
         str_json = root_span.get_tag(APPSEC_JSON)
         assert str_json is None, "JSON tag in root span"
-        assert "triggers" in json.loads(str_json)
         assert query is None
 
 

--- a/tests/contrib/pylons/test_pylons.py
+++ b/tests/contrib/pylons/test_pylons.py
@@ -786,7 +786,7 @@ class PylonsTestCase(TracerTestCase):
 
             root_span = spans[0]
             appsec_json = root_span.get_tag("_dd.appsec.json")
-            assert "triggers" in json.loads(appsec_json if appsec_json else "{}")
+            assert "triggers" not in json.loads(appsec_json if appsec_json else "{}")
 
             span = _context.get_item("http.request.body", span=root_span)
             assert span is None

--- a/tests/contrib/pylons/test_pylons.py
+++ b/tests/contrib/pylons/test_pylons.py
@@ -548,7 +548,6 @@ class PylonsTestCase(TracerTestCase):
 
     def test_pylons_body_urlencoded(self):
         with self.override_global_config(dict(_appsec_enabled=True)):
-
             self.tracer.configure(api_version="v0.4")
             payload = urlencode({"mytestingbody_key": "mytestingbody_value"})
             response = self.app.post(
@@ -679,7 +678,6 @@ class PylonsTestCase(TracerTestCase):
     def test_pylons_body_json_unicode_decode_error_charset(self):
         # Regression test, if request.charset returns None, a TypeError is raised
         with self.override_global_config(dict(_appsec_enabled=True)):
-
             with override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)), mock.patch(
                 "ddtrace.contrib.pylons.middleware.Request.charset", new_callable=mock.PropertyMock
             ) as mock_charset:
@@ -769,8 +767,7 @@ class PylonsTestCase(TracerTestCase):
             assert root_span.get_tag("_dd.appsec.json") is None
 
             span = _context.get_item("http.request.body", span=root_span)
-            assert span
-            assert span == "foo=bar"
+            assert span is None
 
     def test_pylons_body_plain_attack(self):
         with self.override_global_config(dict(_appsec_enabled=True)):
@@ -792,8 +789,7 @@ class PylonsTestCase(TracerTestCase):
             assert "triggers" in json.loads(appsec_json if appsec_json else "{}")
 
             span = _context.get_item("http.request.body", span=root_span)
-            assert span
-            assert span == "1' or '1' = '1'"
+            assert span is None
 
     def test_request_method_get_200(self):
         res = self.app.get(url_for(controller="root", action="index"))


### PR DESCRIPTION
Request body extraction must return a structure. Until now, unparsed request bodies could be directly used as a fallback. This was an incorrect behaviour.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
