### PR TITLE
feat(openai): add support for tagging by API key

### DIFF
--- a/tests/contrib/openai/cassettes/chat_completion_streamed_async.yaml
+++ b/tests/contrib/openai/cassettes/chat_completion_streamed_async.yaml
@@ -1,0 +1,217 @@
+interactions:
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "Who
+      is the captain of the toronto maple leafs?"}], "stream": true}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.6
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.6", "httplib": "requests", "lang": "python", "lang_version":
+        "3.10.3", "platform": "macOS-13.3.1-arm64-arm-64bit", "publisher": "openai",
+        "uname": "Darwin 22.4.0 Darwin Kernel Version 22.4.0: Mon Mar  6 20:59:28
+        PST 2023; root:xnu-8796.101.5~3/RELEASE_ARM64_T6000 arm64"}'
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"role":"assistant"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"As"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        an"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        AI"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        language"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        model"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":","},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        I"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        do"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        not"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        have"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        access"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        to"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        real"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"-time"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        information"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        but"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        as"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        of"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        the"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        "},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"202"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"1"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        season"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":","},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        the"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        captain"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        of"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        the"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        Toronto"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        Maple"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        Leafs"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        is"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        John"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        T"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"ava"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"res"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"."},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-7CIrjpHzy1lBX552SIFeRg4qC7a92","object":"chat.completion.chunk","created":1683166811,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{},"index":0,"finish_reason":"stop"}]}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 7c1d435d7c64ff80-BOS
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Thu, 04 May 2023 02:20:12 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0301
+      openai-organization:
+      - datadog-4
+      openai-processing-ms:
+      - '217'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3500'
+      x-ratelimit-limit-tokens:
+      - '90000'
+      x-ratelimit-remaining-requests:
+      - '3499'
+      x-ratelimit-remaining-tokens:
+      - '89971'
+      x-ratelimit-reset-requests:
+      - 17ms
+      x-ratelimit-reset-tokens:
+      - 19ms
+      x-request-id:
+      - ae37625587fbd4f3417dcd7d042f8d3d
+    status:
+      code: 200
+      message: OK
+    url: https://api.openai.com/v1/chat/completions
+version: 1

--- a/tests/contrib/openai/test_openai.py
+++ b/tests/contrib/openai/test_openai.py
@@ -128,7 +128,7 @@ def snapshot_tracer(openai, patch_openai, mock_logs, mock_metrics):
     pin = Pin.get_from(openai)
     pin.tracer.configure(settings={"FILTERS": [FilterOrg()]})
 
-    yield
+    yield pin.tracer
 
     mock_logs.reset_mock()
     mock_metrics.reset_mock()
@@ -219,6 +219,7 @@ def test_completion(openai, openai_vcr, mock_metrics, snapshot_tracer):
         "openai.endpoint:completions",
         "openai.organization.id:",
         "openai.organization.name:datadog-4",
+        "openai.user.api_key:sk-...key>",
         "error:0",
     ]
     mock_metrics.assert_has_calls(
@@ -302,6 +303,7 @@ async def test_acompletion(openai, openai_vcr, mock_metrics, mock_logs, snapshot
         "openai.endpoint:completions",
         "openai.organization.id:",
         "openai.organization.name:datadog-4",
+        "openai.user.api_key:sk-...key>",
         "error:0",
     ]
     mock_metrics.assert_has_calls(
@@ -392,7 +394,7 @@ def test_logs_completions(openai_vcr, openai, ddtrace_config_openai, mock_logs, 
                     "ddsource": "openai",
                     "service": "",
                     "status": "info",
-                    "ddtags": "env:,version:,openai.endpoint:completions,openai.model:ada,openai.organization.name:datadog-4",  # noqa: E501
+                    "ddtags": "env:,version:,openai.endpoint:completions,openai.model:ada,openai.organization.name:datadog-4,openai.user.api_key:sk-...key>",  # noqa: E501
                     "dd.trace_id": str(trace_id),
                     "dd.span_id": str(span_id),
                     "prompt": "Hello world",
@@ -427,6 +429,7 @@ def test_global_tags(openai_vcr, ddtrace_config_openai, openai, mock_metrics, mo
     assert span.get_tag("openai.model") == "ada"
     assert span.get_tag("openai.endpoint") == "completions"
     assert span.get_tag("openai.organization.name") == "datadog-4"
+    assert span.get_tag("openai.user.api_key") == "sk-...key>"
 
     for _, args, kwargs in mock_metrics.mock_calls:
         expected_metrics = [
@@ -436,6 +439,7 @@ def test_global_tags(openai_vcr, ddtrace_config_openai, openai, mock_metrics, mo
             "openai.model:ada",
             "openai.endpoint:completions",
             "openai.organization.name:datadog-4",
+            "openai.user.api_key:sk-...key>",
         ]
         actual_tags = kwargs.get("tags")
         for m in expected_metrics:
@@ -448,7 +452,7 @@ def test_global_tags(openai_vcr, ddtrace_config_openai, openai, mock_metrics, mo
         assert log["service"] == "test-svc"
         assert (
             log["ddtags"]
-            == "env:staging,version:1234,openai.endpoint:completions,openai.model:ada,openai.organization.name:datadog-4"  # noqa: E501
+            == "env:staging,version:1234,openai.endpoint:completions,openai.model:ada,openai.organization.name:datadog-4,openai.user.api_key:sk-...key>"  # noqa: E501
         )
 
 
@@ -543,10 +547,8 @@ def test_completion_stream(openai, openai_vcr, mock_metrics, mock_tracer):
     assert completion == '! ... A page layouts page drawer? ... Interesting. The "Tools" is'
 
     traces = mock_tracer.pop_traces()
-    assert len(traces) == 2
-    t1, t2 = traces
-    assert len(t1) == len(t2) == 1
-    assert t2[0].parent_id == t1[0].span_id
+    assert len(traces) == 1
+    assert len(traces[0]) == 1
 
     expected_tags = [
         "version:",
@@ -555,30 +557,14 @@ def test_completion_stream(openai, openai_vcr, mock_metrics, mock_tracer):
         "openai.model:ada",
         "openai.endpoint:completions",
         "openai.organization.id:",
-        "openai.organization.name:",
+        "openai.organization.name:user-f23xvdxbrssd56y1ghcjdcue",
+        "openai.user.api_key:sk-...key>",
         "error:0",
         "openai.estimated:true",
     ]
-    mock_metrics.assert_has_calls(
-        [
-            mock.call.distribution(
-                "tokens.prompt",
-                2,
-                tags=expected_tags,
-            ),
-            mock.call.distribution(
-                "tokens.completion",
-                len(chunks),
-                tags=expected_tags,
-            ),
-            mock.call.distribution(
-                "tokens.total",
-                len(chunks) + 2,
-                tags=expected_tags,
-            ),
-        ],
-        any_order=True,
-    )
+    assert mock.call.distribution("tokens.prompt", 2, tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.distribution("tokens.completion", len(chunks), tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.distribution("tokens.total", len(chunks) + 2, tags=expected_tags) in mock_metrics.mock_calls
 
 
 @pytest.mark.asyncio
@@ -592,10 +578,7 @@ async def test_completion_async_stream(openai, openai_vcr, mock_metrics, mock_tr
     assert completion == "\" and just start creating stuff. Don't expect it to draw like this."
 
     traces = mock_tracer.pop_traces()
-    assert len(traces) == 2
-    t1, t2 = traces
-    assert len(t1) == len(t2) == 1
-    assert t2[0].parent_id == t1[0].span_id
+    assert len(traces) == 1
 
     expected_tags = [
         "version:",
@@ -604,34 +587,18 @@ async def test_completion_async_stream(openai, openai_vcr, mock_metrics, mock_tr
         "openai.model:ada",
         "openai.endpoint:completions",
         "openai.organization.id:",
-        "openai.organization.name:",
+        "openai.organization.name:datadog-4",
+        "openai.user.api_key:sk-...key>",
         "error:0",
         "openai.estimated:true",
     ]
-    mock_metrics.assert_has_calls(
-        [
-            mock.call.distribution(
-                "tokens.prompt",
-                2,
-                tags=expected_tags,
-            ),
-            mock.call.distribution(
-                "tokens.completion",
-                len(chunks),
-                tags=expected_tags,
-            ),
-            mock.call.distribution(
-                "tokens.total",
-                len(chunks) + 2,
-                tags=expected_tags,
-            ),
-        ],
-        any_order=True,
-    )
+    assert mock.call.distribution("tokens.prompt", 2, tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.distribution("tokens.completion", len(chunks), tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.distribution("tokens.total", len(chunks) + 2, tags=expected_tags) in mock_metrics.mock_calls
 
 
 @pytest.mark.snapshot(ignores=["meta.http.useragent"])
-def test_chat_completion_stream(openai, openai_vcr, snapshot_tracer):
+def test_chat_completion_stream(openai, openai_vcr, mock_metrics, snapshot_tracer):
     if not hasattr(openai, "ChatCompletion"):
         pytest.skip("ChatCompletion not supported for this version of openai")
 
@@ -643,10 +610,75 @@ def test_chat_completion_stream(openai, openai_vcr, snapshot_tracer):
             ],
             stream=True,
         )
+        span = snapshot_tracer.current_span()
         chunks = [c for c in resp]
         assert len(chunks) == 15
         completion = "".join([c["choices"][0]["delta"].get("content", "") for c in chunks])
         assert completion == "The Los Angeles Dodgers won the World Series in 2020."
+
+    expected_tags = [
+        "version:",
+        "env:",
+        "service:",
+        "openai.model:gpt-3.5-turbo",
+        "openai.endpoint:chat.completions",
+        "openai.organization.id:",
+        "openai.organization.name:user-f23xvdxbrssd56y1ghcjdcue",
+        "openai.user.api_key:sk-...key>",
+        "error:0",
+    ]
+    assert mock.call.distribution("request.duration", span.duration_ns, tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.gauge("ratelimit.requests", "3", tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.gauge("ratelimit.remaining.requests", "2", tags=expected_tags) in mock_metrics.mock_calls
+    expected_tags += ["openai.estimated:true"]
+    assert mock.call.distribution("tokens.prompt", 8, tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.distribution("tokens.completion", len(chunks), tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.distribution("tokens.total", len(chunks) + 8, tags=expected_tags) in mock_metrics.mock_calls
+
+
+@pytest.mark.snapshot(ignores=["meta.http.useragent"])
+@pytest.mark.asyncio
+async def test_chat_completion_async_stream(openai, openai_vcr, mock_metrics, snapshot_tracer):
+    if not hasattr(openai, "ChatCompletion"):
+        pytest.skip("ChatCompletion not supported for this version of openai")
+
+    with openai_vcr.use_cassette("chat_completion_streamed_async.yaml"):
+        resp = await openai.ChatCompletion.acreate(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "user", "content": "Who is the captain of the toronto maple leafs?"},
+            ],
+            stream=True,
+        )
+        span = snapshot_tracer.current_span()
+        chunks = [c async for c in resp]
+        assert len(chunks) == 39
+        completion = "".join([c["choices"][0]["delta"].get("content", "") for c in chunks])
+        assert (
+            completion
+            == "As an AI language model, I do not have access to real-time information but as of the 2021 season, the captain of the Toronto Maple Leafs is John Tavares."  # noqa: E501
+        )
+
+    expected_tags = [
+        "version:",
+        "env:",
+        "service:",
+        "openai.model:gpt-3.5-turbo",
+        "openai.endpoint:chat.completions",
+        "openai.organization.id:",
+        "openai.organization.name:datadog-4",
+        "openai.user.api_key:sk-...key>",
+        "error:0",
+    ]
+    assert mock.call.distribution("request.duration", span.duration_ns, tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.gauge("ratelimit.requests", "3500", tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.gauge("ratelimit.tokens", "90000", tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.gauge("ratelimit.remaining.requests", "3499", tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.gauge("ratelimit.remaining.tokens", "89971", tags=expected_tags) in mock_metrics.mock_calls
+    expected_tags += ["openai.estimated:true"]
+    assert mock.call.distribution("tokens.prompt", 10, tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.distribution("tokens.completion", len(chunks), tags=expected_tags) in mock_metrics.mock_calls
+    assert mock.call.distribution("tokens.total", len(chunks) + 10, tags=expected_tags) in mock_metrics.mock_calls
 
 
 @pytest.mark.snapshot(ignores=["meta.http.useragent"], async_mode=False)

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_achat_completion.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_achat_completion.json
@@ -32,7 +32,8 @@
       "openai.response.choices.1.message.content": "The 2020 World Series was played in Globe Life Field in Arlington, Texas.",
       "openai.response.choices.1.message.role": "assistant",
       "openai.response.object": "chat.completion",
-      "runtime-id": "2f435e80baf945dfbfe44fdeb4837898"
+      "openai.user.api_key": "sk-...key>",
+      "runtime-id": "8154bd1813ea422fa959cacf3fdfa1bc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
@@ -45,8 +46,8 @@
       "openai.response.usage.completion_tokens": 34,
       "openai.response.usage.prompt_tokens": 57,
       "openai.response.usage.total_tokens": 91,
-      "process_id": 82481
+      "process_id": 14806
     },
-    "duration": 1192000,
-    "start": 1682540724470348000
+    "duration": 1189000,
+    "start": 1683148556484839000
   }]]

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_acompletion.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_acompletion.json
@@ -23,7 +23,8 @@
       "openai.response.choices.0.logprobs": "returned",
       "openai.response.choices.0.text": " I am; and I am in a sense a non-human entity woven together from memories, desires and emotions. But, who is to say that I am n...",
       "openai.response.object": "text_completion",
-      "runtime-id": "2f435e80baf945dfbfe44fdeb4837898"
+      "openai.user.api_key": "sk-...key>",
+      "runtime-id": "8154bd1813ea422fa959cacf3fdfa1bc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
@@ -38,8 +39,8 @@
       "openai.response.usage.completion_tokens": 150,
       "openai.response.usage.prompt_tokens": 10,
       "openai.response.usage.total_tokens": 160,
-      "process_id": 82481
+      "process_id": 14806
     },
-    "duration": 1434000,
-    "start": 1682540724341773000
+    "duration": 1166000,
+    "start": 1683148556287285000
   }]]

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_aembedding.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_aembedding.json
@@ -19,7 +19,8 @@
       "openai.organization.ratelimit.requests.remaining": "2999",
       "openai.request.input": "hello world",
       "openai.request.model": "text-embedding-ada-002",
-      "runtime-id": "2f435e80baf945dfbfe44fdeb4837898"
+      "openai.user.api_key": "sk-...key>",
+      "runtime-id": "8154bd1813ea422fa959cacf3fdfa1bc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
@@ -31,8 +32,8 @@
       "openai.response.data.num-embeddings": 1,
       "openai.response.usage.prompt_tokens": 2,
       "openai.response.usage.total_tokens": 2,
-      "process_id": 82481
+      "process_id": 14806
     },
-    "duration": 1323000,
-    "start": 1682540724512000000
+    "duration": 1309000,
+    "start": 1683148556521424000
   }]]

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_chat_completion.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_chat_completion.json
@@ -32,7 +32,8 @@
       "openai.response.choices.1.message.content": "The 2020 World Series was played at Globe Life Field in Arlington, Texas.",
       "openai.response.choices.1.message.role": "assistant",
       "openai.response.object": "chat.completion",
-      "runtime-id": "2f435e80baf945dfbfe44fdeb4837898"
+      "openai.user.api_key": "sk-...key>",
+      "runtime-id": "8154bd1813ea422fa959cacf3fdfa1bc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
@@ -45,8 +46,8 @@
       "openai.response.usage.completion_tokens": 34,
       "openai.response.usage.prompt_tokens": 57,
       "openai.response.usage.total_tokens": 91,
-      "process_id": 82481
+      "process_id": 14806
     },
-    "duration": 2758000,
-    "start": 1682540724419845000
+    "duration": 2540000,
+    "start": 1683148556436719000
   }]]

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_chat_completion_async_stream.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_chat_completion_async_stream.json
@@ -15,13 +15,14 @@
       "language": "python",
       "openai.endpoint": "chat.completions",
       "openai.model": "gpt-3.5-turbo",
-      "openai.organization.name": "user-f23xvdxbrssd56y1ghcjdcue",
-      "openai.organization.ratelimit.requests.remaining": "2",
-      "openai.request.messages.0.content": "Who won the world series in 2020?",
+      "openai.organization.name": "datadog-4",
+      "openai.organization.ratelimit.requests.remaining": "3499",
+      "openai.organization.ratelimit.tokens.remaining": "89971",
+      "openai.request.messages.0.content": "Who is the captain of the toronto maple leafs?",
       "openai.request.messages.0.role": "user",
       "openai.request.stream": "True",
       "openai.user.api_key": "sk-...key>",
-      "runtime-id": "8154bd1813ea422fa959cacf3fdfa1bc"
+      "runtime-id": "c3d12e5c2db84163adebb341d1f6dfa0"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
@@ -29,11 +30,11 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "openai.response.usage.completion_tokens": 15,
-      "openai.response.usage.prompt_tokens": 8,
-      "openai.response.usage.total_tokens": 23,
-      "process_id": 14806
+      "openai.response.usage.completion_tokens": 39,
+      "openai.response.usage.prompt_tokens": 10,
+      "openai.response.usage.total_tokens": 49,
+      "process_id": 54107
     },
-    "duration": 3112000,
-    "start": 1683148556666996000
+    "duration": 10299000,
+    "start": 1683166822191748000
   }]]

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_completion.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_completion.json
@@ -27,7 +27,8 @@
       "openai.response.choices.1.logprobs": "returned",
       "openai.response.choices.1.text": " (1",
       "openai.response.object": "text_completion",
-      "runtime-id": "2f435e80baf945dfbfe44fdeb4837898"
+      "openai.user.api_key": "sk-...key>",
+      "runtime-id": "8154bd1813ea422fa959cacf3fdfa1bc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
@@ -42,8 +43,8 @@
       "openai.response.usage.completion_tokens": 12,
       "openai.response.usage.prompt_tokens": 2,
       "openai.response.usage.total_tokens": 14,
-      "process_id": 82481
+      "process_id": 14806
     },
-    "duration": 16967000,
-    "start": 1682540724264327000
+    "duration": 12100000,
+    "start": 1683148556156614000
   }]]

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_embedding.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_embedding.json
@@ -19,7 +19,8 @@
       "openai.organization.ratelimit.requests.remaining": "2999",
       "openai.request.input": "hello world",
       "openai.request.model": "text-embedding-ada-002",
-      "runtime-id": "2f435e80baf945dfbfe44fdeb4837898"
+      "openai.user.api_key": "sk-...key>",
+      "runtime-id": "8154bd1813ea422fa959cacf3fdfa1bc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
@@ -31,8 +32,8 @@
       "openai.response.data.num-embeddings": 1,
       "openai.response.usage.prompt_tokens": 2,
       "openai.response.usage.total_tokens": 2,
-      "process_id": 82481
+      "process_id": 14806
     },
-    "duration": 2626000,
-    "start": 1682540724489205000
+    "duration": 2550000,
+    "start": 1683148556502335000
   }]]

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_integration_async.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_integration_async.json
@@ -23,7 +23,8 @@
       "openai.response.choices.0.logprobs": "returned",
       "openai.response.choices.0.text": ",\" a male farrago, or \"voices of the people.\" If",
       "openai.response.object": "text_completion",
-      "runtime-id": "35c3f07dcc184e90ae7a1f033948388e"
+      "openai.user.api_key": "sk-...eal>",
+      "runtime-id": "e7e8e1729b2748a6811fe03920383ea8"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
@@ -32,8 +33,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "openai.response.choices.num": 1,
-      "process_id": 92964
+      "process_id": 14817
     },
-    "duration": 8388000,
-    "start": 1682542462368434000
+    "duration": 7521000,
+    "start": 1683148557799162000
   }]]

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_integration_sync.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_integration_sync.json
@@ -23,7 +23,8 @@
       "openai.response.choices.0.logprobs": "returned",
       "openai.response.choices.0.text": "-to-me they will happen.\\n\\nBoth techniques were invented from experience",
       "openai.response.object": "text_completion",
-      "runtime-id": "23f762fd4d0b4cd896ddcebde9a92d62"
+      "openai.user.api_key": "sk-...eal>",
+      "runtime-id": "cf048dcf95484c74a7e7a1b144eba095"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
@@ -32,10 +33,10 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "openai.response.choices.num": 1,
-      "process_id": 74717
+      "process_id": 14813
     },
-    "duration": 15800000,
-    "start": 1682540152858064000
+    "duration": 11498000,
+    "start": 1683148557194072000
   },
      {
        "name": "requests.request",
@@ -51,13 +52,13 @@
          "http.method": "POST",
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/completions",
-         "http.useragent": "OpenAI/v1 PythonBindings/0.27.4",
+         "http.useragent": "OpenAI/v1 PythonBindings/0.27.6",
          "span.kind": "client"
        },
        "metrics": {
          "_dd.measured": 1,
          "_dd.top_level": 1
        },
-       "duration": 2758000,
-       "start": 1682540152870161000
+       "duration": 2319000,
+       "start": 1683148557202475000
      }]]

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_misuse.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_misuse.json
@@ -13,12 +13,13 @@
       "api_base": "https://api.openai.com/v1",
       "component": "openai",
       "error.message": "Must provide an 'engine' or 'model' parameter to create a <class 'openai.api_resources.completion.Completion'>",
-      "error.stack": "Traceback (most recent call last):\n  File \"/Users/kverhoog/dev/dd-trace-py/ddtrace/contrib/openai/patch.py\", line 303, in patched_endpoint\n    resp = func(*args, **kwargs)\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.9/site-packages/openai/api_resources/completion.py\", line 25, in create\n    return super().create(*args, **kwargs)\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.9/site-packages/openai/api_resources/abstract/engine_api_resource.py\", line 149, in create\n    ) = cls.__prepare_create_request(\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.9/site-packages/openai/api_resources/abstract/engine_api_resource.py\", line 90, in __prepare_create_request\n    raise error.InvalidRequestError(\nopenai.error.InvalidRequestError: Must provide an 'engine' or 'model' parameter to create a <class 'openai.api_resources.completion.Completion'>\n",
+      "error.stack": "Traceback (most recent call last):\n  File \"/Users/kverhoog/dev/dd-trace-py/ddtrace/contrib/openai/patch.py\", line 348, in patched_endpoint\n    resp = func(*args, **kwargs)\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.10/site-packages/openai/api_resources/completion.py\", line 25, in create\n    return super().create(*args, **kwargs)\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.10/site-packages/openai/api_resources/abstract/engine_api_resource.py\", line 149, in create\n    ) = cls.__prepare_create_request(\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.10/site-packages/openai/api_resources/abstract/engine_api_resource.py\", line 90, in __prepare_create_request\n    raise error.InvalidRequestError(\nopenai.error.InvalidRequestError: Must provide an 'engine' or 'model' parameter to create a <class 'openai.api_resources.completion.Completion'>\n",
       "error.type": "openai.error.InvalidRequestError",
       "language": "python",
       "openai.endpoint": "completions",
       "openai.request.prompt": "",
-      "runtime-id": "2f435e80baf945dfbfe44fdeb4837898"
+      "openai.user.api_key": "sk-...key>",
+      "runtime-id": "8154bd1813ea422fa959cacf3fdfa1bc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
@@ -26,8 +27,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 82481
+      "process_id": 14806
     },
-    "duration": 1154000,
-    "start": 1682540724572204000
+    "duration": 466000,
+    "start": 1683148556553446000
   }]]


### PR DESCRIPTION
Support tagging traces, logs and metrics with the API key. This enables OpenAI admins and users to see usage per-API key. The API key is obfuscated to include only the last 4 characters which is what OpenAI displays in their UI.

Note: with this change, we no longer trace streamed responses and instead include that in the initial openai request/response span. This was done since having the stream captured in the request span itself is likely more useful to users than having a disjointed trace. For example:
Previous behavior:
<img width="1141" alt="Screenshot 2023-05-04 at 10 02 39 PM" src="https://user-images.githubusercontent.com/35776586/236363999-a61737e7-76a5-4a20-9e66-bea34ba9ccf1.png">

Trace behavior after this change:
<img width="1144" alt="Screenshot 2023-05-04 at 10 02 24 PM" src="https://user-images.githubusercontent.com/35776586/236363976-aa34a907-8ad5-40d9-9533-e3706f88b9ed.png">
The one risk is if a user never consumers the stream generator, then this span will never be finished. This is a low risk, but should be addressed as a future step.


## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
