### PR TITLE
fix(asm): body parsing for django asm [backport #5665 to 1.13]

### DIFF
--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -10,6 +10,7 @@ import six
 import xmltodict
 
 from ddtrace import config
+from ddtrace.appsec.utils import parse_form_params
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.constants import SPAN_MEASURED_KEY
 from ddtrace.contrib import func_name
@@ -251,36 +252,22 @@ def _before_request_tags(pin, span, request):
 
 
 def _extract_body(request):
-    req_body = None
-
+    # DEV: Do not use request.POST or request.data, this could prevent custom parser to be used after
     if config._appsec_enabled and request.method in _BODY_METHODS:
+        req_body = None
         content_type = request.content_type if hasattr(request, "content_type") else request.META.get("CONTENT_TYPE")
-
-        rest_framework = hasattr(request, "data")
-
         try:
             if content_type == "application/x-www-form-urlencoded":
-                req_body = request.data.dict() if rest_framework else request.POST.dict()
+                req_body = parse_form_params(request.body.decode("UTF-8", errors="ignore"))
             elif content_type in ("application/json", "text/json"):
-                req_body = (
-                    json.loads(request.data.decode("UTF-8"))
-                    if rest_framework
-                    else json.loads(request.body.decode("UTF-8"))
-                )
+                req_body = json.loads(request.body.decode("UTF-8", errors="ignore"))
             elif content_type in ("application/xml", "text/xml"):
-                req_body = (
-                    xmltodict.parse(request.data.decode("UTF-8"))
-                    if rest_framework
-                    else xmltodict.parse(request.body.decode("UTF-8"))
-                )
-            elif request.method == "POST" and request.POST:
-                req_body = dict(request.POST)
+                req_body = xmltodict.parse(request.body.decode("UTF-8", errors="ignore"))
             else:  # text/plain, others: don't use them
                 req_body = None
         except BaseException:
             log.debug("Failed to parse request body", exc_info=True)
             # req_body is None
-
         return req_body
 
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -139,6 +139,7 @@ opentracing
 otel
 ObjectProxy
 parameterized
+parsers
 perf
 pid
 plugin

--- a/releasenotes/notes/fix-extract-django-body-185084700323dce6.yaml
+++ b/releasenotes/notes/fix-extract-django-body-185084700323dce6.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: fix extract_body for Django such that users of Django Rest Framework can still use custom parsers.

--- a/tests/appsec/test_tools.py
+++ b/tests/appsec/test_tools.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from ddtrace.appsec.utils import parse_form_params
+
+
+@pytest.mark.parametrize(
+    "body, res",
+    [
+        ("", {}),
+        ("x=1", {"x": "1"}),
+        ("x=1&y=2", {"x": "1", "y": "2"}),
+        ("x=1&y=2&x=3", {"x": ["1", "3"], "y": "2"}),
+        ("x+x=1&y=2&x=3", {"x x": "1", "x": "3", "y": "2"}),
+        ("3%2B3%3D6%20toto=%C3%A9l%C3%A8phant%C3%B8%F0%9F%98%80", {"3+3=6 toto": "élèphantø😀"}),
+    ],
+)
+def test_parse_form_params(body, res):
+    form_params = parse_form_params(body)
+    assert form_params == res

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -647,13 +647,14 @@ def test_request_suspicious_request_block_match_body(client, test_spans, tracer)
             ),
             # form body must be blocked
             ("attack=yqrweytqwreasldhkuqwgervflnmlnli", "application/x-www-form-urlencoded", True),
-            (
-                '--52d1fb4eb9c021e53ac2846190e4ac72\r\nContent-Disposition: form-data; name="attack"\r\n'
-                'Content-Type: application/json\r\n\r\n{"test": "yqrweytqwreasldhkuqwgervflnmlnli"}\r\n'
-                "--52d1fb4eb9c021e53ac2846190e4ac72--\r\n",
-                "multipart/form-data; boundary=52d1fb4eb9c021e53ac2846190e4ac72",
-                True,
-            ),
+            # DEV: multipart/form-data not supported for now
+            #  (
+            #     '--52d1fb4eb9c021e53ac2846190e4ac72\r\nContent-Disposition: form-data; name="attack"\r\n'
+            #     'Content-Type: application/json\r\n\r\n{"test": "yqrweytqwreasldhkuqwgervflnmlnli"}\r\n'
+            #     "--52d1fb4eb9c021e53ac2846190e4ac72--\r\n",
+            #     "multipart/form-data; boundary=52d1fb4eb9c021e53ac2846190e4ac72",
+            #     True,
+            # ),
             # raw body must not be blocked
             ("yqrweytqwreasldhkuqwgervflnmlnli", "text/plain", False),
             # other values must not be blocked

--- a/tests/contrib/djangorestframework/app/views.py
+++ b/tests/contrib/djangorestframework/app/views.py
@@ -1,9 +1,17 @@
+import json
+
 import django
 from django.conf.urls import include
 from django.contrib.auth.models import User
+from django.views.decorators.csrf import csrf_exempt
 from rest_framework import routers
 from rest_framework import serializers
 from rest_framework import viewsets
+from rest_framework.decorators import authentication_classes
+from rest_framework.decorators import permission_classes
+from rest_framework.parsers import MultiPartParser
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 
 # django.conf.urls.url was deprecated in django 3 and removed in django 4
@@ -31,9 +39,44 @@ class UserViewSet(viewsets.ModelViewSet):
 router = routers.DefaultRouter()
 router.register(r"users", UserViewSet)
 
+
+# ASM
+
+
+class CustomParser(MultiPartParser):
+    """
+    Custom parser that extract specific data from request
+    """
+
+    def parse(self, stream, media_type=None, parser_context=None):
+        """
+        Return a dataframe representing mds
+        """
+        parsed_files = MultiPartParser.parse(self, stream, media_type, parser_context)
+        value = json.loads(parsed_files.data.get("json", "")).get("value")
+        return {value: parsed_files.files.get("file1").read().decode("utf-8", errors="ignore")}
+
+
+@authentication_classes([])
+@permission_classes([])
+class ASM_View(APIView):
+    """
+    ASM View with custom parser
+    """
+
+    parser_classes = (CustomParser,)
+
+    @csrf_exempt
+    def post(self, request):
+        return Response({"received data form": request.data})
+
+
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
+
+
 urlpatterns = [
+    handler(r"asm/", ASM_View.as_view()),
     handler(r"^", include(router.urls)),
     handler(r"^api-auth/", include("rest_framework.urls", namespace="rest_framework")),
 ]

--- a/tests/contrib/djangorestframework/test_appsec.py
+++ b/tests/contrib/djangorestframework/test_appsec.py
@@ -1,0 +1,52 @@
+import django
+import pytest
+
+from ddtrace.internal import _context
+from ddtrace.internal.compat import urlencode
+from tests.utils import assert_span_http_status_code
+from tests.utils import override_global_config
+
+
+@pytest.mark.skipif(django.VERSION < (1, 10), reason="requires django version >= 1.10")
+def test_djangorest_request_body_urlencoded(client, test_spans, tracer):
+    with override_global_config(dict(_appsec_enabled=True)):
+        tracer._appsec_enabled = True
+        # Hack: need to pass an argument to configure so that the processors are recreated
+        tracer.configure(api_version="v0.4")
+        payload = urlencode({"mytestingbody_key": "mytestingbody_value"})
+        client.post("/users/", payload, content_type="application/x-www-form-urlencoded")
+        root_span = test_spans.spans[0]
+        assert_span_http_status_code(root_span, 500)
+        query = dict(_context.get_item("http.request.body", span=root_span))
+
+        assert root_span.get_tag("_dd.appsec.json") is None
+        assert root_span.get_tag("component") == "django"
+        assert root_span.get_tag("span.kind") == "server"
+        assert query == {"mytestingbody_key": "mytestingbody_value"}
+
+
+@pytest.mark.skipif(django.VERSION < (1, 10), reason="requires django version >= 1.10")
+def test_djangorest_request_body_custom_parser(client, test_spans, tracer):
+    with override_global_config(dict(_appsec_enabled=True)):
+        tracer._appsec_enabled = True
+        # Hack: need to pass an argument to configure so that the processors are recreated
+        tracer.configure(api_version="v0.4")
+        payload, content_type = (
+            '--52d1fb4eb9c021e53ac2846190e4ac72\r\nContent-Disposition: form-data; name="json"\r\n'
+            'Content-Type: application/json\r\n\r\n{"value": "yqrweytqwreasldhkuqwgervflnmlnli"}\r\n'
+            "--52d1fb4eb9c021e53ac2846190e4ac72\r\n"
+            'Content-Disposition: form-data; name="file1"; filename="a.txt"\r\n'
+            "Content-Type: text/plain\r\n\r\n"
+            "Content of a.txt.\n\r\n"
+            "--52d1fb4eb9c021e53ac2846190e4ac72--\r\n",
+            "multipart/form-data; boundary=52d1fb4eb9c021e53ac2846190e4ac72",
+        )
+        request = client.post("/asm/", payload, content_type=content_type)
+        root_span = test_spans.get_root_span()
+        assert_span_http_status_code(root_span, 200)
+
+        assert root_span.get_tag("_dd.appsec.json") is None
+        assert root_span.get_tag("component") == "django"
+        assert root_span.get_tag("span.kind") == "server"
+        # check that the custom parser was used to parse the body
+        assert request.content == b'{"received data form":{"yqrweytqwreasldhkuqwgervflnmlnli":"Content of a.txt.\\n"}}'

--- a/tests/contrib/djangorestframework/test_djangorestframework.py
+++ b/tests/contrib/djangorestframework/test_djangorestframework.py
@@ -2,10 +2,7 @@ import django
 import pytest
 
 from ddtrace.constants import ERROR_MSG
-from ddtrace.internal import _context
-from ddtrace.internal.compat import urlencode
 from tests.utils import assert_span_http_status_code
-from tests.utils import override_global_config
 
 
 @pytest.mark.skipif(django.VERSION < (1, 10), reason="requires django version >= 1.10")
@@ -38,20 +35,3 @@ def test_trace_exceptions(client, test_spans):  # noqa flake8 complains about sh
     assert err_span.get_tag(ERROR_MSG) == "Authentication credentials were not provided."
     assert "NotAuthenticated" in err_span.get_tag("error.stack")
     assert err_span.get_tag("component") == "django"
-
-
-@pytest.mark.skipif(django.VERSION < (1, 10), reason="requires django version >= 1.10")
-def test_djangorest_request_body_urlencoded(client, test_spans, tracer):
-    with override_global_config(dict(_appsec_enabled=True)):
-        tracer._appsec_enabled = True
-        # Hack: need to pass an argument to configure so that the processors are recreated
-        tracer.configure(api_version="v0.4")
-        payload = urlencode({"mytestingbody_key": "mytestingbody_value"})
-        client.post("/users/", payload, content_type="application/x-www-form-urlencoded")
-        root_span = test_spans.spans[0]
-        query = dict(_context.get_item("http.request.body", span=root_span))
-
-        assert root_span.get_tag("_dd.appsec.json") is None
-        assert root_span.get_tag("component") == "django"
-        assert root_span.get_tag("span.kind") == "server"
-        assert query == {"mytestingbody_key": "mytestingbody_value"}


### PR DESCRIPTION
Backport of #5665 to 1.13

Fix extract Django request body to allow custom parser (Django Rest Framework) to work as expected when activating ASM.

Using `request.POST` or `request.data` before entering client code could parse the body with a non custom parser that would prevent future use of a custom parser. We use only `request.body`

Add a `parse_form_params` function in appsec tools with corresponding tests.
Add a test in djangorestframework to specifically check the problem was fixed.


## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
