### PR TITLE
chore(asm): iast taint Flask path parameters

### DIFF
--- a/tests/contrib/flask/test_flask_appsec.py
+++ b/tests/contrib/flask/test_flask_appsec.py
@@ -11,6 +11,7 @@ from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.appsec.iast import oce
 from ddtrace.appsec.iast._util import _is_python_version_supported as python_supported_by_iast
 from ddtrace.appsec.trace_utils import block_request_if_user_blocked
+from ddtrace.contrib.sqlite3.patch import patch
 from ddtrace.ext import http
 from ddtrace.internal import _context
 from ddtrace.internal import constants
@@ -42,6 +43,10 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
     @pytest.fixture(autouse=True)
     def inject_fixtures(self, caplog):
         self._caplog = caplog
+
+    def setUp(self):
+        super(FlaskAppSecTestCase, self).setUp()
+        patch()
 
     def _aux_appsec_prepare_tracer(self, appsec_enabled=True, iast_enabled=False):
         self.tracer._appsec_enabled = appsec_enabled
@@ -352,9 +357,51 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             assert resp.status_code == 200
 
     @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-    def test_flask_simple_iast_path_header_and_querystring_tainted(self):
+    def test_flask_full_sqli_iast_path_header(self):
         @self.app.route("/sqli/<string:param_str>/", methods=["GET", "POST"])
         def test_sqli(param_str):
+            import sqlite3
+
+            from ddtrace.appsec.iast._ast.aspects import add_aspect
+
+            con = sqlite3.connect(":memory:")
+            cur = con.cursor()
+            cur.execute(add_aspect("SELECT 1 FROM ", param_str))
+
+            return "OK", 200
+
+        with override_global_config(
+            dict(
+                _iast_enabled=True,
+            )
+        ), override_env(IAST_ENV):
+            oce.reconfigure()
+            from ddtrace.appsec.iast._taint_tracking import setup
+
+            setup(bytes.join, bytearray.join)
+
+            self._aux_appsec_prepare_tracer(iast_enabled=True)
+            resp = self.client.post("/sqli/sqlite_master/", data={"name": "test"})
+            assert resp.status_code == 200
+
+            root_span = self.pop_spans()[0]
+            assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+            loaded = json.loads(root_span.get_tag(IAST.JSON))
+            assert loaded["sources"] == [
+                {"origin": "http.request.path.parameter", "name": "param_str", "value": "sqlite_master"}
+            ]
+            assert loaded["vulnerabilities"][0]["type"] == "SQL_INJECTION"
+            assert loaded["vulnerabilities"][0]["evidence"] == {
+                "valueParts": [{"value": "SELECT 1 FROM "}, {"value": "sqlite_master", "source": 0}]
+            }
+            assert loaded["vulnerabilities"][0]["location"]["path"] == "tests/contrib/flask/test_flask_appsec.py"
+            assert loaded["vulnerabilities"][0]["location"]["line"] == 369
+
+    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    def test_flask_simple_iast_path_header_and_querystring_tainted(self):
+        @self.app.route("/sqli/<string:param_str>/<int:param_int>/", methods=["GET", "POST"])
+        def test_sqli(param_str, param_int):
             from flask import request
 
             from ddtrace.appsec.iast._taint_tracking import is_pyobject_tainted
@@ -362,6 +409,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             assert is_pyobject_tainted(request.headers["User-Agent"])
             assert is_pyobject_tainted(request.query_string)
             assert is_pyobject_tainted(param_str)
+            assert not is_pyobject_tainted(param_int)
             assert is_pyobject_tainted(request.path)
             assert is_pyobject_tainted(request.form.get("name"))
             return request.query_string, 200
@@ -377,7 +425,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             setup(bytes.join, bytearray.join)
 
             self._aux_appsec_prepare_tracer(iast_enabled=True)
-            resp = self.client.post("/sqli/hello/?select%20from%20table", data={"name": "test"})
+            resp = self.client.post("/sqli/hello/1000/?select%20from%20table", data={"name": "test"})
             assert resp.status_code == 200
             if hasattr(resp, "text"):
                 # not all flask versions have r.text

--- a/tests/contrib/flask/test_flask_appsec.py
+++ b/tests/contrib/flask/test_flask_appsec.py
@@ -361,8 +361,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
 
             assert is_pyobject_tainted(request.headers["User-Agent"])
             assert is_pyobject_tainted(request.query_string)
-            # TODO: Taint extracted path parameters
-            # assert is_pyobject_tainted(param_str)
+            assert is_pyobject_tainted(param_str)
             assert is_pyobject_tainted(request.path)
             assert is_pyobject_tainted(request.form.get("name"))
             return request.query_string, 200
@@ -398,6 +397,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             # Note: these are not tainted because of request sampling at 0%
             assert not is_pyobject_tainted(request.headers["User-Agent"])
             assert not is_pyobject_tainted(request.query_string)
+            assert not is_pyobject_tainted(param_str)
             assert not is_pyobject_tainted(request.path)
             assert not is_pyobject_tainted(request.form.get("name"))
 


### PR DESCRIPTION
IAST: Taint Flask path parameters as they are part of the request input.

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
