### PR TITLE
chore(service.naming): peerServiceProcessor to use set_tag_str

### DIFF
--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -297,7 +297,7 @@ class PeerServiceProcessor(SpanProcessor):
             return
 
         if span.get_tag(self._config.tag_name):  # If the tag already exists, assume it is user generated
-            span.set_tag(self._config.source_tag_name, self._config.tag_name)
+            span.set_tag_str(self._config.source_tag_name, self._config.tag_name)
             return
 
         if span.get_tag(SPAN_KIND) not in self._config.enabled_span_kinds:
@@ -306,6 +306,6 @@ class PeerServiceProcessor(SpanProcessor):
         for data_source in self._config.prioritized_data_sources:
             peer_service_definition = span.get_tag(data_source)
             if peer_service_definition:
-                span.set_tag(self._config.tag_name, peer_service_definition)
-                span.set_tag(self._config.source_tag_name, data_source)
+                span.set_tag_str(self._config.tag_name, peer_service_definition)
+                span.set_tag_str(self._config.source_tag_name, data_source)
                 return


### PR DESCRIPTION
This commit updates the PeerServiceProcessor to `use set_tag_str` instead of `set_tag`, due to known performance issues.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
