### PR TITLE
ci(telemetry): use a helper to join agent url to the telemetry endpoint

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -11,6 +11,7 @@ from typing import Union
 
 from ...internal import atexit
 from ...internal import forksafe
+from ...internal.compat import parse
 from ...settings import _config as config
 from ..agent import get_connection
 from ..agent import get_trace_url
@@ -66,7 +67,7 @@ class _TelemetryClient:
 
     @property
     def url(self):
-        return "%s/%s" % (self._agent_url, self._endpoint)
+        return parse.urljoin(self._agent_url, self._endpoint)
 
     def send_event(self, request):
         # type: (Dict) -> Optional[httplib.HTTPResponse]


### PR DESCRIPTION
## Description

This PR ensures the url used to send telemetry payloads is consistent.

## Background

When the telemetry test suite is run with `DD_TRACE_AGENT_URL=http://localhost:9126/ riot -v run -p 3.11 --pass-env -s telemetry` [test_send_failing_request](https://github.com/DataDog/dd-trace-py/blob/1.x/tests/telemetry/test_writer.py#L149)  hangs. This is because the agent url and endpoint are combined in a format that is not expected by httpretty
   - Running tests with `http://localhost:9126/telemetry/proxy/api/v2/apmtelemetry` works 
   -  Running tests with `http://localhost:9126//telemetry/proxy/api/v2/apmtelemetry ` hangs   


## Testing Strategy 

Run the telemetry tests with: `DD_TRACE_AGENT_URL=http://localhost:9126/ riot -v run -p 3.11 --pass-env -s telemetry`. With this change the tests complete successfully but on 1.x the tests hang at 72% completion.



## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
