### PR TITLE
fix(appsec): fix partial flush encoding error when request context is active

### DIFF
--- a/releasenotes/notes/fix-appsec-request-context-partial-flushing-42eaf3116230b1a9.yaml
+++ b/releasenotes/notes/fix-appsec-request-context-partial-flushing-42eaf3116230b1a9.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    appsec: Fixes an encoding error from a trace that is partial flushed while an AppSec request context is active.


### PR DESCRIPTION
#5813 made an attempt to prevent leaking AppSec request contexts as span tags by ensuring we always clean up any that are created when the span finishes.

That fix did not take into account partial flushing. When partial flushing we will copy the trace context's tags onto the first span in the payload. This means if the root span creates an AppSec request context it will be put into the `context._meta`, and it is expected to stay there until the root span is finished. Resulting in the request context still being added as a span tag. This is likely the actual root cause that #5913 was trying to solve.

The solution presented here is to stop using `context._meta` to track AppSec request contexts. Instead we are adding a `WeakKeyDictionary` to the `AppSecSpanProcessor` so it can keep track of the request contexts without the need of the span context at all.

A `WeakKeyDictionary` was used to prevent accidentally holding onto strong references to spans potentially causing a memory leak if `on_span_finish` never gets called.

I tried to create a test case for the possible memory leak and it is really hard. There are a lot of pieces that hold strong references to spans in the tracer/context/processors. I think ultimately a memory leak test is just validating that `WeakKeyDictionary` does what it says it does, so it likely is just over testing (happy to have someone disagree with me).

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] OPTIONAL: PR description includes explicit acknowledgement of the performance implications of the change as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
