### PR TITLE
ci: pin riot and fix starlette tests [backport 5304 to 1.10]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
     description: "Install riot"
     steps:
       # Make sure we install and run riot on Python 3
-      - run: pip3 install riot
+      - run: pip3 install riot==0.16.0
 
   restore_tox_cache:
     description: "Restore .tox directory from previous runs for faster installs"

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -12,7 +12,7 @@ fi
 # retry docker pull if fails
 for i in {1..3}; do docker-compose pull -q testrunner && break || sleep 3; done
 
-FULL_CMD="pip install -q --disable-pip-version-check riot tox && $CMD"
+FULL_CMD="pip install -q --disable-pip-version-check riot==0.16.0 tox && $CMD"
 
 # install and upgrade tox and riot in case testrunner image has not been updated
 # DEV: Use `--no-TTY` and `--quiet-pull` when running in CircleCI

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -24,7 +24,7 @@ from tests.utils import snapshot
 
 
 starlette_version_str = getattr(starlette, "__version__", "0.0.0")
-starlette_version = tuple([int(i) for i in starlette_version_str.split(".")])
+starlette_version = tuple([int(i) for i in starlette_version_str.split(".")[:3]])
 
 
 @pytest.fixture


### PR DESCRIPTION
Backports: https://github.com/DataDog/dd-trace-py/pull/5304

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.


