### PR TITLE
chore(ci): fix python interpreter versions in lockfile github action

### DIFF
--- a/.github/workflows/requirements-locks.yml
+++ b/.github/workflows/requirements-locks.yml
@@ -19,9 +19,6 @@ jobs:
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Set python interpreters
-        run: pyenv global 3.10.3 2.7.18 3.5.10 3.6.15 3.7.13 3.8.13 3.9.11 3.11.0
-
       - name: Install Dependencies
         run: pip install --upgrade pip && pip install riot
 

--- a/.github/workflows/requirements-locks.yml
+++ b/.github/workflows/requirements-locks.yml
@@ -19,6 +19,9 @@ jobs:
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Set python interpreters
+        run: pyenv global 3.10 2.7 3.5 3.6 3.7 3.8 3.9 3.11 3.12
+
       - name: Install Dependencies
         run: pip install --upgrade pip && pip install riot
 

--- a/.github/workflows/requirements-locks.yml
+++ b/.github/workflows/requirements-locks.yml
@@ -20,7 +20,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Set python interpreters
-        run: pyenv global 3.10 2.7 3.5 3.6 3.7 3.8 3.9 3.11 3.12
+        run: pyenv global 3.10 2.7 3.5 3.6 3.7 3.8 3.9 3.11
 
       - name: Install Dependencies
         run: pip install --upgrade pip && pip install riot


### PR DESCRIPTION
This PR modifies a step in the requirements lockfile check github action, which was to globally specify all python interpreters required for the riot lockfile check. Since this action runs using the testrunner docker image which already has the required interpreters, this step was changed to only specify the minor version which should still automatically match with the testrunner's installed python versions, making this more resistant to changes in the testrunner.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
