### PR TITLE
chore(debugging): handle HTTP 2xx intake responses

### DIFF
--- a/ddtrace/settings/dynamic_instrumentation.py
+++ b/ddtrace/settings/dynamic_instrumentation.py
@@ -23,11 +23,11 @@ class DynamicInstrumentationConfig(En):
     __prefix__ = "dd.dynamic_instrumentation"
 
     service_name = En.d(str, lambda _: config.service or get_application_name() or DEFAULT_SERVICE_NAME)
-    _snapshot_intake_url = En.d(str, lambda _: get_trace_url())
+    _intake_url = En.d(str, lambda _: get_trace_url())
     max_probes = En.d(int, lambda _: DEFAULT_MAX_PROBES)
     global_rate_limit = En.d(float, lambda _: DEFAULT_GLOBAL_RATE_LIMIT)
     _tags_in_qs = En.d(bool, lambda _: True)
-    _snapshot_intake_endpoint = En.d(str, lambda _: "/debugger/v1/input")
+    _intake_endpoint = En.d(str, lambda _: "/debugger/v1/input")
     tags = En.d(str, _derive_tags)
 
     enabled = En.v(

--- a/tests/debugging/test_config.py
+++ b/tests/debugging/test_config.py
@@ -36,7 +36,7 @@ def test_tags():
 
 
 def test_snapshot_intake_url():
-    DynamicInstrumentationConfig()._snapshot_intake_url == get_trace_url()
+    DynamicInstrumentationConfig()._intake_url == get_trace_url()
 
 
 def test_service_name():


### PR DESCRIPTION
This change ensures that the uploader can handle all HTTP 2xx responses from the agent when uploading payloads.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
