### PR TITLE
chore(debugging): relax safe dict retrieval

### DIFF
--- a/tests/debugging/test_safety.py
+++ b/tests/debugging/test_safety.py
@@ -2,6 +2,8 @@
 
 import inspect
 
+import pytest
+
 from ddtrace.debugging import safety
 
 
@@ -75,3 +77,14 @@ def test_get_fields_slots():
 
     assert safety.get_fields(A()) == {"a": "a"}
     assert safety.get_fields(B()) == {"a": "a", "b": "b"}
+
+
+def test_safe_dict():
+    # Found in the FastAPI test suite
+    class Foo(object):
+        @property
+        def __dict__(self):
+            raise NotImplementedError()
+
+    with pytest.raises(AttributeError):
+        safety._safe_dict(Foo())


### PR DESCRIPTION
The existing safety check around the retrieval of `__dict__` are too strict and lead to many objects not being captured down to their fields. This change relaxes the condition on safety by ensuring that we can get an instance of `__dict__` that is of the _exact_ type `dict`.

## Risks

The example that was found in the FastAPI is probably quite exotic as we don't expect actual objects to implement a `__dict__` attribute on a class with potential side-effects.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
