### PR TITLE
ci(debugging): delete triggered probes in Django runs [backport #6026 to 1.11]

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -96,7 +96,9 @@ jobs:
       DD_TESTING_RAISE: true
       DD_DEBUGGER_EXPL_ENCODE: 0  # Disabled to speed up
       DD_DEBUGGER_EXPL_PROFILER_ENABLED: ${{ matrix.expl_profiler }}
+      DD_DEBUGGER_EXPL_PROFILER_DELETE_FUNCTION_PROBES: 1  # Delete to speed up
       DD_DEBUGGER_EXPL_COVERAGE_ENABLED: ${{ matrix.expl_coverage }}
+      DD_DEBUGGER_EXPL_COVERAGE_DELETE_LINE_PROBES: 1  # Delete to speed up
       DD_DEBUGGER_EXPL_CONSERVATIVE: 1
       PYTHONPATH: ../ddtrace/tests/debugging/exploration/:.
     defaults:

--- a/tests/debugging/exploration/_config.py
+++ b/tests/debugging/exploration/_config.py
@@ -82,6 +82,12 @@ class ExplorationConfig(En):
             default=True,
             help="Whether to enable the exploration deterministic profiler",
         )
+        delete_probes = En.v(
+            bool,
+            "delete_function_probes",
+            default=False,
+            help="Whether to delete function probes after they are triggered",
+        )
 
     class CoverageConfig(En):
         __item__ = "coverage"

--- a/tests/debugging/exploration/_profiler.py
+++ b/tests/debugging/exploration/_profiler.py
@@ -8,6 +8,7 @@ from debugger import config
 from debugger import status
 from debugging.utils import create_snapshot_function_probe
 
+from ddtrace.debugging._capture.snapshot import Snapshot
 from ddtrace.debugging._function.discovery import FunctionDiscovery
 from ddtrace.debugging._probe.model import FunctionLocationMixin
 
@@ -62,6 +63,12 @@ class DeterministicProfiler(ExplorationDebugger):
     def on_disable(cls):
         # type: () -> None
         cls.report_func_calls()
+
+    @classmethod
+    def on_snapshot(cls, snapshot):
+        # type: (Snapshot) -> None
+        if config.profiler.delete_probes:
+            cls.delete_probe(snapshot.probe)
 
 
 if config.profiler.enabled:


### PR DESCRIPTION
Backport of #6026 to 1.11

In an attempt to speed up the Django runs with exploration tests on we delete probes that have been triggered so that future executions can happen with no overhead.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
