### PR TITLE
chore(ci): update black linting version targeting and remove 2.7 target

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ line_length = 120
 
 [tool.black]
 line-length = 120
-target_version = ['py27', 'py35', 'py36', 'py37', 'py38']
+target_version = ['py35', 'py36', 'py37', 'py38', 'py39', 'py310', 'py311']
 include = '''\.py[ix]?$'''
 exclude = '''
 (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ line_length = 120
 
 [tool.black]
 line-length = 120
-target_version = ['py35', 'py36', 'py37', 'py38', 'py39', 'py310', 'py311']
+target_version = ['py35', 'py36', 'py37', 'py38', 'py39']
 include = '''\.py[ix]?$'''
 exclude = '''
 (


### PR DESCRIPTION
2.7-targeted black linting requires black<21.12. When it isn't installed, linting fails.
This can happen when black is used in a pre-commit or on-save hook subject to per-developer customization.

It's hard to find documentation on the linting differences between py2 and py3 code, but as far as I can tell they are minor. Because we have other linters to validate python 2 compatibility, we can afford the small risk that black will generate invalid python 2 code.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
