### PR TITLE
fix(tracing): ensure propagating errors are set correctly

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -282,7 +282,7 @@ class _DatadogMultiHeader:
                 # combine highest and lowest order hex values to create a 128 bit trace_id
                 trace_id = int(trace_id_hob_hex + "{:016x}".format(trace_id), 16)
             except ValueError:
-                meta["_dd.propagation_error"] == "malformed_tid {}".format(trace_id_hob_hex)
+                meta["_dd.propagation_error"] = "malformed_tid {}".format(trace_id_hob_hex)
                 log.warning("malformed_tid: %s. Failed to decode trace id from http headers", trace_id_hob_hex)
             # After the full trace id is reconstructed this tag is no longer required
             del meta[_HIGHER_ORDER_TRACE_ID_BITS]


### PR DESCRIPTION
Introduced by: https://github.com/DataDog/dd-trace-py/commit/da594c74bdf932b970947a380c19fbe2c3a74f6d

This bug was surfaced by the following system tests: https://github.com/DataDog/system-tests/blob/6168fa7e6f485e2655f81801a677356624409620/parametric/test_128_bit_traceids.py#L11

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
