### PR TITLE
fix(redis): add release note for redis cross import fix [backport #5710 to 1.13]

### DIFF
--- a/releasenotes/notes/fix-redis-cross-import-40590b3d41f96dcc.yaml
+++ b/releasenotes/notes/fix-redis-cross-import-40590b3d41f96dcc.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    redis: Resolves an issue where the aioredis/aredis/yaaredis integrations cross-imported a helper method from the 
+    redis integration, which triggered redis patching before the redis integration was fully loaded.


### PR DESCRIPTION
Backports #5710 to 1.13.

This PR adds a release note corresponding to the fix from #5608 that was not marked as a fix.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
