### PR TITLE
fix(falcon): remove reference to github issue

### DIFF
--- a/ddtrace/contrib/falcon/middleware.py
+++ b/ddtrace/contrib/falcon/middleware.py
@@ -60,9 +60,9 @@ class TraceMiddleware(object):
 
         status = resp.status.partition(" ")[0]
 
-        # FIXME[matt] falcon does not map errors or unmatched routes
+        # falcon does not map errors or unmatched routes
         # to proper status codes, so we we have to try to infer them
-        # here. See https://github.com/falconry/falcon/issues/606
+        # here.
         if resource is None:
             status = "404"
             span.resource = "%s 404" % req.method

--- a/ddtrace/contrib/falcon/middleware.py
+++ b/ddtrace/contrib/falcon/middleware.py
@@ -61,7 +61,7 @@ class TraceMiddleware(object):
         status = resp.status.partition(" ")[0]
 
         # falcon does not map errors or unmatched routes
-        # to proper status codes, so we we have to try to infer them
+        # to proper status codes, so we have to try to infer them
         # here.
         if resource is None:
             status = "404"


### PR DESCRIPTION
The linked issue was resolved, but the bit of code the comment references cannot be removed without breaking existing behavior.

Resolves https://github.com/DataDog/dd-trace-py/issues/4660

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
