### PR TITLE
fix(asm): simplify asm request context span registration [backport #5822 to 1.12]

### DIFF
--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -220,8 +220,7 @@ class AppSecSpanProcessor(SpanProcessor):
         else:
             new_asm_context = _asm_request_context.asm_request_context_manager()
             new_asm_context.__enter__()
-            span.context._meta["ASM_CONTEXT_%d" % id(span)] = new_asm_context  # type: ignore
-            _asm_request_context.register(span)
+            _asm_request_context.register(span, new_asm_context)
 
         ctx = self._ddwaf._at_request_start()
 
@@ -379,7 +378,6 @@ class AppSecSpanProcessor(SpanProcessor):
 
     def on_span_finish(self, span):
         # type: (Span) -> None
-        asm_context = span.context._meta.get("ASM_CONTEXT_%d" % id(span), None)
         try:
             if span.span_type != SpanTypes.WEB:
                 return
@@ -396,6 +394,4 @@ class AppSecSpanProcessor(SpanProcessor):
             self._ddwaf._at_request_end()
         finally:
             # release asm context if it was created by the span
-            if asm_context is not None:
-                asm_context.__exit__(None, None, None)  # type: ignore
-                del span.context._meta["ASM_CONTEXT_%d" % id(span)]
+            _asm_request_context.unregister(span)

--- a/releasenotes/notes/fix-asm-request-context-partial-flushing-7c45aaf55e836261.yaml
+++ b/releasenotes/notes/fix-asm-request-context-partial-flushing-7c45aaf55e836261.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    ASM: Fixes encoding error when using AppSec and a trace is partial flushed.

--- a/tests/appsec/test_processor.py
+++ b/tests/appsec/test_processor.py
@@ -654,16 +654,16 @@ def test_ddwaf_run_contained_oserror(tracer_appsec, caplog):
     assert "OSError: ddwaf run failed" in caplog.text
 
 
-def test_asm_context_meta(tracer_appsec):
+def test_asm_context_registration(tracer_appsec):
     tracer = tracer_appsec
 
     # For a web type span, a context manager is added, but then removed
     with tracer.trace("test", span_type=SpanTypes.WEB) as span:
-        assert span.context._meta["ASM_CONTEXT_%d" % (id(span),)]
-    assert span.context._meta.get("ASM_CONTEXT_%d" % (id(span),)) is None
+        assert _asm_request_context._ASM.get().span_asm_context
+    assert _asm_request_context._ASM.get().span_asm_context is None
 
     # Regression test, if the span type changes after being created, we always removed
     with tracer.trace("test", span_type=SpanTypes.WEB) as span:
         span.span_type = SpanTypes.HTTP
-        assert span.context._meta["ASM_CONTEXT_%d" % (id(span),)]
-    assert span.context._meta.get("ASM_CONTEXT_%d" % (id(span),)) is None
+        assert _asm_request_context._ASM.get().span_asm_context
+    assert _asm_request_context._ASM.get().span_asm_context is None


### PR DESCRIPTION
Backport of #5822 to 1.12

Remove the use of span context._meta to store information about context registration.

update tests for asm request context to unit test the new registration process.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] OPTIONAL: PR description includes explicit acknowledgement of the performance implications of the change as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
