### PR TITLE
fix(aws_lambda): fix circular dependency when user handler patches modules [backport #5401 to 1.9]

### DIFF
--- a/releasenotes/notes/fix-aws-lambda-circular-dep-when-patching-in-handler-320de20015a8d5cd.yaml
+++ b/releasenotes/notes/fix-aws-lambda-circular-dep-when-patching-in-handler-320de20015a8d5cd.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    aws_lambda: Fix AttributeError raised when ``ddtrace.patch_all()``, or ``ddtrace.patch(aws_lambda=True)``, is set on user handler.
+    


### PR DESCRIPTION
Backports: https://github.com/DataDog/dd-trace-py/pull/5401

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.