### PR TITLE
Revert "chore(deps): bump mysql-connector-python from 8.0.5 to 8.0.14 in /.riot/requirements"

### DIFF
--- a/.riot/requirements/106972e.txt
+++ b/.riot/requirements/106972e.txt
@@ -11,7 +11,7 @@ greenlet==2.0.2
 hypothesis==6.45.0
 iniconfig==2.0.0
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.32
 opentracing==2.4.0
 packaging==23.0
 pluggy==1.0.0

--- a/.riot/requirements/10d623a.txt
+++ b/.riot/requirements/10d623a.txt
@@ -9,7 +9,7 @@ coverage[toml]==7.2.2
 hypothesis==6.45.0
 iniconfig==2.0.0
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.32
 opentracing==2.4.0
 packaging==23.0
 pluggy==1.0.0

--- a/.riot/requirements/1133f63.txt
+++ b/.riot/requirements/1133f63.txt
@@ -11,7 +11,7 @@ hypothesis==6.45.0
 importlib-metadata==6.0.0
 iniconfig==2.0.0
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.32
 opentracing==2.4.0
 packaging==23.0
 pluggy==1.0.0

--- a/.riot/requirements/1230ff8.txt
+++ b/.riot/requirements/1230ff8.txt
@@ -10,7 +10,7 @@ hypothesis==6.31.6
 importlib-metadata==4.8.3
 iniconfig==1.1.1
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.29
 opentracing==2.4.0
 packaging==21.3
 pluggy==1.0.0

--- a/.riot/requirements/129b0f2.txt
+++ b/.riot/requirements/129b0f2.txt
@@ -10,7 +10,7 @@ exceptiongroup==1.1.1
 hypothesis==6.45.0
 iniconfig==2.0.0
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.5
 opentracing==2.4.0
 packaging==23.0
 pluggy==1.0.0

--- a/.riot/requirements/12db871.txt
+++ b/.riot/requirements/12db871.txt
@@ -10,7 +10,7 @@ exceptiongroup==1.1.1
 hypothesis==6.45.0
 iniconfig==2.0.0
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.32
 opentracing==2.4.0
 packaging==23.0
 pluggy==1.0.0

--- a/.riot/requirements/137147e.txt
+++ b/.riot/requirements/137147e.txt
@@ -10,7 +10,7 @@ exceptiongroup==1.1.1
 hypothesis==6.45.0
 iniconfig==2.0.0
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.32
 opentracing==2.4.0
 packaging==23.0
 pluggy==1.0.0

--- a/.riot/requirements/147a097.txt
+++ b/.riot/requirements/147a097.txt
@@ -11,7 +11,7 @@ greenlet==2.0.2
 hypothesis==6.45.0
 iniconfig==2.0.0
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.32
 opentracing==2.4.0
 packaging==23.0
 pluggy==1.0.0

--- a/.riot/requirements/16025dc.txt
+++ b/.riot/requirements/16025dc.txt
@@ -10,7 +10,7 @@ hypothesis==5.33.2
 importlib-metadata==2.1.3
 iniconfig==1.1.1
 mock==3.0.5
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.23
 opentracing==2.4.0
 packaging==20.9
 pathlib2==2.3.7.post1

--- a/.riot/requirements/16bac29.txt
+++ b/.riot/requirements/16bac29.txt
@@ -17,7 +17,7 @@ hypothesis==4.57.1
 importlib-metadata==2.1.3
 mock==3.0.5
 more-itertools==5.0.0
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.23
 opentracing==2.4.0
 packaging==20.9
 pathlib2==2.3.7.post1

--- a/.riot/requirements/1a1c1fa.txt
+++ b/.riot/requirements/1a1c1fa.txt
@@ -17,7 +17,7 @@ hypothesis==4.57.1
 importlib-metadata==2.1.3
 mock==3.0.5
 more-itertools==5.0.0
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.5
 opentracing==2.4.0
 packaging==20.9
 pathlib2==2.3.7.post1

--- a/.riot/requirements/1ab28fe.txt
+++ b/.riot/requirements/1ab28fe.txt
@@ -10,7 +10,7 @@ hypothesis==5.33.2
 importlib-metadata==2.1.3
 iniconfig==1.1.1
 mock==3.0.5
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.23
 opentracing==2.4.0
 packaging==20.9
 pathlib2==2.3.7.post1

--- a/.riot/requirements/1cdb1c5.txt
+++ b/.riot/requirements/1cdb1c5.txt
@@ -10,7 +10,7 @@ hypothesis==6.31.6
 importlib-metadata==4.8.3
 iniconfig==1.1.1
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.5
 opentracing==2.4.0
 packaging==21.3
 pluggy==1.0.0

--- a/.riot/requirements/1d614be.txt
+++ b/.riot/requirements/1d614be.txt
@@ -11,7 +11,7 @@ greenlet==2.0.2
 hypothesis==6.45.0
 iniconfig==2.0.0
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.32
 opentracing==2.4.0
 packaging==23.0
 pluggy==1.0.0

--- a/.riot/requirements/1e72d9c.txt
+++ b/.riot/requirements/1e72d9c.txt
@@ -10,7 +10,7 @@ hypothesis==5.33.2
 importlib-metadata==2.1.3
 iniconfig==1.1.1
 mock==3.0.5
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.5
 opentracing==2.4.0
 packaging==20.9
 pathlib2==2.3.7.post1

--- a/.riot/requirements/270f95a.txt
+++ b/.riot/requirements/270f95a.txt
@@ -10,7 +10,7 @@ exceptiongroup==1.1.1
 hypothesis==6.45.0
 iniconfig==2.0.0
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.5
 opentracing==2.4.0
 packaging==23.0
 pluggy==1.0.0

--- a/.riot/requirements/2d6d58d.txt
+++ b/.riot/requirements/2d6d58d.txt
@@ -11,7 +11,7 @@ hypothesis==6.31.6
 importlib-metadata==4.8.3
 iniconfig==1.1.1
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.23
 opentracing==2.4.0
 packaging==21.3
 pluggy==1.0.0

--- a/.riot/requirements/2eb00ea.txt
+++ b/.riot/requirements/2eb00ea.txt
@@ -9,7 +9,7 @@ coverage[toml]==7.2.2
 hypothesis==6.45.0
 iniconfig==2.0.0
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.32
 opentracing==2.4.0
 packaging==23.0
 pluggy==1.0.0

--- a/.riot/requirements/543c254.txt
+++ b/.riot/requirements/543c254.txt
@@ -12,7 +12,7 @@ hypothesis==6.45.0
 importlib-metadata==6.0.0
 iniconfig==2.0.0
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.32
 opentracing==2.4.0
 packaging==23.0
 pluggy==1.0.0

--- a/.riot/requirements/729b5a8.txt
+++ b/.riot/requirements/729b5a8.txt
@@ -11,7 +11,7 @@ hypothesis==6.45.0
 importlib-metadata==6.0.0
 iniconfig==2.0.0
 mock==5.0.1
-mysql-connector-python==8.0.14
+mysql-connector-python==8.0.5
 opentracing==2.4.0
 packaging==23.0
 pluggy==1.0.0


### PR DESCRIPTION
- [x] Reverts DataDog/dd-trace-py#5357