### PR TITLE
fix(profiling): memalloc clean restart after fork

### DIFF
--- a/releasenotes/notes/fix-profiler-memory-collector-reinit-after-fork-2e6fa30cb75e03a6.yaml
+++ b/releasenotes/notes/fix-profiler-memory-collector-reinit-after-fork-2e6fa30cb75e03a6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: Fixed a regression in the memory collector that caused it to fail
+    to cleanly re-initialize after a fork, causing error messages to be logged.

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -110,3 +110,17 @@ def test_multiprocessing(method, tmp_path, monkeypatch):
     pid, child_pid = list(s.strip() for s in stdout.decode().strip().split("\n"))
     utils.check_pprof_file(filename + "." + str(pid) + ".1")
     utils.check_pprof_file(filename + "." + str(child_pid) + ".1")
+
+
+@pytest.mark.subprocess(
+    ddtrace_run=True,
+    env=dict(DD_PROFILING_ENABLED="1"),
+    err=lambda _: "RuntimeError: the memalloc module is already started" not in _,
+)
+def test_memalloc_no_init_error_on_fork():
+    import os
+
+    pid = os.fork()
+    if not pid:
+        exit(0)
+    os.waitpid(pid, 0)


### PR DESCRIPTION
This change ensures that the memalloc module of the profiler is restarted cleanly after a fork. This fixes a regression introduced by a previous change whereby error messages would be logged about failed attempts to restart the memalloc module.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
