### PR TITLE
fix: keep the copyreg module

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -123,6 +123,7 @@ def cleanup_loaded_modules():
     KEEP_MODULES = frozenset(
         [
             "atexit",
+            "copyreg",  # pickling issues for tracebacks with gevent
             "ddtrace",
             "asyncio",
             "concurrent",
@@ -133,7 +134,7 @@ def cleanup_loaded_modules():
         ]
     )
     if PY2:
-        KEEP_MODULES_PY2 = frozenset(["encodings", "codecs"])
+        KEEP_MODULES_PY2 = frozenset(["encodings", "codecs", "copy_reg"])
     for m in list(_ for _ in sys.modules if _ not in LOADED_MODULES):
         if any(m == _ or m.startswith(_ + ".") for _ in KEEP_MODULES):
             continue

--- a/releasenotes/notes/fix-keep-copyreg-29c28bcc854e13bb.yaml
+++ b/releasenotes/notes/fix-keep-copyreg-29c28bcc854e13bb.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a bug that caused traceback objects to fail to pickle when using gevent.

--- a/releasenotes/notes/fix-keep-copyreg-29c28bcc854e13bb.yaml
+++ b/releasenotes/notes/fix-keep-copyreg-29c28bcc854e13bb.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix a bug that caused traceback objects to fail to pickle when using gevent.
+    gevent: Fix a bug that caused traceback objects to fail to pickle when using gevent.


### PR DESCRIPTION
Some frameworks might extend the pickle capabilities by interacting with the copyreg module. Unloading it as part of the module clean-up process causes issues, so we add it to the list of modules to keep.

Fixes: #5742 

## Testing strategy

The issue does not occur when the library is installed in edit mode, which makes it tricky to test with `riot` in our CI. Manual testing shows that issue that prompted this fix is resolved.

## Risk

Because we don't have a reproducer in our test suite we are left vulnerable to regressions.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
