### PR TITLE
chore(flake8): exclude ddtrace/__init__.py [backport #5428 to 1.9]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ exclude=
   .git,__pycache__,
   .eggs,*.egg,
   build,
+  ddtrace/__init__.py,
   # We shouldn't lint our vendored dependencies
   ddtrace/vendor/*
   ddtrace/profiling/exporter/pprof_pb2.py


### PR DESCRIPTION
Backport of #5428 to 1.9

This change excludes the ddtrace/__init__.py file from flake8 linting because its structure makes it such that it is hard to ensure that it simultaneously passes both linting and formatting checks. Besides, the source already makes extensive use of the noqa comment to effectively ignore linting errors on many lines.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
