### PR TITLE
chore(asm): use _iast_enabled in config for tests in override_global_config

### DIFF
--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 from ddtrace.vendor.wrapt.importer import when_imported
 
-from .constants import IAST_ENV
 from .internal.compat import PY2
 from .internal.logger import get_logger
 from .internal.telemetry import telemetry_writer
@@ -199,7 +198,7 @@ def patch_iast(**patch_modules):
 
     IAST_PATCH: list of implemented vulnerabilities
     """
-    iast_enabled = formats.asbool(os.environ.get(IAST_ENV, "false"))
+    iast_enabled = config._iast_enabled
     if iast_enabled:
         # TODO: Devise the correct patching strategy for IAST
         for module in (m for m, e in patch_modules.items() if e):

--- a/tests/appsec/iast/test_processor.py
+++ b/tests/appsec/iast/test_processor.py
@@ -12,6 +12,7 @@ from ddtrace.ext import SpanTypes
 from ddtrace.internal import _context
 from tests.utils import DummyTracer
 from tests.utils import override_env
+from tests.utils import override_global_config
 
 
 def traced_function(tracer):
@@ -28,7 +29,7 @@ def traced_function(tracer):
 
 
 def test_appsec_iast_processor():
-    with override_env(dict(DD_IAST_ENABLED="true")):
+    with override_global_config(dict(_iast_enabled=True)):
         patch_iast(**IAST_PATCH)
 
         tracer = DummyTracer(iast_enabled=True)
@@ -45,7 +46,7 @@ def test_appsec_iast_processor():
 
 @pytest.mark.parametrize("sampling_rate", ["0.0", "0.5", "1.0"])
 def test_appsec_iast_processor_ensure_span_is_manual_keep(sampling_rate):
-    with override_env(dict(DD_IAST_ENABLED="true", DD_TRACE_SAMPLE_RATE=sampling_rate)):
+    with override_env(dict(DD_TRACE_SAMPLE_RATE=sampling_rate)), override_global_config(dict(_iast_enabled=True)):
         patch_iast(**IAST_PATCH)
 
         tracer = DummyTracer(iast_enabled=True)

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -389,7 +389,7 @@ def test_django_client_ip_header_set_by_env_var_invalid_2(client, test_spans, tr
 
 
 def test_django_weak_hash(client, test_spans, tracer):
-    with override_env(dict(DD_IAST_ENABLED="true")):
+    with override_global_config(dict(_appsec_enabled=True, _iast_enabled=True)):
         patch_iast(weak_hash=True)
         root_span, _ = _aux_appsec_get_root_span(client, test_spans, tracer, url="/weak-hash/", iast_enabled=True)
         str_json = root_span.get_tag(IAST_JSON)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -102,6 +102,7 @@ def override_global_config(values):
         "_raise",
         "_trace_compute_stats",
         "_appsec_enabled",
+        "_iast_enabled",
         "_obfuscation_query_string_pattern",
         "global_query_string_obfuscation_disabled",
     ]


### PR DESCRIPTION
Add `_iast_enabled` to `override_global_config` to be able to use it for iast tests in the same way as `_appsec_enabled`

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
