### PR TITLE
fix(rcm): check if the product callback exists

### DIFF
--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -35,21 +35,23 @@ if TYPE_CHECKING:  # pragma: no cover
 log = get_logger(__name__)
 
 
-def enable_appsec_rc(tracer=None):
+def enable_appsec_rc(test_tracer=None):
     # type: (Optional[Tracer]) -> None
     # Tracer is a parameter for testing propose
     # Import tracer here to avoid a circular import
-    if tracer is None:
-        from ddtrace import tracer  # type: ignore
+    if test_tracer is None:
+        from ddtrace import tracer
+    else:
+        tracer = test_tracer
 
-    appsec_callback = RCAppSecCallBack(tracer)  # type: ignore
+    appsec_callback = RCAppSecCallBack(tracer)
 
     if _appsec_rc_features_is_enabled():
         from ddtrace.internal.remoteconfig import RemoteConfig
 
         RemoteConfig.register(PRODUCTS.ASM_FEATURES, appsec_callback)
 
-    if tracer._appsec_enabled:  # type: ignore
+    if tracer._appsec_enabled:
         from ddtrace.internal.remoteconfig import RemoteConfig
 
         RemoteConfig.register(PRODUCTS.ASM_DATA, appsec_callback)  # IP Blocking

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -35,19 +35,21 @@ if TYPE_CHECKING:  # pragma: no cover
 log = get_logger(__name__)
 
 
-def enable_appsec_rc():
-    # type: () -> None
+def enable_appsec_rc(tracer=None):
+    # type: (Optional[Tracer]) -> None
+    # Tracer is a parameter for testing propose
     # Import tracer here to avoid a circular import
-    from ddtrace import tracer
+    if tracer is None:
+        from ddtrace import tracer  # type: ignore
 
-    appsec_callback = RCAppSecCallBack(tracer)
+    appsec_callback = RCAppSecCallBack(tracer)  # type: ignore
 
     if _appsec_rc_features_is_enabled():
         from ddtrace.internal.remoteconfig import RemoteConfig
 
         RemoteConfig.register(PRODUCTS.ASM_FEATURES, appsec_callback)
 
-    if tracer._appsec_enabled:
+    if tracer._appsec_enabled:  # type: ignore
         from ddtrace.internal.remoteconfig import RemoteConfig
 
         RemoteConfig.register(PRODUCTS.ASM_DATA, appsec_callback)  # IP Blocking
@@ -88,7 +90,7 @@ class RCAppSecCallBack(RemoteConfigCallBackAfterMerge):
         self.tracer = tracer
 
     def __call__(self, metadata, features):
-        # type: (Optional[ConfigMetadata], Optional[Mapping[str, Any]]) -> None
+        # type: (Optional[ConfigMetadata], Any) -> None
         """This callback updates appsec enabled in tracer and config instances following this logic:
         ```
         | DD_APPSEC_ENABLED | RC Enabled | Result   |

--- a/ddtrace/appsec/ddwaf/__init__.py
+++ b/ddtrace/appsec/ddwaf/__init__.py
@@ -192,6 +192,17 @@ else:
             LOGGER.warning("DDWaf features disabled. dry run")
             return DDWaf_result(None, [], 0.0, 0.0)
 
+        def update_rules(self, _):
+            # type: (dict[text_type, DDWafRulesType]) -> bool
+            LOGGER.warning("DDWaf features disabled. dry update")
+            return True
+
+        def _at_request_start(self):
+            pass
+
+        def _at_request_end(self):
+            pass
+
     def version():
         # type: () -> text_type
         LOGGER.warning("DDWaf features disabled. null version")

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -361,40 +361,43 @@ class RemoteConfigClient(object):
                 log.debug("Disable configuration: %s", target)
                 callback_action = False
 
-            callback = self._products[config.product_name]
-
-            try:
-                callback(config, callback_action)
-            except Exception:
-                log.debug("error while removing product %s config %r", config.product_name, config)
-                continue
+            callback = self._products.get(config.product_name)
+            if callback:
+                try:
+                    callback(config, callback_action)
+                except Exception:
+                    log.debug("error while removing product %s config %r", config.product_name, config)
+                    continue
 
     def _load_new_configurations(self, applied_configs, client_configs, payload):
         # type: (AppliedConfigType, TargetsType, AgentPayload) -> None
         list_callbacks = []
         for target, config in client_configs.items():
-            callback = self._products[config.product_name]
-            applied_config = self._applied_configs.get(target)
-            if applied_config == config:
-                continue
+            callback = self._products.get(config.product_name)
+            if callback:
+                applied_config = self._applied_configs.get(target)
+                if applied_config == config:
+                    continue
 
-            config_content = self._extract_target_file(payload, target, config)
-            if config_content is None:
-                continue
+                config_content = self._extract_target_file(payload, target, config)
+                if config_content is None:
+                    continue
 
-            try:
-                log.debug("Load new configuration: %s. content ", target)
-                if isinstance(callback, RemoteConfigCallBackAfterMerge):
-                    callback.append(config_content)
-                    if callback not in list_callbacks:
-                        list_callbacks.append(callback)
+                try:
+                    log.debug("Load new configuration: %s. content ", target)
+                    if isinstance(callback, RemoteConfigCallBackAfterMerge):
+                        callback.append(config_content)
+                        if callback not in list_callbacks:
+                            list_callbacks.append(callback)
+                    else:
+                        callback(config, config_content)
+                except Exception:
+                    log.debug(
+                        "Failed to load configuration %s for product %r", config, config.product_name, exc_info=True
+                    )
+                    continue
                 else:
-                    callback(config, config_content)
-            except Exception:
-                log.debug("Failed to load configuration %s for product %r", config, config.product_name, exc_info=True)
-                continue
-            else:
-                applied_configs[target] = config
+                    applied_configs[target] = config
         for callback in list_callbacks:
             callback.dispatch()
 

--- a/releasenotes/notes/rcm-fix-product-callback-d4d33b56ed8e17b4.yaml
+++ b/releasenotes/notes/rcm-fix-product-callback-d4d33b56ed8e17b4.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix for KeyError exceptions when when `ASM_FEATURES` (1-click activation) disabled all ASM products. This could
+    cause 1-click activation to work incorrectly in some cases.

--- a/tests/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/test_remoteconfiguration.py
@@ -1,12 +1,18 @@
+import base64
+import hashlib
 import json
 import os
 import time
 
+import mock
+from mock.mock import ANY
 import pytest
 
 from ddtrace.appsec import _asm_request_context
+from ddtrace.appsec._constants import PRODUCTS
 from ddtrace.appsec._remoteconfiguration import RCAppSecCallBack
 from ddtrace.appsec._remoteconfiguration import _appsec_rules_data
+from ddtrace.appsec._remoteconfiguration import enable_appsec_rc
 from ddtrace.appsec.utils import _appsec_rc_capabilities
 from ddtrace.appsec.utils import _appsec_rc_features_is_enabled
 from ddtrace.constants import APPSEC_ENV
@@ -15,6 +21,9 @@ from ddtrace.contrib.trace_utils import set_http_meta
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import _context
 from ddtrace.internal.remoteconfig import RemoteConfig
+from ddtrace.internal.remoteconfig.client import AgentPayload
+from ddtrace.internal.remoteconfig.client import ConfigMetadata
+from ddtrace.internal.remoteconfig.client import TargetFile
 from tests.appsec.test_processor import Config
 from tests.appsec.test_processor import ROOT_DIR
 from tests.utils import override_env
@@ -131,6 +140,145 @@ def test_rc_activation_validate_products(tracer, remote_config_worker):
         RCAppSecCallBack(tracer)(None, rc_config)
 
         assert RemoteConfig._worker._client._products["ASM_DATA"]
+
+
+def test_rc_activation_check_asm_features_product_disables_rest_of_products(tracer, remote_config_worker):
+    with override_global_config(dict(_appsec_enabled=True, api_version="v0.4")):
+        tracer.configure(appsec_enabled=True, api_version="v0.4")
+        enable_appsec_rc(tracer)
+
+        assert RemoteConfig._worker._client._products.get(PRODUCTS.ASM_DATA)
+        assert RemoteConfig._worker._client._products.get(PRODUCTS.ASM)
+        assert RemoteConfig._worker._client._products.get(PRODUCTS.ASM_FEATURES)
+
+        RCAppSecCallBack(tracer)(None, False)
+
+        assert RemoteConfig._worker._client._products.get(PRODUCTS.ASM_DATA) is None
+        assert RemoteConfig._worker._client._products.get(PRODUCTS.ASM) is None
+        assert RemoteConfig._worker._client._products.get(PRODUCTS.ASM_FEATURES)
+
+
+@mock.patch.object(RCAppSecCallBack, "_appsec_1click_activation")
+@mock.patch("ddtrace.appsec._remoteconfiguration._appsec_rules_data")
+def test_load_new_configurations_dispatch_applied_configs(
+    mock_appsec_rules_data, mock_appsec_1click_activation, remote_config_worker, tracer
+):
+    with override_global_config(dict(_appsec_enabled=True, api_version="v0.4")):
+        tracer.configure(appsec_enabled=True, api_version="v0.4")
+        enable_appsec_rc(tracer)
+        asm_features_data = b'{"asm":{"enabled":true}}'
+        asm_data_data = b'{"data":{}}'
+        payload = AgentPayload(
+            target_files=[
+                TargetFile(path="mock/ASM_FEATURES", raw=base64.b64encode(asm_features_data)),
+                TargetFile(path="mock/ASM_DATA", raw=base64.b64encode(asm_data_data)),
+            ]
+        )
+        client_configs = {
+            "mock/ASM_FEATURES": ConfigMetadata(
+                id="",
+                product_name="ASM_FEATURES",
+                sha256_hash=hashlib.sha256(asm_features_data).hexdigest(),
+                length=5,
+                tuf_version=5,
+            ),
+            "mock/ASM_DATA": ConfigMetadata(
+                id="",
+                product_name="ASM_DATA",
+                sha256_hash=hashlib.sha256(asm_data_data).hexdigest(),
+                length=5,
+                tuf_version=5,
+            ),
+        }
+
+        RemoteConfig._worker._client._load_new_configurations({}, client_configs, payload=payload)
+        mock_appsec_rules_data.assert_called_with(ANY, {"asm": {"enabled": True}, "data": {}})
+        mock_appsec_1click_activation.assert_called_with({"asm": {"enabled": True}, "data": {}})
+
+
+@mock.patch.object(RCAppSecCallBack, "_appsec_1click_activation")
+@mock.patch("ddtrace.appsec._remoteconfiguration._appsec_rules_data")
+def test_load_new_configurations_remove_config_and_dispatch_applied_configs(
+    mock_appsec_rules_data, mock_appsec_1click_activation, remote_config_worker
+):
+    enable_appsec_rc()
+    asm_features_data = b'{"asm":{"enabled":true}}'
+    asm_data_data = b'{"data":{}}'
+    payload = AgentPayload(
+        target_files=[
+            TargetFile(path="mock/ASM_FEATURES", raw=base64.b64encode(asm_features_data)),
+            TargetFile(path="mock/ASM_DATA", raw=base64.b64encode(asm_data_data)),
+        ]
+    )
+    client_configs = {
+        "mock/ASM_FEATURES": ConfigMetadata(
+            id="",
+            product_name="ASM_FEATURES",
+            sha256_hash=hashlib.sha256(asm_features_data).hexdigest(),
+            length=5,
+            tuf_version=5,
+        ),
+        "mock/ASM_DATA": ConfigMetadata(
+            id="",
+            product_name="ASM_DATA",
+            sha256_hash=hashlib.sha256(asm_data_data).hexdigest(),
+            length=5,
+            tuf_version=5,
+        ),
+    }
+
+    RemoteConfig._worker._client._applied_configs = client_configs
+    RemoteConfig._worker._client._remove_previously_applied_configurations({}, {}, [])
+
+    mock_appsec_rules_data.assert_called_with(ANY, False)
+    mock_appsec_1click_activation.assert_called_with(False)
+    mock_appsec_1click_activation.reset_mock()
+    mock_appsec_rules_data.reset_mock()
+
+    # Not called because with this configuration the above condition is True:
+    # applied_config = self._applied_configs.get(target)
+    # if applied_config == config:
+    #     continue
+    RemoteConfig._worker._client._load_new_configurations({}, client_configs, payload=payload)
+    mock_appsec_rules_data.assert_not_called()
+    mock_appsec_1click_activation.assert_not_called()
+
+
+def test_load_new_configurations_remove_config_and_dispatch_applied_configs_error(remote_config_worker):
+    """
+    The previous code raises a key error in `self._products[config.product_name]` when appsec features is disabled
+    with ASM_FEATURES product and then loops over the config in _load_new_configurations
+    """
+    enable_appsec_rc()
+    asm_features_data = b'{"asm":{"enabled":true}}'
+    asm_data_data = b'{"data":{}}'
+    payload = AgentPayload(
+        target_files=[
+            TargetFile(path="mock/ASM_FEATURES", raw=base64.b64encode(asm_features_data)),
+            TargetFile(path="mock/ASM_DATA", raw=base64.b64encode(asm_data_data)),
+        ]
+    )
+    client_configs = {
+        "mock/ASM_FEATURES": ConfigMetadata(
+            id="",
+            product_name="ASM_FEATURES",
+            sha256_hash=hashlib.sha256(asm_features_data).hexdigest(),
+            length=5,
+            tuf_version=5,
+        ),
+        "mock/ASM_DATA": ConfigMetadata(
+            id="",
+            product_name="ASM_DATA",
+            sha256_hash=hashlib.sha256(asm_data_data).hexdigest(),
+            length=5,
+            tuf_version=5,
+        ),
+    }
+
+    RemoteConfig._worker._client._applied_configs = client_configs
+    RemoteConfig._worker._client._remove_previously_applied_configurations({}, {}, [])
+
+    RemoteConfig._worker._client._load_new_configurations({}, client_configs, payload=payload)
 
 
 def test_rc_activation_ip_blocking_data(tracer, remote_config_worker):


### PR DESCRIPTION
## Description
The previous code raises a KeyError in `self._products[config.product_name]` when `ASM_FEATURES` (1-click activation) disabled all ASM products (`ASM`, `ASM_DATA` and `ASM_DD` )

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
