### PR TITLE
fix(tracing): avoid dropping extra headers passed to AgentWriter constructor

### DIFF
--- a/ddtrace/internal/writer.py
+++ b/ddtrace/internal/writer.py
@@ -573,25 +573,27 @@ class AgentWriter(HTTPWriter):
         )
 
         endpoint = "%s/traces" % self._api_version
-        headers = {
+        _headers = {
             "Datadog-Meta-Lang": "python",
             "Datadog-Meta-Lang-Version": compat.PYTHON_VERSION,
             "Datadog-Meta-Lang-Interpreter": compat.PYTHON_INTERPRETER,
             "Datadog-Meta-Tracer-Version": ddtrace.__version__,
             "Datadog-Client-Computed-Top-Level": "yes",
         }
+        if headers:
+            _headers.update(headers)
         self._container_info = container.get_container_info()
         if self._container_info and self._container_info.container_id:
-            headers.update(
+            _headers.update(
                 {
                     "Datadog-Container-Id": self._container_info.container_id,
                 }
             )
 
-        headers.update({"Content-Type": encoder.content_type})
+        _headers.update({"Content-Type": encoder.content_type})
         additional_header_str = os.environ.get("_DD_TRACE_WRITER_ADDITIONAL_HEADERS")
         if additional_header_str is not None:
-            headers.update(parse_tags_str(additional_header_str))
+            _headers.update(parse_tags_str(additional_header_str))
         super(AgentWriter, self).__init__(
             intake_url=agent_url,
             endpoint=endpoint,
@@ -605,7 +607,7 @@ class AgentWriter(HTTPWriter):
             dogstatsd=dogstatsd,
             sync_mode=sync_mode,
             reuse_connections=reuse_connections,
-            headers=headers,
+            headers=_headers,
         )
 
     def recreate(self):

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -552,6 +552,14 @@ def test_additional_headers():
         assert writer._headers["header2"] == "value2"
 
 
+def test_additional_headers_constructor():
+    writer = AgentWriter(
+        agent_url="http://localhost:9126", headers={"additional-header": "additional-value", "header2": "value2"}
+    )
+    assert writer._headers["additional-header"] == "additional-value"
+    assert writer._headers["header2"] == "value2"
+
+
 def test_bad_encoding(monkeypatch):
     monkeypatch.setenv("DD_TRACE_API_VERSION", "foo")
 


### PR DESCRIPTION
This change fixes a bug introduced in #5475 that caused headers in `AgentWriter`'s `headers` kwarg to be ignored.

I haven't included a release note because the bug this fixes was introduced after the most recent release.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
