### PR TITLE
refactor(debugging): rate limit mixin

### DIFF
--- a/ddtrace/debugging/_probe/model.py
+++ b/ddtrace/debugging/_probe/model.py
@@ -70,18 +70,6 @@ class Probe(six.with_metaclass(abc.ABCMeta)):
     probe_id = attr.ib(type=str)
     version = attr.ib(type=int)
     tags = attr.ib(type=dict, eq=False)
-    rate = attr.ib(type=float, eq=False)
-    limiter = attr.ib(type=RateLimiter, init=False, repr=False, eq=False)  # type: RateLimiter
-
-    @limiter.default
-    def _(self):
-        return RateLimiter(
-            limit_rate=self.rate,
-            tau=1.0 / self.rate if self.rate else 1.0,
-            on_exceed=lambda: log.warning("Rate limit exceeeded for %r", self),
-            call_once=True,
-            raise_on_exceed=False,
-        )
 
     def update(self, other):
         # type: (Probe) -> None
@@ -98,6 +86,22 @@ class Probe(six.with_metaclass(abc.ABCMeta)):
 
     def __hash__(self):
         return hash(self.probe_id)
+
+
+@attr.s
+class RateLimitMixin(six.with_metaclass(abc.ABCMeta)):
+    rate = attr.ib(type=float, eq=False)
+    limiter = attr.ib(type=RateLimiter, init=False, repr=False, eq=False)  # type: RateLimiter
+
+    @limiter.default
+    def _(self):
+        return RateLimiter(
+            limit_rate=self.rate,
+            tau=1.0 / self.rate if self.rate else 1.0,
+            on_exceed=lambda: log.warning("Rate limit exceeeded for %r", self),
+            call_once=True,
+            raise_on_exceed=False,
+        )
 
 
 @attr.s
@@ -219,12 +223,12 @@ class LogProbeMixin(object):
 
 
 @attr.s
-class LogLineProbe(Probe, LineLocationMixin, LogProbeMixin, ProbeConditionMixin):
+class LogLineProbe(Probe, LineLocationMixin, LogProbeMixin, ProbeConditionMixin, RateLimitMixin):
     pass
 
 
 @attr.s
-class LogFunctionProbe(Probe, FunctionLocationMixin, LogProbeMixin, ProbeConditionMixin):
+class LogFunctionProbe(Probe, FunctionLocationMixin, LogProbeMixin, ProbeConditionMixin, RateLimitMixin):
     pass
 
 

--- a/ddtrace/debugging/_probe/remoteconfig.py
+++ b/ddtrace/debugging/_probe/remoteconfig.py
@@ -181,7 +181,6 @@ def probe_factory(attribs):
             tags=dict(_.split(":", 1) for _ in attribs.get("tags", [])),
             name=attribs["metricName"],
             kind=attribs["kind"],
-            rate=DEFAULT_PROBE_RATE,  # unused
             condition_error_rate=DEFAULT_PROBE_CONDITION_ERROR_RATE,  # TODO: should we take rate limit out of Probe?
             value=_compile_expression(attribs.get("value")),
         )
@@ -194,7 +193,6 @@ def probe_factory(attribs):
             version=attribs.get("version", 0),
             condition=_compile_expression(attribs.get("when")),
             tags=dict(_.split(":", 1) for _ in attribs.get("tags", [])),
-            rate=DEFAULT_PROBE_RATE,  # TODO: should we take rate limit out of Probe?
             condition_error_rate=DEFAULT_PROBE_CONDITION_ERROR_RATE,  # TODO: should we take rate limit out of Probe?
         )
 

--- a/tests/debugging/utils.py
+++ b/tests/debugging/utils.py
@@ -79,7 +79,6 @@ def snapshot_probe_defaults(f):
 
 def metric_probe_defaults(f):
     def _wrapper(*args, **kwargs):
-        kwargs.setdefault("rate", DEFAULT_PROBE_RATE)
         kwargs.setdefault("value", None)
         return f(*args, **kwargs)
 
@@ -88,7 +87,6 @@ def metric_probe_defaults(f):
 
 def span_probe_defaults(f):
     def _wrapper(*args, **kwargs):
-        kwargs.setdefault("rate", DEFAULT_PROBE_RATE)
         return f(*args, **kwargs)
 
     return _wrapper


### PR DESCRIPTION
As not all probes are rate limited, the rate limit fields are not base features of probes. This change move rate limiting data into a mixin that can be added to just those probes that require rate limiting.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
