### PR TITLE
chore(docs): ensures python3.11 is set as default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ launch them through:
    using a Python version management tool, such as
    [pyenv](https://github.com/pyenv/pyenv), to utilize multiple versions of
    Python. [How to install Pyenv](https://github.com/pyenv/pyenv#installation) 
-3. Install the relevant versions of Python in Pyenv: `pyenv install 2.7.18 3.5.10 3.6.15 3.7.13 3.8.13 3.9.13 3.10.5`
-4. Make those versions available globally: `pyenv global 2.7.18 3.5.10 3.6.15 3.7.13 3.8.13 3.9.13 3.10.5`
+3. Install the relevant versions of Python in Pyenv: `pyenv install 3.11.0 2.7.18 3.6.15 3.7.13 3.8.13 3.9.13 3.10.5`
+4. Make those versions available globally: `pyenv global 3.11.0 2.7.18 3.6.15 3.7.13 3.8.13 3.9.13 3.10.5`
 
 ### Testing
 


### PR DESCRIPTION
Currently our onboarding docs instruct contributors to set python2.7 as the default python version. This is less than ideal. 

Also removes python 3.5.10 from installed versions. Python 3.5.10 can not be installed on arm 😢 

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
