### PR TITLE
chore(integration-tests): add timeout to flaky integration test, increase parallelization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -538,16 +538,16 @@ jobs:
 
   integration_agent:
     <<: *machine_executor
+    parallelism: 2
     steps:
       - attach_workspace:
           at: .
       - checkout
       - start_docker_services:
           services: ddagent
-      - run:
-          command: |
-            mv .riot .ddriot
-            ./scripts/ddtest riot -v run --pass-env -s 'integration-latest'
+      - run_test:
+          store_coverage: false
+          pattern: 'integration-latest'
 
   integration_testagent:
     <<: *machine_executor
@@ -555,15 +555,10 @@ jobs:
       - attach_workspace:
           at: .
       - checkout
-      - start_docker_services:
-          env: SNAPSHOT_CI=1
-          services: testagent
-      - run:
-          environment:
-            DD_TRACE_AGENT_URL: http://localhost:9126
-          command: |
-            mv .riot .ddriot
-            ./scripts/ddtest riot -v run --pass-env -s 'integration-snapshot'
+      - run_test:
+          store_coverage: false
+          snapshot: true
+          pattern: 'integration-snapshot'
 
   vendor:
     <<: *contrib_job_small

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -771,7 +771,7 @@ s2.finish()
         [sys.executable, "test.py"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=str(tmpdir), env=env
     )
     try:
-        p.wait(timeout=2)
+        p.wait(timeout=10)
     except TypeError:
         # timeout argument added in Python 3.3
         p.wait()


### PR DESCRIPTION
Fixes #5439.

This PR adds a timeout to the flaky `test_regression_logging_in_context` integration_agent test. Additionally, this PR makes the integration test suites parallel to reduce CI duration.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
