### PR TITLE
chore(debugging): correct probe injection logging

### DIFF
--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -425,13 +425,21 @@ class Debugger(Service):
             failed = self._function_store.inject_hooks(
                 function, [(self._dd_debugger_hook, cast(LineProbe, probe).line, probe) for probe in probes]
             )
+
             for probe in probes:
                 if probe.probe_id in failed:
                     self._probe_registry.set_error(probe, "Failed to inject")
-                    log.error("Failed to inject %r", probe)
                 else:
                     self._probe_registry.set_installed(probe)
-                    log.debug("Injected probes %r in %r", [probe.probe_id for probe in probes], function)
+
+            if failed:
+                log.error("Failed to inject probes %r", failed)
+
+            log.debug(
+                "Injected probes %r in %r",
+                [probe.probe_id for probe in probes if probe.probe_id not in failed],
+                function,
+            )
 
     def _inject_probes(self, probes):
         # type: (List[LineProbe]) -> None


### PR DESCRIPTION
The logic for the debug logging of injected probes was incorrect and could have caused the same log message to be emitted multiple times. In other cases the information emitted would have resulted inaccurate, particularly when a line probe failed to inject.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] OPTIONAL: PR description includes explicit acknowledgement of the performance implications of the change as reported in the benchmarks PR comment.

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
