### PR TITLE
test: fix parametrisation support in subprocess marker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,7 @@ def unwind_params(params):
         yield None
         return
 
-    for _ in product(*(((k, v) for v in vs) for k, vs in params.items())):
+    for _ in product(*([(k, v) for v in vs] for k, vs in params.items())):
         yield dict(_)
 
 


### PR DESCRIPTION
A bug in the handling of the parametrize argument to the subprocess marker prevented it from generating the correct test matrix. This fix ensures that the correct matrix dictionary is generated so that all the intended test cases are actually run.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
