### PR TITLE
feat(celery): instrument tick and maybe_due in redbeat.RedBeatScheduler

### DIFF
--- a/ddtrace/contrib/celery/app.py
+++ b/ddtrace/contrib/celery/app.py
@@ -51,7 +51,7 @@ def patch_app(app, pin=None):
     if redbeat:
         scheduler_module_name = "redbeat.schedulers"
         trace_utils.wrap(
-            "redbeat.schedulers",
+            scheduler_module_name,
             "RedBeatScheduler.maybe_due",
             _traced_beat_function(
                 config.celery,
@@ -61,7 +61,7 @@ def patch_app(app, pin=None):
             ),
         )
         trace_utils.wrap(
-            "redbeat.schedulers",
+            scheduler_module_name,
             "RedBeatScheduler.tick",
             _traced_beat_function(
                 config.celery,

--- a/releasenotes/notes/celery-redbeat-a3b6b7a6131c33d3.yaml
+++ b/releasenotes/notes/celery-redbeat-a3b6b7a6131c33d3.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    tracing: This introduces automatic instrumentation for the celery-redbeat celery task scheduler.


### PR DESCRIPTION
This pull requests adds automatic instrumentation for https://github.com/sibson/redbeat, an alternate implementation of `celery.beat`. There are no tests included for two reasons: the redbeat tracing logic is identical to the celery.beat logic aside from the function and class names, and redbeat does not have an `EmbeddedService` that allows collecting traces within a single test process.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
