### PR TITLE
feat(pytest): put real suite and session ID onto encoded coverage spans

### DIFF
--- a/ddtrace/internal/ci_visibility/encoder.py
+++ b/ddtrace/internal/ci_visibility/encoder.py
@@ -155,7 +155,7 @@ class CIVisibilityCoverageEncoderV02(CIVisibilityEncoderV01):
         # type: (Span, str) -> Dict[str, Any]
         return {
             "span_id": span.span_id,
-            "test_session_id": int(span.get_tag(SESSION_ID)),
-            "test_suite_id": int(span.get_tag(SUITE_ID)),
+            "test_session_id": int(span.get_tag(SESSION_ID) or "1"),
+            "test_suite_id": int(span.get_tag(SUITE_ID) or "1"),
             "files": json.loads(span.get_tag(COVERAGE_TAG_NAME))["files"],
         }

--- a/ddtrace/internal/ci_visibility/encoder.py
+++ b/ddtrace/internal/ci_visibility/encoder.py
@@ -155,7 +155,7 @@ class CIVisibilityCoverageEncoderV02(CIVisibilityEncoderV01):
         # type: (Span, str) -> Dict[str, Any]
         return {
             "span_id": span.span_id,
-            "test_session_id": span.get_tag(SESSION_ID),
-            "test_suite_id": span.get_tag(SUITE_ID),
+            "test_session_id": int(span.get_tag(SESSION_ID)),
+            "test_suite_id": int(span.get_tag(SUITE_ID)),
             "files": json.loads(span.get_tag(COVERAGE_TAG_NAME))["files"],
         }

--- a/ddtrace/internal/ci_visibility/encoder.py
+++ b/ddtrace/internal/ci_visibility/encoder.py
@@ -155,7 +155,7 @@ class CIVisibilityCoverageEncoderV02(CIVisibilityEncoderV01):
         # type: (Span, str) -> Dict[str, Any]
         return {
             "span_id": span.span_id,
-            "test_session_id": 1,  # TODO: populate with real IDs
-            "test_suite_id": 1,
+            "test_session_id": span.get_tag(SESSION_ID),
+            "test_suite_id": span.get_tag(SUITE_ID),
             "files": json.loads(span.get_tag(COVERAGE_TAG_NAME))["files"],
         }

--- a/tests/ci_visibility/test_encoder.py
+++ b/tests/ci_visibility/test_encoder.py
@@ -114,8 +114,8 @@ def test_encode_traces_civisibility_v2_coverage():
     assert len(received_covs) == 1
 
     expected_cov = {
-        b"test_session_id": coverage_span.get_tag(SESSION_ID).encode("utf-8"),
-        b"test_suite_id": coverage_span.get_tag(SUITE_ID).encode("utf-8"),
+        b"test_session_id": int(coverage_span.get_tag(SESSION_ID)),
+        b"test_suite_id": int(coverage_span.get_tag(SUITE_ID)),
         b"span_id": coverage_span.span_id,
         b"files": [
             {k.encode("utf-8"): v.encode("utf-8") if isinstance(v, str) else v for k, v in file.items()}


### PR DESCRIPTION
This change replaces the dummy values for suite ID and session ID in code coverage payloads with real values derived from the pytest integration.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
