### PR TITLE
fix(rcm): validate remote config is enabled [backport #5241 to 1.10]

### DIFF
--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from itertools import chain
+import os
 import sys
 import threading
 from types import FunctionType
@@ -57,6 +58,7 @@ from ddtrace.internal.rate_limiter import RateLimitExceeded
 from ddtrace.internal.remoteconfig import RemoteConfig
 from ddtrace.internal.safety import _isinstance
 from ddtrace.internal.service import Service
+from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.wrapping import Wrapper
 
 
@@ -244,6 +246,12 @@ class Debugger(Service):
             call_once=True,
             raise_on_exceed=False,
         )
+
+        # TODO: this is only temporary and will be reverted once the DD_REMOTE_CONFIGURATION_ENABLED variable
+        #  has been removed
+        if asbool(os.environ.get("DD_REMOTE_CONFIGURATION_ENABLED", True)) is False:
+            os.environ["DD_REMOTE_CONFIGURATION_ENABLED"] = "true"
+            log.info("Disabled Remote Configuration enabled by Dynamic Instrumentation.")
 
         # Register the debugger with the RCM client.
         RemoteConfig.register("LIVE_DEBUGGING", self.__rc_adapter__(self._on_configuration))

--- a/releasenotes/notes/rcm-fix-disable-f45787a4e6576f53.yaml
+++ b/releasenotes/notes/rcm-fix-disable-f45787a4e6576f53.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Ensure DD_REMOTE_CONFIGURATION_ENABLED environment variable disables remote config if set to False

--- a/releasenotes/notes/rcm-fix-disable-f45787a4e6576f53.yaml
+++ b/releasenotes/notes/rcm-fix-disable-f45787a4e6576f53.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Ensure DD_REMOTE_CONFIGURATION_ENABLED environment variable disables remote config if set to False
+    Ensure DD_REMOTE_CONFIGURATION_ENABLED environment variable disables remote config if set to False.

--- a/tests/contrib/gunicorn/test_gunicorn.py
+++ b/tests/contrib/gunicorn/test_gunicorn.py
@@ -108,7 +108,7 @@ def gunicorn_server(gunicorn_server_settings, tmp_path):
         cmd = ["ddtrace-run"]
     cmd += ["gunicorn", "--config", str(cfg_file), str(gunicorn_server_settings.app_path)]
     print("Running %r with configuration file %s" % (" ".join(cmd), cfg))
-
+    gunicorn_server_settings.env["DD_REMOTE_CONFIGURATION_ENABLED"] = "true"
     server_process = subprocess.Popen(
         cmd,
         env=gunicorn_server_settings.env,


### PR DESCRIPTION
  Backport of #5241 to 1.10

  Validate ``DD_REMOTE_CONFIGURATION_ENABLED`` environment variable is false before enable Remote Config worker and register Remote Config products.

Without this fix, Remote Config is enabled in some tests where we expected Remote Config is disabled such as:
- tests/contrib/gunicorn/test_gunicorn.py
- tests/debugging/test_debugger.py
- tests/internal/remoteconfig/test_remoteconfig.py

If an application set DD_REMOTE_CONFIGURATION_ENABLED=False, Remote Config would be activated for ASM products and DI. In that scenario, Remote Config capabilities will be wrong and will raise the below unexpected behaviors:
- Application appears in DD dashboards with RC enabled but if you try to block a IP it doesn't work
- Application appears in DD dashboards with RC enabled but if you try to block an User it doesn't work
- Application appears in DD dashboards with RC enabled but if you try to add RC exclusions it doesn't work

An unexpected result of set DD_REMOTE_CONFIGURATION_ENABLED=False and Remote Configuration is still running, RC creates invalid capabilities in this functions:
https://github.com/DataDog/dd-trace-py/blob/237aac68187683ba5b3c3e59eb26a7e2940c48b0/ddtrace/appsec/utils.py#L19
https://github.com/DataDog/dd-trace-py/blob/237aac68187683ba5b3c3e59eb26a7e2940c48b0/ddtrace/appsec/utils.py#L44


The below lines of code raises an unexpected RC activation if ``DD_REMOTE_CONFIGURATION_ENABLED`` is false 
https://github.com/DataDog/dd-trace-py/blob/58017b1a6f7f616033bf4286954734914c971141/ddtrace/appsec/_remoteconfiguration.py#L49
https://github.com/DataDog/dd-trace-py/blob/58017b1a6f7f616033bf4286954734914c971141/ddtrace/appsec/_remoteconfiguration.py#L52
https://github.com/DataDog/dd-trace-py/blob/58017b1a6f7f616033bf4286954734914c971141/ddtrace/appsec/_remoteconfiguration.py#L57
https://github.com/DataDog/dd-trace-py/blob/58017b1a6f7f616033bf4286954734914c971141/ddtrace/appsec/_remoteconfiguration.py#L58
https://github.com/DataDog/dd-trace-py/blob/58017b1a6f7f616033bf4286954734914c971141/ddtrace/appsec/_remoteconfiguration.py#L59
https://github.com/DataDog/dd-trace-py/blob/58017b1a6f7f616033bf4286954734914c971141/ddtrace/appsec/_remoteconfiguration.py#L134
https://github.com/DataDog/dd-trace-py/blob/58017b1a6f7f616033bf4286954734914c971141/ddtrace/appsec/_remoteconfiguration.py#L135

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
