### PR TITLE
fix: update logging module on threading import

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -7,6 +7,7 @@ import sys
 
 LOADED_MODULES = frozenset(sys.modules.keys())
 
+from functools import partial  # noqa
 import logging  # noqa
 import os  # noqa
 from typing import Any  # noqa
@@ -17,6 +18,7 @@ from ddtrace import config  # noqa
 from ddtrace.debugging._config import config as debugger_config  # noqa
 from ddtrace.internal.compat import PY2  # noqa
 from ddtrace.internal.logger import get_logger  # noqa
+from ddtrace.internal.module import ModuleWatchdog  # noqa
 from ddtrace.internal.module import find_loader  # noqa
 from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker  # noqa
 from ddtrace.internal.utils.formats import asbool  # noqa
@@ -151,6 +153,14 @@ def cleanup_loaded_modules():
             if m == u or m.startswith(u + "."):
                 drop(m)
 
+    # Because we are not unloading it, the logging module requires a reference
+    # to the newly imported threading module to allow it to retrieve the correct
+    # thread object information, like the thread name. We register a post-import
+    # hook on the threading module to perform this update.
+    @partial(ModuleWatchdog.register_module_hook, "threading")
+    def _(threading):
+        logging.threading = threading
+
 
 try:
     from ddtrace import tracer
@@ -179,7 +189,6 @@ try:
             from ddtrace.appsec.iast._ast.ast_patching import _should_iast_patch
             from ddtrace.appsec.iast._loader import _exec_iast_patched_module
             from ddtrace.appsec.iast._taint_tracking import setup
-            from ddtrace.internal.module import ModuleWatchdog
 
             setup(bytes.join, bytearray.join)
 

--- a/releasenotes/notes/fix-update-logging-module-after-cleanup-60d90b0e11a6dc3a.yaml
+++ b/releasenotes/notes/fix-update-logging-module-after-cleanup-60d90b0e11a6dc3a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Ensure that the logging module can report thread information, such as thread
+    names, correctly when a framework like gevent is used that requires modules
+    cleanup.

--- a/releasenotes/notes/fix-update-logging-module-after-cleanup-60d90b0e11a6dc3a.yaml
+++ b/releasenotes/notes/fix-update-logging-module-after-cleanup-60d90b0e11a6dc3a.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Ensure that the logging module can report thread information, such as thread
+    logging: Ensure that the logging module can report thread information, such as thread
     names, correctly when a framework like gevent is used that requires modules
     cleanup.


### PR DESCRIPTION
This change ensures that the logging module can report thread information, such as thread names, correctly when a framework like gevent is used that requires modules cleanup.

Fixes #5516.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
