### PR TITLE
chore(dev): improvements to backporting script

### DIFF
--- a/scripts/backport
+++ b/scripts/backport
@@ -18,6 +18,33 @@ then
    exit 1
 fi
 
+usage () {
+    echo "Usage:"
+    echo "  $0 PR_NUMBER BRANCH_NAME [, BRANCH_NAME, ...]"
+    echo ""
+    echo "  PR_NUMBER     - the GitHub PR number to backport. example: 4376"
+    echo "  BRANCH_NAME   - the name of the branch to backport PR_NUMBER to. example: 1.8"
+    echo ""
+    echo "Examples:"
+    echo ""
+
+    echo "  Backport PR #3489 to branch 0.61"
+    echo "    $0 3489 0.61"
+    echo ""
+    echo "  Backport PR #4376 to branches 1.8, 1.7, and 1.5"
+    echo "    $0 4376 1.8 1.7 1.5"
+}
+
+if [ $# -lt 2 ];
+then
+    echo "Error:"
+    echo "  Too few arguments, must supply at least PR_NUMBER and 1 BRANCH_NAME"
+    echo ""
+    usage
+    exit 1
+fi
+
+
 PR_NUMBER="${1}"
 shift 1
 TO_BRANCHES="$@"
@@ -35,22 +62,6 @@ else
     REMOTE="origin"
 fi
 
-usage () {
-    echo "Usage:"
-    echo "  $0 PR_NUMBER BRANCH_NAME [, BRANCH_NAME, ...]"
-    echo ""
-    echo "  PR_NUMBER     - the GitHub PR number to backport. example: 4376"
-    echo "  BRANCH_NAME   - the name of the branch to backport PR_NUMBER to. example: 1.8"
-    echo ""
-    echo "Examples:"
-    echo ""
-
-    echo "  Backport PR #3489 to branch 0.61"
-    echo "    $0 3489 0.61"
-    echo ""
-    echo "  Backport PR #4376 to branches 1.8, 1.7, and 1.5"
-    echo "    $0 4376 1.8 1.7 1.5"
-}
 
 if [[ -z "${PR_NUMBER}" ]];
 then
@@ -109,13 +120,13 @@ do
   echo "Cherry-picking ${merge_commit_sha} (git commit signing required here)"
   if ! git cherry-pick -x "${merge_commit_sha}";
   then
-      git cherry-pick --abort
-      echo "Cherry-pick failed, exiting"
+      echo "Cherry-pick failed. In a separate shell, please:"
+      echo "  1. Manually resolve merge conflicts"
+      echo "  2. git add resolved files"
+      echo "  3. Run git cherry-pick --continue to complete the merge"
       echo ""
-      echo "Backporting must be done manually to resolve merge-conflict"
+      read -p "Press any key to continue once conflict is manually resolved..." -n1 -s
       echo ""
-      echo "  git cherry-pick -x ${merge_commit_sha}"
-      exit 1
   fi
   echo "Pushing branch ${branch_name}"
   git push --set-upstream ${REMOTE} "${branch_name}"


### PR DESCRIPTION
1. It is possible to end up with "${1}" as an unbound variable, so let's check $# size first
2. Instead of bailing when a merge conflict is found, ask the user to resolve manually and prompt for when to continue

## Testing strategy

I was able to backport https://github.com/DataDog/dd-trace-py/pull/5624 successfully with the script when it had a merge conflict.

The script paused, waiting for me to manually resolve the conflict, and then after hitting enter it successfully completed creating the backport PR as expected.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
