### PR TITLE
refactor(tracing): remove priority sampling configurations from sitecustomize

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -7,8 +7,6 @@ from ddtrace import LOADED_MODULES  # isort:skip
 import logging  # noqa
 import os  # noqa
 import sys
-from typing import Any  # noqa
-from typing import Dict  # noqa
 import warnings  # noqa
 
 from ddtrace import config  # noqa
@@ -154,7 +152,6 @@ def cleanup_loaded_modules():
 try:
     from ddtrace import tracer
 
-    priority_sampling = os.getenv("DD_PRIORITY_SAMPLING")
     profiling = asbool(os.getenv("DD_PROFILING_ENABLED", False))
 
     if profiling:
@@ -183,22 +180,7 @@ try:
 
             ModuleWatchdog.register_pre_exec_module_hook(_should_iast_patch, _exec_iast_patched_module)
 
-    opts = {}  # type: Dict[str, Any]
-
-    dd_trace_enabled = os.getenv("DD_TRACE_ENABLED", default=True)
-    if asbool(dd_trace_enabled):
-        trace_enabled = True
-    else:
-        trace_enabled = False
-        opts["enabled"] = False
-
-    if priority_sampling:
-        opts["priority_sampling"] = asbool(priority_sampling)
-
-    if not opts:
-        tracer.configure(**opts)
-
-    if trace_enabled:
+    if asbool(os.getenv("DD_TRACE_ENABLED", default=True)):
         from ddtrace import patch_all
 
         # We need to clean up after we have imported everything we need from

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -232,7 +232,10 @@ class Tracer(object):
         self.enabled = asbool(os.getenv("DD_TRACE_ENABLED", default=True))
         self.context_provider = DefaultContextProvider()
         self._sampler = DatadogSampler()  # type: BaseSampler
-        self._priority_sampler = RateByServiceSampler()  # type: Optional[BasePrioritySampler]
+        if asbool(os.getenv("DD_PRIORITY_SAMPLING", True)):
+            self._priority_sampler = RateByServiceSampler()  # type: Optional[BasePrioritySampler]
+        else:
+            self._priority_sampler = None
         self._dogstatsd_url = agent.get_stats_url() if dogstatsd_url is None else dogstatsd_url
         self._compute_stats = config._trace_compute_stats
         self._agent_url = agent.get_trace_url() if url is None else url  # type: str


### PR DESCRIPTION
- The tracer's `priority_sampler` and `enabled` fields are set when the tracer is initialized. Calling tracer.configure(...) in `sitecustomize` is unnecessary.  
- Removes opts Dict. This dictionary contained configurations that are set when the tracer is initialized. 

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] OPTIONAL: PR description includes explicit acknowledgement of the performance implications of the change as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
