### PR TITLE
chore(ci): separate tracer riot hashes, increase parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,6 +380,7 @@ jobs:
 
   tracer:
     <<: *contrib_job_large
+    parallelism: 11
     steps:
       - run_test:
           pattern: "tracer"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,8 @@ commands:
                   DD_TRACE_AGENT_URL: http://localhost:9126
                 command: |
                   mv .riot .ddriot
-                  riot list --hash-only '<<parameters.pattern>>' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --exitfirst --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
+                  # Sort the hashes to ensure a consistent ordering/division between each node
+                  riot list --hash-only '<<parameters.pattern>>' | sort | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --exitfirst --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
       - unless:
           condition:
               << parameters.snapshot >>
@@ -182,7 +183,8 @@ commands:
                       command: riot -v run 'wait' << parameters.wait >>
             - run:
                 command: |
-                  riot list --hash-only '<<parameters.pattern>>' | shuf | circleci tests split | xargs -n 1 -I {} riot -v run --exitfirst --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
+                  # Sort the hashes to ensure a consistent ordering/division between each node
+                  riot list --hash-only '<<parameters.pattern>>' | sort | circleci tests split | xargs -n 1 -I {} riot -v run --exitfirst --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
       - save_pip_cache
       - when:
           condition:
@@ -545,7 +547,8 @@ jobs:
       - run:
           command: |
             mv .riot .ddriot
-            riot list --hash-only 'integration-latest' | shuf | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
+            # Sort the hashes to ensure a consistent ordering/division between each node
+            riot list --hash-only 'integration-latest' | sort | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {} $( << pipeline.parameters.coverage >>=false; echo '--no-cov' )
       - when:
           condition:
             << pipeline.parameters.coverage >>

--- a/riotfile.py
+++ b/riotfile.py
@@ -275,15 +275,24 @@ venv = Venv(
                 Venv(pys=select_pys()),
                 # This test variant ensures tracer tests are compatible with both 64bit and 128bit trace ids.
                 Venv(
+                    name="tracer-128-bit-traceid-enabled",
                     pys=MAX_PYTHON_VERSION,
                     env={
-                        "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": ["false", "true"],
+                        "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": "true",
                     },
                 ),
                 Venv(
+                    name="tracer-128-bit-traceid-disabled",
+                    pys=MAX_PYTHON_VERSION,
+                    env={
+                        "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": "false",
+                    },
+                ),
+                Venv(
+                    name="tracer-python-optimize",
                     env={"PYTHONOPTIMIZE": "1"},
                     # Test with the latest version of Python only
-                    pys=".".join((str(_) for _ in SUPPORTED_PYTHON_VERSIONS[-1])),
+                    pys=MAX_PYTHON_VERSION,
                 ),
             ],
         ),


### PR DESCRIPTION
This PR builds off #5592 and does two things:
1. Separates the Python 3.11 Tracer riot hashes into 4 hashes each, as currently a single hash contained 4 env configurations leading to 4 test sessions. This meant that when CircleCI splits riot hashes, it assumed the Python 3.11 hash was a single test session and led to 2 parallel runners running 5 test sessions when they should have been split evenly. This now evenly splits the tracer test suites among the parallel test runners on CircleCI.
2. Increases parallelization of the tracer test suite to 11 from 8, which means that each test runner only needs to run 2 riot hashes each, greatly improving the tracer test suite duration from 13+ minutes to 7 minutes.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
