### PR TITLE
fix(lib-injection): include package in image [backport #5410 to 1.11]

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -214,13 +214,10 @@ jobs:
 
   build-and-publish-init-image:
     needs: [upload_pypi]
-    # We have to wait for the PyPI job since the image that we publish depends on installing
-    # the package from PyPI.
-    uses: ./.github/workflows/build-and-publish-image.yml
-    with:
-      tags: ghcr.io/datadog/dd-trace-py/dd-lib-python-init:${{ github.ref_name }}
-      platforms: 'linux/amd64,linux/arm64/v8'
-      build-args: "DDTRACE_PYTHON_VERSION=${{ github.ref_name }}"
-      context: ./lib-injection
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: ./.github/workflows/lib-inject-publish.yml
+        with:
+          ddtrace-version: ${{ github.ref_name }}
+          image-tag: ${{ github.ref_name }}
+        secrets:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lib-inject-publish.yml
+++ b/.github/workflows/lib-inject-publish.yml
@@ -1,0 +1,38 @@
+name: Build and publish library injection images
+
+on:
+  workflow_call:
+    inputs:
+      ddtrace-version:
+        required: true
+        type: string
+      image-tag:
+        required: true
+        type: string
+    secrets:
+      token:
+        required: true
+
+jobs:
+  wait_for_package:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Wait for package to be available from PyPI
+      run: |
+        until pip install ddtrace==${{ inputs.ddtrace-version }}
+        do
+          sleep 20
+        done
+  build_push:
+    needs: [wait_for_package]
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      tags: ghcr.io/datadog/dd-trace-py/dd-lib-python-init:${{ inputs.image-tag }}
+      build-args: 'DDTRACE_PYTHON_VERSION=${{ inputs.ddtrace-version }}'
+      platforms: 'linux/amd64,linux/arm64/v8'
+      context: ./lib-injection
+    secrets:
+      token: ${{ secrets.token }}

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -5,14 +5,12 @@ on:
 
 jobs:
   build-and-publish-test-image:
-    uses: ./.github/workflows/build-and-publish-image.yml
-    with:
-      tags: 'ghcr.io/datadog/dd-trace-py/dd-lib-python-init:${{ github.sha }}'
-      platforms: 'linux/amd64,linux/arm64/v8'
-      build-args: 'DDTRACE_PYTHON_VERSION=git+https://github.com/Datadog/dd-trace-py@${{ github.sha }}'
-      context: ./lib-injection
+    uses: ./.github/workflows/lib-inject-publish.yml
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      ddtrace-version: v1.10
+      image-tag: ${{ github.sha }}
 
   test:
     needs:
@@ -67,8 +65,23 @@ jobs:
             --network=test-inject \
             -p 8126:8126 \
             ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.7.2
-      - name: Apply a fixed, stable version of the library
-        run: sed -i "s~<DD_TRACE_VERSION_TO_BE_REPLACED>~git+https://github.com/Datadog/dd-trace-py@${{ github.sha }}~g" lib-injection/sitecustomize.py
+      - name: Prepare the volume
+        run: |
+          cd lib-injection
+          mkdir -p lib-injection/ddtrace_pkgs
+          cp sitecustomize.py lib-injection/
+          ./dl_megawheel.py \
+            --ddtrace-version=v1.10 \
+            --python-version=3.11 \
+            --python-version=3.10 \
+            --python-version=3.9 \
+            --python-version=3.8 \
+            --python-version=3.7 \
+            --ddtrace-version=v1.10 \
+            --arch x86_64 \
+            --platform manylinux2014 \
+            --output-dir ddtrace_pkgs \
+            --verbose
       - name: Build test app
         run: |
           docker build \
@@ -83,8 +96,8 @@ jobs:
             -e PYTHONPATH=/lib-injection \
             -v $PWD/lib-injection:/lib-injection \
             ${{matrix.variant}}
-          # Package has to be built from source, wait a while
-          sleep 85
+          # Wait for the app to start
+          sleep 5
           docker logs ${{matrix.variant}}
       - name: Test the app
         run: |

--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -1,15 +1,35 @@
 # This image provides the files needed to install the ddtrace Python package
 # and auto instrument Python applications in containerized environments.
-FROM busybox
-
-ARG UID=10000
+FROM python:3.10
+WORKDIR /build
 ARG DDTRACE_PYTHON_VERSION
-ENV DDTRACE_PYTHON_VERSION=$DDTRACE_PYTHON_VERSION
+RUN python3 -m pip install -U pip==23.0.1
+RUN python3 -m pip install packaging==23.0
+RUN mkdir -p pkgs
+ADD ./dl_megawheel.py .
+# Note that we only get Python >= 3.7. This is to keep the size of the image
+# as small as possible.
+RUN python3 dl_megawheel.py \
+        --python-version=3.11 \
+        --python-version=3.10 \
+        --python-version=3.9 \
+        --python-version=3.8 \
+        --python-version=3.7 \
+        --ddtrace-version=${DDTRACE_PYTHON_VERSION} \
+        --arch x86_64 \
+        --arch aarch64 \
+        --platform musllinux_1_1 \
+        --platform manylinux2014 \
+        --output-dir /build/pkgs \
+        --verbose
+
+FROM busybox
+COPY --from=0 /build/pkgs /datadog-init/ddtrace_pkgs
+ARG UID=10000
 RUN addgroup -g 10000 -S datadog && \
     adduser -u ${UID} -S datadog -G datadog
+RUN chown -R datadog:datadog /datadog-init/ddtrace_pkgs
 USER ${UID}
 WORKDIR /datadog-init
 ADD sitecustomize.py /datadog-init/sitecustomize.py
-# Use ~ as a delimiter because git urls can contain slashes
-RUN sed -i "s~<DD_TRACE_VERSION_TO_BE_REPLACED>~${DDTRACE_PYTHON_VERSION}~g" /datadog-init/sitecustomize.py
 ADD copy-lib.sh /datadog-init/copy-lib.sh

--- a/lib-injection/README.md
+++ b/lib-injection/README.md
@@ -1,0 +1,35 @@
+# Kubernetes library injection
+
+This directory contains scripts and a Docker image for providing the ddtrace
+package via a Kubernetes [init
+container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
+which allows users to easily instrument Python applications without requiring
+changes to the application image.
+
+The `Dockerfile` defines the image that is published for `ddtrace` which is used
+as a Kubernetes InitContainer. Kubernetes runs it before deployment pods start.
+It is responsible for providing the files necessary to run `ddtrace` in an
+arbitrary downstream application container. It also provides a script to copy
+the necessary files to a given directory.
+
+The `dl_megawheel.py` script provides a portable `ddtrace` package. It is
+responsible for downloading and merging the published wheels of `ddtrace` and
+its dependencies.
+
+The Datadog Admission Controller injects the InitContainer with a new volume
+mount to the application deployment. The script to copy files out of the
+InitContainer is run to copy the files to the volume. The `PYTHONPATH`
+environment variable is injected into the application container along with the
+volume mount.
+
+The files copied to the volume are:
+
+- `sitecustomize.py`: Python module that gets run automatically on interpreter startup when it is detected in the `PYTHONPATH`. When executed, it updates the Python path further to include the `ddtrace_pkgs/` directory and then calls `import ddtrace.bootstrap.sitecustomize` which performs automatic instrumentation.
+- `ddtrace_pkgs/`: Directory containing the `ddtrace` package and its dependencies for each Python version, platform and architecture.
+
+
+The `PYTHONPATH` environment variable is set to the shared volume directory
+which contains `sitecustomize.py` and `ddtrace_pkgs`. The environment variable
+is injected into the the application container. This enables the
+`sitecustomize.py` file to execute on any Python interpreter startup which
+results in the automatic instrument being applied to the application.

--- a/lib-injection/copy-lib.sh
+++ b/lib-injection/copy-lib.sh
@@ -3,3 +3,4 @@
 # This script is used by the admission controller to install the library from the
 # init container into the application container.
 cp sitecustomize.py "$1/sitecustomize.py"
+cp -r ddtrace_pkgs "$1/ddtrace_pkgs"

--- a/lib-injection/dl_megawheel.py
+++ b/lib-injection/dl_megawheel.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Script to download all required wheels (including dependencies) of the ddtrace
+Python package for relevant Python versions (+ abis), C library platforms and
+architectures and merge them into a "megawheel" directory.
+
+This directory provides a portable installation of ddtrace which can be used
+on multiple platforms and architectures.
+
+Currently the only OS supported is Linux.
+
+This script has been tested with 21.0.0 and is confirmed to not work with
+20.0.2.
+
+Usage:
+        ./dl_megawheel.py --help
+
+
+The downloaded wheels can then be installed locally using:
+        pip install --no-index --find-links <dir_of_downloaded_wheels> ddtrace
+"""
+import argparse
+import itertools
+import os
+import subprocess
+import sys
+
+import packaging.version
+
+
+# Do a check on the pip version since older versions are known to be
+# incompatible.
+MIN_PIP_VERSION = packaging.version.parse("21.0")
+cmd = [sys.executable, "-m", "pip", "--version"]
+res = subprocess.run(cmd, capture_output=True)
+out = res.stdout.decode().split(" ")[1]
+pip_version = packaging.version.parse(out)
+if pip_version < MIN_PIP_VERSION:
+    print(
+        "WARNING: using known incompatible version, %r, of pip. The minimum compatible pip version is %r"
+        % (pip_version, MIN_PIP_VERSION)
+    )
+
+
+supported_pythons = ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+supported_arches = ["aarch64", "x86_64", "i686"]
+supported_platforms = ["musllinux_1_1", "manylinux2014"]
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument(
+    "--python-version",
+    choices=supported_pythons,
+    action="append",
+    required=True,
+)
+parser.add_argument(
+    "--arch",
+    choices=supported_arches,
+    action="append",
+    required=True,
+)
+parser.add_argument(
+    "--platform",
+    choices=supported_platforms,
+    action="append",
+    required=True,
+)
+parser.add_argument("--ddtrace-version", type=str, required=True)
+parser.add_argument("--output-dir", type=str, required=True)
+parser.add_argument("--dry-run", action="store_true")
+parser.add_argument("--verbose", action="store_true")
+args = parser.parse_args()
+
+dl_dir = args.output_dir
+print("saving wheels to %s" % dl_dir)
+
+for python_version, arch, platform in itertools.product(args.python_version, args.arch, args.platform):
+    print("Downloading %s %s %s wheel" % (python_version, arch, platform))
+    abi = "cp%s" % python_version.replace(".", "")
+    # Have to special-case these versions of Python for some reason.
+    if python_version in ["2.7", "3.5", "3.6", "3.7"]:
+        abi += "m"
+
+    # See the docs for an explanation of all the options used:
+    # https://pip.pypa.io/en/stable/cli/pip_download/
+    #   only-binary=:all: is specified to ensure we get all the dependencies of ddtrace as well.
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "download",
+        "ddtrace==%s" % args.ddtrace_version,
+        "--platform",
+        "%s_%s" % (platform, arch),
+        "--python-version",
+        python_version,
+        "--abi",
+        abi,
+        "--only-binary=:all:",
+        "--dest",
+        dl_dir,
+    ]
+    if args.verbose:
+        print(" ".join(cmd))
+
+    if not args.dry_run:
+        subprocess.run(cmd, capture_output=not args.verbose, check=True)
+
+        # Unzip all the wheels into the output directory
+        wheel_files = [f for f in os.listdir(dl_dir) if f.endswith(".whl")]
+        for whl in wheel_files:
+            wheel_file = os.path.join(dl_dir, whl)
+            # -q for quieter output, else we get all of the files being unzipped.
+            subprocess.run(["unzip", "-q", "-o", wheel_file, "-d", dl_dir])
+            # Remove the wheel as it has been unpacked
+            os.remove(wheel_file)

--- a/lib-injection/sitecustomize.py
+++ b/lib-injection/sitecustomize.py
@@ -1,57 +1,29 @@
 """
-This module when included on the PYTHONPATH will install the ddtrace package from pypi
-for the Python runtime being used.
+When included on the PYTHONPATH this module will initialize the PYTHONPATH to
+include the directory containing the ddtrace package and its dependencies. It
+then imports the ddtrace.bootstrap.sitecustomize module to automatically
+instrument the application.
 """
 import os
 import sys
 
 
-# This special string is to be replaced at container build time so that the
-# version is fixed in the source.
-version = "<DD_TRACE_VERSION_TO_BE_REPLACED>"
-
-
-def _configure_ddtrace():
-    # This import has the same effect as ddtrace-run for the current process.
-    import ddtrace.bootstrap.sitecustomize
-
-    bootstrap_dir = os.path.abspath(os.path.dirname(ddtrace.bootstrap.sitecustomize.__file__))
+def _add_to_pythonpath(path):
+    # type: (str) -> None
+    """Adds a path to the start of PYTHONPATH."""
     prev_python_path = os.getenv("PYTHONPATH", "")
-    os.environ["PYTHONPATH"] = "%s%s%s" % (bootstrap_dir, os.path.pathsep, prev_python_path)
-
-    # Also insert the bootstrap dir in the path of the current python process.
-    sys.path.insert(0, bootstrap_dir)
-    print("datadog autoinstrumentation: successfully configured python package")
+    os.environ["PYTHONPATH"] = "%s%s%s" % (path, os.pathsep, prev_python_path)
+    sys.path.insert(0, path)
 
 
-# Avoid infinite loop when attempting to install ddtrace. This flag is set when
-# the subprocess is launched to perform the installation.
-if "DDTRACE_PYTHON_INSTALL_IN_PROGRESS" not in os.environ:
-    try:
-        import ddtrace  # noqa: F401
+pkgs_path = os.path.join(os.path.dirname(__file__), "ddtrace_pkgs")
+bootstrap_dir = os.path.join(pkgs_path, "ddtrace", "bootstrap")
+_add_to_pythonpath(pkgs_path)
+_add_to_pythonpath(bootstrap_dir)
 
-    except ImportError:
-        import subprocess
-
-        print("datadog autoinstrumentation: installing python package")
-
-        # Set the flag to avoid an infinite loop.
-        env = os.environ.copy()
-        env["DDTRACE_PYTHON_INSTALL_IN_PROGRESS"] = "true"
-
-        if "git" in version:
-            ddtrace_version = version
-        else:
-            ddtrace_version = "ddtrace==%s" % version
-
-        # Execute the installation with the current interpreter
-        try:
-            subprocess.run([sys.executable, "-m", "pip", "install", ddtrace_version], env=env, check=True)
-        except Exception:
-            print("datadog autoinstrumentation: failed to install python package version %r" % ddtrace_version)
-        else:
-            print("datadog autoinstrumentation: successfully installed python package version %r" % ddtrace_version)
-            _configure_ddtrace()
-    else:
-        print("datadog autoinstrumentation: ddtrace already installed, skipping install")
-        _configure_ddtrace()
+try:
+    import ddtrace.bootstrap.sitecustomize  # noqa: F401
+except BaseException as e:
+    print("datadog autoinstrumentation: ddtrace failed to install:\n %s" % str(e))
+else:
+    print("datadog autoinstrumentation: ddtrace successfully installed")

--- a/releasenotes/notes/lib-injection-local-install-3bbbea28517ba0f0.yaml
+++ b/releasenotes/notes/lib-injection-local-install-3bbbea28517ba0f0.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    lib-injection: The ddtrace package is now provided via the Docker image
+    rather than relying on a run-time ``pip install``. This solves issues like
+    containers blocking network requests, installation overhead during
+    application startup, permissions issues with the install.

--- a/tests/lib-injection/dd-lib-python-init-test-django-gunicorn/Dockerfile
+++ b/tests/lib-injection/dd-lib-python-init-test-django-gunicorn/Dockerfile
@@ -1,10 +1,9 @@
-FROM ghcr.io/datadog/dd-trace-py/testrunner:989d6f118d180321399dbc4013467b8eab043396
+FROM python:3.10
 
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_SETTINGS_MODULE django_app
 WORKDIR /src
 ADD . /src
 EXPOSE 18080
-RUN pyenv global 3.10.3
-RUN python -m pip install django==4.1.3 gunicorn==20.1.0
-CMD /root/.pyenv/versions/3.10.3/bin/gunicorn --bind :18080 django_app:application
+RUN pip install django==4.1.3 gunicorn==20.1.0
+CMD gunicorn --bind :18080 django_app:application

--- a/tests/lib-injection/dd-lib-python-init-test-django-uvicorn/Dockerfile
+++ b/tests/lib-injection/dd-lib-python-init-test-django-uvicorn/Dockerfile
@@ -1,10 +1,9 @@
-FROM ghcr.io/datadog/dd-trace-py/testrunner:989d6f118d180321399dbc4013467b8eab043396
+FROM python:3.9
 
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_SETTINGS_MODULE django_app
 WORKDIR /src
 ADD . /src
 EXPOSE 18080
-RUN pyenv global 3.10.3
-RUN python3.10 -m pip install django==4.1.3 uvicorn==0.20.0
-CMD /root/.pyenv/versions/3.10.3/bin/uvicorn --host 0.0.0.0 --port 18080 django_app:application
+RUN pip install django==4.1.3 uvicorn==0.20.0
+CMD uvicorn --host 0.0.0.0 --port 18080 django_app:application

--- a/tests/lib-injection/dd-lib-python-init-test-django/Dockerfile
+++ b/tests/lib-injection/dd-lib-python-init-test-django/Dockerfile
@@ -1,10 +1,9 @@
-FROM ghcr.io/datadog/dd-trace-py/testrunner:989d6f118d180321399dbc4013467b8eab043396
+FROM python:3.11
 
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_SETTINGS_MODULE django_app
 WORKDIR /src
 ADD . /src
 EXPOSE 18080
-RUN pyenv global 3.10.3
-RUN python3.10 -m pip install django==4.1.3
-CMD python3.10 -m django runserver 0.0.0.0:18080
+RUN pip install django==4.1.3
+CMD python -m django runserver 0.0.0.0:18080


### PR DESCRIPTION
Formerly, the Kubernetes lib injection mechanism worked by including a sitecustomize.py file on the path which would execute a `pip install ddtrace==...`. This approach has a few downsides:

- Internet access required
- Application overhead at startup
- python/pip on the path doesn't have permission to install


Instead, the ddtrace package and its dependencies can be baked into the library injection image. This is achieved with the script `dl_wheels.py` which downloads wheels matching ddtrace version, Python versions, platforms and architectures. It downloads the wheels and merges them into one big directory. This works as Python is able to pick out the right binary at run-time to load, so as long as the compatible binary is present, Python will use it correctly.

The sitecustomize.py file now updates the PYTHONPATH to include the directory containing the ddtrace package and its dependencies.

This works as Python is able to identify which binaries to use at runtime so all of the binaries can be included in the injection image.

It was decided to only support Python 3.7 and above (officially supported Python versions) to keep the image size small. If support for additional Pythons is required then we can evaluate adding them in to the image.

Fixes #5291.

## Risk
The risk of this change is minimal compared to what existed previously. If the installation failed previously then it would likely fail here, similarly with no application impact.

There is a risk of the increased image size. The image size is now up to >100MB (from ~3MB).


## Testing

The existing tests are sufficient to test the new mechanism.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
