### PR TITLE
feature(asm): trace subprocess executions

### DIFF
--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -87,18 +87,6 @@ PATCH_MODULES = {
     "tornado": False,
 }
 
-# Patch some more modules for tracing subprocess executions if ASM is enabled
-# XXX JJJ get list from the module dict
-if formats.asbool(os.getenv("DD_APPSEC_ENABLED")):
-    # XXX add more as needed
-    PATCH_MODULES.update(
-        {
-            "os": True,
-            "subprocess": True,
-        }
-    )
-
-
 
 # this information would make sense to live in the contrib modules,
 # but that would mean getting it would require importing those modules,

--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -218,6 +218,7 @@ def patch_subprocess_executions():
         return
 
     from .appsec._patch_subprocess_executions import _patch
+
     _patch()
 
 

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -149,3 +149,21 @@ class DEFAULT(object):
         r"|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]"
         r"{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}"
     )
+
+
+@six.add_metaclass(Constant_Class)
+class COMMANDS(object):
+    """
+    string names used by the library for tagging data for subprocess executions in context or span
+    """
+
+    SPAN_NAME = "command_execution"
+    COMPONENT = "component"
+    SHELL = "cmd.shell"
+    EXEC = "cmd.exec"
+    TRUNCATED = "cmd.truncated"
+    EXIT_CODE = "cmd.exit_code"
+    CTX_SUBP_IS_SHELL = "subprocess_popen_is_shell"
+    CTX_SUBP_TRUNCATED = "subprocess_popen_truncated"
+    CTX_SUBP_LINE = "subprocess_popen_line"
+    CTX_SUBP_BINARY = "subprocess_popen_binary"

--- a/ddtrace/appsec/_patch_subprocess_executions.py
+++ b/ddtrace/appsec/_patch_subprocess_executions.py
@@ -21,11 +21,12 @@ log = get_logger(__name__)
 
 """
 JJJ TODO:
-- add some catching (strings, lists, scrubbed env vars and parameters, et cetera)
-- Truncation
+- add some catching (result for as_string() and as_list(), scrubbed stuff...) 
+- make sure than _unpatch is called at the right time inside the tracer
 - flask snapshot tests from views
 - exception handlers so it never fails and always executes the command
 - constants for the tag names
+- rebase
 """
 
 
@@ -194,7 +195,7 @@ class SubprocessCmdLine(object):
         return str_[0:-(oversize+len(msg))] + msg
 
 
-    def as_list(self):
+    def as_list_and_string(self):
         # type: () -> Tuple[list[str], str]
 
         total_list = self.env_vars + [self.binary] + self.arguments
@@ -203,8 +204,12 @@ class SubprocessCmdLine(object):
         return truncated_list, truncated_str
 
 
+    def as_list(self):
+        return self.as_list_and_string()[0]
+
+
     def as_string(self):
-        return self.as_list()[1]
+        return self.as_list_and_string()[1]
 
 
 def scrub_arg(_arg):

--- a/ddtrace/appsec/_patch_subprocess_executions.py
+++ b/ddtrace/appsec/_patch_subprocess_executions.py
@@ -1,3 +1,4 @@
+import collections
 import re
 import shlex
 import subprocess
@@ -21,9 +22,8 @@ log = get_logger(__name__)
 
 """
 JJJ TODO:
-- Better argument scrubbing with argparse or similar (must work on windows)
+- cmd.exec debe ser un array!
 - Truncation
-- unpatch
 - flask snapshot tests from views
 - exception handlers so it never fails and always executes the command
 - constants for the tag names
@@ -39,7 +39,7 @@ def _patch():
     import os
     Pin().onto(os)
     trace_utils.wrap(os, "system", traced_ossystem(os))
-    # note: popen* uses subprocess, which we alredy wrap below
+    # note: popen* uses subprocess, which we already wrap below
 
     # all os.spawn* variants eventually use this one:
     trace_utils.wrap(os, "_spawnvef", traced_osspawn(os))
@@ -54,15 +54,9 @@ def _patch():
 def _unpatch():
     # type: () -> None
     trace_utils.unwrap(os, "system")
-    # trace_utils.unwrap(os, "popen")
     trace_utils.unwrap(os, "_spawnvef")
     trace_utils.unwrap(subprocess.Popen, "__init__")
     trace_utils.unwrap(subprocess.Popen, "wait")
-
-    if PY2:
-        trace_utils.unwrap(os, "popen2")
-        trace_utils.unwrap(os, "popen3")
-        trace_utils.unwrap(os, "popen4")
 
 
 _COMPILED_ENV_VAR_REGEXP = re.compile(r'\b[A-Z_]+=\w+')
@@ -91,14 +85,25 @@ class SubprocessCmdLine(object):
         self.env_vars = []
         self.binary = ''
         self.arguments = []
-        self.truncated = "false"
+        self.truncated = False
 
         tokens = shell_args if as_list else shlex.split(shell_args)
 
         # Extract previous environment variables, removing all the ones not
         # in ENV_VARS_ALLOWLIST
+        if shell:
+            self.scrub_env_vars(tokens)
+        else:
+            self.binary = tokens[0]
+            self.arguments = tokens[1:]
+
+        self.arguments = list(self.arguments) if isinstance(self.arguments, tuple) else self.arguments
+        self.scrub_arguments()
+
+
+    def scrub_env_vars(self, tokens):
         for idx, token in enumerate(tokens):
-            if shell and re.match(_COMPILED_ENV_VAR_REGEXP, token):
+            if re.match(_COMPILED_ENV_VAR_REGEXP, token):
                 var, value = token.split('=')
                 if var in self.ENV_VARS_ALLOWLIST:
                     self.env_vars.append(token)
@@ -109,14 +114,10 @@ class SubprocessCmdLine(object):
                 # Next after vars are the binary and arguments
                 try:
                     self.binary = tokens[idx]
-                    self.arguments = tokens[idx+1:]
+                    self.arguments = tokens[idx + 1:]
                 except IndexError:
                     pass
                 break
-
-        self.arguments = list(self.arguments) if isinstance(self.arguments, tuple) else self.arguments
-        self.scrub_arguments()
-
 
     def scrub_arguments(self):
         # if the binary is in the denylist, scrub all arguments
@@ -124,21 +125,64 @@ class SubprocessCmdLine(object):
             self.arguments = ['?' for _ in self.arguments]
             return
 
+        param_prefixes = ('-', '/')
         # Scrub case by case
         new_args = []
-        for arg in self.arguments:
+        deque_args = collections.deque(self.arguments)
+        while deque_args:
+            current = deque_args[0]
             for sensitive in self.SENSITIVE_WORDS_WILDCARDS:
-                if fnmatch(arg.lower(), sensitive):
+                if fnmatch(current, sensitive):
+                    is_sensitive = True
+                    break
+            else:
+                is_sensitive=False
+
+            if not is_sensitive:
+                new_args.append(current)
+                deque_args.popleft()
+                continue
+
+            # sensitive
+            if current[0] not in param_prefixes:
+                # potentially not argument, scrub it anyway if it matches a sensitive word
+                new_args.append("?")
+                deque_args.popleft()
+                continue
+
+            # potential --argument
+            if "=" in current:
+                # contains "=" like in "--password=foo", scrub it just in case
+                new_args.append("?")
+                deque_args.popleft()
+                continue
+
+            try:
+                if deque_args[1][0] in param_prefixes:
+                    # Next is another option scrub only the current one
                     new_args.append("?")
+                    deque_args.popleft()
+                    continue
                 else:
-                    new_args.append(arg)
-                break
+                    # Next is not an option but potentially a value, scrub it instead
+                    new_args.extend([current, "?"])
+                    deque_args.popleft()
+                    deque_args.popleft()
+                    continue
+            except IndexError:
+                # No next argument, scrub this one just in case since it's sensitive
+                new_args.append("?")
+                deque_args.popleft()
 
         self.arguments = new_args
 
 
     def as_list(self):
         return self.env_vars + [self.binary] + self.arguments
+
+    def maybe_truncate_string(self, str):
+        # type: (str) -> str
+
 
     def as_string(self):
         return shlex.join(self.as_list())
@@ -150,22 +194,14 @@ def scrub_arg(_arg):
     return _arg
 
 
-def _scrub_params_maybe_truncate(_params):
-    # type: (list[str]) -> tuple[str, list[str]]
-
-    # JJJ do truncation if needed!
-    truncated = "false"
-
-    return truncated, [scrub_arg(a) for a in _params]
-
-
 @trace_utils.with_traced_module
 def traced_ossystem(module, pin, wrapped, instance, args, kwargs):
     with pin.tracer.trace("os.system", span_type=SpanTypes.SYSTEM) as span:
         shellcmd = SubprocessCmdLine(args[0], shell=True)
         span.set_tag_str("name", "command_execution")
         span.set_tag_str("cmd.shell", shellcmd.as_string())
-        span.set_tag_str("cmd.truncated", shellcmd.truncated)
+        if shellcmd.truncated:
+            span.set_tag_str("cmd.truncated", "yes")
         span.set_tag_str("component", "os")
         span.set_tag_str("resource", shellcmd.binary)
         ret = wrapped(*args, **kwargs)
@@ -181,7 +217,8 @@ def traced_osspawn(module, pin, wrapped, instance, args, kwargs):
 
         shellcmd = SubprocessCmdLine(func_args, True, shell=False)
         span.set_tag_str("cmd.exec", shellcmd.as_string())
-        span.set_tag_str("cmd.truncated", shellcmd.truncated)
+        if shellcmd.truncated:
+            span.set_tag_str("cmd.truncated", "true")
         span.set_tag_str("component", "os")
         span.set_tag_str("resource", shellcmd.binary)
 
@@ -202,7 +239,8 @@ def traced_subprocess_init(module, pin, wrapped, instance, args, kwargs):
         _context.set_item("subprocess_popen_is_shell", is_shell, span=span)
 
         shellcmd = SubprocessCmdLine(cmd_args_list, True, shell=is_shell)
-        _context.set_item("subprocess_popen_truncated", shellcmd.truncated, span=span)
+        if shellcmd.truncated:
+            _context.set_item("subprocess_popen_truncated", "yes", span=span)
         _context.set_item("subprocess_popen_line", shellcmd.as_string(), span=span)
         _context.set_item("subprocess_popen_binary", shellcmd.binary, span=span)
 
@@ -216,7 +254,9 @@ def traced_subprocess_wait(module, pin, wrapped, instance, args, kwargs):
 
         sh_tag = "cmd.shell" if _context.get_item("subprocess_popen_is_shell", span=span) else "cmd.exec"
         span.set_tag_str(sh_tag, _context.get_item("subprocess_popen_line", span=span))
-        span.set_tag_str("cmd.truncated", _context.get_item("subprocess_popen_truncated", span=span))
+        truncated = _context.get_item("subprocess_popen_truncated", span=span)
+        if truncated:
+            span.set_tag_str("cmd.truncated", "yes")
         span.set_tag_str("component", "subprocess")
         span.set_tag_str("resource", _context.get_item("subprocess_popen_binary", span=span))
         ret = wrapped(*args, **kwargs)

--- a/ddtrace/appsec/_patch_subprocess_executions.py
+++ b/ddtrace/appsec/_patch_subprocess_executions.py
@@ -180,8 +180,8 @@ class SubprocessCmdLine(object):
     def as_list(self):
         return self.env_vars + [self.binary] + self.arguments
 
-    def maybe_truncate_string(self, str):
-        # type: (str) -> str
+    # def maybe_truncate_string(self, str):
+    #     # type: (str) -> str
 
 
     def as_string(self):
@@ -216,7 +216,7 @@ def traced_osspawn(module, pin, wrapped, instance, args, kwargs):
         mode, file, func_args, _, _ = args
 
         shellcmd = SubprocessCmdLine(func_args, True, shell=False)
-        span.set_tag_str("cmd.exec", shellcmd.as_string())
+        span.set_tag("cmd.exec", shellcmd.as_list())
         if shellcmd.truncated:
             span.set_tag_str("cmd.truncated", "true")
         span.set_tag_str("component", "os")
@@ -241,7 +241,12 @@ def traced_subprocess_init(module, pin, wrapped, instance, args, kwargs):
         shellcmd = SubprocessCmdLine(cmd_args_list, True, shell=is_shell)
         if shellcmd.truncated:
             _context.set_item("subprocess_popen_truncated", "yes", span=span)
-        _context.set_item("subprocess_popen_line", shellcmd.as_string(), span=span)
+
+        if is_shell:
+            _context.set_item("subprocess_popen_line", shellcmd.as_string(), span=span)
+        else:
+            _context.set_item("subprocess_popen_line", shellcmd.as_list(), span=span)
+
         _context.set_item("subprocess_popen_binary", shellcmd.binary, span=span)
 
         wrapped(*args, **kwargs)
@@ -252,8 +257,11 @@ def traced_subprocess_wait(module, pin, wrapped, instance, args, kwargs):
     with pin.tracer.trace("subprocess.Popen.wait", span_type=SpanTypes.SYSTEM) as span:
         span.set_tag_str("name", "command_execution")
 
-        sh_tag = "cmd.shell" if _context.get_item("subprocess_popen_is_shell", span=span) else "cmd.exec"
-        span.set_tag_str(sh_tag, _context.get_item("subprocess_popen_line", span=span))
+        if _context.get_item("subprocess_popen_is_shell", span=span):
+            span.set_tag_str("cmd.shell", _context.get_item("subprocess_popen_line", span=span))
+        else:
+            span.set_tag("cmd.exec", _context.get_item("subprocess_popen_line", span=span))
+
         truncated = _context.get_item("subprocess_popen_truncated", span=span)
         if truncated:
             span.set_tag_str("cmd.truncated", "yes")

--- a/ddtrace/appsec/_patch_subprocess_executions.py
+++ b/ddtrace/appsec/_patch_subprocess_executions.py
@@ -1,8 +1,10 @@
-import copy
+import re
+import shlex
 import subprocess
 from typing import Union
 
 from ddtrace.internal import _context
+from ddtrace import config
 
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.logger import get_logger
@@ -17,70 +19,107 @@ log = get_logger(__name__)
 
 
 """
-XXX JJJ TODO:
+JJJ TODO:
 - Truncation
 - Param scrubbing
 - cmd denylist
-- env var parsing and allowlist
-- shell command parsing
 - unpatch
 - flask snapshot tests from views
-- exception handlers so it never fails
+- exception handlers so it never fails and always executes the command
 - constants for the tag names
 """
 
-_PATCHED = {
-    os: [
-        {
-            "name": "system",
-            "shell_by_default": True,
-            "shell_arg_name": None,
-            "has_direct_return": True
-        },
-    ],
-}
 
 
 def _patch():
+    # type: () -> None
+    if not config._appsec_enabled:
+        return
+
     import os
     Pin().onto(os)
     trace_utils.wrap(os, "system", traced_ossystem(os))
-    trace_utils.wrap(os, "popen", traced_ospopen(os))
+    # note: popen* uses subprocess, which we alredy wrap below
+
     # all os.spawn* variants eventually use this one:
     trace_utils.wrap(os, "_spawnvef", traced_osspawn(os))
 
-    if PY2:
-        trace_utils.wrap(os, "popen2", traced_ospopen(os))
-        trace_utils.wrap(os, "popen3", traced_ospopen(os))
-        trace_utils.wrap(os, "popen4", traced_ospopen(os))
-
     Pin().onto(subprocess)
+    # We store the parameters on __init__ in the context and set the tags on wait
+    # (where all the Popen objects eventually arrive, unless killed before it)
     trace_utils.wrap(subprocess, "Popen.__init__", traced_subprocess_init(subprocess))
     trace_utils.wrap(subprocess, "Popen.wait", traced_subprocess_wait(subprocess))
 
 
+def _unpatch():
+    # type: () -> None
+    trace_utils.unwrap(os, "system")
+    # trace_utils.unwrap(os, "popen")
+    trace_utils.unwrap(os, "_spawnvef")
+    trace_utils.unwrap(subprocess.Popen, "__init__")
+    trace_utils.unwrap(subprocess.Popen, "wait")
+
+    if PY2:
+        trace_utils.unwrap(os, "popen2")
+        trace_utils.unwrap(os, "popen3")
+        trace_utils.unwrap(os, "popen4")
+
+
+_COMPILED_ENV_VAR_REGEXP = re.compile(r'\b[A-Z_]+=\w+')
+
+
+class ShellCmdLine(object):
+    ENV_VARS_ALLOWLIST = {
+        'LD_PRELOAD',
+        'LD_LIBRARY_PATH',
+        'PATH'
+    }
+
+    def __init__(self, shell_args, as_list=False):
+        # type: (Union[str, list], bool) -> None
+        self.env_vars = []
+        self.binary = ''
+        self.arguments = []
+        self.truncated = "false"
+
+        tokens = shell_args if as_list else shlex.split(shell_args)
+
+        # Extract previous environment variables, removing all the ones not
+        # in ENV_VARS_ALLOWLIST
+        for idx, token in enumerate(tokens):
+            if re.match(_COMPILED_ENV_VAR_REGEXP, token):
+                var, value = token.split('=')
+                if var in self.ENV_VARS_ALLOWLIST:
+                    self.env_vars.append(token)
+            else:
+                # Next after vars are the binary and arguments
+                try:
+                    self.binary = tokens[idx]
+                    self.arguments = tokens[idx+1:]
+                except IndexError:
+                    pass
+                break
+
+    def as_list(self):
+        return self.env_vars + [self.binary] + self.arguments
+
+    def as_string(self):
+        return shlex.join(self.as_list())
+
+
 def scrub_arg(_arg):
     # type: (str) -> str
-    # XXX JJJ better scrubbing
+    # JJJ better scrubbing
     return _arg
 
 
 def _scrub_params_maybe_truncate(_params):
     # type: (list[str]) -> tuple[str, list[str]]
 
-    # XXX JJJ do truncation if needed!
+    # JJJ do truncation if needed!
     truncated = "false"
 
     return truncated, [scrub_arg(a) for a in _params]
-
-def parse_shell_args(_args, as_list=False):
-    # type: (Union[str, list], bool) -> tuple[str, list[str]]
-
-    # XXX JJJ better parsing!
-    tokens = _args.split(" ") if not as_list else _args
-    cmd = tokens[0]
-    truncated, params = _scrub_params_maybe_truncate(tokens[1:])
-    return truncated, [cmd] + params
 
 
 def parse_exec_args(_args_list):
@@ -93,27 +132,15 @@ def parse_exec_args(_args_list):
 @trace_utils.with_traced_module
 def traced_ossystem(module, pin, wrapped, instance, args, kwargs):
     with pin.tracer.trace("os.system", span_type=SpanTypes.SYSTEM) as span:
-        truncated, shell_tokens = parse_shell_args(args[0])
+        shellcmd = ShellCmdLine(args[0])
         span.set_tag_str("name", "command_execution")
-        span.set_tag_str("cmd.shell", str(shell_tokens))
-        span.set_tag_str("cmd.truncated", truncated)
+        span.set_tag_str("cmd.shell", shellcmd.as_string())
+        span.set_tag_str("cmd.truncated", shellcmd.truncated)
         span.set_tag_str("component", "os")
-        span.set_tag_str("resource", shell_tokens[0])
+        span.set_tag_str("resource", shellcmd.binary)
         ret = wrapped(*args, **kwargs)
         span.set_tag_str("cmd.exit_code", str(ret))
     return ret
-
-
-@trace_utils.with_traced_module
-def traced_ospopen(module, pin, wrapped, instance, args, kwargs):
-    with pin.tracer.trace("os.popen", span_type=SpanTypes.SYSTEM) as span:
-        truncated, shell_tokens = parse_shell_args(args[0])
-        span.set_tag_str("name", "command_execution")
-        span.set_tag_str("cmd.shell", str(shell_tokens))
-        span.set_tag_str("cmd.truncated", truncated)
-        span.set_tag_str("component", "os")
-        span.set_tag_str("resource", shell_tokens[0])
-        return wrapped(*args, **kwargs)
 
 
 @trace_utils.with_traced_module
@@ -140,15 +167,22 @@ def traced_osspawn(module, pin, wrapped, instance, args, kwargs):
 def traced_subprocess_init(module, pin, wrapped, instance, args, kwargs):
     with pin.tracer.trace("subprocess.Popen.init", span_type=SpanTypes.SYSTEM) as span:
         cmd_args = args[0] if len(args) else kwargs["args"]
+        cmd_args_list = shlex.split(cmd_args) if isinstance(cmd_args, str) else cmd_args
         is_shell = kwargs.get("shell", False)
         _context.set_item("subprocess_popen_is_shell", is_shell, span=span)
 
         if is_shell:
-            truncated, tokens = parse_shell_args(" ".join(cmd_args))
+            shellcmd = ShellCmdLine(cmd_args_list, True)
+            truncated = shellcmd.truncated
+            binary = shellcmd.binary
+            tokens = shellcmd.as_list()
         else:
-            truncated, tokens = parse_exec_args(cmd_args)
+            truncated, tokens = parse_exec_args(cmd_args_list)
+            binary = tokens[0]
+        # JJJ add binary
         _context.set_item("subprocess_popen_truncated", truncated)
-        _context.set_item("subprocess_popen_args", tokens)
+        _context.set_item("subprocess_popen_line", " ".join(tokens))
+        _context.set_item("subprocess_popen_binary", binary)
 
         wrapped(*args, **kwargs)
 
@@ -158,12 +192,12 @@ def traced_subprocess_wait(module, pin, wrapped, instance, args, kwargs):
     with pin.tracer.trace("subprocess.Popen.wait", span_type=SpanTypes.SYSTEM) as span:
         span.set_tag_str("name", "command_execution")
 
-        truncated, exec_tokens = parse_exec_args(instance.args)
         sh_tag = "cmd.shell" if _context.get_item("subprocess_popen_is_shell") else "cmd.exec"
-        span.set_tag_str(sh_tag, " ".join(exec_tokens))
-        span.set_tag_str("cmd.truncated", truncated)
+        span.set_tag_str(sh_tag, _context.get_item("subprocess_popen_line"))
+        span.set_tag_str("cmd.truncated", _context.get_item("subprocess_popen_truncated"))
         span.set_tag_str("component", "subprocess")
-        span.set_tag_str("resource", exec_tokens[0])
-        wrapped(*args, **kwargs)
-        span.set_tag_str("cmd.exit_code", str(instance.returncode))
+        span.set_tag_str("resource", _context.get_item("subprocess_popen_binary"))
+        ret = wrapped(*args, **kwargs)
+        span.set_tag_str("cmd.exit_code", str(ret))
+        return ret
 

--- a/ddtrace/appsec/_patch_subprocess_executions.py
+++ b/ddtrace/appsec/_patch_subprocess_executions.py
@@ -1,0 +1,169 @@
+import copy
+import subprocess
+from typing import Union
+
+from ddtrace.internal import _context
+
+from ddtrace.ext import SpanTypes
+from ddtrace.internal.logger import get_logger
+from ddtrace.internal.compat import PY2
+
+from ddtrace import Pin
+
+from ddtrace.contrib import trace_utils
+import os
+
+log = get_logger(__name__)
+
+
+"""
+XXX JJJ TODO:
+- Truncation
+- Param scrubbing
+- cmd denylist
+- env var parsing and allowlist
+- shell command parsing
+- unpatch
+- flask snapshot tests from views
+- exception handlers so it never fails
+- constants for the tag names
+"""
+
+_PATCHED = {
+    os: [
+        {
+            "name": "system",
+            "shell_by_default": True,
+            "shell_arg_name": None,
+            "has_direct_return": True
+        },
+    ],
+}
+
+
+def _patch():
+    import os
+    Pin().onto(os)
+    trace_utils.wrap(os, "system", traced_ossystem(os))
+    trace_utils.wrap(os, "popen", traced_ospopen(os))
+    # all os.spawn* variants eventually use this one:
+    trace_utils.wrap(os, "_spawnvef", traced_osspawn(os))
+
+    if PY2:
+        trace_utils.wrap(os, "popen2", traced_ospopen(os))
+        trace_utils.wrap(os, "popen3", traced_ospopen(os))
+        trace_utils.wrap(os, "popen4", traced_ospopen(os))
+
+    Pin().onto(subprocess)
+    trace_utils.wrap(subprocess, "Popen.__init__", traced_subprocess_init(subprocess))
+    trace_utils.wrap(subprocess, "Popen.wait", traced_subprocess_wait(subprocess))
+
+
+def scrub_arg(_arg):
+    # type: (str) -> str
+    # XXX JJJ better scrubbing
+    return _arg
+
+
+def _scrub_params_maybe_truncate(_params):
+    # type: (list[str]) -> tuple[str, list[str]]
+
+    # XXX JJJ do truncation if needed!
+    truncated = "false"
+
+    return truncated, [scrub_arg(a) for a in _params]
+
+def parse_shell_args(_args, as_list=False):
+    # type: (Union[str, list], bool) -> tuple[str, list[str]]
+
+    # XXX JJJ better parsing!
+    tokens = _args.split(" ") if not as_list else _args
+    cmd = tokens[0]
+    truncated, params = _scrub_params_maybe_truncate(tokens[1:])
+    return truncated, [cmd] + params
+
+
+def parse_exec_args(_args_list):
+    # type: (list[str]) -> tuple[str, list[str]]
+
+    truncated, params = _scrub_params_maybe_truncate(_args_list)
+    return truncated, params
+
+
+@trace_utils.with_traced_module
+def traced_ossystem(module, pin, wrapped, instance, args, kwargs):
+    with pin.tracer.trace("os.system", span_type=SpanTypes.SYSTEM) as span:
+        truncated, shell_tokens = parse_shell_args(args[0])
+        span.set_tag_str("name", "command_execution")
+        span.set_tag_str("cmd.shell", str(shell_tokens))
+        span.set_tag_str("cmd.truncated", truncated)
+        span.set_tag_str("component", "os")
+        span.set_tag_str("resource", shell_tokens[0])
+        ret = wrapped(*args, **kwargs)
+        span.set_tag_str("cmd.exit_code", str(ret))
+    return ret
+
+
+@trace_utils.with_traced_module
+def traced_ospopen(module, pin, wrapped, instance, args, kwargs):
+    with pin.tracer.trace("os.popen", span_type=SpanTypes.SYSTEM) as span:
+        truncated, shell_tokens = parse_shell_args(args[0])
+        span.set_tag_str("name", "command_execution")
+        span.set_tag_str("cmd.shell", str(shell_tokens))
+        span.set_tag_str("cmd.truncated", truncated)
+        span.set_tag_str("component", "os")
+        span.set_tag_str("resource", shell_tokens[0])
+        return wrapped(*args, **kwargs)
+
+
+@trace_utils.with_traced_module
+def traced_osspawn(module, pin, wrapped, instance, args, kwargs):
+    with pin.tracer.trace("os.spawn", span_type=SpanTypes.SYSTEM) as span:
+        span.set_tag_str("name", "command_execution")
+        mode, file, func_args, _, _ = args
+
+        truncated, exec_tokens = parse_exec_args(func_args)
+        span.set_tag_str("cmd.exec", " ".join(exec_tokens))
+        span.set_tag_str("cmd.truncated", truncated)
+        span.set_tag_str("component", "os")
+        span.set_tag_str("resource", file)
+
+        if mode == os.P_WAIT:
+            ret = wrapped(*args, **kwargs)
+            span.set_tag_str("cmd.exit_code", str(ret))
+            return ret
+
+        return wrapped(*args, **kwargs)
+
+
+@trace_utils.with_traced_module
+def traced_subprocess_init(module, pin, wrapped, instance, args, kwargs):
+    with pin.tracer.trace("subprocess.Popen.init", span_type=SpanTypes.SYSTEM) as span:
+        cmd_args = args[0] if len(args) else kwargs["args"]
+        is_shell = kwargs.get("shell", False)
+        _context.set_item("subprocess_popen_is_shell", is_shell, span=span)
+
+        if is_shell:
+            truncated, tokens = parse_shell_args(" ".join(cmd_args))
+        else:
+            truncated, tokens = parse_exec_args(cmd_args)
+        _context.set_item("subprocess_popen_truncated", truncated)
+        _context.set_item("subprocess_popen_args", tokens)
+
+        wrapped(*args, **kwargs)
+
+
+@trace_utils.with_traced_module
+def traced_subprocess_wait(module, pin, wrapped, instance, args, kwargs):
+    with pin.tracer.trace("subprocess.Popen.wait", span_type=SpanTypes.SYSTEM) as span:
+        span.set_tag_str("name", "command_execution")
+
+        truncated, exec_tokens = parse_exec_args(instance.args)
+        sh_tag = "cmd.shell" if _context.get_item("subprocess_popen_is_shell") else "cmd.exec"
+        span.set_tag_str(sh_tag, " ".join(exec_tokens))
+        span.set_tag_str("cmd.truncated", truncated)
+        span.set_tag_str("component", "subprocess")
+        span.set_tag_str("resource", exec_tokens[0])
+        wrapped(*args, **kwargs)
+        span.set_tag_str("cmd.exit_code", str(instance.returncode))
+

--- a/ddtrace/ext/__init__.py
+++ b/ddtrace/ext/__init__.py
@@ -12,6 +12,7 @@ class SpanTypes(object):
     TEST = "test"
     WEB = "web"
     WORKER = "worker"
+    SYSTEM = "system"
 
 
 class SpanKind(object):

--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -366,14 +366,16 @@ def ip_is_global(ip):
 
     return not (parsed_ip.is_loopback or parsed_ip.is_private)
 
+
 try:
     from shlex import quote as shquote
 except ImportError:
     import re
 
-    _find_unsafe = re.compile(r'[^\w@%+=:,./-]').search
+    _find_unsafe = re.compile(r"[^\w@%+=:,./-]").search
 
     def shquote(s):
+        # type: (str) -> str
         """Return a shell-escaped version of the string *s*."""
         if not s:
             return "''"
@@ -384,9 +386,11 @@ except ImportError:
         # the string $'b is then quoted as '$'"'"'b'
         return "'" + s.replace("'", "'\"'\"'") + "'"
 
+
 try:
     from shlex import join as shjoin
 except ImportError:
-    def shjoin(args):
+    def shjoin(args):  # type: ignore[misc]
+        # type: (Iterable[str]) -> str
         """Return a shell-escaped string from *args*."""
         return " ".join(shquote(arg) for arg in args)

--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -365,3 +365,28 @@ def ip_is_global(ip):
         return parsed_ip.is_global
 
     return not (parsed_ip.is_loopback or parsed_ip.is_private)
+
+try:
+    from shlex import quote as shquote
+except ImportError:
+    import re
+
+    _find_unsafe = re.compile(r'[^\w@%+=:,./-]').search
+
+    def shquote(s):
+        """Return a shell-escaped version of the string *s*."""
+        if not s:
+            return "''"
+        if _find_unsafe(s) is None:
+            return s
+
+        # use single quotes, and put single quotes into double quotes
+        # the string $'b is then quoted as '$'"'"'b'
+        return "'" + s.replace("'", "'\"'\"'") + "'"
+
+try:
+    from shlex import join as shjoin
+except ImportError:
+    def shjoin(args):
+        """Return a shell-escaped string from *args*."""
+        return " ".join(shquote(arg) for arg in args)

--- a/releasenotes/notes/asm-subprocess-executions-479ab8fb59d9f312.yaml
+++ b/releasenotes/notes/asm-subprocess-executions-479ab8fb59d9f312.yaml
@@ -1,0 +1,12 @@
+---
+prelude: >
+  Application Security Management (ASM) has added support for tracing subprocess executions.
+
+features:
+  - |
+    ASM: add support for tracing subprocess executions (like `os.system`, `os.spawn`, `subprocess.Popen` and others) and adding
+      information to a span names `command_execution` with the new type `system`. Currently we add the `cmd.exec` or `cmd.shell` tags
+      to store the full command line (`cmd.shell` will be used when the command is run under a shell like with `os.system` or `Popen` 
+      with `shell=True`), `cmd.exit_code` to hold the return code when available, `component` which will hold the Python module used
+      and the span `resource` will hold the binary used. This feature requires ASM to be activated using the `DD_APPSEC_ENABLED=True`
+      configuration environment variable.

--- a/tests/appsec/test_subprocess_executions.py
+++ b/tests/appsec/test_subprocess_executions.py
@@ -1,0 +1,233 @@
+import os
+import subprocess
+
+import pytest
+from ddtrace.internal import _context
+
+from ddtrace import Pin, patch_all
+from ddtrace.ext import SpanTypes
+from tests.utils import DummyTracer, override_global_config
+
+
+# JJJ test truncated
+# JJJ test scrub_arg
+# JJJ test scrub ENV_VAR=foo cmd
+# JJJ test allowed env vars
+# JJJ test forbidden commands
+# JJJ test parse_shell_args
+# JJJ test parse_exec_args
+
+def test_ossystem(tracer):
+    with override_global_config(dict(_appsec_enabled=True)):
+        patch_all()
+        Pin.get_from(os).clone(tracer=tracer).onto(os)
+        with tracer.trace("os.system", span_type=SpanTypes.SYSTEM):
+            ret = os.system("ls -l /")
+            assert ret == 0
+
+        spans = tracer.pop()
+        assert spans
+        assert len(spans) > 1
+        span = spans[1]
+        assert span.get_tag("name") == "command_execution"
+        assert span.get_tag("cmd.shell") == str(["ls", "-l", "/"])
+        assert span.get_tag("cmd.exit_code") == "0"
+        assert span.get_tag("cmd.truncated") == "false"
+        assert span.get_tag("component") == "os"
+        assert span.get_tag("resource") == "ls"
+
+
+def test_ossystem_noappsec(tracer):
+    with override_global_config(dict(_appsec_enabled=False)):
+        patch_all()
+        assert Pin.get_from(os) is None
+
+
+def test_ospopen(tracer):
+    with override_global_config(dict(_appsec_enabled=True)):
+        patch_all()
+        Pin.get_from(os).clone(tracer=tracer).onto(os)
+        with tracer.trace("os.popen", span_type=SpanTypes.SYSTEM):
+            pipe = os.popen("ls -li /")
+            content = pipe.read()
+            assert content
+            assert pipe.close() is None
+
+        spans = tracer.pop()
+        assert spans
+        assert len(spans) > 1
+        span = spans[1]
+        assert span.get_tag("name") == "command_execution"
+        assert span.get_tag("cmd.shell") == str(["ls", "-li", "/"])
+        assert span.get_tag("cmd.truncated") == "false"
+        assert span.get_tag("component") == "os"
+        assert span.get_tag("resource") == "ls"
+
+
+# XXX JJJ only linux!
+# XXX factorize command, return value, params into a fixture
+
+_PARAMS = ["/usr/bin/ls", "-l", "/"]
+_PARAMS_ENV = _PARAMS + [{"fooenv": "bar"}]  # type: ignore
+@pytest.mark.parametrize(
+    "function,mode,arguments",
+    [
+        (os.spawnl, os.P_WAIT, _PARAMS),
+        (os.spawnl, os.P_NOWAIT, _PARAMS),
+        (os.spawnle, os.P_WAIT, _PARAMS_ENV),
+        (os.spawnle, os.P_NOWAIT, _PARAMS_ENV),
+        (os.spawnlp, os.P_WAIT, _PARAMS),
+        (os.spawnlp, os.P_NOWAIT, _PARAMS),
+        (os.spawnlpe, os.P_WAIT, _PARAMS_ENV),
+        (os.spawnlpe, os.P_NOWAIT, _PARAMS_ENV),
+        (os.spawnv, os.P_WAIT, _PARAMS),
+        (os.spawnv, os.P_NOWAIT, _PARAMS),
+        (os.spawnve, os.P_WAIT, _PARAMS_ENV),
+        (os.spawnve, os.P_NOWAIT, _PARAMS_ENV),
+        (os.spawnvp, os.P_WAIT, _PARAMS),
+        (os.spawnvp, os.P_NOWAIT, _PARAMS),
+        (os.spawnvpe, os.P_WAIT, _PARAMS_ENV),
+        (os.spawnvpe, os.P_NOWAIT, _PARAMS_ENV),
+    ],
+)
+def test_osspawn_variants(tracer, function, mode, arguments):
+    with override_global_config(dict(_appsec_enabled=True)):
+        patch_all()
+        Pin.get_from(os).clone(tracer=tracer).onto(os)
+
+        if "_" in function.__name__:
+            # wrapt changes function names when debugging
+            cleaned_name = function.__name__.split("_")[-1]
+        else:
+            cleaned_name = function.__name__
+
+
+        with tracer.trace("os.spawn", span_type=SpanTypes.SYSTEM):
+            if "spawnv" in cleaned_name:
+                if "e" in cleaned_name:
+                    ret = function(mode, arguments[0], arguments[:-1], arguments[-1])
+                else:
+                    ret = function(mode, arguments[0], arguments)
+            else:
+                ret = function(mode, arguments[0], *arguments)
+            if mode == os.P_WAIT:
+                assert ret == 0
+            else:
+                assert ret > 0  # for P_NOWAIT returned value is the pid
+
+        spans = tracer.pop()
+        assert spans
+        # assert len(spans) > 1
+        span = spans[1]
+        if mode == os.P_WAIT:
+            assert span.get_tag("cmd.exit_code") == str(ret)
+
+        assert span.get_tag("name") == "command_execution"
+        assert span.get_tag("resource") == arguments[0]
+        param_arguments = arguments[1:-1] if "e" in cleaned_name else arguments[1:]
+        assert span.get_tag("cmd.exec") == arguments[0] + " " + " ".join(param_arguments)
+        assert span.get_tag("cmd.truncated") == "false"
+        assert span.get_tag("component") == "os"
+
+
+def test_subprocess_init_shell_true(tracer):
+    with override_global_config(dict(_appsec_enabled=True)):
+        patch_all()
+        Pin.get_from(subprocess).clone(tracer=tracer).onto(subprocess)
+        with tracer.trace("subprocess.Popen.init", span_type=SpanTypes.SYSTEM):
+            subp = subprocess.Popen(["ls", "-li", "/"], shell = True)
+            subp.wait()
+
+        spans = tracer.pop()
+        assert spans
+        assert len(spans) > 1
+        span = spans[1]
+        assert span.get_tag("name") == "command_execution"
+        assert not span.get_tag("cmd.exec")
+        assert span.get_tag("cmd.shell") == "ls -li /"
+        assert span.get_tag("cmd.truncated") == "false"
+        assert span.get_tag("component") == "subprocess"
+        assert span.get_tag("resource") == "ls"
+
+
+def test_subprocess_init_shell_false(tracer):
+    with override_global_config(dict(_appsec_enabled=True)):
+        patch_all()
+        Pin.get_from(subprocess.Popen).clone(tracer=tracer).onto(subprocess.Popen)
+        with tracer.trace("subprocess.Popen.init", span_type=SpanTypes.SYSTEM):
+            subp = subprocess.Popen(["ls", "-li", "/"], shell = False)
+            subp.wait()
+
+        spans = tracer.pop()
+        assert spans
+        assert len(spans) > 1
+        span = spans[1]
+        assert not span.get_tag("cmd.shell")
+        assert span.get_tag("cmd.exec") == "ls -li /"
+
+
+def test_subprocess_wait_shell_false(tracer):
+    with override_global_config(dict(_appsec_enabled=True)):
+        patch_all()
+        Pin.get_from(subprocess).clone(tracer=tracer).onto(subprocess)
+        with tracer.trace("subprocess.Popen.init", span_type=SpanTypes.SYSTEM) as span:
+            subp = subprocess.Popen(args=["ls", "-li", "/"], shell=False)
+            subp.wait()
+
+            assert not _context.get_item("subprocess_popen_is_shell", span=span)
+            assert _context.get_item("subprocess_popen_truncated", span=span) == "false"
+            assert _context.get_item("subprocess_popen_args", span=span) == ["ls", "-li", "/"]
+
+
+def test_subprocess_wait_shell_true(tracer):
+    with override_global_config(dict(_appsec_enabled=True)):
+        patch_all()
+        Pin.get_from(subprocess).clone(tracer=tracer).onto(subprocess)
+        with tracer.trace("subprocess.Popen.init", span_type=SpanTypes.SYSTEM) as span:
+            subp = subprocess.Popen(args=["ls", "-li", "/"], shell=True)
+            subp.wait()
+
+            assert _context.get_item("subprocess_popen_is_shell", span=span)
+
+
+def test_subprocess_run(tracer):
+    with override_global_config(dict(_appsec_enabled=True)):
+        patch_all()
+        Pin.get_from(subprocess).clone(tracer=tracer).onto(subprocess)
+        with tracer.trace("subprocess.Popen.wait", span_type=SpanTypes.SYSTEM):
+            result = subprocess.run(["ls", "-l", "/"], shell=True)
+            assert result.returncode == 0
+
+        spans = tracer.pop()
+        assert spans
+        assert len(spans) > 1
+        span = spans[2]
+        assert span.get_tag("name") == "command_execution"
+        assert not span.get_tag("cmd.exec")
+        assert span.get_tag("cmd.shell") == "ls -l /"
+        assert span.get_tag("cmd.truncated") == "false"
+        assert span.get_tag("component") == "subprocess"
+        assert span.get_tag("cmd.exit_code") == "0"
+        assert span.get_tag("resource") == "ls"
+
+
+
+def test_subprocess_communicate(tracer):
+    with override_global_config(dict(_appsec_enabled=True)):
+        patch_all()
+        Pin.get_from(subprocess).clone(tracer=tracer).onto(subprocess)
+        with tracer.trace("subprocess.Popen.wait", span_type=SpanTypes.SYSTEM):
+            subp = subprocess.Popen(args=["ls", "-li", "/"], shell=True)
+            subp.communicate()
+
+        spans = tracer.pop()
+        assert spans
+        assert len(spans) > 1
+        span = spans[2]
+        assert span.get_tag("name") == "command_execution"
+        assert not span.get_tag("cmd.exec")
+        assert span.get_tag("cmd.shell") == "ls -li /"
+        assert span.get_tag("cmd.truncated") == "false"
+        assert span.get_tag("component") == "subprocess"
+        assert span.get_tag("cmd.exit_code") == "0"
+        assert span.get_tag("resource") == "ls"

--- a/tests/appsec/test_subprocess_executions.py
+++ b/tests/appsec/test_subprocess_executions.py
@@ -3,19 +3,23 @@ import subprocess
 
 import pytest
 
-from ddtrace.appsec._patch_subprocess_executions import _unpatch, SubprocessCmdLine
-from ddtrace.internal import _context
-
-from ddtrace import Pin, patch_all
+from ddtrace import Pin
+from ddtrace import patch_all
+from ddtrace.appsec._patch_subprocess_executions import SubprocessCmdLine
+from ddtrace.appsec._patch_subprocess_executions import _unpatch
 from ddtrace.ext import SpanTypes
+from ddtrace.internal import _context
 from tests.utils import override_global_config
 
 
 # JJJ use some command that can work also on Windoze
 
+
 @pytest.fixture(autouse=True)
 def auto_unpatch():
+    SubprocessCmdLine._clear_cache()
     yield
+    SubprocessCmdLine._clear_cache()
     try:
         _unpatch()
     except AttributeError:
@@ -26,22 +30,24 @@ def auto_unpatch():
 allowed_envvars_fixture_list = []
 for allowed in SubprocessCmdLine.ENV_VARS_ALLOWLIST:
     allowed_envvars_fixture_list.extend(
-    [
-        (
-            SubprocessCmdLine(["%s=bar" % allowed, "BAR=baz", "ls", "-li", "/", "OTHER=any"], True, shell=True),
-            ["%s=bar" % allowed, "BAR=?", "ls", "-li", "/", "OTHER=any"],
-            ["%s=bar"% allowed, "BAR=?"],
-            "ls",
-            ["-li", "/", "OTHER=any"]
-        ),
-        (
-            SubprocessCmdLine(["FOO=bar", "%s=bar" % allowed, "BAR=baz", "ls", "-li", "/", "OTHER=any"], True, shell=True),
-            ["FOO=?", "%s=bar" % allowed, "BAR=?", "ls", "-li", "/", "OTHER=any"],
-            ["FOO=?", "%s=bar" % allowed, "BAR=?"],
-            "ls",
-            ["-li", "/", "OTHER=any"]
-        ),
-    ]
+        [
+            (
+                SubprocessCmdLine(["%s=bar" % allowed, "BAR=baz", "ls", "-li", "/", "OTHER=any"], True, shell=True),
+                ["%s=bar" % allowed, "BAR=?", "ls", "-li", "/", "OTHER=any"],
+                ["%s=bar" % allowed, "BAR=?"],
+                "ls",
+                ["-li", "/", "OTHER=any"],
+            ),
+            (
+                SubprocessCmdLine(
+                    ["FOO=bar", "%s=bar" % allowed, "BAR=baz", "ls", "-li", "/", "OTHER=any"], True, shell=True
+                ),
+                ["FOO=?", "%s=bar" % allowed, "BAR=?", "ls", "-li", "/", "OTHER=any"],
+                ["FOO=?", "%s=bar" % allowed, "BAR=?"],
+                "ls",
+                ["-li", "/", "OTHER=any"],
+            ),
+        ]
     )
 
 
@@ -49,27 +55,28 @@ for allowed in SubprocessCmdLine.ENV_VARS_ALLOWLIST:
     "cmdline_obj,full_list,env_vars,binary,arguments",
     [
         (
-                SubprocessCmdLine(["FOO=bar", "BAR=baz", "ls", "-li", "/"], True, shell=True),
-                ["FOO=?", "BAR=?", "ls", "-li", "/"],
-                ["FOO=?", "BAR=?"],
-                "ls",
-                ["-li", "/"]
+            SubprocessCmdLine(["FOO=bar", "BAR=baz", "ls", "-li", "/"], True, shell=True),
+            ["FOO=?", "BAR=?", "ls", "-li", "/"],
+            ["FOO=?", "BAR=?"],
+            "ls",
+            ["-li", "/"],
         ),
         (
-                SubprocessCmdLine(["FOO=bar", "BAR=baz", "ls", "-li", "/dir with spaces", "OTHER=any"], True, shell=True),
-                ["FOO=?", "BAR=?", "ls", "-li", "/dir with spaces", "OTHER=any"],
-                ["FOO=?", "BAR=?"],
-                "ls",
-                ["-li", "/dir with spaces", "OTHER=any"]
+            SubprocessCmdLine(["FOO=bar", "BAR=baz", "ls", "-li", "/dir with spaces", "OTHER=any"], True, shell=True),
+            ["FOO=?", "BAR=?", "ls", "-li", "/dir with spaces", "OTHER=any"],
+            ["FOO=?", "BAR=?"],
+            "ls",
+            ["-li", "/dir with spaces", "OTHER=any"],
         ),
         (
-                SubprocessCmdLine(["FOO=bar", "lower=baz", "ls", "-li", "/", "OTHER=any"], True, shell=True),
-                ["FOO=?", "lower=baz", "ls", "-li", "/", "OTHER=any"],
-                ["FOO=?"],
-                "lower=baz",
-                ["ls", "-li", "/", "OTHER=any"]
+            SubprocessCmdLine(["FOO=bar", "lower=baz", "ls", "-li", "/", "OTHER=any"], True, shell=True),
+            ["FOO=?", "lower=baz", "ls", "-li", "/", "OTHER=any"],
+            ["FOO=?"],
+            "lower=baz",
+            ["ls", "-li", "/", "OTHER=any"],
         ),
-    ] + allowed_envvars_fixture_list
+    ]
+    + allowed_envvars_fixture_list,
 )
 def test_shellcmdline(cmdline_obj, full_list, env_vars, binary, arguments):
     assert cmdline_obj.as_list() == full_list
@@ -90,37 +97,46 @@ for denied in SubprocessCmdLine.BINARIES_DENYLIST:
         ]
     )
 
+
 @pytest.mark.parametrize(
-    "cmdline_obj,full_list,arguments",
-    [
-        (
-            SubprocessCmdLine(["ls", "-li", "/"], True),
-            ["ls", "-li", "/"],
-            ["-li", "/"]
-        )
-    ]
+    "cmdline_obj,full_list,arguments", [(SubprocessCmdLine(["ls", "-li", "/"], True), ["ls", "-li", "/"], ["-li", "/"])]
 )
 def test_binary_arg_scrubbing(cmdline_obj, full_list, arguments):
     assert cmdline_obj.as_list() == full_list
     assert cmdline_obj.arguments == arguments
 
 
-
 @pytest.mark.parametrize(
     "cmdline_obj,arguments",
     [
         (
-            SubprocessCmdLine(["binary", "-a", "-b1", "-c=foo", "-d bar", "--long1=long1value",
-                               "--long2 long2value"], as_list=True, shell=False),
-            ["-a", "-b1", "-c=foo", "-d bar", "--long1=long1value", "--long2 long2value"]
+            SubprocessCmdLine(
+                ["binary", "-a", "-b1", "-c=foo", "-d bar", "--long1=long1value", "--long2 long2value"],
+                as_list=True,
+                shell=False,
+            ),
+            ["-a", "-b1", "-c=foo", "-d bar", "--long1=long1value", "--long2 long2value"],
         ),
-            (
-            SubprocessCmdLine(["binary", "-a", "-passwd=SCRUB", "-passwd", "SCRUB",
-                               "-d bar", "--apikey=SCRUB", "-efoo", "/auth_tokenSCRUB",
-                               "--secretSCRUB"], as_list=True, shell=False),
-            ["-a", "?", "-passwd", "?", "-d bar", "?", "-efoo", "?", "?"]
-        )
-    ]
+        (
+            SubprocessCmdLine(
+                [
+                    "binary",
+                    "-a",
+                    "-passwd=SCRUB",
+                    "-passwd",
+                    "SCRUB",
+                    "-d bar",
+                    "--apikey=SCRUB",
+                    "-efoo",
+                    "/auth_tokenSCRUB",
+                    "--secretSCRUB",
+                ],
+                as_list=True,
+                shell=False,
+            ),
+            ["-a", "?", "-passwd", "?", "-d bar", "?", "-efoo", "?", "?"],
+        ),
+    ],
 )
 def test_argument_scrubing(cmdline_obj, arguments):
     assert cmdline_obj.arguments == arguments
@@ -130,19 +146,13 @@ def test_argument_scrubing(cmdline_obj, arguments):
     "cmdline_obj,expected_str,expected_list,truncated",
     [
         (
-            SubprocessCmdLine(["ls", "-A" + "loremipsum"* 40, "-B"],
-                              as_list=True),
+            SubprocessCmdLine(["ls", "-A" + "loremipsum" * 40, "-B"], as_list=True),
             'ls -Aloremipsumloremipsumloremipsumlo "4kB argument truncated by 328 characters"',
             ["ls", "-Aloremipsumloremipsumloremipsumlo", "4kB argument truncated by 328 characters"],
-            True
+            True,
         ),
-        (
-            SubprocessCmdLine("ls -A -B -C", as_list=False),
-            "ls -A -B -C",
-            ["ls", "-A", "-B", "-C"],
-            False
-        )
-    ]
+        (SubprocessCmdLine("ls -A -B -C", as_list=False), "ls -A -B -C", ["ls", "-A", "-B", "-C"], False),
+    ],
 )
 def test_truncation(cmdline_obj, expected_str, expected_list, truncated):
     orig_limit = SubprocessCmdLine.TRUNCATE_LIMIT
@@ -163,6 +173,7 @@ def test_truncation(cmdline_obj, expected_str, expected_list, truncated):
     finally:
         SubprocessCmdLine.TRUNCATE_LIMIT = orig_limit
 
+
 def test_ossystem(tracer):
     with override_global_config(dict(_appsec_enabled=True)):
         patch_all()
@@ -176,7 +187,7 @@ def test_ossystem(tracer):
         assert len(spans) > 1
         span = spans[1]
         assert span.get_tag("name") == "command_execution"
-        assert span.get_tag("cmd.shell") == 'ls -l /'
+        assert span.get_tag("cmd.shell") == "ls -l /"
         assert span.get_tag("cmd.exit_code") == "0"
         assert not span.get_tag("cmd.truncated")
         assert span.get_tag("component") == "os"
@@ -195,7 +206,7 @@ def test_unpatch(tracer):
         assert spans
         assert len(spans) > 1
         span = spans[1]
-        assert span.get_tag("cmd.shell") == 'ls -l /'
+        assert span.get_tag("cmd.shell") == "ls -l /"
 
     _unpatch()
     with override_global_config(dict(_appsec_enabled=True)):
@@ -219,9 +230,9 @@ def test_unpatch(tracer):
 def test_ossystem_noappsec(tracer):
     with override_global_config(dict(_appsec_enabled=False)):
         patch_all()
-        assert not hasattr(os.system, '__wrapped__')
-        assert not hasattr(os._spawnvef, '__wrapped__')
-        assert not hasattr(subprocess.Popen.__init__, '__wrapped__')
+        assert not hasattr(os.system, "__wrapped__")
+        assert not hasattr(os._spawnvef, "__wrapped__")
+        assert not hasattr(subprocess.Popen.__init__, "__wrapped__")
 
 
 def test_ospopen(tracer):
@@ -249,6 +260,8 @@ def test_ospopen(tracer):
 
 _PARAMS = ["/usr/bin/ls", "-l", "/"]
 _PARAMS_ENV = _PARAMS + [{"fooenv": "bar"}]  # type: ignore
+
+
 @pytest.mark.parametrize(
     "function,mode,arguments",
     [
@@ -280,7 +293,6 @@ def test_osspawn_variants(tracer, function, mode, arguments):
             cleaned_name = function.__name__.split("_")[-1]
         else:
             cleaned_name = function.__name__
-
 
         with tracer.trace("os.spawn", span_type=SpanTypes.SYSTEM):
             if "spawnv" in cleaned_name:
@@ -315,7 +327,7 @@ def test_subprocess_init_shell_true(tracer):
         patch_all()
         Pin.get_from(subprocess).clone(tracer=tracer).onto(subprocess)
         with tracer.trace("subprocess.Popen.init", span_type=SpanTypes.SYSTEM):
-            subp = subprocess.Popen(["ls", "-li", "/"], shell = True)
+            subp = subprocess.Popen(["ls", "-li", "/"], shell=True)
             subp.wait()
 
         spans = tracer.pop()
@@ -335,7 +347,7 @@ def test_subprocess_init_shell_false(tracer):
         patch_all()
         Pin.get_from(subprocess).clone(tracer=tracer).onto(subprocess)
         with tracer.trace("subprocess.Popen.init", span_type=SpanTypes.SYSTEM):
-            subp = subprocess.Popen(["ls", "-li", "/"], shell = False)
+            subp = subprocess.Popen(["ls", "-li", "/"], shell=False)
             subp.wait()
 
         spans = tracer.pop()
@@ -347,7 +359,7 @@ def test_subprocess_init_shell_false(tracer):
 
 
 def test_subprocess_wait_shell_false(tracer):
-    args = ['ls', '-li', '/']
+    args = ["ls", "-li", "/"]
     with override_global_config(dict(_appsec_enabled=True)):
         patch_all()
         Pin.get_from(subprocess).clone(tracer=tracer).onto(subprocess)
@@ -411,3 +423,44 @@ def test_subprocess_communicate(tracer):
         assert span.get_tag("component") == "subprocess"
         assert span.get_tag("cmd.exit_code") == "0"
         assert span.get_tag("resource") == "ls"
+
+
+def test_cache_hit():
+    cmd1 = SubprocessCmdLine("ls -foo -bar", shell=False)
+    cmd2 = SubprocessCmdLine("ls -foo -bar", shell=False)
+    cmd3 = SubprocessCmdLine("ls -foo -bar", shell=True)
+    cmd4 = SubprocessCmdLine("ls -foo -bar", shell=True)
+    cmd5 = SubprocessCmdLine("ls -foo -baz", shell=False)
+    assert id(cmd1._cache_entry) == id(cmd2._cache_entry)
+    assert id(cmd1._cache_entry) != id(cmd3._cache_entry)
+    assert id(cmd3._cache_entry) == id(cmd4._cache_entry)
+    assert id(cmd1._cache_entry) != id(cmd5._cache_entry)
+
+
+def test_cache_maxsize():
+    orig_cache_maxsize = SubprocessCmdLine._CACHE_MAXSIZE
+    try:
+        assert len(SubprocessCmdLine._CACHE) == 0
+        SubprocessCmdLine._CACHE_MAXSIZE = 2
+        cmd1 = SubprocessCmdLine("ls -foo -bar")  # first entry
+        cmd2 = SubprocessCmdLine("ls -foo -bar")  # first entry
+        assert len(SubprocessCmdLine._CACHE) == 1
+        assert len(SubprocessCmdLine._CACHE_DEQUE) == 1
+        assert id(cmd1._cache_entry) == id(cmd2._cache_entry)
+
+        cmd3 = SubprocessCmdLine("other -foo -bar")  # second entry
+        assert len(SubprocessCmdLine._CACHE) == 2
+        assert len(SubprocessCmdLine._CACHE_DEQUE) == 2
+
+        cmd4 = SubprocessCmdLine("another -bar -foo")  # third entry, should remove first
+        assert len(SubprocessCmdLine._CACHE) == 2
+        assert len(SubprocessCmdLine._CACHE_DEQUE) == 2
+
+        cmd5 = SubprocessCmdLine("ls -foo -bar")  # fourth entry since first was removed, removed second
+        assert len(SubprocessCmdLine._CACHE) == 2
+        assert len(SubprocessCmdLine._CACHE_DEQUE) == 2
+        assert id(cmd1._cache_entry) != id(cmd5._cache_entry)
+    finally:
+        SubprocessCmdLine._CACHE_MAXSIZE = orig_cache_maxsize
+
+

--- a/tests/contrib/django/django1_app/urls.py
+++ b/tests/contrib/django/django1_app/urls.py
@@ -30,5 +30,6 @@ urlpatterns = [
     url(r"^composed-view/$", views.ComposedView.as_view(), name="composed-view"),
     url(r"^alter-resource/$", views.alter_resource, name="alter-resource"),
     url(r"^identify/$", views.identify, name="identify"),
+    url(r"^ossystem/$", views.ossystem, name="ossystem"),
     url("appsec/", include("tests.contrib.django.django_app.appsec_urls")),
 ]

--- a/tests/contrib/django/django_app/urls.py
+++ b/tests/contrib/django/django_app/urls.py
@@ -78,4 +78,5 @@ urlpatterns = [
     handler(r"^shutdown-tracer/$", shutdown, name="shutdown-tracer"),
     handler(r"^alter-resource/$", views.alter_resource),
     handler(r"^identify/$", views.identify, name="identify"),
+    handler(r"^ossystem/$", views.ossystem, name="ossystem"),
 ]

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -1,18 +1,21 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
+import os
 
 import mock
 import pytest
+from ddtrace.contrib import trace_utils
 
-from ddtrace import config
+from ddtrace import config, _monkey, Pin, patch_all
 from ddtrace._monkey import patch_iast
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
+from ddtrace.appsec._patch_subprocess_executions import _patch
 from ddtrace.appsec.iast import oce
 from ddtrace.appsec.iast._util import _is_python_version_supported as python_supported_by_iast
-from ddtrace.ext import http
+from ddtrace.ext import http, SpanTypes
 from ddtrace.internal import _context
 from ddtrace.internal import constants
 from ddtrace.internal.compat import PY3
@@ -25,6 +28,7 @@ from tests.appsec.test_processor import RULES_SRB_METHOD
 from tests.appsec.test_processor import RULES_SRB_RESPONSE
 from tests.appsec.test_processor import _ALLOWED_IP
 from tests.appsec.test_processor import _BLOCKED_IP
+from tests.contrib.patch import PatchTestCase
 from tests.utils import override_env
 from tests.utils import override_global_config
 
@@ -821,3 +825,39 @@ def test_django_tainted_user_agent_iast_disabled(client, test_spans, tracer):
 
         assert response.status_code == 200
         assert response.content == b"test/1.2.3"
+
+
+# XXX move out of test_django_appsec!
+
+def test_django_subexec_system(client, test_spans, tracer):
+    with override_global_config(dict(_appsec_enabled=True)):
+        tracer._appsec_enabled = config._appsec_enabled
+        # Hack: need to pass an argument to configure so that the processors are recreated
+        tracer.configure(api_version="v0.4")
+        _monkey.patch_all()
+        import os
+        root_span, response = _aux_appsec_get_root_span(
+            client,
+            test_spans,
+            tracer,
+            url="/ossystem/",
+        )
+        assert response.status_code == 200
+        assert response.content == b"XXX0"
+        pin = Pin.get_from(os)
+        span = pin.tracer.current_span()
+        pass
+        # system_span = test_spans.find_span(name="os.system")
+        # assert system_span
+
+
+def test_XXX():
+    with override_global_config(dict(_appsec_enabled=True)):
+        import os
+        patch_all()
+
+        ret = os.system("ls")
+        assert ret == "XXX0"
+        pin = Pin.get_from(os)
+        span = pin.tracer.current_span()
+        pass

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -5,9 +5,11 @@ import os
 
 import mock
 import pytest
-from ddtrace.contrib import trace_utils
 
-from ddtrace import config, _monkey, Pin, patch_all
+from ddtrace import Pin
+from ddtrace import _monkey
+from ddtrace import config
+from ddtrace import patch_all
 from ddtrace._monkey import patch_iast
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import IAST
@@ -15,7 +17,9 @@ from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.appsec._patch_subprocess_executions import _patch
 from ddtrace.appsec.iast import oce
 from ddtrace.appsec.iast._util import _is_python_version_supported as python_supported_by_iast
-from ddtrace.ext import http, SpanTypes
+from ddtrace.contrib import trace_utils
+from ddtrace.ext import SpanTypes
+from ddtrace.ext import http
 from ddtrace.internal import _context
 from ddtrace.internal import constants
 from ddtrace.internal.compat import PY3
@@ -829,6 +833,7 @@ def test_django_tainted_user_agent_iast_disabled(client, test_spans, tracer):
 
 # XXX move out of test_django_appsec!
 
+
 def test_django_subexec_system(client, test_spans, tracer):
     with override_global_config(dict(_appsec_enabled=True)):
         tracer._appsec_enabled = config._appsec_enabled
@@ -836,6 +841,7 @@ def test_django_subexec_system(client, test_spans, tracer):
         tracer.configure(api_version="v0.4")
         _monkey.patch_all()
         import os
+
         root_span, response = _aux_appsec_get_root_span(
             client,
             test_spans,
@@ -854,6 +860,7 @@ def test_django_subexec_system(client, test_spans, tracer):
 def test_XXX():
     with override_global_config(dict(_appsec_enabled=True)):
         import os
+
         patch_all()
 
         ret = os.system("ls")

--- a/tests/contrib/django/views.py
+++ b/tests/contrib/django/views.py
@@ -196,5 +196,6 @@ def identify(request):
 
 def ossystem(request):
     import os
+
     ret = os.system("ls")
     return HttpResponse(str(ret), status=200)

--- a/tests/contrib/django/views.py
+++ b/tests/contrib/django/views.py
@@ -192,3 +192,9 @@ def identify(request):
         scope="usr.scope",
     )
     return HttpResponse(status=200)
+
+
+def ossystem(request):
+    import os
+    ret = os.system("ls")
+    return HttpResponse(str(ret), status=200)

--- a/tests/contrib/flask/app.py
+++ b/tests/contrib/flask/app.py
@@ -76,11 +76,13 @@ def run_ossystem():
 
 
 if sys.platform == "linux":
+
     @app.route("/executions/osspawn")
     def run_osspawn():
         args = ["/usr/bin/ls", "-l", "/"]
         ret = os.spawnl(os.P_WAIT, args[0], *args)
         return str(ret), 200
+
 
 @app.route("/executions/subcommunicateshell")
 def run_subcommunicateshell():

--- a/tests/contrib/flask/app.py
+++ b/tests/contrib/flask/app.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 from flask import Flask
@@ -66,3 +67,32 @@ def checkuser(user_id):
 
     block_request_if_user_blocked(tracer, user_id)
     return "Ok", 200
+
+
+@app.route("/executions/ossystem")
+def run_ossystem():
+    ret = os.system("dir -li /")
+    return str(ret), 200
+
+
+if sys.platform == "linux":
+    @app.route("/executions/osspawn")
+    def run_osspawn():
+        args = ["/usr/bin/ls", "-l", "/"]
+        ret = os.spawnl(os.P_WAIT, args[0], *args)
+        return str(ret), 200
+
+@app.route("/executions/subcommunicateshell")
+def run_ossystem():
+    subp = subprocess.Popen(args=["dir", "-li", "/"], shell=True)
+    subp.communicate()
+    ret = subp.returncode
+    return str(ret), 200
+
+
+@app.route("/executions/subcommunicatenoshell")
+def run_ossystem():
+    subp = subprocess.Popen(args=["dir", "-li", "/"], shell=True)
+    subp.communicate()
+    ret = subp.returncode
+    return str(ret), 200

--- a/tests/contrib/flask/app.py
+++ b/tests/contrib/flask/app.py
@@ -83,7 +83,7 @@ if sys.platform == "linux":
         return str(ret), 200
 
 @app.route("/executions/subcommunicateshell")
-def run_ossystem():
+def run_subcommunicateshell():
     subp = subprocess.Popen(args=["dir", "-li", "/"], shell=True)
     subp.communicate()
     ret = subp.returncode
@@ -91,8 +91,8 @@ def run_ossystem():
 
 
 @app.route("/executions/subcommunicatenoshell")
-def run_ossystem():
-    subp = subprocess.Popen(args=["dir", "-li", "/"], shell=True)
+def run_subcommunicatenoshell():
+    subp = subprocess.Popen(args=["dir", "-li", "/"], shell=False)
     subp.communicate()
     ret = subp.returncode
     return str(ret), 200

--- a/tests/contrib/flask/test_appsec_flask_snapshot.py
+++ b/tests/contrib/flask/test_appsec_flask_snapshot.py
@@ -285,6 +285,7 @@ def test_flask_processexec_subprocesscommunicateshell(flask_client):
     assert resp.status_code == 200
     assert resp.text == "0"
 
+
 @pytest.mark.snapshot(
     ignores=[
         "meta._dd.appsec.waf.duration",

--- a/tests/contrib/flask/test_appsec_flask_snapshot.py
+++ b/tests/contrib/flask/test_appsec_flask_snapshot.py
@@ -212,3 +212,98 @@ def test_flask_userblock_match_403_json(flask_client):
 def test_flask_userblock_match_200_json(flask_client):
     resp = flask_client.get("/checkuser/%s" % _ALLOWED_USER)
     assert resp.status_code == 200
+
+
+@pytest.mark.snapshot(
+    ignores=[
+        "meta._dd.appsec.waf.duration",
+        "meta._dd.appsec.waf.duration_ext",
+        "meta.flask.version",
+        "meta.http.request.headers.accept-encoding",
+        "meta.http.request.headers.user-agent",
+        "http.response.headers.content-length",
+        "http.response.headers.content-type",
+        "meta.http.useragent",
+        "meta.error.stack",
+        "metrics._dd.appsec.event_rules.loaded",
+        "metrics._dd.appsec.waf.duration",
+        "metrics._dd.appsec.waf.duration_ext",
+    ],
+    variants={"220": flask_version >= (2, 2, 0), "": flask_version < (2, 2, 0)},
+)
+@pytest.mark.parametrize("flask_env_arg", (flask_appsec_good_rules_env,))
+def test_flask_processexec_ossystem(flask_client):
+    resp = flask_client.get("/executions/ossystem")
+    assert resp.status_code == 200
+    assert resp.text == "0"
+
+
+@pytest.mark.snapshot(
+    ignores=[
+        "meta._dd.appsec.waf.duration",
+        "meta._dd.appsec.waf.duration_ext",
+        "meta.flask.version",
+        "meta.http.request.headers.accept-encoding",
+        "meta.http.request.headers.user-agent",
+        "http.response.headers.content-length",
+        "http.response.headers.content-type",
+        "meta.http.useragent",
+        "meta.error.stack",
+        "metrics._dd.appsec.event_rules.loaded",
+        "metrics._dd.appsec.waf.duration",
+        "metrics._dd.appsec.waf.duration_ext",
+    ],
+    variants={"220": flask_version >= (2, 2, 0), "": flask_version < (2, 2, 0)},
+)
+@pytest.mark.parametrize("flask_env_arg", (flask_appsec_good_rules_env,))
+def test_flask_processexec_osspawn(flask_client):
+    resp = flask_client.get("/executions/osspawn")
+    assert resp.status_code == 200
+    assert resp.text == "0"
+
+
+@pytest.mark.snapshot(
+    ignores=[
+        "meta._dd.appsec.waf.duration",
+        "meta._dd.appsec.waf.duration_ext",
+        "meta.flask.version",
+        "meta.http.request.headers.accept-encoding",
+        "meta.http.request.headers.user-agent",
+        "http.response.headers.content-length",
+        "http.response.headers.content-type",
+        "meta.http.useragent",
+        "meta.error.stack",
+        "metrics._dd.appsec.event_rules.loaded",
+        "metrics._dd.appsec.waf.duration",
+        "metrics._dd.appsec.waf.duration_ext",
+    ],
+    variants={"220": flask_version >= (2, 2, 0), "": flask_version < (2, 2, 0)},
+)
+@pytest.mark.parametrize("flask_env_arg", (flask_appsec_good_rules_env,))
+def test_flask_processexec_subprocesscommunicateshell(flask_client):
+    resp = flask_client.get("/executions/subcommunicateshell")
+    assert resp.status_code == 200
+    assert resp.text == "0"
+
+@pytest.mark.snapshot(
+    ignores=[
+        "meta._dd.appsec.waf.duration",
+        "meta._dd.appsec.waf.duration_ext",
+        "meta.flask.version",
+        "meta.http.request.headers.accept-encoding",
+        "meta.http.request.headers.user-agent",
+        "http.response.headers.content-length",
+        "http.response.headers.content-type",
+        "meta.http.useragent",
+        "meta.error.stack",
+        "metrics._dd.appsec.event_rules.loaded",
+        "metrics._dd.appsec.waf.duration",
+        "metrics._dd.appsec.waf.duration_ext",
+    ],
+    variants={"220": flask_version >= (2, 2, 0), "": flask_version < (2, 2, 0)},
+)
+@pytest.mark.parametrize("flask_env_arg", (flask_appsec_good_rules_env,))
+def test_flask_processexec_subprocesscommunicatenoshell(flask_client):
+    resp = flask_client.get("/executions/subcommunicatenoshell")
+    assert resp.status_code == 200
+    assert resp.text == "0"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env].json
@@ -1,0 +1,202 @@
+[[
+  {
+    "name": "flask.request",
+    "service": "flask",
+    "resource": "GET /executions/osspawn",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.appsec.event_rules.version": "rules_good",
+      "_dd.appsec.waf.version": "1.9.0",
+      "_dd.p.dm": "-0",
+      "_dd.runtime_family": "python",
+      "component": "flask",
+      "flask.endpoint": "run_osspawn",
+      "flask.url_rule": "/executions/osspawn",
+      "flask.version": "2.0.1",
+      "http.client_ip": "127.0.0.1",
+      "http.method": "GET",
+      "http.response.headers.content-length": "1",
+      "http.response.headers.content-type": "text/html; charset=utf-8",
+      "http.route": "/executions/osspawn",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:8000/executions/osspawn",
+      "http.useragent": "python-requests/2.28.1",
+      "language": "python",
+      "network.client.ip": "127.0.0.1",
+      "runtime-id": "c60f7313bb2544f39d51fa10bb69112e",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.appsec.enabled": 1.0,
+      "_dd.appsec.event_rules.error_count": 0,
+      "_dd.appsec.event_rules.loaded": 5,
+      "_dd.appsec.waf.duration": 10.687999999999999,
+      "_dd.appsec.waf.duration_ext": 137.3291015625,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 144662
+    },
+    "duration": 13445428,
+    "start": 1683543714551809754
+  },
+     {
+       "name": "flask.application",
+       "service": "flask",
+       "resource": "GET /executions/osspawn",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask",
+         "flask.endpoint": "run_osspawn",
+         "flask.url_rule": "/executions/osspawn"
+       },
+       "duration": 12313332,
+       "start": 1683543714552376063
+     },
+        {
+          "name": "flask.try_trigger_before_first_request_functions",
+          "service": "flask",
+          "resource": "flask.try_trigger_before_first_request_functions",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 11987,
+          "start": 1683543714552480459
+        },
+        {
+          "name": "flask.preprocess_request",
+          "service": "flask",
+          "resource": "flask.preprocess_request",
+          "trace_id": 0,
+          "span_id": 5,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 17952,
+          "start": 1683543714552540600
+        },
+        {
+          "name": "flask.dispatch_request",
+          "service": "flask",
+          "resource": "flask.dispatch_request",
+          "trace_id": 0,
+          "span_id": 6,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 11301811,
+          "start": 1683543714552581094
+        },
+           {
+             "name": "tests.contrib.flask.app.run_osspawn",
+             "service": "flask",
+             "resource": "/executions/osspawn",
+             "trace_id": 0,
+             "span_id": 10,
+             "parent_id": 6,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "component": "flask"
+             },
+             "duration": 11258768,
+             "start": 1683543714552609521
+           },
+              {
+                "name": "command_execution",
+                "service": "flask",
+                "resource": "/usr/bin/ls",
+                "trace_id": 0,
+                "span_id": 11,
+                "parent_id": 10,
+                "type": "system",
+                "error": 0,
+                "meta": {
+                  "cmd.exec": "['/usr/bin/ls', '-l', '/']",
+                  "cmd.exit_code": "0",
+                  "component": "os"
+                },
+                "duration": 10177136,
+                "start": 1683543714553579024
+              },
+        {
+          "name": "flask.process_response",
+          "service": "flask",
+          "resource": "flask.process_response",
+          "trace_id": 0,
+          "span_id": 7,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 89851,
+          "start": 1683543714564109882
+        },
+        {
+          "name": "flask.do_teardown_request",
+          "service": "flask",
+          "resource": "flask.do_teardown_request",
+          "trace_id": 0,
+          "span_id": 8,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 27040,
+          "start": 1683543714564587748
+        },
+        {
+          "name": "flask.do_teardown_appcontext",
+          "service": "flask",
+          "resource": "flask.do_teardown_appcontext",
+          "trace_id": 0,
+          "span_id": 9,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 12716,
+          "start": 1683543714564652441
+        },
+     {
+       "name": "flask.response",
+       "service": "flask",
+       "resource": "flask.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask"
+       },
+       "duration": 537039,
+       "start": 1683543714564700020
+     }]]

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env]_220.json
@@ -1,0 +1,187 @@
+[[
+  {
+    "name": "flask.request",
+    "service": "flask",
+    "resource": "GET /executions/osspawn",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.appsec.event_rules.version": "rules_good",
+      "_dd.appsec.waf.version": "1.9.0",
+      "_dd.p.dm": "-0",
+      "_dd.runtime_family": "python",
+      "component": "flask",
+      "flask.endpoint": "run_osspawn",
+      "flask.url_rule": "/executions/osspawn",
+      "flask.version": "2.2.3",
+      "http.client_ip": "127.0.0.1",
+      "http.method": "GET",
+      "http.response.headers.content-length": "1",
+      "http.response.headers.content-type": "text/html; charset=utf-8",
+      "http.route": "/executions/osspawn",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:8000/executions/osspawn",
+      "http.useragent": "python-requests/2.28.1",
+      "language": "python",
+      "network.client.ip": "127.0.0.1",
+      "runtime-id": "d035ea0bb64e4270ae0467953a401353",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.appsec.enabled": 1.0,
+      "_dd.appsec.event_rules.error_count": 0,
+      "_dd.appsec.event_rules.loaded": 5,
+      "_dd.appsec.waf.duration": 6.946,
+      "_dd.appsec.waf.duration_ext": 144.95849609375,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 4130837
+    },
+    "duration": 9086579,
+    "start": 1683538863749601193
+  },
+     {
+       "name": "flask.application",
+       "service": "flask",
+       "resource": "GET /executions/osspawn",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask",
+         "flask.endpoint": "run_osspawn",
+         "flask.url_rule": "/executions/osspawn"
+       },
+       "duration": 8262413,
+       "start": 1683538863750047000
+     },
+        {
+          "name": "flask.preprocess_request",
+          "service": "flask",
+          "resource": "flask.preprocess_request",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 18091,
+          "start": 1683538863750160294
+        },
+        {
+          "name": "flask.dispatch_request",
+          "service": "flask",
+          "resource": "flask.dispatch_request",
+          "trace_id": 0,
+          "span_id": 5,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 7595629,
+          "start": 1683538863750201003
+        },
+           {
+             "name": "tests.contrib.flask.app.run_osspawn",
+             "service": "flask",
+             "resource": "/executions/osspawn",
+             "trace_id": 0,
+             "span_id": 9,
+             "parent_id": 5,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "component": "flask"
+             },
+             "duration": 7558051,
+             "start": 1683538863750226908
+           },
+              {
+                "name": "command_execution",
+                "service": "flask",
+                "resource": "/usr/bin/ls",
+                "trace_id": 0,
+                "span_id": 10,
+                "parent_id": 9,
+                "type": "system",
+                "error": 0,
+                "meta": {
+                  "cmd.exec": "['/usr/bin/ls', '-l', '/']",
+                  "cmd.exit_code": "0",
+                  "component": "os"
+                },
+                "duration": 6604634,
+                "start": 1683538863751106925
+              },
+        {
+          "name": "flask.process_response",
+          "service": "flask",
+          "resource": "flask.process_response",
+          "trace_id": 0,
+          "span_id": 6,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 49449,
+          "start": 1683538863757928369
+        },
+        {
+          "name": "flask.do_teardown_request",
+          "service": "flask",
+          "resource": "flask.do_teardown_request",
+          "trace_id": 0,
+          "span_id": 7,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 19556,
+          "start": 1683538863758230419
+        },
+        {
+          "name": "flask.do_teardown_appcontext",
+          "service": "flask",
+          "resource": "flask.do_teardown_appcontext",
+          "trace_id": 0,
+          "span_id": 8,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 11449,
+          "start": 1683538863758279441
+        },
+     {
+       "name": "flask.response",
+       "service": "flask",
+       "resource": "flask.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask"
+       },
+       "duration": 358204,
+       "start": 1683538863758318863
+     }]]

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env].json
@@ -1,0 +1,202 @@
+[[
+  {
+    "name": "flask.request",
+    "service": "flask",
+    "resource": "GET /executions/ossystem",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.appsec.event_rules.version": "rules_good",
+      "_dd.appsec.waf.version": "1.9.0",
+      "_dd.p.dm": "-0",
+      "_dd.runtime_family": "python",
+      "component": "flask",
+      "flask.endpoint": "run_ossystem",
+      "flask.url_rule": "/executions/ossystem",
+      "flask.version": "2.0.1",
+      "http.client_ip": "127.0.0.1",
+      "http.method": "GET",
+      "http.response.headers.content-length": "1",
+      "http.response.headers.content-type": "text/html; charset=utf-8",
+      "http.route": "/executions/ossystem",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:8000/executions/ossystem",
+      "http.useragent": "python-requests/2.28.1",
+      "language": "python",
+      "network.client.ip": "127.0.0.1",
+      "runtime-id": "ca31e0a93fa546eeb08fc216e3b2f9c4",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.appsec.enabled": 1.0,
+      "_dd.appsec.event_rules.error_count": 0,
+      "_dd.appsec.event_rules.loaded": 5,
+      "_dd.appsec.waf.duration": 5.788,
+      "_dd.appsec.waf.duration_ext": 77.24761962890625,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 145282
+    },
+    "duration": 5084445,
+    "start": 1683543721196085934
+  },
+     {
+       "name": "flask.application",
+       "service": "flask",
+       "resource": "GET /executions/ossystem",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask",
+         "flask.endpoint": "run_ossystem",
+         "flask.url_rule": "/executions/ossystem"
+       },
+       "duration": 4491471,
+       "start": 1683543721196473632
+     },
+        {
+          "name": "flask.try_trigger_before_first_request_functions",
+          "service": "flask",
+          "resource": "flask.try_trigger_before_first_request_functions",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 9529,
+          "start": 1683543721196549702
+        },
+        {
+          "name": "flask.preprocess_request",
+          "service": "flask",
+          "resource": "flask.preprocess_request",
+          "trace_id": 0,
+          "span_id": 5,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 13345,
+          "start": 1683543721196597927
+        },
+        {
+          "name": "flask.dispatch_request",
+          "service": "flask",
+          "resource": "flask.dispatch_request",
+          "trace_id": 0,
+          "span_id": 6,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 4091789,
+          "start": 1683543721196628455
+        },
+           {
+             "name": "tests.contrib.flask.app.run_ossystem",
+             "service": "flask",
+             "resource": "/executions/ossystem",
+             "trace_id": 0,
+             "span_id": 10,
+             "parent_id": 6,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "component": "flask"
+             },
+             "duration": 4063848,
+             "start": 1683543721196650930
+           },
+              {
+                "name": "command_execution",
+                "service": "flask",
+                "resource": "dir",
+                "trace_id": 0,
+                "span_id": 11,
+                "parent_id": 10,
+                "type": "system",
+                "error": 0,
+                "meta": {
+                  "cmd.exit_code": "0",
+                  "cmd.shell": "dir -li /",
+                  "component": "os"
+                },
+                "duration": 3270828,
+                "start": 1683543721197431181
+              },
+        {
+          "name": "flask.process_response",
+          "service": "flask",
+          "resource": "flask.process_response",
+          "trace_id": 0,
+          "span_id": 7,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 17866,
+          "start": 1683543721200765002
+        },
+        {
+          "name": "flask.do_teardown_request",
+          "service": "flask",
+          "resource": "flask.do_teardown_request",
+          "trace_id": 0,
+          "span_id": 8,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 12945,
+          "start": 1683543721200910067
+        },
+        {
+          "name": "flask.do_teardown_appcontext",
+          "service": "flask",
+          "resource": "flask.do_teardown_appcontext",
+          "trace_id": 0,
+          "span_id": 9,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 8537,
+          "start": 1683543721200947267
+        },
+     {
+       "name": "flask.response",
+       "service": "flask",
+       "resource": "flask.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask"
+       },
+       "duration": 188600,
+       "start": 1683543721200972462
+     }]]

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env]_220.json
@@ -1,0 +1,187 @@
+[[
+  {
+    "name": "flask.request",
+    "service": "flask",
+    "resource": "GET /executions/ossystem",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.appsec.event_rules.version": "rules_good",
+      "_dd.appsec.waf.version": "1.9.0",
+      "_dd.p.dm": "-0",
+      "_dd.runtime_family": "python",
+      "component": "flask",
+      "flask.endpoint": "run_ossystem",
+      "flask.url_rule": "/executions/ossystem",
+      "flask.version": "2.2.3",
+      "http.client_ip": "127.0.0.1",
+      "http.method": "GET",
+      "http.response.headers.content-length": "1",
+      "http.response.headers.content-type": "text/html; charset=utf-8",
+      "http.route": "/executions/ossystem",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:8000/executions/ossystem",
+      "http.useragent": "python-requests/2.28.1",
+      "language": "python",
+      "network.client.ip": "127.0.0.1",
+      "runtime-id": "994edf5d19694e169dfebe1537610fcc",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.appsec.enabled": 1.0,
+      "_dd.appsec.event_rules.error_count": 0,
+      "_dd.appsec.event_rules.loaded": 5,
+      "_dd.appsec.waf.duration": 14.459,
+      "_dd.appsec.waf.duration_ext": 95.60585021972656,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 104115
+    },
+    "duration": 4126417,
+    "start": 1683542852118726785
+  },
+     {
+       "name": "flask.application",
+       "service": "flask",
+       "resource": "GET /executions/ossystem",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask",
+         "flask.endpoint": "run_ossystem",
+         "flask.url_rule": "/executions/ossystem"
+       },
+       "duration": 3375301,
+       "start": 1683542852119230495
+     },
+        {
+          "name": "flask.preprocess_request",
+          "service": "flask",
+          "resource": "flask.preprocess_request",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 17072,
+          "start": 1683542852119330774
+        },
+        {
+          "name": "flask.dispatch_request",
+          "service": "flask",
+          "resource": "flask.dispatch_request",
+          "trace_id": 0,
+          "span_id": 5,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 2953737,
+          "start": 1683542852119370108
+        },
+           {
+             "name": "tests.contrib.flask.app.run_ossystem",
+             "service": "flask",
+             "resource": "/executions/ossystem",
+             "trace_id": 0,
+             "span_id": 9,
+             "parent_id": 5,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "component": "flask"
+             },
+             "duration": 2921894,
+             "start": 1683542852119395185
+           },
+              {
+                "name": "command_execution",
+                "service": "flask",
+                "resource": "dir",
+                "trace_id": 0,
+                "span_id": 10,
+                "parent_id": 9,
+                "type": "system",
+                "error": 0,
+                "meta": {
+                  "cmd.exit_code": "0",
+                  "cmd.shell": "dir -li /",
+                  "component": "os"
+                },
+                "duration": 2075410,
+                "start": 1683542852120214940
+              },
+        {
+          "name": "flask.process_response",
+          "service": "flask",
+          "resource": "flask.process_response",
+          "trace_id": 0,
+          "span_id": 6,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 20533,
+          "start": 1683542852122381915
+        },
+        {
+          "name": "flask.do_teardown_request",
+          "service": "flask",
+          "resource": "flask.do_teardown_request",
+          "trace_id": 0,
+          "span_id": 7,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 18227,
+          "start": 1683542852122547160
+        },
+        {
+          "name": "flask.do_teardown_appcontext",
+          "service": "flask",
+          "resource": "flask.do_teardown_appcontext",
+          "trace_id": 0,
+          "span_id": 8,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 8824,
+          "start": 1683542852122587456
+        },
+     {
+       "name": "flask.response",
+       "service": "flask",
+       "resource": "flask.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask"
+       },
+       "duration": 230519,
+       "start": 1683542852122613259
+     }]]

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env].json
@@ -1,0 +1,214 @@
+[[
+  {
+    "name": "flask.request",
+    "service": "flask",
+    "resource": "GET /executions/subcommunicatenoshell",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.appsec.event_rules.version": "rules_good",
+      "_dd.appsec.waf.version": "1.9.0",
+      "_dd.p.dm": "-0",
+      "_dd.runtime_family": "python",
+      "component": "flask",
+      "flask.endpoint": "run_subcommunicatenoshell",
+      "flask.url_rule": "/executions/subcommunicatenoshell",
+      "flask.version": "2.0.1",
+      "http.client_ip": "127.0.0.1",
+      "http.method": "GET",
+      "http.response.headers.content-length": "1",
+      "http.response.headers.content-type": "text/html; charset=utf-8",
+      "http.route": "/executions/subcommunicatenoshell",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:8000/executions/subcommunicatenoshell",
+      "http.useragent": "python-requests/2.28.1",
+      "language": "python",
+      "network.client.ip": "127.0.0.1",
+      "runtime-id": "ff1d7290c1e749b7bb99f7d04ad4bf30",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.appsec.enabled": 1.0,
+      "_dd.appsec.event_rules.error_count": 0,
+      "_dd.appsec.event_rules.loaded": 5,
+      "_dd.appsec.waf.duration": 16.107,
+      "_dd.appsec.waf.duration_ext": 158.3099365234375,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 145594
+    },
+    "duration": 7292894,
+    "start": 1683543731542770768
+  },
+     {
+       "name": "flask.application",
+       "service": "flask",
+       "resource": "GET /executions/subcommunicatenoshell",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask",
+         "flask.endpoint": "run_subcommunicatenoshell",
+         "flask.url_rule": "/executions/subcommunicatenoshell"
+       },
+       "duration": 6153323,
+       "start": 1683543731543366101
+     },
+        {
+          "name": "flask.try_trigger_before_first_request_functions",
+          "service": "flask",
+          "resource": "flask.try_trigger_before_first_request_functions",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 10237,
+          "start": 1683543731543461336
+        },
+        {
+          "name": "flask.preprocess_request",
+          "service": "flask",
+          "resource": "flask.preprocess_request",
+          "trace_id": 0,
+          "span_id": 5,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 16816,
+          "start": 1683543731543519031
+        },
+        {
+          "name": "flask.dispatch_request",
+          "service": "flask",
+          "resource": "flask.dispatch_request",
+          "trace_id": 0,
+          "span_id": 6,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 5366132,
+          "start": 1683543731543563507
+        },
+           {
+             "name": "tests.contrib.flask.app.run_subcommunicatenoshell",
+             "service": "flask",
+             "resource": "/executions/subcommunicatenoshell",
+             "trace_id": 0,
+             "span_id": 10,
+             "parent_id": 6,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "component": "flask"
+             },
+             "duration": 5323843,
+             "start": 1683543731543588938
+           },
+              {
+                "name": "command_execution",
+                "service": "flask",
+                "resource": "dir",
+                "trace_id": 0,
+                "span_id": 11,
+                "parent_id": 10,
+                "type": "system",
+                "error": 0,
+                "duration": 3577147,
+                "start": 1683543731544412685
+              },
+              {
+                "name": "command_execution",
+                "service": "flask",
+                "resource": "dir",
+                "trace_id": 0,
+                "span_id": 12,
+                "parent_id": 10,
+                "type": "system",
+                "error": 0,
+                "meta": {
+                  "cmd.exec": "['dir', '-li', '/']",
+                  "cmd.exit_code": "0",
+                  "component": "subprocess"
+                },
+                "duration": 771506,
+                "start": 1683543731548124278
+              },
+        {
+          "name": "flask.process_response",
+          "service": "flask",
+          "resource": "flask.process_response",
+          "trace_id": 0,
+          "span_id": 7,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 49250,
+          "start": 1683543731549063646
+        },
+        {
+          "name": "flask.do_teardown_request",
+          "service": "flask",
+          "resource": "flask.do_teardown_request",
+          "trace_id": 0,
+          "span_id": 8,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 18303,
+          "start": 1683543731549440224
+        },
+        {
+          "name": "flask.do_teardown_appcontext",
+          "service": "flask",
+          "resource": "flask.do_teardown_appcontext",
+          "trace_id": 0,
+          "span_id": 9,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 10000,
+          "start": 1683543731549487849
+        },
+     {
+       "name": "flask.response",
+       "service": "flask",
+       "resource": "flask.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask"
+       },
+       "duration": 515630,
+       "start": 1683543731549529772
+     }]]

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env]_220.json
@@ -1,0 +1,199 @@
+[[
+  {
+    "name": "flask.request",
+    "service": "flask",
+    "resource": "GET /executions/subcommunicatenoshell",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.appsec.event_rules.version": "rules_good",
+      "_dd.appsec.waf.version": "1.9.0",
+      "_dd.p.dm": "-0",
+      "_dd.runtime_family": "python",
+      "component": "flask",
+      "flask.endpoint": "run_subcommunicatenoshell",
+      "flask.url_rule": "/executions/subcommunicatenoshell",
+      "flask.version": "2.2.3",
+      "http.client_ip": "127.0.0.1",
+      "http.method": "GET",
+      "http.response.headers.content-length": "1",
+      "http.response.headers.content-type": "text/html; charset=utf-8",
+      "http.route": "/executions/subcommunicatenoshell",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:8000/executions/subcommunicatenoshell",
+      "http.useragent": "python-requests/2.28.1",
+      "language": "python",
+      "network.client.ip": "127.0.0.1",
+      "runtime-id": "47b8a34bc73746218ce5767aea5b1f77",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.appsec.enabled": 1.0,
+      "_dd.appsec.event_rules.error_count": 0,
+      "_dd.appsec.event_rules.loaded": 5,
+      "_dd.appsec.waf.duration": 5.899,
+      "_dd.appsec.waf.duration_ext": 102.04315185546875,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 108258
+    },
+    "duration": 7730286,
+    "start": 1683542931953470339
+  },
+     {
+       "name": "flask.application",
+       "service": "flask",
+       "resource": "GET /executions/subcommunicatenoshell",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask",
+         "flask.endpoint": "run_subcommunicatenoshell",
+         "flask.url_rule": "/executions/subcommunicatenoshell"
+       },
+       "duration": 6929755,
+       "start": 1683542931953911587
+     },
+        {
+          "name": "flask.preprocess_request",
+          "service": "flask",
+          "resource": "flask.preprocess_request",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 16398,
+          "start": 1683542931954015801
+        },
+        {
+          "name": "flask.dispatch_request",
+          "service": "flask",
+          "resource": "flask.dispatch_request",
+          "trace_id": 0,
+          "span_id": 5,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 6302808,
+          "start": 1683542931954054659
+        },
+           {
+             "name": "tests.contrib.flask.app.run_subcommunicatenoshell",
+             "service": "flask",
+             "resource": "/executions/subcommunicatenoshell",
+             "trace_id": 0,
+             "span_id": 9,
+             "parent_id": 5,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "component": "flask"
+             },
+             "duration": 6259586,
+             "start": 1683542931954080123
+           },
+              {
+                "name": "command_execution",
+                "service": "flask",
+                "resource": "dir",
+                "trace_id": 0,
+                "span_id": 10,
+                "parent_id": 9,
+                "type": "system",
+                "error": 0,
+                "duration": 3950661,
+                "start": 1683542931954933391
+              },
+              {
+                "name": "command_execution",
+                "service": "flask",
+                "resource": "dir",
+                "trace_id": 0,
+                "span_id": 11,
+                "parent_id": 9,
+                "type": "system",
+                "error": 0,
+                "meta": {
+                  "cmd.exec": "['dir', '-li', '/']",
+                  "cmd.exit_code": "0",
+                  "component": "subprocess"
+                },
+                "duration": 1293662,
+                "start": 1683542931959018790
+              },
+        {
+          "name": "flask.process_response",
+          "service": "flask",
+          "resource": "flask.process_response",
+          "trace_id": 0,
+          "span_id": 6,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 40035,
+          "start": 1683542931960480460
+        },
+        {
+          "name": "flask.do_teardown_request",
+          "service": "flask",
+          "resource": "flask.do_teardown_request",
+          "trace_id": 0,
+          "span_id": 7,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 14689,
+          "start": 1683542931960771840
+        },
+        {
+          "name": "flask.do_teardown_appcontext",
+          "service": "flask",
+          "resource": "flask.do_teardown_appcontext",
+          "trace_id": 0,
+          "span_id": 8,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 9918,
+          "start": 1683542931960814284
+        },
+     {
+       "name": "flask.response",
+       "service": "flask",
+       "resource": "flask.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask"
+       },
+       "duration": 341054,
+       "start": 1683542931960850184
+     }]]

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
@@ -1,0 +1,214 @@
+[[
+  {
+    "name": "flask.request",
+    "service": "flask",
+    "resource": "GET /executions/subcommunicateshell",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.appsec.event_rules.version": "rules_good",
+      "_dd.appsec.waf.version": "1.9.0",
+      "_dd.p.dm": "-0",
+      "_dd.runtime_family": "python",
+      "component": "flask",
+      "flask.endpoint": "run_subcommunicateshell",
+      "flask.url_rule": "/executions/subcommunicateshell",
+      "flask.version": "2.0.1",
+      "http.client_ip": "127.0.0.1",
+      "http.method": "GET",
+      "http.response.headers.content-length": "1",
+      "http.response.headers.content-type": "text/html; charset=utf-8",
+      "http.route": "/executions/subcommunicateshell",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:8000/executions/subcommunicateshell",
+      "http.useragent": "python-requests/2.28.1",
+      "language": "python",
+      "network.client.ip": "127.0.0.1",
+      "runtime-id": "2310db8c9e0749e1aae79b5954a319f5",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.appsec.enabled": 1.0,
+      "_dd.appsec.event_rules.error_count": 0,
+      "_dd.appsec.event_rules.loaded": 5,
+      "_dd.appsec.waf.duration": 7.199999999999999,
+      "_dd.appsec.waf.duration_ext": 113.48724365234375,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 145473
+    },
+    "duration": 6053887,
+    "start": 1683543727249624883
+  },
+     {
+       "name": "flask.application",
+       "service": "flask",
+       "resource": "GET /executions/subcommunicateshell",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask",
+         "flask.endpoint": "run_subcommunicateshell",
+         "flask.url_rule": "/executions/subcommunicateshell"
+       },
+       "duration": 5334770,
+       "start": 1683543727250035703
+     },
+        {
+          "name": "flask.try_trigger_before_first_request_functions",
+          "service": "flask",
+          "resource": "flask.try_trigger_before_first_request_functions",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 10863,
+          "start": 1683543727250115762
+        },
+        {
+          "name": "flask.preprocess_request",
+          "service": "flask",
+          "resource": "flask.preprocess_request",
+          "trace_id": 0,
+          "span_id": 5,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 14490,
+          "start": 1683543727250167671
+        },
+        {
+          "name": "flask.dispatch_request",
+          "service": "flask",
+          "resource": "flask.dispatch_request",
+          "trace_id": 0,
+          "span_id": 6,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 4755958,
+          "start": 1683543727250200359
+        },
+           {
+             "name": "tests.contrib.flask.app.run_subcommunicateshell",
+             "service": "flask",
+             "resource": "/executions/subcommunicateshell",
+             "trace_id": 0,
+             "span_id": 10,
+             "parent_id": 6,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "component": "flask"
+             },
+             "duration": 4723391,
+             "start": 1683543727250223728
+           },
+              {
+                "name": "command_execution",
+                "service": "flask",
+                "resource": "dir",
+                "trace_id": 0,
+                "span_id": 11,
+                "parent_id": 10,
+                "type": "system",
+                "error": 0,
+                "duration": 2774528,
+                "start": 1683543727251037074
+              },
+              {
+                "name": "command_execution",
+                "service": "flask",
+                "resource": "dir",
+                "trace_id": 0,
+                "span_id": 12,
+                "parent_id": 10,
+                "type": "system",
+                "error": 0,
+                "meta": {
+                  "cmd.exit_code": "0",
+                  "cmd.shell": "dir -li /",
+                  "component": "subprocess"
+                },
+                "duration": 1007915,
+                "start": 1683543727253924450
+              },
+        {
+          "name": "flask.process_response",
+          "service": "flask",
+          "resource": "flask.process_response",
+          "trace_id": 0,
+          "span_id": 7,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 32092,
+          "start": 1683543727255057218
+        },
+        {
+          "name": "flask.do_teardown_request",
+          "service": "flask",
+          "resource": "flask.do_teardown_request",
+          "trace_id": 0,
+          "span_id": 8,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 14965,
+          "start": 1683543727255307757
+        },
+        {
+          "name": "flask.do_teardown_appcontext",
+          "service": "flask",
+          "resource": "flask.do_teardown_appcontext",
+          "trace_id": 0,
+          "span_id": 9,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 9177,
+          "start": 1683543727255346829
+        },
+     {
+       "name": "flask.response",
+       "service": "flask",
+       "resource": "flask.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask"
+       },
+       "duration": 288702,
+       "start": 1683543727255379588
+     }]]

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env]_220.json
@@ -1,0 +1,199 @@
+[[
+  {
+    "name": "flask.request",
+    "service": "flask",
+    "resource": "GET /executions/subcommunicateshell",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.appsec.event_rules.version": "rules_good",
+      "_dd.appsec.waf.version": "1.9.0",
+      "_dd.p.dm": "-0",
+      "_dd.runtime_family": "python",
+      "component": "flask",
+      "flask.endpoint": "run_subcommunicateshell",
+      "flask.url_rule": "/executions/subcommunicateshell",
+      "flask.version": "2.2.3",
+      "http.client_ip": "127.0.0.1",
+      "http.method": "GET",
+      "http.response.headers.content-length": "1",
+      "http.response.headers.content-type": "text/html; charset=utf-8",
+      "http.route": "/executions/subcommunicateshell",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:8000/executions/subcommunicateshell",
+      "http.useragent": "python-requests/2.28.1",
+      "language": "python",
+      "network.client.ip": "127.0.0.1",
+      "runtime-id": "5d0c5337f12d40a5b61b953b71b8b4b9",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.appsec.enabled": 1.0,
+      "_dd.appsec.event_rules.error_count": 0,
+      "_dd.appsec.event_rules.loaded": 5,
+      "_dd.appsec.waf.duration": 5.914,
+      "_dd.appsec.waf.duration_ext": 97.51319885253906,
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 104947
+    },
+    "duration": 5612586,
+    "start": 1683542869611804763
+  },
+     {
+       "name": "flask.application",
+       "service": "flask",
+       "resource": "GET /executions/subcommunicateshell",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask",
+         "flask.endpoint": "run_subcommunicateshell",
+         "flask.url_rule": "/executions/subcommunicateshell"
+       },
+       "duration": 4857178,
+       "start": 1683542869612196118
+     },
+        {
+          "name": "flask.preprocess_request",
+          "service": "flask",
+          "resource": "flask.preprocess_request",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 15361,
+          "start": 1683542869612288202
+        },
+        {
+          "name": "flask.dispatch_request",
+          "service": "flask",
+          "resource": "flask.dispatch_request",
+          "trace_id": 0,
+          "span_id": 5,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 4292440,
+          "start": 1683542869612324269
+        },
+           {
+             "name": "tests.contrib.flask.app.run_subcommunicateshell",
+             "service": "flask",
+             "resource": "/executions/subcommunicateshell",
+             "trace_id": 0,
+             "span_id": 9,
+             "parent_id": 5,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "component": "flask"
+             },
+             "duration": 4254816,
+             "start": 1683542869612351539
+           },
+              {
+                "name": "command_execution",
+                "service": "flask",
+                "resource": "dir",
+                "trace_id": 0,
+                "span_id": 10,
+                "parent_id": 9,
+                "type": "system",
+                "error": 0,
+                "duration": 2411758,
+                "start": 1683542869613159413
+              },
+              {
+                "name": "command_execution",
+                "service": "flask",
+                "resource": "dir",
+                "trace_id": 0,
+                "span_id": 11,
+                "parent_id": 9,
+                "type": "system",
+                "error": 0,
+                "meta": {
+                  "cmd.exit_code": "0",
+                  "cmd.shell": "dir -li /",
+                  "component": "subprocess"
+                },
+                "duration": 888052,
+                "start": 1683542869615694100
+              },
+        {
+          "name": "flask.process_response",
+          "service": "flask",
+          "resource": "flask.process_response",
+          "trace_id": 0,
+          "span_id": 6,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 32118,
+          "start": 1683542869616723946
+        },
+        {
+          "name": "flask.do_teardown_request",
+          "service": "flask",
+          "resource": "flask.do_teardown_request",
+          "trace_id": 0,
+          "span_id": 7,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 14640,
+          "start": 1683542869616988685
+        },
+        {
+          "name": "flask.do_teardown_appcontext",
+          "service": "flask",
+          "resource": "flask.do_teardown_appcontext",
+          "trace_id": 0,
+          "span_id": 8,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "component": "flask"
+          },
+          "duration": 9151,
+          "start": 1683542869617027738
+        },
+     {
+       "name": "flask.response",
+       "service": "flask",
+       "resource": "flask.response",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "component": "flask"
+       },
+       "duration": 345498,
+       "start": 1683542869617061787
+     }]]


### PR DESCRIPTION
## Description

This PRs implements the internal RFC "Shell Execution Integration" for the Python library. It will add a new span type with information about commands executed by the code either using `os.system`, `os.spawn*` or any of the functions or objects in the `subprocess` module. It will be automatically enabled if ASM is enabled.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] OPTIONAL: PR description includes explicit acknowledgement of the performance implications of the change as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
