### PR TITLE
chore(telemetry): stops sending integrations in app-started

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -394,7 +394,6 @@ class TelemetryWriter(TelemetryBase):
             return
         payload = {
             "dependencies": get_dependencies(),
-            "integrations": self._flush_integrations_queue(),
             "configurations": [],
         }
         self.add_event(payload, "app-started")

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -41,9 +41,10 @@ def test_telemetry_enabled_on_first_tracer_flush(test_agent_session, ddtrace_run
     assert stderr == b""
     # Ensure telemetry events were sent to the agent (snapshot ensures one trace was generated)
     events = test_agent_session.get_events()
-    assert len(events) == 2
-    assert events[0]["request_type"] == "app-closing"
-    assert events[1]["request_type"] == "app-started"
+    assert len(events) == 3
+    assert events[0]["request_type"] == "app-integrations-change"
+    assert events[1]["request_type"] == "app-closing"
+    assert events[2]["request_type"] == "app-started"
 
 
 def test_enable_fork(test_agent_session, run_python_code_in_subprocess):

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -53,9 +53,6 @@ def test_add_event_disabled_writer(telemetry_writer, test_agent_session):
 
 def test_app_started_event(telemetry_writer, test_agent_session, mock_time):
     """asserts that _app_started_event() queues a valid telemetry request which is then sent by periodic()"""
-    # queue integrations
-    telemetry_writer.add_integration("integration-t", True)
-    telemetry_writer.add_integration("integration-f", False)
     # queue an app started event
     telemetry_writer._app_started_event()
     # force a flush
@@ -71,24 +68,6 @@ def test_app_started_event(telemetry_writer, test_agent_session, mock_time):
     # validate request body
     payload = {
         "dependencies": get_dependencies(),
-        "integrations": [
-            {
-                "name": "integration-t",
-                "version": "",
-                "enabled": True,
-                "auto_enabled": True,
-                "compatible": True,
-                "error": "",
-            },
-            {
-                "name": "integration-f",
-                "version": "",
-                "enabled": True,
-                "auto_enabled": False,
-                "compatible": True,
-                "error": "",
-            },
-        ],
         "configurations": [],
     }
     assert events[0] == _get_request_body(payload, "app-started")


### PR DESCRIPTION
Telemetry v2 does not support sending integrations in the app-started payload. Integrations should only be sent in the `app-integtations-changed` event.

Blocks: https://github.com/DataDog/dd-trace-py/pull/5500

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
