### PR TITLE
fix: use psycopg2 DSN parser to parse DSN [backport #5272 to 1.9]

### DIFF
--- a/ddtrace/contrib/psycopg/connection.py
+++ b/ddtrace/contrib/psycopg/connection.py
@@ -5,6 +5,7 @@ import functools
 
 from psycopg2.extensions import connection
 from psycopg2.extensions import cursor
+from psycopg2.extensions import parse_dsn
 
 from ddtrace import config
 from ddtrace.internal.constants import COMPONENT
@@ -13,7 +14,6 @@ from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanTypes
 from ...ext import db
 from ...ext import net
-from ...ext import sql
 
 
 class TracedCursor(cursor):
@@ -60,7 +60,7 @@ class TracedConnection(connection):
         super(TracedConnection, self).__init__(*args, **kwargs)
 
         # add metadata (from the connection, string, etc)
-        dsn = sql.parse_pg_dsn(self.dsn)
+        dsn = parse_dsn(self.dsn)
         self._datadog_tags = {
             net.TARGET_HOST: dsn.get("host"),
             net.TARGET_PORT: dsn.get("port"),

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -1,6 +1,7 @@
 import os
 
 import psycopg2
+from psycopg2.extensions import parse_dsn
 from psycopg2.sql import Composable
 
 from ddtrace import Pin
@@ -11,7 +12,6 @@ from ddtrace.contrib.trace_utils import ext_service
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import db
 from ddtrace.ext import net
-from ddtrace.ext import sql
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.vendor import wrapt
 
@@ -105,7 +105,7 @@ def patch_conn(conn, traced_conn_cls=Psycopg2TracedConnection):
     c = traced_conn_cls(conn)
 
     # fetch tags from the dsn
-    dsn = sql.parse_pg_dsn(conn.dsn)
+    dsn = parse_dsn(conn.dsn)
     tags = {
         net.TARGET_HOST: dsn.get("host"),
         net.TARGET_PORT: dsn.get("port"),

--- a/releasenotes/notes/fix-psycopg-parse-dsn-f645bc9f056305c7.yaml
+++ b/releasenotes/notes/fix-psycopg-parse-dsn-f645bc9f056305c7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    psycopg2: Fixes a bug with DSN parsing integration.


### PR DESCRIPTION
  Backport of #5272 to 1.9

  This change fixes an issue with DSN parsing with the psycopg2 integration, likely introduced after the refactor of #4294.

Fixes #5269.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
