### PR TITLE
fix(ci): sort riot venv hashes instead of shuffling them when splitting tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,8 @@ commands:
                   DD_TRACE_AGENT_URL: http://localhost:9126
                 command: |
                   mv .riot .ddriot
-                  riot list --hash-only '<<parameters.pattern>>' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --exitfirst --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
+                  # Sort the hashes to ensure a consistent ordering/division between each node
+                  riot list --hash-only '<<parameters.pattern>>' | sort | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --exitfirst --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
       - unless:
           condition:
               << parameters.snapshot >>
@@ -182,7 +183,8 @@ commands:
                       command: riot -v run 'wait' << parameters.wait >>
             - run:
                 command: |
-                  riot list --hash-only '<<parameters.pattern>>' | shuf | circleci tests split | xargs -n 1 -I {} riot -v run --exitfirst --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
+                  # Sort the hashes to ensure a consistent ordering/division between each node
+                  riot list --hash-only '<<parameters.pattern>>' | sort | circleci tests split | xargs -n 1 -I {} riot -v run --exitfirst --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
       - save_pip_cache
       - when:
           condition:
@@ -545,7 +547,8 @@ jobs:
       - run:
           command: |
             mv .riot .ddriot
-            riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
+            # Sort the hashes to ensure a consistent ordering/division between each node
+            riot list --hash-only 'integration-latest' | sort | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
       - when:
           condition:
             << pipeline.parameters.coverage >>


### PR DESCRIPTION
Previously we were shuffling the order of the riot venv hashes before passing them to `circleci tests split`. The problem with shuffling them is that we need a consistent ordering between each parallel circleci node so we evenly distribute all jobs. With the way it is now, we sometimes run the same venv twice or (no evidence) we might be skipping a venv entirely.

## Testing
We noticed a few jobs are running more venvs than `riot list --hash-only <filter>` was giving, so we should expect some runtimes to improve.

We do not have a good way to audit all venvs which ran vs the total list of expected venvs to run, so we do not know if they were all running before, or if they are all running now.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
