### PR TITLE
fix(dbapi): don't assume rowcount exists (backport #5139 to 1.9)

### DIFF
--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -149,7 +149,11 @@ class TracedCursor(wrapt.ObjectProxy):
         return self._trace_method(self.__wrapped__.callproc, self._self_datadog_name, proc, {}, None, proc, *args)
 
     def _set_post_execute_tags(self, span):
-        row_count = self.__wrapped__.rowcount
+        # rowcount is in the dbapi specification (https://peps.python.org/pep-0249/#rowcount)
+        # but some database drivers (cassandra-driver specifically) don't implement it.
+        row_count = getattr(self.__wrapped__, "rowcount", None)
+        if row_count is None:
+            return
         span.set_metric(db.ROWCOUNT, row_count)
         # Necessary for django integration backward compatibility. Django integration used to provide its own
         # implementation of the TracedCursor, which used to store the row count into a tag instead of

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -160,6 +160,7 @@ resolvers
 repo
 respawn
 rq
+rowcount
 runnable
 runtime
 runtimes

--- a/releasenotes/notes/dbapi-rowcount-3cf18b68114a6cad.yaml
+++ b/releasenotes/notes/dbapi-rowcount-3cf18b68114a6cad.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dbapi: The dbapi integration no longer assumes that a cursor object will
+      have a rowcount but not all database drivers implement rowcount.


### PR DESCRIPTION
Some database drivers (namely cassandra-driver) do not implement rowcount on cursor objects and so the dbapi integration fails.

I have omitted a test as I believe that the code and inlined comment is sufficient for preventing regressions. Another factor was that it is not trivial to add a test case repro-ing the issue with django + cassandra-driver.

(Aside, perhaps having a special `regression` test suite/environment which can be easily configured to test different permutations of libary and version would be a good addition for cases like this)

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
