### PR TITLE
fix(ci): pin websockets in sanic tests

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -2166,6 +2166,7 @@ venv = Venv(
                             "~=21.6.0",
                         ],
                         "pytest-sanic": latest,
+                        "websockets": ["<11.0"],
                     },
                 ),
                 Venv(
@@ -2176,6 +2177,7 @@ venv = Venv(
                             "~=21.12.0",
                         ],
                         "sanic-testing": "~=0.8.3",
+                        "websockets": ["<11.0"],
                     },
                 ),
                 Venv(
@@ -2183,6 +2185,7 @@ venv = Venv(
                     pkgs={
                         "sanic": "~=22.3.0",
                         "sanic-testing": "~=22.3.0",
+                        "websockets": ["<11.0"],
                     },
                 ),
                 Venv(
@@ -2190,6 +2193,7 @@ venv = Venv(
                     pkgs={
                         "sanic": "~=22.9.0",
                         "sanic-testing": "~=22.9.0",
+                        "websockets": ["<11.0"],
                     },
                 ),
                 Venv(
@@ -2197,6 +2201,7 @@ venv = Venv(
                     pkgs={
                         "sanic": latest,
                         "sanic-testing": latest,
+                        "websockets": ["<11.0"],
                     },
                 ),
             ],


### PR DESCRIPTION
Pin `websockets` dependency for sanic tests. This is not an issue on 1.x after #5246.
 
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
