### PR TITLE
chore(6to7): add microbenchmarks

### DIFF
--- a/benchmarks/span/config.yaml
+++ b/benchmarks/span/config.yaml
@@ -4,6 +4,10 @@ start: &base
   ltags: 0
   nmetrics: 0
   finishspan: false
+  traceid128: false
+start-traceid128:
+  <<: *base
+  traceid128: true
 add-tags:
   <<: *base
   ntags: 100
@@ -14,3 +18,7 @@ add-metrics:
 start-finish:
   <<: *base
   finishspan: true
+start-finish-traceid128:
+  <<: *base
+  finishspan: true
+  traceid128: true

--- a/benchmarks/span/config.yaml
+++ b/benchmarks/span/config.yaml
@@ -22,4 +22,3 @@ start-finish-traceid128:
   <<: *base
   finishspan: true
   traceid128: true
-  

--- a/benchmarks/span/config.yaml
+++ b/benchmarks/span/config.yaml
@@ -22,3 +22,4 @@ start-finish-traceid128:
   <<: *base
   finishspan: true
   traceid128: true
+  

--- a/benchmarks/span/scenario.py
+++ b/benchmarks/span/scenario.py
@@ -1,6 +1,8 @@
 import bm
 import bm.utils as utils
 
+from ddtrace import config
+
 
 class Span(bm.Scenario):
     nspans = bm.var(type=int)
@@ -8,6 +10,7 @@ class Span(bm.Scenario):
     ltags = bm.var(type=int)
     nmetrics = bm.var(type=int)
     finishspan = bm.var_bool()
+    traceid128 = bm.var_bool()
 
     def run(self):
         # run scenario to also set tags on spans
@@ -20,6 +23,7 @@ class Span(bm.Scenario):
 
         # run scenario to include finishing spans
         finishspan = self.finishspan
+        config._128_bit_trace_id_enabled = self.traceid128
 
         def _(loops):
             for _ in range(loops):


### PR DESCRIPTION
Benchmark creating and finishing spans with 128bit trace ids.

Output:
```
.....................
span-start: Mean +- std dev: 944 us +- 20 us
.....................
span-start-traceid128: Mean +- std dev: 1.14 ms +- 0.02 ms
.....................
span-add-tags: Mean +- std dev: 52.1 ms +- 0.6 ms
.....................
span-add-metrics: Mean +- std dev: 29.4 ms +- 0.5 ms
.....................
span-start-finish: Mean +- std dev: 1.19 ms +- 0.02 ms
.....................
span-start-finish-traceid128: Mean +- std dev: 1.28 ms +- 0.02 ms
```

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
