### PR TITLE
Add `shell.nix` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,9 @@ ddtrace/_version.py
 
 # Benchmarks
 artifacts/
+
+# vendored packages
+/vendor/python
+
+# direnv
+.envrc

--- a/riotfile.py
+++ b/riotfile.py
@@ -94,6 +94,7 @@ venv = Venv(
         "pytest-cov": latest,
         "opentracing": latest,
         "hypothesis": "<6.45.1",
+        "ipaddress": latest,
     },
     env={
         "DD_TESTING_RAISE": "1",

--- a/shell.nix
+++ b/shell.nix
@@ -1,23 +1,43 @@
 {
-  # use the environment channel
-  pkgs ? import <nixpkgs> {},
+# use the environment channel
+pkgs ? import <nixpkgs> { },
 
-  # use a pinned package state
-  pinned ? import(fetchTarball("https://github.com/NixOS/nixpkgs/archive/14d9b465c71.tar.gz")) {},
-}:
+# use a pinned package state
+pinned ? import
+  (fetchTarball ("https://github.com/NixOS/nixpkgs/archive/14d9b465c71.tar.gz"))
+  { }, }:
 let
   # get these python packages from nix
   python_packages = python-packages: [
     python-packages.pip
+    python-packages.virtualenv
     python-packages.setuptools
     python-packages.cython
+    python-packages.pip-tools
   ];
 
   # use this python version, and include the abvoe packages
-  python = pinned.python39.withPackages python_packages;
+  python = pinned.python310.withPackages python_packages;
+
+  python27_packages = python-packages:
+    [
+      (python.pkgs.buildPythonPackage rec {
+        pname = "pip-tools";
+        version = "5.5.0";
+        src = python.pkgs.fetchPypi {
+          inherit pname version;
+          sha256 =
+            "sha256-cb0108391366b3ef336185097b3c2c0f3fa115b15098dafbda5e78aef70ea114=";
+        };
+        doCheck = false;
+        propagatedBuildInputs = [ ];
+      })
+    ];
+  python27 = pinned.python27.withPackages python27_packages;
 
   # control llvm/clang version (e.g for packages built form source)
   llvm = pinned.llvmPackages_12;
+
 in llvm.stdenv.mkDerivation {
   # unique project name for this environment derivation
   name = "dd-trace-py.devshell";
@@ -25,21 +45,32 @@ in llvm.stdenv.mkDerivation {
   buildInputs = [
     # version to use + default packages are declared above
     python
+    python27
 
     # for c++ dependencies such as grpcio-tools
     llvm.libcxx.dev
+
+    #pinned.python35Packages.pip-tools
+    #pinned.python36Packages.pip-tools
+    #pinned.python37Packages.pip-tools
+    #pinned.python38Packages.pip-tools
+    pinned.python39Packages.pip-tools
+    pinned.python310Packages.pip-tools
+    #pinned.python311Packages.pip-tools
   ];
 
   shellHook = ''
     export PYTHON_VERSION="$(python -c 'import platform; import re; print(re.sub(r"\.\d+$", "", platform.python_version()))')"
 
-    # replicate virtualenv behaviour
-    export PIP_PREFIX="$PWD/vendor/python/$PYTHON_VERSION/packages"
-    export PYTHONPATH="$PIP_PREFIX/lib/python$PYTHON_VERSION/site-packages:$PYTHONPATH"
     unset SOURCE_DATE_EPOCH
-    export PATH="$PIP_PREFIX/bin:$PATH"
 
     # for c++ stuff like grpcio-tools, which is building from source but doesn't pick up the proper include
     export CFLAGS="-I${llvm.libcxx.dev}/include/c++/v1"
+
+    virtualenv .venv
+    source .venv/bin/activate
+    .venv/bin/pip install -e .
+    .venv/bin/pip install reno riot Cython
+    .venv/bin/python setup.py develop
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,45 @@
+{
+  # use the environment channel
+  pkgs ? import <nixpkgs> {},
+
+  # use a pinned package state
+  pinned ? import(fetchTarball("https://github.com/NixOS/nixpkgs/archive/14d9b465c71.tar.gz")) {},
+}:
+let
+  # get these python packages from nix
+  python_packages = python-packages: [
+    python-packages.pip
+    python-packages.setuptools
+    python-packages.cython
+  ];
+
+  # use this python version, and include the abvoe packages
+  python = pinned.python39.withPackages python_packages;
+
+  # control llvm/clang version (e.g for packages built form source)
+  llvm = pinned.llvmPackages_12;
+in llvm.stdenv.mkDerivation {
+  # unique project name for this environment derivation
+  name = "dd-trace-py.devshell";
+
+  buildInputs = [
+    # version to use + default packages are declared above
+    python
+
+    # for c++ dependencies such as grpcio-tools
+    llvm.libcxx.dev
+  ];
+
+  shellHook = ''
+    export PYTHON_VERSION="$(python -c 'import platform; import re; print(re.sub(r"\.\d+$", "", platform.python_version()))')"
+
+    # replicate virtualenv behaviour
+    export PIP_PREFIX="$PWD/vendor/python/$PYTHON_VERSION/packages"
+    export PYTHONPATH="$PIP_PREFIX/lib/python$PYTHON_VERSION/site-packages:$PYTHONPATH"
+    unset SOURCE_DATE_EPOCH
+    export PATH="$PIP_PREFIX/bin:$PATH"
+
+    # for c++ stuff like grpcio-tools, which is building from source but doesn't pick up the proper include
+    export CFLAGS="-I${llvm.libcxx.dev}/include/c++/v1"
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -64,6 +64,8 @@ in llvm.stdenv.mkDerivation {
 
     # for c++ dependencies such as grpcio-tools
     llvm.libcxx.dev
+    pinned.zlib
+    pinned.openssl
 
     #pinned.python35Packages.pip-tools
     #pinned.python36Packages.pip-tools
@@ -81,10 +83,20 @@ in llvm.stdenv.mkDerivation {
 
     # for c++ stuff like grpcio-tools, which is building from source but doesn't pick up the proper include
     export CFLAGS="-I${llvm.libcxx.dev}/include/c++/v1"
+    export CPPFLAGS="-I${pinned.zlib.dev}/include -I${pinned.openssl.dev}/include/openssl"
+    export LDFLAGS="-L${pinned.zlib}/lib -L${pinned.openssl.out}/lib"
+    echo $CPPFLAGS
+    echo $LDFLAGS
+    ls -al ${pinned.openssl.dev}/include/openssl
+    ls -al ${pinned.openssl.out}/lib
 
-    export PYTHONPATH=${python27.pkgs.setuptools}/lib/python2.7/site-packages:${python27.pkgs.pip}/lib/python2.7/site-packages:${piptools_py27}/lib/python2.7/site-packages:${python27}/lib/python2.7/site-packages:$PYTHONPATH
+    rm -rf ~/.pyenv
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+    export PYENV_ROOT=~/.pyenv
+    export PATH=~/.pyenv/bin:$PATH
+    eval "$(pyenv init --path)"
+    pyenv install 2.7
 
-    virtualenv .venv
     .venv/bin/pip install -e .
     .venv/bin/pip install reno riot Cython
     .venv/bin/python setup.py develop

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,6 @@ let
     python-packages.virtualenv
     python-packages.setuptools
     python-packages.cython
-    python-packages.pip-tools
   ];
 
   # use this python version, and include the abvoe packages
@@ -29,25 +28,7 @@ let
     doCheck = false;
     buildInputs = [ ];
   };
-  piptools_py27 = python27.pkgs.buildPythonPackage rec {
-    pname = "pip-tools";
-    version = "5.5.0";
-    src = python27.pkgs.fetchPypi {
-      inherit pname version;
-      sha256 = "sha256-ywEIORNms+8zYYUJezwsDz+hFbFQmNr72l54rvcOoRQ=";
-    };
-    doCheck = false;
-    buildInputs = [
-      click_py27
-      pinned.python27.pkgs.setuptools
-      pinned.python27.pkgs.setuptools_scm
-    ];
-  };
-  python27_packages = python-packages: [
-    click_py27
-    piptools_py27
-    pinned.python27.pkgs.pip
-  ];
+  python27_packages = python-packages: [ click_py27 pinned.python27.pkgs.pip ];
   python27 = pinned.python27.withPackages python27_packages;
 
   # control llvm/clang version (e.g for packages built form source)
@@ -66,14 +47,6 @@ in llvm.stdenv.mkDerivation {
     llvm.libcxx.dev
     pinned.zlib
     pinned.openssl
-
-    #pinned.python35Packages.pip-tools
-    #pinned.python36Packages.pip-tools
-    #pinned.python37Packages.pip-tools
-    #pinned.python38Packages.pip-tools
-    pinned.python39Packages.pip-tools
-    pinned.python310Packages.pip-tools
-    #pinned.python311Packages.pip-tools
   ];
 
   shellHook = ''
@@ -83,22 +56,12 @@ in llvm.stdenv.mkDerivation {
 
     # for c++ stuff like grpcio-tools, which is building from source but doesn't pick up the proper include
     export CFLAGS="-I${llvm.libcxx.dev}/include/c++/v1"
-    export CPPFLAGS="-I${pinned.zlib.dev}/include -I${pinned.openssl.dev}/include/openssl"
-    export LDFLAGS="-L${pinned.zlib}/lib -L${pinned.openssl.out}/lib"
-    echo $CPPFLAGS
-    echo $LDFLAGS
-    ls -al ${pinned.openssl.dev}/include/openssl
-    ls -al ${pinned.openssl.out}/lib
 
-    rm -rf ~/.pyenv
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv
-    export PYENV_ROOT=~/.pyenv
-    export PATH=~/.pyenv/bin:$PATH
-    eval "$(pyenv init --path)"
-    pyenv install 2.7
-
+    virtualenv .venv
+    source .venv/bin/activate
     .venv/bin/pip install -e .
-    .venv/bin/pip install reno riot Cython
+    .venv/bin/pip install -e ../riot
+    .venv/bin/pip install reno Cython
     .venv/bin/python setup.py develop
   '';
 }


### PR DESCRIPTION
Follows a discussion with @emmettbutler 

This is entirely optional to use but for nixpkgs users this is a really easy way to get things up and running. With just:

```
nix-shell
```

All needed dependencies get automatically pulled in, dropping the user in a ready-to-use shell.

Then as usual:

```
python setup.py
pip install riot
```

Puts everything in a `vendor/python` directory, which behaves like a virtualenv. Should it need to be cleaned up, e.g to start form scratch, a simple `rm -rf vendor/python` is sufficient.

It also pins to a specific commit for the channel, so that tool versions are always consistent.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
