### PR TITLE
fix(debugging): continue after first function probe failure

### DIFF
--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -525,7 +525,7 @@ class Debugger(Service):
                 )
                 self._probe_registry.set_error(probe, message)
                 log.error(message)
-                return
+                continue
 
             if hasattr(function, "__dd_wrappers__"):
                 # TODO: Check if this can be made into a set instead

--- a/releasenotes/notes/fix-debugger-continue-wrapping-07c38a6e7dbe497f.yaml
+++ b/releasenotes/notes/fix-debugger-continue-wrapping-07c38a6e7dbe497f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: Fix a bug where the dynamic instrumentation would
+    stop injecting function probes after the first failed one.

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -1057,3 +1057,24 @@ class SpanProbeTestCase(TracerTestCase):
             assert span.name == "child"
 
             assert span.parent_id is root.span_id
+
+
+def test_debugger_continue_wrapping_after_first_failure():
+    with debugger() as d:
+        probe_nok = create_snapshot_function_probe(
+            probe_id="function-probe-nok",
+            module="tests.submod.stuff",
+            func_qname="nonsense",
+        )
+        probe_ok = create_snapshot_function_probe(
+            probe_id="function-probe-ok",
+            module="tests.submod.stuff",
+            func_qname="Stuff.instancestuff",
+        )
+        d.add_probes(probe_nok, probe_ok)
+
+        assert probe_nok in d._probe_registry
+        assert probe_ok in d._probe_registry
+
+        assert not d._probe_registry[probe_nok.probe_id].installed
+        assert d._probe_registry[probe_ok.probe_id].installed


### PR DESCRIPTION
This change ensures that dynamic instrumentation can continue injecting function probes on a given module after the first failure.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
