### PR TITLE
fix(asm): return correct content-type in blocked responses

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -394,10 +394,9 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
             response = None
 
             def blocked_response():
-                response = HttpResponseForbidden(
-                    appsec_utils._get_blocked_template(request_headers.get("Accept")), content_type="text/plain"
-                )
-                response.content = appsec_utils._get_blocked_template(request_headers.get("Accept"))
+                block_ctype = "text/html" if "text/html" in request_headers.get("Accept", "") else "text/json"
+                response_content = appsec_utils._get_blocked_template(block_ctype)
+                response = HttpResponseForbidden(response_content, content_type=block_ctype)
                 return response
 
             try:

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -563,8 +563,8 @@ def traced_register_error_handler(wrapped, instance, args, kwargs):
 
 def _block_request_callable(headers, span):
     _context.set_item("http.request.blocked", True, span=span)
-    ctype = headers.get("Accept") or "text/json"
-    abort(flask.Response(utils._get_blocked_template(ctype), content_type=ctype, status=403))
+    block_ctype = "text/html" if "text/html" in headers.get("Accept", "") else "text/json"
+    abort(flask.Response(utils._get_blocked_template(block_ctype), content_type=block_ctype, status=403))
 
 
 def request_tracer(name):

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
@@ -30,7 +30,7 @@
       "http.request.headers.host": "0.0.0.0:8000",
       "http.request.headers.user-agent": "python-requests/2.28.2",
       "http.response.headers.content-length": "169",
-      "http.response.headers.content-type": "*/*",
+      "http.response.headers.content-type": "text/json",
       "http.route": "/checkuser/<user_id>",
       "http.status_code": "403",
       "http.url": "http://0.0.0.0:8000/checkuser/123456",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -30,7 +30,7 @@
       "http.request.headers.host": "0.0.0.0:8000",
       "http.request.headers.user-agent": "python-requests/2.28.2",
       "http.response.headers.content-length": "169",
-      "http.response.headers.content-type": "*/*",
+      "http.response.headers.content-type": "text/json",
       "http.route": "/checkuser/<user_id>",
       "http.status_code": "403",
       "http.url": "http://0.0.0.0:8000/checkuser/123456",


### PR DESCRIPTION
## Motivation

Blocking features with Django showed that the content-type returned for HMTL responses was not right even if the content format was.

This PR:

1. Fix the returned content type on blocking responses.
2. Improve the test so they also check the content-type and not only the content.
3. Remove an unnecessary assign to response.content on Django blocks.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
