### PR TITLE
chore: add login event mode argument and tag

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -148,7 +148,7 @@ class LOGIN_EVENTS_MODE(object):
     DISABLED: automatic login events are disabled.
     SAFE: automatic login events are enabled but will only store non-PII fields (id, pk uid...)
     EXTENDED: automatic login events are enabled and will store potentially PII fields (username,
-        email, ...).
+    email, ...).
     SDK: manually issued login events using the SDK.
     """
 

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -142,6 +142,23 @@ class PRODUCTS(object):
 
 
 @six.add_metaclass(Constant_Class)  # required for python2/3 compatibility
+class LOGIN_EVENTS_MODE(object):
+    """
+    string identifier for the mode of the user login events. Can be:
+    DISABLED: automatic login events are disabled.
+    SAFE: automatic login events are enabled but will only store non-PII fields (id, pk uid...)
+    EXTENDED: automatic login events are enabled and will store potentially PII fields (username,
+        email, ...).
+    SDK: manually issued login events using the SDK.
+    """
+
+    DISABLED = "disabled"
+    SAFE = "safe"
+    EXTENDED = "extended"
+    SDK = "sdk"
+
+
+@six.add_metaclass(Constant_Class)  # required for python2/3 compatibility
 class DEFAULT(object):
     ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
     RULES = os.path.join(ROOT_DIR, "rules.json")

--- a/ddtrace/appsec/trace_utils.py
+++ b/ddtrace/appsec/trace_utils.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 from ddtrace import config
 from ddtrace import constants
 from ddtrace.appsec._constants import APPSEC
+from ddtrace.appsec._constants import LOGIN_EVENTS_MODE
 from ddtrace.appsec._constants import WAF_CONTEXT_NAMES
 from ddtrace.ext import user
 from ddtrace.internal.compat import six
@@ -22,16 +23,25 @@ from ddtrace.internal.logger import get_logger
 log = get_logger(__name__)
 
 
-def _track_user_login_common(tracer, user_id, success, metadata=None):
-    # type: (Tracer, str, bool, Optional[dict]) -> Optional[Span]
+def _track_user_login_common(tracer, user_id, success, metadata=None, login_events_mode=LOGIN_EVENTS_MODE.SDK):
+    # type: (Tracer, str, bool, Optional[dict], LOGIN_EVENTS_MODE) -> Optional[Span]
 
     span = tracer.current_root_span()
     if span:
         success_str = "success" if success else "failure"
-        span.set_tag_str("%s.%s.track" % (APPSEC.USER_LOGIN_EVENT_PREFIX, success_str), "true")
+        tag_prefix = "%s.%s" % (APPSEC.USER_LOGIN_EVENT_PREFIX, success_str)
+        span.set_tag_str("%s.track" % tag_prefix, "true")
+
+        # This is used to mark if the call was done from the SDK of the automatic login events
+        if login_events_mode == LOGIN_EVENTS_MODE.SDK:
+            span.set_tag_str("%s.sdk" % tag_prefix, "true")
+        else:
+            span.set_tag_str("%s.auto.mode" % tag_prefix, str(login_events_mode))
+
         if metadata is not None:
             for k, v in six.iteritems(metadata):
                 span.set_tag_str("%s.%s.%s" % (APPSEC.USER_LOGIN_EVENT_PREFIX, success_str, k), str(v))
+
         span.set_tag_str(constants.MANUAL_KEEP_KEY, "true")
         return span
     else:
@@ -53,8 +63,9 @@ def track_user_login_success_event(
     role=None,
     session_id=None,
     propagate=False,
+    login_events_mode=LOGIN_EVENTS_MODE.SDK,
 ):
-    # type: (Tracer, str, Optional[dict], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], bool) -> None # noqa: E501
+    # type: (Tracer, str, Optional[dict], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], bool, LOGIN_EVENTS_MODE) -> None # noqa: E501
     """
     Add a new login success tracking event. The parameters after metadata (name, email,
     scope, role, session_id, propagate) will be passed to the `set_user` function that will be called
@@ -67,7 +78,7 @@ def track_user_login_success_event(
     :param metadata: a dictionary with additional metadata information to be stored with the event
     """
 
-    span = _track_user_login_common(tracer, user_id, True, metadata)
+    span = _track_user_login_common(tracer, user_id, True, metadata, login_events_mode)
     if not span:
         return
 
@@ -75,7 +86,7 @@ def track_user_login_success_event(
     set_user(tracer, user_id, name, email, scope, role, session_id, propagate)
 
 
-def track_user_login_failure_event(tracer, user_id, exists, metadata=None):
+def track_user_login_failure_event(tracer, user_id, exists, metadata=None, login_events_mode=LOGIN_EVENTS_MODE.SDK):
     # type: (Tracer, str, bool, Optional[dict]) -> None
     """
     Add a new login failure tracking event.
@@ -85,7 +96,7 @@ def track_user_login_failure_event(tracer, user_id, exists, metadata=None):
     :param metadata: a dictionary with additional metadata information to be stored with the event
     """
 
-    span = _track_user_login_common(tracer, user_id, False, metadata)
+    span = _track_user_login_common(tracer, user_id, False, metadata, login_events_mode)
     if not span:
         return
 

--- a/ddtrace/appsec/trace_utils.py
+++ b/ddtrace/appsec/trace_utils.py
@@ -24,7 +24,7 @@ log = get_logger(__name__)
 
 
 def _track_user_login_common(tracer, user_id, success, metadata=None, login_events_mode=LOGIN_EVENTS_MODE.SDK):
-    # type: (Tracer, str, bool, Optional[dict], LOGIN_EVENTS_MODE) -> Optional[Span]
+    # type: (Tracer, str, bool, Optional[dict], str) -> Optional[Span]
 
     span = tracer.current_root_span()
     if span:
@@ -65,7 +65,7 @@ def track_user_login_success_event(
     propagate=False,
     login_events_mode=LOGIN_EVENTS_MODE.SDK,
 ):
-    # type: (Tracer, str, Optional[dict], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], bool, LOGIN_EVENTS_MODE) -> None # noqa: E501
+    # type: (Tracer, str, Optional[dict], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], bool, str) -> None # noqa: E501
     """
     Add a new login success tracking event. The parameters after metadata (name, email,
     scope, role, session_id, propagate) will be passed to the `set_user` function that will be called
@@ -87,7 +87,7 @@ def track_user_login_success_event(
 
 
 def track_user_login_failure_event(tracer, user_id, exists, metadata=None, login_events_mode=LOGIN_EVENTS_MODE.SDK):
-    # type: (Tracer, str, bool, Optional[dict]) -> None
+    # type: (Tracer, str, bool, Optional[dict], str) -> None
     """
     Add a new login failure tracking event.
     :param tracer: tracer instance to use


### PR DESCRIPTION
Adds the login event mode and arguments which to keep backwards compatibility will default to `LOGIN_EVENTS_MODE.SDK` (meaning manually called using the SDK). This is a requirements for the next PR which will implement the RFC for automated user events tracking.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
