### PR TITLE
fix(sanic): avoids unloading re module when gevent is installed (backport #5867 to 1.10)

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -52,6 +52,33 @@ jobs:
         # log output and it contains phony error messages.
         run: PYTHONPATH=../ddtrace/tests/debugging/exploration/ ddtrace-run pytest test --continue-on-collection-errors -v -k 'not test_simple'
 
+  sanic-testsuite-22_12:
+    runs-on: ubuntu-20.04
+    env:
+      # Regression test for DataDog/dd-trace-py/issues/5722
+      DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE: true
+    defaults:
+      run:
+        working-directory: sanic
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ddtrace
+      - uses: actions/checkout@v3
+        with:
+          repository: sanic-org/sanic
+          ref: v22.12.0
+          path: sanic
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install sanic and dependencies required to run tests
+        run: pip3 install '.[test]' aioquic
+      - name: Install ddtrace
+        run: pip3 install ../ddtrace
+      - name: Run tests
+        run: ddtrace-run pytest -k "not test_add_signal and not test_ode_removes and not test_skip_touchup and not test_dispatch_signal_triggers and not test_keep_alive_connection_context"
+
   django-testsuite-3_1:
     strategy:
       matrix:

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -128,6 +128,7 @@ def cleanup_loaded_modules():
             "asyncio",
             "concurrent",
             "typing",
+            "re",  # referenced by the typing module
             "logging",
             "attr",
             "google.protobuf",  # the upb backend in >= 4.21 does not like being unloaded

--- a/releasenotes/notes/sanic-fix-is-pattern-check-c6e4109e933bf37f.yaml
+++ b/releasenotes/notes/sanic-fix-is-pattern-check-c6e4109e933bf37f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    sanic: Resolves ``sanic_routing.exceptions.InvalidUsage`` error raised when
+    gevent is installed or ``DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE`` is set to True.


### PR DESCRIPTION
## Background
When gevent is installed (or
`DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE=auto`), all modules imported by [ddtrace.bootstrap.sitecustomize](https://github.com/DataDog/dd-trace-py/blob/1.x/ddtrace/bootstrap/sitecustomize.py#L91) are unloaded from sys.modules (except for a small [exclude list](https://github.com/DataDog/dd-trace-py/blob/1.x/ddtrace/bootstrap/sitecustomize.py#L103-L113)).

## Description

Currently the [typing
module](https://github.com/DataDog/dd-trace-py/blob/1.x/ddtrace/bootstrap/sitecustomize.py#L110) is excluded from module unloading but re is NOT. This causes [isinstance(some_re_pattern,
typing.Pattern)](https://github.com/sanic-org/sanic-routing/blob/main/sanic_routing/router.py#L289) to return False (here typing holds a stale reference to [re.Pattern](https://github.com/python/cpython/blob/main/Lib/typing.py#L3422)).

## Risks

This bug was called out and reproduced in the following github issue: https://github.com/DataDog/dd-trace-py/issues/5722. However this issue could not be reproduced using riot due to how packages are installed. To workaround this limitation a framework test was added for sanic which reproduced this error. This is less than ideal. Module cloning is a vital part of our codebase and should have test coverage for all common use-cases.

### Explanation
Riot uses `pip install -e` to install dependencies. When packages are installed with the `-e` option a `.pth` file is added to `site-packages/` which get run even before `sitecustomize.py`. This is done to extend the Python path to include additional packages. The creation of the `.pth` file has a side-effect of that masks this bug. It loads the re module before importing ddtrace and before LOADED_MODULES can get set, so it is basically the same impact as ignoring/not cleaning up re module.



## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] OPTIONAL: PR description includes explicit acknowledgement of the performance implications of the change as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.