### PR TITLE
fix: guard against django cache result errors when setting row_count [backport #5723 to 1.13]

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -188,12 +188,16 @@ def traced_cache(django, pin, func, instance, args, kwargs):
                 db.ROWCOUNT, sum(1 for doc in result if doc) if result and isinstance(result, Iterable) else 0
             )
         elif command_name == "get":
-            # if valid result and check for special case for Django~3.0 that returns an empty Sentinel object as
-            # missing key
-            if result is not None and result != getattr(instance, "_missing_key", None):
-                span.set_metric(db.ROWCOUNT, 1)
-            # else result is invalid or None, set row count to 0
-            else:
+            try:
+                # check also for special case for Django~3.2 that returns an empty Sentinel object for empty results
+                # also check if result is Iterable first since some iterables return ambiguous truth results with ``==``
+                if result is None or (
+                    not isinstance(result, Iterable) and result == getattr(instance, "_missing_key", None)
+                ):
+                    span.set_metric(db.ROWCOUNT, 0)
+                else:
+                    span.set_metric(db.ROWCOUNT, 1)
+            except (AttributeError, NotImplementedError, ValueError):
                 span.set_metric(db.ROWCOUNT, 0)
         return result
 

--- a/releasenotes/notes/guard-against-django-cache-result-errors-6ed2fe989f96eaf9.yaml
+++ b/releasenotes/notes/guard-against-django-cache-result-errors-6ed2fe989f96eaf9.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    django: Adds catch to guard against a ValueError, AttributeError, or NotImplementedError from being thrown when evaluating
+    a django cache result for ``db.row_count`` tag.


### PR DESCRIPTION
Backport of #5723 to 1.13

Patch for issue: https://github.com/DataDog/dd-trace-py/issues/5460. Added try except block to catch potential errors that may occur. Added tests to verify patch works as intended to catch errors.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
