### PR TITLE
feat(redis): add redis command span tag max length configuration

### DIFF
--- a/ddtrace/contrib/aioredis/__init__.py
+++ b/ddtrace/contrib/aioredis/__init__.py
@@ -27,6 +27,16 @@ Global Configuration
 
    Default: ``"redis"``
 
+.. py:data:: ddtrace.config.aioredis["cmd_max_length"]
+
+   Max allowable size for the aioredis command span tag.
+   Anything beyond the max length will be replaced with ``"..."``.
+
+   This option can also be set with the ``DD_AIOREDIS_CMD_MAX_LENGTH`` environment
+   variable.
+
+   Default: ``1000``
+
 
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/ddtrace/contrib/aioredis/patch.py
+++ b/ddtrace/contrib/aioredis/patch.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import sys
 
 import aioredis
@@ -18,6 +19,7 @@ from ...ext import SpanTypes
 from ...ext import db
 from ...ext import net
 from ...ext import redis as redisx
+from ...internal.utils.formats import CMD_MAX_LEN
 from ...internal.utils.formats import stringify_cache_args
 from ..trace_utils_redis import _trace_redis_cmd
 from ..trace_utils_redis import _trace_redis_execute_pipeline
@@ -28,7 +30,13 @@ try:
 except ImportError:
     _RedisBuffer = None
 
-config._add("aioredis", dict(_default_service="redis"))
+config._add(
+    "aioredis",
+    dict(
+        _default_service="redis",
+        cmd_max_length=int(os.getenv("DD_AIOREDIS_CMD_MAX_LENGTH", CMD_MAX_LEN)),
+    ),
+)
 
 aioredis_version_str = getattr(aioredis, "__version__", "0.0.0")
 aioredis_version = tuple([int(i) for i in aioredis_version_str.split(".")])
@@ -88,7 +96,7 @@ async def traced_execute_pipeline(func, instance, args, kwargs):
     if not pin or not pin.enabled():
         return await func(*args, **kwargs)
 
-    cmds = [stringify_cache_args(c) for c, _ in instance.command_stack]
+    cmds = [stringify_cache_args(c, cmd_max_len=config.aioredis.cmd_max_length) for c, _ in instance.command_stack]
     resource = "\n".join(cmds)
     with _trace_redis_execute_pipeline(pin, config.aioredis, resource, instance):
         return await func(*args, **kwargs)
@@ -128,7 +136,7 @@ def traced_13_execute_command(func, instance, args, kwargs):
     span.set_tag_str(COMPONENT, config.aioredis.integration_name)
     span.set_tag_str(db.SYSTEM, redisx.APP)
     span.set_tag(SPAN_MEASURED_KEY)
-    query = stringify_cache_args(args)
+    query = stringify_cache_args(args, cmd_max_len=config.aioredis.cmd_max_length)
     span.resource = query
     span.set_tag_str(redisx.RAWCMD, query)
     if pin.tags:
@@ -175,7 +183,7 @@ async def traced_13_execute_pipeline(func, instance, args, kwargs):
     for _, cmd, cmd_args, _ in instance._pipeline:
         parts = [cmd]
         parts.extend(cmd_args)
-        cmds.append(stringify_cache_args(parts))
+        cmds.append(stringify_cache_args(parts, cmd_max_len=config.aioredis.cmd_max_length))
     resource = "\n".join(cmds)
     with pin.tracer.trace(
         redisx.CMD,

--- a/ddtrace/contrib/aredis/__init__.py
+++ b/ddtrace/contrib/aredis/__init__.py
@@ -26,6 +26,16 @@ Global Configuration
 
    Default: ``"redis"``
 
+.. py:data:: ddtrace.config.aredis["cmd_max_length"]
+
+   Max allowable size for the aredis command span tag.
+   Anything beyond the max length will be replaced with ``"..."``.
+
+   This option can also be set with the ``DD_AREDIS_CMD_MAX_LENGTH`` environment
+   variable.
+
+   Default: ``1000``
+
 
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/ddtrace/contrib/aredis/patch.py
+++ b/ddtrace/contrib/aredis/patch.py
@@ -1,8 +1,11 @@
+import os
+
 import aredis
 
 from ddtrace import config
 from ddtrace.vendor import wrapt
 
+from ...internal.utils.formats import CMD_MAX_LEN
 from ...internal.utils.formats import stringify_cache_args
 from ...internal.utils.wrappers import unwrap
 from ...pin import Pin
@@ -10,7 +13,13 @@ from ..trace_utils_redis import _trace_redis_cmd
 from ..trace_utils_redis import _trace_redis_execute_pipeline
 
 
-config._add("aredis", dict(_default_service="redis"))
+config._add(
+    "aredis",
+    dict(
+        _default_service="redis",
+        cmd_max_length=int(os.getenv("DD_AREDIS_CMD_MAX_LENGTH", CMD_MAX_LEN)),
+    ),
+)
 
 
 def patch():
@@ -64,7 +73,7 @@ async def traced_execute_pipeline(func, instance, args, kwargs):
     if not pin or not pin.enabled():
         return await func(*args, **kwargs)
 
-    cmds = [stringify_cache_args(c) for c, _ in instance.command_stack]
+    cmds = [stringify_cache_args(c, cmd_max_len=config.aredis.cmd_max_length) for c, _ in instance.command_stack]
     resource = "\n".join(cmds)
     with _trace_redis_execute_pipeline(pin, config.aredis, resource, instance):
         return await func(*args, **kwargs)

--- a/ddtrace/contrib/redis/__init__.py
+++ b/ddtrace/contrib/redis/__init__.py
@@ -27,6 +27,17 @@ Global Configuration
    Default: ``"redis"``
 
 
+.. py:data:: ddtrace.config.redis["cmd_max_length"]
+
+   Max allowable size for the redis command span tag.
+   Anything beyond the max length will be replaced with ``"..."``.
+
+   This option can also be set with the ``DD_REDIS_CMD_MAX_LENGTH`` environment
+   variable.
+
+   Default: ``1000``
+
+
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/ddtrace/contrib/redis/asyncio_patch.py
+++ b/ddtrace/contrib/redis/asyncio_patch.py
@@ -23,7 +23,7 @@ async def traced_async_execute_pipeline(func, instance, args, kwargs):
     if not pin or not pin.enabled():
         return await func(*args, **kwargs)
 
-    cmds = [stringify_cache_args(c) for c, _ in instance.command_stack]
+    cmds = [stringify_cache_args(c, cmd_max_len=config.redis.cmd_max_length) for c, _ in instance.command_stack]
     resource = "\n".join(cmds)
     with _trace_redis_execute_pipeline(pin, config.redis, resource, instance):
         return await func(*args, **kwargs)

--- a/ddtrace/contrib/rediscluster/__init__.py
+++ b/ddtrace/contrib/rediscluster/__init__.py
@@ -25,6 +25,17 @@ Global Configuration
    The option can also be set with the ``DD_REDISCLUSTER_SERVICE`` environment variable
 
    Default: ``'rediscluster'``
+
+
+.. py:data:: ddtrace.config.rediscluster["cmd_max_length"]
+
+   Max allowable size for the rediscluster command span tag.
+   Anything beyond the max length will be replaced with ``"..."``.
+
+   This option can also be set with the ``DD_REDISCLUSTER_CMD_MAX_LENGTH`` environment
+   variable.
+
+   Default: ``1000``
 """
 
 from ...internal.utils.importlib import require_modules

--- a/ddtrace/contrib/rediscluster/patch.py
+++ b/ddtrace/contrib/rediscluster/patch.py
@@ -1,3 +1,5 @@
+import os
+
 # 3p
 import rediscluster
 
@@ -13,6 +15,7 @@ from ddtrace.ext import SpanTypes
 from ddtrace.ext import db
 from ddtrace.ext import redis as redisx
 from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal.utils.formats import CMD_MAX_LEN
 from ddtrace.internal.utils.formats import stringify_cache_args
 from ddtrace.internal.utils.wrappers import unwrap
 from ddtrace.pin import Pin
@@ -25,7 +28,13 @@ from .. import trace_utils
 #      but in `1.x.x` `__version__` is a tuple annd `VERSION` does not exist
 REDISCLUSTER_VERSION = getattr(rediscluster, "VERSION", rediscluster.__version__)
 
-config._add("rediscluster", dict(_default_service="rediscluster"))
+config._add(
+    "rediscluster",
+    dict(
+        _default_service="rediscluster",
+        cmd_max_length=int(os.getenv("DD_REDISCLUSTER_CMD_MAX_LENGTH", CMD_MAX_LEN)),
+    ),
+)
 
 
 def patch():
@@ -71,7 +80,9 @@ def traced_execute_pipeline(func, instance, args, kwargs):
     if not pin or not pin.enabled():
         return func(*args, **kwargs)
 
-    cmds = [stringify_cache_args(c.args) for c in instance.command_stack]
+    cmds = [
+        stringify_cache_args(c.args, cmd_max_len=config.rediscluster.cmd_max_length) for c in instance.command_stack
+    ]
     resource = "\n".join(cmds)
     tracer = pin.tracer
     with tracer.trace(

--- a/ddtrace/contrib/trace_utils_redis.py
+++ b/ddtrace/contrib/trace_utils_redis.py
@@ -45,7 +45,7 @@ def _trace_redis_cmd(pin, config_integration, instance, args):
         span.set_tag_str(COMPONENT, config_integration.integration_name)
         span.set_tag_str(db.SYSTEM, redisx.APP)
         span.set_tag(SPAN_MEASURED_KEY)
-        query = stringify_cache_args(args)
+        query = stringify_cache_args(args, cmd_max_len=config_integration.cmd_max_length)
         span.resource = query
         span.set_tag_str(redisx.RAWCMD, query)
         if pin.tags:

--- a/ddtrace/contrib/yaaredis/__init__.py
+++ b/ddtrace/contrib/yaaredis/__init__.py
@@ -26,6 +26,16 @@ Global Configuration
 
    Default: ``"redis"``
 
+.. py:data:: ddtrace.config.yaaredis["cmd_max_length"]
+
+   Max allowable size for the yaaredis command span tag.
+   Anything beyond the max length will be replaced with ``"..."``.
+
+   This option can also be set with the ``DD_YAAREDIS_CMD_MAX_LENGTH`` environment
+   variable.
+
+   Default: ``1000``
+
 
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/ddtrace/contrib/yaaredis/patch.py
+++ b/ddtrace/contrib/yaaredis/patch.py
@@ -1,8 +1,11 @@
+import os
+
 import yaaredis
 
 from ddtrace import config
 from ddtrace.vendor import wrapt
 
+from ...internal.utils.formats import CMD_MAX_LEN
 from ...internal.utils.formats import stringify_cache_args
 from ...internal.utils.wrappers import unwrap
 from ...pin import Pin
@@ -10,7 +13,13 @@ from ..trace_utils_redis import _trace_redis_cmd
 from ..trace_utils_redis import _trace_redis_execute_pipeline
 
 
-config._add("yaaredis", dict(_default_service="redis"))
+config._add(
+    "yaaredis",
+    dict(
+        _default_service="redis",
+        cmd_max_length=int(os.getenv("DD_YAAREDIS_CMD_MAX_LENGTH", CMD_MAX_LEN)),
+    ),
+)
 
 
 def patch():
@@ -60,7 +69,7 @@ async def traced_execute_pipeline(func, instance, args, kwargs):
     if not pin or not pin.enabled():
         return await func(*args, **kwargs)
 
-    cmds = [stringify_cache_args(c) for c, _ in instance.command_stack]
+    cmds = [stringify_cache_args(c, cmd_max_len=config.yaaredis.cmd_max_length) for c, _ in instance.command_stack]
     resource = "\n".join(cmds)
     with _trace_redis_execute_pipeline(pin, config.yaaredis, resource, instance):
         return await func(*args, **kwargs)

--- a/ddtrace/internal/utils/formats.py
+++ b/ddtrace/internal/utils/formats.py
@@ -129,8 +129,8 @@ def parse_tags_str(tags_str):
     return dict(tag_list)
 
 
-def stringify_cache_args(args):
-    # type: (List[Any]) -> Text
+def stringify_cache_args(args, value_max_len=VALUE_MAX_LEN, cmd_max_len=CMD_MAX_LEN):
+    # type: (List[Any], int, int) -> Text
     """Convert a list of arguments into a space concatenated string
 
     This function is useful to convert a list of cache keys
@@ -145,11 +145,11 @@ def stringify_cache_args(args):
             else:
                 cmd = stringify(arg)
 
-            if len(cmd) > VALUE_MAX_LEN:
-                cmd = cmd[:VALUE_MAX_LEN] + VALUE_TOO_LONG_MARK
+            if len(cmd) > value_max_len:
+                cmd = cmd[:value_max_len] + VALUE_TOO_LONG_MARK
 
-            if length + len(cmd) > CMD_MAX_LEN:
-                prefix = cmd[: CMD_MAX_LEN - length]
+            if length + len(cmd) > cmd_max_len:
+                prefix = cmd[: cmd_max_len - length]
                 out.append("%s%s" % (prefix, VALUE_TOO_LONG_MARK))
                 break
 

--- a/releasenotes/notes/feat-redis-add-cmd-max-length-config-0ec3bc9effe67244.yaml
+++ b/releasenotes/notes/feat-redis-add-cmd-max-length-config-0ec3bc9effe67244.yaml
@@ -1,4 +1,5 @@
 ---
 features:
   - |
-    redis: Introducing redis command span tag max length configuration for ``aioredis``, ``aredis``, ``redis``, ``rediscluster``, and ``yaaredis`` integrations.
+    redis: Introducing redis command span tag max length configuration for :ref:`aioredis<aioredis>`, :ref:`aredis<aredis>`, :ref:`redis<redis>`,
+    :ref:`rediscluster<rediscluster>`, and :ref:`yaaredis<yaaredis>` integrations.

--- a/releasenotes/notes/feat-redis-add-cmd-max-length-config-0ec3bc9effe67244.yaml
+++ b/releasenotes/notes/feat-redis-add-cmd-max-length-config-0ec3bc9effe67244.yaml
@@ -1,29 +1,4 @@
 ---
-#instructions:
-#    The style guide below provides explanations, instructions, and templates to write your own release note.
-#    Once finished, all irrelevant sections (including this instruction section) should be removed,
-#    and the release note should be committed with the rest of the changes.
-#
-#    The main goal of a release note is to provide a brief overview of a change and provide actionable steps to the user.
-#    The release note should clearly communicate what the change is, why the change was made, and how a user can migrate their code.
-#
-#    The release note should also clearly distinguish between announcements and user instructions. Use:
-#    * Past tense for previous/existing behavior (ex: ``resulted, caused, failed``)
-#    * Third person present tense for the change itself (ex: ``adds, fixes, upgrades``)
-#    * Active present infinitive for user instructions (ex: ``set, use, add``)
-#
-#    Release notes should:
-#    * Use plain language
-#    * Be concise
-#    * Include actionable steps with the necessary code changes
-#    * Include relevant links (bug issues, upstream issues or release notes, documentation pages)
-#    * Use full sentences with sentence-casing and punctuation.
-#    * Before using Datadog specific acronyms/terminology, a release note must first introduce them with a definition.
-#
-#    Release notes should not:
-#    * Be vague. Example: ``fixes an issue in tracing``.
-#    * Use overly technical language
-#    * Use dynamic links (``stable/latest/1.x`` URLs). Instead, use static links (specific version, commit hash) whenever possible so that they don't break in the future.
 features:
   - |
     redis: Introducing redis command span tag max length configuration for ``aioredis``, ``aredis``, ``redis``, ``rediscluster``, and ``yaaredis`` integrations.

--- a/releasenotes/notes/feat-redis-add-cmd-max-length-config-0ec3bc9effe67244.yaml
+++ b/releasenotes/notes/feat-redis-add-cmd-max-length-config-0ec3bc9effe67244.yaml
@@ -1,0 +1,29 @@
+---
+#instructions:
+#    The style guide below provides explanations, instructions, and templates to write your own release note.
+#    Once finished, all irrelevant sections (including this instruction section) should be removed,
+#    and the release note should be committed with the rest of the changes.
+#
+#    The main goal of a release note is to provide a brief overview of a change and provide actionable steps to the user.
+#    The release note should clearly communicate what the change is, why the change was made, and how a user can migrate their code.
+#
+#    The release note should also clearly distinguish between announcements and user instructions. Use:
+#    * Past tense for previous/existing behavior (ex: ``resulted, caused, failed``)
+#    * Third person present tense for the change itself (ex: ``adds, fixes, upgrades``)
+#    * Active present infinitive for user instructions (ex: ``set, use, add``)
+#
+#    Release notes should:
+#    * Use plain language
+#    * Be concise
+#    * Include actionable steps with the necessary code changes
+#    * Include relevant links (bug issues, upstream issues or release notes, documentation pages)
+#    * Use full sentences with sentence-casing and punctuation.
+#    * Before using Datadog specific acronyms/terminology, a release note must first introduce them with a definition.
+#
+#    Release notes should not:
+#    * Be vague. Example: ``fixes an issue in tracing``.
+#    * Use overly technical language
+#    * Use dynamic links (``stable/latest/1.x`` URLs). Instead, use static links (specific version, commit hash) whenever possible so that they don't break in the future.
+features:
+  - |
+    redis: Introducing redis command span tag max length configuration for ``aioredis``, ``aredis``, ``redis``, ``rediscluster``, and ``yaaredis`` integrations.

--- a/tests/contrib/aioredis/test_aioredis.py
+++ b/tests/contrib/aioredis/test_aioredis.py
@@ -147,6 +147,28 @@ async def test_long_command(redis_client):
 
 @pytest.mark.asyncio
 @pytest.mark.snapshot
+async def test_cmd_max_length(redis_client):
+    with override_config("aioerdis", dict(cmd_max_length=7)):
+        await redis_client.get("here-is-a-long-key")
+
+
+@pytest.mark.skip(reason="No traces sent to the test agent")
+@pytest.mark.subprocess(env=dict(DD_AIOREDIS_CMD_MAX_LENGTH="10"), ddtrace_run=True)
+@pytest.mark.snapshot
+def test_cmd_max_length_env():
+    import asyncio
+
+    from tests.contrib.aioredis.test_aioredis import get_redis_instance
+
+    async def main():
+        redis_client = await get_redis_instance(1)
+        await redis_client.get("here-is-a-long-key")
+
+    asyncio.run(main())
+
+
+@pytest.mark.asyncio
+@pytest.mark.snapshot
 async def test_override_service_name(redis_client):
     with override_config("aioredis", dict(service_name="myaioredis")):
         val = await redis_client.get("cheese")

--- a/tests/contrib/aredis/test_aredis.py
+++ b/tests/contrib/aredis/test_aredis.py
@@ -54,6 +54,31 @@ async def test_long_command(snapshot_context):
         await r.mget(*range(1000))
 
 
+@pytest.mark.skip(reason="No traces sent to the test agent")
+@pytest.mark.subprocess(env=dict(DD_AREDIS_CMD_MAX_LENGTH="10"), ddtrace_run=True)
+@pytest.mark.snapshot
+def test_cmd_max_length_env():
+    import asyncio
+
+    import aredis
+
+    from tests.contrib.config import REDIS_CONFIG
+
+    async def main():
+        r = aredis.StrictRedis(port=REDIS_CONFIG["port"])
+        await r.get("here-is-a-long-key")
+
+    asyncio.run(main())
+
+
+@pytest.mark.asyncio
+async def test_cmd_max_length(snapshot_context):
+    with override_config("aredis", dict(cmd_max_length=7)):
+        with snapshot_context():
+            r = aredis.StrictRedis(port=REDIS_CONFIG["port"])
+            await r.get("here-is-a-long-key")
+
+
 @pytest.mark.asyncio
 async def test_basics(snapshot_context):
     with snapshot_context():

--- a/tests/contrib/redis/test_redis.py
+++ b/tests/contrib/redis/test_redis.py
@@ -497,3 +497,13 @@ class TestRedisPatchSnapshot(TracerTestCase):
         # Do a manual override
         Pin.override(self.r, service="override-redis", tracer=self.tracer)
         self.r.get("cheese")
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_REDIS_CMD_MAX_LENGTH="10"))
+    @snapshot()
+    def test_custom_cmd_length_env(self):
+        self.r.get("here-is-a-long-key-name")
+
+    @snapshot()
+    def test_custom_cmd_length(self):
+        with self.override_config("redis", dict(cmd_max_length=7)):
+            self.r.get("here-is-a-long-key-name")

--- a/tests/contrib/yaaredis/test_yaaredis.py
+++ b/tests/contrib/yaaredis/test_yaaredis.py
@@ -56,6 +56,30 @@ async def test_long_command(snapshot_context, traced_yaaredis):
 
 
 @pytest.mark.asyncio
+@pytest.mark.snapshot
+async def test_cmd_max_length(traced_yaaredis):
+    with override_config("yaaredis", dict(cmd_max_length=7)):
+        await traced_yaaredis.get("here-is-a-long-key")
+
+
+@pytest.mark.skip(reason="No traces sent to the test agent")
+@pytest.mark.subprocess(env=dict(DD_YAAREDIS_CMD_MAX_LENGTH="10"), ddtrace_run=True)
+@pytest.mark.snapshot
+def test_cmd_max_length_env():
+    import asyncio
+
+    import yaaredis
+
+    from tests.contrib.config import REDIS_CONFIG
+
+    async def main():
+        r = yaaredis.StrictRedis(port=REDIS_CONFIG["port"])
+        await r.get("here-is-a-long-key")
+
+    asyncio.run(main())
+
+
+@pytest.mark.asyncio
 async def test_basics(snapshot_context, traced_yaaredis):
     with snapshot_context():
         await traced_yaaredis.get("cheese")

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_cmd_max_length.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_cmd_max_length.json
@@ -1,0 +1,34 @@
+[[
+  {
+    "name": "redis.command",
+    "service": "redis",
+    "resource": "GET here-is-a-long-key",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "redis",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "aioredis",
+      "db.system": "redis",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "redis.raw_command": "GET here-is-a-long-key",
+      "runtime-id": "1a6ee85b789d420f9c7635b5427f4cb9",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 6379,
+      "out.redis_db": 0,
+      "process_id": 5510,
+      "redis.args_length": 2
+    },
+    "duration": 3439000,
+    "start": 1682635708923438000
+  }]]

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_cmd_max_length.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_cmd_max_length.json
@@ -1,0 +1,34 @@
+[[
+  {
+    "name": "redis.command",
+    "service": "redis",
+    "resource": "GET here...",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "redis",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "aredis",
+      "db.system": "redis",
+      "language": "python",
+      "out.host": "localhost",
+      "redis.raw_command": "GET here...",
+      "runtime-id": "7eb3e52baa84484f9d8c5fa982834f62",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 6379,
+      "out.redis_db": 0,
+      "process_id": 58643,
+      "redis.args_length": 2
+    },
+    "duration": 2768000,
+    "start": 1682634184421226000
+  }]]

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_custom_cmd_length.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_custom_cmd_length.json
@@ -1,0 +1,34 @@
+[[
+  {
+    "name": "redis.command",
+    "service": "redis",
+    "resource": "GET here...",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "redis",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "redis",
+      "db.system": "redis",
+      "language": "python",
+      "out.host": "localhost",
+      "redis.raw_command": "GET here...",
+      "runtime-id": "cf8a0de277294ae5981e47e6c6a48dba",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 6379,
+      "out.redis_db": 0,
+      "process_id": 52367,
+      "redis.args_length": 2
+    },
+    "duration": 1937000,
+    "start": 1682620346382085000
+  }]]

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_custom_cmd_length_env.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_custom_cmd_length_env.json
@@ -1,0 +1,34 @@
+[[
+  {
+    "name": "redis.command",
+    "service": "redis",
+    "resource": "GET here-is...",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "redis",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "redis",
+      "db.system": "redis",
+      "language": "python",
+      "out.host": "localhost",
+      "redis.raw_command": "GET here-is...",
+      "runtime-id": "9f0fc2202543448aafd68181c060ab93",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 6379,
+      "out.redis_db": 0,
+      "process_id": 54095,
+      "redis.args_length": 2
+    },
+    "duration": 3344000,
+    "start": 1682620449315820000
+  }]]

--- a/tests/snapshots/tests.contrib.rediscluster.test.test_cmd_max_length.json
+++ b/tests/snapshots/tests.contrib.rediscluster.test.test_cmd_max_length.json
@@ -1,0 +1,62 @@
+[[
+  {
+    "name": "redis.command",
+    "service": "rediscluster",
+    "resource": "FLUSHALL",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "redis",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "rediscluster",
+      "db.system": "redis",
+      "language": "python",
+      "redis.raw_command": "FLUSHALL",
+      "runtime-id": "f93c3bec8adb438c84065c9ec9583c92",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 48250,
+      "redis.args_length": 1
+    },
+    "duration": 12067000,
+    "start": 1682636830779135000
+  }],
+[
+  {
+    "name": "redis.command",
+    "service": "rediscluster",
+    "resource": "GET here...",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "redis",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "rediscluster",
+      "db.system": "redis",
+      "language": "python",
+      "redis.raw_command": "GET here...",
+      "runtime-id": "f93c3bec8adb438c84065c9ec9583c92",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 48250,
+      "redis.args_length": 2
+    },
+    "duration": 1304000,
+    "start": 1682636830812590000
+  }]]

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_cmd_max_length.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_cmd_max_length.json
@@ -1,0 +1,34 @@
+[[
+  {
+    "name": "redis.command",
+    "service": "redis",
+    "resource": "GET here...",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "redis",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "yaaredis",
+      "db.system": "redis",
+      "language": "python",
+      "out.host": "localhost",
+      "redis.raw_command": "GET here...",
+      "runtime-id": "a6b4c37d481843009d7cb1f8a5bf9d5d",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 6379,
+      "out.redis_db": 0,
+      "process_id": 24026,
+      "redis.args_length": 2
+    },
+    "duration": 2248000,
+    "start": 1682636161212600000
+  }]]


### PR DESCRIPTION
Today we truncate all redis commands to 1000 characters when setting them as tags on spans.

This PR introduces a configuration option for all redis integrations to allow configuring this truncation length.

There is no way to disable the truncation. The trace agent will continue to truncate to 2000 characters regardless of this configuration.

## Testing

There are a few tests I had added but which are skipped because they don't appear to be working. They are async tests using subprocess and snapshots. The subprocess appears to be configured properly, but the test agent never receives any requests. I was unable to figure out what is wrong.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
