### PR TITLE
chore(testing/agent): enable stats to be sent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,8 +129,10 @@ services:
             - DD_REMOTE_CONFIGURATION_KEY=${DD_REMOTE_CONFIGURATION_KEY-invalid_but_this_is_fine}
             - DD_REMOTE_CONFIGURATION_REFRESH_INTERVAL=5s
             - DD_APM_RECEIVER_SOCKET=/tmp/ddagent/trace.sock
+            - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
         ports:
-            - "127.0.0.1:8126:8126"
+            - 8126:8126
+            - 8125:8125/udp
         volumes:
           - ddagent:/tmp/ddagent:rw
     testagent:


### PR DESCRIPTION
The agent wasn't previously configured to accept stats requests.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
