### PR TITLE
docs(fastapi): add note about fastapi middleware

### DIFF
--- a/ddtrace/contrib/fastapi/__init__.py
+++ b/ddtrace/contrib/fastapi/__init__.py
@@ -24,6 +24,12 @@ enabled before using the middleware::
     tracer.configure(context_provider=AsyncioContextProvider())
 
 
+When registering your own ASGI middleware using FastAPI's ``add_middleware()`` function,
+keep in mind that Datadog spans close after your middleware's call to ``await self.app()`` returns.
+This means that accesses of span data from within the middleware should be performed
+prior to this call.
+
+
 Configuration
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
This change adds a note about an unexpected behavior found in https://github.com/DataDog/dd-trace-py/issues/6030 to the FastAPI integration documentation.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
