### PR TITLE
fix(bootstrap): make ddtrace.auto work as expected

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -1,56 +1,47 @@
 import sys
 
 
-if "ddtrace.bootstrap.sitecustomize" in sys.modules:
+LOADED_MODULES = frozenset(sys.modules.keys())
 
-    from ddtrace.internal.module import ModuleWatchdog
+from ddtrace.internal.module import ModuleWatchdog
 
-    ModuleWatchdog.install()
 
-    # Acquire a reference to the threading module. Some parts of the library (e.g.
-    # the profiler) might be enabled programmatically and therefore might end up
-    # getting a reference to the tracee's threading module. By storing a reference
-    # to the threading module used by ddtrace here, we make it easy for those parts
-    # to get a reference to the right threading module.
-    import threading as _threading
+ModuleWatchdog.install()
 
-    from ._logger import configure_ddtrace_logger
+# Acquire a reference to the threading module. Some parts of the library (e.g.
+# the profiler) might be enabled programmatically and therefore might end up
+# getting a reference to the tracee's threading module. By storing a reference
+# to the threading module used by ddtrace here, we make it easy for those parts
+# to get a reference to the right threading module.
+import threading as _threading
 
-    # configure ddtrace logger before other modules log
-    configure_ddtrace_logger()  # noqa: E402
-    from ._monkey import patch  # noqa: E402
-    from ._monkey import patch_all  # noqa: E402
-    from .internal.utils.deprecations import DDTraceDeprecationWarning  # noqa: E402
-    from .pin import Pin  # noqa: E402
-    from .settings import _config as config  # noqa: E402
-    from .span import Span  # noqa: E402
-    from .tracer import Tracer  # noqa: E402
-    from .version import get_version  # noqa: E402
+from ._logger import configure_ddtrace_logger
 
-    __version__ = get_version()
 
-    # a global tracer instance with integration settings
-    tracer = Tracer()
+# configure ddtrace logger before other modules log
+configure_ddtrace_logger()  # noqa: E402
+from ._monkey import patch  # noqa: E402
+from ._monkey import patch_all  # noqa: E402
+from .internal.utils.deprecations import DDTraceDeprecationWarning  # noqa: E402
+from .pin import Pin  # noqa: E402
+from .settings import _config as config  # noqa: E402
+from .span import Span  # noqa: E402
+from .tracer import Tracer  # noqa: E402
+from .version import get_version  # noqa: E402
 
-    __all__ = [
-        "patch",
-        "patch_all",
-        "Pin",
-        "Span",
-        "tracer",
-        "Tracer",
-        "config",
-        "DDTraceDeprecationWarning",
-    ]
 
-else:
-    from os.path import dirname
-    from os.path import sep
+__version__ = get_version()
 
-    # We need to import ddtrace again from the sitecustomize
-    del sys.modules["ddtrace"]
-    sys.path.insert(0, sep.join((dirname(__file__), "bootstrap")))
-    if "sitecustomize" in sys.modules:
-        sys.modules["ddtrace.cache.sitecustomize"] = sys.modules["sitecustomize"]
-        del sys.modules["sitecustomize"]
-    import sitecustomize  # noqa
+# a global tracer instance with integration settings
+tracer = Tracer()
+
+__all__ = [
+    "patch",
+    "patch_all",
+    "Pin",
+    "Span",
+    "tracer",
+    "Tracer",
+    "config",
+    "DDTraceDeprecationWarning",
+]

--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -1,42 +1,56 @@
-from ddtrace.internal.module import ModuleWatchdog
+import sys
 
 
-ModuleWatchdog.install()
+if "ddtrace.bootstrap.sitecustomize" in sys.modules:
 
-# Acquire a reference to the threading module. Some parts of the library (e.g.
-# the profiler) might be enabled programmatically and therefore might end up
-# getting a reference to the tracee's threading module. By storing a reference
-# to the threading module used by ddtrace here, we make it easy for those parts
-# to get a reference to the right threading module.
-import threading as _threading
+    from ddtrace.internal.module import ModuleWatchdog
 
-from ._logger import configure_ddtrace_logger
+    ModuleWatchdog.install()
 
+    # Acquire a reference to the threading module. Some parts of the library (e.g.
+    # the profiler) might be enabled programmatically and therefore might end up
+    # getting a reference to the tracee's threading module. By storing a reference
+    # to the threading module used by ddtrace here, we make it easy for those parts
+    # to get a reference to the right threading module.
+    import threading as _threading
 
-# configure ddtrace logger before other modules log
-configure_ddtrace_logger()  # noqa: E402
-from ._monkey import patch  # noqa: E402
-from ._monkey import patch_all  # noqa: E402
-from .internal.utils.deprecations import DDTraceDeprecationWarning  # noqa: E402
-from .pin import Pin  # noqa: E402
-from .settings import _config as config  # noqa: E402
-from .span import Span  # noqa: E402
-from .tracer import Tracer  # noqa: E402
-from .version import get_version  # noqa: E402
+    from ._logger import configure_ddtrace_logger
 
+    # configure ddtrace logger before other modules log
+    configure_ddtrace_logger()  # noqa: E402
+    from ._monkey import patch  # noqa: E402
+    from ._monkey import patch_all  # noqa: E402
+    from .internal.utils.deprecations import DDTraceDeprecationWarning  # noqa: E402
+    from .pin import Pin  # noqa: E402
+    from .settings import _config as config  # noqa: E402
+    from .span import Span  # noqa: E402
+    from .tracer import Tracer  # noqa: E402
+    from .version import get_version  # noqa: E402
 
-__version__ = get_version()
+    __version__ = get_version()
 
-# a global tracer instance with integration settings
-tracer = Tracer()
+    # a global tracer instance with integration settings
+    tracer = Tracer()
 
-__all__ = [
-    "patch",
-    "patch_all",
-    "Pin",
-    "Span",
-    "tracer",
-    "Tracer",
-    "config",
-    "DDTraceDeprecationWarning",
-]
+    __all__ = [
+        "patch",
+        "patch_all",
+        "Pin",
+        "Span",
+        "tracer",
+        "Tracer",
+        "config",
+        "DDTraceDeprecationWarning",
+    ]
+
+else:
+    from os.path import dirname
+    from os.path import sep
+
+    # We need to import ddtrace again from the sitecustomize
+    del sys.modules["ddtrace"]
+    sys.path.insert(0, sep.join((dirname(__file__), "bootstrap")))
+    if "sitecustomize" in sys.modules:
+        sys.modules["ddtrace.cache.sitecustomize"] = sys.modules["sitecustomize"]
+        del sys.modules["sitecustomize"]
+    import sitecustomize  # noqa

--- a/ddtrace/auto.py
+++ b/ddtrace/auto.py
@@ -1,1 +1,1 @@
-# no-op. We keep this for backwards compatibility.
+import ddtrace.bootstrap.sitecustomize  # noqa

--- a/ddtrace/auto.py
+++ b/ddtrace/auto.py
@@ -1,1 +1,1 @@
-import ddtrace.bootstrap.sitecustomize  # noqa
+# no-op. We keep this for backwards compatibility.

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -2,18 +2,12 @@
 Bootstrapping code that is run when using the `ddtrace-run` Python entrypoint
 Add all monkey-patching that needs to run by default here
 """
-import sys
-
-
-ddtrace_sitecustomize = sys.modules["sitecustomize"]
-sys.modules["ddtrace.bootstrap.sitecustomize"] = ddtrace_sitecustomize
-
-
-LOADED_MODULES = frozenset(sys.modules.keys())
+from ddtrace import LOADED_MODULES  # isort:skip
 
 from functools import partial  # noqa
 import logging  # noqa
 import os  # noqa
+import sys
 from typing import Any  # noqa
 from typing import Dict  # noqa
 import warnings  # noqa
@@ -253,15 +247,10 @@ try:
         # NOTE: this reference to the module is crucial in Python 2.
         # Without it the current module gets gc'd and all subsequent references
         # will be `None`.
+        ddtrace_sitecustomize = sys.modules["sitecustomize"]
         del sys.modules["sitecustomize"]
         try:
-            original_sitecustomize = sys.modules.pop("ddtrace.cache.sitecustomize", None)
-            if original_sitecustomize is None:
-                import sitecustomize  # noqa
-            else:
-                # Do not re-import the original sitecustomize if it was already
-                # imported.
-                sys.modules["sitecustomize"] = original_sitecustomize
+            import sitecustomize  # noqa
         except ImportError:
             # If an additional sitecustomize is not found then put the ddtrace
             # sitecustomize back.

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -5,6 +5,10 @@ Add all monkey-patching that needs to run by default here
 import sys
 
 
+ddtrace_sitecustomize = sys.modules["sitecustomize"]
+sys.modules["ddtrace.bootstrap.sitecustomize"] = ddtrace_sitecustomize
+
+
 LOADED_MODULES = frozenset(sys.modules.keys())
 
 from functools import partial  # noqa
@@ -249,10 +253,15 @@ try:
         # NOTE: this reference to the module is crucial in Python 2.
         # Without it the current module gets gc'd and all subsequent references
         # will be `None`.
-        ddtrace_sitecustomize = sys.modules["sitecustomize"]
         del sys.modules["sitecustomize"]
         try:
-            import sitecustomize  # noqa
+            original_sitecustomize = sys.modules.pop("ddtrace.cache.sitecustomize", None)
+            if original_sitecustomize is None:
+                import sitecustomize  # noqa
+            else:
+                # Do not re-import the original sitecustomize if it was already
+                # imported.
+                sys.modules["sitecustomize"] = original_sitecustomize
         except ImportError:
             # If an additional sitecustomize is not found then put the ddtrace
             # sitecustomize back.

--- a/releasenotes/notes/fix-ddtrace-auto-dfcd9456dd666ca4.yaml
+++ b/releasenotes/notes/fix-ddtrace-auto-dfcd9456dd666ca4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    bootstrap: fixed an issue with the behavior of ``ddtrace.auto`` that could
+    have caused incompatibilities with frameworks such as ``gevent`` when used
+    as a programmatic alternative to the ``ddtrace-run`` command.

--- a/tests/internal/test_auto.py
+++ b/tests/internal/test_auto.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.mark.subprocess(env=dict(DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE="true"))
+def test_auto():
+    import sys
+
+    import ddtrace.auto  # noqa
+
+    assert "threading" not in sys.modules


### PR DESCRIPTION
Importing ddtrace.auto causes the import of ddtrace, which pollutes the module space before the sitecustomize logic can freeze the set of start-up modules and do the clean-up when required. This made the import of ddtrace.auto not behave as expected, that is as a programmatic equivalent of the ddtrace-run command. With the proposed change, we compute the initial set of modules in `ddtrace` and import that in the sitecustomize script. This way we ensure that the set is computed at the right time, regardless of how `ddtrace` is used.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
