### PR TITLE
fix(propagataion): handle whitespace in W3C tracecontext [backport #5351 to 1.9]

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1,6 +1,7 @@
 import re
 from typing import Dict
 from typing import FrozenSet
+from typing import List
 from typing import Optional
 from typing import Text
 from typing import Tuple
@@ -611,12 +612,13 @@ class _TraceContext:
         return trace_id, span_id, sampling_priority
 
     @staticmethod
-    def _get_tracestate_values(ts):
-        # type: (str) -> Tuple[Optional[int], Dict[str, str], Optional[str]]
+    def _get_tracestate_values(ts_l):
+        # type: (List[str]) -> Tuple[Optional[int], Dict[str, str], Optional[str]]
 
-        # tracestate parsing, example: dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE
+        # tracestate list parsing example: ["dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64","congo=t61rcWkgMzE"]
+        # -> 2, {"_dd.p.dm":"-4","_dd.p.usr.id":"baz64"}, "rum"
+
         dd = None
-        ts_l = ts.strip().split(",")
         for list_mem in ts_l:
             if list_mem.startswith("dd="):
                 # cut out dd= before turning into dict
@@ -686,7 +688,12 @@ class _TraceContext:
         meta = {W3C_TRACEPARENT_KEY: tp}  # type: _MetaDictType
 
         ts = _extract_header_value(_POSSIBLE_HTTP_HEADER_TRACESTATE, headers)
+
         if ts:
+            # whitespace is allowed, but whitespace to start or end values should be trimmed
+            # e.g. "foo=1 \t , \t bar=2, \t baz=3" -> "foo=1,bar=2,baz=3"
+            ts_l = [member.strip() for member in ts.split(",")]
+            ts = ",".join(ts_l)
             # the value MUST contain only ASCII characters in the
             # range of 0x20 to 0x7E
             if re.search(r"[^\x20-\x7E]+", ts):
@@ -695,7 +702,7 @@ class _TraceContext:
                 # store tracestate so we keep other vendor data for injection, even if dd ends up being invalid
                 meta[W3C_TRACESTATE_KEY] = ts
                 try:
-                    tracestate_values = _TraceContext._get_tracestate_values(ts)
+                    tracestate_values = _TraceContext._get_tracestate_values(ts_l)
                 except (TypeError, ValueError):
                     log.debug("received invalid dd header value in tracestate: %r ", ts)
                     tracestate_values = None

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -180,6 +180,7 @@ submodule
 submodules
 substring
 timestamp
+tracestate
 tweens
 uWSGI
 unbuffered
@@ -199,6 +200,7 @@ versioned
 vertica
 w3c
 whitelist
+whitespace
 workflow
 wsgi
 xfail

--- a/releasenotes/notes/fix-remove-w3c-tracecontext-whitespace-76e3940e11de1745.yaml
+++ b/releasenotes/notes/fix-remove-w3c-tracecontext-whitespace-76e3940e11de1745.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    propagation: This fix resolves an issue where previously W3C tracestate propagation could not handle whitespace.
+    With this fix whitespace is now removed for incoming and outgoing requests.

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -705,10 +705,10 @@ def test_extract_tracestate(caplog, ts_string, expected_tuple, expected_logging,
     with caplog.at_level(logging.DEBUG):
         if expected_exception:
             with pytest.raises(expected_exception):
-                tracestate_values = _TraceContext._get_tracestate_values(ts_string)
+                tracestate_values = _TraceContext._get_tracestate_values(ts_string.split(","))
                 assert tracestate_values == expected_tuple
         else:
-            tracestate_values = _TraceContext._get_tracestate_values(ts_string)
+            tracestate_values = _TraceContext._get_tracestate_values(ts_string.split(","))
             assert tracestate_values == expected_tuple
             if caplog.text or expected_logging:
                 for expected_log in expected_logging:


### PR DESCRIPTION
Backport of #5351 to 1.9

Previously we were failing system-test `test_tracestate_ows_handling` https://github.com/DataDog/system-tests/blob/main/parametric/test_headers_tracecontext.py#L757-L835

This is because whitespace is allowed in tracecontext and we previously did not account for it. With this change we assure that we deal with whitespace by cutting it out and also ensure we do not send whitespace in our headers.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
