### PR TITLE
fix(asm): fix memory corruption in waf interface [backport #5260 to 1.9]

### DIFF
--- a/ddtrace/appsec/ddwaf/__init__.py
+++ b/ddtrace/appsec/ddwaf/__init__.py
@@ -18,18 +18,17 @@ LOGGER = get_logger(__name__)
 
 try:
     from .ddwaf_types import ddwaf_config
-    from .ddwaf_types import ddwaf_context_destroy
-    from .ddwaf_types import ddwaf_context_init
-    from .ddwaf_types import ddwaf_destroy
+    from .ddwaf_types import ddwaf_context_capsule
     from .ddwaf_types import ddwaf_get_version
-    from .ddwaf_types import ddwaf_init
     from .ddwaf_types import ddwaf_object
+    from .ddwaf_types import ddwaf_object_free
     from .ddwaf_types import ddwaf_result
-    from .ddwaf_types import ddwaf_result_free
     from .ddwaf_types import ddwaf_ruleset_info
     from .ddwaf_types import ddwaf_run
-    from .ddwaf_types import ddwaf_update
+    from .ddwaf_types import py_ddwaf_context_init
+    from .ddwaf_types import py_ddwaf_init
     from .ddwaf_types import py_ddwaf_required_addresses
+    from .ddwaf_types import py_ddwaf_update
 
     _DDWAF_LOADED = True
 except OSError:
@@ -82,16 +81,18 @@ if _DDWAF_LOADED:
                 key_regex=obfuscation_parameter_key_regexp, value_regex=obfuscation_parameter_value_regexp
             )
             self._info = ddwaf_ruleset_info()
-            self._ruleset_map = ddwaf_object.create_without_limits(ruleset_map)
-            self._handle = ddwaf_init(self._ruleset_map, ctypes.byref(config), ctypes.byref(self._info))
-            self._ctx = 0
+            ruleset_map_object = ddwaf_object.create_without_limits(ruleset_map)
+            self._handle = py_ddwaf_init(ruleset_map_object, ctypes.byref(config), ctypes.byref(self._info))
             if not self._handle or self._info.failed:
+                # We keep the handle alive in case of errors, as some valid rules can be loaded
+                # at the same time some invalid ones are rejected
                 LOGGER.error(
                     "DDWAF.__init__: invalid rules\n ruleset: %s\nloaded:%s\nerrors:%s\n",
-                    self._ruleset_map.struct,
+                    ruleset_map_object.struct,
                     self._info.loaded,
                     self.info.errors,
                 )
+            ddwaf_object_free(ctypes.byref(ruleset_map_object))
 
         @property
         def required_data(self):
@@ -110,63 +111,52 @@ if _DDWAF_LOADED:
             # type: (dict[text_type, DDWafRulesType]) -> bool
             """update the rules of the WAF instance. return True if an error occurs."""
             rules = ddwaf_object.create_without_limits(new_rules)
-            result = ddwaf_update(self._handle, rules, ctypes.byref(self._info))
-            if result == 0:
-                LOGGER.error("DDWAF.update_rules: invalid rules")
-                return True
-            else:
+            result = py_ddwaf_update(self._handle, rules, self._info)
+            ddwaf_object_free(rules)
+            if result:
                 LOGGER.debug("DDWAF.update_rules success.\ninfo %s", self.info)
                 self._handle = result
+                return True
+            else:
+                LOGGER.debug("DDWAF.update_rules: keeping the previous handle.")
                 return False
 
         def _at_request_start(self):
-            if self._ctx:
-                ddwaf_context_destroy(self._ctx)
-            self._ctx = ddwaf_context_init(self._handle)
-            if self._ctx == 0:
-                LOGGER.error("DDWaf failure to create the context")
+            # type: () -> ddwaf_context_capsule
+            if self._handle:
+                ctx = py_ddwaf_context_init(self._handle)
+            if not ctx:
+                LOGGER.error("DDWaf._at_request_start: failure to create the context.")
+            return ctx
 
         def _at_request_end(self):
-            if self._ctx:
-                ddwaf_context_destroy(self._ctx)
-                self._ctx = 0
+            # () -> None
+            pass
 
         def run(
             self,  # type: DDWaf
+            ctx,  # type: ddwaf_context_capsule
             data,  # type: DDWafRulesType
             timeout_ms=DEFAULT_DDWAF_TIMEOUT_MS,  # type:int
         ):
             # type: (...) -> DDWaf_result
             start = time.time()
 
-            if self._ctx == 0:
-                LOGGER.warning("DDWaf failsafe to create the context")
-                self._ctx = ddwaf_context_init(self._handle)
-
-            if self._ctx == 0:
-                LOGGER.error("DDWaf failure: no context created")
+            if not ctx:
+                LOGGER.error("DDWaf.run: dry run. no context created.")
                 return DDWaf_result(None, [], 0, (time.time() - start) * 1e6)
 
             result = ddwaf_result()
             wrapper = ddwaf_object(data)
-            error = ddwaf_run(self._ctx, wrapper, ctypes.byref(result), timeout_ms * 1000)
+            error = ddwaf_run(ctx.ctx, wrapper, ctypes.byref(result), timeout_ms * 1000)
             if error < 0:
                 LOGGER.warning("run DDWAF error: %d\ninput %s\nerror %s", error, wrapper.struct, self.info.errors)
-            try:
-                return DDWaf_result(
-                    result.data.decode("UTF-8", errors="ignore") if hasattr(result, "data") and result.data else None,
-                    [result.actions.array[i].decode("UTF-8", errors="ignore") for i in range(result.actions.size)],
-                    result.total_runtime / 1e3,
-                    (time.time() - start) * 1e6,
-                )
-            finally:
-                ddwaf_result_free(ctypes.byref(result))
-
-        def __dealloc__(self):
-            if self._ctx:
-                ddwaf_context_destroy(self._ctx)
-            if self._handle:
-                ddwaf_destroy(self._handle)
+            return DDWaf_result(
+                result.data.decode("UTF-8", errors="ignore") if hasattr(result, "data") and result.data else None,
+                [result.actions.array[i].decode("UTF-8", errors="ignore") for i in range(result.actions.size)],
+                result.total_runtime / 1e3,
+                (time.time() - start) * 1e6,
+            )
 
     def version():
         # type: () -> text_type
@@ -185,12 +175,24 @@ else:
 
         def run(
             self,  # type: DDWaf
+            ctx,  # type: ddwaf_context_capsule
             data,  # type: Union[None, int, text_type, list[Any], dict[text_type, Any]]
             timeout_ms=DEFAULT_DDWAF_TIMEOUT_MS,  # type:int
         ):
             # type: (...) -> DDWaf_result
             LOGGER.warning("DDWaf features disabled. dry run")
             return DDWaf_result(None, [], 0.0, 0.0)
+
+        def update_rules(self, _):
+            # type: (dict[text_type, DDWafRulesType]) -> bool
+            LOGGER.warning("DDWaf features disabled. dry update")
+            return False
+
+        def _at_request_start(self):
+            pass
+
+        def _at_request_end(self):
+            pass
 
     def version():
         # type: () -> text_type

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -42,8 +42,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Tuple
     from typing import Union
 
-    from ddtrace.appsec.ddwaf import DDWaf_result
-    from ddtrace.appsec.ddwaf.ddwaf_types import DDWafRulesType
+    from ddtrace.appsec.ddwaf.ddwaf_types import ddwaf_context_capsule
     from ddtrace.span import Span
 
 
@@ -195,7 +194,7 @@ class AppSecSpanProcessor(SpanProcessor):
 
         if span.span_type != SpanTypes.WEB:
             return
-        self._ddwaf._at_request_start()
+        ctx = self._ddwaf._at_request_start()
 
         peer_ip = _asm_request_context.get_ip()
         headers = _asm_request_context.get_headers()
@@ -205,7 +204,7 @@ class AppSecSpanProcessor(SpanProcessor):
         span.set_tag_str(RUNTIME_FAMILY, "python")
 
         def waf_callable(custom_data=None):
-            return self._waf_action(span._local_root or span, custom_data)
+            return self._waf_action(span._local_root or span, ctx, custom_data)
 
         _asm_request_context.set_waf_callback(waf_callable)
 
@@ -228,8 +227,8 @@ class AppSecSpanProcessor(SpanProcessor):
                 # _asm_request_context.call_callback()
                 _asm_request_context.call_waf_callback({"REQUEST_HTTP_IP": None})
 
-    def _waf_action(self, span, custom_data=None):
-        # type: (Span, dict[str, Any] | None) -> None
+    def _waf_action(self, span, ctx, custom_data=None):
+        # type: (Span, ddwaf_context_capsule, dict[str, Any] | None) -> None
         """
         Call the `WAF` with the given parameters. If `custom_data_names` is specified as
         a list of `(WAF_NAME, WAF_STR)` tuples specifying what values of the `WAF_DATA_NAMES`
@@ -267,7 +266,7 @@ class AppSecSpanProcessor(SpanProcessor):
                     log.debug("[action] WAF missing value %s", SPAN_DATA_NAMES[key])
 
         log.debug("[DDAS-001-00] Executing ASM In-App WAF")
-        waf_results = self._ddwaf.run(data, self._waf_timeout)
+        waf_results = self._ddwaf.run(ctx, data, self._waf_timeout)
         if waf_results and waf_results.data:
             log.debug("[DDAS-011-00] ASM In-App WAF returned: %s", waf_results.data)
 
@@ -342,15 +341,6 @@ class AppSecSpanProcessor(SpanProcessor):
         # type: (str) -> bool
         return address in self._addresses_to_keep
 
-    def _run_ddwaf(self, data):
-        # type: (DDWafRulesType) -> DDWaf_result | None
-        try:
-            return self._ddwaf.run(data, self._waf_timeout)  # res is a serialized json
-        except Exception:
-            log.warning("Error executing ASM In-App WAF: ", exc_info=True)
-
-        return None
-
     def on_span_finish(self, span):
         # type: (Span) -> None
 
@@ -359,5 +349,5 @@ class AppSecSpanProcessor(SpanProcessor):
         # this call is only necessary for tests or frameworks that are not using blocking
         if span.get_tag(APPSEC.JSON) is None:
             log.debug("metrics waf call")
-            self._waf_action(span)
+            _asm_request_context.call_waf_callback()
         self._ddwaf._at_request_end()

--- a/releasenotes/notes/fix-memory-leaks-and-segfaults-9fbdc8d66b32fb4f.yaml
+++ b/releasenotes/notes/fix-memory-leaks-and-segfaults-9fbdc8d66b32fb4f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: fix memory leaks and memory corruption in the interface between ASM and the WAF library

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -473,7 +473,8 @@ def test_ddwaf_run():
             "server.request.cookies": {"attack": "1' or '1' = '1'"},
             "server.response.headers.no_cookies": {"content-type": "text/html; charset=utf-8", "content-length": "207"},
         }
-        res = _ddwaf.run(data, DEFAULT.WAF_TIMEOUT)  # res is a serialized json
+        ctx = _ddwaf._at_request_start()
+        res = _ddwaf.run(ctx, data, DEFAULT.WAF_TIMEOUT)  # res is a serialized json
         assert res.data.startswith('[{"rule":{"id":"crs-942-100"')
         assert res.runtime > 0
         assert res.total_runtime > 0


### PR DESCRIPTION
Backport of https://github.com/DataDog/dd-trace-py/pull/5260 to 1.9

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
