### PR TITLE
chore(asm): replace magic strings with constant in appsec blocking logic

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -2,6 +2,7 @@ import contextlib
 from typing import TYPE_CHECKING
 
 from ddtrace import config
+from ddtrace.appsec._constants import BLOCKED
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.internal import _context
 from ddtrace.internal.logger import get_logger
@@ -77,7 +78,7 @@ def is_blocked():  # type: () -> bool
         env = _ASM.get()
         if not env.active or env.span is None:
             return False
-        return _context.get_item("http.request.blocked", span=env.span)
+        return _context.get_item(BLOCKED, span=env.span)
     except BaseException:
         return False
 

--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -13,6 +13,7 @@ from ddtrace.ext import http
 from ddtrace.internal.constants import COMPONENT
 
 from .. import trace_utils
+from ...appsec._constants import BLOCKED
 from ...internal import _context
 from ...internal.compat import reraise
 from ...internal.logger import get_logger
@@ -80,7 +81,7 @@ def span_from_scope(scope):
 
 
 def _request_blocked(span):
-    return span and config._appsec_enabled and _context.get_item("http.request.blocked", span=span)
+    return span and config._appsec_enabled and _context.get_item(BLOCKED, span=span)
 
 
 async def _blocked_asgi_app(scope, receive, send):

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -8,6 +8,7 @@ from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import abort
 import xmltodict
 
+from ddtrace.appsec._constants import BLOCKED
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec.iast._patch import if_iast_taint_returned_object_for
 from ddtrace.appsec.iast._patch import if_iast_taint_yield_tuple_for
@@ -147,10 +148,10 @@ class _FlaskWSGIMiddleware(_DDWSGIMiddlewareBase):
             req_span, config.flask, status_code=code, response_headers=headers, route=req_span.get_tag(FLASK_URL_RULE)
         )
 
-        if config._appsec_enabled and not _context.get_item("http.request.blocked", span=req_span):
+        if config._appsec_enabled and not _context.get_item(BLOCKED, span=req_span):
             log.debug("Flask WAF call for Suspicious Request Blocking on response")
             _asm_request_context.call_waf_callback()
-            if _context.get_item("http.request.blocked", span=req_span):
+            if _context.get_item(BLOCKED, span=req_span):
                 # response code must be set here, or it will be too late
                 ctype = (
                     "text/html"
@@ -647,7 +648,7 @@ def _set_block_tags(span):
 
 def _block_request_callable(span):
     request = flask.request
-    _context.set_item("http.request.blocked", True, span=span)
+    _context.set_item(BLOCKED, True, span=span)
     _set_block_tags(span)
     ctype = "text/html" if "text/html" in request.headers.get("Accept", "").lower() else "text/json"
     abort(flask.Response(utils._get_blocked_template(ctype), content_type=ctype, status=403))
@@ -678,7 +679,7 @@ def request_tracer(name):
             request_span.set_tag_str(COMPONENT, config.flask.integration_name)
 
             request_span._ignore_exception(werkzeug.exceptions.NotFound)
-            if config._appsec_enabled and _context.get_item("http.request.blocked", span=span):
+            if config._appsec_enabled and _context.get_item(BLOCKED, span=span):
                 _asm_request_context.block_request()
             return wrapped(*args, **kwargs)
 

--- a/ddtrace/contrib/wsgi/wsgi.py
+++ b/ddtrace/contrib/wsgi/wsgi.py
@@ -36,6 +36,7 @@ from ddtrace.vendor import wrapt
 
 from .. import trace_utils
 from ...appsec import utils
+from ...appsec._constants import BLOCKED
 from ...constants import SPAN_KIND
 from ...internal import _context
 
@@ -164,7 +165,7 @@ class _DDWSGIMiddlewareBase(object):
 
             if self.tracer._appsec_enabled:
                 # [IP Blocking]
-                if _context.get_item("http.request.blocked", span=req_span):
+                if _context.get_item(BLOCKED, span=req_span):
                     ctype, content = self._make_block_content(environ, headers, req_span)
                     start_response("403 FORBIDDEN", [("content-type", ctype)])
                     closing_iterator = [content]
@@ -199,7 +200,7 @@ class _DDWSGIMiddlewareBase(object):
                     app_span.finish()
                     req_span.finish()
                     raise
-                if self.tracer._appsec_enabled and _context.get_item("http.request.blocked", span=req_span):
+                if self.tracer._appsec_enabled and _context.get_item(BLOCKED, span=req_span):
                     # [Suspicious Request Blocking on request or response]
                     _, content = self._make_block_content(environ, headers, req_span)
                     closing_iterator = [content]


### PR DESCRIPTION
This change makes the ASM request blocking code slightly more readable and less error-prone by replacing magic strings with a constant.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
