### PR TITLE
chore(lib-inject): fix build_deploy [backport #5472 to 1.11]

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -214,10 +214,10 @@ jobs:
 
   build-and-publish-init-image:
     needs: [upload_pypi]
-    steps:
-      - uses: ./.github/workflows/lib-inject-publish.yml
-        with:
-          ddtrace-version: ${{ github.ref_name }}
-          image-tag: ${{ github.ref_name }}
-        secrets:
-          token: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: ubuntu-latest
+    uses: ./.github/workflows/lib-inject-publish.yml
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      ddtrace-version: ${{ github.ref_name }}
+      image-tag: ${{ github.ref_name }}


### PR DESCRIPTION
Re-usable workflows don't support being run in `steps` which isn't well documented. This manifests as

```
The workflow is not valid. .github/workflows/build_deploy.yml (Line: 222, Col: 9): Unexpected value 'secrets' .github/workflows/build_deploy.yml
```

https://github.com/DataDog/dd-trace-py/actions/runs/4612728372

Unfortunately, there isn't a really good way to verify this job before the release. Github doesn't validate the workflows until they have match criteria and are executed.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
