### PR TITLE
fix(telemetry): call platform.platform once on import and save the result

### DIFF
--- a/ddtrace/internal/telemetry/data.py
+++ b/ddtrace/internal/telemetry/data.py
@@ -9,13 +9,14 @@ from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.internal.packages import get_distributions
 from ddtrace.internal.runtime.container import get_container_info
 from ddtrace.internal.utils.cache import cached
+from ddtrace.internal.utils.cache import callonce
 
 from ...settings import _config as config
 from ...version import get_version
 from ..hostname import get_hostname
 
 
-_platform = platform.platform(aliased=True, terse=True)
+_platform = callonce(lambda: platform.platform(aliased=True, terse=True))()
 
 
 def _format_version_info(vi):

--- a/ddtrace/internal/telemetry/data.py
+++ b/ddtrace/internal/telemetry/data.py
@@ -15,6 +15,9 @@ from ...version import get_version
 from ..hostname import get_hostname
 
 
+_platform = platform.platform(aliased=True, terse=True)
+
+
 def _format_version_info(vi):
     # type: (sys._version_info) -> str
     """Converts sys.version_info into a string with the format x.x.x"""
@@ -110,7 +113,7 @@ def get_host_info():
     global _host_info
     if _host_info is None:
         _host_info = {
-            "os": platform.platform(aliased=True, terse=True),
+            "os": _platform,
             "hostname": get_hostname(),
             "os_version": _get_os_version(),
             "kernel_name": platform.system(),


### PR DESCRIPTION
This change avoids conflicts between different copies of the platform module when gevent monkeypatching is active.

Fixes https://github.com/DataDog/dd-trace-py/issues/5337

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
