### PR TITLE
feat(celery): trace celery's "beat" scheduling service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ target/
 .python-version
 
 # celery beat schedule file
-celerybeat-schedule
+celerybeat-schedule*
 
 # docker-compose env file
 # it must be versioned to keep track of backing services defaults

--- a/ddtrace/contrib/celery/app.py
+++ b/ddtrace/contrib/celery/app.py
@@ -1,9 +1,18 @@
+import celery
 from celery import signals
 
 from ddtrace import Pin
 from ddtrace import config
 from ddtrace.pin import _DD_PIN_NAME
+from ddtrace.vendor import wrapt
 
+from .. import trace_utils
+from ...constants import ANALYTICS_SAMPLE_RATE_KEY
+from ...constants import SPAN_KIND
+from ...constants import SPAN_MEASURED_KEY
+from ...ext import SpanKind
+from ...ext import SpanTypes
+from ..trace_utils import unwrap
 from .signals import trace_after_publish
 from .signals import trace_before_publish
 from .signals import trace_failure
@@ -26,8 +35,21 @@ def patch_app(app, pin=None):
         _config=config.celery,
     )
     pin.onto(app)
-    # connect to the Signal framework
 
+    wrapt.wrap_function_wrapper(
+        "celery.beat",
+        "Scheduler.apply_entry",
+        _traced_beat_function(config.celery, "apply_entry", lambda args: args[0].name),
+    )
+    # NB wrapping the tick() function is the closest Celery allows us to get to generating traces when
+    # celery.beat.Scheduler fails to start. This is because celery.beat.Scheduler._ensure_connected does not impose a
+    # maximum number of connection retries and does not allow the maximum to be configured. Thus, when
+    # celery.beat.Scheduler's connection_for_writing is unavailable at startup, _ensure_connected will spin
+    # forever and this integration will not generate any traces until that connection becomes available.
+    wrapt.wrap_function_wrapper("celery.beat", "Scheduler.tick", _traced_beat_function(config.celery, "tick"))
+    Pin(service=None).onto(celery.beat.Scheduler)
+
+    # connect to the Signal framework
     signals.task_prerun.connect(trace_prerun, weak=False)
     signals.task_postrun.connect(trace_postrun, weak=False)
     signals.before_task_publish.connect(trace_before_publish, weak=False)
@@ -49,9 +71,36 @@ def unpatch_app(app):
     if pin is not None:
         delattr(app, _DD_PIN_NAME)
 
+    unwrap(celery.beat.Scheduler, "apply_entry")
+    unwrap(celery.beat.Scheduler, "tick")
+
     signals.task_prerun.disconnect(trace_prerun)
     signals.task_postrun.disconnect(trace_postrun)
     signals.before_task_publish.disconnect(trace_before_publish)
     signals.after_task_publish.disconnect(trace_after_publish)
     signals.task_failure.disconnect(trace_failure)
     signals.task_retry.disconnect(trace_retry)
+
+
+def _traced_beat_function(integration_config, fn_name, resource_fn=None):
+    def _traced_beat_inner(func, instance, args, kwargs):
+        pin = Pin.get_from(instance)
+        if not pin or not pin.enabled():
+            return func(*args, **kwargs)
+
+        with pin.tracer.trace(
+            "celery.beat.{}".format(fn_name),
+            span_type=SpanTypes.WORKER,
+            service=trace_utils.ext_service(pin, integration_config),
+        ) as span:
+            if resource_fn:
+                span.resource = resource_fn(args)
+            span.set_tag_str(SPAN_KIND, SpanKind.PRODUCER)
+            rate = config.celery.get_analytics_sample_rate()
+            if rate is not None:
+                span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, rate)
+            span.set_tag(SPAN_MEASURED_KEY)
+
+            return func(*args, **kwargs)
+
+    return _traced_beat_inner

--- a/ddtrace/contrib/celery/app.py
+++ b/ddtrace/contrib/celery/app.py
@@ -41,10 +41,8 @@ def patch_app(app, pin=None):
         "Scheduler.apply_entry",
         _traced_beat_function(config.celery, "apply_entry", lambda args: args[0].name),
     )
-    # NB wrapping the tick() function is the closest Celery allows us to get to generating traces when
-    # celery.beat.Scheduler fails to start. This is because celery.beat.Scheduler._ensure_connected does not impose a
-    # maximum number of connection retries and does not allow the maximum to be configured. Thus, when
-    # celery.beat.Scheduler's connection_for_writing is unavailable at startup, _ensure_connected will spin
+    # NB If celery.Celery.conf.broker_max_connection_retries is not set and
+    # celery.beat.Scheduler's connection_for_writing is unavailable at celery.beat startup, _ensure_connected will spin
     # forever and this integration will not generate any traces until that connection becomes available.
     wrapt.wrap_function_wrapper("celery.beat", "Scheduler.tick", _traced_beat_function(config.celery, "tick"))
     Pin(service=None).onto(celery.beat.Scheduler)

--- a/ddtrace/contrib/celery/app.py
+++ b/ddtrace/contrib/celery/app.py
@@ -39,9 +39,6 @@ def patch_app(app, pin=None):
         "Scheduler.apply_entry",
         _traced_beat_function(config.celery, "apply_entry", lambda args: args[0].name),
     )
-    # If celery.Celery.conf.broker_max_connection_retries is not set and
-    # celery.beat.Scheduler's connection_for_writing is unavailable at startup, _ensure_connected will spin
-    # forever and this integration will not generate any traces until that connection becomes available.
     trace_utils.wrap("celery.beat", "Scheduler.tick", _traced_beat_function(config.celery, "tick"))
     pin.onto(celery.beat.Scheduler)
 

--- a/ddtrace/contrib/celery/app.py
+++ b/ddtrace/contrib/celery/app.py
@@ -41,11 +41,11 @@ def patch_app(app, pin=None):
         "Scheduler.apply_entry",
         _traced_beat_function(config.celery, "apply_entry", lambda args: args[0].name),
     )
-    # NB If celery.Celery.conf.broker_max_connection_retries is not set and
-    # celery.beat.Scheduler's connection_for_writing is unavailable at celery.beat startup, _ensure_connected will spin
+    # If celery.Celery.conf.broker_max_connection_retries is not set and
+    # celery.beat.Scheduler's connection_for_writing is unavailable at startup, _ensure_connected will spin
     # forever and this integration will not generate any traces until that connection becomes available.
     wrapt.wrap_function_wrapper("celery.beat", "Scheduler.tick", _traced_beat_function(config.celery, "tick"))
-    Pin(service=None).onto(celery.beat.Scheduler)
+    pin.onto(celery.beat.Scheduler)
 
     # connect to the Signal framework
     signals.task_prerun.connect(trace_prerun, weak=False)

--- a/releasenotes/notes/celerybeat-64b7b984461c6d12.yaml
+++ b/releasenotes/notes/celerybeat-64b7b984461c6d12.yaml
@@ -1,3 +1,3 @@
 features:
   - |
-    celery: Adds automatic tracing of the ``celery.beat`` scheduling service to the ``celery`` contrib
+    celery: Adds automatic tracing of the ``celery.beat`` scheduling service to the ``celery`` integration

--- a/releasenotes/notes/celerybeat-64b7b984461c6d12.yaml
+++ b/releasenotes/notes/celerybeat-64b7b984461c6d12.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    celery: Adds automatic tracing of the ``celery.beat`` scheduling service to the ``celery`` contrib

--- a/releasenotes/notes/celerybeat-64b7b984461c6d12.yaml
+++ b/releasenotes/notes/celerybeat-64b7b984461c6d12.yaml
@@ -1,3 +1,3 @@
 features:
   - |
-    celery: Adds automatic tracing of the ``celery.beat`` scheduling service to the ``celery`` integration
+    celery: Adds automatic tracing of the ``celery.beat`` scheduling service to the ``celery`` integration.

--- a/tests/contrib/celery/base.py
+++ b/tests/contrib/celery/base.py
@@ -85,6 +85,7 @@ class CeleryBaseTestCase(TracerTestCase):
         self.pin = Pin(service="celery-unittest", tracer=self.tracer)
         # override pins to use our Dummy Tracer
         Pin.override(self.app, tracer=self.tracer)
+        Pin.override(celery.beat.Scheduler, tracer=self.tracer)
 
     def tearDown(self):
         self.app = None

--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -747,7 +747,7 @@ class CeleryIntegrationTask(CeleryBaseTestCase):
                 assert trace[1].name == "celery.beat.apply_entry"
                 assert trace[2].name == "celery.apply"
         assert deep_traces_count >= target_task_run_count
-        assert target_task_run_count <= spans_counter["celery.run"] <= deep_traces_count
+        assert 0 < spans_counter["celery.run"] <= deep_traces_count
         # beat_service.stop() can happen any time during the beat thread's execution.
         # When by chance it happends between apply_entry() and run(), the number of spans
         # for apply() and apply_entry() will be one greater than the number of spans for run()

--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -749,7 +749,7 @@ class CeleryIntegrationTask(CeleryBaseTestCase):
         assert deep_traces_count >= target_task_run_count
         assert 0 < spans_counter["celery.run"] <= deep_traces_count
         # beat_service.stop() can happen any time during the beat thread's execution.
-        # When by chance it happends between apply_entry() and run(), the number of spans
+        # When by chance it happens between apply_entry() and run(), the number of spans
         # for apply() and apply_entry() will be one greater than the number of spans for run()
         assert deep_traces_count <= spans_counter["celery.beat.apply_entry"] <= deep_traces_count + 1
         assert deep_traces_count <= spans_counter["celery.apply"] <= deep_traces_count + 1

--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -720,7 +720,7 @@ class CeleryIntegrationTask(CeleryBaseTestCase):
 
         beat_service = celery.beat.EmbeddedService(self.app, thread=True)
         beat_service.start()
-        sleep(run_time_seconds + 0.1)
+        sleep(run_time_seconds + 0.3)
         beat_service.stop()
 
         traces = self.pop_traces()
@@ -747,7 +747,7 @@ class CeleryIntegrationTask(CeleryBaseTestCase):
                 assert trace[1].name == "celery.beat.apply_entry"
                 assert trace[2].name == "celery.apply"
         assert deep_traces_count >= target_task_run_count
-        assert target_task_run_count < spans_counter["celery.run"] <= deep_traces_count
+        assert target_task_run_count <= spans_counter["celery.run"] <= deep_traces_count
         # beat_service.stop() can happen any time during the beat thread's execution.
         # When by chance it happends between apply_entry() and run(), the number of spans
         # for apply() and apply_entry() will be one greater than the number of spans for run()


### PR DESCRIPTION
This pull request adds to the Celery integration support for `celery.beat`. This is a module that can trigger Celery tasks on a schedule. Supporting it in the integration means that users will have more visibility into the conditions under which their tasks are triggered and will get traces when Beat scheduling fails.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
