### PR TITLE
fix(django): guard against cache truthiness [backport #5477 to 1.11]

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -179,8 +179,9 @@ def traced_cache(django, pin, func, instance, args, kwargs):
         elif command_name == "get":
             # if valid result and check for special case for Django~3.0 that returns an empty Sentinel object as
             # missing key
-            if result and result != getattr(instance, "_missing_key", None):
+            if result is not None and result != getattr(instance, "_missing_key", None):
                 span.set_metric(db.ROWCOUNT, 1)
+            # else result is invalid or None, set row count to 0
             else:
                 span.set_metric(db.ROWCOUNT, 0)
         return result

--- a/releasenotes/notes/fix-django-rowcount-bug-52d4f30236049c1b.yaml
+++ b/releasenotes/notes/fix-django-rowcount-bug-52d4f30236049c1b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    django: Adds fix for bug where Django cache return object throws an error if it does not implement ``__bool__()``.


### PR DESCRIPTION
Fixes #5460 

Add guard against when a Django cache result has ambiguous truth because the class doesn't implement the __bool__() function.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
