### PR TITLE
fix(ci): remove unnecessary pyenv global call from requirements check

### DIFF
--- a/.github/workflows/requirements-locks.yml
+++ b/.github/workflows/requirements-locks.yml
@@ -20,8 +20,9 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: List available Python versions
-        run: pyenv versions
-        run: pyenv global
+        run: |
+          pyenv versions
+          pyenv global
 
       - name: Install Dependencies
         run: pip install --upgrade pip && pip install riot

--- a/.github/workflows/requirements-locks.yml
+++ b/.github/workflows/requirements-locks.yml
@@ -19,8 +19,9 @@ jobs:
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Set python interpreters
-        run: pyenv global 3.10.3 2.7.18 3.5.10 3.6.15 3.7.13 3.8.13 3.9.11 3.11.0
+      - name: List available Python versions
+        run: pyenv versions
+        run: pyenv global
 
       - name: Install Dependencies
         run: pip install --upgrade pip && pip install riot


### PR DESCRIPTION
Since we are using our `testrunner` docker image, this should not be necessary as they are already set.

I have replaced the call with calls to `pyenv versions` to list all installed versions, and `pyenv global` to confirm which versions are set as global (and in what order!)

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
