### PR TITLE
chore(docs): readme.md and contributing doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ See [the contributing docs](https://ddtrace.readthedocs.io/en/stable/contributin
 
 ### Pre-commit Hooks
 
+**NOTE**: If pre-commit hooks fail to run in your development environment, you can uninstall them by deleting the symlink created by the installation script:
+
+    $ rm .git/hooks/pre-commit
 The tracer library uses formatting/linting tools including black, flake8, and mypy.
 While these are run in each CI pipeline for pull requests, they are automated to run
 when you call `git commit` as pre-commit hooks to catch any formatting errors before

--- a/docs/contributing-integrations.rst
+++ b/docs/contributing-integrations.rst
@@ -29,7 +29,7 @@ The development process looks like this:
   - Write the integration (see more on this below).
 
   - Open up a draft PR using the `integration checklist
-    <https://github.com/DataDog/dd-trace-py/.github/PULL_REQUEST_TEMPLATE/integration.md>`_.
+    <https://github.com/DataDog/dd-trace-py/blob/1.x/.github/PULL_REQUEST_TEMPLATE.md>`_.
 
 
 Integration Fundamentals


### PR DESCRIPTION
This commit contains two small changes to documentation:

1. Adds a WARNING message for installing git pre-commit hooks and instructions on how to uninstall.
2. Updates the link to the integration checklist template in the contributing to integrations document

Testing Strategy: N/A
Risks: None

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
