### PR TITLE
chore(ci): allow coverage reporting on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,7 +545,11 @@ jobs:
       - run:
           command: |
             mv .riot .ddriot
-            riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {} $([[ << pipeline.parameters.coverage >> == false ]] && echo '--no-cov' )
+            if [ << pipeline.parameters.coverage >> == true ]; then
+              riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {}
+            else
+              riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {} --no-cov
+            fi
       - when:
           condition:
             << pipeline.parameters.coverage >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,18 +545,12 @@ jobs:
       - run:
           command: |
             mv .riot .ddriot
-            riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {}
-#            if [ << pipeline.parameters.coverage >> == true ]; then
-#              riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {}
-#            else
-#              riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {} --no-cov
-#            fi
-      - save_coverage
-#      - when:
-#          condition:
-#            << pipeline.parameters.coverage >>
-#          steps:
-#            - save_coverage
+            riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {} $([[ << pipeline.parameters.coverage >> == false ]] && echo '--no-cov' )
+      - when:
+          condition:
+            << pipeline.parameters.coverage >>
+          steps:
+            - save_coverage
 
   integration_testagent:
     <<: *machine_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ commands:
                   DD_TRACE_AGENT_URL: http://localhost:9126
                 command: |
                   mv .riot .ddriot
-                  riot list --hash-only '<<parameters.pattern>>' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --exitfirst --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
+                  riot list --hash-only '<<parameters.pattern>>' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --exitfirst --pass-env -s {} $([[ << pipeline.parameters.coverage >> == false ]] && echo '--no-cov' )
       - unless:
           condition:
               << parameters.snapshot >>
@@ -182,7 +182,7 @@ commands:
                       command: riot -v run 'wait' << parameters.wait >>
             - run:
                 command: |
-                  riot list --hash-only '<<parameters.pattern>>' | shuf | circleci tests split | xargs -n 1 -I {} riot -v run --exitfirst --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
+                  riot list --hash-only '<<parameters.pattern>>' | shuf | circleci tests split | xargs -n 1 -I {} riot -v run --exitfirst --pass-env -s {} $([[ << pipeline.parameters.coverage >> == false ]] && echo '--no-cov' )
       - save_pip_cache
       - when:
           condition:
@@ -545,7 +545,7 @@ jobs:
       - run:
           command: |
             mv .riot .ddriot
-            riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
+            riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {} $([[ << pipeline.parameters.coverage >> == false ]] && echo '--no-cov' )
       - when:
           condition:
             << pipeline.parameters.coverage >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,18 +545,14 @@ jobs:
       - run:
           command: |
             mv .riot .ddriot
-            riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {} $([[ << pipeline.parameters.coverage >> == false ]] && echo '--no-cov' )
-      - when:
-          condition:
-            << pipeline.parameters.coverage >>
-          steps:
-            - save_coverage
+            riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {}
 
   integration_testagent:
     <<: *machine_executor
     steps:
       - run_test:
           snapshot: true
+          store_coverage: false
           pattern: 'integration-snapshot'
 
   vendor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,16 +545,18 @@ jobs:
       - run:
           command: |
             mv .riot .ddriot
-            if [ << pipeline.parameters.coverage >> == true ]; then
-              riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {}
-            else
-              riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {} --no-cov
-            fi
-      - when:
-          condition:
-            << pipeline.parameters.coverage >>
-          steps:
-            - save_coverage
+            riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {}
+#            if [ << pipeline.parameters.coverage >> == true ]; then
+#              riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {}
+#            else
+#              riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {} --no-cov
+#            fi
+      - save_coverage
+#      - when:
+#          condition:
+#            << pipeline.parameters.coverage >>
+#          steps:
+#            - save_coverage
 
   integration_testagent:
     <<: *machine_executor

--- a/riotfile.py
+++ b/riotfile.py
@@ -298,7 +298,8 @@ venv = Venv(
         ),
         Venv(
             name="integration",
-            command="pytest {cmdargs} tests/integration/",
+            # Enabling coverage for integration tests breaks certain tests in CI
+            command="pytest --no-cov {cmdargs} tests/integration/",
             pkgs={"msgpack": [latest]},
             venvs=[
                 Venv(

--- a/riotfile.py
+++ b/riotfile.py
@@ -298,7 +298,7 @@ venv = Venv(
         ),
         Venv(
             name="integration",
-            command="pytest --no-cov {cmdargs} tests/integration/",
+            command="pytest {cmdargs} tests/integration/",
             pkgs={"msgpack": [latest]},
             venvs=[
                 Venv(


### PR DESCRIPTION
This PR fixes the bash conditional on our `run_test` pipeline jobs so that when a pipeline is manually triggered with `coverage=true` on CircleCI, coverage reporting is enabled.

Note: certain integration tests break when running with coverage enabled, for that reason they have been disabled.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
