### PR TITLE
docs: fix formatting and spelling in kafka release note [backport #5931 to 1.14]

### DIFF
--- a/releasenotes/notes/pass-args-kwargs-to-kafka-f3ca8128a2c4d612.yaml
+++ b/releasenotes/notes/pass-args-kwargs-to-kafka-f3ca8128a2c4d612.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    kafka: Fixes ``TypeError` raised when artibrary keyword arguments are passed to ``confluent_kafka.Consumer``
+    kafka: Fixes ``TypeError`` raised when arbitrary keyword arguments are passed to ``confluent_kafka.Consumer``


### PR DESCRIPTION
Backport of #5931 to 1.14

Blocks the release of v1.12.9, v1.13.4, and 1.14.0

Introduced by: https://github.com/DataDog/dd-trace-py/pull/5887

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
