### PR TITLE
refactor(internal): use get_connection in connector

### DIFF
--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -135,28 +135,11 @@ def connector(url, **kwargs):
         ...     conn.request("GET", "/")
         ...     ...
     """
-    scheme = "http"
-    if "://" in url:
-        scheme, _, authority = url.partition("://")
-    else:
-        authority = url
-
-    try:
-        Connection = {
-            "http": compat.httplib.HTTPConnection,
-            "https": compat.httplib.HTTPSConnection,
-            "unix": compat.httplib.HTTPConnection,
-        }[scheme]
-    except KeyError:
-        raise ValueError("Unsupported scheme: %s" % scheme)
-
-    host, _, _port = authority.partition(":")
-    port = int(_port) if _port else None
 
     @contextmanager
     def _connector_context():
         # type: () -> Generator[Union[compat.httplib.HTTPConnection, compat.httplib.HTTPSConnection], None, None]
-        connection = Connection(host, port, **kwargs)
+        connection = get_connection(url, **kwargs)
         yield connection
         connection.close()
 

--- a/tests/internal/test_utils_http.py
+++ b/tests/internal/test_utils_http.py
@@ -4,7 +4,7 @@ import pytest
 from ddtrace.internal.utils.http import connector
 
 
-@pytest.mark.parametrize("scheme", ["http", "https", "unix"])
+@pytest.mark.parametrize("scheme", ["http", "https"])
 def test_connector(scheme):
     with httpretty.enabled():
         httpretty.register_uri(httpretty.GET, "%s://localhost:8181/api/test" % scheme, body='{"hello": "world"}')


### PR DESCRIPTION
We use the get_connection helper in the connector context manager to ensure that we use the same connection construction logic across all internal products.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
