### PR TITLE
chore(ci): add special branches for testing build_deploy, fix lib-injection [backport #5486 to 1.11]

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '[0-9].[0-9]*'
       - '[0-9].x'
+      # special branches used to test this workflow
+      # before merging/releasing
+      - build_deploy*
   pull_request:
     paths:
       - "setup.py"
@@ -214,7 +217,6 @@ jobs:
 
   build-and-publish-init-image:
     needs: [upload_pypi]
-    runs-on: ubuntu-latest
     uses: ./.github/workflows/lib-inject-publish.yml
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In order to test build_deploy jobs a special branch pattern is added.

Github doesn't verify that jobs adhere to its workflow schema until the job matches the `on` criteria and is run. Previously this workflow only ran on release branches and on releases. This meant that there was no way to ensure the jobs actually parsed correctly before a PR was merged or a release was done.


To demonstrate the fix, a bug exists in the lib-injection job which results in


![image](https://user-images.githubusercontent.com/6321485/230226834-4e5bc217-9dd9-4925-8d0c-cf75c4657910.png)

on the first commit of this PR.

A commit is pushed with the fix which shows that the workflow at least parses:


![image](https://user-images.githubusercontent.com/6321485/230227458-1c2ef63c-48f0-4ee7-8795-780ffc68eb4a.png)


This of course doesn't verify that the job runs successfully but it at least lets us know that it loads fine (which given Github's workflow rules and lack of documentation goes a long way).

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
