### PR TITLE
chore(rcm/di): disable multiple target files

### DIFF
--- a/ddtrace/internal/remoteconfig/_connectors.py
+++ b/ddtrace/internal/remoteconfig/_connectors.py
@@ -47,9 +47,9 @@ class PublisherSubscriberConnector(object):
         self.shared_data_counter = 0
 
     @staticmethod
-    def _hash_config(config_raw):
-        # type: (SharedDataType) -> int
-        return hash(str(config_raw))
+    def _hash_config(config_raw, metadata_raw):
+        # type: (Any, Any) -> int
+        return hash(str(config_raw) + str(metadata_raw))
 
     def read(self):
         # type: () -> SharedDataType
@@ -64,7 +64,7 @@ class PublisherSubscriberConnector(object):
 
     def write(self, metadata, config_raw):
         # type: (Any, Any) -> None
-        last_checksum = self._hash_config(config_raw)
+        last_checksum = self._hash_config(config_raw, metadata)
         if last_checksum != self.checksum:
             data_len = len(self.data.value)
             if data_len >= (SHARED_MEMORY_SIZE - 1000):

--- a/tests/debugging/probe/test_remoteconfig.py
+++ b/tests/debugging/probe/test_remoteconfig.py
@@ -106,7 +106,7 @@ def test_poller_env_version(env, version, expected, remote_config_worker, mock_c
             ]
         )
 
-        adapter = ProbeRCAdapter("", callback)
+        adapter = ProbeRCAdapter(None, callback)
         remoteconfig_poller.register("TEST", adapter)
         adapter.append_and_publish({"test": random.randint(0, 11111111)}, "", config_metadata())
         remoteconfig_poller._poll_data()
@@ -127,7 +127,7 @@ def test_poller_remove_probe():
     old_interval = config.diagnostics_interval
     config.diagnostics_interval = 0.5
     try:
-        adapter = ProbeRCAdapter("", cb)
+        adapter = ProbeRCAdapter(None, cb)
         # Wait to allow the next call to the adapter to generate a status event
         remoteconfig_poller.register("TEST", adapter, skip_enabled=True)
         adapter.append_and_publish(
@@ -181,7 +181,7 @@ def test_poller_remove_multiple_probe():
     old_interval = config.diagnostics_interval
     config.diagnostics_interval = 0.5
     try:
-        adapter = ProbeRCAdapter("", cb)
+        adapter = ProbeRCAdapter(None, cb)
         # Wait to allow the next call to the adapter to generate a status event
         remoteconfig_poller.register("TEST", adapter, skip_enabled=True)
         adapter.append(
@@ -287,7 +287,7 @@ def test_poller_events(remote_config_worker, mock_config):
     old_interval = config.diagnostics_interval
     config.diagnostics_interval = 0.5
     try:
-        adapter = ProbeRCAdapter("", callback)
+        adapter = ProbeRCAdapter(None, callback)
         remoteconfig_poller.register("TEST2", adapter, skip_enabled=True)
         adapter.append_and_publish({"test": 2}, "", metadata)
         remoteconfig_poller._poll_data()
@@ -341,7 +341,7 @@ def test_multiple_configs(remote_config_worker):
     old_interval = config.diagnostics_interval
     config.diagnostics_interval = 0.5
     try:
-        adapter = ProbeRCAdapter("", cb)
+        adapter = ProbeRCAdapter(None, cb)
         # Wait to allow the next call to the adapter to generate a status event
         remoteconfig_poller.register("TEST", adapter, skip_enabled=True)
         adapter.append_and_publish(
@@ -537,7 +537,7 @@ def test_modified_probe_events(remote_config_worker, mock_config):
     old_interval = config.diagnostics_interval
     config.diagnostics_interval = 0.5
     try:
-        adapter = ProbeRCAdapter("", cb)
+        adapter = ProbeRCAdapter(None, cb)
         # Wait to allow the next call to the adapter to generate a status event
         remoteconfig_poller.register("TEST", adapter)
         sleep(0.5)

--- a/tests/internal/remoteconfig/test_remoteconfig_connector.py
+++ b/tests/internal/remoteconfig/test_remoteconfig_connector.py
@@ -16,7 +16,7 @@ from ddtrace.internal.remoteconfig._connectors import PublisherSubscriberConnect
 )
 def test_hash(data):
     connector = PublisherSubscriberConnector()
-    assert type(connector._hash_config(data)) is int
+    assert type(connector._hash_config(data, None)) is int
 
 
 def test_connector():


### PR DESCRIPTION
Remote Config detects if there is new information to poll from subscribers by validating a checksum of the Remote Config payloads. When we remove a Dynamic Instrumentation Probe from the UI, the payload is set to 'False'.

The problem occurs when we remove two probes. In both cases, the "config" is set to False, they have the same checksum, and the second probe is not removed correctly.

No change log is needed because this error was introduced in version 1.15.0.

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
