### PR TITLE
Revert "chore(ci): separate tracer riot hashes, increase parallelism"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,6 @@ commands:
                   DD_TRACE_AGENT_URL: http://localhost:9126
                 command: |
                   mv .riot .ddriot
-                  # Sort the hashes to ensure a consistent ordering/division between each node
                   riot list --hash-only '<<parameters.pattern>>' | sort | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --exitfirst --pass-env -s {} $([[ << pipeline.parameters.coverage >> == false ]] && echo '--no-cov' )
       - unless:
           condition:
@@ -183,7 +182,6 @@ commands:
                       command: riot -v run 'wait' << parameters.wait >>
             - run:
                 command: |
-                  # Sort the hashes to ensure a consistent ordering/division between each node
                   riot list --hash-only '<<parameters.pattern>>' | sort | circleci tests split | xargs -n 1 -I {} riot -v run --exitfirst --pass-env -s {} $([[ << pipeline.parameters.coverage >> == false ]] && echo '--no-cov' )
       - save_pip_cache
       - when:
@@ -380,7 +378,6 @@ jobs:
 
   tracer:
     <<: *contrib_job_large
-    parallelism: 11
     steps:
       - run_test:
           pattern: "tracer"
@@ -548,7 +545,6 @@ jobs:
       - run:
           command: |
             mv .riot .ddriot
-            # Sort the hashes to ensure a consistent ordering/division between each node
             riot list --hash-only 'integration-latest' | sort | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --pass-env -s {}
 
   integration_testagent:

--- a/riotfile.py
+++ b/riotfile.py
@@ -275,24 +275,15 @@ venv = Venv(
                 Venv(pys=select_pys()),
                 # This test variant ensures tracer tests are compatible with both 64bit and 128bit trace ids.
                 Venv(
-                    name="tracer-128-bit-traceid-enabled",
                     pys=MAX_PYTHON_VERSION,
                     env={
-                        "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": "true",
+                        "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": ["false", "true"],
                     },
                 ),
                 Venv(
-                    name="tracer-128-bit-traceid-disabled",
-                    pys=MAX_PYTHON_VERSION,
-                    env={
-                        "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": "false",
-                    },
-                ),
-                Venv(
-                    name="tracer-python-optimize",
                     env={"PYTHONOPTIMIZE": "1"},
                     # Test with the latest version of Python only
-                    pys=MAX_PYTHON_VERSION,
+                    pys=".".join((str(_) for _ in SUPPORTED_PYTHON_VERSIONS[-1])),
                 ),
             ],
         ),


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#5593