### PR TITLE
refactor(tracer): remove redundant parent check in _start_span

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -639,12 +639,8 @@ class Tracer(object):
         else:
             context = Context()
 
-        if parent:
-            trace_id = parent.trace_id  # type: Optional[int]
-            parent_id = parent.span_id  # type: Optional[int]
-        else:
-            trace_id = context.trace_id
-            parent_id = context.span_id
+        trace_id = context.trace_id
+        parent_id = context.span_id
 
         # The following precedence is used for a new span's service:
         # 1. Explicitly provided service name


### PR DESCRIPTION
This PR removes a redundant check in `tracer._start_span()` where the new span's traceID/parentID are set from the parent span directly or from the context object. Since the [parent span is guaranteed to have a context object which includes its traceID and spanID](https://github.com/DataDog/dd-trace-py/blob/acd0fbaa9d6dde9f60d13848a9b70cd85e6e4f2b/ddtrace/span.py#L512), this logic is redundant.

Existing tests are sufficient for this change as this is a refactor.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
