### PR TITLE
fix(runtime): submit metrics as gauges

### DIFF
--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -140,7 +140,7 @@ class RuntimeWorker(periodic.PeriodicService):
         with self._dogstatsd_client:
             for key, value in self._runtime_metrics:
                 log.debug("Writing metric %s:%s", key, value)
-                self._dogstatsd_client.distribution(key, value)
+                self._dogstatsd_client.gauge(key, value)
 
     def _stop_service(self):
         # type: (...) -> None

--- a/releasenotes/notes/fix-runtime-gauges-17cc2350b15ad453.yaml
+++ b/releasenotes/notes/fix-runtime-gauges-17cc2350b15ad453.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Send Python runtime metrics as gauge metrics to match the metric type used across supported runtimes.


### PR DESCRIPTION
The metric type used for runtime metrics in other supported runtime platform is gauges. 

This change reverts #2788. The reason for using distributions is no longer valid given how runtime metrics is currently being aggregated in the Datadog product.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
