### PR TITLE
chore(internal/dogstatsd): add constant tags

### DIFF
--- a/ddtrace/internal/dogstatsd.py
+++ b/ddtrace/internal/dogstatsd.py
@@ -1,3 +1,4 @@
+from typing import List
 from typing import Optional
 
 from ddtrace.internal.compat import parse
@@ -5,8 +6,8 @@ from ddtrace.vendor.dogstatsd import DogStatsd
 from ddtrace.vendor.dogstatsd import base
 
 
-def get_dogstatsd_client(url, namespace=None):
-    # type: (str, Optional[str]) -> DogStatsd
+def get_dogstatsd_client(url, namespace=None, tags=None):
+    # type: (str, Optional[str], Optional[List[str]]) -> DogStatsd
     # url can be either of the form `udp://<host>:<port>` or `unix://<path>`
     # also support without url scheme included
     if url.startswith("/"):
@@ -17,12 +18,13 @@ def get_dogstatsd_client(url, namespace=None):
     parsed = parse.urlparse(url)
 
     if parsed.scheme == "unix":
-        return DogStatsd(socket_path=parsed.path, namespace=namespace)
+        return DogStatsd(socket_path=parsed.path, namespace=namespace, constant_tags=tags)
     elif parsed.scheme == "udp":
         return DogStatsd(
             host=parsed.hostname,
             port=base.DEFAULT_PORT if parsed.port is None else parsed.port,
             namespace=namespace,
+            constant_tags=tags,
         )
 
     raise ValueError("Unknown scheme `%s` for DogStatsD URL `{}`".format(parsed.scheme))


### PR DESCRIPTION
The dogstatsd client as an option to provide "constant tags" that get applied to every metric produced by the client.

We are planning to use this in the OpenAI integration.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
