### PR TITLE
fix(ci-visibility): add dd_origin propagation to CIVisibilityEncoder

### DIFF
--- a/ddtrace/internal/ci_visibility/encoder.py
+++ b/ddtrace/internal/ci_visibility/encoder.py
@@ -22,13 +22,14 @@ class CIVisibilityEncoderV01(BufferedEncoder):
         super(CIVisibilityEncoderV01, self).__init__()
         self._lock = threading.RLock()
         self._init_buffer()
+        self._metadata = {}
 
     def __len__(self):
         with self._lock:
             return len(self.buffer)
 
     def set_metadata(self, metadata):
-        self._metadata = metadata or dict()
+        self._metadata.update(metadata)
 
     def _init_buffer(self):
         with self._lock:
@@ -48,7 +49,9 @@ class CIVisibilityEncoderV01(BufferedEncoder):
             return payload
 
     def _build_payload(self, traces):
-        normalized_spans = [CIVisibilityEncoderV01._convert_span(span) for trace in traces for span in trace]
+        normalized_spans = [
+            CIVisibilityEncoderV01._convert_span(span, trace[0].context.dd_origin) for trace in traces for span in trace
+        ]
         self._metadata = {k: v for k, v in self._metadata.items() if k in self.ALLOWED_METADATA_KEYS}
         # TODO: Split the events in several payloads as needed to avoid hitting the intake's maximum payload size.
         return msgpack_packb(
@@ -56,13 +59,15 @@ class CIVisibilityEncoderV01(BufferedEncoder):
         )
 
     @staticmethod
-    def _convert_span(span):
-        # type: (Span) -> Dict[str, Any]
+    def _convert_span(span, dd_origin):
+        # type: (Span, str) -> Dict[str, Any]
         sp = JSONEncoderV2._convert_span(span)
         sp["type"] = span.span_type
         sp["duration"] = span.duration_ns
         sp["meta"] = dict(sorted(span._meta.items()))
         sp["metrics"] = dict(sorted(span._metrics.items()))
+        if dd_origin is not None:
+            sp["meta"].update({"_dd.origin": dd_origin})
         if span.span_type == "test":
             event_type = "test"
         else:

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -12,6 +12,7 @@ from ddtrace.contrib.pytest.plugin import is_enabled
 from ddtrace.ext import ci
 from ddtrace.ext import test
 from ddtrace.internal.ci_visibility import CIVisibility
+from ddtrace.internal.ci_visibility.encoder import CIVisibilityEncoderV01
 from tests.utils import DummyCIVisibilityWriter
 from tests.utils import TracerTestCase
 from tests.utils import override_env
@@ -547,7 +548,6 @@ class PytestTestCase(TracerTestCase):
         file_name = os.path.basename(py_file.strpath)
         rec = self.inline_run("--ddtrace", file_name)
         rec.assertoutcome(passed=1)
-
         spans = self.pop_spans()
         # Check if spans tagged with dd_origin after encoding and decoding as the tagging occurs at encode time
         encoder = self.tracer.encoder
@@ -557,6 +557,15 @@ class PytestTestCase(TracerTestCase):
         assert len(decoded_trace) == 4
         for span in decoded_trace:
             assert span[b"meta"][b"_dd.origin"] == b"ciapp-test"
+
+        ci_agentless_encoder = CIVisibilityEncoderV01(0, 0)
+        ci_agentless_encoder.put(spans)
+        trace = ci_agentless_encoder.encode()
+        decoded_trace = self.tracer.encoder._decode(trace)
+        assert len(decoded_trace[b"events"]) == 4
+        for event in decoded_trace[b"events"]:
+            assert event[b"content"][b"meta"][b"_dd.origin"] == b"ciapp-test"
+        pass
 
     def test_pytest_doctest_module(self):
         """Test that pytest with doctest works as expected."""


### PR DESCRIPTION
This PR builds on  #5489 by adding dd_origin propagation to the CIVisibilityEncoder, which is necessary for CI Visibility. This is not a new feature as this functionality is already present in the regular encoder.

This doesn't need a changelog since this is internal and is a fix to an unreleased change.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
