### PR TITLE
ci(benchmarks): disable unstable benchmarks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,6 @@
 - [ ] Change is maintainable (easy to change, telemetry, documentation).
 - [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
 - [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
-- [x] OPTIONAL: PR description includes explicit acknowledgement of the performance implications of the change as reported in the benchmarks PR comment.
 
 ## Reviewer Checklist
 

--- a/benchmarks/flask_simple/config.yaml
+++ b/benchmarks/flask_simple/config.yaml
@@ -24,13 +24,15 @@ appsec-post:
 appsec-telemetry:
   <<: *appsec
   telemetry_metrics_enabled: true
-tracer-and-profiler:
-  <<: *baseline
-  tracer_enabled: true
-  profiler_enabled: true
-tracer-and-profiler-and-appsec:
-  <<: *baseline
-  tracer_enabled: true
-  profiler_enabled: true
-  appsec_enabled: true
-  post_request: true
+# The scenarios below produce inconsistent results. We plan to 
+# disbable these scenarios until the root cause is identified:
+# tracer-and-profiler:
+#   <<: *baseline
+#   tracer_enabled: true
+#   profiler_enabled: true
+# tracer-and-profiler-and-appsec:
+#   <<: *baseline
+#   tracer_enabled: true
+#   profiler_enabled: true
+#   appsec_enabled: true
+#   post_request: true


### PR DESCRIPTION
This PR disables benchmarks scenarios that produce unstable results. These benchmarks report random performance improvements and regressions. We should reenable these benchmarks after a root cause of the instability is identified.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] OPTIONAL: PR description includes explicit acknowledgement of the performance implications of the change as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
