### PR TITLE
feat(lib-injection): add support for uwsgi

### DIFF
--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -44,3 +44,52 @@ jobs:
           docker-registry-username: ${{ github.repository_owner }}
           docker-registry-password: ${{ secrets.GITHUB_TOKEN }}
           test-script: ./lib-injection/run-manual-lib-injection.sh
+
+  test_unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [
+          'dd-lib-python-init-test-django',
+          'dd-lib-python-init-test-django-gunicorn',
+          'dd-lib-python-init-test-django-uvicorn',
+          'dd-lib-python-init-test-django-uwsgi',
+        ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create a docker network for the app and test agent
+        run: |
+          docker network create test-inject
+      - name: Run the test agent
+        run: |
+          docker run \
+            -d \
+            --network=test-inject \
+            -p 8126:8126 \
+            ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.7.2
+      - name: Apply a fixed, stable version of the library
+        run: sed -i "s~<DD_TRACE_VERSION_TO_BE_REPLACED>~1.8.0~g" lib-injection/sitecustomize.py
+      - name: Build test app
+        run: |
+          docker build \
+            -t ${{ matrix.variant }} \
+            tests/lib-injection/${{ matrix.variant }}/
+      - name: Run the app
+        run: |
+          docker run -d \
+            --name ${{ matrix.variant }} \
+            --network test-inject \
+            -p 18080:18080 \
+            -e PYTHONPATH=/lib-injection \
+            -v $PWD/lib-injection:/lib-injection \
+            ${{matrix.variant}}
+          sleep 20
+          docker logs ${{matrix.variant}}
+      - name: Test the app
+        run: |
+          curl http://localhost:18080
+          sleep 1  # wait for traces to be sent
+      - name: Check test agent
+        run: |
+          curl http://localhost:8126/test/traces

--- a/releasenotes/notes/uwsgi-lib-injection-9a90fc9e9e852e43.yaml
+++ b/releasenotes/notes/uwsgi-lib-injection-9a90fc9e9e852e43.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    lib-injection: Add support for uwsgi.

--- a/tests/lib-injection/dd-lib-python-init-test-django-uwsgi/Dockerfile
+++ b/tests/lib-injection/dd-lib-python-init-test-django-uwsgi/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10
+
+ENV PYTHONUNBUFFERED 1
+ENV DJANGO_SETTINGS_MODULE django_app
+WORKDIR /src
+ADD . /src
+EXPOSE 18080
+RUN pip install django==4.1.3 uwsgi
+CMD uwsgi --http 0.0.0.0:18080 --module django_app:application

--- a/tests/lib-injection/dd-lib-python-init-test-django-uwsgi/django_app.py
+++ b/tests/lib-injection/dd-lib-python-init-test-django-uwsgi/django_app.py
@@ -1,0 +1,23 @@
+import os
+
+from django.core.wsgi import get_wsgi_application
+from django.http import HttpResponse
+from django.urls import path
+
+
+filepath, extension = os.path.splitext(__file__)
+ROOT_URLCONF = os.path.basename(filepath)
+DEBUG = False
+SECRET_KEY = "fdsfdasfa"
+ALLOWED_HOSTS = ["*"]
+
+
+def index(request):
+    return HttpResponse("test")
+
+
+urlpatterns = [
+    path("", index),
+]
+
+application = get_wsgi_application()


### PR DESCRIPTION
Add support to library injection for uwsgi. uwsgi is tricky to support as it invokes a python interpreter itself using the C-API, so `sys.executable` is the uwsgi executable. Validation is added for when incompatible uwsgi configurations are detected, using the pre-existing logic that existed in the library.

Automated unit tests are added to maintain this functionality.

Currently blocked on #5410.


## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
