### PR TITLE
chore(lib-injection): use provided delay, retry options

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,16 +71,8 @@ deploy_to_docker_registries:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    # Wait 1 day to trigger the downstream job.
-    # This is a work-around since there isn't a way to trigger
-    # Gitlab from the Github workflow (build_deploy.yml:upload_pypi).
-    #
-    # The caveat here is that if there is a failure to build to PyPI
-    # and it isn't fixed in a day then this job will fail and images
-    # will not be published.
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
-      when: delayed
-      start_in: 1 day
+      when: on_success
     - when: manual
       allow_failure: true
   trigger:
@@ -91,16 +83,23 @@ deploy_to_docker_registries:
     IMG_SOURCES: ghcr.io/datadog/dd-trace-py/dd-lib-python-init:$CI_COMMIT_TAG
     IMG_DESTINATIONS: dd-lib-python-init:$CI_COMMIT_TAG
     IMG_SIGNING: "false"
+    # Wait 4 hours to trigger the downstream job.
+    # This is a work-around since there isn't a way to trigger
+    # Gitlab from the Github workflow (build_deploy.yml:upload_pypi).
+    #
+    # The caveat here is that if there is a failure to build to PyPI and it
+    # isn't fixed in the retry period then this job will fail and images will
+    # not be published.
+    RETRY_DELAY: 14400
+    RETRY_COUNT: 3
 
 deploy_latest_tag_to_docker_registries:
   stage: deploy
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    # See above note in the `deploy_to_docker_registries` job.
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
-      when: delayed
-      start_in: 1 day
+      when: on_success
     - when: manual
       allow_failure: true
   trigger:
@@ -111,3 +110,6 @@ deploy_latest_tag_to_docker_registries:
     IMG_SOURCES: ghcr.io/datadog/dd-trace-py/dd-lib-python-init:$CI_COMMIT_TAG
     IMG_DESTINATIONS: dd-lib-python-init:latest
     IMG_SIGNING: "false"
+    # See above note in the `deploy_to_docker_registries` job.
+    RETRY_DELAY: 14400
+    RETRY_COUNT: 3


### PR DESCRIPTION
The public-images job provides RETRY_DELAY and RETRY_COUNT options, use these instead of trying to replicate the behaviour ourselves.

Instead of publishing after 1 day, try after 4 hours which is closer to the time it takes to publish the package.

This new functionality can be tested manually during the next release. The risk is that it might not work due to gitlab killing the job for taking so long. In that case, the images can still be published by manually invoking the job from the gitlab UI.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
