### PR TITLE
chore(otel/span): reduce noise in start span benchmarks

### DIFF
--- a/benchmarks/otel_span/scenario.py
+++ b/benchmarks/otel_span/scenario.py
@@ -14,9 +14,6 @@ os.environ["OTEL_PYTHON_CONTEXT"] = "ddcontextvars_context"
 otel_tracer = get_tracer(__name__)
 
 
-utils.drop_traces(tracer)
-
-
 class OtelSpan(bm.Scenario):
     nspans = bm.var(type=int)
     ntags = bm.var(type=int)
@@ -34,7 +31,11 @@ class OtelSpan(bm.Scenario):
         setmetrics = len(metrics) > 0
 
         # run scenario to include finishing spans
+        # Note - if finishspan is False the span will be gc'd when the SpanAggregrator is recreated
+        # (ex: tracer.configure(filter) is called)
         finishspan = self.finishspan
+        # Recreate span processors and ensure no traces are sent by the agent writer
+        utils.drop_traces(tracer)
 
         def _(loops):
             for _ in range(loops):

--- a/benchmarks/otel_span/scenario.py
+++ b/benchmarks/otel_span/scenario.py
@@ -31,10 +31,10 @@ class OtelSpan(bm.Scenario):
         setmetrics = len(metrics) > 0
 
         # run scenario to include finishing spans
-        # Note - if finishspan is False the span will be gc'd when the SpanAggregrator is recreated
+        # Note - if finishspan is False the span will be gc'd when the SpanAggregrator._traces is reset
         # (ex: tracer.configure(filter) is called)
         finishspan = self.finishspan
-        # Recreate span processors and ensure no traces are sent by the agent writer
+        # Recreate span processors and configure global tracer to avoid sending traces to the agent
         utils.drop_traces(tracer)
 
         def _(loops):

--- a/benchmarks/span/scenario.py
+++ b/benchmarks/span/scenario.py
@@ -5,9 +5,6 @@ from ddtrace import config
 from ddtrace import tracer
 
 
-utils.drop_traces(tracer)
-
-
 class Span(bm.Scenario):
     nspans = bm.var(type=int)
     ntags = bm.var(type=int)
@@ -26,8 +23,12 @@ class Span(bm.Scenario):
         setmetrics = len(metrics) > 0
 
         # run scenario to include finishing spans
+        # Note - if finishspan is False the span will be gc'd when the SpanAggregrator is recreated
+        # (ex: tracer.configure(filter) is called)
         finishspan = self.finishspan
         config._128_bit_trace_id_enabled = self.traceid128
+        # Recreate span processors and configure global tracer to avoid sending traces to the agent
+        utils.drop_traces(tracer)
 
         def _(loops):
             for _ in range(loops):

--- a/benchmarks/span/scenario.py
+++ b/benchmarks/span/scenario.py
@@ -23,7 +23,7 @@ class Span(bm.Scenario):
         setmetrics = len(metrics) > 0
 
         # run scenario to include finishing spans
-        # Note - if finishspan is False the span will be gc'd when the SpanAggregrator is recreated
+        # Note - if finishspan is False the span will be gc'd when the SpanAggregrator._traces is reset
         # (ex: tracer.configure(filter) is called)
         finishspan = self.finishspan
         config._128_bit_trace_id_enabled = self.traceid128


### PR DESCRIPTION
Start span scenarios generates thousands of spans without calling `Span.finish()`. The handling increased memory usage results in unstable span benchmarks. This fix ensures the span processors (specifically the SpanAggregator) is recreated at the start of each benchmark. This operation ensures SpanAggregator._traces is reset between benchmarks (dereferences spans from previous benchmarks). 

Running benchmarks on 1.x produces the following output:
```
.....................
WARNING: the benchmark result may be unstable
* the standard deviation (1.31 ms) is 11% of the mean (12.5 ms)

Try to rerun the benchmark with more runs, values and/or loops.
Run 'python -m pyperf system tune' command to reduce the system jitter.
Use pyperf stats, pyperf dump and pyperf hist to analyze results.
Use --quiet option to hide these warnings.

span-start: Mean +- std dev: 12.5 ms +- 1.3 ms
.....................
WARNING: the benchmark result may be unstable
* the standard deviation (1.38 ms) is 11% of the mean (12.8 ms)

Try to rerun the benchmark with more runs, values and/or loops.
Run 'python -m pyperf system tune' command to reduce the system jitter.
Use pyperf stats, pyperf dump and pyperf hist to analyze results.
Use --quiet option to hide these warnings.

span-start-traceid128: Mean +- std dev: 12.8 ms +- 1.4 ms
span-start-finish: Mean +- std dev: 11.5 ms +- 0.1 ms
.....................
span-start-finish-traceid128: Mean +- std dev: 12.4 ms +- 0.1 ms
.....................
otelspan-start: Mean +- std dev: 15.0 ms +- 0.8 ms
.....................
otelspan-start-finish: Mean +- std dev: 13.9 ms +- 0.2 ms
```

Running benchmarks using this "fix":

.....................
span-start: Mean +- std dev: 9.86 ms +- 0.29 ms
.....................
span-start-traceid128: Mean +- std dev: 10.1 ms +- 0.3 ms
.....................
span-start-finish: Mean +- std dev: 11.5 ms +- 0.1 ms
.....................
span-start-finish-traceid128: Mean +- std dev: 12.5 ms +- 0.2 ms
.....................
otelspan-start: Mean +- std dev: 13.2 ms +- 0.3 ms
.....................
otelspan-start-finish: Mean +- std dev: 13.9 ms +- 0.1 ms


## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
