### PR TITLE
fix(django): adding http.route tag regardless of resource naming [backports #5306 to 1.10]

### DIFF
--- a/releasenotes/notes/django-http-route-fix-913850f0d53a74b7.yaml
+++ b/releasenotes/notes/django-http-route-fix-913850f0d53a74b7.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    django: Fixes an issue where ``http.route`` was only set if ``use_handler_resource_format`` and ``use_legacy_resource_format`` were set to ``False``.

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -1699,6 +1699,8 @@ def test_django_use_handler_resource_format(client, test_spans):
         resource = "GET tests.contrib.django.views.index"
 
         root.assert_matches(resource=resource, parent_id=None, span_type="web")
+        if django.VERSION >= (2, 2, 0):
+            root.assert_meta({"http.route": "^$"})
 
 
 def test_django_use_handler_with_url_name_resource_format(client, test_spans):


### PR DESCRIPTION
Backports: https://github.com/DataDog/dd-trace-py/pull/5306

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
