### PR TITLE
chore(telemetry): rename telemetry_writer

### DIFF
--- a/benchmarks/ddtrace_run/scenario.py
+++ b/benchmarks/ddtrace_run/scenario.py
@@ -33,17 +33,17 @@ class DDtraceRun(bm.Scenario):
             code += """
 import httpretty
 from ddtrace import tracer
-from ddtrace.internal.telemetry import telemetry_writer
+from ddtrace.internal.telemetry import telemetry_lifecycle_writer
 
 httpretty.enable(allow_net_connect=False)
 httpretty.register_uri(httpretty.PUT, '%s/%s' % (tracer.agent_trace_url, 'v0.4/traces'))
-httpretty.register_uri(httpretty.POST, '%s/%s' % (tracer.agent_trace_url, telemetry_writer.ENDPOINT))
+httpretty.register_uri(httpretty.POST, '%s/%s' % (tracer.agent_trace_url, telemetry_lifecycle_writer.ENDPOINT))
 # profiler will collect snapshot during shutdown
 httpretty.register_uri(httpretty.POST, '%s/%s' % (tracer.agent_trace_url, 'profiling/v1/input'))
 """
 
         if self.telemetry:
-            code += "telemetry_writer.enable()\n"
+            code += "telemetry_lifecycle_writer.enable()\n"
 
         if self.tracing:
             code += "span = tracer.trace('test-x', service='bench-test'); span.finish()\n"

--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -7,7 +7,7 @@ from ddtrace.vendor.wrapt.importer import when_imported
 
 from .internal.compat import PY2
 from .internal.logger import get_logger
-from .internal.telemetry import telemetry_writer
+from .internal.telemetry import telemetry_lifecycle_writer
 from .internal.utils import formats
 from .settings import _config as config
 
@@ -160,7 +160,7 @@ def _on_import_factory(module, prefix="ddtrace.contrib", raise_errors=True):
             log.error("failed to import ddtrace module %r when patching on import", path, exc_info=True)
         else:
             imported_module.patch()
-            telemetry_writer.add_integration(module, PATCH_MODULES.get(module) is True)
+            telemetry_lifecycle_writer.add_integration(module, PATCH_MODULES.get(module) is True)
 
     return on_import
 

--- a/ddtrace/internal/telemetry/__init__.py
+++ b/ddtrace/internal/telemetry/__init__.py
@@ -3,14 +3,14 @@ Instrumentation Telemetry API.
 This is normally started automatically by ``ddtrace-run`` when the
 ``DD_INSTRUMENTATION_TELEMETRY_ENABLED`` variable is set.
 To start the service manually, invoke the ``enable`` method::
-    from ddtrace.internal.telemetry import telemetry_writer
-    telemetry_writer.enable()
+    from ddtrace.internal.telemetry import telemetry_lifecycle_writer
+    telemetry_lifecycle_writer.enable()
 """
 from .writer import TelemetryLogsMetricsWriter
 from .writer import TelemetryWriter
 
 
 telemetry_metrics_writer = TelemetryLogsMetricsWriter()
-telemetry_writer = TelemetryWriter()
+telemetry_lifecycle_writer = TelemetryWriter()
 
-__all__ = ["telemetry_writer"]
+__all__ = ["telemetry_lifecycle_writer"]

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -24,8 +24,8 @@ from .. import compat
 from .. import periodic
 from .. import service
 from ...constants import KEEP_SPANS_RATE_KEY
+from ...internal.telemetry import telemetry_lifecycle_writer
 from ...internal.telemetry import telemetry_metrics_writer
-from ...internal.telemetry import telemetry_writer
 from ...internal.utils.formats import asbool
 from ...internal.utils.formats import parse_tags_str
 from ...internal.utils.http import Response
@@ -645,7 +645,7 @@ class AgentWriter(HTTPWriter):
     def start(self):
         super(AgentWriter, self).start()
         try:
-            telemetry_writer.enable()
+            telemetry_lifecycle_writer.enable()
             telemetry_metrics_writer.enable()
 
             # appsec remote config should be enabled/started after the global tracer and configs

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -19,11 +19,11 @@ from tests.utils import request_token
 
 
 @pytest.fixture
-def telemetry_writer():
-    telemetry_writer = TelemetryWriter()
-    telemetry_writer.start = lambda *args, **kwargs: None
-    telemetry_writer.stop = lambda *args, **kwargs: None
-    yield telemetry_writer
+def telemetry_lifecycle_writer():
+    telemetry_lifecycle_writer = TelemetryWriter()
+    telemetry_lifecycle_writer.start = lambda *args, **kwargs: None
+    telemetry_lifecycle_writer.stop = lambda *args, **kwargs: None
+    yield telemetry_lifecycle_writer
 
 
 @pytest.fixture
@@ -86,11 +86,11 @@ class TelemetryTestSession(object):
 
 
 @pytest.fixture
-def test_agent_session(telemetry_writer, request):
+def test_agent_session(telemetry_lifecycle_writer, request):
     # type: (TelemetryWriter, Any) -> Generator[TelemetryTestSession, None, None]
     token = request_token(request)
-    telemetry_writer._restart_sequence()
-    telemetry_writer._client._headers["X-Datadog-Test-Session-Token"] = token
+    telemetry_lifecycle_writer._restart_sequence()
+    telemetry_lifecycle_writer._client._headers["X-Datadog-Test-Session-Token"] = token
 
     # Also add a header to the environment for subprocesses test cases that might use snapshotting.
     existing_headers = parse_tags_str(os.environ.get("_DD_TELEMETRY_WRITER_ADDITIONAL_HEADERS", ""))
@@ -99,7 +99,7 @@ def test_agent_session(telemetry_writer, request):
         ["%s:%s" % (k, v) for k, v in existing_headers.items()]
     )
 
-    requests = TelemetryTestSession(token=token, telemetry_writer=telemetry_writer)
+    requests = TelemetryTestSession(token=token, telemetry_writer=telemetry_lifecycle_writer)
 
     conn = requests.create_connection()
     try:
@@ -111,8 +111,8 @@ def test_agent_session(telemetry_writer, request):
     try:
         yield requests
     finally:
-        telemetry_writer.periodic()
-        del telemetry_writer._client._headers["X-Datadog-Test-Session-Token"]
+        telemetry_lifecycle_writer.periodic()
+        del telemetry_lifecycle_writer._client._headers["X-Datadog-Test-Session-Token"]
         del os.environ["_DD_TELEMETRY_WRITER_ADDITIONAL_HEADERS"]
 
 

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -5,8 +5,8 @@ import pytest
 
 def test_enable(test_agent_session, run_python_code_in_subprocess):
     code = """
-from ddtrace.internal.telemetry import telemetry_writer
-telemetry_writer.enable()
+from ddtrace.internal.telemetry import telemetry_lifecycle_writer
+telemetry_lifecycle_writer.enable()
 """
 
     stdout, stderr, status, _ = run_python_code_in_subprocess(code)
@@ -52,16 +52,16 @@ def test_enable_fork(test_agent_session, run_python_code_in_subprocess):
 import os
 
 from ddtrace.internal.runtime import get_runtime_id
-from ddtrace.internal.telemetry import telemetry_writer
+from ddtrace.internal.telemetry import telemetry_lifecycle_writer
 
 # We have to start before forking since fork hooks are not enabled until after enabling
-telemetry_writer.enable()
+telemetry_lifecycle_writer.enable()
 
 if os.fork() == 0:
     # Send multiple started events to confirm none get sent
-    telemetry_writer._app_started_event()
-    telemetry_writer._app_started_event()
-    telemetry_writer._app_started_event()
+    telemetry_lifecycle_writer._app_started_event()
+    telemetry_lifecycle_writer._app_started_event()
+    telemetry_lifecycle_writer._app_started_event()
 else:
     # Print the parent process runtime id for validation
     print(get_runtime_id())
@@ -90,20 +90,20 @@ def test_enable_fork_heartbeat(test_agent_session, run_python_code_in_subprocess
 import os
 
 from ddtrace.internal.runtime import get_runtime_id
-from ddtrace.internal.telemetry import telemetry_writer
+from ddtrace.internal.telemetry import telemetry_lifecycle_writer
 
-telemetry_writer.enable()
+telemetry_lifecycle_writer.enable()
 # Reset queue to avoid sending app-started event
-telemetry_writer.reset_queues()
+telemetry_lifecycle_writer.reset_queues()
 
 if os.fork() > 0:
     # Print the parent process runtime id for validation
     print(get_runtime_id())
 
 # Call periodic to send heartbeat event
-telemetry_writer.periodic()
+telemetry_lifecycle_writer.periodic()
 # Disable telemetry writer to avoid sending app-closed event
-telemetry_writer.disable()
+telemetry_lifecycle_writer.disable()
     """
 
     stdout, stderr, status, _ = run_python_code_in_subprocess(code)
@@ -127,8 +127,8 @@ def test_heartbeat_interval_configuration(run_python_code_in_subprocess):
     env = os.environ.copy()
     env["DD_TELEMETRY_HEARTBEAT_INTERVAL"] = heartbeat_interval
     code = """
-from ddtrace.internal.telemetry import telemetry_writer
-assert telemetry_writer.interval == {}
+from ddtrace.internal.telemetry import telemetry_lifecycle_writer
+assert telemetry_lifecycle_writer.interval == {}
     """.format(
         heartbeat_interval
     )
@@ -147,7 +147,7 @@ import logging
 import os
 
 logging.basicConfig() # required for python 2.7
-ddtrace.internal.telemetry.telemetry_writer.enable()
+ddtrace.internal.telemetry.telemetry_lifecycle_writer.enable()
 os.fork()
 """,
     )

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -17,14 +17,14 @@ from ddtrace.settings import _config as config
 from .conftest import TelemetryTestSession
 
 
-def test_add_event(telemetry_writer, test_agent_session, mock_time):
+def test_add_event(telemetry_lifecycle_writer, test_agent_session, mock_time):
     """asserts that add_event queues a telemetry request with valid headers and payload"""
     payload = {"test": "123"}
     payload_type = "test-event"
     # add event to the queue
-    telemetry_writer.add_event(payload, payload_type)
+    telemetry_lifecycle_writer.add_event(payload, payload_type)
     # send request to the agent
-    telemetry_writer.periodic()
+    telemetry_lifecycle_writer.periodic()
 
     requests = test_agent_session.get_requests()
     assert len(requests) == 1
@@ -37,29 +37,29 @@ def test_add_event(telemetry_writer, test_agent_session, mock_time):
     assert requests[0]["body"] == _get_request_body(payload, payload_type)
 
 
-def test_add_event_disabled_writer(telemetry_writer, test_agent_session):
+def test_add_event_disabled_writer(telemetry_lifecycle_writer, test_agent_session):
     """asserts that add_event() does not create a telemetry request when telemetry writer is disabled"""
-    telemetry_writer.disable()
+    telemetry_lifecycle_writer.disable()
 
     payload = {"test": "123"}
     payload_type = "test-event"
     # ensure events are not queued when telemetry is disabled
-    telemetry_writer.add_event(payload, payload_type)
+    telemetry_lifecycle_writer.add_event(payload, payload_type)
 
     # ensure no request were sent
-    telemetry_writer.periodic()
+    telemetry_lifecycle_writer.periodic()
     assert len(test_agent_session.get_requests()) == 0
 
 
-def test_app_started_event(telemetry_writer, test_agent_session, mock_time):
+def test_app_started_event(telemetry_lifecycle_writer, test_agent_session, mock_time):
     """asserts that _app_started_event() queues a valid telemetry request which is then sent by periodic()"""
     # queue integrations
-    telemetry_writer.add_integration("integration-t", True)
-    telemetry_writer.add_integration("integration-f", False)
+    telemetry_lifecycle_writer.add_integration("integration-t", True)
+    telemetry_lifecycle_writer.add_integration("integration-f", False)
     # queue an app started event
-    telemetry_writer._app_started_event()
+    telemetry_lifecycle_writer._app_started_event()
     # force a flush
-    telemetry_writer.periodic()
+    telemetry_lifecycle_writer.periodic()
 
     requests = test_agent_session.get_requests()
     assert len(requests) == 1
@@ -94,10 +94,10 @@ def test_app_started_event(telemetry_writer, test_agent_session, mock_time):
     assert events[0] == _get_request_body(payload, "app-started")
 
 
-def test_app_closing_event(telemetry_writer, test_agent_session, mock_time):
+def test_app_closing_event(telemetry_lifecycle_writer, test_agent_session, mock_time):
     """asserts that on_shutdown() queues and sends an app-closing telemetry request"""
     # send app closed event
-    telemetry_writer.on_shutdown()
+    telemetry_lifecycle_writer.on_shutdown()
 
     requests = test_agent_session.get_requests()
     assert len(requests) == 1
@@ -106,13 +106,13 @@ def test_app_closing_event(telemetry_writer, test_agent_session, mock_time):
     assert requests[0]["body"] == _get_request_body({}, "app-closing")
 
 
-def test_add_integration(telemetry_writer, test_agent_session, mock_time):
+def test_add_integration(telemetry_lifecycle_writer, test_agent_session, mock_time):
     """asserts that add_integration() queues a valid telemetry request"""
     # queue integrations
-    telemetry_writer.add_integration("integration-t", True)
-    telemetry_writer.add_integration("integration-f", False)
+    telemetry_lifecycle_writer.add_integration("integration-t", True)
+    telemetry_lifecycle_writer.add_integration("integration-f", False)
     # send integrations to the agent
-    telemetry_writer.periodic()
+    telemetry_lifecycle_writer.periodic()
 
     requests = test_agent_session.get_requests()
     assert len(requests) == 1
@@ -143,39 +143,39 @@ def test_add_integration(telemetry_writer, test_agent_session, mock_time):
     assert requests[0]["body"] == _get_request_body(expected_payload, "app-integrations-change")
 
 
-def test_add_integration_disabled_writer(telemetry_writer, test_agent_session):
+def test_add_integration_disabled_writer(telemetry_lifecycle_writer, test_agent_session):
     """asserts that add_integration() does not queue an integration when telemetry is disabled"""
-    telemetry_writer.disable()
+    telemetry_lifecycle_writer.disable()
 
-    telemetry_writer.add_integration("integration-name", False)
-    telemetry_writer.periodic()
+    telemetry_lifecycle_writer.add_integration("integration-name", False)
+    telemetry_lifecycle_writer.periodic()
 
     assert len(test_agent_session.get_requests()) == 0
 
 
 @pytest.mark.parametrize("mock_status", [300, 400, 401, 403, 500])
-def test_send_failing_request(mock_status, telemetry_writer):
+def test_send_failing_request(mock_status, telemetry_lifecycle_writer):
     """asserts that a warning is logged when an unsuccessful response is returned by the http client"""
 
     with httpretty.enabled():
-        httpretty.register_uri(httpretty.POST, telemetry_writer._client.url, status=mock_status)
+        httpretty.register_uri(httpretty.POST, telemetry_lifecycle_writer._client.url, status=mock_status)
         with mock.patch("ddtrace.internal.telemetry.writer.log") as log:
             # sends failing app-closing event
-            telemetry_writer.on_shutdown()
+            telemetry_lifecycle_writer.on_shutdown()
             # asserts unsuccessful status code was logged
             log.debug.assert_called_with(
                 "failed to send telemetry to the Datadog Agent at %s. response: %s",
-                telemetry_writer._client.url,
+                telemetry_lifecycle_writer._client.url,
                 mock_status,
             )
         # ensure one failing request was sent
         assert len(httpretty.latest_requests()) == 1
 
 
-@pytest.mark.parametrize("telemetry_writer", [TelemetryWriter()])
-def test_telemetry_graceful_shutdown(telemetry_writer, test_agent_session, mock_time):
-    telemetry_writer.start()
-    telemetry_writer.stop()
+@pytest.mark.parametrize("telemetry_lifecycle_writer", [TelemetryWriter()])
+def test_telemetry_graceful_shutdown(telemetry_lifecycle_writer, test_agent_session, mock_time):
+    telemetry_lifecycle_writer.start()
+    telemetry_lifecycle_writer.stop()
 
     events = test_agent_session.get_events()
     assert len(events) == 2
@@ -186,18 +186,18 @@ def test_telemetry_graceful_shutdown(telemetry_writer, test_agent_session, mock_
     assert events[1]["request_type"] == "app-started"
 
 
-def test_app_heartbeat_event_periodic(mock_time, telemetry_writer, test_agent_session):
+def test_app_heartbeat_event_periodic(mock_time, telemetry_lifecycle_writer, test_agent_session):
     # type: (mock.Mock, Any, TelemetryWriter) -> None
     """asserts that we queue/send app-heartbeat when periodc() is called"""
 
     # Assert default hearbeat interval is 60 seconds
-    assert telemetry_writer.interval == 60
+    assert telemetry_lifecycle_writer.interval == 60
     # Assert next flush contains app-heartbeat event
-    telemetry_writer.periodic()
+    telemetry_lifecycle_writer.periodic()
     _assert_app_heartbeat_event(1, test_agent_session)
 
 
-def test_app_heartbeat_event(mock_time, telemetry_writer, test_agent_session):
+def test_app_heartbeat_event(mock_time, telemetry_lifecycle_writer, test_agent_session):
     # type: (mock.Mock, Any, TelemetryWriter) -> None
     """asserts that we queue/send app-heartbeat event every 60 seconds when app_heartbeat_event() is called"""
 
@@ -206,8 +206,8 @@ def test_app_heartbeat_event(mock_time, telemetry_writer, test_agent_session):
     assert len(events) == 0
 
     # Assert a maximum of one heartbeat is queued per flush
-    telemetry_writer._app_heartbeat_event()
-    telemetry_writer.periodic()
+    telemetry_lifecycle_writer._app_heartbeat_event()
+    telemetry_lifecycle_writer.periodic()
     events = test_agent_session.get_events()
     assert len(events) == 1
 


### PR DESCRIPTION
The telemetry_writer is used to track the state of an application.  It is responsible for sending app-started, app-closed, app-integrations-changed, and app-configurations-changed events. With the introduction of the telemetry_metrics_writer, we should rename `telemetry_writer` to something more descriptive. In this PR I am proposing renaming this variable to  `telemetry_lifecycle_writer`.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
