### PR TITLE
fix(opentelemetry): fix timestamps on otel spans

### DIFF
--- a/ddtrace/_opentelemetry/span.py
+++ b/ddtrace/_opentelemetry/span.py
@@ -39,8 +39,8 @@ class Span(OtelSpan):
     ):
         # type: (...) -> None
         if start_time is not None:
-            # otel instrumentation tracks time in nanoseconds while ddtrace uses seconds
-            datadog_span.start = start_time / 1e9
+            # start_time should be set in nanoseconds
+            datadog_span.start_ns = start_time
 
         self._ddspan = datadog_span
         if record_exception is not None:
@@ -79,7 +79,14 @@ class Span(OtelSpan):
 
     def end(self, end_time=None):
         # type: (Optional[int]) -> None
-        self._ddspan.finish(finish_time=end_time)
+        """
+        Marks the end time of a span. This method should be called once.
+
+        :param end_time: The end time of the span, in nanoseconds. Defaults to ``now``.
+        """
+        # end_time set in nanoseconds while Datadog finish_time is set in seconds
+        dd_finish_time = end_time if end_time is None else end_time / 1e9
+        self._ddspan.finish(dd_finish_time)
 
     @property
     def kind(self):

--- a/ddtrace/_opentelemetry/span.py
+++ b/ddtrace/_opentelemetry/span.py
@@ -9,6 +9,7 @@ from opentelemetry.trace.span import TraceFlags
 from opentelemetry.trace.span import TraceState
 
 from ddtrace.constants import SPAN_KIND
+from ddtrace.internal.compat import time_ns
 
 
 if TYPE_CHECKING:
@@ -84,9 +85,9 @@ class Span(OtelSpan):
 
         :param end_time: The end time of the span, in nanoseconds. Defaults to ``now``.
         """
-        # end_time set in nanoseconds while Datadog finish_time is set in seconds
-        dd_finish_time = end_time if end_time is None else end_time / 1e9
-        self._ddspan.finish(dd_finish_time)
+        if end_time is None:
+            end_time = time_ns()
+        self._ddspan._finish_ns(end_time)
 
     @property
     def kind(self):

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -257,12 +257,18 @@ class Span(object):
 
         :param finish_time: The end time of the span, in seconds. Defaults to ``now``.
         """
+        if finish_time is None:
+            self._finish_ns(time_ns())
+        else:
+            self._finish_ns(int(finish_time * 1e9))
+
+    def _finish_ns(self, finish_time_ns):
+        # type: (int) -> None
         if self.duration_ns is not None:
             return
 
-        ft = time_ns() if finish_time is None else int(finish_time * 1e9)
         # be defensive so we don't die if start isn't set
-        self.duration_ns = ft - (self.start_ns or ft)
+        self.duration_ns = finish_time_ns - (self.start_ns or finish_time_ns)
 
         for cb in self._on_finish_callbacks:
             cb(self)

--- a/tests/opentelemetry/test_span.py
+++ b/tests/opentelemetry/test_span.py
@@ -107,6 +107,21 @@ def test_otel_span_is_recording(oteltracer):
     assert span.is_recording() is False
 
 
+def test_otel_span_end(oteltracer):
+    start_time_ns = 1680522337 * 1e9
+    duration_sec = 11
+    end_time_ns = start_time_ns + duration_sec * 1e9
+
+    span = oteltracer.start_span("otel1", start_time=start_time_ns)
+    span.end(end_time_ns)
+    assert span._ddspan.duration == duration_sec
+    # Span.end() should be set once, all subsecquent calls should be noops
+    span.end()
+    span.end(end_time_ns + 1_0000_000)
+    span.end(end_time_ns + 100_0000_000)
+    assert span._ddspan.duration == duration_sec
+
+
 def test_otel_span_exception_handling(oteltracer):
     with pytest.raises(Exception):
         with oteltracer.start_span("otel1") as span:


### PR DESCRIPTION
Timestamps in OpenTelemetry Spans are integers and have a precession of nanoseconds ([reference](
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#timestamp), [code](https://github.com/open-telemetry/opentelemetry-python/blob/v1.0.0/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L741)).

- In `Span.__init__(self, ...., start_time, ...)` start_time should be an integer with a precision of nanoseconds.
- In `Span.end(end_time)` end_time should be an integer with a precision of nanoseconds.
  

Opentelemetry support is unannounced so a release note is not required.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
