### PR TITLE
refactor(tracing): do not import when checking requirements

### DIFF
--- a/ddtrace/internal/utils/importlib.py
+++ b/ddtrace/internal/utils/importlib.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import
 
-from importlib import import_module
 from types import TracebackType
 from typing import Any
 from typing import Callable
 from typing import List
 from typing import Optional
 from typing import Type
+
+from ddtrace.internal.module import find_loader
 
 
 class require_modules(object):
@@ -16,9 +17,9 @@ class require_modules(object):
         # type: (List[str]) -> None
         self._missing_modules = []
         for module in modules:
-            try:
-                import_module(module)
-            except ImportError:
+            # Look for the loader to avoid the side effects of importing the
+            # module.
+            if find_loader(module) is None:
                 self._missing_modules.append(module)
 
     def __enter__(self):


### PR DESCRIPTION
The require_modules helper has been refactored to avoid importing the required modules. Instead we simply look for their loaders to avoid the side-effects of actually importing them.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
