### PR TITLE
fix(ci/lib-inject): pin buildx [backport #5496 to 1.11]

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        # Images after this version (>=v0.10) are incompatible with gcr and aws.
+        version: v0.9.1  # https://github.com/docker/buildx/issues/1533
     - name: Login to Docker
       run: docker login -u publisher -p ${{ secrets.token }} ghcr.io
     - name: Docker Build


### PR DESCRIPTION
v0.10 of buildx by default creates images which aren't compatible with gcr/aws lambda: https://github.com/docker/buildx/releases/tag/v0.10.0.

This was causing the publish for the lib-injection images to fail when pushed to gcr:

```
2023/04/06 21:22:10 Failed to publish image, err: publish failed for registry id: gcr-datadoghq, err: PUT https://gcr.io/v2/datadoghq/dd-lib-python-init/manifests/v1.11.1: MANIFEST_INVALID: Failed to parse manifest for request "/v2/datadoghq/dd-lib-python-init/manifests/v1.11.1": Failed to deserialize application/vnd.docker.distribution.manifest.list.v2+json.
```

Pin buildx to v0.9.1, the version prior to avoid this issue.

## Testing

The fix was validated by rebuilding `v1.11.1` with buildx v0.9.1 and retrying the `build-images` job which succeeded.

## Risk
This change pins the version for all builds that we do but given that v0.9.1 isn't that old it's probably a good thing to have it pinned anyway for deterministic building and publishing.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
