### PR TITLE
chore(redis): extract redis common helpers to contrib utils [backport #5608 to 1.11]

### DIFF
--- a/ddtrace/contrib/aioredis/patch.py
+++ b/ddtrace/contrib/aioredis/patch.py
@@ -19,8 +19,8 @@ from ...ext import db
 from ...ext import net
 from ...ext import redis as redisx
 from ...internal.utils.formats import stringify_cache_args
-from ..redis.util import _trace_redis_cmd
-from ..redis.util import _trace_redis_execute_pipeline
+from ..trace_utils_redis import _trace_redis_cmd
+from ..trace_utils_redis import _trace_redis_execute_pipeline
 
 
 try:

--- a/ddtrace/contrib/aredis/patch.py
+++ b/ddtrace/contrib/aredis/patch.py
@@ -6,8 +6,8 @@ from ddtrace.vendor import wrapt
 from ...internal.utils.formats import stringify_cache_args
 from ...internal.utils.wrappers import unwrap
 from ...pin import Pin
-from ..redis.util import _trace_redis_cmd
-from ..redis.util import _trace_redis_execute_pipeline
+from ..trace_utils_redis import _trace_redis_cmd
+from ..trace_utils_redis import _trace_redis_execute_pipeline
 
 
 config._add("aredis", dict(_default_service="redis"))

--- a/ddtrace/contrib/flask_cache/utils.py
+++ b/ddtrace/contrib/flask_cache/utils.py
@@ -1,7 +1,7 @@
 # project
 from ...ext import net
 from ..pylibmc.addrs import parse_addresses
-from ..redis.util import _extract_conn_tags as extract_redis_tags
+from ..trace_utils_redis import _extract_conn_tags as extract_redis_tags
 
 
 def _resource_from_cache_prefix(resource, cache):

--- a/ddtrace/contrib/redis/asyncio_patch.py
+++ b/ddtrace/contrib/redis/asyncio_patch.py
@@ -2,8 +2,8 @@ from ddtrace import config
 
 from ...internal.utils.formats import stringify_cache_args
 from ...pin import Pin
-from .util import _trace_redis_cmd
-from .util import _trace_redis_execute_pipeline
+from ..trace_utils_redis import _trace_redis_cmd
+from ..trace_utils_redis import _trace_redis_execute_pipeline
 
 
 #

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -7,8 +7,8 @@ from ddtrace.vendor import wrapt
 from ...internal.utils.formats import stringify_cache_args
 from ...pin import Pin
 from ..trace_utils import unwrap
-from .util import _trace_redis_cmd
-from .util import _trace_redis_execute_pipeline
+from ..trace_utils_redis import _trace_redis_cmd
+from ..trace_utils_redis import _trace_redis_execute_pipeline
 
 
 config._add("redis", dict(_default_service="redis"))

--- a/ddtrace/contrib/trace_utils_redis.py
+++ b/ddtrace/contrib/trace_utils_redis.py
@@ -3,18 +3,17 @@ Some utils used by the dogtrace redis integration
 """
 from contextlib import contextmanager
 
+from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.constants import SPAN_KIND
+from ddtrace.constants import SPAN_MEASURED_KEY
+from ddtrace.contrib import trace_utils
+from ddtrace.ext import SpanKind
+from ddtrace.ext import SpanTypes
+from ddtrace.ext import db
+from ddtrace.ext import net
+from ddtrace.ext import redis as redisx
 from ddtrace.internal.constants import COMPONENT
-
-from .. import trace_utils
-from ...constants import ANALYTICS_SAMPLE_RATE_KEY
-from ...constants import SPAN_KIND
-from ...constants import SPAN_MEASURED_KEY
-from ...ext import SpanKind
-from ...ext import SpanTypes
-from ...ext import db
-from ...ext import net
-from ...ext import redis as redisx
-from ...internal.utils.formats import stringify_cache_args
+from ddtrace.internal.utils.formats import stringify_cache_args
 
 
 format_command_args = stringify_cache_args

--- a/ddtrace/contrib/yaaredis/patch.py
+++ b/ddtrace/contrib/yaaredis/patch.py
@@ -6,8 +6,8 @@ from ddtrace.vendor import wrapt
 from ...internal.utils.formats import stringify_cache_args
 from ...internal.utils.wrappers import unwrap
 from ...pin import Pin
-from ..redis.util import _trace_redis_cmd
-from ..redis.util import _trace_redis_execute_pipeline
+from ..trace_utils_redis import _trace_redis_cmd
+from ..trace_utils_redis import _trace_redis_execute_pipeline
 
 
 config._add("yaaredis", dict(_default_service="redis"))


### PR DESCRIPTION
Backport #5608 to 1.11.

This PR extracts redis-common helpers to outside the `ddtrace.contrib.redis` module and into
`ddtrace.contrib.trace_utils_redis.py`, as `aioredis/aredis/yaaredis` were also using the contained helper functions.

This PR should fix #5601 (see
[comment](https://github.com/DataDog/dd-trace-py/issues/5601#issuecomment-1516265155))

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
