### PR TITLE
chore(docs): add instructions on compiling release notes

### DIFF
--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -151,4 +151,13 @@ The note is a brief description of the change. It should consist of full sentenc
 The note should also follow valid restructured text (RST) formatting. See the template release note for
 more details and instructions.
 
+Compiling Release Notes
++++++++++++++++++++++++
 
+To compile all release notes since a given version, do this::
+
+    $ pip install reno
+    $ brew install pandoc
+    $ reno report --no-show-source | pandoc -f rst -t gfm --wrap=none | pbcopy
+
+This will generate all release notes in the library's history in a single text string, ordered from latest to earliest.


### PR DESCRIPTION
This pull request adds a helpful note to the release notes documentation on how to compile all release notes, which can be useful when cutting releases of the library.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
