### PR TITLE
fix(asm): fix 403 response being inadequatly replaced by datadog response block response (1.9)

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -384,7 +384,7 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
                     )
                 else:
                     response = func(*args, **kwargs)
-                    if isinstance(response, HttpResponseForbidden):
+                    if config._appsec_enabled and isinstance(response, HttpResponseForbidden):
                         # Add our custom block template
                         response.content = appsec_utils._get_blocked_template(request_headers.get("Accept"))
                 return response

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -384,7 +384,11 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
                     )
                 else:
                     response = func(*args, **kwargs)
-                    if config._appsec_enabled and isinstance(response, HttpResponseForbidden):
+                    if (
+                        config._appsec_enabled
+                        and _context.get_item("http.request.blocked", span=span)
+                        and isinstance(response, HttpResponseForbidden)
+                    ):
                         # Add our custom block template
                         response.content = appsec_utils._get_blocked_template(request_headers.get("Accept"))
                 return response

--- a/releasenotes/notes/asm_fix_403_django_body-9adabde1f2f95c98.yaml
+++ b/releasenotes/notes/asm_fix_403_django_body-9adabde1f2f95c98.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where some 403 body responses in Django where wrongly replaced by datadog 403 block response body.


### PR DESCRIPTION
Fix 403 response being inadequatly replaced by datadog response block response in 1.9 branch.

This bug was automatically fixed in 1.10rc2 by suspicious request blocking PRs.

Patch to solve tickets #1131460 and #1132841

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
