### PR TITLE
fix(debugging): handle disabled probes via RCM [backport 5282 to 1.10]

### DIFF
--- a/ddtrace/debugging/_probe/remoteconfig.py
+++ b/ddtrace/debugging/_probe/remoteconfig.py
@@ -236,7 +236,7 @@ class ProbeRCAdapter(RemoteConfigCallBack):
         # type: (str, Any) -> None
         prev_probes = self._configs.get(config_id, {})  # type: Dict[str, Probe]
         next_probes = (
-            {probe.probe_id: probe for probe in get_probes(config_id, config)} if config is not None else {}
+            {probe.probe_id: probe for probe in get_probes(config_id, config)} if config not in (None, False) else {}
         )  # type: Dict[str, Probe]
 
         self._dispatch_probe_events(prev_probes, next_probes)

--- a/releasenotes/notes/fix-debugger-rcm-disable-events-8e5797d5d0606f50.yaml
+++ b/releasenotes/notes/fix-debugger-rcm-disable-events-8e5797d5d0606f50.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    dynamic_instrumentation: This change fixes a bug whereby probes that have
+    been disabled/removed from the front-end would not be removed by the client
+    library.


### PR DESCRIPTION
This change fixes the handling of disabled configuration targets in dynamic instrumentation. Because of the currently broken RCM callback signature, the disable events were not handled correctly and caused an exception to be thrown during processing of the RCM event. We fix this by working around the problematic callback signature.

Testing is performed via the backend demo job monitoring, which is what allowed the issue to surface in the first place.

(cherry picked from commit a3b25ada12bcf9459197dd849535ab5338bcf8dd)

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
