### PR TITLE
fix(httplib): ensure httplib is patched on import [backport #5287 to 1.10]

### DIFF
--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from ddtrace.vendor.wrapt.importer import when_imported
 
 from .constants import IAST_ENV
+from .internal.compat import PY2
 from .internal.logger import get_logger
 from .internal.telemetry import telemetry_writer
 from .internal.utils import formats
@@ -118,6 +119,7 @@ _MODULES_FOR_CONTRIB = {
     "futures": ("concurrent.futures",),
     "vertica": ("vertica_python",),
     "aws_lambda": ("datadog_lambda",),
+    "httplib": ("httplib" if PY2 else "http.client",),
 }
 
 IAST_PATCH = {

--- a/releasenotes/notes/patch-on-import-httplib-f98bad4b73cee387.yaml
+++ b/releasenotes/notes/patch-on-import-httplib-f98bad4b73cee387.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    httplib: Fixes an issue with patching of http client upon import

--- a/tests/contrib/httplib/test_httplib_patch.py
+++ b/tests/contrib/httplib/test_httplib_patch.py
@@ -1,0 +1,25 @@
+from ddtrace.contrib.httplib.patch import patch
+from ddtrace.internal.compat import PY2
+
+
+try:
+    from ddtrace.contrib.httplib.patch import unpatch
+except ImportError:
+    unpatch = None
+from tests.contrib.patch import PatchTestCase
+
+
+class TestHttplibPatch(PatchTestCase.Base):
+    __integration_name__ = "httplib"
+    __module_name__ = "httplib" if PY2 else "http.client"
+    __patch_func__ = patch
+    __unpatch_func__ = unpatch
+
+    def assert_module_patched(self, http_client):
+        pass
+
+    def assert_not_module_patched(self, http_client):
+        pass
+
+    def assert_not_module_double_patched(self, http_client):
+        pass


### PR DESCRIPTION
Backports: https://github.com/DataDog/dd-trace-py/pull/5287

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
