### PR TITLE
chore(docs): clarify gunicorn/gevent documentation

### DIFF
--- a/ddtrace/contrib/gunicorn/__init__.py
+++ b/ddtrace/contrib/gunicorn/__init__.py
@@ -1,5 +1,8 @@
 """
-**Note:** ``ddtrace-run`` and Python 2 are both not supported with `Gunicorn <https://gunicorn.org>`__.
+``ddtrace-run`` can be used with `Gunicorn <https://gunicorn.org>`__ when not using Gunicorn's ``gevent`` worker type.
+
+**Note:** ``ddtrace-run`` and Python 2 are both not supported with `Gunicorn <https://gunicorn.org>`__ when using
+Gunicorn's ``gevent`` worker type.
 
 ``ddtrace`` only supports Gunicorn's ``gevent`` worker type when configured as follows:
 

--- a/releasenotes/notes/gunicorn-issue-09308901fa00e76c.yaml
+++ b/releasenotes/notes/gunicorn-issue-09308901fa00e76c.yaml
@@ -1,4 +1,5 @@
 ---
 issues:
   - |
-    gunicorn: ddtrace-run does not work with gunicorn. To instrument a gunicorn application, follow the instructions `here <https://ddtrace.readthedocs.io/en/latest/integrations.html#gunicorn>`_.
+    gunicorn: ``ddtrace-run`` does not work with gunicorn when using Gunicorn's ``gevent`` worker type. 
+    To instrument a gunicorn application, follow the instructions `here <https://ddtrace.readthedocs.io/en/latest/integrations.html#gunicorn>`_.


### PR DESCRIPTION
We've had a bit of confusion with our recent changes to our gunicorn documentation (#5228, #5248). This PR clarifies the gunicorn documentation and changelog to make it clear for users that `ddtrace-run` supports Gunicorn when not being run with Gunicorn's `gevent` worker type.

This should fix #5248.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
