### PR TITLE
feat: add wrap_generator function

### DIFF
--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -127,6 +127,27 @@ class TracerTestCases(TracerTestCase):
             meta=dict(a="b"),
         )
 
+    def test_tracer_wrap_generator(self):
+        @self.tracer.wrap_generator("decorated_generator", service="s", resource="r", span_type="t")
+        def f(tag_name, tag_value):
+            # make sure we can still set tags
+            span = self.tracer.current_span()
+            span.set_tag(tag_name, tag_value)
+            yield 1
+
+        result = list(f("a", "b"))
+        assert result == [1]
+
+        self.assert_span_count(1)
+        span = self.get_root_span()
+        span.assert_matches(
+            name="decorated_generator",
+            service="s",
+            resource="r",
+            span_type="t",
+            meta=dict(a="b"),
+        )
+
     def test_tracer_pid(self):
         with self.trace("root") as root_span:
             with self.trace("child") as child_span:


### PR DESCRIPTION
Draft PR to start a discussion for how to solve: https://github.com/DataDog/dd-trace-py/issues/5403

right now the code is copy and pasted and tweaked accordingly to allow this to work. The aim is to gain early feedback about whether this approach is acceptable.

Once we have concluded that we are happy with a separate `wrap_generator` to handle the case for generators I can start working to try reduce the amount of repeated code between `wrap` and `wrap_generator`

## What is the problem?

I dont think its possible to get `wrap` to work with both functions and generators. The reason is that once a `yield` is used within `wrap()`, python considers it a generator and as a result would stop working with standard functions.

This PR aims to solve this issue by suggesting we have an alternative, `wrap_generator` function instead.

## How was this tested?

I've tested this code locally using the following script:

```python
from ddtrace import tracer


@tracer.wrap()
def foobar():
    current_span = tracer.current_span()
    current_span.set_tag("hello", "world")
    return [1]

@tracer.wrap_generator()
def bazbang():
    current_span = tracer.current_span()
    current_span.set_tag("hello", "world")
    yield 1


def main():
    print(foobar())
    print(list(bazbang()))


if __name__ == "__main__":
    main()
```

Which gives the output:

```
[1]
[1]
```

Compared to current `1.x` with both using `wrap`:

```
[1]
Traceback (most recent call last):
  File "/home/michael/Development/OSS/dd-trace-py-test/test.py", line 23, in <module>
    main()
  File "/home/michael/Development/OSS/dd-trace-py-test/test.py", line 19, in main
    print(list(bazbang()))
  File "/home/michael/Development/OSS/dd-trace-py-test/test.py", line 13, in bazbang
    current_span.set_tag("hello", "world")
AttributeError: 'NoneType' object has no attribute 'set_tag'
```

The checklist below is not completely filled in yet because this is still a PR for some early feedback before committing to the approach.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
