### PR TITLE
chore(pytest): move CI visibility initialization to start of pytest command

### DIFF
--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -82,10 +82,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "dd_tags(**kwargs): add tags to current span")
-
-
-def pytest_sessionstart(session):
-    if is_enabled(session.config):
+    if is_enabled(config):
         _CIVisibility.enable(config=ddtrace.config.pytest)
 
 

--- a/ddtrace/contrib/pytest_bdd/plugin.py
+++ b/ddtrace/contrib/pytest_bdd/plugin.py
@@ -25,9 +25,10 @@ def _store_span(item, span):
     setattr(item, "_datadog_span", span)
 
 
-def pytest_sessionstart(session):
-    if session.config.pluginmanager.hasplugin("pytest-bdd"):
-        session.config.pluginmanager.register(_PytestBddPlugin(), "_datadog-pytest-bdd")
+def pytest_configure(config):
+    # pass
+    if config.pluginmanager.hasplugin("pytest-bdd"):
+        config.pluginmanager.register(_PytestBddPlugin(), "_datadog-pytest-bdd")
 
 
 class _PytestBddPlugin:

--- a/ddtrace/contrib/pytest_bdd/plugin.py
+++ b/ddtrace/contrib/pytest_bdd/plugin.py
@@ -26,7 +26,6 @@ def _store_span(item, span):
 
 
 def pytest_configure(config):
-    # pass
     if config.pluginmanager.hasplugin("pytest-bdd"):
         config.pluginmanager.register(_PytestBddPlugin(), "_datadog-pytest-bdd")
 

--- a/tests/contrib/asynctest/test_asynctest.py
+++ b/tests/contrib/asynctest/test_asynctest.py
@@ -22,8 +22,9 @@ class TestPytest(TracerTestCase):
         class CIVisibilityPlugin:
             @staticmethod
             def pytest_configure(config):
-                assert not CIVisibility.enabled
                 if is_enabled(config):
+                    assert CIVisibility.enabled
+                    CIVisibility.disable()
                     CIVisibility.enable(tracer=self.tracer, config=ddtrace.config.pytest)
 
         return self.testdir.inline_run(*args, plugins=[CIVisibilityPlugin()])

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -27,8 +27,9 @@ class PytestTestCase(TracerTestCase):
         class CIVisibilityPlugin:
             @staticmethod
             def pytest_configure(config):
-                assert not CIVisibility.enabled
                 if is_enabled(config):
+                    assert CIVisibility.enabled
+                    CIVisibility.disable()
                     CIVisibility.enable(tracer=self.tracer, config=ddtrace.config.pytest)
 
         return self.testdir.inline_run(*args, plugins=[CIVisibilityPlugin()])

--- a/tests/contrib/pytest_bdd/test_pytest_bdd.py
+++ b/tests/contrib/pytest_bdd/test_pytest_bdd.py
@@ -32,8 +32,9 @@ class TestPytest(TracerTestCase):
         class CIVisibilityPlugin:
             @staticmethod
             def pytest_configure(config):
-                assert not CIVisibility.enabled
                 if is_enabled(config):
+                    assert CIVisibility.enabled
+                    CIVisibility.disable()
                     CIVisibility.enable(tracer=self.tracer, config=ddtrace.config.pytest)
 
         return self.testdir.inline_run(*args, plugins=[CIVisibilityPlugin()])


### PR DESCRIPTION
This PR moves the CI Visibility enabling step to the `pytest_configure` hook instead of the `pytest_sessionstart` hook so that we can enable CI Visibility as early as possible in the pytest run command. See https://github.com/DataDog/dd-trace-py/pull/5446/files#r1156967374 for more context.

This is because the planned test suite level visibility for CI Visibility aims to track the entire pytest command (including test command, test modules, test functions) instead of our current test function traces. This requires the ddtrace pytest plugin to enable the CIRecorder at the earliest possible step in the pytest test command.

This functionally does not change the current behavior of the pytest plugin, since the `pytest_configure` and `pytest_sessionstart` hooks happen almost immediately after each other in the pytest command lifecycle. All this does is to lay the groundwork for test suite level visibility work for CI Visibility. **Note that this change does not implement the test suite level visibility for CI Visibility, but is a pre-requisite for it.**

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
