### PR TITLE
fix(tracing): honor sample rate set by agent

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -729,6 +729,9 @@ class Tracer(object):
             span._metrics[PID] = self._pid
 
         # Apply default global tags.
+        if ENV_KEY not in span.get_tags() and self._env:
+            span.set_tag_str(ENV_KEY, self._env)
+
         if self._tags:
             span.set_tags(self._tags)
 

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -230,6 +230,7 @@ class Tracer(object):
         self._dogstatsd_url = agent.get_stats_url() if dogstatsd_url is None else dogstatsd_url
         self._compute_stats = config._trace_compute_stats
         self._agent_url = agent.get_trace_url() if url is None else url  # type: str
+        self._env = config.env
         agent.verify_url(self._agent_url)
 
         if self._use_log_writer() and url is None:
@@ -694,6 +695,9 @@ class Tracer(object):
             span._local_root = span
             if config.report_hostname:
                 span.set_tag_str(HOSTNAME_KEY, hostname.get_hostname())
+
+            if self._env:
+                span.set_tag_str(ENV_KEY, self._env)  # env tag is used by _sampler.sample
             span.sampled = self._sampler.sample(span)
             # Old behavior
             # DEV: The new sampler sets metrics and priority sampling on the span for us
@@ -727,9 +731,6 @@ class Tracer(object):
         # Apply default global tags.
         if self._tags:
             span.set_tags(self._tags)
-
-        if config.env:
-            span.set_tag_str(ENV_KEY, config.env)
 
         # Only set the version tag on internal spans.
         if config.version:

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -230,7 +230,6 @@ class Tracer(object):
         self._dogstatsd_url = agent.get_stats_url() if dogstatsd_url is None else dogstatsd_url
         self._compute_stats = config._trace_compute_stats
         self._agent_url = agent.get_trace_url() if url is None else url  # type: str
-        self._env = config.env
         agent.verify_url(self._agent_url)
 
         if self._use_log_writer() and url is None:
@@ -696,8 +695,8 @@ class Tracer(object):
             if config.report_hostname:
                 span.set_tag_str(HOSTNAME_KEY, hostname.get_hostname())
 
-            if self._env:
-                span.set_tag_str(ENV_KEY, self._env)  # env tag is used by _sampler.sample
+            if config.env:
+                span.set_tag_str(ENV_KEY, config.env)  # env tag is used by _sampler.sample
             span.sampled = self._sampler.sample(span)
             # Old behavior
             # DEV: The new sampler sets metrics and priority sampling on the span for us
@@ -729,11 +728,11 @@ class Tracer(object):
             span._metrics[PID] = self._pid
 
         # Apply default global tags.
-        if ENV_KEY not in span.get_tags() and self._env:
-            span.set_tag_str(ENV_KEY, self._env)
-
         if self._tags:
             span.set_tags(self._tags)
+
+        if config.env:
+            span.set_tag_str(ENV_KEY, config.env)
 
         # Only set the version tag on internal spans.
         if config.version:

--- a/releasenotes/notes/agent-sample-rate-fix-92c7b15bc8f2e058.yaml
+++ b/releasenotes/notes/agent-sample-rate-fix-92c7b15bc8f2e058.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    tracing: This fix resolves an issue where making a sampling decision before the environment span tag had been set caused
+    sample rate data from the Datadog Agent to be ignored.

--- a/releasenotes/notes/agent-sample-rate-fix-92c7b15bc8f2e058.yaml
+++ b/releasenotes/notes/agent-sample-rate-fix-92c7b15bc8f2e058.yaml
@@ -1,4 +1,4 @@
 fixes:
   - |
-    tracing: This fix resolves an issue where making a sampling decision before the environment span tag had been set caused
+    tracing: This fix resolves an issue where making a sampling decision before the ``env`` span tag had been set caused
     sample rate data from the Datadog Agent to be ignored.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -494,7 +494,7 @@ def test_priority_sampling_rate_honored(encoding, monkeypatch):
         sampled_ratio = len(sampled_spans) / captured_span_count
         diff_magnitude = abs(sampled_ratio - rate_from_agent)
         assert (
-            diff_magnitude < 0.3
+            diff_magnitude < 0.1
         ), "the proportion of sampled spans should approximate the sample rate given by the agent"
 
         t.shutdown()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -494,7 +494,7 @@ def test_priority_sampling_rate_honored(encoding, monkeypatch):
         sampled_ratio = len(sampled_spans) / captured_span_count
         diff_magnitude = abs(sampled_ratio - rate_from_agent)
         assert (
-            diff_magnitude < 0.1
+            diff_magnitude < 0.3
         ), "the proportion of sampled spans should approximate the sample rate given by the agent"
 
         t.shutdown()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -447,9 +447,10 @@ def _turn_tracer_into_dummy(tracer):
 def test_priority_sampling_response(encoding, monkeypatch):
     monkeypatch.setenv("DD_TRACE_API_VERSION", encoding)
 
-    env = "my-env-{}".format(time.time())
+    _id = time.time()
+    env = "my-env-{}".format(_id)
     with override_global_config(dict(env=env)):
-        service = "my-svc-{}".format(time.time())
+        service = "my-svc-{}".format(_id)
         sampler_key = "service:{},env:{}".format(service, env)
         t = Tracer()
         assert sampler_key not in t._writer._priority_sampler._by_service_samplers
@@ -463,9 +464,10 @@ def test_priority_sampling_response(encoding, monkeypatch):
 def test_priority_sampling_rate_honored(encoding, monkeypatch):
     monkeypatch.setenv("DD_TRACE_API_VERSION", encoding)
 
-    env = "my-env-{}".format(time.time())
+    _id = time.time()
+    env = "my-env-{}".format(_id)
     with override_global_config(dict(env=env)):
-        service = "my-svc-{}".format(time.time())
+        service = "my-svc-{}".format(_id)
         t = Tracer()
 
         # send a ton of traces from different services to make the agent adjust its sample rate for ``service,env``

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -430,7 +430,7 @@ def _prime_tracer_with_priority_sample_rate_from_agent(t, service, env):
             s.set_tag("env", "my-env")
 
 
-def _turn_tracer_into_dummy(tracer: Tracer):
+def _turn_tracer_into_dummy(tracer):
     """Override tracer's writer's write() method to keep traces instead of sending them away"""
 
     def monkeypatched_write(self, spans=None):
@@ -475,7 +475,7 @@ def test_priority_sampling_rate_honored(encoding, monkeypatch):
 
     # send a ton of traces from different services to make the agent adjust its sample rate for ``service,env``
     for i in range(100):
-        s = t.trace("operation", service=f"my-svc{i}")
+        s = t.trace("operation", service="my-svc{}".format(i))
         s.finish()
     t.flush()
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -494,7 +494,7 @@ def test_priority_sampling_rate_honored(encoding, monkeypatch):
         assert len(t._writer.traces) == captured_span_count
         sampled_spans = [s for s in t._writer.spans if s.context._metrics[SAMPLING_PRIORITY_KEY] == AUTO_KEEP]
         assert (
-            abs(len(sampled_spans) / captured_span_count - rate_from_agent) < 0.1
+            abs(len(sampled_spans) / captured_span_count - rate_from_agent) < 0.13
         ), "the proportion of sampled spans should match the sample rate given by the agent"
 
         t.shutdown()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -11,6 +11,7 @@ import six
 
 import ddtrace
 from ddtrace import Tracer
+from ddtrace.constants import AUTO_KEEP
 from ddtrace.internal import agent
 from ddtrace.internal.encoding import JSONEncoder
 from ddtrace.internal.encoding import MsgpackEncoderV03 as Encoder
@@ -405,18 +406,12 @@ def test_writer_headers(encoding, monkeypatch):
     assert headers.get("X-Datadog-Trace-Count") == "10"
 
 
-@allencodings
-@pytest.mark.skipif(AGENT_VERSION == "testagent", reason="Test agent doesn't support priority sampling responses.")
-def test_priority_sampling_response(encoding, monkeypatch):
-    monkeypatch.setenv("DD_TRACE_API_VERSION", encoding)
-
+def _prime_tracer_with_priority_sample_rate_from_agent(t, service, env):
     # Send the data once because the agent doesn't respond with them on the
     # first payload.
-    t = Tracer()
     s = t.trace("operation", service="my-svc")
     s.set_tag("env", "my-env")
     s.finish()
-    assert "service:my-svc,env:my-env" not in t._writer._priority_sampler._by_service_samplers
     t.flush()
 
     # If a previous test has run then the agent might reply immediately
@@ -432,44 +427,10 @@ def test_priority_sampling_response(encoding, monkeypatch):
         # Agent will now reply with the sampling rates
         with t.trace("operation", service="my-svc") as s:
             s.set_tag("env", "my-env")
-    t.shutdown()
-    assert "service:my-svc,env:my-env" in t._writer._priority_sampler._by_service_samplers
 
 
-@allencodings
-@pytest.mark.skipif(AGENT_VERSION == "testagent", reason="Test agent doesn't support priority sampling responses.")
-def test_priority_sampling_rate_honored(encoding, monkeypatch):
-    monkeypatch.setenv("DD_TRACE_API_VERSION", encoding)
-
-    # Send the data once because the agent doesn't respond with them on the
-    # first payload.
-    t = Tracer()
-    s = t.trace("operation", service="my-svc")
-    s.set_tag("env", "my-env")
-    s.finish()
-    for i in range(100):
-        s = t.trace("operation", service=f"my-svc{i}")
-        s.set_tag("env", f"my-env{i}")
-        s.finish()
-    assert "service:my-svc,env:my-env" not in t._writer._priority_sampler._by_service_samplers
-    t.flush()
-
-    # If a previous test has run then the agent might reply immediately
-    if "service:my-svc,env:my-env" not in t._writer._priority_sampler._by_service_samplers:
-        # The Agent only returns updated sampling rates once 5 seconds have passed and another request has been sent.
-        import time
-
-        time.sleep(5)
-        with t.trace("operation", service="my-svc") as s:
-            s.set_tag("env", "my-env")
-        t.flush()
-
-        # Agent will now reply with the sampling rates
-        with t.trace("operation", service="my-svc") as s:
-            s.set_tag("env", "my-env")
-    assert "service:my-svc,env:my-env" in t._writer._priority_sampler._by_service_samplers
-    rate_from_agent = t._writer._priority_sampler._by_service_samplers["service:my-svc,env:my-env"].sample_rate
-    assert 0.2 < rate_from_agent < 0.5
+def _turn_tracer_into_dummy(tracer: Tracer):
+    """Override tracer's writer's write() method to keep traces instead of sending them away"""
 
     def monkeypatched_write(self, spans=None):
         if spans:
@@ -480,20 +441,63 @@ def test_priority_sampling_rate_honored(encoding, monkeypatch):
             self.spans += spans
             self.traces += traces
 
-    t._writer.spans = []
-    t._writer.traces = []
-    t._writer.json_encoder = JSONEncoder()
-    t._writer.msgpack_encoder = Encoder(4 << 20, 4 << 20)
-    t._writer.write = monkeypatched_write.__get__(t._writer, AgentWriter)
+    tracer._writer.spans = []
+    tracer._writer.traces = []
+    tracer._writer.json_encoder = JSONEncoder()
+    tracer._writer.msgpack_encoder = Encoder(4 << 20, 4 << 20)
+    tracer._writer.write = monkeypatched_write.__get__(tracer._writer, AgentWriter)
 
-    captured_trace_count = 100
-    for _ in range(captured_trace_count):
+
+@allencodings
+@pytest.mark.skipif(AGENT_VERSION == "testagent", reason="Test agent doesn't support priority sampling responses.")
+def test_priority_sampling_response(encoding, monkeypatch):
+    monkeypatch.setenv("DD_TRACE_API_VERSION", encoding)
+
+    service = "my-svc"
+    env = "my-env"
+    t = Tracer()
+    assert "service:my-svc,env:my-env" not in t._writer._priority_sampler._by_service_samplers
+    _prime_tracer_with_priority_sample_rate_from_agent(t, service, env)
+    assert "service:my-svc,env:my-env" in t._writer._priority_sampler._by_service_samplers
+    t.shutdown()
+
+
+@allencodings
+@pytest.mark.skipif(AGENT_VERSION == "testagent", reason="Test agent doesn't support priority sampling responses.")
+def test_priority_sampling_rate_honored(encoding, monkeypatch):
+    monkeypatch.setenv("DD_TRACE_API_VERSION", encoding)
+
+    service = "my-svc"
+    env = "my-env"
+    t = Tracer()
+
+    # send a ton of traces from different services to make the agent adjust its sample rate for ``service,env``
+    for i in range(100):
+        s = t.trace("operation", service=f"my-svc{i}")
+        s.set_tag("env", f"my-env{i}")
+        s.finish()
+
+    _prime_tracer_with_priority_sample_rate_from_agent(t, service, env)
+
+    rate_from_agent = t._writer._priority_sampler._by_service_samplers["service:my-svc,env:my-env"].sample_rate
+    assert 0.2 < rate_from_agent < 0.5
+
+    _turn_tracer_into_dummy(t)
+
+    captured_span_count = 100
+    for _ in range(captured_span_count):
         with t.trace("operation", service="my-svc") as s:
             s.set_tag("env", "my-env")
         t.flush()
-    assert len(t._writer.traces) == captured_trace_count
+    assert len(t._writer.traces) == captured_span_count
     sampled_spans = [s for s in t._writer.spans if s.sampled]
-    assert len(sampled_spans) / captured_trace_count == rate_from_agent
+    priority_spans = [s for s in t._writer.spans if s.context.sampling_priority == AUTO_KEEP]
+    assert len(priority_spans) == len(
+        sampled_spans
+    ), "span.sampled and span.context.sampling_priority should always update together"
+    assert (
+        len(sampled_spans) / captured_span_count == rate_from_agent
+    ), "the proportion of sampled spans should match the sample rate given by the agent"
 
     t.shutdown()
 
@@ -728,6 +732,8 @@ def test_regression_logging_in_context(tmpdir, logs_injection, debug_mode, patch
     f.write(
         """
 import ddtrace
+
+
 ddtrace.patch(logging=%s)
 
 s1 = ddtrace.tracer.trace("1")
@@ -785,6 +791,8 @@ def test_call_basic_config(ddtrace_run_python_code_in_subprocess, call_basic_con
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """
 import logging
+
+
 root = logging.getLogger()
 print(len(root.handlers))
 """,
@@ -832,6 +840,7 @@ def test_writer_env_configuration_ddtrace_run(ddtrace_run_python_code_in_subproc
         """
 import ddtrace
 
+
 assert ddtrace.tracer._writer._encoder.max_size == 1000
 assert ddtrace.tracer._writer._encoder.max_item_size == 1000
 assert ddtrace.tracer._writer._interval == 5.0
@@ -845,6 +854,7 @@ def test_writer_env_configuration_ddtrace_run_defaults(ddtrace_run_python_code_i
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """
 import ddtrace
+
 
 assert ddtrace.tracer._writer._encoder.max_size == 8 << 20
 assert ddtrace.tracer._writer._encoder.max_item_size == 8 << 20

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -730,8 +730,6 @@ def test_regression_logging_in_context(tmpdir, logs_injection, debug_mode, patch
     f.write(
         """
 import ddtrace
-
-
 ddtrace.patch(logging=%s)
 
 s1 = ddtrace.tracer.trace("1")
@@ -789,8 +787,6 @@ def test_call_basic_config(ddtrace_run_python_code_in_subprocess, call_basic_con
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """
 import logging
-
-
 root = logging.getLogger()
 print(len(root.handlers))
 """,
@@ -838,7 +834,6 @@ def test_writer_env_configuration_ddtrace_run(ddtrace_run_python_code_in_subproc
         """
 import ddtrace
 
-
 assert ddtrace.tracer._writer._encoder.max_size == 1000
 assert ddtrace.tracer._writer._encoder.max_item_size == 1000
 assert ddtrace.tracer._writer._interval == 5.0
@@ -852,7 +847,6 @@ def test_writer_env_configuration_ddtrace_run_defaults(ddtrace_run_python_code_i
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """
 import ddtrace
-
 
 assert ddtrace.tracer._writer._encoder.max_size == 8 << 20
 assert ddtrace.tracer._writer._encoder.max_item_size == 8 << 20


### PR DESCRIPTION
This change fixes a bug causing sample rate data from the agent not to be honored in the tracer's sampling behavior. The bug is that the sampling decision is made before the `env` tag is set. This tag is a key piece of information necessary to make sampling decisions based on responses from the agent.

The change also includes a regression test.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
