### PR TITLE
chore(ci): increase parallelism for stdlib test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,6 +601,7 @@ jobs:
 
   stdlib:
     <<: *contrib_job_small
+    parallelism: 2
     steps:
       - run_test:
           pattern: 'asyncio$|sqlite3$|futures$|dbapi$'


### PR DESCRIPTION
This PR increases the parallel workers for the stdlib from 1 to 2, as `stdlib` was one of our longest running (>10 minutes) test suite.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
