### PR TITLE
fix(lib-injection): always install from local packages (backport #5758 to 1.13)

### DIFF
--- a/lib-injection/sitecustomize.py
+++ b/lib-injection/sitecustomize.py
@@ -38,7 +38,9 @@ if "DDTRACE_PYTHON_INSTALL_IN_PROGRESS" not in os.environ:
         try:
             pkgs_path = os.path.join(os.path.dirname(__file__), "ddtrace_pkgs")
             subprocess.run(
-                [sys.executable, "-m", "pip", "install", "--find-links", pkgs_path, "ddtrace"], env=env, check=True
+                [sys.executable, "-m", "pip", "install", "--no-index", "--find-links", pkgs_path, "ddtrace"],
+                env=env,
+                check=True,
             )
         except BaseException as e:
             print("datadog autoinstrumentation: failed to install python package %s" % str(e))

--- a/releasenotes/notes/lib-inject-fix-offline-0349ef25100f5420.yaml
+++ b/releasenotes/notes/lib-inject-fix-offline-0349ef25100f5420.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    lib-injection: Ensure local package is installed. Previously the package
+      could still be pulled from the internet causing application slowdowns.


### PR DESCRIPTION
pip will by default always try to check the internet for packages even when a --find-links option is specified.

This results in a very slow install when there is no internet available in the container:

```
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0xffffa2e8b070>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/ddtrace/
WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0xffffa2e89120>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/ddtrace/
WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0xffffa2e89480>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/ddtrace/
WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0xffffa2e88bb0>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/ddtrace/
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0xffffa2e8a410>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/ddtrace/
Processing /wheels/ddtrace-1.10.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0xffffa24828c0>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/attrs/
WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0xffffa24832e0>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/attrs/
WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0xffffa24834c0>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/attrs/
WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0xffffa2483a90>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/attrs/
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0xffffa24831c0>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/attrs/
```

The fix is to use the `--no-index` option to instruct pip to not try the internet at all and only use the local package.

Fixes #5770

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.

