### PR TITLE
fix(futures): unload futures submodule during module cleanup [backport #5402 to 1.9]

### DIFF
--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -116,7 +116,7 @@ _MODULES_FOR_CONTRIB = {
     "cassandra": ("cassandra.cluster",),
     "dogpile_cache": ("dogpile.cache",),
     "mysqldb": ("MySQLdb",),
-    "futures": ("concurrent.futures",),
+    "futures": ("concurrent.futures.thread",),
     "vertica": ("vertica_python",),
     "aws_lambda": ("datadog_lambda",),
     "httplib": ("httplib" if PY2 else "http.client",),

--- a/ddtrace/contrib/futures/patch.py
+++ b/ddtrace/contrib/futures/patch.py
@@ -1,24 +1,45 @@
-from concurrent import futures
+import sys
 
-from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
+from ddtrace.internal.compat import PY2
+from ddtrace.internal.wrapping import unwrap as _u
+from ddtrace.internal.wrapping import wrap as _w
 
-from ..trace_utils import unwrap as _u
 from .threading import _wrap_submit
 
 
 def patch():
     """Enables Context Propagation between threads"""
-    if getattr(futures, "__datadog_patch", False):
-        return
-    setattr(futures, "__datadog_patch", True)
+    try:
+        # Ensure that we get hold of the reloaded module if module cleanup was
+        # performed.
+        thread = sys.modules["concurrent.futures.thread"]
+    except KeyError:
+        import concurrent.futures.thread as thread
 
-    _w("concurrent.futures", "ThreadPoolExecutor.submit", _wrap_submit)
+    if getattr(thread, "__datadog_patch", False):
+        return
+    setattr(thread, "__datadog_patch", True)
+
+    if PY2:
+        _w(thread.ThreadPoolExecutor.submit.__func__, _wrap_submit)
+    else:
+        _w(thread.ThreadPoolExecutor.submit, _wrap_submit)
 
 
 def unpatch():
     """Disables Context Propagation between threads"""
-    if not getattr(futures, "__datadog_patch", False):
+    try:
+        # Ensure that we get hold of the reloaded module if module cleanup was
+        # performed.
+        thread = sys.modules["concurrent.futures.thread"]
+    except KeyError:
         return
-    setattr(futures, "__datadog_patch", False)
 
-    _u(futures.ThreadPoolExecutor, "submit")
+    if not getattr(thread, "__datadog_patch", False):
+        return
+    setattr(thread, "__datadog_patch", False)
+
+    if PY2:
+        _u(thread.ThreadPoolExecutor.submit.__func__, _wrap_submit)
+    else:
+        _u(thread.ThreadPoolExecutor.submit, _wrap_submit)

--- a/ddtrace/contrib/futures/threading.py
+++ b/ddtrace/contrib/futures/threading.py
@@ -1,7 +1,7 @@
 import ddtrace
 
 
-def _wrap_submit(func, instance, args, kwargs):
+def _wrap_submit(func, args, kwargs):
     """
     Wrap `Executor` method used to submit a work executed in another
     thread. This wrapper ensures that a new `Context` is created and
@@ -22,12 +22,13 @@ def _wrap_submit(func, instance, args, kwargs):
         current_ctx = ddtrace.tracer.context_provider.active()
 
     # The target function can be provided as a kwarg argument "fn" or the first positional argument
+    self = args[0]
     if "fn" in kwargs:
         fn = kwargs.pop("fn")
-        fn_args = args
+        fn_args = args[1:]
     else:
-        fn, fn_args = args[0], args[1:]
-    return func(_wrap_execution, current_ctx, fn, fn_args, kwargs)
+        fn, fn_args = args[1], args[2:]
+    return func(self, _wrap_execution, current_ctx, fn, fn_args, kwargs)
 
 
 def _wrap_execution(ctx, fn, args, kwargs):

--- a/releasenotes/notes/fix-futures-module-unload-e84900affff06152.yaml
+++ b/releasenotes/notes/fix-futures-module-unload-e84900affff06152.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    futures: Resolves an issue that prevents tasks from being submitted to a
+    thread pool executor when gevent is used (e.g. as a worker class for
+    gunicorn or celery).

--- a/riotfile.py
+++ b/riotfile.py
@@ -2330,6 +2330,7 @@ venv = Venv(
         Venv(
             name="futures",
             command="pytest {cmdargs} tests/contrib/futures",
+            pkgs={"gevent": latest},
             venvs=[
                 # futures is backported for 2.7
                 Venv(pys=["2.7"], pkgs={"futures": ["~=3.0", "~=3.1", "~=3.2", "~=3.4"]}),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,8 @@ def run_function_from_file(item, params=None):
 
     args = [sys.executable]
 
+    timeout = marker.kwargs.get("timeout", None)
+
     # Add ddtrace-run prefix in ddtrace-run mode
     if marker.kwargs.get("ddtrace_run", False):
         args.insert(0, "ddtrace-run")
@@ -222,7 +224,7 @@ def run_function_from_file(item, params=None):
         args.extend(marker.kwargs.get("args", []))
 
         def _subprocess_wrapper():
-            out, err, status, _ = call_program(*args, env=env, cwd=cwd)
+            out, err, status, _ = call_program(*args, env=env, cwd=cwd, timeout=timeout)
 
             if status != expected_status:
                 raise AssertionError(

--- a/tests/contrib/futures/test_futures_patch_generated.py
+++ b/tests/contrib/futures/test_futures_patch_generated.py
@@ -15,7 +15,7 @@ from tests.contrib.patch import PatchTestCase
 
 class TestFuturesPatch(PatchTestCase.Base):
     __integration_name__ = "futures"
-    __module_name__ = "concurrent.futures"
+    __module_name__ = "concurrent.futures.thread"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,6 +16,7 @@ from ddtrace import Span
 from ddtrace import Tracer
 from ddtrace.constants import SPAN_MEASURED_KEY
 from ddtrace.ext import http
+from ddtrace.internal.compat import PY2
 from ddtrace.internal.compat import httplib
 from ddtrace.internal.compat import parse
 from ddtrace.internal.compat import to_unicode
@@ -1027,9 +1028,14 @@ class AnyFloat(object):
 
 
 def call_program(*args, **kwargs):
+    timeout = kwargs.pop("timeout", None)
     close_fds = sys.platform != "win32"
     subp = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=close_fds, **kwargs)
-    stdout, stderr = subp.communicate()
+    if PY2:
+        # Python 2 doesn't support timeout
+        stdout, stderr = subp.communicate()
+    else:
+        stdout, stderr = subp.communicate(timeout=timeout)
     return stdout, stderr, subp.wait(), subp.pid
 
 


### PR DESCRIPTION
backport https://github.com/DataDog/dd-trace-py/pull/5402
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
