### PR TITLE
fix(iast): add hash and spanid values to Vulnerability

### DIFF
--- a/ddtrace/appsec/iast/reporter.py
+++ b/ddtrace/appsec/iast/reporter.py
@@ -21,7 +21,7 @@ class Vulnerability(object):
     evidence = attr.ib(type=Evidence)
     location = attr.ib(type=Location)
     span_id = attr.ib(type=int, eq=False, hash=False)
-    hash = attr.field(init=False, eq=False, hash=False)
+    hash = attr.ib(init=False, eq=False, hash=False)
 
     def __attrs_post_init__(self):
         self.hash = hash(self.type) ^ hash(self.evidence) ^ hash(self.location)

--- a/ddtrace/appsec/iast/reporter.py
+++ b/ddtrace/appsec/iast/reporter.py
@@ -33,16 +33,16 @@ class Vulnerability(object):
     evidence = attr.ib(type=Evidence)
     location = attr.ib(type=Location)
     span_id = attr.ib(type=int)
-    hash = attr.field(init=False)
+
+    @property
+    def hash(self):
+        return hash(self)
 
     def __eq__(self, other):
         return self.type == other.type and self.evidence == other.evidence and self.location == other.location
 
     def __hash__(self):
         return hash(self.type) ^ hash(self.evidence) ^ hash(self.location)
-
-    def __attrs_post_init__(self):
-        self.hash = hash(self)
 
 
 @attr.s(eq=False)

--- a/ddtrace/appsec/iast/reporter.py
+++ b/ddtrace/appsec/iast/reporter.py
@@ -3,59 +3,35 @@ from typing import Set
 import attr
 
 
-@attr.s(eq=False)
+@attr.s(eq=True, hash=True)
 class Evidence(object):
     type = attr.ib(type=str)
     value = attr.ib(type=str, default="")
 
-    def __eq__(self, other):
-        return self.type == other.type and self.value == other.value
 
-    def __hash__(self):
-        return hash(self.type) ^ hash(self.value)
-
-
-@attr.s(eq=False)
+@attr.s(eq=True, hash=True)
 class Location(object):
     path = attr.ib(type=str)
     line = attr.ib(type=int)
 
-    def __eq__(self, other):
-        return self.path == other.path and self.line == other.line
 
-    def __hash__(self):
-        return hash(self.path) ^ hash(self.line)
-
-
-@attr.s(eq=False)
+@attr.s(eq=True, hash=True)
 class Vulnerability(object):
     type = attr.ib(type=str)
     evidence = attr.ib(type=Evidence)
     location = attr.ib(type=Location)
-    span_id = attr.ib(type=int)
+    span_id = attr.ib(type=int, eq=False, hash=False)
+    hash = attr.field(init=False, eq=False, hash=False)
 
-    @property
-    def hash(self):
-        return hash(self)
-
-    def __eq__(self, other):
-        return self.type == other.type and self.evidence == other.evidence and self.location == other.location
-
-    def __hash__(self):
-        return hash(self.type) ^ hash(self.evidence) ^ hash(self.location)
+    def __attrs_post_init__(self):
+        self.hash = hash(self.type) ^ hash(self.evidence) ^ hash(self.location)
 
 
-@attr.s(eq=False)
+@attr.s(eq=True, hash=True)
 class Source(object):
     origin = attr.ib(type=str)
     name = attr.ib(type=str)
     value = attr.ib(type=str)
-
-    def __eq__(self, other):
-        return self.origin == other.origin and self.name == other.name and self.value == other.value
-
-    def __hash__(self):
-        return hash(self.origin) ^ hash(self.name) ^ hash(self.value)
 
 
 @attr.s(eq=False)

--- a/ddtrace/appsec/iast/reporter.py
+++ b/ddtrace/appsec/iast/reporter.py
@@ -8,11 +8,23 @@ class Evidence(object):
     type = attr.ib(type=str)
     value = attr.ib(type=str, default="")
 
+    def __eq__(self, other):
+        return self.type == other.type and self.value == other.value
+
+    def __hash__(self):
+        return hash(self.type) ^ hash(self.value)
+
 
 @attr.s(eq=False)
 class Location(object):
     path = attr.ib(type=str)
     line = attr.ib(type=int)
+
+    def __eq__(self, other):
+        return self.path == other.path and self.line == other.line
+
+    def __hash__(self):
+        return hash(self.path) ^ hash(self.line)
 
 
 @attr.s(eq=False)
@@ -20,6 +32,17 @@ class Vulnerability(object):
     type = attr.ib(type=str)
     evidence = attr.ib(type=Evidence)
     location = attr.ib(type=Location)
+    span_id = attr.ib(type=int)
+    hash = attr.field(init=False)
+
+    def __eq__(self, other):
+        return self.type == other.type and self.evidence == other.evidence and self.location == other.location
+
+    def __hash__(self):
+        return hash(self.type) ^ hash(self.evidence) ^ hash(self.location)
+
+    def __attrs_post_init__(self):
+        self.hash = hash(self)
 
 
 @attr.s(eq=False)
@@ -27,6 +50,12 @@ class Source(object):
     origin = attr.ib(type=str)
     name = attr.ib(type=str)
     value = attr.ib(type=str)
+
+    def __eq__(self, other):
+        return self.origin == other.origin and self.name == other.name and self.value == other.value
+
+    def __hash__(self):
+        return hash(self.origin) ^ hash(self.name) ^ hash(self.value)
 
 
 @attr.s(eq=False)

--- a/ddtrace/appsec/iast/taint_sinks/_base.py
+++ b/ddtrace/appsec/iast/taint_sinks/_base.py
@@ -71,6 +71,7 @@ class VulnerabilityBase(Operation):
                                 type=cls.vulnerability_type,
                                 evidence=Evidence(type=cls.evidence_type, value=evidence_value),
                                 location=Location(path=file_name, line=line_number),
+                                span_id=span.span_id,
                             )
                         )
 
@@ -81,6 +82,7 @@ class VulnerabilityBase(Operation):
                                     type=cls.vulnerability_type,
                                     evidence=Evidence(type=cls.evidence_type, value=evidence_value),
                                     location=Location(path=file_name, line=line_number),
+                                    span_id=span.span_id,
                                 )
                             }
                         )

--- a/tests/appsec/iast/test_reporter.py
+++ b/tests/appsec/iast/test_reporter.py
@@ -54,9 +54,6 @@ def test_vulnerability_hash_and_equality():
     _do_assert_hash(e, f, g, e2)
     _do_assert_equality(e, f, g, e2)
 
-    e2.type = "AnotherType"
-    assert e.hash != e2.hash
-
 
 def test_source_hash_and_equality():
     e = Source(origin="SomeOrigin", name="SomeName", value="SomeValue")

--- a/tests/appsec/iast/test_reporter.py
+++ b/tests/appsec/iast/test_reporter.py
@@ -54,6 +54,9 @@ def test_vulnerability_hash_and_equality():
     _do_assert_hash(e, f, g, e2)
     _do_assert_equality(e, f, g, e2)
 
+    e2.type = "AnotherType"
+    assert e.hash != e2.hash
+
 
 def test_source_hash_and_equality():
     e = Source(origin="SomeOrigin", name="SomeName", value="SomeValue")

--- a/tests/appsec/iast/test_reporter.py
+++ b/tests/appsec/iast/test_reporter.py
@@ -1,0 +1,65 @@
+from ddtrace.appsec.iast.reporter import Evidence
+from ddtrace.appsec.iast.reporter import Location
+from ddtrace.appsec.iast.reporter import Source
+from ddtrace.appsec.iast.reporter import Vulnerability
+
+
+# e and e2 must be logically equal, f and g not equal to e
+
+
+def _do_assert_hash(e, f, g, e2):
+    assert hash(e) == hash(e2)
+    assert hash(e) != hash(f) and hash(f) != hash(g) and hash(g) != hash(e)
+
+
+def _do_assert_equality(e, f, g, e2):
+    assert e == e2
+    assert e != f and f != g and g != e
+
+
+def test_evidence_hash_and_equality():
+    e = Evidence(type="SomeEvidenceType", value="SomeEvidenceValue")
+    f = Evidence(type="SomeOtherEvidenceType", value="SomeEvidenceValue")
+    g = Evidence(type="SomeEvidenceType", value="SomeOtherEvidenceValue")
+    e2 = Evidence(type="SomeEvidenceType", value="SomeEvidenceValue")
+
+    _do_assert_hash(e, f, g, e2)
+    _do_assert_equality(e, f, g, e2)
+
+
+def test_location_hash_and_equality():
+    e = Location(path="foobar.py", line=35)
+    f = Location(path="foobar2.py", line=35)
+    g = Location(path="foobar.py", line=36)
+    e2 = Location(path="foobar.py", line=35)
+
+    _do_assert_hash(e, f, g, e2)
+    _do_assert_equality(e, f, g, e2)
+
+
+def test_vulnerability_hash_and_equality():
+    ev1 = Evidence(type="SomeEvidenceType", value="SomeEvidenceValue")
+    ev1bis = Evidence(type="SomeEvidenceType", value="SomeEvidenceValue")
+    ev2 = Evidence(type="SomeOtherEvidenceType", value="SomeEvidenceValue")
+
+    loc = Location(path="foobar.py", line=35)
+
+    e = Vulnerability(type="VulnerabilityType", evidence=ev1, location=loc, span_id=123)
+    f = Vulnerability(type="VulnerabilityType", evidence=ev2, location=loc, span_id=123)
+    g = Vulnerability(type="OtherVulnerabilityType", evidence=ev1, location=loc, span_id=123)
+    e2 = Vulnerability(type="VulnerabilityType", evidence=ev1bis, location=loc, span_id=123)
+
+    assert e.hash
+
+    _do_assert_hash(e, f, g, e2)
+    _do_assert_equality(e, f, g, e2)
+
+
+def test_source_hash_and_equality():
+    e = Source(origin="SomeOrigin", name="SomeName", value="SomeValue")
+    f = Source(origin="SomeOtherOrigin", name="SomeName", value="SomeValue")
+    g = Source(origin="SomeOrigin", name="SomeOtherName", value="SomeValue")
+    e2 = Source(origin="SomeOrigin", name="SomeName", value="SomeValue")
+
+    _do_assert_hash(e, f, g, e2)
+    _do_assert_equality(e, f, g, e2)


### PR DESCRIPTION
Adds the `hash` and `vulnerability` values to the Vulnerability objects. Also add `__hash__` and `__eq__` to the other objects in the module to ensure comparisons are correct and we can generate hashes from them (e.g. to use as part of hashes of other objects).

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
