### PR TITLE
chore(test): ignore commented lines in riot requirements

### DIFF
--- a/scripts/check-diff
+++ b/scripts/check-diff
@@ -2,10 +2,10 @@
 
 directory=${1:-"."}
 message=${2:-"Files were changed or added."}
-changed_files="$(git diff -- ${directory})"
+changed_files="$(git diff -I '^#' -- ${directory})"
 new_files="$(git ls-files -o --exclude-standard -- ${directory})"
 
-if [[ "$(git diff --exit-code -- ${directory})" || -n $new_files ]]
+if [[ "$(git diff -I '^#' --exit-code -- ${directory})" || -n $new_files ]]
 then
     echo "${changed_files}"
     echo "${new_files}"


### PR DESCRIPTION
Add an option in the diff script to ignore commented lines that can be different due to different versions of pip-tools

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
