### PR TITLE
fix(propagation): add padding for b3 span id and trace id [backport #4976 to 1.8]

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -116,7 +116,7 @@ def _dd_id_to_b3_id(dd_id):
     """Helper to convert Datadog trace/span int ids into hex ids"""
     # DEV: `hex(dd_id)` will give us `0xDEADBEEF`
     # DEV: this gives us lowercase hex, which is what we want
-    return "{:x}".format(dd_id)
+    return "{:016x}".format(dd_id)
 
 
 class _DatadogMultiHeader:

--- a/releasenotes/notes/fix-add-b3-traceid-and-spanid-padding-919b698c8008346d.yaml
+++ b/releasenotes/notes/fix-add-b3-traceid-and-spanid-padding-919b698c8008346d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: Pads trace_id and span_ids in b3 headers to have a minimum length of 16.

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -1647,6 +1647,19 @@ INJECT_FIXTURES = [
         VALID_DATADOG_CONTEXT,
         {_HTTP_HEADER_B3_SINGLE: "b5a2814f70060771-7197677932a62370-1"},
     ),
+    # we want to make sure that if the Datadog trace_id or span_id is not
+    # the standard length int we'd expect, we pad the value with 0s so it's still a valid b3 header
+    (
+        "valid_b3_single_style_in_need_of_padding",
+        [PROPAGATION_STYLE_B3_SINGLE_HEADER],
+        {
+            "trace_id": 123,
+            "span_id": 4567,
+            "sampling_priority": 1,
+            "dd_origin": "synthetics",
+        },
+        {_HTTP_HEADER_B3_SINGLE: "000000000000007b-00000000000011d7-1"},
+    ),
     (
         "valid_b3_single_style_user_keep",
         [PROPAGATION_STYLE_B3_SINGLE_HEADER],


### PR DESCRIPTION
Backport of #4976 to 1.8

## Description
If we don't have a full length trace id or span id we should add padding of `0`s to the translated b3 hexadecimal value. For example a Datadog trace_id of `123` should be changed to `'000000000000007b'`

## Relevant issue(s)
This issue was discoverd in the new system-tests tests: https://github.com/DataDog/system-tests/pull/691/files#r1086730900

## Testing strategy
added regression test.

## Checklist
- [x] Followed the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) when writing a release note.
- [x] Add additional sections for `feat` and `fix` pull requests.
- [x] [Library documentation](https://github.com/DataDog/dd-trace-py/tree/1.x/docs) and/or [Datadog's documentation site](https://github.com/DataDog/documentation/) is updated. Link to doc PR in description.


## Reviewer Checklist
- [x] Title is accurate.
- [x] Description motivates each change.
- [x] No unnecessary changes were introduced in this PR.
- [x] Avoid breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Tests provided or description of manual testing performed is included in the code or PR.
- [x] Release note has been added and follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines), or else `changelog/no-changelog` label added.
- [x] All relevant GitHub issues are correctly linked.
- [x] Change contains telemetry where appropriate (logs, metrics, etc.).
- [x] Telemetry is meaningful, actionable and does not have the potential to leak sensitive data.
