### PR TITLE
chore(peer.service): add peer.service remap logic

### DIFF
--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -335,7 +335,7 @@ class SpanSamplingProcessor(SpanProcessor):
 class PeerServiceProcessor(SpanProcessor):
     def __init__(self, peer_service_config):
         self._config = peer_service_config
-        self.enabled = self._config.enabled
+        self._set_defaults_enabled = self._config.set_defaults_enabled
 
     def on_span_start(self, span):
         """
@@ -344,11 +344,9 @@ class PeerServiceProcessor(SpanProcessor):
         pass
 
     def on_span_finish(self, span):
-        if not self.enabled:
-            return
-
-        self._set_span_tag(span)
-        self._remap_peer_service(span)
+        if self._set_defaults_enabled:
+            self._set_span_tag(span)
+        self._remap_peer_service(span)  # Remap regardless of whether defaults are enabled
 
     def _set_span_tag(self, span):
         if span.get_tag(self._config.tag_name):  # If the tag already exists, assume it is user generated

--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -347,6 +347,10 @@ class PeerServiceProcessor(SpanProcessor):
         if not self.enabled:
             return
 
+        self._set_span_tag(span)
+        self._remap_peer_service(span)
+
+    def _set_span_tag(self, span):
         if span.get_tag(self._config.tag_name):  # If the tag already exists, assume it is user generated
             span.set_tag_str(self._config.source_tag_name, self._config.tag_name)
             return
@@ -360,3 +364,10 @@ class PeerServiceProcessor(SpanProcessor):
                 span.set_tag_str(self._config.tag_name, peer_service_definition)
                 span.set_tag_str(self._config.source_tag_name, data_source)
                 return
+
+    def _remap_peer_service(self, span):
+        current_peer_service = span.get_tag(self._config.tag_name)
+
+        if current_peer_service in self._config.peer_service_mapping:
+            span.set_tag_str(self._config.remap_tag_name, current_peer_service)
+            span.set_tag_str(self._config.tag_name, self._config.peer_service_mapping[current_peer_service])

--- a/ddtrace/settings/peer_service.py
+++ b/ddtrace/settings/peer_service.py
@@ -3,16 +3,27 @@ import os
 from ddtrace.ext import SpanKind
 from ddtrace.internal.schema import SCHEMA_VERSION
 from ddtrace.internal.utils.formats import asbool
+from ddtrace.internal.utils.formats import parse_tags_str
 
 
 class PeerServiceConfig(object):
+    remap_tag_name = "_dd.peer.service.remapped_from"
     source_tag_name = "_dd.peer.service.source"
     tag_name = "peer.service"
     enabled_span_kinds = {SpanKind.CLIENT, SpanKind.PRODUCER}
     prioritized_data_sources = ["messaging.kafka.bootstrap.servers", "db.name", "rpc.service", "out.host"]
 
+    def __init__(self, enabled=None):
+        self._enabled = enabled
+
     @property
     def enabled(self):
-        env_enabled = asbool(os.getenv("DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED", default=False))
+        if self._enabled is None:
+            env_enabled = asbool(os.getenv("DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED", default=False))
+            self._enabled = SCHEMA_VERSION == "v1" or (SCHEMA_VERSION == "v0" and env_enabled)
 
-        return SCHEMA_VERSION == "v1" or (SCHEMA_VERSION == "v0" and env_enabled)
+        return self._enabled
+
+    @property
+    def peer_service_mapping(self):
+        return parse_tags_str(os.getenv("DD_TRACE_PEER_SERVICE_MAPPING", default=""))

--- a/ddtrace/settings/peer_service.py
+++ b/ddtrace/settings/peer_service.py
@@ -13,8 +13,9 @@ class PeerServiceConfig(object):
     enabled_span_kinds = {SpanKind.CLIENT, SpanKind.PRODUCER}
     prioritized_data_sources = ["messaging.kafka.bootstrap.servers", "db.name", "rpc.service", "out.host"]
 
-    def __init__(self, enabled=None):
+    def __init__(self, enabled=None, peer_service_mapping=None):
         self._enabled = enabled
+        self._peer_service_mapping = peer_service_mapping
 
     @property
     def enabled(self):
@@ -26,4 +27,7 @@ class PeerServiceConfig(object):
 
     @property
     def peer_service_mapping(self):
-        return parse_tags_str(os.getenv("DD_TRACE_PEER_SERVICE_MAPPING", default=""))
+        if self._peer_service_mapping is None:
+            self._peer_service_mapping = parse_tags_str(os.getenv("DD_TRACE_PEER_SERVICE_MAPPING", default=""))
+
+        return self._peer_service_mapping

--- a/ddtrace/settings/peer_service.py
+++ b/ddtrace/settings/peer_service.py
@@ -13,17 +13,17 @@ class PeerServiceConfig(object):
     enabled_span_kinds = {SpanKind.CLIENT, SpanKind.PRODUCER}
     prioritized_data_sources = ["messaging.kafka.bootstrap.servers", "db.name", "rpc.service", "out.host"]
 
-    def __init__(self, enabled=None, peer_service_mapping=None):
-        self._enabled = enabled
+    def __init__(self, set_defaults_enabled=None, peer_service_mapping=None):
+        self._set_defaults_enabled = set_defaults_enabled
         self._peer_service_mapping = peer_service_mapping
 
     @property
-    def enabled(self):
-        if self._enabled is None:
+    def set_defaults_enabled(self):
+        if self._set_defaults_enabled is None:
             env_enabled = asbool(os.getenv("DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED", default=False))
-            self._enabled = SCHEMA_VERSION == "v1" or (SCHEMA_VERSION == "v0" and env_enabled)
+            self._set_defaults_enabled = SCHEMA_VERSION == "v1" or (SCHEMA_VERSION == "v0" and env_enabled)
 
-        return self._enabled
+        return self._set_defaults_enabled
 
     @property
     def peer_service_mapping(self):

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -180,8 +180,7 @@ def _default_span_processors_factory(
     if single_span_sampling_rules:
         span_processors.append(SpanSamplingProcessor(single_span_sampling_rules))
 
-    if peer_service_processor.enabled:
-        span_processors.append(peer_service_processor)
+    span_processors.append(peer_service_processor)
 
     # These need to run after all the other processors
     deferred_processors = [

--- a/tests/internal/peer_service/test_processor.py
+++ b/tests/internal/peer_service/test_processor.py
@@ -32,7 +32,7 @@ def test_span():
 
 @pytest.mark.parametrize("span_kind", [SpanKind.CLIENT, SpanKind.PRODUCER])
 def test_processing_peer_service_exists(processor, test_span, span_kind, peer_service_config):
-    processor.enabled = True
+    processor._set_defaults_enabled = True
     test_span.set_tag(SPAN_KIND, span_kind)
     test_span.set_tag(peer_service_config.tag_name, "fake_peer_service")
     test_span.set_tag("out.host", "fake_falue")  # Should not show up
@@ -44,7 +44,7 @@ def test_processing_peer_service_exists(processor, test_span, span_kind, peer_se
 
 @pytest.mark.parametrize("span_kind", [SpanKind.SERVER, SpanKind.CONSUMER])
 def test_nothing_happens_for_server_and_consumer(processor, test_span, span_kind, peer_service_config):
-    processor.enabled = True
+    processor._set_defaults_enabled = True
     test_span.set_tag(SPAN_KIND, span_kind)
     test_span.set_tag("out.host", "fake_host")
     processor.on_span_finish(test_span)
@@ -54,7 +54,7 @@ def test_nothing_happens_for_server_and_consumer(processor, test_span, span_kind
 
 @pytest.mark.parametrize("data_source", PeerServiceConfig.prioritized_data_sources)
 def test_existing_data_sources(processor, test_span, data_source, peer_service_config):
-    processor.enabled = True
+    processor._set_defaults_enabled = True
     test_span.set_tag(SPAN_KIND, SpanKind.CLIENT)
     test_span.set_tag(data_source, "test_value")
 
@@ -66,7 +66,7 @@ def test_existing_data_sources(processor, test_span, data_source, peer_service_c
 
 @pytest.mark.parametrize("data_source", PeerServiceConfig.prioritized_data_sources)
 def test_disabled_peer_service(processor, test_span, data_source, peer_service_config):
-    processor.enabled = False
+    processor._set_defaults_enabled = False
     test_span.set_tag(data_source, "test_value")
     processor.on_span_finish(test_span)
 
@@ -88,7 +88,7 @@ def test_peer_service_enablement(schema_peer_enabled):
 
     with mock.patch.dict(os.environ, {"DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED": env_enabled}):
         with mock.patch("ddtrace.settings.peer_service.SCHEMA_VERSION", schema_version):
-            assert PeerServiceConfig().enabled == expected
+            assert PeerServiceConfig().set_defaults_enabled == expected
 
 
 @pytest.mark.subprocess(env=dict(DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED="True"), ddtrace_run=True)
@@ -117,9 +117,9 @@ def test_tracer_hooks():
 
 def test_peer_service_remap(test_span):
     with mock.patch.dict(os.environ, {"DD_TRACE_PEER_SERVICE_MAPPING": "fake_peer_service:remapped_service"}):
-        peer_service_config = PeerServiceConfig(enabled=True)
+        peer_service_config = PeerServiceConfig(set_defaults_enabled=True)
         processor = PeerServiceProcessor(peer_service_config)
-        processor.enabled = True
+        processor._set_defaults_enabled = True
         test_span.set_tag(SPAN_KIND, SpanKind.CLIENT)
         test_span.set_tag(peer_service_config.tag_name, "fake_peer_service")
         processor.on_span_finish(test_span)
@@ -127,3 +127,29 @@ def test_peer_service_remap(test_span):
         assert test_span.get_tag(peer_service_config.tag_name) == "remapped_service"
         assert test_span.get_tag(peer_service_config.remap_tag_name) == "fake_peer_service"
         assert test_span.get_tag(peer_service_config.source_tag_name) == "peer.service"
+
+
+def test_peer_service_remap(test_span):
+    with mock.patch.dict(os.environ, {"DD_TRACE_PEER_SERVICE_MAPPING": "fake_peer_service:remapped_service"}):
+        peer_service_config = PeerServiceConfig(set_defaults_enabled=True)
+        processor = PeerServiceProcessor(peer_service_config)
+        processor._set_defaults_enabled = True
+        test_span.set_tag(SPAN_KIND, SpanKind.CLIENT)
+        test_span.set_tag(peer_service_config.tag_name, "fake_peer_service")
+        processor.on_span_finish(test_span)
+
+        assert test_span.get_tag(peer_service_config.tag_name) == "remapped_service"
+        assert test_span.get_tag(peer_service_config.remap_tag_name) == "fake_peer_service"
+        assert test_span.get_tag(peer_service_config.source_tag_name) == "peer.service"
+
+
+def test_remap_still_happens_when_defaults_disabled(test_span):
+    with mock.patch.dict(os.environ, {"DD_TRACE_PEER_SERVICE_MAPPING": "fake_peer_service:remapped_service"}):
+        peer_service_config = PeerServiceConfig(set_defaults_enabled=False)
+        processor = PeerServiceProcessor(peer_service_config)
+        processor._set_defaults_enabled = False
+        test_span.set_tag(peer_service_config.tag_name, "fake_peer_service")
+        processor.on_span_finish(test_span)
+
+        assert test_span.get_tag(peer_service_config.tag_name) == "remapped_service"
+        assert test_span.get_tag(peer_service_config.remap_tag_name) == "fake_peer_service"

--- a/tests/internal/peer_service/test_processor.py
+++ b/tests/internal/peer_service/test_processor.py
@@ -129,20 +129,6 @@ def test_peer_service_remap(test_span):
         assert test_span.get_tag(peer_service_config.source_tag_name) == "peer.service"
 
 
-def test_peer_service_remap(test_span):
-    with mock.patch.dict(os.environ, {"DD_TRACE_PEER_SERVICE_MAPPING": "fake_peer_service:remapped_service"}):
-        peer_service_config = PeerServiceConfig(set_defaults_enabled=True)
-        processor = PeerServiceProcessor(peer_service_config)
-        processor._set_defaults_enabled = True
-        test_span.set_tag(SPAN_KIND, SpanKind.CLIENT)
-        test_span.set_tag(peer_service_config.tag_name, "fake_peer_service")
-        processor.on_span_finish(test_span)
-
-        assert test_span.get_tag(peer_service_config.tag_name) == "remapped_service"
-        assert test_span.get_tag(peer_service_config.remap_tag_name) == "fake_peer_service"
-        assert test_span.get_tag(peer_service_config.source_tag_name) == "peer.service"
-
-
 def test_remap_still_happens_when_defaults_disabled(test_span):
     with mock.patch.dict(os.environ, {"DD_TRACE_PEER_SERVICE_MAPPING": "fake_peer_service:remapped_service"}):
         peer_service_config = PeerServiceConfig(set_defaults_enabled=False)


### PR DESCRIPTION
Peer.Service is currently a beta product and is hidden behind a feature flag, alongside service naming.

This change provides users with the ability to change peer.service names via an environment variable, `DD_TRACE_PEER_SERVICE_MAPPING`. When users specify this variable, any services in the mapping will be automatically remapped to a different value, and the tag `_dd.peer.service.remapped_from` will be set to the prior value.  Note that the remapping happens irregardless of whether or not `DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED` is enabled

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
