### PR TITLE
feat(asm): add timeout info to ddwaf result

### DIFF
--- a/ddtrace/appsec/ddwaf/__init__.py
+++ b/ddtrace/appsec/ddwaf/__init__.py
@@ -43,14 +43,15 @@ DEFAULT_DDWAF_TIMEOUT_MS = 2
 
 
 class DDWaf_result(object):
-    __slots__ = ["data", "actions", "runtime", "total_runtime"]
+    __slots__ = ["data", "actions", "runtime", "total_runtime", "timeout"]
 
-    def __init__(self, data, actions, runtime, total_runtime):
-        # type: (DDWaf_result, text_type|None, list[text_type], float, float) -> None
+    def __init__(self, data, actions, runtime, total_runtime, timeout):
+        # type: (DDWaf_result, text_type|None, list[text_type], float, float, bool) -> None
         self.data = data
         self.actions = actions
         self.runtime = runtime
         self.total_runtime = total_runtime
+        self.timeout = timeout
 
 
 class DDWaf_info(object):
@@ -137,18 +138,18 @@ if _DDWAF_LOADED:
             self,  # type: DDWaf
             ctx,  # type: ddwaf_context_capsule
             data,  # type: DDWafRulesType
-            timeout_ms=DEFAULT_DDWAF_TIMEOUT_MS,  # type:int
+            timeout_ms=DEFAULT_DDWAF_TIMEOUT_MS,  # type:float
         ):
             # type: (...) -> DDWaf_result
             start = time.time()
 
             if not ctx:
                 LOGGER.error("DDWaf.run: dry run. no context created.")
-                return DDWaf_result(None, [], 0, (time.time() - start) * 1e6)
+                return DDWaf_result(None, [], 0, (time.time() - start) * 1e6, False)
 
             result = ddwaf_result()
             wrapper = ddwaf_object(data)
-            error = ddwaf_run(ctx.ctx, wrapper, ctypes.byref(result), timeout_ms * 1000)
+            error = ddwaf_run(ctx.ctx, wrapper, ctypes.byref(result), int(timeout_ms * 1000))
             if error < 0:
                 LOGGER.warning("run DDWAF error: %d\ninput %s\nerror %s", error, wrapper.struct, self.info.errors)
             return DDWaf_result(
@@ -156,6 +157,7 @@ if _DDWAF_LOADED:
                 [result.actions.array[i].decode("UTF-8", errors="ignore") for i in range(result.actions.size)],
                 result.total_runtime / 1e3,
                 (time.time() - start) * 1e6,
+                result.timeout,
             )
 
     def version():
@@ -181,7 +183,7 @@ else:
         ):
             # type: (...) -> DDWaf_result
             LOGGER.warning("DDWaf features disabled. dry run")
-            return DDWaf_result(None, [], 0.0, 0.0)
+            return DDWaf_result(None, [], 0.0, 0.0, False)
 
         def update_rules(self, _):
             # type: (dict[text_type, DDWafRulesType]) -> bool

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -283,10 +283,9 @@ class AppSecSpanProcessor(SpanProcessor):
                 else:
                     log.debug("[action] WAF missing value %s", SPAN_DATA_NAMES[key])
 
-        log.debug("[DDAS-001-00] Executing ASM In-App WAF")
         waf_results = self._ddwaf.run(ctx, data, self._waf_timeout)
         if waf_results and waf_results.data:
-            log.debug("[DDAS-011-00] ASM In-App WAF returned: %s", waf_results.data)
+            log.debug("[DDAS-011-00] ASM In-App WAF returned: %s. Timeout %s", waf_results.data, waf_results.timeout)
 
         blocked = WAF_ACTIONS.BLOCK in waf_results.actions
         _asm_request_context.set_waf_results(waf_results, self._ddwaf.info, blocked)

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -482,6 +482,23 @@ def test_ddwaf_run():
         assert res.runtime > 0
         assert res.total_runtime > 0
         assert res.total_runtime > res.runtime
+        assert res.timeout is False
+
+
+def test_ddwaf_run_timeout():
+    with open(RULES_GOOD_PATH) as rules:
+        rules_json = json.loads(rules.read())
+        _ddwaf = DDWaf(rules_json, b"", b"")
+        data = {
+            "server.request.path_params": {"param_{}".format(i): "value_{}".format(i) for i in range(100)},
+            "server.request.cookies": {"attack{}".format(i): "1' or '1' = '{}'".format(i) for i in range(100)},
+        }
+        ctx = _ddwaf._at_request_start()
+        res = _ddwaf.run(ctx, data, 0.001)  # res is a serialized json
+        assert res.runtime > 0
+        assert res.total_runtime > 0
+        assert res.total_runtime > res.runtime
+        assert res.timeout is True
 
 
 def test_ddwaf_info():


### PR DESCRIPTION
Add timeout info to ddwaf result

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
