### PR TITLE
chore(pre-commit hooks): remove slotscheck from pre-commit hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ See [the contributing docs](https://ddtrace.readthedocs.io/en/stable/contributin
 
 ### Pre-commit Hooks
 
-**NOTE**: If pre-commit hooks fail to run in your development environment, you can uninstall them by deleting the symlink created by the installation script:
+**NOTE**: Pre-commit hooks are optional and provided as a convenience for contributors. 
+If pre-commit hooks fail to run in your development environment, you can uninstall them by deleting the symlink created by the installation script:
 
     $ rm .git/hooks/pre-commit
 The tracer library uses formatting/linting tools including black, flake8, and mypy.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -73,3 +73,14 @@ alongside the corresponding changes to `riotfile.py`.
 
     contributing-integrations
     releasenotes
+
+Pre-commit Hooks
+================
+
+The tracer library uses formatting/linting tools including black, flake8, and mypy.
+While these are run in each CI pipeline for pull requests, they are also **optionally** available to be automated to run
+when you call git commit as pre-commit hooks to catch any formatting errors before you commit.
+To initialize the pre-commit hook script to run in your development branch, run the following command:
+
+    $ rm .git/hooks/pre-commit
+

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -141,6 +141,7 @@ pid
 plugin
 posix
 postgres
+pre
 prepended
 profiler
 protobuf

--- a/hooks/pre-commit/run-slotscheck.sh
+++ b/hooks/pre-commit/run-slotscheck.sh
@@ -1,1 +1,0 @@
-../scripts/run-slotscheck.sh

--- a/hooks/scripts/run-slotscheck.sh
+++ b/hooks/scripts/run-slotscheck.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-riot -v run -s slotscheck


### PR DESCRIPTION
This PR removes slotscheck from the list of precommit hooks as they have been broken for quite some time and do not provide much benefit, especially considering we always run them in CI anyway.

Contributing docs have also been edited to point out that pre-commit hooks are optional and steps to uninstall them if necessary.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
