### PR TITLE
fix(telemetry): resolve unboundlocalerror raised by get_connection

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -72,6 +72,7 @@ class _TelemetryClient:
         # type: (Dict) -> Optional[httplib.HTTPResponse]
         """Sends a telemetry request to the trace agent"""
         resp = None
+        conn = None
         try:
             rb_json = self._encoder.encode(request)
             headers = self.get_headers(request)
@@ -86,7 +87,8 @@ class _TelemetryClient:
         except Exception:
             log.debug("failed to send telemetry to the Datadog Agent at %s.", self.url, exc_info=True)
         finally:
-            conn.close()
+            if conn is not None:
+                conn.close()
         return resp
 
     def get_headers(self, request):


### PR DESCRIPTION
`conn` will be uninitialized if `ddtrace.internal.agent.get_connection()` raises an exception. Calling method on an initalized object raises an `UnboundLocalError`.

This fix resolves an edge case in an internal feature. A release note is not required. 

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
