### PR TITLE
chore(telemetry): stops sending dependencies in app-started

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -393,7 +393,6 @@ class TelemetryWriter(TelemetryBase):
             # app-started events should only be sent by the main process
             return
         payload = {
-            "dependencies": get_dependencies(),
             "integrations": self._flush_integrations_queue(),
             "configurations": [],
         }
@@ -428,6 +427,10 @@ class TelemetryWriter(TelemetryBase):
         }
         self.add_event(payload, "app-integrations-change")
 
+    def _app_dependencies_loaded(self):
+        payload = {"dependencies": get_dependencies()}
+        self.add_event(payload, "app-dependencies-loaded")
+
     def periodic(self):
         integrations = self._flush_integrations_queue()
         if integrations:
@@ -454,6 +457,7 @@ class TelemetryWriter(TelemetryBase):
         super(TelemetryBase, self).start(*args, **kwargs)
         # Queue app-started event after the telemetry worker thread is running
         self._app_started_event()
+        self._app_dependencies_loaded()
 
     def on_shutdown(self):
         self._app_closing_event()

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -16,12 +16,13 @@ telemetry_writer.enable()
     assert stderr == b""
 
     events = test_agent_session.get_events()
-    assert len(events) == 2
+    assert len(events) == 3
 
     # Same runtime id is used
     assert events[0]["runtime_id"] == events[1]["runtime_id"]
     assert events[0]["request_type"] == "app-closing"
-    assert events[1]["request_type"] == "app-started"
+    assert events[1]["request_type"] == "app-dependencies-loaded"
+    assert events[2]["request_type"] == "app-started"
 
 
 @pytest.mark.snapshot
@@ -41,9 +42,10 @@ def test_telemetry_enabled_on_first_tracer_flush(test_agent_session, ddtrace_run
     assert stderr == b""
     # Ensure telemetry events were sent to the agent (snapshot ensures one trace was generated)
     events = test_agent_session.get_events()
-    assert len(events) == 2
+    assert len(events) == 3
     assert events[0]["request_type"] == "app-closing"
-    assert events[1]["request_type"] == "app-started"
+    assert events[1]["request_type"] == "app-dependencies-loaded"
+    assert events[2]["request_type"] == "app-started"
 
 
 def test_enable_fork(test_agent_session, run_python_code_in_subprocess):
@@ -76,12 +78,15 @@ else:
     requests = test_agent_session.get_requests()
 
     # We expect 2 events from the parent process to get sent, but none from the child process
-    assert len(requests) == 2
+    assert len(requests) == 3
     # Validate that the runtime id sent for every event is the parent processes runtime id
     assert requests[0]["body"]["runtime_id"] == runtime_id
     assert requests[0]["body"]["request_type"] == "app-closing"
     assert requests[1]["body"]["runtime_id"] == runtime_id
-    assert requests[1]["body"]["request_type"] == "app-started"
+    assert requests[1]["body"]["request_type"] == "app-dependencies-loaded"
+    assert requests[1]["body"]["runtime_id"] == runtime_id
+    assert requests[2]["body"]["request_type"] == "app-started"
+    assert requests[2]["body"]["runtime_id"] == runtime_id
 
 
 def test_enable_fork_heartbeat(test_agent_session, run_python_code_in_subprocess):

--- a/tests/telemetry/test_telemetry_metrics_e2e.py
+++ b/tests/telemetry/test_telemetry_metrics_e2e.py
@@ -97,6 +97,6 @@ def test_telemetry_metrics_enabled_on_gunicorn_child_process(test_agent_session)
         response_content = json.loads(response.content)
         assert response_content["telemetry_metrics_writer_queue"][0]["points"][0][1] == 2.0
     events = test_agent_session.get_events()
-    assert len(events) == 6
-    assert events[2]["payload"]["series"][0]["metric"] == "test_metric"
-    assert events[4]["payload"]["series"][0]["metric"] == "test_metric"
+    assert len(events) == 8
+    assert events[1]["payload"]["series"][0]["metric"] == "test_metric"
+    assert events[3]["payload"]["series"][0]["metric"] == "test_metric"


### PR DESCRIPTION
Telemetry v2 does not support sending dependencies in the app-started payload. Integrations should only be sent in the app-dependencies-loaded event.

Blocks: https://github.com/DataDog/dd-trace-py/pull/5500
May conflict with: https://github.com/DataDog/dd-trace-py/pull/5734

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
