### PR TITLE
fix(sql): use psycopg's parse_dsn when available

### DIFF
--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -53,7 +53,7 @@ parse_pg_dsn = _dd_parse_pg_dsn
 
 @ModuleWatchdog.after_module_imported("psycopg2")
 def use_psycopg2_parse_dsn(psycopg_module):
-    """Replaces parse_pg_dsn with the helper function defined in psycopg 2 library"""
+    """Replaces parse_pg_dsn with the helper function defined in psycopg2"""
     global parse_pg_dsn
 
     try:

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -36,8 +36,9 @@ def _dd_parse_pg_dsn(dsn):
     """
     dsn_dict = dict()
     try:
-        # dsn strings with the following format raise a TypeError:
-        # dsn="db=moon user=ears options='-c statement_timeout=1000 -c lock_timeout=250'"
+        # Provides a default implementation for parsing DSN strings.
+        # The following is an example of a valid DSN string that fails to be parsed:
+        # "db=moon user=ears options='-c statement_timeout=1000 -c lock_timeout=250'"
         dsn_dict = dict(_.split("=", 1) for _ in dsn.split())
     except Exception:
         log.debug("Failed to parse dsn string", exc_info=True)

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -45,8 +45,9 @@ def _dd_parse_pg_dsn(dsn):
     return dsn_dict
 
 
-# Do not import from psycopg directly! This reference will be updated at runtime if we can
-# import psycopg 2 or psycopg 3 and use a better implementation.
+# Do not import from psycopg directly! This reference will be updated at runtime to use
+# a better implementation that is provided by the psycopg library.
+# This is done to avoid circular imports.
 parse_pg_dsn = _dd_parse_pg_dsn
 
 

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -39,7 +39,7 @@ def _dd_parse_pg_dsn(dsn):
         # dsn strings with the following format raise a TypeError:
         # dsn="db=moon user=ears options='-c statement_timeout=1000 -c lock_timeout=250'"
         dsn_dict = dict(_.split("=", 1) for _ in dsn.split())
-    except Exception as e:
+    except Exception:
         log.debug("Failed to parse dsn string", exc_info=True)
     return dsn_dict
 

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -41,7 +41,7 @@ def _dd_parse_pg_dsn(dsn):
         # "db=moon user=ears options='-c statement_timeout=1000 -c lock_timeout=250'"
         dsn_dict = dict(_.split("=", 1) for _ in dsn.split())
     except Exception:
-        log.debug("Failed to parse dsn string", exc_info=True)
+        log.debug("Failed to parse postgres dsn connection", exc_info=True)
     return dsn_dict
 
 

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -5,6 +5,7 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.vendor.debtcollector import deprecate
 
+
 log = get_logger(__name__)
 
 # tags

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -3,7 +3,6 @@ from typing import Dict
 from ddtrace.internal.compat import ensure_pep562
 from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.vendor.debtcollector import deprecate
-from ddtrace.internal.logger import get_logger
 
 log = get_logger(__name__)
 

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -67,7 +67,7 @@ def use_psycopg2_parse_dsn(psycopg_module):
 
 @ModuleWatchdog.after_module_imported("psycopg")
 def use_psycopg3_parse_dsn(psycopg_module):
-    """Replaces parse_pg_dsn with the helper function defined in psycopg 3 library"""
+    """Replaces parse_pg_dsn with the helper function defined in psycopg3"""
     global parse_pg_dsn
 
     try:

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 from ddtrace.internal.compat import ensure_pep562
+from ddtrace.internal.logger import get_logger
 from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.vendor.debtcollector import deprecate
 

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -1,8 +1,11 @@
 from typing import Dict
 
 from ddtrace.internal.compat import ensure_pep562
+from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.vendor.debtcollector import deprecate
+from ddtrace.internal.logger import get_logger
 
+log = get_logger(__name__)
 
 # tags
 QUERY = "sql.query"  # the query text
@@ -23,14 +26,54 @@ def normalize_vendor(vendor):
         return vendor
 
 
-def parse_pg_dsn(dsn):
+def _dd_parse_pg_dsn(dsn):
     # type: (str) -> Dict[str, str]
     """
     Return a dictionary of the components of a postgres DSN.
     >>> parse_pg_dsn('user=dog port=1543 dbname=dogdata')
     {'user':'dog', 'port':'1543', 'dbname':'dogdata'}
     """
-    return dict(_.split("=", 1) for _ in dsn.split())
+    dsn_dict = dict()
+    try:
+        # dsn strings with the following format raise a TypeError:
+        # dsn="db=moon user=ears options='-c statement_timeout=1000 -c lock_timeout=250'"
+        dsn_dict = dict(_.split("=", 1) for _ in dsn.split())
+    except Exception as e:
+        log.debug("Failed to parse dsn string: %s", str(e))
+    return dsn_dict
+
+
+# Do not import from psycopg directly! This reference will be updated at runtime if we can
+# import psycopg 2 or psycopg 3 and use a better implementation.
+parse_pg_dsn = _dd_parse_pg_dsn
+
+
+@ModuleWatchdog.after_module_imported("psycopg2")
+def use_psycopg2_parse_dsn(psycopg_module):
+    """Replaces parse_pg_dsn with the helper function defined in psycopg 2 library"""
+    global parse_pg_dsn
+
+    try:
+        from psycopg2.extensions import parse_dsn
+
+        parse_pg_dsn = parse_dsn
+    except ImportError:
+        # Best effort, we'll use our own parser: _dd_parse_pg_dsn
+        pass
+
+
+@ModuleWatchdog.after_module_imported("psycopg")
+def use_psycopg3_parse_dsn(psycopg_module):
+    """Replaces parse_pg_dsn with the helper function defined in psycopg 3 library"""
+    global parse_pg_dsn
+
+    try:
+        from psycopg.conninfo import conninfo_to_dict
+
+        parse_pg_dsn = conninfo_to_dict
+    except ImportError:
+        # Best effort, we'll use our own parser: _dd_parse_pg_dsn
+        pass
 
 
 def __getattr__(name):

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -40,7 +40,7 @@ def _dd_parse_pg_dsn(dsn):
         # dsn="db=moon user=ears options='-c statement_timeout=1000 -c lock_timeout=250'"
         dsn_dict = dict(_.split("=", 1) for _ in dsn.split())
     except Exception as e:
-        log.debug("Failed to parse dsn string: %s", str(e))
+        log.debug("Failed to parse dsn string", exc_info=True)
     return dsn_dict
 
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -72,6 +72,7 @@ doctest
 dogpile
 dogpile.cache
 dogstatsd
+dsn
 elasticsearch
 elasticsearch1
 elasticsearch7

--- a/releasenotes/notes/fix-tracer-parse-pg-dsn-take2-7ef89362545b2721.yaml
+++ b/releasenotes/notes/fix-tracer-parse-pg-dsn-take2-7ef89362545b2721.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    psycopg: Fixes ``ValueError`` raised when dsn connection strings are parsed. This was fixed in ddtrace v1.9.0 and was re-introduced in v1.13.0.

--- a/releasenotes/notes/fix-tracer-parse-pg-dsn-take2-7ef89362545b2721.yaml
+++ b/releasenotes/notes/fix-tracer-parse-pg-dsn-take2-7ef89362545b2721.yaml
@@ -1,4 +1,3 @@
----
 fixes:
   - |
     psycopg: Fixes ``ValueError`` raised when dsn connection strings are parsed. This was fixed in ddtrace v1.9.0 and was re-introduced in v1.13.0.

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -141,8 +141,7 @@ class PsycopgCore(TracerTestCase):
         # Regression test for DataDog/dd-trace-py/issues/5926
         configs_arr = ["{}={}".format(k, v) for k, v in POSTGRES_CONFIG.items()]
         configs_arr.append("options='-c statement_timeout=1000 -c lock_timeout=250'")
-        configs_str = " ".join(configs_arr)
-        conn = psycopg.connect(configs_str)
+        conn = psycopg.connect(" ".join(configs_arr))
 
         Pin.get_from(conn).clone(service="postgres", tracer=self.tracer).onto(conn)
         self.assert_conn_is_traced(conn, "postgres")

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -137,6 +137,16 @@ class PsycopgCore(TracerTestCase):
         self.assertIsNone(root.get_tag("sql.query"))
         self.reset()
 
+    def test_psycopg3_connection_with_string(self):
+        # Regression test for DataDog/dd-trace-py/issues/5926
+        configs_arr = ["{}={}".format(k, v) for k, v in POSTGRES_CONFIG.items()]
+        configs_arr.append("options='-c statement_timeout=1000 -c lock_timeout=250'")
+        configs_str = " ".join(configs_arr)
+        conn = psycopg.connect(configs_str)
+
+        Pin.get_from(conn).clone(service="postgres", tracer=self.tracer).onto(conn)
+        self.assert_conn_is_traced(conn, "postgres")
+
     def test_opentracing_propagation(self):
         # ensure OpenTracing plays well with our integration
         query = """SELECT 'tracing'"""

--- a/tests/contrib/psycopg2/test_psycopg.py
+++ b/tests/contrib/psycopg2/test_psycopg.py
@@ -147,7 +147,7 @@ class PsycopgCore(TracerTestCase):
         # Regression test for DataDog/dd-trace-py/issues/5926
         configs_arr = ["{}={}".format(k, v) for k, v in POSTGRES_CONFIG.items()]
         configs_arr.append("options='-c statement_timeout=1000 -c lock_timeout=250'")
-        conn = psycopg.connect(" ".join(configs_arr))
+        conn = psycopg2.connect(" ".join(configs_arr))
 
         Pin.get_from(conn).clone(service="postgres", tracer=self.tracer).onto(conn)
         self.assert_conn_is_traced(conn, "postgres")

--- a/tests/contrib/psycopg2/test_psycopg.py
+++ b/tests/contrib/psycopg2/test_psycopg.py
@@ -147,8 +147,7 @@ class PsycopgCore(TracerTestCase):
         # Regression test for DataDog/dd-trace-py/issues/5926
         configs_arr = ["{}={}".format(k, v) for k, v in POSTGRES_CONFIG.items()]
         configs_arr.append("options='-c statement_timeout=1000 -c lock_timeout=250'")
-        configs_str = " ".join(configs_arr)
-        conn = psycopg2.connect(configs_str)
+        conn = psycopg.connect(" ".join(configs_arr))
 
         Pin.get_from(conn).clone(service="postgres", tracer=self.tracer).onto(conn)
         self.assert_conn_is_traced(conn, "postgres")

--- a/tests/contrib/psycopg2/test_psycopg.py
+++ b/tests/contrib/psycopg2/test_psycopg.py
@@ -143,6 +143,16 @@ class PsycopgCore(TracerTestCase):
         self.assertIsNone(root.get_tag("sql.query"))
         self.reset()
 
+    def test_psycopg2_connection_with_string(self):
+        # Regression test for DataDog/dd-trace-py/issues/5926
+        configs_arr = ["{}={}".format(k, v) for k, v in POSTGRES_CONFIG.items()]
+        configs_arr.append("options='-c statement_timeout=1000 -c lock_timeout=250'")
+        configs_str = " ".join(configs_arr)
+        conn = psycopg2.connect(configs_str)
+
+        Pin.get_from(conn).clone(service="postgres", tracer=self.tracer).onto(conn)
+        self.assert_conn_is_traced(conn, "postgres")
+
     def test_opentracing_propagation(self):
         # ensure OpenTracing plays well with our integration
         query = """SELECT 'tracing'"""


### PR DESCRIPTION
Resolves: https://github.com/DataDog/dd-trace-py/issues/5926, https://github.com/DataDog/dd-trace-py/issues/5823

This change re-introduces the use of the psycopg's parse_dsn helper when available. Since we cannot import from psycopg directly because of potential patch-on-import circular references, we delegate the job to a post-module import hook to update the function reference from our own fallback one to psycopg's one.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
