### PR TITLE
fix(celery): remove reference to github issue

### DIFF
--- a/ddtrace/contrib/celery/signals.py
+++ b/ddtrace/contrib/celery/signals.py
@@ -134,9 +134,7 @@ def trace_before_publish(*args, **kwargs):
         trace_headers = {}
         propagator.inject(span.context, trace_headers)
 
-        # This weirdness is due to yet another Celery bug concerning
-        # how headers get propagated in async flows
-        # https://github.com/celery/celery/issues/4875
+        # put distributed trace headers where celery will propagate them
         task_headers = kwargs.get("headers") or {}
         task_headers.setdefault("headers", {})
         task_headers["headers"].update(trace_headers)


### PR DESCRIPTION
The issue referenced was [resolved](https://github.com/celery/celery/pull/6374), but it actually does not apply to the bit of code it's pointing to.

Fixes https://github.com/DataDog/dd-trace-py/issues/4649

I tried removing the code referenced by the comment, and it causes the test `tests/contrib/celery/test_integration.py::CeleryDistributedTracingIntegrationTask::test_distributed_tracing_propagation_async` to fail. As far as I can tell from about an hour of investigation, the celery [fix](https://github.com/celery/celery/issues/4356) only affects "hybrid messages" (those that blend protocol 1 and 2 syntax as part of a rolling Celery upgrade), which our test suite doesn't use.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
