### PR TITLE
chore(asm): iast narrow stacktrace to user code

### DIFF
--- a/ddtrace/appsec/iast/_stacktrace.c
+++ b/ddtrace/appsec/iast/_stacktrace.c
@@ -68,9 +68,9 @@ static PyObject *get_file_and_line(PyObject *Py_UNUSED(module),
       filename_o = GET_FILENAME(frame);
       filename = PyBytes_AsString(
           PyUnicode_AsEncodedString(filename_o, "utf-8", "surrogatepass"));
-      if (strstr(filename, cwd) == NULL &&
-          strstr(filename, DD_TRACE_INSTALLED_PREFIX) != NULL &&
-          strstr(filename, TESTS_PREFIX) == NULL) {
+      if ((strstr(filename, DD_TRACE_INSTALLED_PREFIX) != NULL &&
+           strstr(filename, TESTS_PREFIX) == NULL) ||
+          strstr(filename, cwd) == NULL) {
         frame = GET_PREVIOUS(frame);
         continue;
       }

--- a/ddtrace/appsec/iast/_stacktrace.c
+++ b/ddtrace/appsec/iast/_stacktrace.c
@@ -36,8 +36,7 @@
 /**
  * get_file_and_line
  *
- * Get the filename (path + filename) and line number of the original
- *wrapped function to report it.
+ * Get the filename (path + filename) and line number of the original wrapped function to report it.
  *
  * @return Tuple, string and integer.
  **/

--- a/ddtrace/appsec/iast/_stacktrace.c
+++ b/ddtrace/appsec/iast/_stacktrace.c
@@ -5,9 +5,11 @@
 #ifdef _WIN32
 #define DD_TRACE_INSTALLED_PREFIX "\\ddtrace\\"
 #define TESTS_PREFIX "\\tests\\"
+#define SITE_PACKAGES_PREFIX "\\site-packages\\"
 #else
 #define DD_TRACE_INSTALLED_PREFIX "/ddtrace/"
 #define TESTS_PREFIX "/tests/"
+#define SITE_PACKAGES_PREFIX "/site-packages/"
 #endif
 
 #if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 11
@@ -16,9 +18,8 @@
 #define GET_FRAME(tstate) PyThreadState_GetFrame(tstate)
 #define GET_PREVIOUS(frame) frame->previous
 #define GET_FILENAME(frame) frame->current_frame->f_code->co_filename
-#define GET_LINENO(frame)                                                      \
-  PyCode_Addr2Line(frame->current_frame->f_code,                               \
-                   PyFrame_GetLasti(_PyFrame_GetFrameObject(frame)))
+#define GET_LINENO(frame)                                                                                              \
+    PyCode_Addr2Line(frame->current_frame->f_code, PyFrame_GetLasti(_PyFrame_GetFrameObject(frame)))
 #else
 #define FrameType PyFrameObject
 #define GET_FRAME(tstate) tstate->frame
@@ -35,75 +36,78 @@
 /**
  * get_file_and_line
  *
- * Get the filename (path + filename) and line number of the original wrapped
- * function to report it.
+ * Get the filename (path + filename) and line number of the original
+ *wrapped function to report it.
  *
  * @return Tuple, string and integer.
  **/
-static PyObject *get_file_and_line(PyObject *Py_UNUSED(module),
-                                   PyObject *args) {
-  PyThreadState *tstate = PyThreadState_GET();
-  FrameType *frame;
-  PyObject *filename_o;
-  char *filename;
-  int line;
+static PyObject*
+get_file_and_line(PyObject* Py_UNUSED(module), PyObject* args)
+{
+    PyThreadState* tstate = PyThreadState_GET();
+    FrameType* frame;
+    PyObject* filename_o;
+    char* filename;
+    int line;
 
-  PyObject *cwd_obj = Py_None, *cwd_bytes;
-  char *cwd;
-  int err;
-  if (!PyArg_ParseTuple(args, "O", &cwd_obj))
-    return NULL;
-  if (cwd_obj != Py_None) {
-    if (!PyUnicode_FSConverter(cwd_obj, &cwd_bytes))
-      return NULL;
-    cwd = PyBytes_AsString(cwd_bytes);
-  } else {
-    return NULL;
-  }
-
-  if (NULL != tstate && NULL != GET_FRAME(tstate)) {
-    frame = GET_FRAME(tstate);
-    while (NULL != frame) {
-
-      filename_o = GET_FILENAME(frame);
-      filename = PyBytes_AsString(
-          PyUnicode_AsEncodedString(filename_o, "utf-8", "surrogatepass"));
-      if ((strstr(filename, DD_TRACE_INSTALLED_PREFIX) != NULL &&
-           strstr(filename, TESTS_PREFIX) == NULL) ||
-          strstr(filename, cwd) == NULL) {
-        frame = GET_PREVIOUS(frame);
-        continue;
-      }
-      /*
-       frame->f_lineno will not always return the correct line number
-       you need to call PyCode_Addr2Line().
-      */
-      line = GET_LINENO(frame);
-
-      return PyTuple_Pack(2, filename_o, Py_BuildValue("i", line));
+    PyObject *cwd_obj = Py_None, *cwd_bytes;
+    char* cwd;
+    int err;
+    if (!PyArg_ParseTuple(args, "O", &cwd_obj))
+        return NULL;
+    if (cwd_obj != Py_None) {
+        if (!PyUnicode_FSConverter(cwd_obj, &cwd_bytes))
+            return NULL;
+        cwd = PyBytes_AsString(cwd_bytes);
+    } else {
+        return NULL;
     }
-  }
+
+    if (NULL != tstate && NULL != GET_FRAME(tstate)) {
+        frame = GET_FRAME(tstate);
+        while (NULL != frame) {
+
+            filename_o = GET_FILENAME(frame);
+            filename = PyBytes_AsString(PyUnicode_AsEncodedString(filename_o, "utf-8", "surrogatepass"));
+            if ((strstr(filename, DD_TRACE_INSTALLED_PREFIX) != NULL && strstr(filename, TESTS_PREFIX) == NULL) ||
+                strstr(filename, SITE_PACKAGES_PREFIX) != NULL || strstr(filename, cwd) == NULL) {
+                frame = GET_PREVIOUS(frame);
+                continue;
+            }
+            /*
+             frame->f_lineno will not always return the correct line number
+             you need to call PyCode_Addr2Line().
+            */
+            line = GET_LINENO(frame);
+
+            return PyTuple_Pack(2, filename_o, Py_BuildValue("i", line));
+        }
+    }
 #if PY_MAJOR_VERSION > 3 || PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 10
-  return Py_NewRef(Py_None);
+    return Py_NewRef(Py_None);
 #else
-  Py_INCREF(Py_None);
-  return Py_None;
+    Py_INCREF(Py_None);
+    return Py_None;
 #endif
 }
 
 static PyMethodDef StacktraceMethods[] = {
-    {"get_info_frame", (PyCFunction)get_file_and_line, METH_VARARGS,
-     "stacktrace functions"},
-    {NULL, NULL, 0, NULL}};
+    { "get_info_frame", (PyCFunction)get_file_and_line, METH_VARARGS, "stacktrace functions" },
+    { NULL, NULL, 0, NULL }
+};
 
-static struct PyModuleDef stacktrace = {
-    PyModuleDef_HEAD_INIT, "ddtrace.appsec.iast._stacktrace",
-    "stacktrace module", -1, StacktraceMethods};
+static struct PyModuleDef stacktrace = { PyModuleDef_HEAD_INIT,
+                                         "ddtrace.appsec.iast._stacktrace",
+                                         "stacktrace module",
+                                         -1,
+                                         StacktraceMethods };
 
-PyMODINIT_FUNC PyInit__stacktrace(void) {
-  PyObject *m;
-  m = PyModule_Create(&stacktrace);
-  if (m == NULL)
-    return NULL;
-  return m;
+PyMODINIT_FUNC
+PyInit__stacktrace(void)
+{
+    PyObject* m;
+    m = PyModule_Create(&stacktrace);
+    if (m == NULL)
+        return NULL;
+    return m;
 }

--- a/ddtrace/appsec/iast/_stacktrace.c
+++ b/ddtrace/appsec/iast/_stacktrace.c
@@ -16,8 +16,9 @@
 #define GET_FRAME(tstate) PyThreadState_GetFrame(tstate)
 #define GET_PREVIOUS(frame) frame->previous
 #define GET_FILENAME(frame) frame->current_frame->f_code->co_filename
-#define GET_LINENO(frame)                                                                                              \
-    PyCode_Addr2Line(frame->current_frame->f_code, PyFrame_GetLasti(_PyFrame_GetFrameObject(frame)))
+#define GET_LINENO(frame)                                                      \
+  PyCode_Addr2Line(frame->current_frame->f_code,                               \
+                   PyFrame_GetLasti(_PyFrame_GetFrameObject(frame)))
 #else
 #define FrameType PyFrameObject
 #define GET_FRAME(tstate) tstate->frame
@@ -34,63 +35,75 @@
 /**
  * get_file_and_line
  *
- * Get the filename (path + filename) and line number of the original wrapped function to report it.
+ * Get the filename (path + filename) and line number of the original wrapped
+ * function to report it.
  *
  * @return Tuple, string and integer.
  **/
-static PyObject*
-get_file_and_line(PyObject* Py_UNUSED(module), PyObject* Py_UNUSED(args))
-{
-    PyThreadState* tstate = PyThreadState_GET();
-    FrameType* frame;
-    PyObject* filename_o;
-    char* filename;
-    int line;
+static PyObject *get_file_and_line(PyObject *Py_UNUSED(module),
+                                   PyObject *args) {
+  PyThreadState *tstate = PyThreadState_GET();
+  FrameType *frame;
+  PyObject *filename_o;
+  char *filename;
+  int line;
 
-    if (NULL != tstate && NULL != GET_FRAME(tstate)) {
-        frame = GET_FRAME(tstate);
-        while (NULL != frame) {
+  PyObject *cwd_obj = Py_None, *cwd_bytes;
+  char *cwd;
+  int err;
+  if (!PyArg_ParseTuple(args, "O", &cwd_obj))
+    return NULL;
+  if (cwd_obj != Py_None) {
+    if (!PyUnicode_FSConverter(cwd_obj, &cwd_bytes))
+      return NULL;
+    cwd = PyBytes_AsString(cwd_bytes);
+  } else {
+    return NULL;
+  }
 
-            filename_o = GET_FILENAME(frame);
-            filename = PyBytes_AsString(PyUnicode_AsEncodedString(filename_o, "utf-8", "surrogatepass"));
-            if (strstr(filename, DD_TRACE_INSTALLED_PREFIX) != NULL && strstr(filename, TESTS_PREFIX) == NULL) {
-                frame = GET_PREVIOUS(frame);
-                continue;
-            }
-            /*
-             frame->f_lineno will not always return the correct line number
-             you need to call PyCode_Addr2Line().
-            */
-            line = GET_LINENO(frame);
+  if (NULL != tstate && NULL != GET_FRAME(tstate)) {
+    frame = GET_FRAME(tstate);
+    while (NULL != frame) {
 
-            return PyTuple_Pack(2, filename_o, Py_BuildValue("i", line));
-        }
+      filename_o = GET_FILENAME(frame);
+      filename = PyBytes_AsString(
+          PyUnicode_AsEncodedString(filename_o, "utf-8", "surrogatepass"));
+      if (strstr(filename, cwd) == NULL &&
+          strstr(filename, DD_TRACE_INSTALLED_PREFIX) != NULL &&
+          strstr(filename, TESTS_PREFIX) == NULL) {
+        frame = GET_PREVIOUS(frame);
+        continue;
+      }
+      /*
+       frame->f_lineno will not always return the correct line number
+       you need to call PyCode_Addr2Line().
+      */
+      line = GET_LINENO(frame);
+
+      return PyTuple_Pack(2, filename_o, Py_BuildValue("i", line));
     }
+  }
 #if PY_MAJOR_VERSION > 3 || PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 10
-    return Py_NewRef(Py_None);
+  return Py_NewRef(Py_None);
 #else
-    Py_INCREF(Py_None);
-    return Py_None;
+  Py_INCREF(Py_None);
+  return Py_None;
 #endif
 }
 
 static PyMethodDef StacktraceMethods[] = {
-    { "get_info_frame", (PyCFunction)get_file_and_line, METH_VARARGS, "stacktrace functions" },
-    { NULL, NULL, 0, NULL }
-};
+    {"get_info_frame", (PyCFunction)get_file_and_line, METH_VARARGS,
+     "stacktrace functions"},
+    {NULL, NULL, 0, NULL}};
 
-static struct PyModuleDef stacktrace = { PyModuleDef_HEAD_INIT,
-                                         "ddtrace.appsec.iast._stacktrace",
-                                         "stacktrace module",
-                                         -1,
-                                         StacktraceMethods };
+static struct PyModuleDef stacktrace = {
+    PyModuleDef_HEAD_INIT, "ddtrace.appsec.iast._stacktrace",
+    "stacktrace module", -1, StacktraceMethods};
 
-PyMODINIT_FUNC
-PyInit__stacktrace(void)
-{
-    PyObject* m;
-    m = PyModule_Create(&stacktrace);
-    if (m == NULL)
-        return NULL;
-    return m;
+PyMODINIT_FUNC PyInit__stacktrace(void) {
+  PyObject *m;
+  m = PyModule_Create(&stacktrace);
+  if (m == NULL)
+    return NULL;
+  return m;
 }

--- a/ddtrace/appsec/iast/_stacktrace_py2.py
+++ b/ddtrace/appsec/iast/_stacktrace_py2.py
@@ -13,11 +13,12 @@ if TYPE_CHECKING:  # pragma: no cover
 FIRST_FRAME_NO_DDTRACE = 4
 
 DD_TRACE_INSTALLED_PREFIX = os.sep + "ddtrace" + os.sep
+SITE_PACKAGES_PREFIX = os.sep + "site-packages" + os.sep
 TESTS_PREFIX = os.sep + "tests" + os.sep
 
 
-def get_info_frame():
-    # type: () -> Optional[Tuple[Text, int]]
+def get_info_frame(cwd):
+    # type: (Text) -> Optional[Tuple[Text, int]]
     """Get the filename (path + filename) and line number of the original wrapped function to report it.
 
     CAVEAT: We should migrate this function to native code to improve the performance.
@@ -31,7 +32,11 @@ def get_info_frame():
             filename = frame.filename
             lineno = frame.lineno
 
-        if DD_TRACE_INSTALLED_PREFIX in filename and TESTS_PREFIX not in filename:
+        if (
+            (DD_TRACE_INSTALLED_PREFIX in filename and TESTS_PREFIX not in filename)
+            or (cwd not in filename)
+            or (SITE_PACKAGES_PREFIX in filename)
+        ):
             continue
 
         return filename, lineno

--- a/ddtrace/appsec/iast/taint_sinks/_base.py
+++ b/ddtrace/appsec/iast/taint_sinks/_base.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+import os
 from ddtrace import tracer
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec.iast import oce
@@ -30,6 +31,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from ddtrace.appsec.iast._input_info import Input_info
 
 log = get_logger(__name__)
+
+CWD = os.path.abspath(os.getcwd())
 
 
 class VulnerabilityBase(Operation):
@@ -65,7 +68,7 @@ class VulnerabilityBase(Operation):
                 log.debug("No root span in the current execution. Skipping IAST taint sink.")
                 return None
 
-            frame_info = get_info_frame()
+            frame_info = get_info_frame(CWD)
             if frame_info:
                 file_name, line_number = frame_info
 

--- a/ddtrace/appsec/iast/taint_sinks/_base.py
+++ b/ddtrace/appsec/iast/taint_sinks/_base.py
@@ -1,6 +1,6 @@
+import os
 from typing import TYPE_CHECKING
 
-import os
 from ddtrace import tracer
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec.iast import oce
@@ -71,6 +71,10 @@ class VulnerabilityBase(Operation):
             frame_info = get_info_frame(CWD)
             if frame_info:
                 file_name, line_number = frame_info
+
+                # Remove CWD prefix
+                if file_name.startswith(CWD):
+                    file_name = file_name[len(CWD) :]
 
                 if isinstance(evidence_value, (str, bytes, bytearray)):
                     evidence = Evidence(value=evidence_value)


### PR DESCRIPTION
IAST: Iterate stacktrace frames to make sure the evidence reported is actually user code, based on CWD as prefix, and making sure that ``site-packages`` is not in the path reported.

Also removes the CWD prefix if present.

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
