### PR TITLE
feat(rcm): update remote config warning message

### DIFF
--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -6,6 +6,7 @@ from ddtrace.internal import periodic
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.remoteconfig.client import RemoteConfigClient
 from ddtrace.internal.remoteconfig.constants import REMOTE_CONFIG_AGENT_ENDPOINT
+from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.time import StopWatch
 from ddtrace.vendor.debtcollector import deprecate
 
@@ -60,13 +61,18 @@ class RemoteConfigWorker(periodic.PeriodicService):
                 self._state = self._online
                 return
 
-        log.warning(
+        if asbool(os.environ.get("DD_TRACE_DEBUG")) or "DD_REMOTE_CONFIGURATION_ENABLED" in os.environ:
+            LOG_LEVEL = logging.WARNING
+        else:
+            LOG_LEVEL = logging.DEBUG
+
+        log.log(
+            LOG_LEVEL,
             "Agent is down or Remote Config is not enabled in the Agent\n"
             "Check your Agent version, you need an Agent running on 7.39.1 version or above.\n"
             "Check Your Remote Config environment variables on your Agent:\n"
             "DD_REMOTE_CONFIGURATION_ENABLED=true\n"
-            "DD_REMOTE_CONFIGURATION_KEY=<YOUR-KEY>\n"
-            "See: https://app.datadoghq.com/organization-settings/remote-config"
+            "See: https://docs.datadoghq.com/agent/guide/how_remote_config_works/",
         )
 
     def _online(self):


### PR DESCRIPTION
# Motivation
Because Remote Configuration is still in beta, display a warning message at this moment is so intrusive to our customers. Update code to show a warning message if the customers are trying to configure RC or tracer is running in debug mode.

Update configuration message with Remote Config with a URL more accurate to configure RC

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
