### PR TITLE
fix(elasticsearch): omit large body tag values [backport #5229 to 1.8]

### DIFF
--- a/ddtrace/_tracing/_limits.py
+++ b/ddtrace/_tracing/_limits.py
@@ -1,0 +1,6 @@
+"""
+Limits for trace data.
+"""
+
+MAX_SPAN_META_KEY_LEN = 200
+MAX_SPAN_META_VALUE_LEN = 25000

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -1,6 +1,7 @@
 from importlib import import_module
 
 from ddtrace import config
+from ddtrace._tracing import _limits
 from ddtrace.contrib.trace_utils import ext_service
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
@@ -95,7 +96,19 @@ def _get_perform_request(elasticsearch):
                 span.set_tag_str(http.QUERY_STRING, encoded_params)
 
             if method in ["GET", "POST"]:
-                span.set_tag_str(metadata.BODY, instance.serializer.dumps(body))
+                ser_body = instance.serializer.dumps(body)
+                # Elasticsearch request bodies can be very large resulting in traces being too large
+                # to send.
+                # When this occurs, drop the value.
+                # Ideally the body should be truncated, however we cannot truncate as the obfuscation
+                # logic for the body lives in the agent and truncating would make the body undecodable.
+                if len(ser_body) <= _limits.MAX_SPAN_META_VALUE_LEN:
+                    span.set_tag_str(metadata.BODY, ser_body)
+                else:
+                    span.set_tag_str(
+                        metadata.BODY,
+                        "<body size %s exceeds limit of %s>" % (len(ser_body), _limits.MAX_SPAN_META_VALUE_LEN),
+                    )
             status = None
 
             # set analytics sample rate

--- a/releasenotes/notes/elasticsearch-body-75bfd855099e9e5a.yaml
+++ b/releasenotes/notes/elasticsearch-body-75bfd855099e9e5a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    elasticsearch: Omit large ``elasticsearch.body`` tag values that are
+      greater than 25000 characters to prevent traces from being too large to
+      send.


### PR DESCRIPTION
Backport of #5229 to 1.8

The elasticsearch body tag value in practice can be very large. Since the value is not truncated, it can easily result in traces exceeding the max size limit which results in dropped traces.

The proposed solution is to omit the value. This is because obfuscation logic lives in the Agent and so the body cannot be truncated as sensitive data would be leaked. No body tag is better than no trace.

Ideally the obfuscation logic should exist in the client so that the body can be truncated.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
