### PR TITLE
chore(ci): increase flask-simple timeout

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -68,6 +68,7 @@ benchmark-set-http-meta:
 
 benchmark-flask-simple:
   extends: .benchmarks
+  timeout: 1h 30m
   variables:
     SCENARIO: "flask_simple"
 


### PR DESCRIPTION
Plenty of flask-simple jobs are failing on timeout, e.g. https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/264295530

This is a temporary fix to reduce failures count until flask benchmark execution is parallelized.

![image](https://user-images.githubusercontent.com/88330911/236814247-5af5d6f7-efe9-448c-9465-c2639f839f3e.png)

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
