### PR TITLE
fix(algoliasearch): use set_tag for non text type search query args

### DIFF
--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -130,7 +130,7 @@ def _patched_search(func, instance, wrapt_args, wrapt_kwargs):
             for query_arg, tag_name in QUERY_ARGS_DD_TAG_MAP.items():
                 value = query_args.get(query_arg)
                 if value is not None:
-                    span.set_tag_str("query.args.{}".format(tag_name), value)
+                    span.set_tag("query.args.{}".format(tag_name), value)
 
         # Result would look like this
         # {

--- a/releasenotes/notes/fix-algoliasearch-tag-non-text-6a2d90b486ca2553.yaml
+++ b/releasenotes/notes/fix-algoliasearch-tag-non-text-6a2d90b486ca2553.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    algoliasearch: This fix resolves an issue where non-text search query arguments caused Type Errors when being
+    added as tags.

--- a/tests/contrib/algoliasearch/test.py
+++ b/tests/contrib/algoliasearch/test.py
@@ -100,6 +100,19 @@ class AlgoliasearchTest(TracerTestCase):
         spans = self.get_spans()
         span = spans[0]
         assert span.get_tag("query.text") == "test search"
+        assert span.get_tag("query.args.attributes_to_retrieve") == "firstname,lastname"
+        assert span.get_tag("query.args.unsupportedTotallyNewArgument") is None
+
+    def test_algoliasearch_with_query_args_nontext(self):
+        self.patch_algoliasearch()
+        config.algoliasearch.collect_query_text = True
+
+        self.perform_search("test search", {"hitsPerPage": 1, "page": 3})
+        spans = self.get_spans()
+        span = spans[0]
+        assert span.get_tag("query.text") == "test search"
+        assert span.get_metric("query.args.page") == 3
+        assert span.get_metric("query.args.hits_per_page") == 1
 
     def test_patch_unpatch(self):
         self.patch_algoliasearch()


### PR DESCRIPTION
Fixes #5557.

A previous change replaced all usages of `set_tag()` with `set_tag_str()` in the algoliasearch integration, however some arguments to the patched `search` method can be non-text types (e.g. `page`, `hitsPerPage`). This PR reverts usage of `set_tag_str` back to `set_tag`.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
