### PR TITLE
fix(bootstrap): make ddtrace.auto work as expected [backport #5716 to 1.12]

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -1,3 +1,8 @@
+import sys
+
+
+LOADED_MODULES = frozenset(sys.modules.keys())
+
 from ddtrace.internal.module import ModuleWatchdog
 
 

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -2,13 +2,11 @@
 Bootstrapping code that is run when using the `ddtrace-run` Python entrypoint
 Add all monkey-patching that needs to run by default here
 """
-import sys
-
-
-LOADED_MODULES = frozenset(sys.modules.keys())
+from ddtrace import LOADED_MODULES  # isort:skip
 
 import logging  # noqa
 import os  # noqa
+import sys
 from typing import Any  # noqa
 from typing import Dict  # noqa
 import warnings  # noqa

--- a/releasenotes/notes/fix-ddtrace-auto-dfcd9456dd666ca4.yaml
+++ b/releasenotes/notes/fix-ddtrace-auto-dfcd9456dd666ca4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    bootstrap: fixed an issue with the behavior of ``ddtrace.auto`` that could
+    have caused incompatibilities with frameworks such as ``gevent`` when used
+    as a programmatic alternative to the ``ddtrace-run`` command.

--- a/tests/internal/test_auto.py
+++ b/tests/internal/test_auto.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.mark.subprocess(env=dict(DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE="true"))
+def test_auto():
+    import sys
+
+    import ddtrace.auto  # noqa
+
+    assert "threading" not in sys.modules


### PR DESCRIPTION
Backport of #5716 to 1.12

Importing ddtrace.auto causes the import of ddtrace, which pollutes the module space before the sitecustomize logic can freeze the set of start-up modules and do the clean-up when required. This made the import of ddtrace.auto not behave as expected, that is as a programmatic equivalent of the ddtrace-run command. With the proposed change, we compute the initial set of modules in `ddtrace` and import that in the sitecustomize script. This way we ensure that the set is computed at the right time, regardless of how `ddtrace` is used.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
