### PR TITLE
fix(tracing): ensure 128 trace ids are propagated by datadog headers

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -275,13 +275,14 @@ class _DatadogMultiHeader:
             # When 128 bit trace ids are propagated the 64 lowest order bits are set in the `x-datadog-trace-id`
             # header. The 64 highest order bits are encoded in base 16 and store in the `_dd.p.tid` tag.
             # Here we reconstruct the full 128 bit trace_id.
-            trace_id_hob_hex = meta.get(_HIGHER_ORDER_TRACE_ID_BITS, "")
+            trace_id_hob_hex = meta[_HIGHER_ORDER_TRACE_ID_BITS]
             try:
                 if len(trace_id_hob_hex) != 16:
-                    ValueError("Invalid size")
+                    raise ValueError("Invalid size")
                 # combine highest and lowest order hex values to create a 128 bit trace_id
                 trace_id = int(trace_id_hob_hex + "{:016x}".format(trace_id), 16)
             except ValueError:
+                meta["_dd.propagation_error"] == "malformed_tid {}".format(trace_id_hob_hex)
                 log.warning("malformed_tid: %s. Failed to decode trace id from http headers", trace_id_hob_hex)
             # After the full trace id is reconstructed this tag is no longer required
             del meta[_HIGHER_ORDER_TRACE_ID_BITS]

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -271,19 +271,20 @@ class _DatadogMultiHeader:
                 }
                 log.debug("failed to decode x-datadog-tags: %r", tags_value, exc_info=True)
 
-        if meta is not None and config._128_bit_trace_id_enabled:
-            # When 128 bit trace ids are propagated the 64 lowest order bits are encoded as an integer
-            # and set in the `x-datadog-trace-id` header (this was done for backwards compatibility).
-            # The 64 highest order bits are encoded in base 16 and store in the `_dd.p.tid` tag.
+        if meta and _HIGHER_ORDER_TRACE_ID_BITS in meta:
+            # When 128 bit trace ids are propagated the 64 lowest order bits are set in the `x-datadog-trace-id`
+            # header. The 64 highest order bits are encoded in base 16 and store in the `_dd.p.tid` tag.
             # Here we reconstruct the full 128 bit trace_id.
-            trace_id_hob_hex = meta.get(_HIGHER_ORDER_TRACE_ID_BITS)  # type: Optional[str]
-            if trace_id_hob_hex is not None:
-                # convert lowest order bits in trace_id to base 16
-                trace_id_lod_hex = "{:016x}".format(trace_id)
+            trace_id_hob_hex = meta.get(_HIGHER_ORDER_TRACE_ID_BITS, "")
+            try:
+                if len(trace_id_hob_hex) != 16:
+                    ValueError("Invalid size")
                 # combine highest and lowest order hex values to create a 128 bit trace_id
-                trace_id = int(trace_id_hob_hex + trace_id_lod_hex, 16)
-                # After the full trace id is reconstructed this tag is no longer required
-                del meta[_HIGHER_ORDER_TRACE_ID_BITS]
+                trace_id = int(trace_id_hob_hex + "{:016x}".format(trace_id), 16)
+            except ValueError:
+                log.warning("malformed_tid: %s. Failed to decode trace id from http headers", trace_id_hob_hex)
+            # After the full trace id is reconstructed this tag is no longer required
+            del meta[_HIGHER_ORDER_TRACE_ID_BITS]
 
         # Try to parse values into their expected types
         try:

--- a/releasenotes/notes/fix-128bit-trace-id-propagation-b0e262f0fdf45044.yaml
+++ b/releasenotes/notes/fix-128bit-trace-id-propagation-b0e262f0fdf45044.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: Ensure datadog headers propagate 128 bit trace ids when ``DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=False``

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -52,7 +52,7 @@ def test_inject(tracer):
 
 
 @pytest.mark.subprocess(
-    env=dict(DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED="true", DD_TRACE_PROPAGATION_STYLE=PROPAGATION_STYLE_DATADOG),
+    env=dict(DD_TRACE_PROPAGATION_STYLE=PROPAGATION_STYLE_DATADOG),
 )
 def test_inject_128bit_trace_id_datadog():
     from ddtrace.context import Context
@@ -286,7 +286,7 @@ def test_extract(tracer):
 
 
 @pytest.mark.subprocess(
-    env=dict(DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED="true", DD_TRACE_PROPAGATION_STYLE=PROPAGATION_STYLE_DATADOG),
+    env=dict(DD_TRACE_PROPAGATION_STYLE=PROPAGATION_STYLE_DATADOG),
 )
 def test_extract_128bit_trace_ids_datadog():
     from ddtrace.internal.constants import HIGHER_ORDER_TRACE_ID_BITS


### PR DESCRIPTION
- Ensure datadog headers propagate 128 bit trace ids when ``DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=False``.
- Ensure only valid `tid` values are propagated. `_dd.p.tid` tag must contain 16 hex characters.

This edge case surfaced by this system tests: https://github.com/DataDog/system-tests/blob/6168fa7e6f485e2655f81801a677356624409620/parametric/test_128_bit_traceids.py#L11

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
