### PR TITLE
ci: pin riot and update starlette tests to pass with non-semvar versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
     description: "Install riot"
     steps:
       # Make sure we install and run riot on Python 3
-      - run: pip3 install riot
+      - run: pip3 install riot==0.16.0
 
   restore_tox_cache:
     description: "Restore .tox directory from previous runs for faster installs"

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -12,7 +12,7 @@ fi
 # retry docker pull if fails
 for i in {1..3}; do docker-compose pull -q testrunner && break || sleep 3; done
 
-FULL_CMD="pip install -q --disable-pip-version-check riot tox && $CMD"
+FULL_CMD="pip install -q --disable-pip-version-check riot==0.16.0 tox && $CMD"
 
 # install and upgrade tox and riot in case testrunner image has not been updated
 # DEV: Use `--no-TTY` and `--quiet-pull` when running in CircleCI

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -24,7 +24,7 @@ from tests.utils import snapshot
 
 
 starlette_version_str = getattr(starlette, "__version__", "0.0.0")
-starlette_version = tuple([int(i) for i in starlette_version_str.split(".")])
+starlette_version = tuple([int(i) for i in starlette_version_str.split(".")[:3]])
 
 
 @pytest.fixture


### PR DESCRIPTION
This change resolves 2 issues that are blocking ci. Ideally both of these issues would be broken into their own PRs however we can not merge a PR unless all required checks pass. 

## Riot issue

Downgrading riot from v1.17.0 to v0.16.0 resolves the following error: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/30677/workflows/e8202b8d-3b73-4753-9bf5-8e32ba7c8241/jobs/2081446.

```
#!/bin/bash -eo pipefail
riot run -s flake8

[notice] A new release of pip is available: 23.0 -> 23.0.1
[notice] To update, run: pip install --upgrade pip
/home/circleci/.pyenv/versions/3.10.10/lib/python3.10/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
/bin/bash: line 1: flake8: command not found
Test failed with exit code 127

-------------------summary-------------------
x flake8: [1b0226e] DD_TESTING_RAISE=1 DD_REMOTE_CONFIGURATION_ENABLED=false pythonInterpreter(_hint='3') 'mock<=4.0.3' 'pytest<=7.2.0' 'pytest-mock<=3.10.0' 'coverage<=6.5.0' 'pytest-cov<=4.0.0' 'opentracing<=2.4.0' 'hypothesis<6.45.1' 'flake8>=3.8,<3.9' 'flake8-blind-except<=0.2.1' 'flake8-builtins<=2.0.1' 'flake8-docstrings<=1.6.0' 'flake8-logging-format<=0.9.0' 'flake8-rst-docstrings<=0.3.0' 'flake8-isort<=5.0.3' 'pygments<=2.13.0'
0 passed with 0 warnings, 1 failed

Exited with code exit status 1
```

## Starlette issue

In our starlette tests we assume the version can only contain integers delimited by a dot (ex: `0.25.0`). With the latest starlette release this is no longer the case:  https://github.com/encode/starlette/releases/tag/0.26.0.post1.


## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
