### PR TITLE
chore(rcm): add missing release note

### DIFF
--- a/releasenotes/notes/address-noisy-rcm-warnings-62eb36fb64e0f28f.yaml
+++ b/releasenotes/notes/address-noisy-rcm-warnings-62eb36fb64e0f28f.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    remote_config: Change the level of remote config startup logs to debug.


### PR DESCRIPTION
Adds a release note for the following change: https://github.com/DataDog/dd-trace-py/pull/5223. This fix and release note will be backported to 1.9

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
