### PR TITLE
fix(wsgi): ensure traced iterable does not implement __len__ (backport #5858 to 1.13)

### DIFF
--- a/ddtrace/contrib/wsgi/wsgi.py
+++ b/ddtrace/contrib/wsgi/wsgi.py
@@ -88,6 +88,14 @@ class _TracedIterable(wrapt.ObjectProxy):
             self._self_parent_span.finish()
             self._self_span_finished = True
 
+    def __getattribute__(self, name):
+        if name == "__len__":
+            # __len__ is defined by the parent class, wrapt.ObjectProxy.
+            # However this attribute should not be defined for iterables.
+            # By definition, iterables should not support len(...).
+            raise AttributeError("__len__ is not supported")
+        return super(_TracedIterable, self).__getattribute__(name)
+
 
 class _DDWSGIMiddlewareBase(object):
     """Base WSGI middleware class.

--- a/releasenotes/notes/fix-wsgi-iterable-len-14777de93b723b00.yaml
+++ b/releasenotes/notes/fix-wsgi-iterable-len-14777de93b723b00.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    wsgi: Resolves an issue where accessing the ``__len__`` attribute on traced wsgi middlewares raised a TypeError


### PR DESCRIPTION
Streaming responses with [waitress](https://github.com/Pylons/waitress) is not supported by the wsgi middleware. This incompatibility was introduced by the following commit:
https://github.com/DataDog/dd-trace-py/commit/7ce49bd78b0d510766fc5db12756a8840724febc.

## Reproduction

1. `pip install "waitress>=2.1.2" "ddtrace==1.13.0" "Flask>=2.2.4,<2.3.0"`
2. Create a flask application and add an endpoint that streams a response:
   app.py: ``` from waitress import serve from flask import Flask
    
    app = Flask(__name__)
    
    @app.route('/large.csv')
    def generate_large_csv():
        def generate():
            for row in [1, 2, 3, 4]:
                yield f"{row}\n"
        return app.response_class(generate(), mimetype='text/csv')
    
    @app.route("/")
    def hello():
        return "Hello, World!"

    serve(app, listen='*:8080')
    ```
3. Run ` python path/to/flask_app/app.py`
3. Run `curl http://localhost:8080/large.csv`
4. Error: ``` ERROR:waitress:Exception while serving /large.csv Traceback (most recent call last): File
"/s1/remote-venvs/tesla/lib/python3.10/site-packages/waitress/channel.py", line 428, in service
        task.service()
File
"/s1/remote-venvs/tesla/lib/python3.10/site-packages/waitress/task.py", line 168, in service
        self.execute()
File
"/s1/remote-venvs/tesla/lib/python3.10/site-packages/waitress/task.py", line 466, in execute
        app_iter_len = len(app_iter)
    TypeError: object of type 'ClosingIterator' has no len()
    ```

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] OPTIONAL: PR description includes explicit acknowledgement of the performance implications of the change as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
