### PR TITLE
chore(service_name): enable service naming schema for multiple contribs

### DIFF
--- a/ddtrace/contrib/aiomysql/patch.py
+++ b/ddtrace/contrib/aiomysql/patch.py
@@ -15,11 +15,12 @@ from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...ext import db
 from ...ext import net
+from ...internal.schema import schematize_service_name
 
 
 config._add(
     "aiomysql",
-    dict(_default_service="mysql"),
+    dict(_default_service=schematize_service_name("mysql")),
 )
 
 CONN_ATTR_BY_TAG = {

--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -13,6 +13,7 @@ from ddtrace.ext import SpanTypes
 from ddtrace.ext import db
 from ddtrace.ext import sql
 from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.pin import Pin
 from ddtrace.vendor import wrapt
@@ -86,7 +87,8 @@ class AIOTracedConnection(wrapt.ObjectProxy):
 
     def __init__(self, conn, pin=None, cursor_cls=AIOTracedCursor):
         super(AIOTracedConnection, self).__init__(conn)
-        name = dbapi._get_vendor(conn)
+        vendor = dbapi._get_vendor(conn)
+        name = schematize_service_name(vendor)
         db_pin = pin or Pin(service=name)
         db_pin.onto(self)
         # wrapt requires prefix of `_self` for attributes that are only in the

--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -2,8 +2,8 @@ from ddtrace import config
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.constants import COMPONENT
-from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.internal.schema import schematize_service_name
+from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.pin import Pin
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 

--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -3,6 +3,7 @@ from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.utils.wrappers import unwrap as _u
+from ddtrace.internal.schema import schematize_service_name
 from ddtrace.pin import Pin
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
@@ -13,7 +14,7 @@ from ...constants import SPAN_MEASURED_KEY
 
 DD_PATCH_ATTR = "_datadog_patch"
 
-SERVICE_NAME = "algoliasearch"
+SERVICE_NAME = schematize_service_name("algoliasearch")
 APP_NAME = "algoliasearch"
 
 try:

--- a/ddtrace/contrib/asyncpg/patch.py
+++ b/ddtrace/contrib/asyncpg/patch.py
@@ -12,6 +12,7 @@ from ...ext import SpanTypes
 from ...ext import db
 from ...ext import net
 from ...internal.logger import get_logger
+from ...internal.schema import schematize_service_name
 from ...internal.utils import get_argument_value
 from ..trace_utils import ext_service
 from ..trace_utils import unwrap
@@ -34,7 +35,7 @@ DBMS_NAME = "postgresql"
 config._add(
     "asyncpg",
     dict(
-        _default_service="postgres",
+        _default_service=schematize_service_name("postgres"),
     ),
 )
 

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -25,6 +25,7 @@ from ...ext import net
 from ...internal.compat import maybe_stringify
 from ...internal.compat import stringify
 from ...internal.logger import get_logger
+from ...internal.schema import schematize_service_name
 from ...internal.utils import get_argument_value
 from ...internal.utils.formats import deep_getattr
 from ...pin import Pin
@@ -34,7 +35,7 @@ from ...vendor import wrapt
 log = get_logger(__name__)
 
 RESOURCE_MAX_LENGTH = 5000
-SERVICE = "cassandra"
+SERVICE = schematize_service_name("cassandra")
 CURRENT_SPAN = "_ddtrace_current_span"
 PAGE_NUMBER = "_ddtrace_page_number"
 

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -14,6 +14,7 @@ from ...ext import SpanTypes
 from ...ext import elasticsearch as metadata
 from ...ext import http
 from ...internal.compat import urlencode
+from ...internal.schema import schematize_service_name
 from ...internal.utils.wrappers import unwrap as _u
 from ...pin import Pin
 from .quantize import quantize
@@ -22,7 +23,7 @@ from .quantize import quantize
 config._add(
     "elasticsearch",
     {
-        "_default_service": "elasticsearch",
+        "_default_service": schematize_service_name("elasticsearch"),
     },
 )
 

--- a/ddtrace/contrib/mongoengine/trace.py
+++ b/ddtrace/contrib/mongoengine/trace.py
@@ -11,6 +11,7 @@ from ddtrace.vendor import wrapt
 # We should also extract the "alias" attribute and set it as a meta
 _SERVICE = schematize_service_name(mongox.SERVICE)
 
+
 class WrappedConnect(wrapt.ObjectProxy):
     """WrappedConnect wraps mongoengines 'connect' function to ensure
     that all returned connections are wrapped for tracing.

--- a/ddtrace/contrib/mongoengine/trace.py
+++ b/ddtrace/contrib/mongoengine/trace.py
@@ -3,11 +3,14 @@
 import ddtrace
 from ddtrace.contrib.pymongo.client import TracedMongoClient
 from ddtrace.ext import mongo as mongox
+from ddtrace.internal.schema import schematize_service_name
 from ddtrace.vendor import wrapt
 
 
 # TODO(Benjamin): we should instrument register_connection instead, because more generic
 # We should also extract the "alias" attribute and set it as a meta
+_SERVICE = schematize_service_name(mongox.SERVICE)
+
 class WrappedConnect(wrapt.ObjectProxy):
     """WrappedConnect wraps mongoengines 'connect' function to ensure
     that all returned connections are wrapped for tracing.
@@ -15,7 +18,7 @@ class WrappedConnect(wrapt.ObjectProxy):
 
     def __init__(self, connect):
         super(WrappedConnect, self).__init__(connect)
-        ddtrace.Pin(service=mongox.SERVICE, tracer=ddtrace.tracer).onto(self)
+        ddtrace.Pin(_SERVICE, tracer=ddtrace.tracer).onto(self)
 
     def __call__(self, *args, **kwargs):
         client = self.__wrapped__(*args, **kwargs)

--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -9,13 +9,14 @@ from ddtrace.vendor import wrapt
 
 from ...ext import db
 from ...ext import net
+from ...internal.schema import schematize_service_name
 from ...internal.utils.formats import asbool
 
 
 config._add(
     "mysql",
     dict(
-        _default_service="mysql",
+        _default_service=schematize_service_name("mysql"),
         _dbapi_span_name_prefix="mysql",
         trace_fetch_methods=asbool(os.getenv("DD_MYSQL_TRACE_FETCH_METHODS", default=False)),
     ),

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -15,6 +15,7 @@ from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...ext import db
 from ...ext import net
+from ...internal.schema import schematize_service_name
 from ...internal.utils.formats import asbool
 from ...internal.utils.wrappers import unwrap as _u
 
@@ -22,7 +23,7 @@ from ...internal.utils.wrappers import unwrap as _u
 config._add(
     "mysqldb",
     dict(
-        _default_service="mysql",
+        _default_service=schematize_service_name("mysql"),
         _dbapi_span_name_prefix="mysql",
         trace_fetch_methods=asbool(os.getenv("DD_MYSQLDB_TRACE_FETCH_METHODS", default=False)),
         trace_connect=asbool(os.getenv("DD_MYSQLDB_TRACE_CONNECT", default=False)),

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -23,6 +23,7 @@ from ddtrace.contrib.psycopg.extensions import get_psycopg2_extensions
 from ddtrace.propagation._database_monitoring import default_sql_injector as _default_sql_injector
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
+from ...internal.schema import schematize_service_name
 from ...internal.utils.formats import asbool
 from ...internal.utils.wrappers import unwrap as _u
 from ...propagation._database_monitoring import _DBM_Propagator
@@ -42,7 +43,7 @@ def _psycopg_sql_injector(dbm_comment, sql_statement):
 config._add(
     "psycopg",
     dict(
-        _default_service="postgres",
+        _default_service=schematize_service_name("postgres"),
         _dbapi_span_name_prefix="postgres",
         _patched_modules=set(),
         _patched_functions=dict(),

--- a/ddtrace/contrib/pymemcache/patch.py
+++ b/ddtrace/contrib/pymemcache/patch.py
@@ -6,7 +6,6 @@ from ddtrace.internal.schema import schematize_service_name
 from ddtrace.pin import Pin
 from ddtrace.pin import _DD_PIN_NAME
 from ddtrace.pin import _DD_PIN_PROXY_NAME
-from ddtrace.internal.schema import schematize_service_name
 
 from .client import WrappedClient
 

--- a/ddtrace/contrib/pymemcache/patch.py
+++ b/ddtrace/contrib/pymemcache/patch.py
@@ -5,6 +5,7 @@ from ddtrace.ext import memcached as memcachedx
 from ddtrace.pin import Pin
 from ddtrace.pin import _DD_PIN_NAME
 from ddtrace.pin import _DD_PIN_PROXY_NAME
+from ddtrace.internal.schema import schematize_service_name
 
 from .client import WrappedClient
 
@@ -28,7 +29,8 @@ def patch():
         pymemcache.client.hash.HashClient.client_class = WrappedClient
 
     # Create a global pin with default configuration for our pymemcache clients
-    Pin(service=memcachedx.SERVICE).onto(pymemcache)
+    service = schematize_service_name(memcachedx.SERVICE)
+    Pin(service=service).onto(pymemcache)
 
 
 def unpatch():

--- a/ddtrace/contrib/pymemcache/patch.py
+++ b/ddtrace/contrib/pymemcache/patch.py
@@ -2,6 +2,7 @@ import pymemcache
 import pymemcache.client.hash
 
 from ddtrace.ext import memcached as memcachedx
+from ddtrace.internal.schema import schematize_service_name
 from ddtrace.pin import Pin
 from ddtrace.pin import _DD_PIN_NAME
 from ddtrace.pin import _DD_PIN_PROXY_NAME

--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -22,6 +22,7 @@ from ...ext import mongo as mongox
 from ...ext import net as netx
 from ...internal.compat import iteritems
 from ...internal.logger import get_logger
+from ...internal.schema import schematize_service_name
 from ...internal.utils import get_argument_value
 from .parse import parse_msg
 from .parse import parse_query
@@ -41,6 +42,7 @@ if VERSION < (3, 6, 0):
 
 log = get_logger(__name__)
 
+_DEFAULT_SERVICE = schematize_service_name("pymongo")
 
 class TracedMongoClient(ObjectProxy):
     def __init__(self, client=None, *args, **kwargs):
@@ -73,7 +75,7 @@ class TracedMongoClient(ObjectProxy):
             client._topology = TracedTopology(client._topology)
 
         # Default Pin
-        ddtrace.Pin(service="pymongo").onto(self)
+        ddtrace.Pin(service=_DEFAULT_SERVICE).onto(self)
 
     def __setddpin__(self, pin):
         pin.onto(self._topology)

--- a/ddtrace/contrib/pymongo/client.py
+++ b/ddtrace/contrib/pymongo/client.py
@@ -44,6 +44,7 @@ log = get_logger(__name__)
 
 _DEFAULT_SERVICE = schematize_service_name("pymongo")
 
+
 class TracedMongoClient(ObjectProxy):
     def __init__(self, client=None, *args, **kwargs):
         # To support the former trace_mongo_client interface, we have to keep this old interface

--- a/ddtrace/contrib/pymysql/patch.py
+++ b/ddtrace/contrib/pymysql/patch.py
@@ -9,14 +9,14 @@ from ddtrace.vendor import wrapt
 
 from ...ext import db
 from ...ext import net
+from ...internal.schema import schematize_service_name
 from ...internal.utils.formats import asbool
 
 
 config._add(
     "pymysql",
     dict(
-        # TODO[v1.0] this should be "mysql"
-        _default_service="pymysql",
+        _default_service=schematize_service_name("pymysql"),
         _dbapi_span_name_prefix="pymysql",
         trace_fetch_methods=asbool(os.getenv("DD_PYMYSQL_TRACE_FETCH_METHODS", default=False)),
     ),

--- a/ddtrace/contrib/sqlite3/patch.py
+++ b/ddtrace/contrib/sqlite3/patch.py
@@ -10,6 +10,7 @@ from ...contrib.dbapi import FetchTracedCursor
 from ...contrib.dbapi import TracedConnection
 from ...contrib.dbapi import TracedCursor
 from ...ext import db
+from ...internal.schema import schematize_service_name
 from ...internal.utils.formats import asbool
 from ...pin import Pin
 
@@ -20,7 +21,7 @@ _connect = sqlite3.connect
 config._add(
     "sqlite",
     dict(
-        _default_service="sqlite",
+        _default_service=schematize_service_name("sqlite"),
         _dbapi_span_name_prefix="sqlite",
         trace_fetch_methods=asbool(os.getenv("DD_SQLITE_TRACE_FETCH_METHODS", default=False)),
     ),

--- a/tests/contrib/aiomysql/test_aiomysql.py
+++ b/tests/contrib/aiomysql/test_aiomysql.py
@@ -7,7 +7,6 @@ from ddtrace import Pin
 from ddtrace import Tracer
 from ddtrace.contrib.aiomysql import patch
 from ddtrace.contrib.aiomysql import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.config import MYSQL_CONFIG
 
 
@@ -171,7 +170,7 @@ asyncio.run(test())""",
 async def test_unspecified_service_v1(ddtrace_run_python_code_in_subprocess):
     """
     v1: When a user specifies nothing for a service,
-        it should default to DEFAULT_SPAN_SERVICE_NAME
+        it should default to internal.schema.DEFAULT_SPAN_SERVICE_NAME
     """
     env = os.environ.copy()
     env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"

--- a/tests/contrib/aiomysql/test_aiomysql.py
+++ b/tests/contrib/aiomysql/test_aiomysql.py
@@ -7,6 +7,7 @@ from ddtrace import Pin
 from ddtrace import Tracer
 from ddtrace.contrib.aiomysql import patch
 from ddtrace.contrib.aiomysql import unpatch
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.config import MYSQL_CONFIG
 
 
@@ -109,13 +110,14 @@ async def test_patch_unpatch(tracer, test_spans):
 
 @pytest.mark.asyncio
 @pytest.mark.snapshot
-async def test_user_specified_service(ddtrace_run_python_code_in_subprocess):
+async def test_user_specified_service_v0(ddtrace_run_python_code_in_subprocess):
     """
-    When a user specifies a service for the app
+    v0: When a user specifies a service for the app
         The aiomysql integration should not use it.
     """
     env = os.environ.copy()
     env["DD_SERVICE"] = "my-service-name"
+    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v0"
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """
 import asyncio
@@ -124,6 +126,62 @@ from ddtrace import config
 from tests.contrib.aiomysql.test_aiomysql import AIOMYSQL_CONFIG
 
 assert config.service == "my-service-name"
+async def test():
+    conn = await aiomysql.connect(**AIOMYSQL_CONFIG)
+    await (await conn.cursor()).execute("select 'dba4x4'")
+    conn.close()
+asyncio.run(test())""",
+        env=env,
+    )
+    assert status == 0, err
+    assert out == err == b""
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_user_specified_service_v1(ddtrace_run_python_code_in_subprocess):
+    """
+    v1: When a user specifies a service for the app
+        The aiomysql integration should use it.
+    """
+    env = os.environ.copy()
+    env["DD_SERVICE"] = "my-service-name"
+    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(
+        """
+import asyncio
+import aiomysql
+from ddtrace import config
+from tests.contrib.aiomysql.test_aiomysql import AIOMYSQL_CONFIG
+
+assert config.service == "my-service-name"
+async def test():
+    conn = await aiomysql.connect(**AIOMYSQL_CONFIG)
+    await (await conn.cursor()).execute("select 'dba4x4'")
+    conn.close()
+asyncio.run(test())""",
+        env=env,
+    )
+    assert status == 0, err
+    assert out == err == b""
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_unspecified_service_v1(ddtrace_run_python_code_in_subprocess):
+    """
+    v1: When a user specifies nothing for a service,
+        it should default to DEFAULT_SPAN_SERVICE_NAME
+    """
+    env = os.environ.copy()
+    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(
+        """
+import asyncio
+import aiomysql
+from ddtrace import config
+from tests.contrib.aiomysql.test_aiomysql import AIOMYSQL_CONFIG
+
 async def test():
     conn = await aiomysql.connect(**AIOMYSQL_CONFIG)
     await (await conn.cursor()).execute("select 'dba4x4'")

--- a/tests/contrib/aiopg/test.py
+++ b/tests/contrib/aiopg/test.py
@@ -9,6 +9,7 @@ from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.aiopg.patch import patch
 from ddtrace.contrib.aiopg.patch import unpatch
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio
 from tests.contrib.config import POSTGRES_CONFIG
@@ -190,10 +191,10 @@ class AiopgTestCase(AsyncioTestCase):
         assert spans, spans
         assert len(spans) == 1
 
-    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_service(self):
+    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_user_specified_service_v0(self):
         """
-        When a user specifies a service for the app
+        v0: When a user specifies a service for the app
             The aiopg integration should not use it.
         """
         # Ensure that the service name was configured
@@ -210,6 +211,48 @@ class AiopgTestCase(AsyncioTestCase):
         assert spans, spans
         assert len(spans) == 1
         assert spans[0].service != "mysvc"
+
+    @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_user_specified_service_v0(self):
+        """
+        v1: When a user specifies a service for the app
+            The aiopg integration should use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
+        conn = yield from aiopg.connect(**POSTGRES_CONFIG)
+        Pin.get_from(conn).clone(tracer=self.tracer).onto(conn)
+        yield from (yield from conn.cursor()).execute("select 'blah'")
+        conn.close()
+
+        spans = self.get_spans()
+        assert spans, spans
+        assert len(spans) == 1
+        assert spans[0].service == "mysvc"
+
+    @run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_unspecified_service_v0(self):
+        """
+        v1: When a user specifies a service for the app
+            The aiopg integration should use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
+        conn = yield from aiopg.connect(**POSTGRES_CONFIG)
+        Pin.get_from(conn).clone(tracer=self.tracer).onto(conn)
+        yield from (yield from conn.cursor()).execute("select 'blah'")
+        conn.close()
+
+        spans = self.get_spans()
+        assert spans, spans
+        assert len(spans) == 1
+        assert spans[0].service == DEFAULT_SERVICE_NAME
 
 
 class AiopgAnalyticsTestCase(AiopgTestCase):

--- a/tests/contrib/aiopg/test.py
+++ b/tests/contrib/aiopg/test.py
@@ -191,11 +191,15 @@ class AiopgTestCase(AsyncioTestCase):
         assert spans, spans
         assert len(spans) == 1
 
+    @mark_asyncio
     @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_user_specified_service_v0(self):
         """
         v0: When a user specifies a service for the app
-            The aiopg integration should not use it.
+            The aiopg integration does use it.
+
+            **note** Unlike other integrations, the current behavior already matches v1 behavior,
+            as the service specified by aiopg is overwritten with `service=None` by psycopg
         """
         # Ensure that the service name was configured
         from ddtrace import config
@@ -210,8 +214,9 @@ class AiopgTestCase(AsyncioTestCase):
         spans = self.get_spans()
         assert spans, spans
         assert len(spans) == 1
-        assert spans[0].service != "mysvc"
+        assert spans[0].service == "mysvc"
 
+    @mark_asyncio
     @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_user_specified_service_v1(self):
         """
@@ -233,6 +238,7 @@ class AiopgTestCase(AsyncioTestCase):
         assert len(spans) == 1
         assert spans[0].service == "mysvc"
 
+    @mark_asyncio
     @run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_unspecified_service_v0(self):
         """
@@ -240,10 +246,6 @@ class AiopgTestCase(AsyncioTestCase):
             The aiopg integration should use it.
         """
         # Ensure that the service name was configured
-        from ddtrace import config
-
-        assert config.service == "mysvc"
-
         conn = yield from aiopg.connect(**POSTGRES_CONFIG)
         Pin.get_from(conn).clone(tracer=self.tracer).onto(conn)
         yield from (yield from conn.cursor()).execute("select 'blah'")

--- a/tests/contrib/aiopg/test.py
+++ b/tests/contrib/aiopg/test.py
@@ -213,7 +213,7 @@ class AiopgTestCase(AsyncioTestCase):
         assert spans[0].service != "mysvc"
 
     @run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
-    def test_user_specified_service_v0(self):
+    def test_user_specified_service_v1(self):
         """
         v1: When a user specifies a service for the app
             The aiopg integration should use it.
@@ -252,7 +252,7 @@ class AiopgTestCase(AsyncioTestCase):
         spans = self.get_spans()
         assert spans, spans
         assert len(spans) == 1
-        assert spans[0].service == DEFAULT_SERVICE_NAME
+        assert spans[0].service == DEFAULT_SPAN_SERVICE_NAME
 
 
 class AiopgAnalyticsTestCase(AiopgTestCase):

--- a/tests/contrib/algoliasearch/test.py
+++ b/tests/contrib/algoliasearch/test.py
@@ -3,7 +3,6 @@ from ddtrace import patch_all
 from ddtrace.contrib.algoliasearch.patch import algoliasearch_version
 from ddtrace.contrib.algoliasearch.patch import patch
 from ddtrace.contrib.algoliasearch.patch import unpatch
-from ddtrace.internal.schema import schematize_service_name
 from ddtrace.pin import Pin
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
@@ -77,7 +76,7 @@ class AlgoliasearchTest(TracerTestCase):
         assert span.name == "algoliasearch.search"
         assert span.span_type == "http"
         assert span.error == 0
-        assert span.service == schematize_service_name("algoliasearch")
+        assert span.service == "algoliasearch"
         assert span.get_tag("query.args.attributes_to_retrieve") == "firstname,lastname"
         # Verify that adding new arguments to the search API will simply be ignored and not cause
         # errors

--- a/tests/contrib/algoliasearch/test.py
+++ b/tests/contrib/algoliasearch/test.py
@@ -77,7 +77,7 @@ class AlgoliasearchTest(TracerTestCase):
         assert span.name == "algoliasearch.search"
         assert span.span_type == "http"
         assert span.error == 0
-        assert span.service == schematize_service_name('algoliasearch')
+        assert span.service == schematize_service_name("algoliasearch")
         assert span.get_tag("query.args.attributes_to_retrieve") == "firstname,lastname"
         # Verify that adding new arguments to the search API will simply be ignored and not cause
         # errors

--- a/tests/contrib/algoliasearch/test.py
+++ b/tests/contrib/algoliasearch/test.py
@@ -199,8 +199,8 @@ class AlgoliasearchTest(TracerTestCase):
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1", DD_SERVICE="mysvc"))
     def test_user_specified_service_v1(self):
         """
-        When a service name is specified by the user
-            The algoliasearch integration shouldn't use it as the service name
+        In the v1 service name schema, services default to $DD_SERVICE,
+            so make sure that is used and not the v0 schema 'algoliasearch'
         """
         patch_all()
         Pin.override(self.index, tracer=self.tracer)

--- a/tests/contrib/algoliasearch/test.py
+++ b/tests/contrib/algoliasearch/test.py
@@ -3,6 +3,7 @@ from ddtrace import patch_all
 from ddtrace.contrib.algoliasearch.patch import algoliasearch_version
 from ddtrace.contrib.algoliasearch.patch import patch
 from ddtrace.contrib.algoliasearch.patch import unpatch
+from ddtrace.internal.schema import schematize_service_name
 from ddtrace.pin import Pin
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
@@ -73,10 +74,10 @@ class AlgoliasearchTest(TracerTestCase):
         assert len(spans) == 1
         span = spans[0]
         assert_is_measured(span)
-        assert span.service == "algoliasearch"
         assert span.name == "algoliasearch.search"
         assert span.span_type == "http"
         assert span.error == 0
+        assert span.service == schematize_service_name('algoliasearch')
         assert span.get_tag("query.args.attributes_to_retrieve") == "firstname,lastname"
         # Verify that adding new arguments to the search API will simply be ignored and not cause
         # errors
@@ -164,7 +165,7 @@ class AlgoliasearchTest(TracerTestCase):
         assert not spans, spans
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_service(self):
+    def test_user_specified_service_default(self):
         """
         When a service name is specified by the user
             The algoliasearch integration shouldn't use it as the service name
@@ -177,4 +178,36 @@ class AlgoliasearchTest(TracerTestCase):
         assert spans, spans
         assert len(spans) == 1
         assert spans[0].service == "algoliasearch"
+        unpatch()
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0", DD_SERVICE="mysvc"))
+    def test_user_specified_service_v0(self):
+        """
+        When a service name is specified by the user
+            The algoliasearch integration shouldn't use it as the service name
+        """
+        patch_all()
+        Pin.override(self.index, tracer=self.tracer)
+        self.perform_search("test search")
+        spans = self.get_spans()
+        self.reset()
+        assert spans, spans
+        assert len(spans) == 1
+        assert spans[0].service == "algoliasearch"
+        unpatch()
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1", DD_SERVICE="mysvc"))
+    def test_user_specified_service_v1(self):
+        """
+        When a service name is specified by the user
+            The algoliasearch integration shouldn't use it as the service name
+        """
+        patch_all()
+        Pin.override(self.index, tracer=self.tracer)
+        self.perform_search("test search")
+        spans = self.get_spans()
+        self.reset()
+        assert spans, spans
+        assert len(spans) == 1
+        assert spans[0].service == "mysvc"
         unpatch()

--- a/tests/contrib/asyncpg/test_asyncpg.py
+++ b/tests/contrib/asyncpg/test_asyncpg.py
@@ -306,17 +306,3 @@ def test_patch_unpatch_asyncpg():
     assert not iswrapped(asyncpg.protocol.Protocol.bind_execute)
     assert not iswrapped(asyncpg.protocol.Protocol.query)
     assert not iswrapped(asyncpg.protocol.Protocol.bind_execute_many)
-
-
-def test_patch_unpatch_asyncpg():
-    assert iswrapped(asyncpg.connect)
-    assert iswrapped(asyncpg.protocol.Protocol.execute)
-    assert iswrapped(asyncpg.protocol.Protocol.bind_execute)
-    assert iswrapped(asyncpg.protocol.Protocol.query)
-    assert iswrapped(asyncpg.protocol.Protocol.bind_execute_many)
-    unpatch()
-    assert not iswrapped(asyncpg.connect)
-    assert not iswrapped(asyncpg.protocol.Protocol.execute)
-    assert not iswrapped(asyncpg.protocol.Protocol.bind_execute)
-    assert not iswrapped(asyncpg.protocol.Protocol.query)
-    assert not iswrapped(asyncpg.protocol.Protocol.bind_execute_many)

--- a/tests/contrib/asyncpg/test_asyncpg.py
+++ b/tests/contrib/asyncpg/test_asyncpg.py
@@ -169,7 +169,7 @@ async def test_parenting(patched_conn):
 
 
 @pytest.mark.snapshot(async_mode=False)
-def test_configure_service_name_env(ddtrace_run_python_code_in_subprocess):
+def test_configure_service_name_env_v0(ddtrace_run_python_code_in_subprocess):
     code = """
 import asyncio
 import sys
@@ -194,9 +194,118 @@ else:
     """
     env = os.environ.copy()
     env["DD_ASYNCPG_SERVICE"] = "global-service-name"
+    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v0"
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
     assert err == b""
+
+
+@pytest.mark.snapshot(async_mode=False)
+def test_configure_service_name_env_v1(ddtrace_run_python_code_in_subprocess):
+    code = """
+import asyncio
+import sys
+import asyncpg
+from tests.contrib.config import POSTGRES_CONFIG
+
+async def test():
+    conn = await asyncpg.connect(
+        host=POSTGRES_CONFIG["host"],
+        port=POSTGRES_CONFIG["port"],
+        user=POSTGRES_CONFIG["user"],
+        database=POSTGRES_CONFIG["dbname"],
+        password=POSTGRES_CONFIG["password"],
+    )
+    await conn.execute("SELECT 1")
+    await conn.close()
+
+if sys.version_info >= (3, 7, 0):
+    asyncio.run(test())
+else:
+    asyncio.get_event_loop().run_until_complete(test())
+    """
+    env = os.environ.copy()
+    env["DD_ASYNCPG_SERVICE"] = "global-service-name"
+    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    assert status == 0, err
+    assert err == b""
+
+
+@pytest.mark.snapshot(async_mode=False)
+def test_unspecified_service_name_env_v0(ddtrace_run_python_code_in_subprocess):
+    code = """
+import asyncio
+import sys
+import asyncpg
+from tests.contrib.config import POSTGRES_CONFIG
+
+async def test():
+    conn = await asyncpg.connect(
+        host=POSTGRES_CONFIG["host"],
+        port=POSTGRES_CONFIG["port"],
+        user=POSTGRES_CONFIG["user"],
+        database=POSTGRES_CONFIG["dbname"],
+        password=POSTGRES_CONFIG["password"],
+    )
+    await conn.execute("SELECT 1")
+    await conn.close()
+
+if sys.version_info >= (3, 7, 0):
+    asyncio.run(test())
+else:
+    asyncio.get_event_loop().run_until_complete(test())
+    """
+    env = os.environ.copy()
+    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v0"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    assert status == 0, err
+    assert err == b""
+
+
+@pytest.mark.snapshot(async_mode=False)
+def test_unspecified_service_name_env_v1(ddtrace_run_python_code_in_subprocess):
+    code = """
+import asyncio
+import sys
+import asyncpg
+from tests.contrib.config import POSTGRES_CONFIG
+
+async def test():
+    conn = await asyncpg.connect(
+        host=POSTGRES_CONFIG["host"],
+        port=POSTGRES_CONFIG["port"],
+        user=POSTGRES_CONFIG["user"],
+        database=POSTGRES_CONFIG["dbname"],
+        password=POSTGRES_CONFIG["password"],
+    )
+    await conn.execute("SELECT 1")
+    await conn.close()
+
+if sys.version_info >= (3, 7, 0):
+    asyncio.run(test())
+else:
+    asyncio.get_event_loop().run_until_complete(test())
+    """
+    env = os.environ.copy()
+    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    assert status == 0, err
+    assert err == b""
+
+
+def test_patch_unpatch_asyncpg():
+    assert iswrapped(asyncpg.connect)
+    assert iswrapped(asyncpg.protocol.Protocol.execute)
+    assert iswrapped(asyncpg.protocol.Protocol.bind_execute)
+    assert iswrapped(asyncpg.protocol.Protocol.query)
+    assert iswrapped(asyncpg.protocol.Protocol.bind_execute_many)
+    unpatch()
+    assert not iswrapped(asyncpg.connect)
+    assert not iswrapped(asyncpg.protocol.Protocol.execute)
+    assert not iswrapped(asyncpg.protocol.Protocol.bind_execute)
+    assert not iswrapped(asyncpg.protocol.Protocol.query)
+    assert not iswrapped(asyncpg.protocol.Protocol.bind_execute_many)
 
 
 def test_patch_unpatch_asyncpg():

--- a/tests/contrib/cassandra/test.py
+++ b/tests/contrib/cassandra/test.py
@@ -18,6 +18,7 @@ from ddtrace.contrib.cassandra.patch import unpatch
 from ddtrace.contrib.cassandra.session import SERVICE
 from ddtrace.ext import cassandra as cassx
 from ddtrace.ext import net
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.config import CASSANDRA_CONFIG
 from tests.opentracer.utils import init_tracer
 from tests.utils import DummyTracer
@@ -469,10 +470,10 @@ class TestCassandraConfig(TracerTestCase):
         Pin.get_from(self.cluster).clone(tracer=self.tracer).onto(self.cluster)
         self.session = self.cluster.connect(self.TEST_KEYSPACE)
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_service(self):
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_user_specified_service_v0(self):
         """
-        When a user specifies a service for the app
+        v0: When a user specifies a service for the app
             The cassandra integration should not use it.
         """
         # Ensure that the service name was configured
@@ -486,3 +487,39 @@ class TestCassandraConfig(TracerTestCase):
         assert len(spans) == 1
         query = spans[0]
         assert query.service != "mysvc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_user_specified_service_v1(self):
+        """
+        v1: When a user specifies a service for the app
+            The cassandra integration should not use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
+        self.session.execute(self.TEST_QUERY)
+        spans = self.pop_spans()
+        assert spans
+        assert len(spans) == 1
+        query = spans[0]
+        assert query.service == "mysvc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_unspecified_service_v1(self):
+        """
+        v1: When a user specifies a service for the app
+            The cassandra integration should not use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+
+        assert config.service == DEFAULT_SPAN_SERVICE_NAME
+
+        self.session.execute(self.TEST_QUERY)
+        spans = self.pop_spans()
+        assert spans
+        assert len(spans) == 1
+        query = spans[0]
+        assert query.service == DEFAULT_SPAN_SERVICE_NAME

--- a/tests/contrib/cassandra/test.py
+++ b/tests/contrib/cassandra/test.py
@@ -492,7 +492,7 @@ class TestCassandraConfig(TracerTestCase):
     def test_user_specified_service_v1(self):
         """
         v1: When a user specifies a service for the app
-            The cassandra integration should not use it.
+            The cassandra integration should use it.
         """
         # Ensure that the service name was configured
         from ddtrace import config
@@ -509,8 +509,8 @@ class TestCassandraConfig(TracerTestCase):
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_unspecified_service_v1(self):
         """
-        v1: When a user specifies a service for the app
-            The cassandra integration should not use it.
+        v1: When a user does not specify a service for the app
+            dd-trace-py should default to internal.schema.DEFAULT_SPAN_SERVICE_NAME
         """
         # Ensure that the service name was configured
         from ddtrace import config

--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -245,7 +245,7 @@ class ElasticsearchPatchTest(TracerTestCase):
     def test_user_specified_service_v1(self):
         """
         v1: When a user specifies a service for the app
-            The elasticsearch integration should not use it.
+            The elasticsearch integration should use it.
         """
         assert config.service == "mysvc"
 

--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -234,11 +234,10 @@ class ElasticsearchPatchTest(TracerTestCase):
         assert config.service == "mysvc"
 
         self.es.indices.create(index=self.ES_INDEX, ignore=400)
-        Pin(service="es", tracer=self.tracer).onto(self.es.transport)
         spans = self.get_spans()
         self.reset()
         assert len(spans) == 1
-        assert spans[0].service != "es"
+        assert spans[0].service != "mysvc"
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_user_specified_service_v1(self):

--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -9,7 +9,6 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.elasticsearch.patch import patch
 from ddtrace.contrib.elasticsearch.patch import unpatch
 from ddtrace.ext import http
-from ddtrace.internal.schema import schematize_service_name
 from tests.utils import TracerTestCase
 
 from ..config import ELASTICSEARCH_CONFIG
@@ -76,7 +75,7 @@ class ElasticsearchPatchTest(TracerTestCase):
         assert len(spans) == 1
         span = spans[0]
         TracerTestCase.assert_is_measured(span)
-        assert span.service == schematize_service_name("elasticsearch")
+        assert span.service == "elasticsearch"
         assert span.name == "elasticsearch.query"
         assert span.span_type == "elasticsearch"
         assert span.error == 0

--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -8,8 +8,8 @@ from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.elasticsearch.patch import patch
 from ddtrace.contrib.elasticsearch.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.ext import http
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 
 from ..config import ELASTICSEARCH_CONFIG

--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -264,7 +264,7 @@ class ElasticsearchPatchTest(TracerTestCase):
         assert spans[0].service == "elasticsearch"
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
-    def test_user_specified_service_v1(self):
+    def test_unspecified_service_v1(self):
         self.es.indices.create(index=self.ES_INDEX, ignore=400)
         Pin(service="es", tracer=self.tracer).onto(self.es.transport)
         spans = self.get_spans()

--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -269,19 +269,6 @@ class ElasticsearchPatchTest(TracerTestCase):
         assert len(spans) == 1
         assert spans[0].service == "custom-elasticsearch"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE_MAPPING="elasticsearch:custom-elasticsearch"))
-    def test_service_mapping_config(self):
-        """
-        When a user specifies a service mapping it should override the default
-        """
-        assert config.elasticsearch.service != "custom-elasticsearch"
-
-        self.es.indices.create(index=self.ES_INDEX, ignore=400)
-        spans = self.get_spans()
-        self.reset()
-        assert len(spans) == 1
-        assert spans[0].service == "custom-elasticsearch"
-
     def test_service_name_config_override(self):
         """
         When a user specifies a service mapping it should override the default

--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -9,6 +9,7 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.elasticsearch.patch import patch
 from ddtrace.contrib.elasticsearch.patch import unpatch
 from ddtrace.ext import http
+from ddtrace.internal.schema import schematize_service_name
 from tests.utils import TracerTestCase
 
 from ..config import ELASTICSEARCH_CONFIG
@@ -75,7 +76,7 @@ class ElasticsearchPatchTest(TracerTestCase):
         assert len(spans) == 1
         span = spans[0]
         TracerTestCase.assert_is_measured(span)
-        assert span.service == "elasticsearch"
+        assert span.service == schematize_service_name("elasticsearch")
         assert span.name == "elasticsearch.query"
         assert span.span_type == "elasticsearch"
         assert span.error == 0
@@ -225,10 +226,10 @@ class ElasticsearchPatchTest(TracerTestCase):
         assert spans, spans
         assert len(spans) == 1
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_service(self):
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_user_specified_service_v0(self):
         """
-        When a user specifies a service for the app
+        v0: When a user specifies a service for the app
             The elasticsearch integration should not use it.
         """
         assert config.service == "mysvc"
@@ -239,6 +240,34 @@ class ElasticsearchPatchTest(TracerTestCase):
         self.reset()
         assert len(spans) == 1
         assert spans[0].service != "es"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_user_specified_service_v1(self):
+        """
+        v1: When a user specifies a service for the app
+            The elasticsearch integration should not use it.
+        """
+        assert config.service == "mysvc"
+
+        self.es.indices.create(index=self.ES_INDEX, ignore=400)
+        Pin(service="es", tracer=self.tracer).onto(self.es.transport)
+        spans = self.get_spans()
+        self.reset()
+        assert len(spans) == 1
+        assert spans[0].service == "mysvc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE_MAPPING="elasticsearch:custom-elasticsearch"))
+    def test_service_mapping_config(self):
+        """
+        When a user specifies a service mapping it should override the default
+        """
+        assert config.elasticsearch.service != "custom-elasticsearch"
+
+        self.es.indices.create(index=self.ES_INDEX, ignore=400)
+        spans = self.get_spans()
+        self.reset()
+        assert len(spans) == 1
+        assert spans[0].service == "custom-elasticsearch"
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE_MAPPING="elasticsearch:custom-elasticsearch"))
     def test_service_mapping_config(self):

--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -8,6 +8,7 @@ from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.elasticsearch.patch import patch
 from ddtrace.contrib.elasticsearch.patch import unpatch
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.ext import http
 from tests.utils import TracerTestCase
 
@@ -269,7 +270,7 @@ class ElasticsearchPatchTest(TracerTestCase):
         spans = self.get_spans()
         self.reset()
         assert len(spans) == 1
-        assert spans[0].service == "unnamed-python-service"
+        assert spans[0].service == DEFAULT_SPAN_SERVICE_NAME
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE_MAPPING="elasticsearch:custom-elasticsearch"))
     def test_service_mapping_config(self):

--- a/tests/contrib/mongoengine/test.py
+++ b/tests/contrib/mongoengine/test.py
@@ -282,7 +282,7 @@ class TestMongoEnginePatchConnectDefaultOnly(TestMongoEnginePatchConnectDefault)
 
         spans = tracer.pop()
         assert len(spans) == 1
-        assert spans[0].service == "mongodb", f"{spans[0].service} - 'mongodb'"
+        assert spans[0].service == "mongodb"
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_unspecified_service_v1(self):
@@ -299,9 +299,7 @@ class TestMongoEnginePatchConnectDefaultOnly(TestMongoEnginePatchConnectDefault)
 
         spans = tracer.pop()
         assert len(spans) == 1
-        assert (
-            spans[0].service == DEFAULT_SPAN_SERVICE_NAME
-        ), f"{config.service} - {spans[0].service} - {DEFAULT_SPAN_SERVICE_NAME}"
+        assert spans[0].service == DEFAULT_SPAN_SERVICE_NAME
 
 
 class TestMongoEnginePatchConnect(TestMongoEnginePatchConnectDefault):

--- a/tests/contrib/mongoengine/test.py
+++ b/tests/contrib/mongoengine/test.py
@@ -233,7 +233,7 @@ class TestMongoEnginePatchConnectDefaultOnly(TestMongoEnginePatchConnectDefault)
         assert len(spans) == 1
         assert spans[0].service != "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0', DD_SERVICE="mysvc"))
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0", DD_SERVICE="mysvc"))
     def test_user_specified_service_v0(self):
         """
         When a user specifies a service for the app
@@ -250,7 +250,7 @@ class TestMongoEnginePatchConnectDefaultOnly(TestMongoEnginePatchConnectDefault)
         assert len(spans) == 1
         assert spans[0].service != "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v1', DD_SERVICE="mysvc"))
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1", DD_SERVICE="mysvc"))
     def test_user_specified_service_v1(self):
         """
         In v1 of the span attribute schema, when a user specifies a service for the app
@@ -267,8 +267,8 @@ class TestMongoEnginePatchConnectDefaultOnly(TestMongoEnginePatchConnectDefault)
         assert len(spans) == 1
         assert spans[0].service == "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0'))
-    def test_unspecified_service_v0(self): 
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_unspecified_service_v0(self):
         """
         In v0 of the span attribute schema, when there is no specified DD_SERVICE
             The mongoengine integration should use None as the default.
@@ -282,13 +282,13 @@ class TestMongoEnginePatchConnectDefaultOnly(TestMongoEnginePatchConnectDefault)
 
         spans = tracer.pop()
         assert len(spans) == 1
-        assert spans[0].service == 'mongodb', f"{spans[0].service} - 'mongodb'"
+        assert spans[0].service == "mongodb", f"{spans[0].service} - 'mongodb'"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v1'))
-    def test_unspecified_service_v1(self): 
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_unspecified_service_v1(self):
         """
         In v1 of the span attribute schema, when there is no specified DD_SERVICE
-            The mongoengine integration should use 'unnamed-python-service' as the default.
+            The mongoengine integration should use DEFAULT_SPAN_SERVICE_NAME as the default.
         """
         from ddtrace import config
 
@@ -299,7 +299,10 @@ class TestMongoEnginePatchConnectDefaultOnly(TestMongoEnginePatchConnectDefault)
 
         spans = tracer.pop()
         assert len(spans) == 1
-        assert spans[0].service == DEFAULT_SPAN_SERVICE_NAME, f"{config.service} - {spans[0].service} - {DEFAULT_SPAN_SERVICE_NAME}"
+        assert (
+            spans[0].service == DEFAULT_SPAN_SERVICE_NAME
+        ), f"{config.service} - {spans[0].service} - {DEFAULT_SPAN_SERVICE_NAME}"
+
 
 class TestMongoEnginePatchConnect(TestMongoEnginePatchConnectDefault):
     """Test suite with a global Pin for the connect function with custom service"""

--- a/tests/contrib/mongoengine/test.py
+++ b/tests/contrib/mongoengine/test.py
@@ -219,7 +219,7 @@ class TestMongoEnginePatchConnectDefaultOnly(TestMongoEnginePatchConnectDefault)
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
     def test_user_specified_service_default(self):
         """
-        When a user specifies a service for the app
+        : When a user specifies a service for the app
             The mongoengine integration should not use it.
         """
         from ddtrace import config
@@ -236,7 +236,7 @@ class TestMongoEnginePatchConnectDefaultOnly(TestMongoEnginePatchConnectDefault)
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0", DD_SERVICE="mysvc"))
     def test_user_specified_service_v0(self):
         """
-        When a user specifies a service for the app
+        v0: When a user specifies a service for the app
             The mongoengine integration should not use it.
         """
         from ddtrace import config

--- a/tests/contrib/mongoengine/test.py
+++ b/tests/contrib/mongoengine/test.py
@@ -10,6 +10,7 @@ from ddtrace.contrib.mongoengine.patch import unpatch
 from ddtrace.contrib.pymongo.client import TracedMongoClient
 from ddtrace.contrib.pymongo.client import TracedTopology
 from ddtrace.ext import mongo as mongox
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.opentracer.utils import init_tracer
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase
@@ -192,23 +193,6 @@ class MongoEngineCore(object):
             assert len(spans) == 1
             assert spans[0].get_metric(ANALYTICS_SAMPLE_RATE_KEY) == 1.0
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_service(self):
-        """
-        When a user specifies a service for the app
-            The mongoengine integration should not use it.
-        """
-        from ddtrace import config
-
-        assert config.service == "mysvc"
-
-        tracer = self.get_tracer_and_connect()
-        Artist.drop_collection()
-
-        spans = tracer.pop()
-        assert len(spans) == 1
-        assert spans[0].service != "mysvc"
-
 
 class TestMongoEnginePatchConnectDefault(TracerTestCase, MongoEngineCore):
     """Test suite with a global Pin for the connect function with the default configuration"""
@@ -230,6 +214,92 @@ class TestMongoEnginePatchConnectDefault(TracerTestCase, MongoEngineCore):
 
         return tracer
 
+
+class TestMongoEnginePatchConnectDefaultOnly(TestMongoEnginePatchConnectDefault):
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_user_specified_service_default(self):
+        """
+        When a user specifies a service for the app
+            The mongoengine integration should not use it.
+        """
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
+        tracer = self.get_tracer_and_connect()
+        Artist.drop_collection()
+
+        spans = tracer.pop()
+        assert len(spans) == 1
+        assert spans[0].service != "mysvc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0', DD_SERVICE="mysvc"))
+    def test_user_specified_service_v0(self):
+        """
+        When a user specifies a service for the app
+            The mongoengine integration should not use it.
+        """
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
+        tracer = self.get_tracer_and_connect()
+        Artist.drop_collection()
+
+        spans = tracer.pop()
+        assert len(spans) == 1
+        assert spans[0].service != "mysvc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v1', DD_SERVICE="mysvc"))
+    def test_user_specified_service_v1(self):
+        """
+        In v1 of the span attribute schema, when a user specifies a service for the app
+            The mongoengine integration should use it as the default.
+        """
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
+        tracer = self.get_tracer_and_connect()
+        Artist.drop_collection()
+
+        spans = tracer.pop()
+        assert len(spans) == 1
+        assert spans[0].service == "mysvc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0'))
+    def test_unspecified_service_v0(self): 
+        """
+        In v0 of the span attribute schema, when there is no specified DD_SERVICE
+            The mongoengine integration should use None as the default.
+        """
+        from ddtrace import config
+
+        assert config.service is DEFAULT_SPAN_SERVICE_NAME
+
+        tracer = self.get_tracer_and_connect()
+        Artist.drop_collection()
+
+        spans = tracer.pop()
+        assert len(spans) == 1
+        assert spans[0].service == 'mongodb', f"{spans[0].service} - 'mongodb'"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v1'))
+    def test_unspecified_service_v1(self): 
+        """
+        In v1 of the span attribute schema, when there is no specified DD_SERVICE
+            The mongoengine integration should use 'unnamed-python-service' as the default.
+        """
+        from ddtrace import config
+
+        assert config.service == DEFAULT_SPAN_SERVICE_NAME
+
+        tracer = self.get_tracer_and_connect()
+        Artist.drop_collection()
+
+        spans = tracer.pop()
+        assert len(spans) == 1
+        assert spans[0].service == DEFAULT_SPAN_SERVICE_NAME, f"{config.service} - {spans[0].service} - {DEFAULT_SPAN_SERVICE_NAME}"
 
 class TestMongoEnginePatchConnect(TestMongoEnginePatchConnectDefault):
     """Test suite with a global Pin for the connect function with custom service"""

--- a/tests/contrib/mysql/test_mysql.py
+++ b/tests/contrib/mysql/test_mysql.py
@@ -4,7 +4,6 @@ from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.mysql.patch import patch
 from ddtrace.contrib.mysql.patch import unpatch
-from ddtrace.internal.schema import schematize_service_name
 from tests.contrib.config import MYSQL_CONFIG
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
@@ -45,7 +44,7 @@ class MySQLCore(object):
 
         span = spans[0]
         assert_is_measured(span)
-        assert span.service == schematize_service_name("mysql")
+        assert span.service == "mysql"
         assert span.name == "mysql.query"
         assert span.span_type == "sql"
         assert span.error == 0
@@ -74,7 +73,7 @@ class MySQLCore(object):
 
             span = spans[0]
             assert_is_measured(span)
-            assert span.service == schematize_service_name("mysql")
+            assert span.service == "mysql"
             assert span.name == "mysql.query"
             assert span.span_type == "sql"
             assert span.error == 0
@@ -230,7 +229,7 @@ class MySQLCore(object):
         # can expect the last closed span to be our proc.
         span = spans[len(spans) - 1]
         assert_is_measured(span)
-        assert span.service == schematize_service_name("mysql")
+        assert span.service == "mysql"
         assert span.name == "mysql.query"
         assert span.span_type == "sql"
         assert span.error == 0
@@ -273,7 +272,7 @@ class MySQLCore(object):
         assert ot_span.name == "mysql_op"
 
         assert_is_measured(dd_span)
-        assert dd_span.service == schematize_service_name("mysql")
+        assert dd_span.service == "mysql"
         assert dd_span.name == "mysql.query"
         assert dd_span.span_type == "sql"
         assert dd_span.error == 0
@@ -316,7 +315,7 @@ class MySQLCore(object):
             assert ot_span.name == "mysql_op"
 
             assert_is_measured(dd_span)
-            assert dd_span.service == schematize_service_name("mysql")
+            assert dd_span.service == "mysql"
             assert dd_span.name == "mysql.query"
             assert dd_span.span_type == "sql"
             assert dd_span.error == 0
@@ -341,7 +340,7 @@ class MySQLCore(object):
         spans = tracer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.service == schematize_service_name("mysql")
+        assert span.service == "mysql"
         assert span.name == "mysql.connection.commit"
 
     def test_rollback(self):
@@ -350,7 +349,7 @@ class MySQLCore(object):
         spans = tracer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.service == schematize_service_name("mysql")
+        assert span.service == "mysql"
         assert span.name == "mysql.connection.rollback"
 
     def test_analytics_default(self):

--- a/tests/contrib/mysqldb/test_mysqldb.py
+++ b/tests/contrib/mysqldb/test_mysqldb.py
@@ -6,7 +6,6 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.mysqldb.patch import patch
 from ddtrace.contrib.mysqldb.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.internal.schema import schematize_service_name
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_dict_issuperset
@@ -55,7 +54,7 @@ class MySQLCore(object):
 
         span = spans[0]
         assert_is_measured(span)
-        assert span.service == schematize_service_name("mysql")
+        assert span.service == "mysql"
         assert span.name == "mysql.query"
         assert span.span_type == "sql"
         assert span.error == 0
@@ -85,7 +84,7 @@ class MySQLCore(object):
 
             span = spans[0]
             assert_is_measured(span)
-            assert span.service == schematize_service_name("mysql")
+            assert span.service == "mysql"
             assert span.name == "mysql.query"
             assert span.span_type == "sql"
             assert span.error == 0
@@ -116,7 +115,7 @@ class MySQLCore(object):
 
         span = spans[0]
         assert_is_measured(span)
-        assert span.service == schematize_service_name("mysql")
+        assert span.service == "mysql"
         assert span.name == "mysql.query"
         assert span.span_type == "sql"
         assert span.error == 0
@@ -146,7 +145,7 @@ class MySQLCore(object):
 
             span = spans[0]
             assert_is_measured(span)
-            assert span.service == schematize_service_name("mysql")
+            assert span.service == "mysql"
             assert span.name == "mysql.query"
             assert span.span_type == "sql"
             assert span.error == 0
@@ -302,7 +301,7 @@ class MySQLCore(object):
         # can expect the next to the last closed span to be our proc.
         span = spans[-2]
         assert_is_measured(span)
-        assert span.service == schematize_service_name("mysql")
+        assert span.service == "mysql"
         assert span.name == "mysql.query"
         assert span.span_type == "sql"
         assert span.error == 0
@@ -343,7 +342,7 @@ class MySQLCore(object):
         assert ot_span.name == "mysql_op"
 
         assert_is_measured(dd_span)
-        assert dd_span.service == schematize_service_name("mysql")
+        assert dd_span.service == "mysql"
         assert dd_span.name == "mysql.query"
         assert dd_span.span_type == "sql"
         assert dd_span.error == 0
@@ -384,7 +383,7 @@ class MySQLCore(object):
             assert ot_span.name == "mysql_op"
 
             assert_is_measured(dd_span)
-            assert dd_span.service == schematize_service_name("mysql")
+            assert dd_span.service == "mysql"
             assert dd_span.name == "mysql.query"
             assert dd_span.span_type == "sql"
             assert dd_span.error == 0
@@ -410,7 +409,7 @@ class MySQLCore(object):
         spans = tracer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.service == schematize_service_name("mysql")
+        assert span.service == "mysql"
         assert span.name == "MySQLdb.connection.commit"
 
     def test_rollback(self):
@@ -420,7 +419,7 @@ class MySQLCore(object):
         spans = tracer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.service == schematize_service_name("mysql")
+        assert span.service == "mysql"
         assert span.name == "MySQLdb.connection.rollback"
 
     def test_analytics_default(self):
@@ -524,7 +523,7 @@ class MySQLCore(object):
 
             span = spans[0]
             assert_is_measured(span)
-            assert span.service == schematize_service_name("mysql")
+            assert span.service == "mysql"
             assert span.name == "mysql.query"
             assert span.span_type == "sql"
             assert span.error == 0
@@ -624,7 +623,7 @@ class TestMysqlPatch(MySQLCore, TracerTestCase):
             assert len(spans) == 1
 
             span = spans[0]
-            assert span.service == schematize_service_name("mysql")
+            assert span.service == "mysql"
             assert span.name == "mysql.query"
             assert span.span_type == "sql"
             assert span.error == 0
@@ -720,7 +719,7 @@ class TestMysqlPatch(MySQLCore, TracerTestCase):
             self.assertEqual(len(spans), 1)
             span = spans[0]
             assert_is_measured(span)
-            assert span.service == schematize_service_name("mysql")
+            assert span.service == "mysql"
             assert span.name == "MySQLdb.connection.connect"
             assert span.span_type == "sql"
             assert span.error == 0
@@ -734,7 +733,7 @@ class TestMysqlPatch(MySQLCore, TracerTestCase):
         self.assertEqual(len(spans), 1)
         span = spans[0]
         assert_is_measured(span)
-        assert span.service == schematize_service_name("mysql")
+        assert span.service == "mysql"
         assert span.name == "MySQLdb.connection.connect"
         assert span.span_type == "sql"
         assert span.error == 0

--- a/tests/contrib/mysqldb/test_mysqldb.py
+++ b/tests/contrib/mysqldb/test_mysqldb.py
@@ -6,6 +6,7 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.mysqldb.patch import patch
 from ddtrace.contrib.mysqldb.patch import unpatch
 from ddtrace.internal.schema import schematize_service_name
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_dict_issuperset
@@ -703,7 +704,7 @@ class TestMysqlPatch(MySQLCore, TracerTestCase):
         assert len(rows) == 1
         spans = tracer.pop()
 
-        assert spans[0].service == "unnamed-python-service"
+        assert spans[0].service == DEFAULT_SPAN_SERVICE_NAME
 
     def test_trace_connect(self):
         # No span when trace_connect is False (the default)

--- a/tests/contrib/mysqldb/test_mysqldb.py
+++ b/tests/contrib/mysqldb/test_mysqldb.py
@@ -5,8 +5,8 @@ from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.mysqldb.patch import patch
 from ddtrace.contrib.mysqldb.patch import unpatch
-from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema import schematize_service_name
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_dict_issuperset

--- a/tests/contrib/mysqldb/test_mysqldb.py
+++ b/tests/contrib/mysqldb/test_mysqldb.py
@@ -467,7 +467,7 @@ class MySQLCore(object):
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_user_specified_service_v0(self):
         """
-        When a user specifies a service for the app
+        v0: When a user specifies a service for the app
             The mysql integration should not use it.
         """
         # Ensure that the service name was configured
@@ -488,8 +488,8 @@ class MySQLCore(object):
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_user_specified_service_v1(self):
         """
-        When a user specifies a service for the app
-            The mysql integration should not use it.
+        v1: When a user specifies a service for the app
+            The mysql integration should not it.
         """
         # Ensure that the service name was configured
         from ddtrace import config

--- a/tests/contrib/mysqldb/test_mysqldb.py
+++ b/tests/contrib/mysqldb/test_mysqldb.py
@@ -504,7 +504,7 @@ class MySQLCore(object):
         assert len(rows) == 1
         spans = tracer.pop()
 
-        assert spans[0].service == "mysvc", f"{spans[0].service} - mysvc"
+        assert spans[0].service == "mysvc"
 
     @pytest.mark.skipif((1, 4) < MySQLdb.version_info < (2, 0), reason="context manager interface not supported")
     def test_contextmanager_connection(self):
@@ -692,7 +692,7 @@ class TestMysqlPatch(MySQLCore, TracerTestCase):
         assert len(rows) == 1
         spans = tracer.pop()
 
-        assert spans[0].service == "mysvc", f"{spans[0].service} - mysvc"
+        assert spans[0].service == "mysvc"
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_unspecified_service_v1(self):

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -12,6 +12,7 @@ from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.psycopg.patch import patch
 from ddtrace.contrib.psycopg.patch import unpatch
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.opentracer.utils import init_tracer
@@ -341,10 +342,10 @@ class PsycopgCore(TracerTestCase):
         query_span = spans[0]
         assert query_span.name == "postgres.query"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_app_service(self):
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_user_specified_app_service_v0(self):
         """
-        When a user specifies a service for the app
+        v0: When a user specifies a service for the app
             The psycopg integration should not use it.
         """
         # Ensure that the service name was configured
@@ -359,14 +360,63 @@ class PsycopgCore(TracerTestCase):
         self.assertEqual(len(spans), 1)
         assert spans[0].service != "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_PSYCOPG_SERVICE="mysvc"))
-    def test_user_specified_service(self):
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_user_specified_app_service_v1(self):
+        """
+        v0: When a user specifies a service for the app
+            The psycopg integration should use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
         conn = self._get_conn()
         conn.cursor().execute("""select 'blah'""")
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
         assert spans[0].service == "mysvc"
+
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_PSYCOPG_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0")
+    )
+    def test_user_specified_service_v0(self):
+        conn = self._get_conn()
+        conn.cursor().execute("""select 'blah'""")
+
+        spans = self.get_spans()
+        self.assertEqual(len(spans), 1)
+        assert spans[0].service == "mysvc"
+
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_PSYCOPG_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1")
+    )
+    def test_user_specified_service_v1(self):
+        conn = self._get_conn()
+        conn.cursor().execute("""select 'blah'""")
+
+        spans = self.get_spans()
+        self.assertEqual(len(spans), 1)
+        assert spans[0].service == "mysvc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_unspecified_service_v0(self):
+        conn = self._get_conn()
+        conn.cursor().execute("""select 'blah'""")
+
+        spans = self.get_spans()
+        self.assertEqual(len(spans), 1)
+        assert spans[0].service == "postgres"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_unspecified_service_v1(self):
+        conn = self._get_conn()
+        conn.cursor().execute("""select 'blah'""")
+
+        spans = self.get_spans()
+        self.assertEqual(len(spans), 1)
+        assert spans[0].service == "unnamed-python-service", f"{spans[0].service}"
 
     def test_contextmanager_connection(self):
         service = "fo"

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -12,7 +12,6 @@ from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.psycopg.patch import patch
 from ddtrace.contrib.psycopg.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.opentracer.utils import init_tracer

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -12,6 +12,7 @@ from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.psycopg.patch import patch
 from ddtrace.contrib.psycopg.patch import unpatch
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.opentracer.utils import init_tracer
@@ -415,7 +416,7 @@ class PsycopgCore(TracerTestCase):
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
-        assert spans[0].service == "unnamed-python-service", f"{spans[0].service}"
+        assert spans[0].service == DEFAULT_SPAN_SERVICE_NAME
 
     def test_contextmanager_connection(self):
         service = "fo"

--- a/tests/contrib/psycopg2/test_psycopg.py
+++ b/tests/contrib/psycopg2/test_psycopg.py
@@ -11,8 +11,8 @@ from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.psycopg.patch import patch
 from ddtrace.contrib.psycopg.patch import unpatch
-from ddtrace.internal.utils.version import parse_version
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.utils.version import parse_version
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/psycopg2/test_psycopg.py
+++ b/tests/contrib/psycopg2/test_psycopg.py
@@ -357,10 +357,10 @@ class PsycopgCore(TracerTestCase):
             span = spans[0]
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_app_service(self):
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_user_specified_app_service_v0(self):
         """
-        When a user specifies a service for the app
+        v0: When a user specifies a service for the app
             The psycopg2 integration should not use it.
         """
         # Ensure that the service name was configured
@@ -375,14 +375,63 @@ class PsycopgCore(TracerTestCase):
         self.assertEqual(len(spans), 1)
         assert spans[0].service != "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_PSYCOPG_SERVICE="mysvc"))
-    def test_user_specified_service(self):
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_user_specified_app_service_v1(self):
+        """
+        v1: When a user specifies a service for the app
+            The psycopg2 integration should not use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
         conn = self._get_conn()
         conn.cursor().execute("""select 'blah'""")
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
         assert spans[0].service == "mysvc"
+
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_PSYCOPG_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0")
+    )
+    def test_user_specified_service_v0(self):
+        conn = self._get_conn()
+        conn.cursor().execute("""select 'blah'""")
+
+        spans = self.get_spans()
+        self.assertEqual(len(spans), 1)
+        assert spans[0].service == "mysvc"
+
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_PSYCOPG_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1")
+    )
+    def test_user_specified_service_v1(self):
+        conn = self._get_conn()
+        conn.cursor().execute("""select 'blah'""")
+
+        spans = self.get_spans()
+        self.assertEqual(len(spans), 1)
+        assert spans[0].service == "mysvc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_unspecified_service_v0(self):
+        conn = self._get_conn()
+        conn.cursor().execute("""select 'blah'""")
+
+        spans = self.get_spans()
+        self.assertEqual(len(spans), 1)
+        assert spans[0].service == "postgres"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_unspecified_service_v0(self):
+        conn = self._get_conn()
+        conn.cursor().execute("""select 'blah'""")
+
+        spans = self.get_spans()
+        self.assertEqual(len(spans), 1)
+        assert spans[0].service == "unnamed-python-service"
 
     @skipIf(PSYCOPG2_VERSION < (2, 5), "Connection context managers not defined in <2.5.")
     def test_contextmanager_connection(self):

--- a/tests/contrib/psycopg2/test_psycopg.py
+++ b/tests/contrib/psycopg2/test_psycopg.py
@@ -379,7 +379,7 @@ class PsycopgCore(TracerTestCase):
     def test_user_specified_app_service_v1(self):
         """
         v1: When a user specifies a service for the app
-            The psycopg2 integration should not use it.
+            The psycopg2 integration should use it.
         """
         # Ensure that the service name was configured
         from ddtrace import config

--- a/tests/contrib/psycopg2/test_psycopg.py
+++ b/tests/contrib/psycopg2/test_psycopg.py
@@ -12,6 +12,7 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.psycopg.patch import patch
 from ddtrace.contrib.psycopg.patch import unpatch
 from ddtrace.internal.utils.version import parse_version
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
@@ -431,7 +432,7 @@ class PsycopgCore(TracerTestCase):
 
         spans = self.get_spans()
         self.assertEqual(len(spans), 1)
-        assert spans[0].service == "unnamed-python-service"
+        assert spans[0].service == DEFAULT_SPAN_SERVICE_NAME
 
     @skipIf(PSYCOPG2_VERSION < (2, 5), "Connection context managers not defined in <2.5.")
     def test_contextmanager_connection(self):

--- a/tests/contrib/psycopg2/test_psycopg.py
+++ b/tests/contrib/psycopg2/test_psycopg.py
@@ -425,7 +425,7 @@ class PsycopgCore(TracerTestCase):
         assert spans[0].service == "postgres"
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
-    def test_unspecified_service_v0(self):
+    def test_unspecified_service_v1(self):
         conn = self._get_conn()
         conn.cursor().execute("""select 'blah'""")
 

--- a/tests/contrib/pymemcache/test_client.py
+++ b/tests/contrib/pymemcache/test_client.py
@@ -378,7 +378,7 @@ class PymemcacheClientConfiguration(TracerTestCase):
 
         assert spans[0].service != "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", SPAN_ATTRIBUTE_SCHEMA_VERSIONS='v0'))
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0'))
     def test_user_specified_service_v0(self):
         """
         In the v0 naming schema -
@@ -399,7 +399,7 @@ class PymemcacheClientConfiguration(TracerTestCase):
 
         assert spans[0].service != "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", SPAN_ATTRIBUTE_SCHEMA_VERSIONS='v1'))
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v1'))
     def test_user_specified_service_v1(self):
         """
         In the v1 naming schema -
@@ -418,4 +418,4 @@ class PymemcacheClientConfiguration(TracerTestCase):
         tracer = pin.tracer
         spans = tracer.pop()
 
-        assert spans[0].service != "mysvc"
+        assert spans[0].service == "mysvc"

--- a/tests/contrib/pymemcache/test_client.py
+++ b/tests/contrib/pymemcache/test_client.py
@@ -358,10 +358,53 @@ class PymemcacheClientConfiguration(TracerTestCase):
         self.assertEqual(spans[0].service, "mysvc2")
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_service(self):
+    def test_user_specified_service_default(self):
         """
+        In the default naming schema (v0) -
         When a user specifies a service for the app
-            The pymemcache integration should not use it.
+            The pymemcache integration **should not** use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
+        client = self.make_client([b"STORED\r\n", b"VALUE key 0 5\r\nvalue\r\nEND\r\n"])
+        client.set(b"key", b"value", noreply=False)
+
+        pin = Pin.get_from(pymemcache)
+        tracer = pin.tracer
+        spans = tracer.pop()
+
+        assert spans[0].service != "mysvc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", SPAN_ATTRIBUTE_SCHEMA_VERSIONS='v0'))
+    def test_user_specified_service_v0(self):
+        """
+        In the v0 naming schema -
+        When a user specifies a service for the app
+            The pymemcache integration **should not** use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
+        client = self.make_client([b"STORED\r\n", b"VALUE key 0 5\r\nvalue\r\nEND\r\n"])
+        client.set(b"key", b"value", noreply=False)
+
+        pin = Pin.get_from(pymemcache)
+        tracer = pin.tracer
+        spans = tracer.pop()
+
+        assert spans[0].service != "mysvc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", SPAN_ATTRIBUTE_SCHEMA_VERSIONS='v1'))
+    def test_user_specified_service_v1(self):
+        """
+        In the v1 naming schema -
+        When a user specifies a service for the app
+            The pymemcache integration **should** use it.
         """
         # Ensure that the service name was configured
         from ddtrace import config

--- a/tests/contrib/pymemcache/test_client.py
+++ b/tests/contrib/pymemcache/test_client.py
@@ -378,7 +378,7 @@ class PymemcacheClientConfiguration(TracerTestCase):
 
         assert spans[0].service != "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0'))
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_user_specified_service_v0(self):
         """
         In the v0 naming schema -
@@ -399,7 +399,7 @@ class PymemcacheClientConfiguration(TracerTestCase):
 
         assert spans[0].service != "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v1'))
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_user_specified_service_v1(self):
         """
         In the v1 naming schema -

--- a/tests/contrib/pymemcache/test_client_mixin.py
+++ b/tests/contrib/pymemcache/test_client_mixin.py
@@ -8,6 +8,7 @@ from ddtrace.contrib.pymemcache.patch import patch
 from ddtrace.contrib.pymemcache.patch import unpatch
 from ddtrace.ext import memcached as memcachedx
 from ddtrace.ext import net
+from ddtrace.internal.schema import schematize_service_name
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase
 
@@ -42,7 +43,7 @@ class PymemcacheClientTestCaseMixin(TracerTestCase):
             self.assertEqual(span.get_metric("network.destination.port"), TEST_PORT)
             self.assertEqual(span.name, memcachedx.CMD)
             self.assertEqual(span.span_type, "cache")
-            self.assertEqual(span.service, memcachedx.SERVICE)
+            self.assertEqual(span.service, schematize_service_name(memcachedx.SERVICE))
             self.assertEqual(span.get_tag(memcachedx.QUERY), query)
             self.assertEqual(span.resource, resource)
             self.assertEqual(span.get_tag("component"), "pymemcache")

--- a/tests/contrib/pymemcache/test_client_mixin.py
+++ b/tests/contrib/pymemcache/test_client_mixin.py
@@ -8,7 +8,6 @@ from ddtrace.contrib.pymemcache.patch import patch
 from ddtrace.contrib.pymemcache.patch import unpatch
 from ddtrace.ext import memcached as memcachedx
 from ddtrace.ext import net
-from ddtrace.internal.schema import schematize_service_name
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase
 
@@ -43,7 +42,7 @@ class PymemcacheClientTestCaseMixin(TracerTestCase):
             self.assertEqual(span.get_metric("network.destination.port"), TEST_PORT)
             self.assertEqual(span.name, memcachedx.CMD)
             self.assertEqual(span.span_type, "cache")
-            self.assertEqual(span.service, schematize_service_name(memcachedx.SERVICE))
+            self.assertEqual(span.service, memcachedx.SERVICE)
             self.assertEqual(span.get_tag(memcachedx.QUERY), query)
             self.assertEqual(span.resource, resource)
             self.assertEqual(span.get_tag("component"), "pymemcache")

--- a/tests/contrib/pymongo/test.py
+++ b/tests/contrib/pymongo/test.py
@@ -500,9 +500,9 @@ class TestPymongoPatchConfigured(TracerTestCase, PymongoCore):
         assert len(spans) == 1
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_service(self):
+    def test_user_specified_service_default(self):
         """
-        When a user specifies a service for the app
+        v0 (default): When a user specifies a service for the app
             The pymongo integration should not use it.
         """
         # Ensure that the service name was configured
@@ -520,8 +520,50 @@ class TestPymongoPatchConfigured(TracerTestCase, PymongoCore):
         assert len(spans) == 1
         assert spans[0].service != "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_PYMONGO_SERVICE="mypymongo"))
-    def test_user_specified_pymongo_service(self):
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0'))
+    def test_user_specified_service_v0(self):
+        """
+        v0: When a user specifies a service for the app
+            The pymongo integration should not use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
+        tracer = DummyTracer()
+        client = pymongo.MongoClient(port=MONGO_CONFIG["port"])
+        Pin.get_from(client).clone(tracer=tracer).onto(client)
+        # We do not wish to trace tcp spans here
+        Pin.get_from(pymongo.server.Server).remove_from(pymongo.server.Server)
+        client["testdb"].drop_collection("whatever")
+        spans = tracer.pop()
+        assert len(spans) == 1
+        assert spans[0].service != "mysvc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v1'))
+    def test_user_specified_service_v1(self):
+        """
+        v1: When a user specifies a service for the app
+            The pymongo integration should use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
+        tracer = DummyTracer()
+        client = pymongo.MongoClient(port=MONGO_CONFIG["port"])
+        Pin.get_from(client).clone(tracer=tracer).onto(client)
+        # We do not wish to trace tcp spans here
+        Pin.get_from(pymongo.server.Server).remove_from(pymongo.server.Server)
+        client["testdb"].drop_collection("whatever")
+        spans = tracer.pop()
+        assert len(spans) == 1
+        assert spans[0].service == "mysvc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_PYMONGO_SERVICE="mypymongo", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0'))
+    def test_user_specified_pymongo_service_v0(self):
 
         tracer = DummyTracer()
         client = pymongo.MongoClient(port=MONGO_CONFIG["port"])
@@ -534,8 +576,35 @@ class TestPymongoPatchConfigured(TracerTestCase, PymongoCore):
         assert len(spans) == 1
         assert spans[0].service == "mypymongo"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_PYMONGO_SERVICE="mypymongo"))
-    def test_service_precedence(self):
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_PYMONGO_SERVICE="mypymongo", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0'))
+    def test_user_specified_pymongo_service_v1(self):
+
+        tracer = DummyTracer()
+        client = pymongo.MongoClient(port=MONGO_CONFIG["port"])
+        Pin(service="mypymongo", tracer=self.tracer).onto(client)
+        Pin.get_from(client).clone(tracer=tracer).onto(client)
+        # We do not wish to trace tcp spans here
+        Pin.get_from(pymongo.server.Server).remove_from(pymongo.server.Server)
+        client["testdb"].drop_collection("whatever")
+        spans = tracer.pop()
+        assert len(spans) == 1
+        assert spans[0].service == "mypymongo"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_PYMONGO_SERVICE="mypymongo", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0'))
+    def test_service_precedence_v0(self):
+        tracer = DummyTracer()
+        client = pymongo.MongoClient(port=MONGO_CONFIG["port"])
+        Pin(service="mypymongo", tracer=self.tracer).onto(client)
+        Pin.get_from(client).clone(tracer=tracer).onto(client)
+        # We do not wish to trace tcp spans here
+        Pin.get_from(pymongo.server.Server).remove_from(pymongo.server.Server)
+        client["testdb"].drop_collection("whatever")
+        spans = tracer.pop()
+        assert len(spans) == 1
+        assert spans[0].service == "mypymongo"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_PYMONGO_SERVICE="mypymongo", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v1'))
+    def test_service_precedence_v1(self):
         tracer = DummyTracer()
         client = pymongo.MongoClient(port=MONGO_CONFIG["port"])
         Pin(service="mypymongo", tracer=self.tracer).onto(client)

--- a/tests/contrib/pymongo/test.py
+++ b/tests/contrib/pymongo/test.py
@@ -520,7 +520,7 @@ class TestPymongoPatchConfigured(TracerTestCase, PymongoCore):
         assert len(spans) == 1
         assert spans[0].service != "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0'))
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_user_specified_service_v0(self):
         """
         v0: When a user specifies a service for the app
@@ -541,7 +541,7 @@ class TestPymongoPatchConfigured(TracerTestCase, PymongoCore):
         assert len(spans) == 1
         assert spans[0].service != "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v1'))
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_user_specified_service_v1(self):
         """
         v1: When a user specifies a service for the app
@@ -562,7 +562,9 @@ class TestPymongoPatchConfigured(TracerTestCase, PymongoCore):
         assert len(spans) == 1
         assert spans[0].service == "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_PYMONGO_SERVICE="mypymongo", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0'))
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_PYMONGO_SERVICE="mypymongo", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0")
+    )
     def test_user_specified_pymongo_service_v0(self):
 
         tracer = DummyTracer()
@@ -576,7 +578,9 @@ class TestPymongoPatchConfigured(TracerTestCase, PymongoCore):
         assert len(spans) == 1
         assert spans[0].service == "mypymongo"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_PYMONGO_SERVICE="mypymongo", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0'))
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_PYMONGO_SERVICE="mypymongo", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0")
+    )
     def test_user_specified_pymongo_service_v1(self):
 
         tracer = DummyTracer()
@@ -590,7 +594,9 @@ class TestPymongoPatchConfigured(TracerTestCase, PymongoCore):
         assert len(spans) == 1
         assert spans[0].service == "mypymongo"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_PYMONGO_SERVICE="mypymongo", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v0'))
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_SERVICE="mysvc", DD_PYMONGO_SERVICE="mypymongo", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0")
+    )
     def test_service_precedence_v0(self):
         tracer = DummyTracer()
         client = pymongo.MongoClient(port=MONGO_CONFIG["port"])
@@ -603,7 +609,9 @@ class TestPymongoPatchConfigured(TracerTestCase, PymongoCore):
         assert len(spans) == 1
         assert spans[0].service == "mypymongo"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_PYMONGO_SERVICE="mypymongo", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA='v1'))
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_SERVICE="mysvc", DD_PYMONGO_SERVICE="mypymongo", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1")
+    )
     def test_service_precedence_v1(self):
         tracer = DummyTracer()
         client = pymongo.MongoClient(port=MONGO_CONFIG["port"])

--- a/tests/contrib/pymysql/test_pymysql.py
+++ b/tests/contrib/pymysql/test_pymysql.py
@@ -7,7 +7,6 @@ from ddtrace.contrib.pymysql.patch import unpatch
 from ddtrace.internal.compat import PY2
 from ddtrace.internal.compat import stringify
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.internal.schema import schematize_service_name
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_dict_issuperset
@@ -65,7 +64,7 @@ class PyMySQLCore(object):
 
         span = spans[0]
         assert_is_measured(span)
-        assert span.service == schematize_service_name("pymysql")
+        assert span.service == "pymysql"
         assert span.name == "pymysql.query"
         assert span.span_type == "sql"
         assert span.error == 0
@@ -90,7 +89,7 @@ class PyMySQLCore(object):
 
             span = spans[0]
             assert_is_measured(span)
-            assert span.service == schematize_service_name("pymysql")
+            assert span.service == "pymysql"
             assert span.name == "pymysql.query"
             assert span.span_type == "sql"
             assert span.error == 0
@@ -242,7 +241,7 @@ class PyMySQLCore(object):
         # can expect the last closed span to be our proc.
         span = spans[len(spans) - 2]
         assert_is_measured(span)
-        assert span.service == schematize_service_name("pymysql")
+        assert span.service == "pymysql"
         assert span.name == "pymysql.query"
         assert span.span_type == "sql"
         assert span.error == 0
@@ -274,7 +273,7 @@ class PyMySQLCore(object):
         assert ot_span.name == "mysql_op"
 
         assert_is_measured(dd_span)
-        assert dd_span.service == schematize_service_name("pymysql")
+        assert dd_span.service == "pymysql"
         assert dd_span.name == "pymysql.query"
         assert dd_span.span_type == "sql"
         assert dd_span.error == 0
@@ -307,7 +306,7 @@ class PyMySQLCore(object):
             assert ot_span.name == "mysql_op"
 
             assert_is_measured(dd_span)
-            assert dd_span.service == schematize_service_name("pymysql")
+            assert dd_span.service == "pymysql"
             assert dd_span.name == "pymysql.query"
             assert dd_span.span_type == "sql"
             assert dd_span.error == 0
@@ -325,7 +324,7 @@ class PyMySQLCore(object):
         spans = tracer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.service == schematize_service_name("pymysql")
+        assert span.service == "pymysql"
         assert span.name == "pymysql.connection.commit"
 
     def test_rollback(self):
@@ -335,7 +334,7 @@ class PyMySQLCore(object):
         spans = tracer.pop()
         assert len(spans) == 1
         span = spans[0]
-        assert span.service == schematize_service_name("pymysql")
+        assert span.service == "pymysql"
         assert span.name == "pymysql.connection.rollback"
 
     def test_analytics_default(self):
@@ -417,7 +416,7 @@ class TestPyMysqlPatch(PyMySQLCore, TracerTestCase):
             assert len(spans) == 1
 
             span = spans[0]
-            assert span.service == schematize_service_name("pymysql")
+            assert span.service == "pymysql"
             assert span.name == "pymysql.query"
             assert span.span_type == "sql"
             assert span.error == 0

--- a/tests/contrib/pymysql/test_pymysql.py
+++ b/tests/contrib/pymysql/test_pymysql.py
@@ -6,6 +6,7 @@ from ddtrace.contrib.pymysql.patch import patch
 from ddtrace.contrib.pymysql.patch import unpatch
 from ddtrace.internal.compat import PY2
 from ddtrace.internal.compat import stringify
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.schema import schematize_service_name
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
@@ -511,4 +512,4 @@ class TestPyMysqlPatch(PyMySQLCore, TracerTestCase):
         spans = self.pop_spans()
         assert len(spans) == 1
         span = spans[0]
-        assert span.service == "unnamed-python-service"
+        assert span.service == DEFAULT_SPAN_SERVICE_NAME

--- a/tests/contrib/redis/test_redis.py
+++ b/tests/contrib/redis/test_redis.py
@@ -6,6 +6,7 @@ from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.redis.patch import patch
 from ddtrace.contrib.redis.patch import unpatch
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.opentracer.utils import init_tracer
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase
@@ -66,7 +67,7 @@ class TestRedisPatch(TracerTestCase):
         assert us is None
         spans = self.get_spans()
         span = spans[0]
-        assert span.service == "unnamed-python-service"
+        assert span.service == DEFAULT_SPAN_SERVICE_NAME
 
     def test_basics(self):
         us = self.r.get("cheese")

--- a/tests/contrib/redis/test_redis_cluster.py
+++ b/tests/contrib/redis/test_redis_cluster.py
@@ -5,6 +5,7 @@ import redis
 from ddtrace import Pin
 from ddtrace.contrib.redis.patch import patch
 from ddtrace.contrib.redis.patch import unpatch
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.config import REDISCLUSTER_CONFIG
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase
@@ -38,7 +39,7 @@ class TestRedisClusterPatch(TracerTestCase):
         assert us is None
         spans = self.get_spans()
         span = spans[0]
-        assert span.service == "unnamed-python-service"
+        assert span.service == DEFAULT_SPAN_SERVICE_NAME
 
     def test_basics(self):
         us = self.r.get("cheese")

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -15,7 +15,6 @@ from ddtrace.contrib.sqlite3.patch import TracedSQLiteCursor
 from ddtrace.contrib.sqlite3.patch import patch
 from ddtrace.contrib.sqlite3.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.internal.schema import schematize_service_name
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
@@ -220,7 +219,7 @@ class TestSQLite(TracerTestCase):
             dict(name="sqlite_op", service="sqlite_svc"),
             (
                 dict(
-                    name="sqlite.query", service=schematize_service_name("sqlite"), span_type="sql", resource=q, error=0
+                    name="sqlite.query", service="sqlite", span_type="sql", resource=q, error=0
                 ),
             ),
         )
@@ -251,14 +250,14 @@ class TestSQLite(TracerTestCase):
         connection.commit()
         self.assertEqual(len(self.spans), 1)
         span = self.spans[0]
-        self.assertEqual(span.service, schematize_service_name("sqlite"))
+        self.assertEqual(span.service, "sqlite")
         self.assertEqual(span.name, "sqlite.connection.commit")
 
     def test_rollback(self):
         connection = self._given_a_traced_connection(self.tracer)
         connection.rollback()
         self.assert_structure(
-            dict(name="sqlite.connection.rollback", service=schematize_service_name("sqlite")),
+            dict(name="sqlite.connection.rollback", service="sqlite"),
         )
 
     def test_patch_unpatch(self):

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -14,6 +14,8 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.sqlite3.patch import TracedSQLiteCursor
 from ddtrace.contrib.sqlite3.patch import patch
 from ddtrace.contrib.sqlite3.patch import unpatch
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema import schematize_service_name
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
@@ -216,7 +218,11 @@ class TestSQLite(TracerTestCase):
 
         self.assert_structure(
             dict(name="sqlite_op", service="sqlite_svc"),
-            (dict(name="sqlite.query", service="sqlite", span_type="sql", resource=q, error=0),),
+            (
+                dict(
+                    name="sqlite.query", service=schematize_service_name("sqlite"), span_type="sql", resource=q, error=0
+                ),
+            ),
         )
         assert_is_measured(self.get_spans()[1])
         self.reset()
@@ -245,14 +251,14 @@ class TestSQLite(TracerTestCase):
         connection.commit()
         self.assertEqual(len(self.spans), 1)
         span = self.spans[0]
-        self.assertEqual(span.service, "sqlite")
+        self.assertEqual(span.service, schematize_service_name("sqlite"))
         self.assertEqual(span.name, "sqlite.connection.commit")
 
     def test_rollback(self):
         connection = self._given_a_traced_connection(self.tracer)
         connection.rollback()
         self.assert_structure(
-            dict(name="sqlite.connection.rollback", service="sqlite"),
+            dict(name="sqlite.connection.rollback", service=schematize_service_name("sqlite")),
         )
 
     def test_patch_unpatch(self):
@@ -333,10 +339,10 @@ class TestSQLite(TracerTestCase):
             span = spans[0]
             self.assertEqual(span.get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_app_service(self):
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_app_service_v0(self):
         """
-        When a user specifies a service for the app
+        v0: When a user specifies a service for the app
             The sqlite3 integration should not use it.
         """
         # Ensure that the service name was configured
@@ -355,8 +361,32 @@ class TestSQLite(TracerTestCase):
         span = spans[0]
         assert span.service != "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SQLITE_SERVICE="my-svc"))
-    def test_user_specified_service(self):
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_app_service_v1(self):
+        """
+        v1: When a user specifies a service for the app
+            The sqlite3 integration should use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+
+        q = "select * from sqlite_master"
+        connection = self._given_a_traced_connection(self.tracer)
+        cursor = connection.execute(q)
+        cursor.fetchall()
+
+        spans = self.get_spans()
+
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        assert span.service == "mysvc"
+
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_SQLITE_SERVICE="my-svc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0")
+    )
+    def test_user_specified_service_v0(self):
         q = "select * from sqlite_master"
         connection = self._given_a_traced_connection(self.tracer)
         cursor = connection.execute(q)
@@ -367,6 +397,34 @@ class TestSQLite(TracerTestCase):
         self.assertEqual(len(spans), 1)
         span = spans[0]
         assert span.service == "my-svc"
+
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_SQLITE_SERVICE="my-svc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1")
+    )
+    def test_user_specified_service_v1(self):
+        q = "select * from sqlite_master"
+        connection = self._given_a_traced_connection(self.tracer)
+        cursor = connection.execute(q)
+        cursor.fetchall()
+
+        spans = self.get_spans()
+
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        assert span.service == "my-svc"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_unspecified_service_v1(self):
+        q = "select * from sqlite_master"
+        connection = self._given_a_traced_connection(self.tracer)
+        cursor = connection.execute(q)
+        cursor.fetchall()
+
+        spans = self.get_spans()
+
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        assert span.service == DEFAULT_SPAN_SERVICE_NAME
 
     def test_context_manager(self):
         conn = self._given_a_traced_connection(self.tracer)

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -217,11 +217,7 @@ class TestSQLite(TracerTestCase):
 
         self.assert_structure(
             dict(name="sqlite_op", service="sqlite_svc"),
-            (
-                dict(
-                    name="sqlite.query", service="sqlite", span_type="sql", resource=q, error=0
-                ),
-            ),
+            (dict(name="sqlite.query", service="sqlite", span_type="sql", resource=q, error=0),),
         )
         assert_is_measured(self.get_spans()[1])
         self.reset()

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_unspecified_service_v1.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_unspecified_service_v1.json
@@ -1,0 +1,36 @@
+[[
+  {
+    "name": "mysql.query",
+    "service": "unnamed-python-service",
+    "resource": "select 'dba4x4'",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "aiomysql",
+      "db.name": "test",
+      "db.system": "mysql",
+      "db.user": "test",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "f446781b5d244b95abc64fb246064c81",
+      "span.kind": "client",
+      "sql.query": "select 'dba4x4'"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "db.row_count": 1,
+      "db.rownumber": 0,
+      "network.destination.port": 3306,
+      "process_id": 1959
+    },
+    "duration": 336750,
+    "start": 1682181472030042004
+  }]]

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v0.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v0.json
@@ -16,7 +16,7 @@
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "2ba0d890e92448718fffeb1d278f2400",
+      "runtime-id": "edd004724e314daf9ff1e51e8234b4df",
       "span.kind": "client",
       "sql.query": "select 'dba4x4'"
     },
@@ -29,8 +29,8 @@
       "db.row_count": 1,
       "db.rownumber": 0,
       "network.destination.port": 3306,
-      "process_id": 41643
+      "process_id": 1191
     },
-    "duration": 2190000,
-    "start": 1667240729554151000
+    "duration": 339958,
+    "start": 1682180471955479013
   }]]

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v1.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v1.json
@@ -1,0 +1,36 @@
+[[
+  {
+    "name": "mysql.query",
+    "service": "my-service-name",
+    "resource": "select 'dba4x4'",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "aiomysql",
+      "db.name": "test",
+      "db.system": "mysql",
+      "db.user": "test",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "ae2b5fb6b2b849ed9a299852cb4df1d5",
+      "span.kind": "client",
+      "sql.query": "select 'dba4x4'"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "db.row_count": 1,
+      "db.rownumber": 0,
+      "network.destination.port": 3306,
+      "process_id": 1196
+    },
+    "duration": 361500,
+    "start": 1682180472703443222
+  }]]

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_configure_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_configure_service_name_env_v0.json
@@ -1,0 +1,65 @@
+[[
+  {
+    "name": "postgres.connect",
+    "service": "global-service-name",
+    "resource": "postgres.connect",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "4c461cdeb0554257b6e27c8547849757",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 9106
+    },
+    "duration": 5427625,
+    "start": 1682196620618275918
+  }],
+[
+  {
+    "name": "postgres.query",
+    "service": "global-service-name",
+    "resource": "SELECT 1",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "4c461cdeb0554257b6e27c8547849757",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 9106
+    },
+    "duration": 749666,
+    "start": 1682196620657433127
+  }]]

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_configure_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_configure_service_name_env_v1.json
@@ -1,0 +1,65 @@
+[[
+  {
+    "name": "postgres.connect",
+    "service": "global-service-name",
+    "resource": "postgres.connect",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "f4cf631eaf9b4be0b728f535891258cb",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 9111
+    },
+    "duration": 5450334,
+    "start": 1682196621282179335
+  }],
+[
+  {
+    "name": "postgres.query",
+    "service": "global-service-name",
+    "resource": "SELECT 1",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "f4cf631eaf9b4be0b728f535891258cb",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 9111
+    },
+    "duration": 741542,
+    "start": 1682196621321476252
+  }]]

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_unspecified_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_unspecified_service_name_env_v0.json
@@ -1,0 +1,65 @@
+[[
+  {
+    "name": "postgres.connect",
+    "service": "postgres",
+    "resource": "postgres.connect",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "d6cd7e65ab6e44e4a388e6b6f730b3a0",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 9116
+    },
+    "duration": 5836167,
+    "start": 1682196621953697419
+  }],
+[
+  {
+    "name": "postgres.query",
+    "service": "postgres",
+    "resource": "SELECT 1",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "d6cd7e65ab6e44e4a388e6b6f730b3a0",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 9116
+    },
+    "duration": 1054166,
+    "start": 1682196622007020586
+  }]]

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_unspecified_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_unspecified_service_name_env_v1.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "postgres.connect",
-    "service": "global-service-name",
+    "service": "unnamed-python-service",
     "resource": "postgres.connect",
     "trace_id": 0,
     "span_id": 1,
@@ -16,7 +16,7 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "a74529965e9c4740a0e8aa3b63796593",
+      "runtime-id": "7c899677ad1a43d0af04b7c66e92a50f",
       "span.kind": "client"
     },
     "metrics": {
@@ -25,15 +25,15 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "network.destination.port": 5432,
-      "process_id": 811
+      "process_id": 9121
     },
-    "duration": 19132000,
-    "start": 1667241404094944000
+    "duration": 5466833,
+    "start": 1682196622655105461
   }],
 [
   {
     "name": "postgres.query",
-    "service": "global-service-name",
+    "service": "unnamed-python-service",
     "resource": "SELECT 1",
     "trace_id": 1,
     "span_id": 1,
@@ -48,7 +48,7 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "a74529965e9c4740a0e8aa3b63796593",
+      "runtime-id": "7c899677ad1a43d0af04b7c66e92a50f",
       "span.kind": "client"
     },
     "metrics": {
@@ -58,8 +58,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "network.destination.port": 5432,
-      "process_id": 811
+      "process_id": 9121
     },
-    "duration": 2116000,
-    "start": 1667241404130488000
+    "duration": 765917,
+    "start": 1682196622695551086
   }]]


### PR DESCRIPTION
(chore) enable service naming schema for multiple contribs

### Service Naming Summary
Datadog is updating its method of determining service names!

The changes introduced in [PR5427](https://github.com/DataDog/dd-trace-py/pull/5427)
introduced a few concepts:
* Versioned service name "schemas":
  * `v0`: The existing mechanism for determining service names
  * `v1`: Replacing the 'default' contrib-specific service name with the env var `$DD_SERVICE`

These changes are being in conjunction with changes to `peer.service` updates to bring a
better service-naming experience to customers.  In particular, these changes will help:
* Remove the creation of fake services, such as `grpc.client`
* Standardize service names across and within tracers
* Remove the need to create *as many* fake services to take advantage of Datadog features, such as metrics
* Make more sense to humans

At the moment, these changes are opt-in via feature flag. Users
who do not specify the change will see no changes.

### Changes in this PR
This PR implements the `v1` naming schema for the following contribs:
* aiomysql
* aiopg
* algoliasearch
* asyncpg
* cassandra
* elasticsearch
* mongoengine
* mysql
* mysqldb
* psycopg(2)
* pymemcache
* pymongo
* pymysql
* sqlalchemy
* sqlite3
       

### Performance Implications
The performance impact is minimal both in scope and value.

### Risks

Please see the risks in the [original service naming PR](https://github.com/DataDog/dd-trace-py/pull/5427)

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
