### PR TITLE
fix(openai): update metric names in docs

### DIFF
--- a/ddtrace/contrib/openai/__init__.py
+++ b/ddtrace/contrib/openai/__init__.py
@@ -3,13 +3,14 @@ The OpenAI integration instruments the OpenAI Python library to emit metrics,
 traces, and logs (logs are disabled by default) for requests made to the
 completions, chat completions, and embeddings endpoints.
 
-All metrics, logs, and traces submitted from the OpenAI integration are tagged with:
+All metrics, logs, and traces submitted from the OpenAI integration are tagged by:
 
 - ``service``, ``env``, ``version``: see the `Unified Service Tagging docs <https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging>`_.
 - ``endpoint``: OpenAI API endpoint used in the request.
 - ``model``: OpenAI model used in the request.
-- ``organization.name``: OpenAI organization name used in the request.
-- ``organization.id``: OpenAI organization ID used in the request (when available).
+- ``openai.organization.name``: OpenAI organization name used in the request.
+- ``openai.organization.id``: OpenAI organization ID used in the request (when available).
+- ``openai.api_key``: OpenAI API key used to make the request (obfuscated to match the OpenAI UI representation ``sk-...XXXX`` where ``XXXX`` is the last 4 digits of the key).
 
 
 Metrics


### PR DESCRIPTION
This PR fixes the openai patch docs to include the api_key span tag, as well as adding a missing `openai.organization.` to the org name and org id span tags.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] OPTIONAL: PR description includes explicit acknowledgement of the performance implications of the change as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
