### PR TITLE
chore(boto): add timeouts to all boto tests

### DIFF
--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -339,7 +339,11 @@ class BotocoreTest(TracerTestCase):
             trace_data_injected = json.loads(trace_json)
             assert trace_data_injected[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
             assert trace_data_injected[HTTP_HEADER_PARENT_ID] == str(span.span_id)
-            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+            response = sqs.receive_message(
+                QueueUrl=queue["QueueUrl"],
+                MessageAttributeNames=["_datadog"],
+                WaitTimeSeconds=2,
+            )
             assert len(response["Messages"]) == 1
             trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
             sqs.delete_queue(QueueUrl=queue["QueueUrl"])
@@ -370,8 +374,11 @@ class BotocoreTest(TracerTestCase):
             assert span.service == "test-botocore-tracing.sqs"
             assert span.resource == "sqs.sendmessage"
             assert span.get_tag("params.MessageAttributes._datadog.StringValue") is None
-
-            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+            response = sqs.receive_message(
+                QueueUrl=queue["QueueUrl"],
+                MessageAttributeNames=["_datadog"],
+                WaitTimeSeconds=2,
+            )
             assert len(response["Messages"]) == 1
             trace_in_message = "MessageAttributes" in response["Messages"][0]
             assert trace_in_message is False
@@ -413,7 +420,11 @@ class BotocoreTest(TracerTestCase):
             trace_data_injected = json.loads(trace_json)
             assert trace_data_injected[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
             assert trace_data_injected[HTTP_HEADER_PARENT_ID] == str(span.span_id)
-            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+            response = sqs.receive_message(
+                QueueUrl=queue["QueueUrl"],
+                MessageAttributeNames=["_datadog"],
+                WaitTimeSeconds=2,
+            )
             assert len(response["Messages"]) == 1
             trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
             trace_data_in_message = json.loads(trace_json_message)
@@ -456,7 +467,11 @@ class BotocoreTest(TracerTestCase):
             assert span.resource == "sqs.sendmessage"
             trace_json = span.get_tag("params.MessageAttributes._datadog.StringValue")
             assert trace_json is None
-            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+            response = sqs.receive_message(
+                QueueUrl=queue["QueueUrl"],
+                MessageAttributeNames=["_datadog"],
+                WaitTimeSeconds=2,
+            )
             assert len(response["Messages"]) == 1
             trace_in_message = "MessageAttributes" in response["Messages"][0]
             assert trace_in_message is False
@@ -489,7 +504,11 @@ class BotocoreTest(TracerTestCase):
             assert_span_http_status_code(span, 200)
             assert span.service == "test-botocore-tracing.sqs"
             assert span.resource == "sqs.sendmessagebatch"
-            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+            response = sqs.receive_message(
+                QueueUrl=queue["QueueUrl"],
+                MessageAttributeNames=["_datadog"],
+                WaitTimeSeconds=2,
+            )
             assert len(response["Messages"]) == 1
             trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
             trace_data_in_message = json.loads(trace_json_message)
@@ -536,7 +555,11 @@ class BotocoreTest(TracerTestCase):
             assert_span_http_status_code(span, 200)
             assert span.service == "test-botocore-tracing.sqs"
             assert span.resource == "sqs.sendmessagebatch"
-            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+            response = sqs.receive_message(
+                QueueUrl=queue["QueueUrl"],
+                MessageAttributeNames=["_datadog"],
+                WaitTimeSeconds=2,
+            )
             assert len(response["Messages"]) == 1
             trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
             trace_data_in_message = json.loads(trace_json_message)
@@ -582,7 +605,11 @@ class BotocoreTest(TracerTestCase):
         assert_span_http_status_code(span, 200)
         assert span.service == "test-botocore-tracing.sqs"
         assert span.resource == "sqs.sendmessagebatch"
-        response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+        response = sqs.receive_message(
+            QueueUrl=queue["QueueUrl"],
+            MessageAttributeNames=["_datadog"],
+            WaitTimeSeconds=2,
+        )
         assert len(response["Messages"]) == 1
         trace_in_message = "MessageAttributes" in response["Messages"][0]
         assert trace_in_message is False
@@ -1314,7 +1341,11 @@ class BotocoreTest(TracerTestCase):
             spans = self.get_spans()
 
             # get SNS messages via SQS
-            response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+            response = sqs.receive_message(
+                QueueUrl=queue["QueueUrl"],
+                MessageAttributeNames=["_datadog"],
+                WaitTimeSeconds=2,
+            )
 
             # clean up resources
             sqs.delete_queue(QueueUrl=sqs_url)
@@ -1458,7 +1489,11 @@ class BotocoreTest(TracerTestCase):
         spans = self.get_spans()
 
         # get SNS messages via SQS
-        response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+        response = sqs.receive_message(
+            QueueUrl=queue["QueueUrl"],
+            MessageAttributeNames=["_datadog"],
+            WaitTimeSeconds=2,
+        )
 
         # clean up resources
         sqs.delete_queue(QueueUrl=sqs_url)
@@ -1531,7 +1566,11 @@ class BotocoreTest(TracerTestCase):
         spans = self.get_spans()
 
         # get SNS messages via SQS
-        response = sqs.receive_message(QueueUrl=queue["QueueUrl"], MessageAttributeNames=["_datadog"])
+        response = sqs.receive_message(
+            QueueUrl=queue["QueueUrl"],
+            MessageAttributeNames=["_datadog"],
+            WaitTimeSeconds=2,
+        )
 
         # clean up resources
         sqs.delete_queue(QueueUrl=sqs_url)
@@ -1608,7 +1647,7 @@ class BotocoreTest(TracerTestCase):
         response = sqs.receive_message(
             QueueUrl=queue["QueueUrl"],
             MessageAttributeNames=["_datadog"],
-            WaitTimeSeconds=10,
+            WaitTimeSeconds=2,
         )
 
         # clean up resources


### PR DESCRIPTION
This PR builds on #5518 by adding timeouts to all boto test cases.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
