### PR TITLE
ci: split products in Django test suite run

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -56,23 +56,27 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        expl_profiler: [0, 1]
-        expl_coverage: [0 ,1]
-        exclude:
-          - expl_profiler: 1
-            expl_coverage: 1
-          - expl_profiler: 0
+        include:
+          - suffix: "profiler"
+            profiler: 1
+            expl_profiler: 0
             expl_coverage: 0
-          # Temporarily disabling line coverage to investigate cause of hangs
-          - expl_profiler: 0
+          - suffix: "DI profiling"
+            profiler: 0
+            expl_profiler: 1
+            expl_coverage: 0
+          - suffix: "DI coverage"
+            profiler: 0
+            expl_profiler: 0
             expl_coverage: 1
     runs-on: ubuntu-20.04
+    name: Django 3.1 (with ${{ matrix.suffix }})
     env:
-      DD_PROFILING_ENABLED: true
-      DD_TESTING_RAISE: true
-      DD_DEBUGGER_EXPL_ENCODE: 0  # Disabled to speed up
+      DD_PROFILING_ENABLED: ${{ matrix.profiler }}
       DD_DEBUGGER_EXPL_PROFILER_ENABLED: ${{ matrix.expl_profiler }}
       DD_DEBUGGER_EXPL_COVERAGE_ENABLED: ${{ matrix.expl_coverage }}
+      DD_TESTING_RAISE: true
+      DD_DEBUGGER_EXPL_ENCODE: 0  # Disabled to speed up
       PYTHONPATH: ../ddtrace/tests/debugging/exploration/:.
     defaults:
       run:


### PR DESCRIPTION
Create separate runs of the Django test suite with the different products turned on in turn. The workflow has been hanging randomly and because there are many products running at the same time, it is hard to determine which one is the main responsible. With this change we aim at isolating the effects of each product on the test suite to better pin-point potential issues.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
