### PR TITLE
chore(service_naming): multiple contribs

### DIFF
--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -9,6 +9,7 @@ from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...ext import http
 from ...internal.compat import stringify
+from ...internal.schema import schematize_url_operation
 from ..asyncio import context_provider
 
 
@@ -43,7 +44,7 @@ async def trace_middleware(app, handler):
 
         # trace the handler
         request_span = tracer.trace(
-            "aiohttp.request",
+            schematize_url_operation("aiohttp.request", protocol="http", direction="inbound"),
             service=service,
             span_type=SpanTypes.WEB,
         )

--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -13,6 +13,7 @@ from ddtrace.vendor import wrapt
 from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...internal.compat import parse
+from ...internal.schema import schematize_url_operation
 from ...pin import Pin
 from ...propagation.http import HTTPPropagator
 from ..trace_utils import ext_service
@@ -71,7 +72,9 @@ async def _traced_clientsession_request(aiohttp, pin, func, instance, args, kwar
     headers = kwargs.get("headers") or {}
 
     with pin.tracer.trace(
-        "aiohttp.request", span_type=SpanTypes.HTTP, service=ext_service(pin, config.aiohttp_client)
+        schematize_url_operation("aiohttp.request", protocol="http", direction="outbound"),
+        span_type=SpanTypes.HTTP,
+        service=ext_service(pin, config.aiohttp_client),
     ) as span:
         if pin._config["distributed_tracing"]:
             HTTPPropagator.inject(span.context, headers)

--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -11,6 +11,7 @@ from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import http
 from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal.schema import schematize_url_operation
 
 from .. import trace_utils
 from ...internal import _context
@@ -133,10 +134,12 @@ class TraceMiddleware:
             ip = ""
 
         resource = " ".join((scope["method"], scope["path"]))
+        operation_name = self.integration_config.get("request_span_name", "asgi.request")
+        operation_name = schematize_url_operation(operation_name, direction="inbound", protocol="http")
 
         with _asm_request_context.asm_request_context_manager(ip, headers):
             span = self.tracer.trace(
-                name=self.integration_config.get("request_span_name", "asgi.request"),
+                name=operation_name,
                 service=trace_utils.int_service(None, self.integration_config),
                 resource=resource,
                 span_type=SpanTypes.WEB,

--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -13,6 +13,7 @@ from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanKind
 from ...ext import SpanTypes
+from ...internal.schema import schematize_url_operation
 from ...internal.utils.formats import asbool
 
 
@@ -46,7 +47,7 @@ class TracePlugin(object):
             )
 
             with self.tracer.trace(
-                "bottle.request",
+                schematize_url_operation("bottle.request", protocol="http", direction="inbound"),
                 service=self.service,
                 resource=resource,
                 span_type=SpanTypes.WEB,

--- a/ddtrace/contrib/cherrypy/middleware.py
+++ b/ddtrace/contrib/cherrypy/middleware.py
@@ -18,6 +18,8 @@ from .. import trace_utils
 from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...internal import compat
+from ...internal.schema import schematize_service_name
+from ...internal.schema import schematize_url_operation
 from ...internal.utils.formats import asbool
 
 
@@ -32,7 +34,7 @@ config._add(
     ),
 )
 
-SPAN_NAME = "cherrypy.request"
+SPAN_NAME = schematize_url_operation("cherrypy.request", protocol="http", direction="inbound")
 
 
 class TraceTool(cherrypy.Tool):
@@ -61,7 +63,7 @@ class TraceTool(cherrypy.Tool):
 
     @service.setter
     def service(self, service):
-        config.cherrypy["service"] = service
+        config.cherrypy["service"] = schematize_service_name(service)
 
     def _setup(self):
         cherrypy.Tool._setup(self)

--- a/ddtrace/contrib/falcon/middleware.py
+++ b/ddtrace/contrib/falcon/middleware.py
@@ -11,10 +11,12 @@ from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
 from ...internal.compat import iteritems
+from ...internal.schema import schematize_service_name
+from ...internal.schema import schematize_url_operation
 
 
 class TraceMiddleware(object):
-    def __init__(self, tracer, service="falcon", distributed_tracing=None):
+    def __init__(self, tracer, service=schematize_service_name("falcon"), distributed_tracing=None):
         # store tracing references
         self.tracer = tracer
         self.service = service
@@ -27,7 +29,7 @@ class TraceMiddleware(object):
         trace_utils.activate_distributed_headers(self.tracer, int_config=config.falcon, request_headers=headers)
 
         span = self.tracer.trace(
-            "falcon.request",
+            schematize_url_operation("falcon.request", protocol="http", direction="inbound"),
             service=self.service,
             span_type=SpanTypes.WEB,
         )

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -19,6 +19,8 @@ from ddtrace.internal.constants import COMPONENT
 from ...appsec import _asm_request_context
 from ...appsec import utils
 from ...internal import _context
+from ...internal.schema import schematize_service_name
+from ...internal.schema import schematize_url_operation
 
 
 # Not all versions of flask/werkzeug have this mixin
@@ -74,7 +76,7 @@ config._add(
     "flask",
     dict(
         # Flask service configuration
-        _default_service="flask",
+        _default_service=schematize_service_name("flask"),
         collect_view_args=True,
         distributed_tracing_enabled=True,
         template_default_name="<memory>",
@@ -125,7 +127,7 @@ def taint_request_init(wrapped, instance, args, kwargs):
 
 
 class _FlaskWSGIMiddleware(_DDWSGIMiddlewareBase):
-    _request_span_name = "flask.request"
+    _request_span_name = schematize_url_operation("flask.request", protocol="http", direction="inbound")
     _application_span_name = "flask.application"
     _response_span_name = "flask.response"
 

--- a/ddtrace/contrib/httplib/patch.py
+++ b/ddtrace/contrib/httplib/patch.py
@@ -16,6 +16,7 @@ from ...internal.compat import PY2
 from ...internal.compat import httplib
 from ...internal.compat import parse
 from ...internal.logger import get_logger
+from ...internal.schema import schematize_url_operation
 from ...internal.utils.formats import asbool
 from ...pin import Pin
 from ...propagation.http import HTTPPropagator
@@ -23,6 +24,7 @@ from ..trace_utils import unwrap as _u
 
 
 span_name = "httplib.request" if PY2 else "http.client.request"
+span_name = schematize_url_operation(span_name, protocol="http", direction="outbound")
 
 log = get_logger(__name__)
 

--- a/ddtrace/contrib/httpx/patch.py
+++ b/ddtrace/contrib/httpx/patch.py
@@ -15,6 +15,7 @@ from ddtrace.contrib.trace_utils import set_http_meta
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.version import parse_version
@@ -120,7 +121,8 @@ async def _wrapped_async_send(
     if not pin or not pin.enabled():
         return await wrapped(*args, **kwargs)
 
-    with pin.tracer.trace("http.request", service=_get_service_name(pin, req), span_type=SpanTypes.HTTP) as span:
+    operation_name = schematize_url_operation("http.request", protocol="http", direction="outbound")
+    with pin.tracer.trace(operation_name, service=_get_service_name(pin, req), span_type=SpanTypes.HTTP) as span:
         span.set_tag_str(COMPONENT, config.httpx.integration_name)
 
         # set span.kind to the operation type being performed
@@ -148,7 +150,8 @@ def _wrapped_sync_send(
 
     req = get_argument_value(args, kwargs, 0, "request")
 
-    with pin.tracer.trace("http.request", service=_get_service_name(pin, req), span_type=SpanTypes.HTTP) as span:
+    operation_name = schematize_url_operation("http.request", protocol="http", direction="outbound")
+    with pin.tracer.trace(operation_name, service=_get_service_name(pin, req), span_type=SpanTypes.HTTP) as span:
         span.set_tag_str(COMPONENT, config.httpx.integration_name)
 
         # set span.kind to the operation type being performed

--- a/ddtrace/contrib/molten/patch.py
+++ b/ddtrace/contrib/molten/patch.py
@@ -15,6 +15,8 @@ from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...internal.compat import urlencode
+from ...internal.schema import schematize_service_name
+from ...internal.schema import schematize_url_operation
 from ...internal.utils.formats import asbool
 from ...internal.utils.importlib import func_name
 from ...internal.utils.version import parse_version
@@ -32,7 +34,7 @@ MOLTEN_VERSION = parse_version(molten.__version__)
 config._add(
     "molten",
     dict(
-        _default_service="molten",
+        _default_service=schematize_service_name("molten"),
         distributed_tracing=asbool(os.getenv("DD_MOLTEN_DISTRIBUTED_TRACING", default=True)),
     ),
 )
@@ -87,7 +89,7 @@ def patch_app_call(wrapped, instance, args, kwargs):
     )
 
     with pin.tracer.trace(
-        "molten.request",
+        schematize_url_operation("molten.request", protocol="http", direction="inbound"),
         service=trace_utils.int_service(pin, config.molten),
         resource=resource,
         span_type=SpanTypes.WEB,

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -22,6 +22,8 @@ from ...ext import SpanTypes
 from ...ext import http
 from ...internal.compat import reraise
 from ...internal.logger import get_logger
+from ...internal.schema import schematize_service_name
+from ...internal.schema import schematize_url_operation
 from ...internal.utils.formats import asbool
 from .constants import CONFIG_MIDDLEWARE
 from .renderer import trace_rendering
@@ -38,7 +40,7 @@ _BODY_METHODS = {"POST", "PUT", "DELETE", "PATCH"}
 
 
 class PylonsTraceMiddleware(object):
-    def __init__(self, app, tracer, service="pylons", distributed_tracing=None):
+    def __init__(self, app, tracer, service=schematize_service_name("pylons"), distributed_tracing=None):
         self.app = app
         self._service = service
         self._tracer = tracer
@@ -86,7 +88,8 @@ class PylonsTraceMiddleware(object):
             self._tracer, int_config=ddconfig.pylons, request_headers=request.headers
         )
 
-        with self._tracer.trace("pylons.request", service=self._service, span_type=SpanTypes.WEB) as span:
+        span_name = schematize_url_operation("pylons.request", protocol="http", direction="inbound")
+        with self._tracer.trace(span_name, service=self._service, span_type=SpanTypes.WEB) as span:
             span.set_tag_str(COMPONENT, ddconfig.pylons.integration_name)
 
             # set span.kind to the type of operation being performed

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -15,6 +15,8 @@ from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...internal.logger import get_logger
+from ...internal.schema import schematize_service_name
+from ...internal.schema import schematize_url_operation
 from .constants import SETTINGS_ANALYTICS_ENABLED
 from .constants import SETTINGS_ANALYTICS_SAMPLE_RATE
 from .constants import SETTINGS_DISTRIBUTED_TRACING
@@ -61,7 +63,7 @@ def trace_render(func, instance, args, kwargs):
 def trace_tween_factory(handler, registry):
     # configuration
     settings = registry.settings
-    service = settings.get(SETTINGS_SERVICE) or "pyramid"
+    service = settings.get(SETTINGS_SERVICE) or schematize_service_name("pyramid")
     tracer = settings.get(SETTINGS_TRACER) or ddtrace.tracer
     enabled = asbool(settings.get(SETTINGS_TRACE_ENABLED, tracer.enabled))
     distributed_tracing = asbool(settings.get(SETTINGS_DISTRIBUTED_TRACING, True))
@@ -73,7 +75,8 @@ def trace_tween_factory(handler, registry):
                 tracer, int_config=config.pyramid, request_headers=request.headers, override=distributed_tracing
             )
 
-            with tracer.trace("pyramid.request", service=service, resource="404", span_type=SpanTypes.WEB) as span:
+            span_name = schematize_url_operation("pyramid.request", protocol="http", direction="inbound")
+            with tracer.trace(span_name, service=service, resource="404", span_type=SpanTypes.WEB) as span:
                 span.set_tag_str(COMPONENT, config.pyramid.integration_name)
 
                 # set span.kind to the type of operation being performed

--- a/ddtrace/contrib/requests/connection.py
+++ b/ddtrace/contrib/requests/connection.py
@@ -12,6 +12,7 @@ from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...internal.compat import parse
 from ...internal.logger import get_logger
+from ...internal.schema import schematize_url_operation
 from ...internal.utils import get_argument_value
 from ...propagation.http import HTTPPropagator
 
@@ -81,7 +82,8 @@ def _wrap_send(func, instance, args, kwargs):
     if service is None:
         service = trace_utils.ext_service(None, config.requests)
 
-    with tracer.trace("requests.request", service=service, span_type=SpanTypes.HTTP) as span:
+    operation_name = schematize_url_operation("requests.request", protocol="http", direction="outbound")
+    with tracer.trace(operation_name, service=service, span_type=SpanTypes.HTTP) as span:
         span.set_tag_str(COMPONENT, config.requests.integration_name)
 
         # set span.kind to the type of operation being performed

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -5,6 +5,7 @@ import requests
 from ddtrace import config
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
+from ...internal.schema import schematize_service_name
 from ...internal.utils.formats import asbool
 from ...pin import Pin
 from ..trace_utils import unwrap as _u
@@ -18,7 +19,7 @@ config._add(
         "distributed_tracing": asbool(os.getenv("DD_REQUESTS_DISTRIBUTED_TRACING", default=True)),
         "split_by_domain": asbool(os.getenv("DD_REQUESTS_SPLIT_BY_DOMAIN", default=False)),
         "default_http_tag_query_string": os.getenv("DD_HTTP_CLIENT_TAG_QUERY_STRING", "true"),
-        "_default_service": "requests",
+        "_default_service": schematize_service_name("requests"),
     },
 )
 

--- a/ddtrace/contrib/sanic/patch.py
+++ b/ddtrace/contrib/sanic/patch.py
@@ -9,6 +9,8 @@ from ddtrace.constants import SPAN_KIND
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal.schema import schematize_service_name
+from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.pin import Pin
 from ddtrace.vendor import wrapt
@@ -20,7 +22,7 @@ from ...internal.logger import get_logger
 
 log = get_logger(__name__)
 
-config._add("sanic", dict(_default_service="sanic", distributed_tracing=True))
+config._add("sanic", dict(_default_service=schematize_service_name("sanic"), distributed_tracing=True))
 
 SANIC_VERSION = (0, 0, 0)
 
@@ -196,7 +198,7 @@ def _create_sanic_request_span(request):
     trace_utils.activate_distributed_headers(ddtrace.tracer, int_config=config.sanic, request_headers=headers)
 
     span = pin.tracer.trace(
-        "sanic.request",
+        schematize_url_operation("sanic.request", protocol="http", direction="inbound"),
         service=trace_utils.int_service(None, config.sanic),
         resource=resource,
         span_type=SpanTypes.WEB,

--- a/ddtrace/contrib/tornado/application.py
+++ b/ddtrace/contrib/tornado/application.py
@@ -2,6 +2,7 @@ from tornado import template
 
 import ddtrace
 from ddtrace import config
+from ddtrace.internal.schema import schematize_service_name
 
 from . import context_provider
 from . import decorators
@@ -19,7 +20,7 @@ def tracer_config(__init__, app, args, kwargs):
     # default settings
     settings = {
         "tracer": ddtrace.tracer,
-        "default_service": config._get_service("tornado-web"),
+        "default_service": schematize_service_name(config._get_service("tornado-web")),
         "distributed_tracing": None,
         "analytics_enabled": None,
     }

--- a/ddtrace/contrib/tornado/handlers.py
+++ b/ddtrace/contrib/tornado/handlers.py
@@ -9,6 +9,7 @@ from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanKind
 from ...ext import SpanTypes
+from ...internal.schema import schematize_url_operation
 from ...internal.utils import ArgumentError
 from ...internal.utils import get_argument_value
 from ..trace_utils import set_http_meta
@@ -36,7 +37,7 @@ def execute(func, handler, args, kwargs):
 
         # store the request span in the request so that it can be used later
         request_span = tracer.trace(
-            "tornado.request",
+            schematize_url_operation("tornado.request", protocol="http", direction="inbound"),
             service=service,
             span_type=SpanTypes.WEB,
         )

--- a/ddtrace/contrib/urllib3/patch.py
+++ b/ddtrace/contrib/urllib3/patch.py
@@ -13,6 +13,8 @@ from ...constants import SPAN_KIND
 from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...internal.compat import parse
+from ...internal.schema import schematize_service_name
+from ...internal.schema import schematize_url_operation
 from ...internal.utils import ArgumentError
 from ...internal.utils import get_argument_value
 from ...internal.utils.formats import asbool
@@ -27,7 +29,7 @@ DROP_PORTS = (80, 443)
 config._add(
     "urllib3",
     {
-        "_default_service": "urllib3",
+        "_default_service": schematize_service_name("urllib3"),
         "distributed_tracing": asbool(os.getenv("DD_URLLIB3_DISTRIBUTED_TRACING", default=True)),
         "default_http_tag_query_string": os.getenv("DD_HTTP_CLIENT_TAG_QUERY_STRING", "true"),
         "split_by_domain": asbool(os.getenv("DD_URLLIB3_SPLIT_BY_DOMAIN", default=False)),
@@ -97,7 +99,9 @@ def _wrap_urlopen(func, instance, args, kwargs):
         return func(*args, **kwargs)
 
     with pin.tracer.trace(
-        "urllib3.request", service=trace_utils.ext_service(pin, config.urllib3), span_type=SpanTypes.HTTP
+        schematize_url_operation("urllib3.request", protocol="http", direction="outbound"),
+        service=trace_utils.ext_service(pin, config.urllib3),
+        span_type=SpanTypes.HTTP,
     ) as span:
         span.set_tag_str(COMPONENT, config.urllib3.integration_name)
 

--- a/ddtrace/contrib/vertica/patch.py
+++ b/ddtrace/contrib/vertica/patch.py
@@ -84,7 +84,7 @@ config._add(
                         "measured": True,
                     },
                     "copy": {
-                        "operation_name": schematize_database_operation("vertica.copy", database_provider="vertica"),
+                        "operation_name": "vertica.copy",
                         "span_type": SpanTypes.SQL,
                         "span_start": copy_span_start,
                         "measured": False,
@@ -106,7 +106,7 @@ config._add(
                         "measured": False,
                     },
                     "nextset": {
-                        "operation_name": schematize_database_operation("vertica.nextset", database_provider="vertica"),
+                        "operation_name": "vertica.nextset",
                         "span_type": SpanTypes.SQL,
                         "span_end": fetch_span_end,
                         "measured": False,

--- a/ddtrace/contrib/vertica/patch.py
+++ b/ddtrace/contrib/vertica/patch.py
@@ -14,6 +14,8 @@ from ...ext import SpanTypes
 from ...ext import db as dbx
 from ...ext import net
 from ...internal.logger import get_logger
+from ...internal.schema import schematize_database_operation
+from ...internal.schema import schematize_service_name
 from ...internal.utils import get_argument_value
 from ...internal.utils.wrappers import unwrap
 from ...pin import Pin
@@ -61,7 +63,7 @@ def cursor_span_end(instance, cursor, _, conf, *args, **kwargs):
 config._add(
     "vertica",
     {
-        "_default_service": "vertica",
+        "_default_service": schematize_service_name("vertica"),
         "_dbapi_span_name_prefix": "vertica",
         "patch": {
             "vertica_python.vertica.connection.Connection": {
@@ -75,32 +77,36 @@ config._add(
             "vertica_python.vertica.cursor.Cursor": {
                 "routines": {
                     "execute": {
-                        "operation_name": "vertica.query",
+                        "operation_name": schematize_database_operation("vertica.query", database_provider="vertica"),
                         "span_type": SpanTypes.SQL,
                         "span_start": execute_span_start,
                         "span_end": execute_span_end,
                         "measured": True,
                     },
                     "copy": {
-                        "operation_name": "vertica.copy",
+                        "operation_name": schematize_database_operation("vertica.copy", database_provider="vertica"),
                         "span_type": SpanTypes.SQL,
                         "span_start": copy_span_start,
                         "measured": False,
                     },
                     "fetchone": {
-                        "operation_name": "vertica.fetchone",
+                        "operation_name": schematize_database_operation(
+                            "vertica.fetchone", database_provider="vertica"
+                        ),
                         "span_type": SpanTypes.SQL,
                         "span_end": fetch_span_end,
                         "measured": False,
                     },
                     "fetchall": {
-                        "operation_name": "vertica.fetchall",
+                        "operation_name": schematize_database_operation(
+                            "vertica.fetchall", database_provider="vertica"
+                        ),
                         "span_type": SpanTypes.SQL,
                         "span_end": fetch_span_end,
                         "measured": False,
                     },
                     "nextset": {
-                        "operation_name": "vertica.nextset",
+                        "operation_name": schematize_database_operation("vertica.nextset", database_provider="vertica"),
                         "span_type": SpanTypes.SQL,
                         "span_end": fetch_span_end,
                         "measured": False,

--- a/ddtrace/contrib/vertica/patch.py
+++ b/ddtrace/contrib/vertica/patch.py
@@ -106,7 +106,7 @@ config._add(
                         "measured": False,
                     },
                     "nextset": {
-                        "operation_name": "vertica.nextset",
+                        "operation_name": schematize_database_operation("vertica.nextset", database_provider="vertica"),
                         "span_type": SpanTypes.SQL,
                         "span_end": fetch_span_end,
                         "measured": False,

--- a/ddtrace/contrib/wsgi/wsgi.py
+++ b/ddtrace/contrib/wsgi/wsgi.py
@@ -30,6 +30,7 @@ from ddtrace.ext import SpanTypes
 from ddtrace.ext import http
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.propagation._utils import from_wsgi_header
 from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.vendor import wrapt
@@ -292,7 +293,7 @@ class DDWSGIMiddleware(_DDWSGIMiddlewareBase):
                             Defaults to using the request method and url in the resource.
     """
 
-    _request_span_name = "wsgi.request"
+    _request_span_name = schematize_url_operation("wsgi.request", protocol="http", direction="inbound")
     _application_span_name = "wsgi.application"
     _response_span_name = "wsgi.response"
 

--- a/ddtrace/internal/schema/__init__.py
+++ b/ddtrace/internal/schema/__init__.py
@@ -25,6 +25,7 @@ schematize_service_name = _SPAN_ATTRIBUTE_TO_FUNCTION[__schema_version]["service
 schematize_database_operation = _SPAN_ATTRIBUTE_TO_FUNCTION[__schema_version]["database_operation"]
 schematize_cache_operation = _SPAN_ATTRIBUTE_TO_FUNCTION[__schema_version]["cache_operation"]
 schematize_cloud_api_operation = _SPAN_ATTRIBUTE_TO_FUNCTION[__schema_version]["cloud_api_operation"]
+schematize_url_operation = _SPAN_ATTRIBUTE_TO_FUNCTION[__schema_version]["url_operation"]
 
 __all__ = [
     "DEFAULT_SPAN_SERVICE_NAME",
@@ -32,4 +33,5 @@ __all__ = [
     "schematize_database_operation",
     "schematize_cache_operation",
     "schematize_cloud_api_operation",
+    "schematize_url_operation",
 ]

--- a/ddtrace/internal/schema/span_attribute_schema.py
+++ b/ddtrace/internal/schema/span_attribute_schema.py
@@ -36,18 +36,38 @@ def cloud_api_operation_v1(v0_operation, cloud_provider=None, cloud_service=None
     return "{}.{}.request".format(cloud_provider, cloud_service)
 
 
+def url_operation_v0(v0_operation, protocol=None, direction=None):
+    return v0_operation
+
+
+def url_operation_v1(v0_operation, protocol=None, direction=None):
+    acceptable_directions = {"inbound", "outbound"}
+    acceptable_protocols = {"http", "grpc"}
+    assert direction in acceptable_directions, "You must specify a direction as one of {}. You specified {}".format(
+        acceptable_directions, direction
+    )
+    assert protocol in acceptable_protocols, "You must specify a protocol as one of {}. You specified {}.".format(
+        acceptable_protocols, protocol
+    )
+
+    server_or_client = {"inbound": "server", "outbound": "client"}[direction]
+    return "{}.{}.request".format(protocol, server_or_client)
+
+
 _SPAN_ATTRIBUTE_TO_FUNCTION = {
     "v0": {
         "service_name": service_name_v0,
         "database_operation": database_operation_v0,
         "cache_operation": cache_operation_v0,
         "cloud_api_operation": cloud_api_operation_v0,
+        "url_operation": url_operation_v0,
     },
     "v1": {
         "service_name": service_name_v1,
         "database_operation": database_operation_v1,
         "cache_operation": cache_operation_v1,
         "cloud_api_operation": cloud_api_operation_v1,
+        "url_operation": url_operation_v1,
     },
 }
 

--- a/tests/contrib/aiohttp/test_aiohttp_client.py
+++ b/tests/contrib/aiohttp/test_aiohttp_client.py
@@ -103,11 +103,12 @@ else:
     assert err == b""
 
 
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
 @pytest.mark.snapshot(async_mode=False)
-def test_configure_global_service_name_env(ddtrace_run_python_code_in_subprocess):
+def test_configure_global_service_name_env(ddtrace_run_python_code_in_subprocess, schema_version):
     """
-    When only setting DD_SERVICE
-        The value from DD_SERVICE is used
+    default/v0/v1 schemas: When only setting DD_SERVICE
+        The value from DD_SERVICE is used for all schemas
     """
     code = """
 import asyncio
@@ -126,6 +127,38 @@ else:
     """
     env = os.environ.copy()
     env["DD_SERVICE"] = "global-service-name"
+    if schema_version is not None:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    assert status == 0, err
+    assert err == b""
+
+
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+@pytest.mark.snapshot(async_mode=False)
+def test_unspecified_service_name_env(ddtrace_run_python_code_in_subprocess, schema_version):
+    """
+    default (v0 schema): When only setting DD_SERVICE
+        The value from DD_SERVICE is used
+    """
+    code = """
+import asyncio
+import sys
+import aiohttp
+from tests.contrib.aiohttp.test_aiohttp_client import URL_200
+async def test():
+    async with aiohttp.ClientSession() as session:
+        async with session.get(URL_200) as resp:
+            pass
+
+if sys.version_info >= (3, 7, 0):
+    asyncio.run(test())
+else:
+    asyncio.get_event_loop().run_until_complete(test())
+    """
+    env = os.environ.copy()
+    if schema_version is not None:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
     assert err == b""

--- a/tests/contrib/aiohttp_jinja2/test_aiohttp_jinja2.py
+++ b/tests/contrib/aiohttp_jinja2/test_aiohttp_jinja2.py
@@ -45,7 +45,10 @@ async def test_template_rendering_snapshot(untraced_app_tracer_jinja, aiohttp_cl
 
 @pytest.mark.parametrize("use_global_tracer", [True])
 async def test_template_rendering_snapshot_patched_server(
-    patched_app_tracer_jinja, aiohttp_client, snapshot_context, use_global_tracer
+    patched_app_tracer_jinja,
+    aiohttp_client,
+    snapshot_context,
+    use_global_tracer,
 ):
     app, _ = patched_app_tracer_jinja
     Pin.override(aiohttp_jinja2, tracer=tracer)

--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -236,7 +236,7 @@ if __name__ == "__main__":
     if schema_version:
         env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
-    assert status == 0, (err.decode() if err else "") or (out.decode() if out else "")
+    assert status == 0, (err, out)
     assert err == b""
 
 
@@ -294,7 +294,7 @@ if __name__ == "__main__":
     if schema_version:
         env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
-    assert status == 0, (err.decode() if err else "") or (out.decode() if out else "")
+    assert status == 0, (err, out)
     assert err == b""
 
 

--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -1,5 +1,6 @@
 import asyncio
 from functools import partial
+import os
 import random
 import sys
 
@@ -10,6 +11,7 @@ import pytest
 from ddtrace.constants import ERROR_MSG
 from ddtrace.contrib.asgi import TraceMiddleware
 from ddtrace.contrib.asgi import span_from_scope
+from ddtrace.internal.schema.span_attribute_schema import _DEFAULT_SPAN_SERVICE_NAMES
 from ddtrace.propagation import http as http_propagation
 from tests.utils import DummyTracer
 from tests.utils import override_http_config
@@ -186,6 +188,114 @@ async def test_basic_asgi(scope, tracer, test_spans):
     assert request_span.get_tag("component") == "asgi"
     assert request_span.get_tag("span.kind") == "server"
     _check_span_tags(scope, request_span)
+
+
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+def test_span_attribute_schema_operation_name(ddtrace_run_python_code_in_subprocess, schema_version):
+    expected_span_name = {None: "asgi.request", "v0": "asgi.request", "v1": "http.server.request"}[schema_version]
+    code = """
+import pytest
+from tests.conftest import *
+from tests.contrib.asgi.test_asgi import basic_app
+from tests.contrib.asgi.test_asgi import scope
+from tests.contrib.asgi.test_asgi import tracer
+from asgiref.testing import ApplicationCommunicator
+from ddtrace.contrib.asgi import TraceMiddleware
+from ddtrace.contrib.asgi import span_from_scope
+
+@pytest.mark.asyncio
+async def test(scope, tracer, test_spans):
+    app = TraceMiddleware(basic_app, tracer=tracer)
+    instance = ApplicationCommunicator(app, scope)
+    await instance.send_input({{"type": "http.request", "body": b""}})
+    response_start = await instance.receive_output(1)
+    assert response_start == {{
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [[b"Content-Type", b"text/plain"]],
+    }}
+    response_body = await instance.receive_output(1)
+    assert response_body == {{
+        "type": "http.response.body",
+        "body": b"*",
+    }}
+
+    spans = test_spans.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 1
+    request_span = spans[0][0]
+    assert request_span.name == "{}"
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_span_name
+    )
+    env = os.environ.copy()
+    if schema_version:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    assert status == 0, (err.decode() if err else "") or (out.decode() if out else "")
+    assert err == b""
+
+
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+@pytest.mark.parametrize("global_service_name", [None, "mysvc"])
+def test_span_attribute_schema_service_name(ddtrace_run_python_code_in_subprocess, schema_version, global_service_name):
+    expected_service_name = {
+        None: global_service_name or "",
+        "v0": global_service_name or "",
+        "v1": global_service_name or _DEFAULT_SPAN_SERVICE_NAMES["v1"],
+    }[schema_version]
+    code = """
+import pytest
+from tests.conftest import *
+from tests.contrib.asgi.test_asgi import basic_app
+from tests.contrib.asgi.test_asgi import scope
+from tests.contrib.asgi.test_asgi import tracer
+from asgiref.testing import ApplicationCommunicator
+from ddtrace.contrib.asgi import TraceMiddleware
+from ddtrace.contrib.asgi import span_from_scope
+
+@pytest.mark.asyncio
+async def test(scope, tracer, test_spans):
+    app = TraceMiddleware(basic_app, tracer=tracer)
+    instance = ApplicationCommunicator(app, scope)
+    await instance.send_input({{"type": "http.request", "body": b""}})
+    response_start = await instance.receive_output(1)
+    assert response_start == {{
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [[b"Content-Type", b"text/plain"]],
+    }}
+    response_body = await instance.receive_output(1)
+    assert response_body == {{
+        "type": "http.response.body",
+        "body": b"*",
+    }}
+
+    spans = test_spans.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 1
+    request_span = spans[0][0]
+    service = "{}"
+    assert request_span.service == (service or None)
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_service_name
+    )
+    env = os.environ.copy()
+    if global_service_name:
+        env["DD_SERVICE"] = global_service_name
+    if schema_version:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    assert status == 0, (err.decode() if err else "") or (out.decode() if out else "")
+    assert err == b""
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/bottle/test.py
+++ b/tests/contrib/bottle/test.py
@@ -518,11 +518,12 @@ class TraceBottleTest(TracerTestCase):
         def hi(name):
             return "hi %s" % name
 
-        self._trace_app(self.tracer)
+        self.app.install(TracePlugin(tracer=self.tracer))
+        self.app = webtest.TestApp(self.app)
         resp = self.app.get("/hi/dougie")
         assert resp.status_int == 200
         root = self.get_root_span()
-        root.assert_matches(service="bottle-app")
+        root.assert_matches(service="bottle")
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_unspecified_service_v0_schema(self):
@@ -535,11 +536,12 @@ class TraceBottleTest(TracerTestCase):
         def hi(name):
             return "hi %s" % name
 
-        self._trace_app(self.tracer)
+        self.app.install(TracePlugin(tracer=self.tracer))
+        self.app = webtest.TestApp(self.app)
         resp = self.app.get("/hi/dougie")
         assert resp.status_int == 200
         root = self.get_root_span()
-        root.assert_matches(service="bottle-app")
+        root.assert_matches(service="bottle")
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_unspecified_service_v1_schema(self):

--- a/tests/contrib/bottle/test.py
+++ b/tests/contrib/bottle/test.py
@@ -7,6 +7,7 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.bottle import TracePlugin
 from ddtrace.ext import http
 from ddtrace.internal import compat
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
@@ -456,9 +457,9 @@ class TraceBottleTest(TracerTestCase):
         assert dd_span.get_tag("span.kind") == "server"
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_service(self):
+    def test_user_specified_service_default_schema(self):
         """
-        When a service name is specified by the user
+        default/v0: When a service name is specified by the user
             The bottle integration should use it as the service name
         """
 
@@ -470,10 +471,130 @@ class TraceBottleTest(TracerTestCase):
         resp = self.app.get("/hi/dougie")
         assert resp.status_int == 200
         root = self.get_root_span()
-        root.assert_matches(
-            name="bottle.request",
-            service="mysvc",
-        )
+        root.assert_matches(service="mysvc")
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_user_specified_service_v0_schema(self):
+        """
+        v0: When a service name is specified by the user
+            The bottle integration should use it as the service name
+        """
+
+        @self.app.route("/hi/<name>")
+        def hi(name):
+            return "hi %s" % name
+
+        self._trace_app(self.tracer)
+        resp = self.app.get("/hi/dougie")
+        assert resp.status_int == 200
+        root = self.get_root_span()
+        root.assert_matches(service="mysvc")
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_user_specified_service_v1_schema(self):
+        """
+        v1: When a service name is specified by the user
+            The bottle integration should use it as the service name
+        """
+
+        @self.app.route("/hi/<name>")
+        def hi(name):
+            return "hi %s" % name
+
+        self._trace_app(self.tracer)
+        resp = self.app.get("/hi/dougie")
+        assert resp.status_int == 200
+        root = self.get_root_span()
+        root.assert_matches(service="mysvc")
+
+    @TracerTestCase.run_in_subprocess()
+    def test_unspecified_service_default_schema(self):
+        """
+        default/v0: When a service name is not specified by the user
+            The bottle integration should use the applications name as the service name (or "bottle")
+        """
+
+        @self.app.route("/hi/<name>")
+        def hi(name):
+            return "hi %s" % name
+
+        self._trace_app(self.tracer)
+        resp = self.app.get("/hi/dougie")
+        assert resp.status_int == 200
+        root = self.get_root_span()
+        root.assert_matches(service="bottle-app")
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_unspecified_service_v0_schema(self):
+        """
+        default/v0: When a service name is not specified by the user
+            The bottle integration should use "bottle" as the service name
+        """
+
+        @self.app.route("/hi/<name>")
+        def hi(name):
+            return "hi %s" % name
+
+        self._trace_app(self.tracer)
+        resp = self.app.get("/hi/dougie")
+        assert resp.status_int == 200
+        root = self.get_root_span()
+        root.assert_matches(service="bottle-app")
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_unspecified_service_v1_schema(self):
+        """
+        v1: When a service name is not specified by the user
+            The bottle integration should use "unnamed-python-service" as the service name
+        """
+
+        @self.app.route("/hi/<name>")
+        def hi(name):
+            return "hi %s" % name
+
+        self._trace_app(self.tracer)
+        resp = self.app.get("/hi/dougie")
+        assert resp.status_int == 200
+        root = self.get_root_span()
+        root.assert_matches(service=DEFAULT_SPAN_SERVICE_NAME)
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_operation_name_v0_schema(self):
+        """
+        v0: When a service name is not specified by the user
+            Then we expect 'bottle.request'
+        """
+
+        @self.app.route("/hi/<name>")
+        def hi(name):
+            return "hi %s" % name
+
+        self._trace_app(self.tracer)
+        resp = self.app.get("/hi/dougie")
+        assert resp.status_int == 200
+        root = self.get_root_span()
+        root.assert_matches(name="bottle.request")
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_operation_name_v1_schema(self):
+        """
+        v1: When a service name is not specified by the user
+            Then we expect 'http.server.request'
+        """
+
+        @self.app.route("/hi/<name>")
+        def hi(name):
+            return "hi %s" % name
+
+        self._trace_app(self.tracer)
+        resp = self.app.get("/hi/dougie")
+        assert resp.status_int == 200
+        root = self.get_root_span()
+        import os
+
+        assert "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA" in os.environ
+        assert os.environ["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] == "v1"
+        root.assert_matches(name="http.server.request")
 
     def test_http_request_header_tracing(self):
         config.bottle.http.trace_headers(["my-header"])

--- a/tests/contrib/cherrypy/test_middleware.py
+++ b/tests/contrib/cherrypy/test_middleware.py
@@ -469,53 +469,6 @@ class TestCherrypy(TracerTestCase, helper.CPWebCase):
 
         cherrypy.tools.tracer.service = previous_service
 
-    # @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE='mysvc'))
-    # def test_service_name_default_schema(self):
-    #    helper.stop()
-    #    helper.start()
-    #    import os
-
-    #    self.getPage("/")
-    #    time.sleep(0.1)
-    #    self.assertStatus("200 OK")
-    #    #self.assertHeader("Content-Type", "text/html;charset=utf-8")
-    #    #self.assertBody("Hello world!")
-
-    #    #assert not self.tracer.current_span()
-    #    #spans = self.pop_spans()
-    #    #assert len(spans) == 1
-    #    #s = spans[0]
-    #    #assert s.service == "test.cherrypy.service"
-
-
-# @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE='mysvc'))
-# def test_service_name_v0_schema(self):
-#     self.getPage("/")
-#     time.sleep(0.1)
-#     self.assertStatus("200 OK")
-#     self.assertHeader("Content-Type", "text/html;charset=utf-8")
-#     self.assertBody("Hello world!")
-
-#     assert not self.tracer.current_span()
-#     spans = self.pop_spans()
-#     assert len(spans) == 1
-#     s = spans[0]
-#     assert s.service == "test.cherrypy.service"
-
-# @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE='mysvc'))
-# def test_service_name_v1_schema(self):
-#     self.getPage("/")
-#     time.sleep(0.1)
-#     self.assertStatus("200 OK")
-#     self.assertHeader("Content-Type", "text/html;charset=utf-8")
-#     self.assertBody("Hello world!")
-
-#     assert not self.tracer.current_span()
-#     spans = self.pop_spans()
-#     assert len(spans) == 1
-#     s = spans[0]
-#     assert s.service == "mysvc"
-
 
 class TestCherrypySnapshot(helper.CPWebCase):
     @staticmethod

--- a/tests/contrib/cherrypy/test_middleware.py
+++ b/tests/contrib/cherrypy/test_middleware.py
@@ -573,7 +573,7 @@ if __name__ == "__main__":
         env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     env["DD_SERVICE"] = "mysvc"
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
-    assert status == 0, (err.decode() if err else "") or (out.decode() if out else "")
+    assert status == 0, (err, out)
     assert err == b""
 
 
@@ -632,5 +632,5 @@ if __name__ == "__main__":
         env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     env["DD_SERVICE"] = "mysvc"
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
-    assert status == 0, (err.decode() if err else "") or (out.decode() if out else "")
+    assert status == 0, (err, out)
     assert err == b""

--- a/tests/contrib/cherrypy/test_middleware.py
+++ b/tests/contrib/cherrypy/test_middleware.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 import logging
+import os
 import re
 import time
 
 import cherrypy
 from cherrypy.test import helper
+import pytest
 from six.moves.urllib.parse import quote as url_quote
 
 import ddtrace
@@ -19,7 +21,7 @@ from tests.utils import TracerTestCase
 from tests.utils import assert_span_http_status_code
 from tests.utils import snapshot
 
-from .web import TestApp
+from .web import StubApp
 
 
 logger = logging.getLogger()
@@ -35,7 +37,7 @@ class TestCherrypy(TracerTestCase, helper.CPWebCase):
     @staticmethod
     def setup_server():
         cherrypy.tree.mount(
-            TestApp(),
+            StubApp(),
             "/",
             {
                 "/": {"tools.tracer.on": True},
@@ -467,12 +469,59 @@ class TestCherrypy(TracerTestCase, helper.CPWebCase):
 
         cherrypy.tools.tracer.service = previous_service
 
+    # @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE='mysvc'))
+    # def test_service_name_default_schema(self):
+    #    helper.stop()
+    #    helper.start()
+    #    import os
+
+    #    self.getPage("/")
+    #    time.sleep(0.1)
+    #    self.assertStatus("200 OK")
+    #    #self.assertHeader("Content-Type", "text/html;charset=utf-8")
+    #    #self.assertBody("Hello world!")
+
+    #    #assert not self.tracer.current_span()
+    #    #spans = self.pop_spans()
+    #    #assert len(spans) == 1
+    #    #s = spans[0]
+    #    #assert s.service == "test.cherrypy.service"
+
+
+# @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE='mysvc'))
+# def test_service_name_v0_schema(self):
+#     self.getPage("/")
+#     time.sleep(0.1)
+#     self.assertStatus("200 OK")
+#     self.assertHeader("Content-Type", "text/html;charset=utf-8")
+#     self.assertBody("Hello world!")
+
+#     assert not self.tracer.current_span()
+#     spans = self.pop_spans()
+#     assert len(spans) == 1
+#     s = spans[0]
+#     assert s.service == "test.cherrypy.service"
+
+# @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE='mysvc'))
+# def test_service_name_v1_schema(self):
+#     self.getPage("/")
+#     time.sleep(0.1)
+#     self.assertStatus("200 OK")
+#     self.assertHeader("Content-Type", "text/html;charset=utf-8")
+#     self.assertBody("Hello world!")
+
+#     assert not self.tracer.current_span()
+#     spans = self.pop_spans()
+#     assert len(spans) == 1
+#     s = spans[0]
+#     assert s.service == "mysvc"
+
 
 class TestCherrypySnapshot(helper.CPWebCase):
     @staticmethod
     def setup_server():
         cherrypy.tree.mount(
-            TestApp(),
+            StubApp(),
             "/",
             {
                 "/": {"tools.tracer.on": True},
@@ -514,3 +563,121 @@ class TestCherrypySnapshot(helper.CPWebCase):
         self.getPage("/fatal")
         time.sleep(0.1)
         self.assertErrorPage(500)
+
+
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+def test_service_name_schema(ddtrace_run_python_code_in_subprocess, schema_version):
+    expected_service_name = {
+        None: "cherrypy",
+        "v0": "cherrypy",
+        "v1": "mysvc",
+    }[schema_version]
+    code = """
+import pytest
+import cherrypy
+import time
+from cherrypy.test import helper
+from tests.utils import TracerTestCase
+from tests.contrib.cherrypy.web import StubApp
+from ddtrace.contrib.cherrypy import TraceMiddleware
+class TestCherrypy(TracerTestCase, helper.CPWebCase):
+    @staticmethod
+    def setup_server():
+        cherrypy.tree.mount(
+            StubApp(),
+            "/",
+            {{
+                "/": {{"tools.tracer.on": True}},
+            }},
+        )
+
+    def setUp(self):
+        super(TestCherrypy, self).setUp()
+        self.traced_app = TraceMiddleware(
+            cherrypy,
+            self.tracer,
+            distributed_tracing=True,
+        )
+
+    def test(self):
+        import os
+
+        self.getPage("/")
+        time.sleep(0.1)
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+        assert s.service == "{}", "Schema Version: {{}}".format(os.environ.get("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"))
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_service_name
+    )
+    env = os.environ.copy()
+    if schema_version:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    env["DD_SERVICE"] = "mysvc"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    assert status == 0, (err.decode() if err else "") or (out.decode() if out else "")
+    assert err == b""
+
+
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+def test_operation_name_schema(ddtrace_run_python_code_in_subprocess, schema_version):
+    expected_operation_name = {
+        None: "cherrypy.request",
+        "v0": "cherrypy.request",
+        "v1": "http.server.request",
+    }[schema_version]
+    code = """
+import pytest
+import cherrypy
+import time
+from cherrypy.test import helper
+from tests.utils import TracerTestCase
+from tests.contrib.cherrypy.web import StubApp
+from ddtrace.contrib.cherrypy import TraceMiddleware
+class TestCherrypy(TracerTestCase, helper.CPWebCase):
+    @staticmethod
+    def setup_server():
+        cherrypy.tree.mount(
+            StubApp(),
+            "/",
+            {{
+                "/": {{"tools.tracer.on": True}},
+            }},
+        )
+
+    def setUp(self):
+        super(TestCherrypy, self).setUp()
+        self.traced_app = TraceMiddleware(
+            cherrypy,
+            self.tracer,
+            distributed_tracing=True,
+        )
+
+    def test(self):
+        import os
+
+        self.getPage("/")
+        time.sleep(0.1)
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+        assert s.name == "{}", "Schema Version: {{}}".format(os.environ.get("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"))
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_operation_name
+    )
+    env = os.environ.copy()
+    if schema_version:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    env["DD_SERVICE"] = "mysvc"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    assert status == 0, (err.decode() if err else "") or (out.decode() if out else "")
+    assert err == b""

--- a/tests/contrib/cherrypy/web.py
+++ b/tests/contrib/cherrypy/web.py
@@ -30,7 +30,7 @@ else:
     UNICODE_ENDPOINT = u"üŋïĉóđē"
 
 
-class TestApp:
+class StubApp:
     """Sample request handler class."""
 
     def __init__(self):
@@ -94,4 +94,4 @@ if __name__ == "__main__":
     # CherryPy always starts with app.root when trying to map request URIs
     # to objects, so we need to mount a request handler root. A request
     # to '/' will be mapped to HelloWorld().index().
-    cherrypy.quickstart(TestApp(), config=testconf)
+    cherrypy.quickstart(StubApp(), config=testconf)

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -30,6 +30,7 @@ from ddtrace.ext import user
 from ddtrace.internal.compat import PY2
 from ddtrace.internal.compat import binary_type
 from ddtrace.internal.compat import string_type
+from ddtrace.internal.schema.span_attribute_schema import _DEFAULT_SPAN_SERVICE_NAMES
 from ddtrace.propagation._utils import get_wsgi_header
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_SAMPLING_PRIORITY
@@ -1482,6 +1483,84 @@ def test_service_can_be_overridden(client, test_spans):
 
     span = spans[0]
     assert span.service == "test-service"
+
+
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+def test_schematized_default_service_name(ddtrace_run_python_code_in_subprocess, schema_version):
+    expected_service_name = {None: "django", "v0": "django", "v1": _DEFAULT_SPAN_SERVICE_NAMES["v1"]}[schema_version]
+    code = """
+import pytest
+import sys
+
+import django
+
+from tests.contrib.django.conftest import *
+from tests.utils import override_config
+
+def test(client, test_spans):
+    response = client.get("/")
+    assert response.status_code == 200
+
+    spans = test_spans.get_spans()
+    assert len(spans) > 0
+
+    span = spans[0]
+    assert span.service == "{}", span.service
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_service_name
+    )
+
+    env = os.environ.copy()
+    if schema_version is not None:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(
+        code,
+        env=env,
+    )
+    assert status == 0, (out, err)
+
+
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+def test_schematized_operation_name(ddtrace_run_python_code_in_subprocess, schema_version):
+    expected_operation_name = {None: "django.request", "v0": "django.request", "v1": "http.server.request"}[
+        schema_version
+    ]
+    code = """
+import pytest
+import sys
+
+import django
+
+from tests.contrib.django.conftest import *
+from tests.utils import override_config
+
+def test(client, test_spans):
+    response = client.get("/")
+    assert response.status_code == 200
+
+    spans = test_spans.get_spans()
+    assert len(spans) > 0
+
+    span = spans[0]
+    assert span.name == "{}", span.service
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_operation_name
+    )
+
+    env = os.environ.copy()
+    if schema_version is not None:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(
+        code,
+        env=env,
+    )
+    assert status == 0, (out, err)
 
 
 @pytest.mark.django_db

--- a/tests/contrib/djangorestframework/test_djangorestframework.py
+++ b/tests/contrib/djangorestframework/test_djangorestframework.py
@@ -1,7 +1,10 @@
+import os
+
 import django
 import pytest
 
 from ddtrace.constants import ERROR_MSG
+from ddtrace.internal.schema.span_attribute_schema import _DEFAULT_SPAN_SERVICE_NAMES
 from tests.utils import assert_span_http_status_code
 
 
@@ -35,3 +38,73 @@ def test_trace_exceptions(client, test_spans):  # noqa flake8 complains about sh
     assert err_span.get_tag(ERROR_MSG) == "Authentication credentials were not provided."
     assert "NotAuthenticated" in err_span.get_tag("error.stack")
     assert err_span.get_tag("component") == "django"
+
+
+@pytest.mark.skipif(django.VERSION < (1, 10), reason="requires django version >= 1.10")
+@pytest.mark.django_db
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+def test_schematized_service_names(ddtrace_run_python_code_in_subprocess, schema_version):
+    expected_service_name = {None: "django", "v0": "django", "v1": _DEFAULT_SPAN_SERVICE_NAMES["v1"]}[schema_version]
+    code = """
+import pytest
+import sys
+from tests.contrib.djangorestframework.conftest import *
+
+def test(client, test_spans):
+    response = client.get("/users/")
+
+    # Our custom exception handler is setting the status code to 500
+    assert response.status_code == 500
+
+    sp = test_spans.get_root_span()
+    assert sp.service == "{}"
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_service_name
+    )
+    env = os.environ.copy()
+    if schema_version is not None:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(
+        code,
+        env=env,
+    )
+    assert status == 0, (out, err)
+
+
+@pytest.mark.skipif(django.VERSION < (1, 10), reason="requires django version >= 1.10")
+@pytest.mark.django_db
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+def test_schematized_operation_names(ddtrace_run_python_code_in_subprocess, schema_version):
+    expected_operation_name = {None: "django.request", "v0": "django.request", "v1": "http.server.request"}[
+        schema_version
+    ]
+    code = """
+import pytest
+import sys
+from tests.contrib.djangorestframework.conftest import *
+
+def test(client, test_spans):
+    response = client.get("/users/")
+
+    # Our custom exception handler is setting the status code to 500
+    assert response.status_code == 500
+
+    sp = test_spans.get_root_span()
+    assert sp.name == "{}"
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_operation_name
+    )
+    env = os.environ.copy()
+    if schema_version is not None:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(
+        code,
+        env=env,
+    )
+    assert status == 0, (out, err)

--- a/tests/contrib/falcon/test_schematization.py
+++ b/tests/contrib/falcon/test_schematization.py
@@ -1,0 +1,99 @@
+import os
+
+import pytest
+
+from ddtrace.internal.schema.span_attribute_schema import _DEFAULT_SPAN_SERVICE_NAMES
+
+
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+def test_schematized_service_name(ddtrace_run_python_code_in_subprocess, schema_version):
+    expected_service_name = {None: "falcon", "v0": "falcon", "v1": _DEFAULT_SPAN_SERVICE_NAMES["v1"]}[schema_version]
+    code = """
+import pytest
+import falcon
+import sys
+
+from falcon import testing
+from ddtrace.contrib.falcon.patch import FALCON_VERSION
+from tests.contrib.falcon.test_suite import FalconTestMixin
+from tests.utils import TracerTestCase
+
+from tests.contrib.falcon.app import get_app
+
+
+class TestCase(TracerTestCase, testing.TestCase, FalconTestMixin):
+    def setUp(self):
+        super(TestCase, self).setUp()
+        self.api = get_app(tracer=self.tracer)
+        if FALCON_VERSION >= (2, 0, 0):
+            self.client = testing.TestClient(self.api)
+        else:
+            self.client = self
+
+    def test(self, query_string="", trace_query_string=False):
+        out = self.make_test_call("/200", expected_status_code=200, query_string=query_string)
+        traces = self.tracer.pop_traces()
+        span = traces[0][0]
+        assert span.service == "{}"
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_service_name
+    )
+    env = os.environ.copy()
+    if schema_version is not None:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(
+        code,
+        env=env,
+    )
+    assert status == 0, (out, err)
+
+
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+def test_schematized_operation_name(ddtrace_run_python_code_in_subprocess, schema_version):
+    expected_operation_name = {None: "falcon.request", "v0": "falcon.request", "v1": "http.server.request"}[
+        schema_version
+    ]
+    code = """
+import pytest
+import falcon
+import sys
+
+from falcon import testing
+from ddtrace.contrib.falcon.patch import FALCON_VERSION
+from tests.contrib.falcon.test_suite import FalconTestMixin
+from tests.utils import TracerTestCase
+
+from tests.contrib.falcon.app import get_app
+
+
+class TestCase(TracerTestCase, testing.TestCase, FalconTestMixin):
+    def setUp(self):
+        super(TestCase, self).setUp()
+        self.api = get_app(tracer=self.tracer)
+        if FALCON_VERSION >= (2, 0, 0):
+            self.client = testing.TestClient(self.api)
+        else:
+            self.client = self
+
+    def test(self, query_string="", trace_query_string=False):
+        out = self.make_test_call("/200", expected_status_code=200, query_string=query_string)
+        traces = self.tracer.pop_traces()
+        span = traces[0][0]
+        assert span.name == "{}"
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_operation_name
+    )
+    env = os.environ.copy()
+    if schema_version is not None:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(
+        code,
+        env=env,
+    )
+    assert status == 0, (out, err)

--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -1121,7 +1121,7 @@ if __name__ == "__main__":
     if service_name:
         env["DD_SERVICE"] = service_name
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
-    assert status == 0, err.decode() or out.decode()
+    assert status == 0, (out, err)
     assert err == b""
 
 
@@ -1164,5 +1164,5 @@ if __name__ == "__main__":
     if schema_version:
         env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
-    assert status == 0, err.decode() or out.decode()
+    assert status == 0, (out, err)
     assert err == b""

--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import os
 
 import flask
 from flask import abort
@@ -12,6 +13,7 @@ from ddtrace.constants import ERROR_MSG
 from ddtrace.contrib.flask.patch import flask_version
 from ddtrace.ext import http
 from ddtrace.internal.compat import PY2
+from ddtrace.internal.schema import _DEFAULT_SPAN_SERVICE_NAMES
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
 from tests.utils import assert_is_measured
@@ -1073,3 +1075,94 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         assert traces[0][-3].name == "hello_0"
         assert traces[0][-2].name == "hello_1"
         assert traces[0][-1].name == "hello_2"
+
+
+@pytest.mark.parametrize("service_name", [None, "mysvc"])
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+def test_schematized_service_name(ddtrace_run_python_code_in_subprocess, schema_version, service_name):
+    """
+    v0/Default: expect the service name to be "flask"
+    v1: expect the service name to be "unnamed-python-service"
+    """
+
+    expected_service_name = {
+        None: service_name or "flask",
+        "v0": service_name or "flask",
+        "v1": service_name or _DEFAULT_SPAN_SERVICE_NAMES["v1"],
+    }[schema_version]
+
+    code = """
+import pytest
+from ddtrace.internal.compat import PY2
+from tests.contrib.flask import BaseFlaskTestCase
+
+class TestCase(BaseFlaskTestCase):
+    def test(self):
+        @self.app.route("/")
+        def index():
+            return "Hello Flask", 200
+
+        res = self.client.get("/")
+        spans = self.get_spans()
+
+        # Root request span
+        req_span = spans[0]
+        self.assertEqual(req_span.service, "{}")
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_service_name
+    )
+    env = os.environ.copy()
+    if schema_version:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    if service_name:
+        env["DD_SERVICE"] = service_name
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    assert status == 0, err.decode() or out.decode()
+    assert err == b""
+
+
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+def test_schematized_operation_name(ddtrace_run_python_code_in_subprocess, schema_version):
+    """
+    v0/Default: expect the service name to be "flask.request"
+    v1: expect the service name to be "http.server.request"
+    """
+
+    expected_operation_name = {None: "flask.request", "v0": "flask.request", "v1": "http.server.request"}[
+        schema_version
+    ]
+
+    code = """
+import pytest
+from ddtrace.internal.compat import PY2
+from tests.contrib.flask import BaseFlaskTestCase
+
+class TestCase(BaseFlaskTestCase):
+    def test(self):
+        @self.app.route("/")
+        def index():
+            return "Hello Flask", 200
+
+        res = self.client.get("/")
+        spans = self.pop_spans()
+
+        # Root request span
+        req_span = spans[0]
+        self.assertEqual(req_span.name, "{}")
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_operation_name
+    )
+    env = os.environ.copy()
+    if schema_version:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    assert status == 0, err.decode() or out.decode()
+    assert err == b""

--- a/tests/contrib/httpx/test_httpx.py
+++ b/tests/contrib/httpx/test_httpx.py
@@ -192,9 +192,9 @@ def test_configure_service_name_env():
 
 
 @pytest.mark.subprocess(env=dict(DD_SERVICE="global-service-name"))
-def test_configure_global_service_name_env():
+def test_schematized_configure_global_service_name_env_default():
     """
-    When only setting DD_SERVICE
+    v0/default: When only setting DD_SERVICE
         We use the value from DD_SERVICE for the service name
     """
 
@@ -211,7 +211,261 @@ def test_configure_global_service_name_env():
     url = get_url("/status/200")
 
     async def test():
-        token = "tests.contrib.httpx.test_httpx.test_configure_global_service_name_env"
+        token = "tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_default"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            httpx.get(url, headers=DEFAULT_HEADERS)
+
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            async with httpx.AsyncClient() as client:
+                await client.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess(env=dict(DD_SERVICE="global-service-name", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+def test_schematized_configure_global_service_name_env_v0():
+    """
+    v0/default: When only setting DD_SERVICE
+        We use the value from DD_SERVICE for the service name
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v0"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            httpx.get(url, headers=DEFAULT_HEADERS)
+
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            async with httpx.AsyncClient() as client:
+                await client.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess(env=dict(DD_SERVICE="global-service-name", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+def test_schematized_configure_global_service_name_env_v1():
+    """
+    v1: When only setting DD_SERVICE
+        We use the value from DD_SERVICE for the service name
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v1"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            httpx.get(url, headers=DEFAULT_HEADERS)
+
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            async with httpx.AsyncClient() as client:
+                await client.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess()
+def test_schematized_unspecified_service_name_env_default():
+    """
+    v0/default: With no service name, we use httpx
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            httpx.get(url, headers=DEFAULT_HEADERS)
+
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            async with httpx.AsyncClient() as client:
+                await client.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+def test_schematized_unspecified_service_name_env_v0():
+    """
+    v0/default: With no service name, we use httpx
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            httpx.get(url, headers=DEFAULT_HEADERS)
+
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            async with httpx.AsyncClient() as client:
+                await client.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+def test_schematized_unspecified_service_name_env_v1():
+    """
+    v1: With no service name, we expect ddtrace.internal.DEFAULT_SPAN_SERVICE_NAME
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v1"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            httpx.get(url, headers=DEFAULT_HEADERS)
+
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            async with httpx.AsyncClient() as client:
+                await client.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+def test_schematized_operation_name_env_v0():
+    """
+    v0: Operation name is httpx.request
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v0"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            httpx.get(url, headers=DEFAULT_HEADERS)
+
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            async with httpx.AsyncClient() as client:
+                await client.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+def test_schematized_operation_name_env_v1():
+    """
+    v0: Operation name is http.client.request
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v1"
         with snapshot_context(wait_for_num_traces=1, token=token):
             DEFAULT_HEADERS = {
                 "User-Agent": "python-httpx/x.xx.x",

--- a/tests/contrib/httpx/test_httpx_pre_0_11.py
+++ b/tests/contrib/httpx/test_httpx_pre_0_11.py
@@ -199,6 +199,265 @@ def test_configure_global_service_name_env():
         asyncio.get_event_loop().run_until_complete(test())
 
 
+@pytest.mark.subprocess(env=dict(DD_SERVICE="global-service-name"))
+def test_schematized_configure_global_service_name_env_default():
+    """
+    v0/default: When only setting DD_SERVICE
+        We use the value from DD_SERVICE for the service name
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_default"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            await httpx.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess(env=dict(DD_SERVICE="global-service-name", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+def test_schematized_configure_global_service_name_env_v0():
+    """
+    v0/default: When only setting DD_SERVICE
+        We use the value from DD_SERVICE for the service name
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v0"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            await httpx.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess(env=dict(DD_SERVICE="global-service-name", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+def test_schematized_configure_global_service_name_env_v1():
+    """
+    v1: When only setting DD_SERVICE
+        We use the value from DD_SERVICE for the service name
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v1"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            await httpx.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess()
+def test_schematized_unspecified_service_name_env_default():
+    """
+    v0/default: With no service name, we use httpx
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            await httpx.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+def test_schematized_unspecified_service_name_env_v0():
+    """
+    v0/default: With no service name, we use httpx
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            await httpx.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+def test_schematized_unspecified_service_name_env_v1():
+    """
+    v1: With no service name, we expect ddtrace.internal.DEFAULT_SPAN_SERVICE_NAME
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v1"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            await httpx.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+def test_schematized_operation_name_env_v0():
+    """
+    v0: Operation name is httpx.request
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v0"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            await httpx.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
+@pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+def test_schematized_operation_name_env_v1():
+    """
+    v0: Operation name is http.client.request
+    """
+
+    import asyncio
+    import sys
+
+    import httpx
+
+    from ddtrace.contrib.httpx import patch
+    from tests.contrib.httpx.test_httpx import get_url
+    from tests.utils import snapshot_context
+
+    patch()
+    url = get_url("/status/200")
+
+    async def test():
+        token = "tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v1"
+        with snapshot_context(wait_for_num_traces=1, token=token):
+            DEFAULT_HEADERS = {
+                "User-Agent": "python-httpx/x.xx.x",
+            }
+            await httpx.get(url, headers=DEFAULT_HEADERS)
+
+    if sys.version_info >= (3, 7, 0):
+        asyncio.run(test())
+    else:
+        asyncio.get_event_loop().run_until_complete(test())
+
+
 @pytest.mark.asyncio
 async def test_get_500(snapshot_context):
     """

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -346,7 +346,7 @@ class TestMolten(TracerTestCase):
         molten_client()
         spans = self.pop_spans()
         for span in spans:
-            assert span.service == "mysvc", span.service
+            assert span.service == "mysvc", "Expected 'mysvc' but got {}".format(span.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_user_specified_service_v0_schema(self):
@@ -357,7 +357,7 @@ class TestMolten(TracerTestCase):
         molten_client()
         spans = self.pop_spans()
         for span in spans:
-            assert span.service == "mysvc", span.service
+            assert span.service == "mysvc", "Expected 'mysvc' but got {}".format(span.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_user_specified_service_v1_schema(self):
@@ -368,7 +368,7 @@ class TestMolten(TracerTestCase):
         molten_client()
         spans = self.pop_spans()
         for span in spans:
-            assert span.service == "mysvc", span.service
+            assert span.service == "mysvc", "Expected 'mysvc' but got {}".format(span.service)
 
     @TracerTestCase.run_in_subprocess()
     def test_unspecified_service_default_schema(self):
@@ -390,7 +390,7 @@ class TestMolten(TracerTestCase):
         molten_client()
         spans = self.pop_spans()
         for span in spans:
-            assert span.service == "molten", span.service
+            assert span.service == "molten", "Expected 'molten' but got {}".format(span.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_unspecified_service_v1_schema(self):
@@ -411,7 +411,7 @@ class TestMolten(TracerTestCase):
         molten_client()
         spans = self.pop_spans()
         root_span = spans[0]
-        assert root_span.name == "molten.request", root_span.name
+        assert root_span.name == "molten.request", "Expected 'molten.request' but got {}".format(root_span.name)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_schematized_operation_name_v0(self):
@@ -421,7 +421,7 @@ class TestMolten(TracerTestCase):
         molten_client()
         spans = self.pop_spans()
         root_span = spans[0]
-        assert root_span.name == "molten.request", root_span.name
+        assert root_span.name == "molten.request", "Expected 'molten.request' but got {}".format(root_span.name)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_schematized_operation_name_v1(self):
@@ -431,7 +431,9 @@ class TestMolten(TracerTestCase):
         molten_client()
         spans = self.pop_spans()
         root_span = spans[0]
-        assert root_span.name == "http.server.request", root_span.name
+        assert root_span.name == "http.server.request", "Expected 'http.server.request' but got {}".format(
+            root_span.name
+        )
 
     def test_http_request_header_tracing(self):
         config.molten.http.trace_headers(["my-header"])

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -9,6 +9,7 @@ from ddtrace.contrib.molten import patch
 from ddtrace.contrib.molten import unpatch
 from ddtrace.contrib.molten.patch import MOLTEN_VERSION
 from ddtrace.ext import http
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
 from tests.utils import TracerTestCase
@@ -337,15 +338,100 @@ class TestMolten(TracerTestCase):
         self.assertTrue(len(spans) > 0)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
-    def test_user_specified_service(self):
+    def test_user_specified_service_default_schema(self):
         """
-        When a service name is specified by the user
+        default: When a service name is specified by the user
             The molten integration should use it as the service name
         """
         molten_client()
         spans = self.pop_spans()
         for span in spans:
-            assert span.service == "mysvc"
+            assert span.service == "mysvc", span.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_user_specified_service_v0_schema(self):
+        """
+        v0: When a service name is specified by the user
+            The molten integration should use it as the service name
+        """
+        molten_client()
+        spans = self.pop_spans()
+        for span in spans:
+            assert span.service == "mysvc", span.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_user_specified_service_v1_schema(self):
+        """
+        v1: When a service name is specified by the user
+            The molten integration should use it as the service name
+        """
+        molten_client()
+        spans = self.pop_spans()
+        for span in spans:
+            assert span.service == "mysvc", span.service
+
+    @TracerTestCase.run_in_subprocess()
+    def test_unspecified_service_default_schema(self):
+        """
+        default: When a service name is not specified by the user
+            The molten integration should use 'molten' as the service name
+        """
+        molten_client()
+        spans = self.pop_spans()
+        for span in spans:
+            assert span.service == "molten", span.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_unspecified_service_v0_schema(self):
+        """
+        v0: When a service name is not specified by the user
+            The molten integration should use 'molten' as the service name
+        """
+        molten_client()
+        spans = self.pop_spans()
+        for span in spans:
+            assert span.service == "molten", span.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_unspecified_service_v1_schema(self):
+        """
+        v1: When a service name is not specified by the user
+            The molten integration should use 'unnamed-python-service' as the service name
+        """
+        molten_client()
+        spans = self.pop_spans()
+        for span in spans:
+            assert span.service == DEFAULT_SPAN_SERVICE_NAME, span.service
+
+    @TracerTestCase.run_in_subprocess()
+    def test_schematized_operation_name_default(self):
+        """
+        v0: The molten span name should be "request.span"
+        """
+        molten_client()
+        spans = self.pop_spans()
+        root_span = spans[0]
+        assert root_span.name == "molten.request", root_span.name
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_schematized_operation_name_v0(self):
+        """
+        v0: The molten span name should be "request.span"
+        """
+        molten_client()
+        spans = self.pop_spans()
+        root_span = spans[0]
+        assert root_span.name == "molten.request", root_span.name
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_schematized_operation_name_v1(self):
+        """
+        v1: The molten span name should be "http.server.request"
+        """
+        molten_client()
+        spans = self.pop_spans()
+        root_span = spans[0]
+        assert root_span.name == "http.server.request", root_span.name
 
     def test_http_request_header_tracing(self):
         config.molten.http.trace_headers(["my-header"])

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -379,7 +379,7 @@ class TestMolten(TracerTestCase):
         molten_client()
         spans = self.pop_spans()
         for span in spans:
-            assert span.service == "molten", span.service
+            assert span.service == "molten", "Expected 'molten' but got {}".format(span.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_unspecified_service_v0_schema(self):
@@ -401,7 +401,9 @@ class TestMolten(TracerTestCase):
         molten_client()
         spans = self.pop_spans()
         for span in spans:
-            assert span.service == DEFAULT_SPAN_SERVICE_NAME, span.service
+            assert span.service == DEFAULT_SPAN_SERVICE_NAME, "Expected '{}' but got {}".format(
+                DEFAULT_SPAN_SERVICE_NAME, span.service
+            )
 
     @TracerTestCase.run_in_subprocess()
     def test_schematized_operation_name_default(self):

--- a/tests/contrib/pylons/test_pylons.py
+++ b/tests/contrib/pylons/test_pylons.py
@@ -21,6 +21,7 @@ from ddtrace.ext import http
 from ddtrace.ext import user
 from ddtrace.internal import _context
 from ddtrace.internal.compat import urlencode
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.appsec.test_processor import RULES_GOOD_PATH
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
@@ -888,3 +889,92 @@ class PylonsTestCase(TracerTestCase):
         assert root_span.get_tag(user.SCOPE) == "usr.scope"
         assert root_span.get_tag("component") == "pylons"
         assert root_span.get_tag("span.kind") == "server"
+
+
+class PylonsSchemaTestCase(TracerTestCase):
+    """Pylons Test Controller that is used to test specific
+    cases defined in the Pylons controller. To test a new behavior,
+    add a new action in the `app.controllers.root` module.
+    """
+
+    conf_dir = os.path.dirname(os.path.abspath(__file__))
+
+    def setUp(self):
+        super(PylonsSchemaTestCase, self).setUp()
+        # initialize a real traced Pylons app
+        wsgiapp = loadapp("config:test.ini", relative_to=PylonsTestCase.conf_dir)
+        self._wsgiapp = wsgiapp
+        app = PylonsTraceMiddleware(wsgiapp, self.tracer)
+        self.app = fixture.TestApp(app)
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_schematized_service_name_default(self):
+        self.app.get("/identify")
+
+        spans = self.pop_spans()
+        root_span = spans[0]
+
+        assert root_span.service == "pylons", root_span.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_schematized_service_name_v0(self):
+        self.app.get("/identify")
+
+        spans = self.pop_spans()
+        root_span = spans[0]
+
+        assert root_span.service == "pylons", root_span.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_schematized_service_name_v1(self):
+        self.app.get("/identify")
+
+        spans = self.pop_spans()
+        root_span = spans[0]
+
+        assert root_span.service == "mysvc", root_span.service
+
+    @TracerTestCase.run_in_subprocess()
+    def test_schematized_unspecified_service_name_default(self):
+        self.app.get("/identify")
+
+        spans = self.pop_spans()
+        root_span = spans[0]
+
+        assert root_span.service == "pylons"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_schematized_unspecified_service_name_v0(self):
+        self.app.get("/identify")
+
+        spans = self.pop_spans()
+        root_span = spans[0]
+
+        assert root_span.service == "pylons"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_schematized_unspecified_service_name_v1(self):
+        self.app.get("/identify")
+
+        spans = self.pop_spans()
+        root_span = spans[0]
+
+        assert root_span.service == DEFAULT_SPAN_SERVICE_NAME
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_schematized_operation_name_v0(self):
+        self.app.get("/identify")
+
+        spans = self.pop_spans()
+        root_span = spans[0]
+
+        assert root_span.name == "pylons.request", root_span.name
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_schematized_operation_name_v1(self):
+        self.app.get("/identify")
+
+        spans = self.pop_spans()
+        root_span = spans[0]
+
+        assert root_span.name == "http.server.request", root_span.name

--- a/tests/contrib/pylons/test_pylons.py
+++ b/tests/contrib/pylons/test_pylons.py
@@ -970,7 +970,7 @@ class PylonsSchemaTestCase(TracerTestCase):
         spans = self.pop_spans()
         root_span = spans[0]
 
-        assert root_span.name == "pylons.request", root_span.name
+        assert root_span.name == "pylons.request", "Expected 'pylons.request' but got {}".format(root_span.name)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_schematized_operation_name_v1(self):
@@ -979,4 +979,6 @@ class PylonsSchemaTestCase(TracerTestCase):
         spans = self.pop_spans()
         root_span = spans[0]
 
-        assert root_span.name == "http.server.request", root_span.name
+        assert root_span.name == "http.server.request", "Expected 'http.server.request' but got {}".format(
+            root_span.name
+        )

--- a/tests/contrib/pylons/test_pylons.py
+++ b/tests/contrib/pylons/test_pylons.py
@@ -914,7 +914,7 @@ class PylonsSchemaTestCase(TracerTestCase):
         spans = self.pop_spans()
         root_span = spans[0]
 
-        assert root_span.service == "pylons", root_span.service
+        assert root_span.service == "pylons", "Expected 'pylons' but got {}".format(root_span.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_schematized_service_name_v0(self):
@@ -923,7 +923,7 @@ class PylonsSchemaTestCase(TracerTestCase):
         spans = self.pop_spans()
         root_span = spans[0]
 
-        assert root_span.service == "pylons", root_span.service
+        assert root_span.service == "pylons", "Expected 'pylons' but got {}".format(root_span.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_schematized_service_name_v1(self):
@@ -932,7 +932,7 @@ class PylonsSchemaTestCase(TracerTestCase):
         spans = self.pop_spans()
         root_span = spans[0]
 
-        assert root_span.service == "mysvc", root_span.service
+        assert root_span.service == "mysvc", "Expected 'mysvc' but got {}".format(root_span.service)
 
     @TracerTestCase.run_in_subprocess()
     def test_schematized_unspecified_service_name_default(self):
@@ -941,7 +941,7 @@ class PylonsSchemaTestCase(TracerTestCase):
         spans = self.pop_spans()
         root_span = spans[0]
 
-        assert root_span.service == "pylons"
+        assert root_span.service == "pylons", "Expected 'pylons' but got {}".format(root_span.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_schematized_unspecified_service_name_v0(self):
@@ -950,7 +950,7 @@ class PylonsSchemaTestCase(TracerTestCase):
         spans = self.pop_spans()
         root_span = spans[0]
 
-        assert root_span.service == "pylons"
+        assert root_span.service == "pylons", "Expected 'pylons' but got {}".format(root_span.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_schematized_unspecified_service_name_v1(self):
@@ -959,7 +959,9 @@ class PylonsSchemaTestCase(TracerTestCase):
         spans = self.pop_spans()
         root_span = spans[0]
 
-        assert root_span.service == DEFAULT_SPAN_SERVICE_NAME
+        assert root_span.service == DEFAULT_SPAN_SERVICE_NAME, "Expected '{}' but got {}".format(
+            DEFAULT_SPAN_SERVICE_NAME, root_span.service
+        )
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_schematized_operation_name_v0(self):

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -130,7 +130,7 @@ class TestSchematization(PyramidBase):
         spans = self.pop_spans()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == "pyramid", s.service
+        assert s.service == "pyramid", "Expected 'pyramid' and got {}".format(s.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_schematized_service_name_v0(self):
@@ -138,7 +138,7 @@ class TestSchematization(PyramidBase):
         spans = self.pop_spans()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == "pyramid", s.service
+        assert s.service == "pyramid", "Expected 'pyramid' and got {}".format(s.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_schematized_service_name_v1(self):
@@ -146,7 +146,7 @@ class TestSchematization(PyramidBase):
         spans = self.pop_spans()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == "mysvc", s.service
+        assert s.service == "mysvc", "Expected 'mysvc' and got {}".format(s.service)
 
     @TracerTestCase.run_in_subprocess()
     def test_schematized_unspecified_service_name_default(self):
@@ -154,7 +154,7 @@ class TestSchematization(PyramidBase):
         spans = self.pop_spans()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == "pyramid", s.service
+        assert s.service == "pyramid", "Expected 'pyramid' and got {}".format(s.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_schematized_unspecified_service_name_v0(self):
@@ -162,7 +162,7 @@ class TestSchematization(PyramidBase):
         spans = self.pop_spans()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == "pyramid", s.service
+        assert s.service == "pyramid", "Expected 'pyramid' and got {}".format(s.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_schematized_unspecified_service_name_v1(self):
@@ -170,7 +170,9 @@ class TestSchematization(PyramidBase):
         spans = self.pop_spans()
         assert len(spans) == 1
         s = spans[0]
-        assert s.service == DEFAULT_SPAN_SERVICE_NAME, s.service
+        assert s.service == DEFAULT_SPAN_SERVICE_NAME, "Expected '{}' and got {}".format(
+            DEFAULT_SPAN_SERVICE_NAME, s.service
+        )
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_schematized_operation_name_v0(self):
@@ -178,7 +180,7 @@ class TestSchematization(PyramidBase):
         spans = self.pop_spans()
         assert len(spans) == 1
         s = spans[0]
-        assert s.name == "pyramid.request", s.name
+        assert s.name == "pyramid.request", "Expected 'pyramid.request' and got {}".format(s.name)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_schematized_operation_name_v1(self):
@@ -186,7 +188,7 @@ class TestSchematization(PyramidBase):
         spans = self.pop_spans()
         assert len(spans) == 1
         s = spans[0]
-        assert s.name == "http.server.request", s.name
+        assert s.name == "http.server.request", "Expected 'http.server.request' and got {}".format(s.name)
 
 
 @pytest.fixture

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -6,6 +6,8 @@ import pytest
 from ddtrace import config
 from ddtrace.constants import ORIGIN_KEY
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from tests.utils import TracerTestCase
 from tests.webclient import Client
 
 from .utils import PyramidBase
@@ -117,6 +119,74 @@ class TestPyramidDistributedTracingDisabled(PyramidBase):
         assert span.parent_id != 42
         assert span.get_metric(SAMPLING_PRIORITY_KEY) != 2
         assert span.get_tag(ORIGIN_KEY) != "synthetics"
+
+
+class TestSchematization(PyramidBase):
+    instrument = True
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_schematized_service_name_default(self):
+        self.app.get("/", status=200)
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+        assert s.service == "pyramid", s.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_schematized_service_name_v0(self):
+        self.app.get("/", status=200)
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+        assert s.service == "pyramid", s.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_schematized_service_name_v1(self):
+        self.app.get("/", status=200)
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+        assert s.service == "mysvc", s.service
+
+    @TracerTestCase.run_in_subprocess()
+    def test_schematized_unspecified_service_name_default(self):
+        self.app.get("/", status=200)
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+        assert s.service == "pyramid", s.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_schematized_unspecified_service_name_v0(self):
+        self.app.get("/", status=200)
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+        assert s.service == "pyramid", s.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_schematized_unspecified_service_name_v1(self):
+        self.app.get("/", status=200)
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+        assert s.service == DEFAULT_SPAN_SERVICE_NAME, s.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_schematized_operation_name_v0(self):
+        self.app.get("/", status=200)
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+        assert s.name == "pyramid.request", s.name
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_schematized_operation_name_v1(self):
+        self.app.get("/", status=200)
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+        assert s.name == "http.server.request", s.name
 
 
 @pytest.fixture

--- a/tests/contrib/sanic/test_sanic.py
+++ b/tests/contrib/sanic/test_sanic.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import random
 import re
 
@@ -17,6 +18,7 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
+from ddtrace.internal.schema.span_attribute_schema import _DEFAULT_SPAN_SERVICE_NAMES
 from ddtrace.propagation import http as http_propagation
 from tests.utils import override_config
 from tests.utils import override_http_config
@@ -434,3 +436,108 @@ async def test_endpoint_with_numeric_arg(tracer, client, test_spans):
     response = await client.get("/42/count")
     assert _response_status(response) == 200
     assert (await _response_text(response)) == '{"hello":42}'
+
+
+@pytest.mark.parametrize("service_name", [None, "mysvc"])
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+def test_service_name_schematization(ddtrace_run_python_code_in_subprocess, schema_version, service_name):
+    expected_service_name = {
+        None: service_name or "sanic",
+        "v0": service_name or "sanic",
+        "v1": service_name or _DEFAULT_SPAN_SERVICE_NAMES["v1"],
+    }[schema_version]
+    code = """
+import asyncio
+import pytest
+import sys
+
+# prevent circular import issue
+import sanic
+
+# import fixtures
+from tests.conftest import *
+from tests.contrib.sanic.conftest import *
+from tests.contrib.sanic.test_sanic import app
+from tests.contrib.sanic.test_sanic import client
+from tests.contrib.sanic.test_sanic import integration_config
+from tests.contrib.sanic.test_sanic import integration_http_config
+from tests.contrib.sanic.test_sanic import _response_status
+
+from ddtrace.propagation import http as http_propagation
+
+async def test(client, integration_config, integration_http_config, test_spans):
+    response = await client.get("/hello", params=[("foo", "bar")])
+    assert _response_status(response) == 200
+
+    spans = test_spans.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 2
+    request_span = spans[0][0]
+    assert request_span.service == "{}"
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_service_name
+    )
+
+    env = os.environ.copy()
+    if schema_version is not None:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    if service_name is not None:
+        env["DD_SERVICE"] = service_name
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(
+        code,
+        env=env,
+    )
+    assert status == 0, out or err
+
+
+@pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
+def test_operation_name_schematization(ddtrace_run_python_code_in_subprocess, schema_version):
+    expected_operation_name = {None: "sanic.request", "v0": "sanic.request", "v1": "http.server.request"}[
+        schema_version
+    ]
+    code = """
+import asyncio
+import pytest
+import sys
+
+# prevent circular import issue
+import sanic
+
+# import fixtures
+from tests.conftest import *
+from tests.contrib.sanic.conftest import *
+from tests.contrib.sanic.test_sanic import app
+from tests.contrib.sanic.test_sanic import client
+from tests.contrib.sanic.test_sanic import integration_config
+from tests.contrib.sanic.test_sanic import integration_http_config
+from tests.contrib.sanic.test_sanic import _response_status
+
+from ddtrace.propagation import http as http_propagation
+
+async def test(client, integration_config, integration_http_config, test_spans):
+    response = await client.get("/hello", params=[("foo", "bar")])
+    assert _response_status(response) == 200
+
+    spans = test_spans.pop_traces()
+    assert len(spans) == 1
+    assert len(spans[0]) == 2
+    request_span = spans[0][0]
+    assert request_span.name == "{}"
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-x", __file__]))
+    """.format(
+        expected_operation_name
+    )
+
+    env = os.environ.copy()
+    if schema_version is not None:
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(
+        code,
+        env=env,
+    )
+    assert status == 0, out or err

--- a/tests/contrib/tornado/test_tornado_web.py
+++ b/tests/contrib/tornado/test_tornado_web.py
@@ -7,6 +7,7 @@ from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ORIGIN_KEY
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.ext import http
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.opentracer.utils import init_tracer
 from tests.utils import assert_is_measured
 from tests.utils import assert_span_http_status_code
@@ -659,3 +660,89 @@ class TestCustomTornadoWeb(TornadoTestCase):
         assert 0 == request_span.error
         assert request_span.get_tag("component") == "tornado"
         assert request_span.get_tag("span.kind") == "server"
+
+
+class TestSchematization(TornadoTestCase):
+    """
+    Ensure that schematization works for both service name and operations.
+    """
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_service_name_schematization_default(self):
+        self.fetch("/success/")
+        traces = self.pop_traces()
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+
+        request_span = traces[0][0]
+        assert "mysvc" == request_span.service, request_span.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_service_name_schematization_v0(self):
+        self.fetch("/success/")
+        traces = self.pop_traces()
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+
+        request_span = traces[0][0]
+        assert "mysvc" == request_span.service, request_span.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_service_name_schematization_v1(self):
+        self.fetch("/success/")
+        traces = self.pop_traces()
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+
+        request_span = traces[0][0]
+        assert "mysvc" == request_span.service, request_span.service
+
+    @TracerTestCase.run_in_subprocess()
+    def test_unspecified_service_name_schematization_default(self):
+        self.fetch("/success/")
+        traces = self.pop_traces()
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+
+        request_span = traces[0][0]
+        assert "tornado-web" == request_span.service, request_span.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_unspecified_service_name_schematization_v0(self):
+        self.fetch("/success/")
+        traces = self.pop_traces()
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+
+        request_span = traces[0][0]
+        assert "tornado-web" == request_span.service, request_span.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_unspecified_service_name_schematization_v1(self):
+        self.fetch("/success/")
+        traces = self.pop_traces()
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+
+        request_span = traces[0][0]
+        assert DEFAULT_SPAN_SERVICE_NAME == request_span.service, request_span.service
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_unspecified_operation_name_schematization_v0(self):
+        self.fetch("/success/")
+        traces = self.pop_traces()
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+
+        request_span = traces[0][0]
+        assert "tornado.request" == request_span.name, request_span.name
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_unspecified_operation_name_schematization_v1(self):
+        self.fetch("/success/")
+        traces = self.pop_traces()
+        assert 1 == len(traces)
+        assert 1 == len(traces[0])
+
+        request_span = traces[0][0]
+        assert "http.server.request" == request_span.name, request_span.name

--- a/tests/contrib/tornado/test_tornado_web.py
+++ b/tests/contrib/tornado/test_tornado_web.py
@@ -675,7 +675,7 @@ class TestSchematization(TornadoTestCase):
         assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        assert "mysvc" == request_span.service, request_span.service
+        assert "mysvc" == request_span.service, "Expected 'mysvc' but got {}".format(request_span.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_service_name_schematization_v0(self):
@@ -685,7 +685,7 @@ class TestSchematization(TornadoTestCase):
         assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        assert "mysvc" == request_span.service, request_span.service
+        assert "mysvc" == request_span.service, "Expected 'mysvc' but got {}".format(request_span.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_service_name_schematization_v1(self):
@@ -695,7 +695,7 @@ class TestSchematization(TornadoTestCase):
         assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        assert "mysvc" == request_span.service, request_span.service
+        assert "mysvc" == request_span.service, "Expected 'mysvc' but got {}".format(request_span.service)
 
     @TracerTestCase.run_in_subprocess()
     def test_unspecified_service_name_schematization_default(self):
@@ -705,7 +705,7 @@ class TestSchematization(TornadoTestCase):
         assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        assert "tornado-web" == request_span.service, request_span.service
+        assert "tornado-web" == request_span.service, "Expected 'tornado-web' but got {}".format(request_span.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_unspecified_service_name_schematization_v0(self):
@@ -715,7 +715,7 @@ class TestSchematization(TornadoTestCase):
         assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        assert "tornado-web" == request_span.service, request_span.service
+        assert "tornado-web" == request_span.service, "Expected 'tornado-web' but got {}".format(request_span.service)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_unspecified_service_name_schematization_v1(self):
@@ -725,7 +725,9 @@ class TestSchematization(TornadoTestCase):
         assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        assert DEFAULT_SPAN_SERVICE_NAME == request_span.service, request_span.service
+        assert DEFAULT_SPAN_SERVICE_NAME == request_span.service, "Expected '{}' but got {}".format(
+            DEFAULT_SPAN_SERVICE_NAME, request_span.service
+        )
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
     def test_unspecified_operation_name_schematization_v0(self):
@@ -735,7 +737,7 @@ class TestSchematization(TornadoTestCase):
         assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        assert "tornado.request" == request_span.name, request_span.name
+        assert "tornado.request" == request_span.name, "Expected 'tornado.request' but got {}".format(request_span.name)
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
     def test_unspecified_operation_name_schematization_v1(self):
@@ -745,4 +747,6 @@ class TestSchematization(TornadoTestCase):
         assert 1 == len(traces[0])
 
         request_span = traces[0][0]
-        assert "http.server.request" == request_span.name, request_span.name
+        assert "http.server.request" == request_span.name, "Expected 'http.server.request' but got {}".format(
+            request_span.name
+        )

--- a/tests/contrib/urllib3/test_urllib3.py
+++ b/tests/contrib/urllib3/test_urllib3.py
@@ -10,6 +10,7 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.urllib3 import patch
 from ddtrace.contrib.urllib3 import unpatch
 from ddtrace.ext import http
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.pin import Pin
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
@@ -236,6 +237,102 @@ class TestUrllib3(BaseUrllib3TestCase):
         s = spans[0]
 
         assert s.service == "clients"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    def test_schematized_service_name_default(self):
+        """Test the user-set service name is set on the span"""
+        with self.override_config("urllib3", dict(split_by_domain=False)):
+            out = self.http.request("GET", URL_200)
+        assert out.status == 200
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+
+        assert s.service == "urllib3"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_schematized_service_name_v0(self):
+        """Test the user-set service name is set on the span"""
+        with self.override_config("urllib3", dict(split_by_domain=False)):
+            out = self.http.request("GET", URL_200)
+        assert out.status == 200
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+
+        assert s.service == "urllib3"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_schematized_service_name_v1(self):
+        """Test the user-set service name is set on the span"""
+        with self.override_config("urllib3", dict(split_by_domain=False)):
+            out = self.http.request("GET", URL_200)
+        assert out.status == 200
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+
+        assert s.service == "mysvc"
+
+    @TracerTestCase.run_in_subprocess()
+    def test_schematized_unspecified_service_name_default(self):
+        """Test the user-set service name is set on the span"""
+        with self.override_config("urllib3", dict(split_by_domain=False)):
+            out = self.http.request("GET", URL_200)
+        assert out.status == 200
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+
+        assert s.service == "urllib3"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_schematized_unspecified_service_name_v0(self):
+        """Test the user-set service name is set on the span"""
+        with self.override_config("urllib3", dict(split_by_domain=False)):
+            out = self.http.request("GET", URL_200)
+        assert out.status == 200
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+
+        assert s.service == "urllib3"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_schematized_unspecified_service_name_v1(self):
+        """Test the user-set service name is set on the span"""
+        with self.override_config("urllib3", dict(split_by_domain=False)):
+            out = self.http.request("GET", URL_200)
+        assert out.status == 200
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+
+        assert s.service == DEFAULT_SPAN_SERVICE_NAME
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    def test_schematized_operation_name_v0(self):
+        """Test the user-set service name is set on the span"""
+        with self.override_config("urllib3", dict(split_by_domain=False)):
+            out = self.http.request("GET", URL_200)
+        assert out.status == 200
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+
+        assert s.name == "urllib3.request"
+
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    def test_schematized_operation_name_v1(self):
+        """Test the user-set service name is set on the span"""
+        with self.override_config("urllib3", dict(split_by_domain=False)):
+            out = self.http.request("GET", URL_200)
+        assert out.status == 200
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        s = spans[0]
+
+        assert s.name == "http.client.request"
 
     def test_parent_service_name_split_by_domain(self):
         """

--- a/tests/contrib/vertica/test_vertica.py
+++ b/tests/contrib/vertica/test_vertica.py
@@ -9,6 +9,7 @@ from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.vertica.patch import patch
 from ddtrace.contrib.vertica.patch import unpatch
+from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.settings.config import _deepmerge
 from ddtrace.vendor import wrapt
 from tests.contrib.config import VERTICA_CONFIG
@@ -437,23 +438,200 @@ class TestVertica(TracerTestCase):
         self.assertEqual(len(spans), 2)
         self.assertEqual(spans[0].get_metric(ANALYTICS_SAMPLE_RATE_KEY), 1.0)
 
-    def test_user_specified_service(self):
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"), use_pytest=True)
+    @pytest.mark.usefixtures("test_tracer", "test_conn")
+    def test_user_specified_service_default(self):
         """
-        When a user specifies a service for the app
+        v0 (default): When a user specifies a service for the app
             The vertica integration should not use it.
         """
         # Ensure that the service name was configured
-        with self.override_global_config(dict(service="mysvc")):
-            from ddtrace import config
+        from ddtrace import config
 
-            assert config.service == "mysvc"
-            conn, cur = self.test_conn
-            Pin.override(cur, tracer=self.test_tracer)
-            with conn:
-                cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
-                cur.execute("SELECT * FROM {};".format(TEST_TABLE))
+        assert config.service == "mysvc"
+        conn, cur = self.test_conn
+        Pin.override(cur, tracer=self.test_tracer)
+        with conn:
+            cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
+            cur.execute("SELECT * FROM {};".format(TEST_TABLE))
 
         spans = self.test_tracer.pop()
         assert len(spans) == 2
         span = spans[0]
         assert span.service != "mysvc"
+
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"), use_pytest=True
+    )
+    @pytest.mark.usefixtures("test_tracer", "test_conn")
+    def test_user_specified_service_v0(self):
+        """
+        v0: When a user specifies a service for the app
+            The vertica integration should not use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+        conn, cur = self.test_conn
+        Pin.override(cur, tracer=self.test_tracer)
+        with conn:
+            cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
+            cur.execute("SELECT * FROM {};".format(TEST_TABLE))
+
+        spans = self.test_tracer.pop()
+        assert len(spans) == 2
+        span = spans[0]
+        assert span.service != "mysvc"
+
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"), use_pytest=True
+    )
+    @pytest.mark.usefixtures("test_tracer", "test_conn")
+    def test_user_specified_service_v1(self):
+        """
+        v1: When a user specifies a service for the app
+            The vertica integration should use it.
+        """
+        # Ensure that the service name was configured
+        from ddtrace import config
+
+        assert config.service == "mysvc"
+        conn, cur = self.test_conn
+        Pin.override(cur, tracer=self.test_tracer)
+        with conn:
+            cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
+            cur.execute("SELECT * FROM {};".format(TEST_TABLE))
+
+        spans = self.test_tracer.pop()
+        assert len(spans) == 2
+        span = spans[0]
+        assert span.service == "mysvc"
+
+    @pytest.mark.usefixtures("test_tracer", "test_conn")
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"), use_pytest=True)
+    def test_unspecified_service_v0(self):
+        """
+        v1: When a service is unspecified, vertica
+            should result in the default DD_SERVICE the span service
+        """
+        conn, cur = self.test_conn
+        Pin.override(cur, tracer=self.test_tracer)
+        with conn:
+            cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
+            cur.execute("SELECT * FROM {};".format(TEST_TABLE))
+
+        spans = self.test_tracer.pop()
+        assert len(spans) == 2
+        span = spans[0]
+        assert span.service == "vertica"
+
+    @pytest.mark.usefixtures("test_tracer", "test_conn")
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"), use_pytest=True)
+    def test_unspecified_service_v1(self):
+        """
+        v1: When a service is unspecified, vertica
+            should result in the default DD_SERVICE the span service
+        """
+        conn, cur = self.test_conn
+        Pin.override(cur, tracer=self.test_tracer)
+        with conn:
+            cur.execute("INSERT INTO {} (a, b) VALUES (1, 'aa');".format(TEST_TABLE))
+            cur.execute("SELECT * FROM {};".format(TEST_TABLE))
+
+        spans = self.test_tracer.pop()
+        assert len(spans) == 2
+        span = spans[0]
+        assert span.service == DEFAULT_SPAN_SERVICE_NAME
+
+    @pytest.mark.usefixtures("test_tracer", "test_conn")
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"), use_pytest=True)
+    def test_operation_name_v0(self):
+        """
+        v0: Vertica has several different names for operations, including 'fetchall, 'fetchone', and 'query'
+        """
+        conn, cur = self.test_conn
+
+        with conn:
+            cur.execute(
+                """
+                INSERT INTO {} (a, b)
+                SELECT 1, 'a'
+                UNION ALL
+                SELECT 2, 'b'
+                UNION ALL
+                SELECT 3, 'c'
+                UNION ALL
+                SELECT 4, 'd'
+                UNION ALL
+                SELECT 5, 'e'
+                """.format(
+                    TEST_TABLE
+                )
+            )
+            assert cur.rowcount == -1
+
+            cur.execute("SELECT * FROM {};".format(TEST_TABLE))
+            cur.fetchone()
+            cur.rowcount == 1
+            cur.fetchone()
+            cur.rowcount == 2
+            # fetchall just calls fetchone for each remaining row
+            cur.fetchall()
+            cur.rowcount == 5
+
+        spans = self.test_tracer.pop()
+        assert len(spans) == 9
+
+        # check all the rowcounts
+        assert spans[0].name == "vertica.query"
+        assert spans[1].name == "vertica.query"
+        assert spans[2].name == "vertica.fetchone"
+        assert spans[3].name == "vertica.fetchone"
+        assert spans[4].name == "vertica.fetchall"
+
+    @pytest.mark.usefixtures("test_tracer", "test_conn")
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"), use_pytest=True)
+    def test_operation_name_v1(self):
+        """
+        v1: Vertica should use 'query' for all operation names
+        """
+        conn, cur = self.test_conn
+
+        with conn:
+            cur.execute(
+                """
+                INSERT INTO {} (a, b)
+                SELECT 1, 'a'
+                UNION ALL
+                SELECT 2, 'b'
+                UNION ALL
+                SELECT 3, 'c'
+                UNION ALL
+                SELECT 4, 'd'
+                UNION ALL
+                SELECT 5, 'e'
+                """.format(
+                    TEST_TABLE
+                )
+            )
+            assert cur.rowcount == -1
+
+            cur.execute("SELECT * FROM {};".format(TEST_TABLE))
+            cur.fetchone()
+            cur.rowcount == 1
+            cur.fetchone()
+            cur.rowcount == 2
+            # fetchall just calls fetchone for each remaining row
+            cur.fetchall()
+            cur.rowcount == 5
+
+        spans = self.test_tracer.pop()
+        assert len(spans) == 9
+
+        # check all the rowcounts
+        assert spans[0].name == "vertica.query"
+        assert spans[1].name == "vertica.query"
+        assert spans[2].name == "vertica.query"  # previously fetchone
+        assert spans[3].name == "vertica.query"  # previously fetchone
+        assert spans[4].name == "vertica.query"  # previously fetchall

--- a/tests/contrib/vertica/test_vertica.py
+++ b/tests/contrib/vertica/test_vertica.py
@@ -482,7 +482,7 @@ class TestVertica(TracerTestCase):
         spans = self.test_tracer.pop()
         assert len(spans) == 2
         span = spans[0]
-        assert span.service != "mysvc"
+        assert span.service == "vertica"
 
     @TracerTestCase.run_in_subprocess(
         env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"), use_pytest=True

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -348,8 +348,8 @@ app.get("/")"""
 
     env = os.environ.copy()
     if schema_version is not None:
-        env['DD_TRACE_SPAN_ATTRIBUTE_SCHEMA'] = schema_version
+        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     if service_name is not None:
-        env['DD_SERVICE'] = service_name
+        env["DD_SERVICE"] = service_name
     _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, stderr

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[None].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[None].json
@@ -1,0 +1,46 @@
+[[
+  {
+    "name": "aiohttp.request",
+    "service": "global-service-name",
+    "resource": "aiohttp.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "http",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "aiohttp_client",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.status_msg": "OK",
+      "http.url": "http://localhost:8001/status/200",
+      "language": "python",
+      "runtime-id": "619b9561b22945e49ad04ae92e6ee4ea",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 7674
+    },
+    "duration": 20324500,
+    "start": 1683309835903156255
+  },
+     {
+       "name": "TCPConnector.connect",
+       "service": "global-service-name",
+       "resource": "TCPConnector.connect",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "aiohttp"
+       },
+       "duration": 17044417,
+       "start": 1683309835903554588
+     }]]

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v0].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v0].json
@@ -16,7 +16,7 @@
       "http.status_msg": "OK",
       "http.url": "http://localhost:8001/status/200",
       "language": "python",
-      "runtime-id": "199b022a2b424271839012721b577861",
+      "runtime-id": "190046d5f5024712a5fbc3c5095b6308",
       "span.kind": "client"
     },
     "metrics": {
@@ -24,10 +24,10 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 48841
+      "process_id": 7682
     },
-    "duration": 21637000,
-    "start": 1667240262983497000
+    "duration": 6760625,
+    "start": 1683309836972104713
   },
      {
        "name": "TCPConnector.connect",
@@ -41,6 +41,6 @@
        "meta": {
          "component": "aiohttp"
        },
-       "duration": 4452000,
-       "start": 1646721315459826000
+       "duration": 5299167,
+       "start": 1683309836972417005
      }]]

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v1].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v1].json
@@ -1,0 +1,46 @@
+[[
+  {
+    "name": "http.client.request",
+    "service": "global-service-name",
+    "resource": "http.client.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "http",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "aiohttp_client",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.status_msg": "OK",
+      "http.url": "http://localhost:8001/status/200",
+      "language": "python",
+      "runtime-id": "b3d83691a6a8417b8ef35d1924f5fb15",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 7690
+    },
+    "duration": 6850334,
+    "start": 1683309837892326047
+  },
+     {
+       "name": "TCPConnector.connect",
+       "service": "global-service-name",
+       "resource": "TCPConnector.connect",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "aiohttp"
+       },
+       "duration": 5461250,
+       "start": 1683309837892608547
+     }]]

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
@@ -1,0 +1,46 @@
+[[
+  {
+    "name": "aiohttp.request",
+    "service": "",
+    "resource": "aiohttp.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "http",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "aiohttp_client",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.status_msg": "OK",
+      "http.url": "http://localhost:8001/status/200",
+      "language": "python",
+      "runtime-id": "a342157ec6bc478986ad85fd068e3a23",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 7896
+    },
+    "duration": 6532625,
+    "start": 1683309873304028883
+  },
+     {
+       "name": "TCPConnector.connect",
+       "service": "",
+       "resource": "TCPConnector.connect",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "aiohttp"
+       },
+       "duration": 5140833,
+       "start": 1683309873304361800
+     }]]

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
@@ -1,0 +1,46 @@
+[[
+  {
+    "name": "aiohttp.request",
+    "service": "",
+    "resource": "aiohttp.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "http",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "aiohttp_client",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.status_msg": "OK",
+      "http.url": "http://localhost:8001/status/200",
+      "language": "python",
+      "runtime-id": "355f9b8a08c5436ab0bd048e89a5eae8",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 7904
+    },
+    "duration": 6393959,
+    "start": 1683309874270600425
+  },
+     {
+       "name": "TCPConnector.connect",
+       "service": "",
+       "resource": "TCPConnector.connect",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "aiohttp"
+       },
+       "duration": 5044542,
+       "start": 1683309874270919550
+     }]]

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v1].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v1].json
@@ -1,0 +1,46 @@
+[[
+  {
+    "name": "http.client.request",
+    "service": "unnamed-python-service",
+    "resource": "http.client.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "http",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "aiohttp_client",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.status_msg": "OK",
+      "http.url": "http://localhost:8001/status/200",
+      "language": "python",
+      "runtime-id": "da917e48b6e4471bb4f574683c218cb8",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 7912
+    },
+    "duration": 6693042,
+    "start": 1683309875262124884
+  },
+     {
+       "name": "TCPConnector.connect",
+       "service": "unnamed-python-service",
+       "resource": "TCPConnector.connect",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "aiohttp"
+       },
+       "duration": 5268000,
+       "start": 1683309875262429842
+     }]]

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_default.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_default.json
@@ -1,0 +1,32 @@
+[[
+  {
+    "name": "http.request",
+    "service": "global-service-name",
+    "resource": "http.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "http",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "httpx",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.url": "http://localhost:8001/status/200",
+      "http.useragent": "python-httpx/x.xx.x",
+      "language": "python",
+      "runtime-id": "2e9b8ccb504849009439e60cd0df50e8",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 1215
+    },
+    "duration": 3689000,
+    "start": 1683920916207275000
+  }]]

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v0.json
@@ -1,0 +1,32 @@
+[[
+  {
+    "name": "http.request",
+    "service": "global-service-name",
+    "resource": "http.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "http",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "httpx",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.url": "http://localhost:8001/status/200",
+      "http.useragent": "python-httpx/x.xx.x",
+      "language": "python",
+      "runtime-id": "d0d4ed5a680c4edfb181da67ddd73117",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 1222
+    },
+    "duration": 2441000,
+    "start": 1683920917044321000
+  }]]

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v1.json
@@ -1,0 +1,32 @@
+[[
+  {
+    "name": "http.client.request",
+    "service": "global-service-name",
+    "resource": "http.client.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "http",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "httpx",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.url": "http://localhost:8001/status/200",
+      "http.useragent": "python-httpx/x.xx.x",
+      "language": "python",
+      "runtime-id": "a6c74ff7ad5f42439ed7ce053efd1765",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 1229
+    },
+    "duration": 2431000,
+    "start": 1683920917783882000
+  }]]

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v0.json
@@ -1,0 +1,32 @@
+[[
+  {
+    "name": "http.request",
+    "service": "",
+    "resource": "http.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "http",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "httpx",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.url": "http://localhost:8001/status/200",
+      "http.useragent": "python-httpx/x.xx.x",
+      "language": "python",
+      "runtime-id": "c42c9007e51f4f268848a67a8a5b1887",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 933
+    },
+    "duration": 2389000,
+    "start": 1683920783348488000
+  }]]

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v1.json
@@ -1,0 +1,32 @@
+[[
+  {
+    "name": "http.client.request",
+    "service": "unnamed-python-service",
+    "resource": "http.client.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "http",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "httpx",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.url": "http://localhost:8001/status/200",
+      "http.useragent": "python-httpx/x.xx.x",
+      "language": "python",
+      "runtime-id": "af42544f532343e6bbd42753ebb3440e",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 940
+    },
+    "duration": 2484000,
+    "start": 1683920784101870000
+  }]]

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
@@ -1,0 +1,32 @@
+[[
+  {
+    "name": "http.request",
+    "service": "",
+    "resource": "http.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "http",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "httpx",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.url": "http://localhost:8001/status/200",
+      "http.useragent": "python-httpx/x.xx.x",
+      "language": "python",
+      "runtime-id": "7c3530b5d697442eae42e163e446edf0",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 912
+    },
+    "duration": 2486000,
+    "start": 1683920781034007000
+  }]]

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
@@ -1,0 +1,32 @@
+[[
+  {
+    "name": "http.request",
+    "service": "",
+    "resource": "http.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "http",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "httpx",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.url": "http://localhost:8001/status/200",
+      "http.useragent": "python-httpx/x.xx.x",
+      "language": "python",
+      "runtime-id": "6f9d8b39083d4c69b64e0c0adb09dd7e",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 919
+    },
+    "duration": 2441000,
+    "start": 1683920781812906000
+  }]]

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v1.json
@@ -1,8 +1,8 @@
 [[
   {
-    "name": "http.request",
-    "service": "global-service-name",
-    "resource": "http.request",
+    "name": "http.client.request",
+    "service": "unnamed-python-service",
+    "resource": "http.client.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
@@ -16,7 +16,7 @@
       "http.url": "http://localhost:8001/status/200",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "ed5d4610c6c04210b54dcd43a0b8767f",
+      "runtime-id": "74048d49dc6e49ee89fe82f51d84dcf2",
       "span.kind": "client"
     },
     "metrics": {
@@ -25,8 +25,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 85267
+      "process_id": 926
     },
-    "duration": 13840000,
-    "start": 1667242897599408000
+    "duration": 2350000,
+    "start": 1683920782595878000
   }]]

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-None].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-None].json
@@ -1,0 +1,78 @@
+[[
+  {
+    "name": "wsgi.request",
+    "service": "wsgi",
+    "resource": "GET /",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "wsgi",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.status_msg": "OK",
+      "http.url": "http://localhost:80/",
+      "language": "python",
+      "runtime-id": "68188ac8eb38484c8c6fef0f4a9730c0",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 4472
+    },
+    "duration": 219750,
+    "start": 1683916668720254340
+  },
+     {
+       "name": "wsgi.application",
+       "service": "wsgi",
+       "resource": "wsgi.application",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "wsgi"
+       },
+       "duration": 64792,
+       "start": 1683916668720353465
+     },
+        {
+          "name": "wsgi.start_response",
+          "service": "wsgi",
+          "resource": "wsgi.start_response",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "web",
+          "error": 0,
+          "meta": {
+            "component": "wsgi",
+            "span.kind": "server"
+          },
+          "duration": 25375,
+          "start": 1683916668720381257
+        },
+     {
+       "name": "wsgi.response",
+       "service": "wsgi",
+       "resource": "wsgi.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "wsgi",
+         "result_class": "list"
+       },
+       "duration": 44750,
+       "start": 1683916668720424632
+     }]]

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v0].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v0].json
@@ -1,0 +1,78 @@
+[[
+  {
+    "name": "wsgi.request",
+    "service": "wsgi",
+    "resource": "GET /",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "wsgi",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.status_msg": "OK",
+      "http.url": "http://localhost:80/",
+      "language": "python",
+      "runtime-id": "b904f09c4f7f44a4838ed05d333148f6",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 4477
+    },
+    "duration": 256458,
+    "start": 1683916669702136174
+  },
+     {
+       "name": "wsgi.application",
+       "service": "wsgi",
+       "resource": "wsgi.application",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "wsgi"
+       },
+       "duration": 73291,
+       "start": 1683916669702258591
+     },
+        {
+          "name": "wsgi.start_response",
+          "service": "wsgi",
+          "resource": "wsgi.start_response",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "web",
+          "error": 0,
+          "meta": {
+            "component": "wsgi",
+            "span.kind": "server"
+          },
+          "duration": 24917,
+          "start": 1683916669702287924
+        },
+     {
+       "name": "wsgi.response",
+       "service": "wsgi",
+       "resource": "wsgi.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "wsgi",
+         "result_class": "list"
+       },
+       "duration": 47125,
+       "start": 1683916669702340466
+     }]]

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v1].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v1].json
@@ -1,0 +1,78 @@
+[[
+  {
+    "name": "http.server.request",
+    "service": "unnamed-python-service",
+    "resource": "GET /",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "wsgi",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.status_msg": "OK",
+      "http.url": "http://localhost:80/",
+      "language": "python",
+      "runtime-id": "04d60c8cdfbe40de9659ca95512e531a",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 4482
+    },
+    "duration": 265125,
+    "start": 1683916670672439508
+  },
+     {
+       "name": "wsgi.application",
+       "service": "unnamed-python-service",
+       "resource": "wsgi.application",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "wsgi"
+       },
+       "duration": 82250,
+       "start": 1683916670672558341
+     },
+        {
+          "name": "wsgi.start_response",
+          "service": "unnamed-python-service",
+          "resource": "wsgi.start_response",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "web",
+          "error": 0,
+          "meta": {
+            "component": "wsgi",
+            "span.kind": "server"
+          },
+          "duration": 23333,
+          "start": 1683916670672587050
+        },
+     {
+       "name": "wsgi.response",
+       "service": "unnamed-python-service",
+       "resource": "wsgi.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "wsgi",
+         "result_class": "list"
+       },
+       "duration": 52334,
+       "start": 1683916670672647216
+     }]]

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-None].json
@@ -1,0 +1,78 @@
+[[
+  {
+    "name": "wsgi.request",
+    "service": "mysvc",
+    "resource": "GET /",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "wsgi",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.status_msg": "OK",
+      "http.url": "http://localhost:80/",
+      "language": "python",
+      "runtime-id": "ea9ef2b2811f4aa8bf7eb52a5384863a",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 4487
+    },
+    "duration": 281583,
+    "start": 1683916671647470425
+  },
+     {
+       "name": "wsgi.application",
+       "service": "mysvc",
+       "resource": "wsgi.application",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "wsgi"
+       },
+       "duration": 81833,
+       "start": 1683916671647585175
+     },
+        {
+          "name": "wsgi.start_response",
+          "service": "mysvc",
+          "resource": "wsgi.start_response",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "web",
+          "error": 0,
+          "meta": {
+            "component": "wsgi",
+            "span.kind": "server"
+          },
+          "duration": 37708,
+          "start": 1683916671647611842
+        },
+     {
+       "name": "wsgi.response",
+       "service": "mysvc",
+       "resource": "wsgi.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "wsgi",
+         "result_class": "list"
+       },
+       "duration": 73667,
+       "start": 1683916671647673550
+     }]]

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v0].json
@@ -1,0 +1,78 @@
+[[
+  {
+    "name": "wsgi.request",
+    "service": "mysvc",
+    "resource": "GET /",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "wsgi",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.status_msg": "OK",
+      "http.url": "http://localhost:80/",
+      "language": "python",
+      "runtime-id": "9f59477e7928454985ee983f7b494291",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 4492
+    },
+    "duration": 286833,
+    "start": 1683916672641178634
+  },
+     {
+       "name": "wsgi.application",
+       "service": "mysvc",
+       "resource": "wsgi.application",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "wsgi"
+       },
+       "duration": 71084,
+       "start": 1683916672641323592
+     },
+        {
+          "name": "wsgi.start_response",
+          "service": "mysvc",
+          "resource": "wsgi.start_response",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "web",
+          "error": 0,
+          "meta": {
+            "component": "wsgi",
+            "span.kind": "server"
+          },
+          "duration": 25917,
+          "start": 1683916672641353842
+        },
+     {
+       "name": "wsgi.response",
+       "service": "mysvc",
+       "resource": "wsgi.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "wsgi",
+         "result_class": "list"
+       },
+       "duration": 58209,
+       "start": 1683916672641401592
+     }]]

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v1].json
@@ -1,0 +1,78 @@
+[[
+  {
+    "name": "http.server.request",
+    "service": "mysvc",
+    "resource": "GET /",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "component": "wsgi",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.status_msg": "OK",
+      "http.url": "http://localhost:80/",
+      "language": "python",
+      "runtime-id": "2b5ecd4c54864a88a4656a33853d7c13",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 4497
+    },
+    "duration": 242958,
+    "start": 1683916673662208718
+  },
+     {
+       "name": "wsgi.application",
+       "service": "mysvc",
+       "resource": "wsgi.application",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "wsgi"
+       },
+       "duration": 70709,
+       "start": 1683916673662317259
+     },
+        {
+          "name": "wsgi.start_response",
+          "service": "mysvc",
+          "resource": "wsgi.start_response",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "web",
+          "error": 0,
+          "meta": {
+            "component": "wsgi",
+            "span.kind": "server"
+          },
+          "duration": 26417,
+          "start": 1683916673662346051
+        },
+     {
+       "name": "wsgi.response",
+       "service": "mysvc",
+       "resource": "wsgi.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "wsgi",
+         "result_class": "list"
+       },
+       "duration": 52000,
+       "start": 1683916673662394593
+     }]]


### PR DESCRIPTION
    chore(service naming): Multiple Contribs

== Special Note ==
These changes are gated behind a feature flag and are not expected to be
stable until a release note is generated.  Existing customers should be
unaffected.

== Service Naming Summary ==
Datadog is updating its method of determining service names!

Service naming introduces a few concepts:

* Versioned service name "schemas":
  * v0: The existing mechanism for determining service names
  * v1: Replacing the 'default' contrib-specific service name with the env var $DD_SERVICE

These changes are being in conjunction with changes to peer.service updates to bring a better service-naming experience to customers. In particular, these changes will help:

* Remove the creation of fake services, such as grpc.client
* Standardize service names across and within tracers
* Remove the need to create as many fake services to take advantage of Datadog features, such as metrics
* Make more sense to humans

== Operation Naming Summary ==
The service name changes mean that generated spans can no longer rely on `span.service` to differentiate between processes.  A subclass of spans now have a new problem - differentiating between inbound and outbound requests (for the purposes of metrics).  For instance, spans with names `http.request` used to be differentiated by the service they belonged to (incoming requests under `span.service=$DD_SERVICE` and outgoing under `span.service=$DD_CONTRIB_SERVICE_NAME`).  These are now no longer differentiated.

To remedy these issues, operation names are also being changed as part of the service naming effort.  In the above example, `http.request` turns into `http.server.request` (incoming) and `http.client.request` (outgoing).

== This Change ==
This change updates the following contribs:
* urllib3
* requests
* httpx
* httplib
* wsgi
* tornado
* sanic
* pyramid
* pylons
* molten
* flask
* falcon
* djangorestframework
* django
* cherrypy
* bottle
* asgi
* aiohttpvertica
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] OPTIONAL: PR description includes explicit acknowledgement of the performance implications of the change as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.