### PR TITLE
chore(span): bump traceback limit from 20 to 30

### DIFF
--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -446,7 +446,7 @@ class Span(object):
         """Return all metrics."""
         return self._metrics.copy()
 
-    def set_traceback(self, limit=20):
+    def set_traceback(self, limit=30):
         # type: (int) -> None
         """If the current stack has an exception, tag the span with the
         relevant error info. If not, set the span to the current python stack.
@@ -474,7 +474,7 @@ class Span(object):
     def _set_exc_tags(self, exc_type, exc_val, exc_tb):
         # get the traceback
         buff = StringIO()
-        traceback.print_exception(exc_type, exc_val, exc_tb, file=buff, limit=20)
+        traceback.print_exception(exc_type, exc_val, exc_tb, file=buff, limit=30)
         tb = buff.getvalue()
 
         # readable version of type (e.g. exceptions.ZeroDivisionError)

--- a/releasenotes/notes/bump-traceback-limit-4b7702bc8f771d65.yaml
+++ b/releasenotes/notes/bump-traceback-limit-4b7702bc8f771d65.yaml
@@ -1,4 +1,4 @@
 ---
 other:
   - |
-    span: Increases the maximum number of stackframes in ``error.stack`` tags from 20 to 30
+    span: Increases the traceback limit in ``error.stack`` tags from 20 to 30

--- a/releasenotes/notes/bump-traceback-limit-4b7702bc8f771d65.yaml
+++ b/releasenotes/notes/bump-traceback-limit-4b7702bc8f771d65.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    span: Increases the maximum number of stackframes in ``error.stack`` tags from 20 to 30


### PR DESCRIPTION
Currently we truncate the error.stack tag to 20 frames. Some ddtrace integrations (ex: flask) can produce stacktraces that add almost 10-15 frames that reference the ddtrace libraries. A limit of 20 frames is clearly not enough visibility to debug errors in customers application code. This PR bumps the limit to 30 (another arbitrary value).


## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] OPTIONAL: PR description includes explicit acknowledgement of the performance implications of the change as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
