### PR TITLE
ci(debugging): reduce exploration limits [backport #5600 to 1.9]

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -55,23 +55,22 @@ jobs:
   django-testsuite-3_1:
     strategy:
       matrix:
-        expl_profiler: [0, 1]
-        expl_coverage: [0 ,1]
-        exclude:
-          - expl_profiler: 1
-            expl_coverage: 1
-          - expl_profiler: 0
+        include:
+          - suffix: DI profiler
+            expl_profiler: 1
             expl_coverage: 0
-          # Temporarily disabling line coverage to investigate cause of hangs
-          - expl_profiler: 0
+          - suffix: DI coverage
+            expl_profiler: 0
             expl_coverage: 1
     runs-on: ubuntu-20.04
+    name: Django 3.1 (with ${{ matrix.suffix }})
     env:
       DD_PROFILING_ENABLED: true
       DD_TESTING_RAISE: true
       DD_DEBUGGER_EXPL_ENCODE: 0  # Disabled to speed up
       DD_DEBUGGER_EXPL_PROFILER_ENABLED: ${{ matrix.expl_profiler }}
       DD_DEBUGGER_EXPL_COVERAGE_ENABLED: ${{ matrix.expl_coverage }}
+      DD_DEBUGGER_EXPL_CONSERVATIVE: 1
       PYTHONPATH: ../ddtrace/tests/debugging/exploration/:.
     defaults:
       run:

--- a/tests/debugging/exploration/_config.py
+++ b/tests/debugging/exploration/_config.py
@@ -4,6 +4,8 @@ from warnings import warn
 
 from envier import En
 
+from ddtrace.debugging._probe.model import CaptureLimits
+
 
 def parse_venv(value):
     # type: (str) -> t.Optional[str]
@@ -51,6 +53,23 @@ class ExplorationConfig(En):
         "dd.debugger.expl.elusive",
         default=False,
         help="Whether to include elusive modules in the exploration",
+    )
+
+    conservative = En.v(
+        bool,
+        "dd.debugger.expl.conservative",
+        default=False,
+        help="Use extremely low capture limits to reduce overhead",
+    )
+
+    limits = En.d(
+        CaptureLimits,
+        lambda c: CaptureLimits(
+            max_level=0 if c.conservative else 1,
+            max_size=1,
+            max_len=1 if c.conservative else 8,
+            max_fields=1,
+        ),
     )
 
     class ProfilerConfig(En):

--- a/tests/debugging/exploration/_coverage.py
+++ b/tests/debugging/exploration/_coverage.py
@@ -4,6 +4,7 @@ import sys
 from types import ModuleType
 import typing as t
 
+from _config import config as expl_config
 from debugger import COLS
 from debugger import CWD
 from debugger import ExplorationDebugger
@@ -35,6 +36,7 @@ class LineCollector(ModuleCollector):
                     source_file=origin(sys.modules[f.__module__]),
                     line=line,
                     rate=0.0,
+                    limits=expl_config.limits,
                 )
                 for line, functions in discovery.items()
                 for f in functions

--- a/tests/debugging/exploration/_profiler.py
+++ b/tests/debugging/exploration/_profiler.py
@@ -1,5 +1,6 @@
 import typing as t
 
+from _config import config as expl_config
 from debugger import COLS
 from debugger import ExplorationDebugger
 from debugger import ModuleCollector
@@ -28,6 +29,7 @@ class FunctionCollector(ModuleCollector):
                     module=module.__name__,
                     func_qname=fname.replace(module.__name__, "").lstrip("."),
                     rate=float("inf"),
+                    limits=expl_config.limits,
                 )
             )
 

--- a/tests/debugging/exploration/debugger.py
+++ b/tests/debugging/exploration/debugger.py
@@ -235,8 +235,8 @@ class ExplorationDebugger(Debugger):
         cls._instance._collector.on_snapshot = cls.on_snapshot
 
     @classmethod
-    def disable(cls):
-        # type: () -> None
+    def disable(cls, join=True):
+        # type: (bool) -> None
         registry = cls._instance._probe_registry
 
         nprobes = len(registry)
@@ -254,7 +254,7 @@ class ExplorationDebugger(Debugger):
         if snapshots and snapshots[-1]:
             print(snapshots[-1].decode())
 
-        super(ExplorationDebugger, cls).disable()
+        super(ExplorationDebugger, cls).disable(join=join)
 
     @classmethod
     def get_snapshots(cls):


### PR DESCRIPTION
Backport of #5600 to 1.9

We reduce the capture limits in probe installed during exploration testing to reduce the overhead introduced and allow test runs to complete more quickly. The main objective of the exploration tests is to validate the bytecode manipulations, so this does not affect the usefulness of the test runs.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
