### PR TITLE
fix(profiler): do not unload google.protobuf in module clean-up [backport #5747 to 1.10]

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -121,7 +121,18 @@ def cleanup_loaded_modules():
     # uses a copy of that module that is distinct from the copy that user code
     # gets when it does `import threading`. The same applies to every module
     # not in `KEEP_MODULES`.
-    KEEP_MODULES = frozenset(["atexit", "ddtrace", "asyncio", "concurrent", "typing", "logging", "attr"])
+    KEEP_MODULES = frozenset(
+        [
+            "atexit",
+            "ddtrace",
+            "asyncio",
+            "concurrent",
+            "typing",
+            "logging",
+            "attr",
+            "google.protobuf",  # the upb backend in >= 4.21 does not like being unloaded
+        ]
+    )
     if PY2:
         KEEP_MODULES_PY2 = frozenset(["encodings", "codecs"])
     for m in list(_ for _ in sys.modules if _ not in LOADED_MODULES):

--- a/releasenotes/notes/fix-profiler-segfault-in-protobuf-apps-032558829864cdfe.yaml
+++ b/releasenotes/notes/fix-profiler-segfault-in-protobuf-apps-032558829864cdfe.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiler: Fixed a bug that caused segmentation faults in applications that
+    use protobuf as a runtime dependency.

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -124,3 +124,20 @@ def test_memalloc_no_init_error_on_fork():
     if not pid:
         exit(0)
     os.waitpid(pid, 0)
+
+
+@pytest.mark.subprocess(
+    ddtrace_run=True,
+    env=dict(
+        DD_PROFILING_ENABLED="1",
+        DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE="1",
+    ),
+    out="OK\n",
+    err=None,
+)
+def test_profiler_start_up_with_module_clean_up_in_protobuf_app():
+    # This can cause segfaults if we do module clean up with later versions of
+    # protobuf. This is a regression test.
+    from google.protobuf import empty_pb2  # noqa
+
+    print("OK")


### PR DESCRIPTION
Backport of #5747 to 1.10

When cleaning up the modules as part of the support for gevent, we also unload google.protobuf. However, starting with version 4.21, the new default upb backend does not tolerate being unloaded, which resulted in segfaults in applications with a runtime dependency on protobuf.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
