### PR TITLE
chore(asm): add env var for modules to be patched by iast

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -8,8 +8,6 @@ if TYPE_CHECKING:
     from typing import Any
     from typing import Iterator
 
-DD_IAST_PATCH_MODULES = "_DD_IAST_PATCH_MODULES"
-
 
 class Constant_Class(type):
     """
@@ -68,6 +66,9 @@ class IAST(object):
     JSON = "_dd.iast.json"
     ENABLED = "_dd.iast.enabled"
     CONTEXT_KEY = "_iast_data"
+    PATCH_MODULES = "_DD_IAST_PATCH_MODULES"
+    DENY_MODULES = "_DD_IAST_DENY_MODULES"
+    SEP_MODULES = ","
 
 
 @six.add_metaclass(Constant_Class)  # required for python2/3 compatibility

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from typing import Any
     from typing import Iterator
 
-DD_IAST_PATCH_MODULES = "_DD_IAST_PATH_MODULES"
+DD_IAST_PATCH_MODULES = "_DD_IAST_PATCH_MODULES"
 
 
 class Constant_Class(type):

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -8,6 +8,8 @@ if TYPE_CHECKING:
     from typing import Any
     from typing import Iterator
 
+DD_IAST_PATCH_MODULES = "_DD_IAST_PATH_MODULES"
+
 
 class Constant_Class(type):
     """

--- a/ddtrace/appsec/iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/iast/_ast/ast_patching.py
@@ -7,13 +7,18 @@ from types import ModuleType
 from typing import Optional
 from typing import Tuple
 
+from ddtrace.appsec._constants import DD_IAST_PATCH_MODULES
 from ddtrace.appsec.iast._ast.visitor import AstVisitor
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.module import origin
 
 
 # Prefixes for modules where IAST patching is allowed
-IAST_ALLOWLIST = ("tests.appsec.iast",)
+IAST_ALLOWLIST = ("tests.appsec.iast",)  # type: tuple[str, ...]
+
+if DD_IAST_PATCH_MODULES in os.environ:
+    IAST_ALLOWLIST += tuple(os.environ[DD_IAST_PATCH_MODULES].split(":"))
+
 
 ENCODING = ""
 

--- a/ddtrace/appsec/iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/iast/_ast/ast_patching.py
@@ -7,7 +7,7 @@ from types import ModuleType
 from typing import Optional
 from typing import Tuple
 
-from ddtrace.appsec._constants import DD_IAST_PATCH_MODULES
+from ddtrace.appsec._constants import IAST
 from ddtrace.appsec.iast._ast.visitor import AstVisitor
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.module import origin
@@ -15,9 +15,14 @@ from ddtrace.internal.module import origin
 
 # Prefixes for modules where IAST patching is allowed
 IAST_ALLOWLIST = ("tests.appsec.iast",)  # type: tuple[str, ...]
+IAST_DENYLIST = ("ddtrace",)  # type: tuple[str, ...]
 
-if DD_IAST_PATCH_MODULES in os.environ:
-    IAST_ALLOWLIST += tuple(os.environ[DD_IAST_PATCH_MODULES].split(":"))
+
+if IAST.PATCH_MODULES in os.environ:
+    IAST_ALLOWLIST += tuple(os.environ[IAST.PATCH_MODULES].split(IAST.SEP_MODULES))
+
+if IAST.DENY_MODULES in os.environ:
+    IAST_DENYLIST += tuple(os.environ[IAST.DENY_MODULES].split(IAST.SEP_MODULES))
 
 
 ENCODING = ""
@@ -40,7 +45,13 @@ def get_encoding(module_path):  # type: (str) -> str
 
 
 def _should_iast_patch(module_name):
-    return not module_name.startswith("ddtrace") and module_name.startswith(IAST_ALLOWLIST)
+    """
+    select if module_name should be patch from the longuest prefix that match in allow or deny list.
+    if a prefix is in both list, deny is selected.
+    """
+    max_allow = max((len(prefix) for prefix in IAST_ALLOWLIST if module_name.startswith(prefix)), default=-1)
+    max_deny = max((len(prefix) for prefix in IAST_DENYLIST if module_name.startswith(prefix)), default=-1)
+    return max_allow > max_deny
 
 
 def visit_ast(

--- a/tests/appsec/iast/ast/test_ast_patching.py
+++ b/tests/appsec/iast/ast/test_ast_patching.py
@@ -120,6 +120,7 @@ def test_astpatch_source_unchanged(module_name):
     assert ("", "") == astpatch_module(__import__(module_name, fromlist=[None]))
 
 
+@pytest.mark.skipif(PY2, reason="Python 3 only")
 def test_module_should_iast_patch():
     assert not _should_iast_patch("ddtrace.internal.module")
     assert not _should_iast_patch("ddtrace.appsec.iast")

--- a/tests/appsec/iast/test_env_var.py
+++ b/tests/appsec/iast/test_env_var.py
@@ -96,13 +96,14 @@ def test_env_var_iast_enabled_gevent_patch_all_true(capfd):
 @pytest.mark.skipif(not _is_python_version_supported(), reason="IAST compatible versions")
 def test_A_env_var_iast_modules_to_patch(capfd):
     # type: (...) -> None
+    import gc
     import sys
 
     from ddtrace.appsec._constants import IAST
 
     if "ddtrace.appsec.iast._ast.ast_patching" in sys.modules:
-        # this module must not be already loaded
-        assert False
+        del sys.modules["ddtrace.appsec.iast._ast.ast_patching"]
+        gc.collect()
 
     os.environ[IAST.PATCH_MODULES] = IAST.SEP_MODULES.join(
         ["please_patch", "also.that", "ddtrace", "please_patch.do_not.but_yes"]


### PR DESCRIPTION
**This is works in progress and should not be used by regular users for now**

Add environment variables to allow the user to define the list of modules to be patched by IAST.
For now:

1. _DD_IAST_PATCH_MODULES is a pass list of module name prefixes separated by commas
2. _DD_IAST_DENY_MODULES is a deny list of module name prefixes separated by commas

The longest prefix will be used to choose if a module must be patched or not.
If a prefix is in both lists, the deny list takes priority.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
