### PR TITLE
refactor(internal): after module import decorator

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -7,7 +7,6 @@ import sys
 
 LOADED_MODULES = frozenset(sys.modules.keys())
 
-from functools import partial  # noqa
 import logging  # noqa
 import os  # noqa
 from typing import Any  # noqa
@@ -157,7 +156,7 @@ def cleanup_loaded_modules():
     # to the newly imported threading module to allow it to retrieve the correct
     # thread object information, like the thread name. We register a post-import
     # hook on the threading module to perform this update.
-    @partial(ModuleWatchdog.register_module_hook, "threading")
+    @ModuleWatchdog.after_module_imported("threading")
     def _(threading):
         logging.threading = threading
 

--- a/ddtrace/internal/module.py
+++ b/ddtrace/internal/module.py
@@ -526,6 +526,15 @@ class ModuleWatchdog(dict):
             raise ValueError("Hook %r not registered for module %r" % (hook, module))
 
     @classmethod
+    def after_module_imported(cls, module):
+        # type: (str) -> Callable[[ModuleHookType], None]
+        def _(hook):
+            # type: (ModuleHookType) -> None
+            cls.register_module_hook(module, hook)
+
+        return _
+
+    @classmethod
     def register_pre_exec_module_hook(cls, cond, hook):
         # type: (Type[ModuleWatchdog], PreExecHookCond, PreExecHookType) -> None
         """Register a hook to execute before/instead of exec_module.

--- a/tests/internal/test_module.py
+++ b/tests/internal/test_module.py
@@ -73,6 +73,14 @@ def test_import_module_hook_for_imported_module(module_watchdog):
     hook.assert_called_once_with(module)
 
 
+def test_after_module_imported_decorator(module_watchdog):
+    hook = mock.Mock()
+    module = sys.modules[__name__]
+    module_watchdog.after_module_imported(module.__name__)(hook)
+
+    hook.assert_called_once_with(module)
+
+
 def test_register_hook_without_install():
     with pytest.raises(RuntimeError):
         ModuleWatchdog.register_origin_hook(__file__, mock.Mock())


### PR DESCRIPTION
Add an after module import decorator to register module hooks.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
