### PR TITLE
ci(gunicorn): ensure tests are correctly parallelized [backport #5922 to 1.13]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -648,19 +648,12 @@ jobs:
 
   gunicorn:
     <<: *machine_executor
-    parallelism: 4
+    parallelism: 6
     steps:
-      - attach_workspace:
-          at: .
-      - checkout
-      - start_docker_services:
-          services: ddagent
-      - run:
-          environment:
-            RIOT_RUN_RECOMPILE_REQS: "<< pipeline.parameters.riot_run_latest >>"
-          command: |
-            mv .riot .ddriot
-            ./scripts/ddtest riot -v run --pass-env -s 'gunicorn'
+      - run_test:
+          pattern: "gunicorn"
+          snapshot: true
+          docker_services: 'ddagent'
 
   httplib:
     <<: *machine_executor


### PR DESCRIPTION
Backport of #5922 to 1.13

Currently all gunicorn tests are run 4 times ([link](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/36115/workflows/ba450883-49a6-41a8-86ba-c9642e76570e/jobs/2438853)).  

This change ensure gunicorn tests are split up across four runners and each test is run once.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] OPTIONAL: PR description includes explicit acknowledgement of the performance implications of the change as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
