### PR TITLE
fix(tests): use riot lockfiles [backport #5246 to 1.11]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ jobs:
       - run_test:
           pattern: 'appsec'
           snapshot: true
-    
+
   aws_lambda:
     <<: *machine_executor
     steps:


### PR DESCRIPTION
Backport of #5246 to 1.11

This change makes the Riot test suite build its virtual environments using fully-specified dependency tree files that live in source control.

## How to Review

1. Review https://github.com/DataDog/dd-trace-py/pull/5227 and leave your comments on this change, or use [this filtered diff view](https://github.com/DataDog/dd-trace-py/pull/5246/files?file-filters%5B%5D=.py&file-filters%5B%5D=.rst&file-filters%5B%5D=.yml&file-filters%5B%5D=No+extension&file-filters%5B%5D=dotfile&show-deleted-files=true&show-viewed-files=true)

## Why?

The computation involved in building the tree of dependencies for a given test virtual environment is not small. By performing that work only when the tree changes rather than on every test run, we make our CI build time shorter.

Having the entire dependency tree in source control allows developers to unambiguously understand which versions of nth-order dependencies are in use in a given test environment without needing to run the tests locally, which can make debugging tests easier.

Using `riot run -c` to automatically rebuild these requirements files when necessary facilitates future changes like [having a bot rebuild and PR them periodically](https://github.com/DataDog/dd-trace-py/tree/emmett.butler/latest-automation).

## How?

By depending on riot==0.17.1, Riot runs on this branch look for requirements lockfiles and create them if they don't exist. That combined with the fact that the repo now contains a lockfile for each venv means that there are no changes necessary to the testing logic itself.

This change adds `scripts/compile-and-prune-test-requirements`. That script builds requirements.txt lockfiles for all Riot hashes in the current working tree that don't already have one in `.riot/requirements`. It also deletes such files for Riot hashes that don't exist. In a future change, this script could run under automation, commit its changes, and open pull requests.

## Notes

**If you're running tests locally and making changes to the riotfile, you'll need to run `riot` with the `-c` flag to ensure that those changes are reflected in the new dependency trees. You should commit these changes to dependency tree lockfiles and include them in pull requests that change the riotfile.**

This change removes the list of latest tested versions in `dependencies.py` as well as the logic that parses that list and uses it in tests. The finding of the latest version is now handled by Riot, which runs `pip-compile` internally.

Most of the changes to the riotfile in this diff are either:

* workarounds for the fact that versions of `pip-compile` prior to 3.7 don't do "[backtracking](https://pip.pypa.io/en/stable/topics/dependency-resolution/#backtracking)" during dependency resolution
* pins to the same versions as in the deleted `dependencies.py` file due to compile or test failures with newer versions

## Risk

The main risk I can think of is that this adds some confusion for contributors about how to get riot to notice their venv changes. I've updated the contributor docs accordingly.

## Checklist

- [x] Finish riot pull request https://github.com/DataDog/riot/pull/196
- [x] Finish the next riot pull request https://github.com/DataDog/riot/pull/202
- [x] Generate all requirements lockfiles
- [x] Fix riotfile to make tests pass on this PR
- [x] Move automation changes to separate PR
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Author is aware of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer is aware of, and discussed the performance implications of this PR as reported in the benchmarks PR comment.
