### PR TITLE
chore(asm): allow empty updates from remote config

### DIFF
--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -60,10 +60,12 @@ def enable_appsec_rc(test_tracer=None):
 
 
 def _add_rules_to_list(features, feature, message, rule_list):
-    # type: (Mapping[str, Any], str, str, list[Any]) -> None
-    rules = features.get(feature, [])
-    if rules:
+    # type: (Mapping[str, Any], str, str, Optional[list[Any]]) -> None
+    rules = features.get(feature, None)
+    if rules is not None:
         try:
+            if rule_list is None:
+                rule_list = []
             rule_list += rules
             log.debug("Reloading Appsec %s: %s", message, rules)
         except JSONDecodeError:
@@ -73,14 +75,18 @@ def _add_rules_to_list(features, feature, message, rule_list):
 def _appsec_rules_data(tracer, features):
     # type: (Tracer, Mapping[str, Any]) -> bool
     if features and tracer._appsec_processor:
-        ruleset = {"rules": [], "rules_data": [], "exclusions": [], "rules_override": []}  # type: dict[str, list[Any]]
+        ruleset = {
+            "rules": None,
+            "rules_data": None,
+            "exclusions": None,
+            "rules_override": None,
+        }  # type: dict[str, Optional[list[Any]]]
         _add_rules_to_list(features, "rules_data", "rules data", ruleset["rules_data"])
         _add_rules_to_list(features, "custom_rules", "custom rules", ruleset["rules"])
         _add_rules_to_list(features, "rules", "Datadog rules", ruleset["rules"])
         _add_rules_to_list(features, "exclusions", "exclusion filters", ruleset["exclusions"])
         _add_rules_to_list(features, "rules_override", "rules override", ruleset["rules_override"])
-        if any(ruleset.values()):
-            return tracer._appsec_processor._update_rules({k: v for k, v in ruleset.items() if v})
+        return tracer._appsec_processor._update_rules({k: v for k, v in ruleset.items() if v is not None})
 
     return False
 


### PR DESCRIPTION
Some new information (such as ``rules_override``) may change from a list of rules to an empty rule, and that is to be sent to the waf.

This wasn't being sent because the empty list is _falsy_ in Python

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
