### PR TITLE
fix(asm): add missing `track` tag to custom events tracking

### DIFF
--- a/ddtrace/appsec/trace_utils.py
+++ b/ddtrace/appsec/trace_utils.py
@@ -122,6 +122,8 @@ def track_custom_event(tracer, event_name, metadata):
         )
         return
 
+    span.set_tag_str("%s.%s.track" % (APPSEC.CUSTOM_EVENT_PREFIX, event_name), "true")
+
     for k, v in six.iteritems(metadata):
         span.set_tag_str("%s.%s.%s" % (APPSEC.CUSTOM_EVENT_PREFIX, event_name, k), str(v))
         span.set_tag_str(constants.MANUAL_KEEP_KEY, "true")

--- a/tests/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/test_appsec_trace_utils.py
@@ -113,6 +113,7 @@ class EventsSDKTestCase(TracerTestCase):
             root_span = self.tracer.current_root_span()
 
             assert root_span.get_tag("%s.%s.foo" % (APPSEC.CUSTOM_EVENT_PREFIX, event)) == "bar"
+            assert root_span.get_tag("%s.%s.track" % (APPSEC.CUSTOM_EVENT_PREFIX, event)) == "true"
 
     def test_set_user_blocked(self):
         tracer = self._tracer_appsec


### PR DESCRIPTION
## Motivation

The `track_custom_event()` function was not setting the `appsec.events.<event name>.track` tag, which is required for the event tracking SDK. This PR fixes this.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X ] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
