### PR TITLE
feat(asm): add telemetry metrics support

### DIFF
--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -27,6 +27,8 @@ from ddtrace.internal import _context
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.processor import SpanProcessor
 from ddtrace.internal.rate_limiter import RateLimiter
+from ddtrace.internal.telemetry import telemetry_metrics_writer
+from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE_TAG_APPSEC
 
 
 try:
@@ -190,6 +192,60 @@ class AppSecSpanProcessor(SpanProcessor):
         except TypeError:
             log.debug("Error updating ASM rules", exc_info=True)
 
+    def _set_metrics(self):
+        try:
+            list_results, list_result_info, list_is_blocked = _asm_request_context.get_waf_results()
+            if any((list_results, list_result_info, list_is_blocked)):
+                is_blocked = any(list_is_blocked)
+                is_triggered = any((result.data for result in list_results))
+                has_info = any(list_result_info)
+
+                tags = {
+                    "waf_version": version(),
+                    "lib_language": "python",
+                    "rule_triggered": is_triggered,
+                    "request_blocked": is_blocked,
+                }
+
+                if has_info:
+                    for ddwaf_info in list_result_info:
+                        if ddwaf_info.version:
+                            tags["event_rules_version"] = ddwaf_info.version
+                            telemetry_metrics_writer.add_count_metric(
+                                TELEMETRY_NAMESPACE_TAG_APPSEC,
+                                "event_rules.loaded",
+                                float(ddwaf_info.loaded),
+                                tags=tags,
+                            )
+                if list_results:
+                    # runtime is the result in microseconds. Update to milliseconds
+                    ddwaf_result_runtime = sum(float(ddwaf_result.runtime) for ddwaf_result in list_results)
+                    ddwaf_result_total_runtime = sum(float(ddwaf_result.runtime) for ddwaf_result in list_results)
+                    telemetry_metrics_writer.add_distribution_metric(
+                        TELEMETRY_NAMESPACE_TAG_APPSEC,
+                        "waf.duration",
+                        float(ddwaf_result_runtime / 1e3),
+                        tags=tags,
+                    )
+                    telemetry_metrics_writer.add_distribution_metric(
+                        TELEMETRY_NAMESPACE_TAG_APPSEC,
+                        "waf.duration_ext",
+                        float(ddwaf_result_total_runtime / 1e3),
+                        tags=tags,
+                    )
+
+                telemetry_metrics_writer.add_count_metric(
+                    TELEMETRY_NAMESPACE_TAG_APPSEC,
+                    "waf.requests",
+                    1.0,
+                    tags=tags,
+                )
+                # TODO: add log metric to report info.failed and info.errors
+        except Exception:
+            log.warning("Error reporting ASM metrics: %s", exc_info=True)
+        finally:
+            _asm_request_context.reset_waf_results()
+
     def on_span_start(self, span):
         # type: (Span) -> None
 
@@ -272,6 +328,7 @@ class AppSecSpanProcessor(SpanProcessor):
             log.debug("[DDAS-011-00] ASM In-App WAF returned: %s", waf_results.data)
 
         blocked = WAF_ACTIONS.BLOCK in waf_results.actions
+        _asm_request_context.set_waf_results(waf_results, self._ddwaf.info, blocked)
         if blocked:
             _context.set_item(WAF_CONTEXT_NAMES.BLOCKED, True, span=span)
 
@@ -318,6 +375,7 @@ class AppSecSpanProcessor(SpanProcessor):
                 span.set_tag_str(APPSEC.JSON, '{"triggers":%s}' % (waf_results.data,))
             if blocked:
                 span.set_tag(APPSEC.BLOCKED, "true")
+                self._set_metrics()
 
             # Partial DDAS-011-00
             span.set_tag_str(APPSEC.EVENT, "true")
@@ -360,6 +418,7 @@ class AppSecSpanProcessor(SpanProcessor):
         if span.get_tag(APPSEC.JSON) is None:
             log.debug("metrics waf call")
             self._waf_action(span)
+        self._set_metrics()
         self._ddwaf._at_request_end()
         # Force to set respond headers at the end
         headers_req = _context.get_item(SPAN_DATA_NAMES.RESPONSE_HEADERS_NO_COOKIES, span=span)

--- a/tests/appsec/rules-good.json
+++ b/tests/appsec/rules-good.json
@@ -1,5 +1,8 @@
 {
   "version": "2.1",
+  "metadata": {
+    "rules_version": "1.5.1"
+  },
   "rules": [
     {
       "id": "blk-001-001",

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -492,7 +492,7 @@ def test_ddwaf_info():
         assert info.loaded == 5
         assert info.failed == 0
         assert info.errors == {}
-        assert info.version == ""
+        assert info.version == "1.5.1"
 
 
 def test_ddwaf_info_with_2_errors():

--- a/tests/appsec/test_telemety.py
+++ b/tests/appsec/test_telemety.py
@@ -1,0 +1,112 @@
+import pytest
+
+from ddtrace.appsec import _asm_request_context
+from ddtrace.contrib.trace_utils import set_http_meta
+from ddtrace.ext import SpanTypes
+from ddtrace.internal.telemetry import telemetry_metrics_writer
+from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE_TAG_APPSEC
+from ddtrace.internal.telemetry.constants import TELEMETRY_TYPE_DISTRIBUTION
+from ddtrace.internal.telemetry.constants import TELEMETRY_TYPE_GENERATE_METRICS
+from tests.appsec.test_processor import Config
+from tests.appsec.test_processor import RULES_GOOD_PATH
+from tests.appsec.test_processor import _BLOCKED_IP
+from tests.appsec.test_processor import _enable_appsec
+from tests.utils import override_env
+from tests.utils import override_global_config
+
+
+@pytest.fixture
+def mock_telemetry_metrics_writer():
+    metrics_result = telemetry_metrics_writer._namespace._metrics_data
+    assert len(metrics_result[TELEMETRY_TYPE_GENERATE_METRICS][TELEMETRY_NAMESPACE_TAG_APPSEC]) == 0
+    assert len(metrics_result[TELEMETRY_TYPE_DISTRIBUTION][TELEMETRY_NAMESPACE_TAG_APPSEC]) == 0
+    yield telemetry_metrics_writer
+    telemetry_metrics_writer._flush_namespace_metrics()
+
+
+def _assert_generate_metrics(metrics_result, is_rule_triggered=False, is_blocked_request=False):
+    generate_metrics = metrics_result[TELEMETRY_TYPE_GENERATE_METRICS][TELEMETRY_NAMESPACE_TAG_APPSEC]
+    assert len(generate_metrics) == 2, "Expected 2 generate_metrics"
+    for metric_id, metric in generate_metrics.items():
+        if metric.name == "waf.requests":
+            assert metric._tags["rule_triggered"] is is_rule_triggered
+            assert metric._tags["request_blocked"] is is_blocked_request
+            assert len(metric._tags["waf_version"]) > 0
+            assert len(metric._tags["event_rules_version"]) > 0
+        elif metric.name == "event_rules.loaded":
+            pass
+        else:
+            pytest.fail("Unexpected generate_metrics {}".format(metric.name))
+
+
+def _assert_distributions_metrics(metrics_result, is_rule_triggered=False, is_blocked_request=False):
+    distributions_metrics = metrics_result[TELEMETRY_TYPE_DISTRIBUTION][TELEMETRY_NAMESPACE_TAG_APPSEC]
+
+    assert len(distributions_metrics) == 2, "Expected 2 distributions_metrics"
+    for metric_id, metric in distributions_metrics.items():
+        if metric.name in ["waf.duration", "waf.duration_ext"]:
+            assert len(metric._points) >= 1
+            assert type(metric._points[0]) is float
+            assert metric._tags["rule_triggered"] is is_rule_triggered
+            assert metric._tags["request_blocked"] is is_blocked_request
+            assert len(metric._tags["waf_version"]) > 0
+            assert len(metric._tags["event_rules_version"]) > 0
+        else:
+            pytest.fail("Unexpected distributions_metrics {}".format(metric.name))
+
+
+def test_metrics_when_appsec_doesnt_runs(mock_telemetry_metrics_writer, tracer):
+    with override_global_config(dict(_appsec_enabled=False, _telemetry_metrics_enabled=True)):
+        tracer.configure(api_version="v0.4", appsec_enabled=False)
+        mock_telemetry_metrics_writer._flush_namespace_metrics()
+        with tracer.trace("test", span_type=SpanTypes.WEB) as span:
+            set_http_meta(
+                span,
+                Config(),
+            )
+    metrics_data = mock_telemetry_metrics_writer._namespace._metrics_data
+    assert len(metrics_data[TELEMETRY_TYPE_GENERATE_METRICS][TELEMETRY_NAMESPACE_TAG_APPSEC]) == 0
+    assert len(metrics_data[TELEMETRY_TYPE_DISTRIBUTION][TELEMETRY_NAMESPACE_TAG_APPSEC]) == 0
+
+
+def test_metrics_when_appsec_runs(mock_telemetry_metrics_writer, tracer):
+    with override_global_config(dict(_appsec_enabled=True, _telemetry_metrics_enabled=True)):
+        _enable_appsec(tracer)
+        with tracer.trace("test", span_type=SpanTypes.WEB) as span:
+            set_http_meta(
+                span,
+                Config(),
+            )
+    _assert_generate_metrics(mock_telemetry_metrics_writer._namespace._metrics_data)
+    _assert_distributions_metrics(mock_telemetry_metrics_writer._namespace._metrics_data)
+
+
+def test_metrics_when_appsec_attack(mock_telemetry_metrics_writer, tracer):
+    with override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)), override_global_config(
+        dict(_appsec_enabled=True, _telemetry_metrics_enabled=True)
+    ):
+        _enable_appsec(tracer)
+        with tracer.trace("test", span_type=SpanTypes.WEB) as span:
+            set_http_meta(span, Config(), request_cookies={"attack": "1' or '1' = '1'"})
+    _assert_generate_metrics(mock_telemetry_metrics_writer._namespace._metrics_data, is_rule_triggered=True)
+    _assert_distributions_metrics(mock_telemetry_metrics_writer._namespace._metrics_data, is_rule_triggered=True)
+
+
+def test_metrics_when_appsec_block(mock_telemetry_metrics_writer, tracer):
+    with override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)), override_global_config(
+        dict(_appsec_enabled=True, _telemetry_metrics_enabled=True)
+    ):
+        _enable_appsec(tracer)
+        with _asm_request_context.asm_request_context_manager(_BLOCKED_IP, {}):
+            with tracer.trace("test", span_type=SpanTypes.WEB) as span:
+                set_http_meta(
+                    span,
+                    Config(),
+                )
+
+    _assert_generate_metrics(
+        mock_telemetry_metrics_writer._namespace._metrics_data, is_rule_triggered=True, is_blocked_request=True
+    )
+    _assert_distributions_metrics(
+        mock_telemetry_metrics_writer._namespace._metrics_data, is_rule_triggered=True, is_blocked_request=True
+    )

--- a/tests/contrib/flask/test_flask_appsec_telemetry.py
+++ b/tests/contrib/flask/test_flask_appsec_telemetry.py
@@ -1,0 +1,65 @@
+import json
+
+import pytest
+
+from ddtrace.constants import APPSEC_JSON
+from ddtrace.internal import _context
+from ddtrace.internal.compat import urlencode
+from ddtrace.internal.constants import APPSEC_BLOCKED_RESPONSE_JSON
+from tests.appsec.test_processor import RULES_GOOD_PATH
+from tests.appsec.test_processor import _BLOCKED_IP
+from tests.appsec.test_telemety import _assert_distributions_metrics
+from tests.appsec.test_telemety import _assert_generate_metrics
+from tests.appsec.test_telemety import mock_telemetry_metrics_writer  # noqa: F401
+from tests.contrib.flask import BaseFlaskTestCase
+from tests.utils import override_env
+from tests.utils import override_global_config
+
+
+class FlaskAppSecTestCase(BaseFlaskTestCase):
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, mock_telemetry_metrics_writer):  # noqa: F811
+        self.mock_telemetry_metrics_writer = mock_telemetry_metrics_writer
+
+    def _aux_appsec_prepare_tracer(self, appsec_enabled=True):
+        self.tracer._appsec_enabled = appsec_enabled
+        # Hack: need to pass an argument to configure so that the processors are recreated
+        self.tracer.configure(api_version="v0.4")
+
+    def test_telemetry_metrics_block(self):
+        with override_global_config(dict(_appsec_enabled=True, _telemetry_metrics_enabled=True)), override_env(
+            dict(DD_APPSEC_RULES=RULES_GOOD_PATH)
+        ):
+            self._aux_appsec_prepare_tracer()
+            resp = self.client.get("/", headers={"Via": _BLOCKED_IP})
+            assert resp.status_code == 403
+            if hasattr(resp, "text"):
+                assert resp.text == APPSEC_BLOCKED_RESPONSE_JSON
+
+        _assert_generate_metrics(
+            self.mock_telemetry_metrics_writer._namespace._metrics_data, is_rule_triggered=True, is_blocked_request=True
+        )
+        _assert_distributions_metrics(
+            self.mock_telemetry_metrics_writer._namespace._metrics_data, is_rule_triggered=True, is_blocked_request=True
+        )
+
+    def test_telemetry_metrics_attack(self):
+        with override_global_config(dict(_appsec_enabled=True, _telemetry_metrics_enabled=True)):
+            self._aux_appsec_prepare_tracer()
+            payload = urlencode({"attack": "1' or '1' = '1'"})
+            self.client.post("/", data=payload, content_type="application/x-www-form-urlencoded")
+            root_span = self.pop_spans()[0]
+            query = dict(_context.get_item("http.request.body", span=root_span))
+            assert "triggers" in json.loads(root_span.get_tag(APPSEC_JSON))
+            assert query == {"attack": "1' or '1' = '1'"}
+
+        _assert_generate_metrics(
+            self.mock_telemetry_metrics_writer._namespace._metrics_data,
+            is_rule_triggered=True,
+            is_blocked_request=False,
+        )
+        _assert_distributions_metrics(
+            self.mock_telemetry_metrics_writer._namespace._metrics_data,
+            is_rule_triggered=True,
+            is_blocked_request=False,
+        )

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403.json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "",
+      "_dd.appsec.event_rules.version": "1.5.1",
       "_dd.appsec.json": "{\"triggers\":[{\"rule\":{\"id\":\"blk-001-001\",\"name\":\"Block IP addresses\",\"tags\":{\"type\":\"ip_addresses\",\"category\":\"blocking\"},\"on_match\":[\"block\"]},\"rule_matches\":[{\"operator\":\"ip_match\",\"operator_value\":\"\",\"parameters\":[{\"address\":\"http.client_ip\",\"key_path\":[],\"value\":\"8.8.4.4\",\"highlight\":[\"8.8.4.4\"]}]}]}]}",
       "_dd.appsec.waf.duration": "21.695",
       "_dd.appsec.waf.duration_ext": "158.78677368164062",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403_json.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403_json.json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "",
+      "_dd.appsec.event_rules.version": "1.5.1",
       "_dd.appsec.json": "{\"triggers\":[{\"rule\":{\"id\":\"blk-001-001\",\"name\":\"Block IP addresses\",\"tags\":{\"type\":\"ip_addresses\",\"category\":\"blocking\"},\"on_match\":[\"block\"]},\"rule_matches\":[{\"operator\":\"ip_match\",\"operator_value\":\"\",\"parameters\":[{\"address\":\"http.client_ip\",\"key_path\":[],\"value\":\"8.8.4.4\",\"highlight\":[\"8.8.4.4\"]}]}]}]}",
       "_dd.appsec.waf.duration": "19.857",
       "_dd.appsec.waf.duration_ext": "157.1178436279297",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_nomatch_200.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_nomatch_200.json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "",
+      "_dd.appsec.event_rules.version": "1.5.1",
       "_dd.appsec.waf.version": "1.8.2",
       "_dd.p.dm": "-0",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env].json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "",
+      "_dd.appsec.event_rules.version": "1.5.1",
       "_dd.appsec.json": "{\"triggers\":[{\"rule\":{\"id\":\"blk-001-001\",\"name\":\"Block IP addresses\",\"tags\":{\"type\":\"ip_addresses\",\"category\":\"blocking\"},\"on_match\":[\"block\"]},\"rule_matches\":[{\"operator\":\"ip_match\",\"operator_value\":\"\",\"parameters\":[{\"address\":\"http.client_ip\",\"key_path\":[],\"value\":\"8.8.4.4\",\"highlight\":[\"8.8.4.4\"]}]}]}]}",
       "_dd.appsec.waf.version": "1.8.2",
       "_dd.origin": "appsec",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env]_220.json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "",
+      "_dd.appsec.event_rules.version": "1.5.1",
       "_dd.appsec.json": "{\"triggers\":[{\"rule\":{\"id\":\"blk-001-001\",\"name\":\"Block IP addresses\",\"tags\":{\"type\":\"ip_addresses\",\"category\":\"blocking\"},\"on_match\":[\"block\"]},\"rule_matches\":[{\"operator\":\"ip_match\",\"operator_value\":\"\",\"parameters\":[{\"address\":\"http.client_ip\",\"key_path\":[],\"value\":\"8.8.4.4\",\"highlight\":[\"8.8.4.4\"]}]}]}]}",
       "_dd.appsec.waf.version": "1.8.2",
       "_dd.origin": "appsec",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env].json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "",
+      "_dd.appsec.event_rules.version": "1.5.1",
       "_dd.appsec.json": "{\"triggers\":[{\"rule\":{\"id\":\"blk-001-001\",\"name\":\"Block IP addresses\",\"tags\":{\"type\":\"ip_addresses\",\"category\":\"blocking\"},\"on_match\":[\"block\"]},\"rule_matches\":[{\"operator\":\"ip_match\",\"operator_value\":\"\",\"parameters\":[{\"address\":\"http.client_ip\",\"key_path\":[],\"value\":\"8.8.4.4\",\"highlight\":[\"8.8.4.4\"]}]}]}]}",
       "_dd.appsec.waf.version": "1.8.2",
       "_dd.origin": "appsec",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "",
+      "_dd.appsec.event_rules.version": "1.5.1",
       "_dd.appsec.json": "{\"triggers\":[{\"rule\":{\"id\":\"blk-001-001\",\"name\":\"Block IP addresses\",\"tags\":{\"type\":\"ip_addresses\",\"category\":\"blocking\"},\"on_match\":[\"block\"]},\"rule_matches\":[{\"operator\":\"ip_match\",\"operator_value\":\"\",\"parameters\":[{\"address\":\"http.client_ip\",\"key_path\":[],\"value\":\"8.8.4.4\",\"highlight\":[\"8.8.4.4\"]}]}]}]}",
       "_dd.appsec.waf.version": "1.8.2",
       "_dd.origin": "appsec",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "",
+      "_dd.appsec.event_rules.version": "1.5.1",
       "_dd.appsec.waf.version": "1.8.2",
       "_dd.p.dm": "-0",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "",
+      "_dd.appsec.event_rules.version": "1.5.1",
       "_dd.appsec.waf.version": "1.8.2",
       "_dd.p.dm": "-0",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "",
+      "_dd.appsec.event_rules.version": "1.5.1",
       "_dd.appsec.json": "{\"triggers\":[{\"rule\":{\"id\":\"blk-001-002\",\"name\":\"Block User Addresses\",\"tags\":{\"type\":\"block_user\",\"category\":\"security_response\"},\"on_match\":[\"block\"]},\"rule_matches\":[{\"operator\":\"exact_match\",\"operator_value\":\"\",\"parameters\":[{\"address\":\"usr.id\",\"key_path\":[],\"value\":\"123456\",\"highlight\":[\"123456\"]}]}]}]}",
       "_dd.appsec.waf.version": "1.8.2",
       "_dd.origin": "appsec",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "",
+      "_dd.appsec.event_rules.version": "1.5.1",
       "_dd.appsec.json": "{\"triggers\":[{\"rule\":{\"id\":\"blk-001-002\",\"name\":\"Block User Addresses\",\"tags\":{\"type\":\"block_user\",\"category\":\"security_response\"},\"on_match\":[\"block\"]},\"rule_matches\":[{\"operator\":\"exact_match\",\"operator_value\":\"\",\"parameters\":[{\"address\":\"usr.id\",\"key_path\":[],\"value\":\"123456\",\"highlight\":[\"123456\"]}]}]}]}",
       "_dd.appsec.waf.version": "1.8.2",
       "_dd.origin": "appsec",


### PR DESCRIPTION
# Description
ASM Telemetry Metrics support such as `waf.requests`, `waf.duration`, etc.

This PR is part of the main PR https://github.com/DataDog/dd-trace-py/pull/5046

# Motivation
ASM needs to report telemetry metrics

# PRs related:
System tests: 
- https://github.com/DataDog/system-tests/pull/823
- https://github.com/DataDog/system-tests/pull/890

This PR comes from
- https://github.com/DataDog/dd-trace-py/pull/5191
- https://github.com/DataDog/dd-trace-py/pull/5046
- https://github.com/DataDog/dd-trace-py/pull/4943 cc @mabdinur 

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
