### PR TITLE
fix(writer): truncate very large strings before writing

### DIFF
--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -244,6 +244,9 @@ cdef class MsgpackStringTable(StringTable):
     cdef insert(self, object string):
         cdef int ret
 
+        if len(string) > self.max_size:
+            string = string[:10] + "<truncated in ddtrace.internal._encoding.pyx due to buffer overrun"
+
         if self.pk.length + len(string) > self.max_size:
             raise ValueError(
                 "Cannot insert '%s': string table is full (current size: %d, max size: %d)." % (

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -192,6 +192,20 @@ def test_payload_too_large(encoding, monkeypatch):
         log.error.assert_not_called()
 
 
+@pytest.mark.skipif(AGENT_VERSION == "testagent", reason="FIXME: Test agent doesn't support this for some reason.")
+def test_resource_name_too_large(monkeypatch):
+    SIZE = 1 << 12  # 4KB
+    monkeypatch.setenv("DD_TRACE_API_VERSION", "v0.5")
+    monkeypatch.setenv("DD_TRACE_WRITER_BUFFER_SIZE_BYTES", str(SIZE))
+
+    t = Tracer()
+    assert t._writer._buffer_size == SIZE
+    s = t.trace("operation", service="foo")
+    s.resource = "B" * (SIZE + 1)
+    with pytest.raises(ValueError):
+        s.finish()
+
+
 @allencodings
 def test_large_payload(encoding, monkeypatch):
     monkeypatch.setenv("DD_TRACE_API_VERSION", encoding)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -202,8 +202,10 @@ def test_resource_name_too_large(monkeypatch):
     assert t._writer._buffer_size == SIZE
     s = t.trace("operation", service="foo")
     s.resource = "B" * (SIZE + 1)
-    with pytest.raises(ValueError):
+    try:
         s.finish()
+    except ValueError:
+        pytest.fail()
 
 
 @allencodings


### PR DESCRIPTION
This change suggests a fix for https://github.com/DataDog/dd-trace-py/issues/4945 that handles very large span attribute strings in the `AgentWriter` encoder by truncating them. This causes information to be lost (in the issue example, most of the SQL query), but in return it makes the `AgentWriter` resilient to integrations that may include very long strings like SQL queries in their span attributes.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
