### PR TITLE
fix(asm): add missing track tag to custom events tracking [backport #5365 to 1.10]

### DIFF
--- a/ddtrace/appsec/trace_utils.py
+++ b/ddtrace/appsec/trace_utils.py
@@ -122,6 +122,8 @@ def track_custom_event(tracer, event_name, metadata):
         )
         return
 
+    span.set_tag_str("%s.%s.track" % (APPSEC.CUSTOM_EVENT_PREFIX, event_name), "true")
+
     for k, v in six.iteritems(metadata):
         span.set_tag_str("%s.%s.%s" % (APPSEC.CUSTOM_EVENT_PREFIX, event_name, k), str(v))
         span.set_tag_str(constants.MANUAL_KEEP_KEY, "true")

--- a/releasenotes/notes/asm-missing-tag-custom-events-b4d4087a2a3ce660.yaml
+++ b/releasenotes/notes/asm-missing-tag-custom-events-b4d4087a2a3ce660.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: make ``track_custom_event()`` also set ``appsec.events.<custom_event>.track`` which was missing.

--- a/tests/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/test_appsec_trace_utils.py
@@ -99,5 +99,4 @@ class EventsSDKTestCase(TracerTestCase):
             root_span = self.tracer.current_root_span()
 
             assert root_span.get_tag("%s.%s.foo" % (APPSEC.CUSTOM_EVENT_PREFIX, event)) == "bar"
-            assert root_span.get_tag("%s.%s.track" % (APPSEC.CUSTOM_EVENT_PREFIX, event)) == "true"
-            
+            assert root_span.get_tag("%s.%s.track" % (APPSEC.CUSTOM_EVENT_PREFIX, event)) == "true"           

--- a/tests/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/test_appsec_trace_utils.py
@@ -99,4 +99,4 @@ class EventsSDKTestCase(TracerTestCase):
             root_span = self.tracer.current_root_span()
 
             assert root_span.get_tag("%s.%s.foo" % (APPSEC.CUSTOM_EVENT_PREFIX, event)) == "bar"
-            assert root_span.get_tag("%s.%s.track" % (APPSEC.CUSTOM_EVENT_PREFIX, event)) == "true"           
+            assert root_span.get_tag("%s.%s.track" % (APPSEC.CUSTOM_EVENT_PREFIX, event)) == "true"

--- a/tests/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/test_appsec_trace_utils.py
@@ -100,26 +100,4 @@ class EventsSDKTestCase(TracerTestCase):
 
             assert root_span.get_tag("%s.%s.foo" % (APPSEC.CUSTOM_EVENT_PREFIX, event)) == "bar"
             assert root_span.get_tag("%s.%s.track" % (APPSEC.CUSTOM_EVENT_PREFIX, event)) == "true"
-
-    def test_set_user_blocked(self):
-        tracer = self._tracer_appsec
-        with override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
-            tracer.configure(api_version="v0.4")
-            with tracer.trace("fake_span", span_type=SpanTypes.WEB) as span:
-                set_user(
-                    self.tracer,
-                    user_id=self._BLOCKED_USER,
-                    email="usr.email",
-                    name="usr.name",
-                    session_id="usr.session_id",
-                    role="usr.role",
-                    scope="usr.scope",
-                )
-                assert span.get_tag(user.ID)
-                assert span.get_tag(user.EMAIL)
-                assert span.get_tag(user.SESSION_ID)
-                assert span.get_tag(user.NAME)
-                assert span.get_tag(user.ROLE)
-                assert span.get_tag(user.SCOPE)
-                assert span.get_tag(user.SESSION_ID)
-                assert _context.get_item("http.request.blocked", span=span)
+            

--- a/tests/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/test_appsec_trace_utils.py
@@ -99,3 +99,27 @@ class EventsSDKTestCase(TracerTestCase):
             root_span = self.tracer.current_root_span()
 
             assert root_span.get_tag("%s.%s.foo" % (APPSEC.CUSTOM_EVENT_PREFIX, event)) == "bar"
+            assert root_span.get_tag("%s.%s.track" % (APPSEC.CUSTOM_EVENT_PREFIX, event)) == "true"
+
+    def test_set_user_blocked(self):
+        tracer = self._tracer_appsec
+        with override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+            tracer.configure(api_version="v0.4")
+            with tracer.trace("fake_span", span_type=SpanTypes.WEB) as span:
+                set_user(
+                    self.tracer,
+                    user_id=self._BLOCKED_USER,
+                    email="usr.email",
+                    name="usr.name",
+                    session_id="usr.session_id",
+                    role="usr.role",
+                    scope="usr.scope",
+                )
+                assert span.get_tag(user.ID)
+                assert span.get_tag(user.EMAIL)
+                assert span.get_tag(user.SESSION_ID)
+                assert span.get_tag(user.NAME)
+                assert span.get_tag(user.ROLE)
+                assert span.get_tag(user.SCOPE)
+                assert span.get_tag(user.SESSION_ID)
+                assert _context.get_item("http.request.blocked", span=span)


### PR DESCRIPTION
Backport to 1.10

The `track_custom_event()` function was not setting the `appsec.events.<event name>.track` tag, which is required for the event tracking SDK. This PR fixes this.

Signed-off-by: Juanjo Alvarez <juanjo.alvarezmartinez@datadoghq.com>
(cherry picked from commit aced65eef11e85eb8cc745b84125710c90cdac9d)

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
