### PR TITLE
chore(grpc): wait for traces in flaky snapshot test

### DIFF
--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -685,7 +685,7 @@ class _UnaryUnaryRpcHandler(grpc.GenericRpcHandler):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="flaky on older python versions")
-@snapshot(ignores=["meta.network.destination.port"])
+@snapshot(ignores=["meta.network.destination.port"], wait_for_num_traces=2)
 def test_method_service(patch_grpc):
     def handler(request, context):
         return b""


### PR DESCRIPTION
This PR adds the `wait_for_traces` argument in the snapshot test `test_method_service` which has been repeatedly flaky. 

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
