### PR TITLE
chore: make FI team members co-owners of folders containing integrations and tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,12 @@
 # APM Core Python is the default owner of all files
 *                                   @DataDog/apm-core-python
 
+# Framework Integrations
+ddtrace/ext/                        @DataDog/apm-core-python @DataDog/apm-framework-integrations-reviewers-py
+ddtrace/contrib/                    @DataDog/apm-core-python @DataDog/apm-framework-integrations-reviewers-py
+ddtrace/internal/schema/            @DataDog/apm-core-python @DataDog/apm-framework-integrations-reviewers-py
+tests/                              @DataDog/apm-core-python @DataDog/apm-framework-integrations-reviewers-py
+
 # Files which can be approved by anyone
 # DEV: This helps not requiring apm-core-python to review new files added
 #      or files which changes often with most PRs

--- a/releasenotes/notes/add-fi-owners-52de8ce02f69e946.yaml
+++ b/releasenotes/notes/add-fi-owners-52de8ce02f69e946.yaml
@@ -1,3 +1,0 @@
-other:
-  - |
-    Made Framework Integrations team co-owner of folders related to instrumentations.

--- a/releasenotes/notes/add-fi-owners-52de8ce02f69e946.yaml
+++ b/releasenotes/notes/add-fi-owners-52de8ce02f69e946.yaml
@@ -1,0 +1,3 @@
+other:
+  - |
+    Made Framework Integrations team co-owner of folders related to instrumentations.


### PR DESCRIPTION
This is the first step toward the Framework Integrations team to co-own folders related to instrumentations.
Since changes to span naming and attributes can have a large impact, we also propose to co-own `tests`.
The change is high in the file, so individual teams (e.g. ASM) can set stricter rules on specific files (including tests) that are relevant to them.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.~
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
