### PR TITLE
[dbapi] Pass on `exc_...` params to wrapped `__aexit__` calls.

### DIFF
--- a/ddtrace/contrib/dbapi_async/__init__.py
+++ b/ddtrace/contrib/dbapi_async/__init__.py
@@ -33,7 +33,7 @@ class TracedAsyncCursor(TracedCursor):
         # previous versions of the dbapi didn't support context managers. let's
         # reference the func that would be called to ensure that error
         # messages will be the same.
-        return await self.__wrapped__.__aexit__()
+        return await self.__wrapped__.__aexit__(exc_type, exc_val, exc_tb)
 
     async def _trace_method(self, method, name, resource, extra_tags, dbm_propagator, *args, **kwargs):
         """
@@ -221,7 +221,7 @@ class TracedAsyncConnection(TracedConnection):
         # previous versions of the dbapi didn't support context managers. let's
         # reference the func that would be called to ensure that errors
         # messages will be the same.
-        return await self.__wrapped__.__aexit__()
+        return await self.__wrapped__.__aexit__(exc_type, exc_val, exc_tb)
 
     async def _trace_method(self, method, name, extra_tags, *args, **kwargs):
         pin = Pin.get_from(self)

--- a/tests/contrib/psycopg/test_psycopg_async.py
+++ b/tests/contrib/psycopg/test_psycopg_async.py
@@ -320,6 +320,18 @@ class PsycopgCore(AsyncioTestCase):
         assert rows[0][0] == "one"
 
     @mark_asyncio
+    async def test_connection_context_execute(self):
+        """Checks whether connection context manager works as normal."""
+
+        query = SQL("""select 'one' as x""")
+        async with (await psycopg.AsyncConnection.connect(**POSTGRES_CONFIG)) as conn:
+            cur = await conn.execute(query)
+            rows = await cur.fetchall()
+
+        assert len(rows) == 1, rows
+        assert rows[0][0] == "one"
+
+    @mark_asyncio
     async def test_cursor_from_connection_shortcut(self):
         """Checks whether connection execute shortcute method works as normal"""
 


### PR DESCRIPTION
## Changes

Updates the dbapi_async implementation to pass along the `exc_...` parameters to the `__wrapped__.__aexit__` calls.

This should not introduce any breaking changes or cause any changes to performance.

This resolves #6001 

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
