### PR TITLE
fix(rcm): remote config payloads error 

### DIFF
--- a/ddtrace/debugging/_encoding.py
+++ b/ddtrace/debugging/_encoding.py
@@ -164,14 +164,6 @@ class BatchJsonEncoder(BufferedEncoder):
             with self._lock:
                 size = self._buffer.put(encoded)
                 self.count += 1
-                log.debug(
-                    "[%s][P: %s] BatchJsonEncoder (%s) put_encoded. size %s. Count %s",
-                    os.getpid(),
-                    os.getppid(),
-                    self,
-                    self._buffer,
-                    self.count,
-                )
                 return size
         except BufferFull:
             if self._on_full is not None:

--- a/ddtrace/debugging/_uploader.py
+++ b/ddtrace/debugging/_uploader.py
@@ -1,4 +1,3 @@
-import os
 from typing import Optional
 
 from ddtrace.debugging._config import config
@@ -76,7 +75,6 @@ class LogsIntakeUploaderV1(AwakeablePeriodicService):
                 else:
                     meter.increment("upload.success")
                     meter.distribution("upload.size", len(payload))
-                    log.debug("[%s][P: %s] Payload uploaded: %s", os.getpid(), os.getppid(), payload)
         except Exception:
             log.error("Failed to write payload", exc_info=True)
             meter.increment("error")

--- a/ddtrace/internal/remoteconfig/_subscribers.py
+++ b/ddtrace/internal/remoteconfig/_subscribers.py
@@ -29,7 +29,7 @@ class RemoteConfigSubscriber(object):
         self._callback = callback
         self._name = name
         log.debug("[%s] Subscriber %s init", os.getpid(), self._name)
-        self.interval = get_poll_interval_seconds()
+        self.interval = get_poll_interval_seconds() / 2
 
     def _exec_callback(self, data, test_tracer=None):
         # type: (SharedDataType, Optional[Tracer]) -> None

--- a/releasenotes/notes/rcm-fix-payload-errors-808e827b978c829a.yaml
+++ b/releasenotes/notes/rcm-fix-payload-errors-808e827b978c829a.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    The 1.15.0 version has a bug that arises when Remote Config receives both kinds of actions (removing target file 
+    configurations and loading new target file configurations) simultaneously, as the load action overrides the remove
+    action. This error occurs if someone creates and removes Dynamic Instrumentation Probes rapidly, within a time 
+    interval shorter than the Remote Config interval (5s). To fix this issue, this update appends all new configurations
+    and configurations to remove, and dispatches them at the end of the RC request.

--- a/tests/internal/remoteconfig/test_remoteconfig_client.py
+++ b/tests/internal/remoteconfig/test_remoteconfig_client.py
@@ -52,7 +52,9 @@ def test_load_new_configurations_update_applied_configs(mock_extract_target_file
     rc_client = RemoteConfigClient()
     rc_client.register_product("ASM_FEATURES", mock_callback)
 
-    rc_client._load_new_configurations(applied_configs, client_configs, payload=payload)
+    list_callbacks = []
+    rc_client._load_new_configurations(list_callbacks, applied_configs, client_configs, payload=payload)
+    rc_client._publish_configuration(list_callbacks)
 
     mock_extract_target_file.assert_called_with(payload, "mock/ASM_FEATURES", mock_config)
     mock_callback.append.assert_called_once_with(mock_config_content, "mock/ASM_FEATURES", mock_config)
@@ -96,8 +98,12 @@ def test_load_new_configurations_dispatch_applied_configs(mock_extract_target_fi
     rc_client.register_product("ASM_DATA", asm_callback)
     rc_client.register_product("ASM_FEATURES", asm_callback)
     asm_callback.start_subscriber()
-    rc_client._load_new_configurations(applied_configs, client_configs, payload=payload)
+
+    list_callbacks = []
+    rc_client._load_new_configurations(list_callbacks, applied_configs, client_configs, payload=payload)
+    rc_client._publish_configuration(list_callbacks)
     time.sleep(0.5)
+
     mock_callback.assert_called_once_with({"metadata": {}, "config": expected_results, "shared_data_counter": ANY})
     assert applied_configs == client_configs
     rc_client._products = {}
@@ -117,7 +123,9 @@ def test_load_new_configurations_config_exists(mock_extract_target_file):
     rc_client.register_product("ASM_FEATURES", mock_callback)
     rc_client._applied_configs = {"mock/ASM_FEATURES": mock_config}
 
-    rc_client._load_new_configurations(applied_configs, client_configs, payload=payload)
+    list_callbacks = []
+    rc_client._load_new_configurations(list_callbacks, applied_configs, client_configs, payload=payload)
+    rc_client._publish_configuration(list_callbacks)
 
     mock_extract_target_file.assert_not_called()
     mock_callback.assert_not_called()
@@ -137,7 +145,9 @@ def test_load_new_configurations_error_extract_target_file(mock_extract_target_f
     rc_client = RemoteConfigClient()
     rc_client.register_product("ASM_FEATURES", mock_callback)
 
-    rc_client._load_new_configurations(applied_configs, client_configs, payload=payload)
+    list_callbacks = []
+    rc_client._load_new_configurations(list_callbacks, applied_configs, client_configs, payload=payload)
+    rc_client._publish_configuration(list_callbacks)
 
     mock_extract_target_file.assert_called_with(payload, "mock/ASM_FEATURES", mock_config)
     mock_callback.assert_not_called()
@@ -163,7 +173,9 @@ def test_load_new_configurations_error_callback(mock_extract_target_file):
     rc_client = RemoteConfigClient()
     rc_client.register_product("ASM_FEATURES", exception_callback)
 
-    rc_client._load_new_configurations(applied_configs, client_configs, payload=payload)
+    list_callbacks = []
+    rc_client._load_new_configurations(list_callbacks, applied_configs, client_configs, payload=payload)
+    rc_client._publish_configuration(list_callbacks)
 
     mock_extract_target_file.assert_called_with(payload, "mock/ASM_FEATURES", mock_config)
 

--- a/tests/internal/remoteconfig/test_remoteconfig_subscriber.py
+++ b/tests/internal/remoteconfig/test_remoteconfig_subscriber.py
@@ -17,7 +17,7 @@ def test_subscriber_thread():
     subscriber.start()
     sleep(0.15)
     assert subscriber.is_running
-    mock_callback.assert_called_once_with({"example": "data"}, test_tracer=None)
+    mock_callback.assert_called_with({"example": "data"}, test_tracer=None)
 
     subscriber.stop()
     assert not subscriber.is_running


### PR DESCRIPTION
When Remote Configuration (RC) receives new configurations, the RC Client has two kinds of actions: removing target file configurations and loading new target file configurations.

The problem arises when we receive both kinds of actions simultaneously, as the load action overrides the remove action. This error occurs if someone creates and removes Dynamic Instrumentation Probes rapidly, within a time interval shorter than the Remote Config interval (5s).

To fix this issue, we append all new configurations and configurations to remove, and dispatch them at the end of the RC request.

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
