### PR TITLE
chore(service name): initial schema for span attributes (service name)

### DIFF
--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -4,6 +4,7 @@ from six import PY3
 from ddtrace import config
 from ddtrace.vendor import wrapt
 
+from ...internal.schema import schematize_service_name
 from ...internal.utils.formats import stringify_cache_args
 from ...pin import Pin
 from ..trace_utils import unwrap
@@ -11,7 +12,12 @@ from .util import _trace_redis_cmd
 from .util import _trace_redis_execute_pipeline
 
 
-config._add("redis", dict(_default_service="redis"))
+config._add(
+    "redis",
+    {
+        "_default_service": schematize_service_name("redis"),
+    },
+)
 
 
 def patch():

--- a/ddtrace/internal/schema/__init__.py
+++ b/ddtrace/internal/schema/__init__.py
@@ -1,0 +1,24 @@
+import os
+
+from .span_attribute_schema import SPAN_ATTRIBUTE_SCHEMA_VERSIONS
+from .span_attribute_schema import _DEFAULT_SPAN_SERVICE_NAMES
+
+
+# Span attribute schema
+def _validate_schema(version):
+    error_message = (
+        "You have specified an invalid span attribute schema version: '{}'.".format(__schema_version),
+        "Valid options are: {}. You can change the specified value by updating".format(SPAN_ATTRIBUTE_SCHEMA_VERSIONS),
+        "the value exported in the 'DD_TRACE_SPAN_ATTRIBUTE_SCHEMA' environment variable.",
+    )
+
+    assert version in SPAN_ATTRIBUTE_SCHEMA_VERSIONS, error_message
+
+
+__schema_version = os.getenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", default="v0")
+_validate_schema(__schema_version)
+
+DEFAULT_SPAN_SERVICE_NAME = _DEFAULT_SPAN_SERVICE_NAMES[__schema_version]
+schematize_service_name = SPAN_ATTRIBUTE_SCHEMA_VERSIONS.get(__schema_version)
+
+__all__ = ["schematize_service_name", "DEFAULT_SPAN_SERVICE_NAME"]

--- a/ddtrace/internal/schema/span_attribute_schema.py
+++ b/ddtrace/internal/schema/span_attribute_schema.py
@@ -1,0 +1,23 @@
+SPAN_ATTRIBUTE_SCHEMA_VERSIONS = dict()
+
+_DEFAULT_SPAN_SERVICE_NAMES = {"v0": None, "v1": "unnamed-python-service"}
+
+
+def register_schema_version(version):
+    def _wrap(func):
+        assert version not in SPAN_ATTRIBUTE_SCHEMA_VERSIONS, "duplicate version entry for {}".format(version)
+        SPAN_ATTRIBUTE_SCHEMA_VERSIONS[version] = func
+
+    return _wrap
+
+
+@register_schema_version("v0")
+def service_name_v0(v0_service_name):
+    return v0_service_name
+
+
+@register_schema_version("v1")
+def service_name_v1(*_, **__):
+    from ddtrace import config as dd_config
+
+    return dd_config.service

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -17,6 +17,7 @@ from ..internal.constants import PROPAGATION_STYLE_ALL
 from ..internal.constants import PROPAGATION_STYLE_B3
 from ..internal.constants import _PROPAGATION_STYLE_DEFAULT
 from ..internal.logger import get_logger
+from ..internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ..internal.utils.formats import asbool
 from ..internal.utils.formats import parse_tags_str
 from ..pin import Pin
@@ -204,7 +205,7 @@ class Config(object):
         self.tags = gitmetadata.clean_tags(parse_tags_str(os.getenv("DD_TAGS") or ""))
 
         self.env = os.getenv("DD_ENV") or self.tags.get("env")
-        self.service = os.getenv("DD_SERVICE", default=self.tags.get("service"))
+        self.service = os.getenv("DD_SERVICE", default=self.tags.get("service", DEFAULT_SPAN_SERVICE_NAME))
         self.version = os.getenv("DD_VERSION", default=self.tags.get("version"))
         self.http_server = self._HTTPServerConfig()
 

--- a/tests/contrib/redis/test_redis.py
+++ b/tests/contrib/redis/test_redis.py
@@ -60,6 +60,14 @@ class TestRedisPatch(TracerTestCase):
         assert span.get_tag("span.kind") == "client"
         assert span.get_tag("db.system") == "redis"
 
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_service_name_v1(self):
+        us = self.r.get("cheese")
+        assert us is None
+        spans = self.get_spans()
+        span = spans[0]
+        assert span.service == "unnamed-python-service"
+
     def test_basics(self):
         us = self.r.get("cheese")
         assert us is None
@@ -226,7 +234,7 @@ class TestRedisPatch(TracerTestCase):
         assert dd_span.resource == "GET cheese"
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_service(self):
+    def test_user_specified_service_default(self):
         from ddtrace import config
 
         assert config.service == "mysvc"
@@ -235,8 +243,30 @@ class TestRedisPatch(TracerTestCase):
         span = self.get_spans()[0]
         assert span.service == "redis"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_REDIS_SERVICE="myredis"))
-    def test_env_user_specified_redis_service(self):
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_user_specified_service_v0(self):
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
+        self.r.get("cheese")
+        span = self.get_spans()[0]
+        assert span.service == "redis"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_user_specified_service_v1(self):
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
+        self.r.get("cheese")
+        span = self.get_spans()[0]
+        assert span.service == "mysvc"
+
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_REDIS_SERVICE="myredis", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0")
+    )
+    def test_env_user_specified_redis_service_v0(self):
         self.r.get("cheese")
         span = self.get_spans()[0]
         assert span.service == "myredis", span.service
@@ -245,9 +275,6 @@ class TestRedisPatch(TracerTestCase):
 
         # Global config
         with self.override_config("redis", dict(service="cfg-redis")):
-            from ddtrace import config
-
-            print(config.redis.service)
             self.r.get("cheese")
             span = self.get_spans()[0]
             assert span.service == "cfg-redis", span.service
@@ -260,8 +287,50 @@ class TestRedisPatch(TracerTestCase):
         span = self.get_spans()[0]
         assert span.service == "mysvc", span.service
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="app-svc", DD_REDIS_SERVICE="env-redis"))
-    def test_service_precedence(self):
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_REDIS_SERVICE="myredis", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1")
+    )
+    def test_env_user_specified_redis_service_v1(self):
+        self.r.get("cheese")
+        span = self.get_spans()[0]
+        assert span.service == "myredis", span.service
+
+        self.reset()
+
+        # Global config
+        with self.override_config("redis", dict(service="cfg-redis")):
+            self.r.get("cheese")
+            span = self.get_spans()[0]
+            assert span.service == "cfg-redis", span.service
+
+        self.reset()
+
+        # Manual override
+        Pin.override(self.r, service="mysvc", tracer=self.tracer)
+        self.r.get("cheese")
+        span = self.get_spans()[0]
+        assert span.service == "mysvc", span.service
+
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_SERVICE="app-svc", DD_REDIS_SERVICE="env-redis", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0")
+    )
+    def test_service_precedence_v0(self):
+        self.r.get("cheese")
+        span = self.get_spans()[0]
+        assert span.service == "env-redis", span.service
+
+        self.reset()
+
+        # Do a manual override
+        Pin.override(self.r, service="override-redis", tracer=self.tracer)
+        self.r.get("cheese")
+        span = self.get_spans()[0]
+        assert span.service == "override-redis", span.service
+
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_SERVICE="app-svc", DD_REDIS_SERVICE="env-redis", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1")
+    )
+    def test_service_precedence_v1(self):
         self.r.get("cheese")
         span = self.get_spans()[0]
         assert span.service == "env-redis", span.service

--- a/tests/contrib/redis/test_redis.py
+++ b/tests/contrib/redis/test_redis.py
@@ -312,7 +312,9 @@ class TestRedisPatch(TracerTestCase):
         assert span.service == "mysvc", span.service
 
     @TracerTestCase.run_in_subprocess(
-        env_overrides=dict(DD_SERVICE="app-svc", DD_REDIS_SERVICE="env-specified-redis-svc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0")
+        env_overrides=dict(
+            DD_SERVICE="app-svc", DD_REDIS_SERVICE="env-specified-redis-svc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"
+        )
     )
     def test_service_precedence_v0(self):
         self.r.get("cheese")
@@ -328,7 +330,9 @@ class TestRedisPatch(TracerTestCase):
         assert span.service == "override-redis", span.service
 
     @TracerTestCase.run_in_subprocess(
-        env_overrides=dict(DD_SERVICE="app-svc", DD_REDIS_SERVICE="env-specified-redis-svc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1")
+        env_overrides=dict(
+            DD_SERVICE="app-svc", DD_REDIS_SERVICE="env-specified-redis-svc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"
+        )
     )
     def test_service_precedence_v1(self):
         self.r.get("cheese")

--- a/tests/contrib/redis/test_redis.py
+++ b/tests/contrib/redis/test_redis.py
@@ -312,12 +312,12 @@ class TestRedisPatch(TracerTestCase):
         assert span.service == "mysvc", span.service
 
     @TracerTestCase.run_in_subprocess(
-        env_overrides=dict(DD_SERVICE="app-svc", DD_REDIS_SERVICE="env-redis", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0")
+        env_overrides=dict(DD_SERVICE="app-svc", DD_REDIS_SERVICE="env-specified-redis-svc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0")
     )
     def test_service_precedence_v0(self):
         self.r.get("cheese")
         span = self.get_spans()[0]
-        assert span.service == "env-redis", span.service
+        assert span.service == "env-specified-redis-svc", span.service
 
         self.reset()
 
@@ -328,12 +328,12 @@ class TestRedisPatch(TracerTestCase):
         assert span.service == "override-redis", span.service
 
     @TracerTestCase.run_in_subprocess(
-        env_overrides=dict(DD_SERVICE="app-svc", DD_REDIS_SERVICE="env-redis", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1")
+        env_overrides=dict(DD_SERVICE="app-svc", DD_REDIS_SERVICE="env-specified-redis-svc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1")
     )
     def test_service_precedence_v1(self):
         self.r.get("cheese")
         span = self.get_spans()[0]
-        assert span.service == "env-redis", span.service
+        assert span.service == "env-specified-redis-svc", span.service
 
         self.reset()
 


### PR DESCRIPTION
### Special Note

This is the first of several changes dealing with service naming, gated behind a feature flag.  A future (feat) request will be made when the changes for service naming AND peer.service are complete.

### Introduction

Span service names are the wild west today, both within and across tracers, which has led to a variety of issues:

1. Lack of consistency in naming across tracer libraries in different languages (grpc-client vs grpc.client).
2. Inconsistency with operation names across integrations, even within a tracer. (requests vs httplib)
3. Too-generic service names act as naming 'sinks' (i.e. all databases for 'postgres' are represented as 'postgres')
4. Some clients (i.e. grpc) are represented as full-on services, which is generally unexpected.

The above issues occur because DataDog's features (such as metrics and flame-graphs) require tracer libraries to delineate between services appropriately, and the existing mechanism for doing so was specifying a separate service within an application (either manually or by integration default).  This issue is further compounded by a lack of standardization across DataDog's libraries and selection of some too-board fakes and defaults.

In order to remediate the issues, there are two efforts on-going to update the libraries:

1. Provide (and switch to) a secondary mechanism for specifying calls to outside services ([peer.service](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/span-general/#general-remote-service-attributes))
2. Standardizing all tracer libraries to using the current application name as a default for existing services (service naming).

(1) allows DataDog's feature set to continue differentiating between internal and external services (using peer.service instead of service) while (2) removes the existing behavior and standardizes the new behavior across all tracers.

This PR deals with (2).

### What's changing in this PR?

This PR introduces the initial changes for "(2) Standardizing all tracer libraries to using the current application name as a default for existing services (service naming)".  The major changes in this revision are:

1. Set a default value for DD_SERVICE of `unnamed-python-service` instead of relying on the agent to do so
2. Create a new concept, 'span attribute schema,' which controls the service naming behavior and control it with a new environment variable `DD_TRACE_SPAN_ATTRIBUTE_SCHEMA`.
3. Create 'v0' (existing behavior) and 'v1' (new behavior)  schemas and behaviors:
    1. v0 (Default) - The existing behavior
    2. v1 - Default integration service names are now set to the value of
       `$DD_SERVICE` (config().service) instead of the prior default values
       (such as 'redis')


Notes:
* These changes only affect the *default* service name, and will not affect overridden values, such as user-defined values or those set by other environment variables such as `DD_REDIS_SERVICE`.
* v0 (current behavior) is also the default. Users will not get the new defaults unless they specify 'v1' for the env var DD_TRACE_SPAN_ATTRIBUTE_SCHEMA.
* $DD_<INTEGRATION>_SERVICE overrides are not affected, only the defaults
* The value of $DD_SERVICE is selected instead of parent.service
* A default value for DD_SERVICE has been added (unnamed-python-service) to prevent fallback for ^

### Risks
The feature flag gate must work appropriately to toggle between behaviors.  If it does not, users may face the following with existing applications due to the way metrics/etc are leveraged by DataDog:
* Alarms firing when they shouldn't
* Alarms NOT firing when they should
* Unexpected phase shifts in metrics
* Disappearance or shifts in services

### Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
