### PR TITLE
chore(asm): add encode and decode aspects to iast

### DIFF
--- a/ddtrace/appsec/iast/_ast/aspects/__init__.py
+++ b/ddtrace/appsec/iast/_ast/aspects/__init__.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 
 from builtins import str as builtin_str
+import codecs
 
 from ddtrace.appsec.iast._input_info import Input_info
 from ddtrace.appsec.iast._taint_tracking import add_taint_pyobject  # type: ignore[attr-defined]
+from ddtrace.appsec.iast._taint_tracking import get_tainted_ranges  # type: ignore[attr-defined]
 from ddtrace.appsec.iast._taint_tracking import is_pyobject_tainted  # type: ignore[attr-defined]
+from ddtrace.appsec.iast._taint_tracking import set_tainted_ranges  # type: ignore[attr-defined]
 from ddtrace.appsec.iast._taint_tracking import taint_pyobject  # type: ignore[attr-defined]
 
 
@@ -24,7 +27,35 @@ def add_aspect(op1, op2):
 
 
 def decode_aspect(self, *args, **kwargs):
-    result = self.decode(*args, **kwargs)
+    if not is_pyobject_tainted(self) or not isinstance(self, bytes):
+        return self.decode(*args, **kwargs)
+    codec = args[0] if args else "utf-8"
+    tainted_ranges = get_tainted_ranges(self)
+    inc_dec = codecs.getincrementaldecoder(codec)(**kwargs)
+    res = []
+    pos = 0
+    id_range = 0
+    new_ranges = []
+    i = 0
+    try:
+        for i in range(len(self)):
+            if id_range < len(tainted_ranges) and i == tainted_ranges[id_range][1]:  # start
+                new_ranges.append([tainted_ranges[id_range][0], pos])
+            new_prod = inc_dec.decode(self[i : i + 1])
+            res.append(new_prod)
+            pos += len(new_prod)
+            if (
+                id_range < len(tainted_ranges) and i + 1 == tainted_ranges[id_range][1] + tainted_ranges[id_range][2]
+            ):  # end_range
+                new_ranges[-1].append(pos)
+                id_range += 1
+        res.append(inc_dec.decode(b"", True))
+    except UnicodeDecodeError as e:
+        raise UnicodeDecodeError(
+            e.args[0], self, i + 1 - len(e.args[1]), i + 1 - len(e.args[1]) + e.args[3], *e.args[4:]
+        )
+    result = "".join(res)
+    set_tainted_ranges(result, new_ranges)
     return result
 
 

--- a/ddtrace/appsec/iast/_ast/aspects/__init__.py
+++ b/ddtrace/appsec/iast/_ast/aspects/__init__.py
@@ -21,3 +21,13 @@ def add_aspect(op1, op2):
         return op1 + op2
 
     return add_taint_pyobject(getattr(op1.__class__, "__add__")(op1, op2), op1, op2)
+
+
+def decode_aspect(self, *args, **kwargs):
+    result = self.decode(*args, **kwargs)
+    return result
+
+
+def encode_aspect(self, *args, **kwargs):
+    result = self.encode(*args, **kwargs)
+    return result

--- a/ddtrace/appsec/iast/_ast/visitor.py
+++ b/ddtrace/appsec/iast/_ast/visitor.py
@@ -21,6 +21,8 @@ class AstVisitor(ast.NodeTransformer):
             "alias_module": "ddtrace_aspects",
             "functions": {
                 "str": "ddtrace_aspects.str_aspect",
+                "decode": "ddtrace_aspects.decode_aspect",
+                "encode": "ddtrace_aspects.encode_aspect",
             },
             "operators": {
                 ast.Add: "ddtrace_aspects.add_aspect",

--- a/ddtrace/appsec/iast/_taint_tracking/_taint_tracking.cpp
+++ b/ddtrace/appsec/iast/_taint_tracking/_taint_tracking.cpp
@@ -46,7 +46,6 @@ static PyObject *new_pyobject_id(PyObject *tainted_object,
     Py_INCREF(tainted_object);
     return tainted_object;
   } else if (PyBytes_Check(tainted_object)) {
-
     return PyObject_CallFunctionObjArgs(
         bytes_join, empty_bytes,
         Py_BuildValue("(OO)", tainted_object, empty_bytes), NULL);

--- a/tests/appsec/iast/aspects/test_encode_decode_aspect.py
+++ b/tests/appsec/iast/aspects/test_encode_decode_aspect.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# -*- encoding: utf-8 -*-
+import sys
+
+import pytest
+
+
+# from ddtrace.appsec.iast._input_info import Input_info
+
+
+def catch_all(fun, args, kwargs):
+    try:
+        return True, fun(*args, **kwargs)
+    except BaseException as e:
+        return False, type(e), e.args
+
+
+@pytest.mark.parametrize(
+    "self",
+    [
+        b"ascii123",
+        b"\xc3\xa9\xc3\xa7\xc3\xa0\xc3\xb1\xc3\x94\xc3\x8b",
+        b"\xe9\xe7\xe0\xf1\xd4\xcb",
+        b"\x83v\x83\x8d\x83_\x83N\x83g\x83e\x83X\x83g",
+        b"\xe1\xe3\xe9\xf7\xfa \xee\xe5\xf6\xf8",
+    ],
+)
+@pytest.mark.parametrize("args", [(), ("utf-8",), ("latin1",), ("iso-8859-8",), ("sjis",)])
+@pytest.mark.parametrize("kwargs", [{}, {"errors": "ignore"}, {"errors": "strict"}, {"errors": "replace"}])
+@pytest.mark.skipif(sys.version_info < (3, 6, 0), reason="Python 3.6+ only")
+def test_decode_aspect(self, args, kwargs):
+    import ddtrace.appsec.iast._ast.aspects as ddtrace_aspects
+
+    assert catch_all(ddtrace_aspects.decode_aspect, (self,) + args, kwargs) == catch_all(
+        self.__class__.decode, (self,) + args, kwargs
+    )
+
+
+@pytest.mark.parametrize(
+    "self",
+    [
+        "ascii123",
+        "éçàñÔË",
+        "プロダクトテスト",
+        "בדיקת מוצר",
+        "😀😱💻❤️🏳️🐶",
+    ],
+)
+@pytest.mark.parametrize("args", [(), ("utf-8",), ("latin1",), ("iso-8859-8",), ("sjis",)])
+@pytest.mark.parametrize("kwargs", [{}, {"errors": "ignore"}, {"errors": "strict"}, {"errors": "replace"}])
+@pytest.mark.skipif(sys.version_info < (3, 6, 0), reason="Python 3.6+ only")
+def test_encode_aspect(self, args, kwargs):
+    import ddtrace.appsec.iast._ast.aspects as ddtrace_aspects
+
+    assert catch_all(ddtrace_aspects.encode_aspect, (self,) + args, kwargs) == catch_all(
+        self.__class__.encode, (self,) + args, kwargs
+    )
+
+
+# @pytest.mark.parametrize(
+#     "obj, kwargs, should_be_tainted",
+#     [
+#         (3.5, {}, False),
+#         ("Hi", {}, True),
+#         ("🙀", {}, True),
+#         (b"Hi", {}, True),
+#         (bytearray(b"Hi"), {}, True),
+#         (b"Hi", {"encoding": "utf-8", "errors": "strict"}, True),
+#         (b"Hi", {"encoding": "utf-8", "errors": "ignore"}, True),
+#         ({"a": "b", "c": "d"}, {}, False),
+#         ({"a", "b", "c", "d"}, {}, False),
+#         (("a", "b", "c", "d"), {}, False),
+#         (["a", "b", "c", "d"], {}, False),
+#     ],
+# )
+# @pytest.mark.skipif(sys.version_info < (3, 6, 0), reason="Python 3.6+ only")
+# def test_str_aspect_tainting(obj, kwargs, should_be_tainted):
+#     import ddtrace.appsec.iast._ast.aspects as ddtrace_aspects
+#     from ddtrace.appsec.iast._taint_tracking import clear_taint_mapping
+#     from ddtrace.appsec.iast._taint_tracking import is_pyobject_tainted
+#     from ddtrace.appsec.iast._taint_tracking import setup
+#     from ddtrace.appsec.iast._taint_tracking import taint_pyobject
+
+#     setup(bytes.join, bytearray.join)
+#     clear_taint_mapping()
+#     if should_be_tainted:
+#         obj = taint_pyobject(obj, Input_info("test_str_aspect_tainting", obj, 0))
+
+#     result = ddtrace_aspects.str_aspect(obj, **kwargs)
+#     assert is_pyobject_tainted(result) == should_be_tainted
+
+#     assert result == str(obj, **kwargs)

--- a/tests/appsec/iast/aspects/test_encode_decode_aspect.py
+++ b/tests/appsec/iast/aspects/test_encode_decode_aspect.py
@@ -15,7 +15,7 @@ def catch_all(fun, args, kwargs):
 
 
 @pytest.mark.parametrize(
-    "self",
+    "infix",
     [
         b"ascii123",
         b"\xc3\xa9\xc3\xa7\xc3\xa0\xc3\xb1\xc3\x94\xc3\x8b",
@@ -27,8 +27,10 @@ def catch_all(fun, args, kwargs):
 @pytest.mark.parametrize("args", [(), ("utf-8",), ("latin1",), ("iso-8859-8",), ("sjis",)])
 @pytest.mark.parametrize("kwargs", [{}, {"errors": "ignore"}, {"errors": "strict"}, {"errors": "replace"}])
 @pytest.mark.parametrize("should_be_tainted", [False, True])
+@pytest.mark.parametrize("prefix", [b"", b"abc", b"\xc3\xa9\xc3\xa7"])
+@pytest.mark.parametrize("suffix", [b"", b"abc", b"\xc3\xa9\xc3\xa7"])
 @pytest.mark.skipif(sys.version_info < (3, 6, 0), reason="Python 3.6+ only")
-def test_decode_aspect(self, args, kwargs, should_be_tainted):
+def test_decode_and_add_aspect(infix, args, kwargs, should_be_tainted, prefix, suffix):
     import ddtrace.appsec.iast._ast.aspects as ddtrace_aspects
     from ddtrace.appsec.iast._taint_tracking import clear_taint_mapping
     from ddtrace.appsec.iast._taint_tracking import get_tainted_ranges
@@ -36,16 +38,23 @@ def test_decode_aspect(self, args, kwargs, should_be_tainted):
 
     clear_taint_mapping()
     if should_be_tainted:
-        self = taint_pyobject(self, Input_info("test_decode_aspect", self, 0))
+        infix = taint_pyobject(infix, Input_info("test_decode_aspect", infix, 0))
 
-    ok, res = catch_all(ddtrace_aspects.decode_aspect, (self,) + args, kwargs)
-    assert (ok, res) == catch_all(self.__class__.decode, (self,) + args, kwargs)
+    main_string = ddtrace_aspects.add_aspect(prefix, infix)
+    if should_be_tainted:
+        assert len(get_tainted_ranges(main_string))
+    main_string = ddtrace_aspects.add_aspect(main_string, suffix)
+    if should_be_tainted:
+        assert len(get_tainted_ranges(main_string))
+    ok, res = catch_all(ddtrace_aspects.decode_aspect, (main_string,) + args, kwargs)
+    assert (ok, res) == catch_all(main_string.__class__.decode, (main_string,) + args, kwargs)
     if should_be_tainted and ok:
         list_tr = get_tainted_ranges(res)
         assert len(list_tr) == 1
-        assert list_tr[0][1] == 0
+        assert list_tr[0][1] == len(prefix.decode(*args, **kwargs))
         # assert length of tainted is ok. If last char was replaced due to some missing bytes, it may be shorter.
-        assert list_tr[0][2] == len(res) or (kwargs == {"errors": "replace"} and list_tr[0][2] == len(res) - 1)
+        len_infix = len(infix.decode(*args, **kwargs))
+        assert list_tr[0][2] == len_infix or (kwargs == {"errors": "replace"} and list_tr[0][2] == len_infix - 1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
1. Add encode and decode aspect for iast. Should support all regular codecs supported by Python and all error modes
2. Fix the add operator aspect by not tainting the result if it is the same object as one of the operand
3. Add large tests for encode and decode with a large combination of codecs, error modes and input.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
