### PR TITLE
ci(integrations): makes test_single_trace_too_large less flaky

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -326,33 +326,33 @@ def test_metrics_partial_flush_disabled(encoding, monkeypatch):
 @allencodings
 def test_single_trace_too_large(encoding, monkeypatch):
     monkeypatch.setenv("DD_TRACE_API_VERSION", encoding)
-    # setting writer interval to 5 seconds so that buffer can fit larger traces
-    monkeypatch.setenv("DD_TRACE_WRITER_INTERVAL_SECONDS", "10.0")
 
     t = Tracer()
     assert t._partial_flush_enabled is True
-    with mock.patch("ddtrace.internal.writer.writer.log") as log:
-        key = "a" * 250
-        with t.trace("huge"):
-            for i in range(200000):
-                with t.trace("operation") as s:
-                    # Need to make the strings unique so that the v0.5 encoding doesn’t compress the data
-                    s.set_tag(key + str(i), key + str(i))
-        t.shutdown()
-        assert (
-            mock.call(
-                "trace buffer (%s traces %db/%db) cannot fit trace of size %db, dropping (writer status: %s)",
-                AnyInt(),
-                AnyInt(),
-                AnyInt(),
-                AnyInt(),
-                AnyStr(),
-            )
-            in log.warning.mock_calls
-        ), log.mock_calls[
-            :20
-        ]  # limits number of logs, this test could generate hundreds of thousands of logs.
-        log.error.assert_not_called()
+    # This test asserts that a BufferFull exception is raised. We need to ensure the encoders queue is not flushed
+    # while trace chunks are being queued.
+    with mock.patch.object(AgentWriter, "flush_queue", return_value=None):
+        with mock.patch("ddtrace.internal.writer.writer.log") as log:
+            key = "a" * 250
+            with t.trace("huge"):
+                for i in range(30000):
+                    with t.trace("operation") as s:
+                        # Need to make the strings unique so that the v0.5 encoding doesn’t compress the data
+                        s.set_tag(key + str(i), key + str(i))
+            assert (
+                mock.call(
+                    "trace buffer (%s traces %db/%db) cannot fit trace of size %db, dropping (writer status: %s)",
+                    AnyInt(),
+                    AnyInt(),
+                    AnyInt(),
+                    AnyInt(),
+                    AnyStr(),
+                )
+                in log.warning.mock_calls
+            ), log.mock_calls[
+                :20
+            ]  # limits number of logs, this test could generate hundreds of thousands of logs.
+            log.error.assert_not_called()
 
 
 @allencodings


### PR DESCRIPTION
## Description

Looking at the failing test below we can see `test_single_trace_too_large` generates  over 20MB of trace data but these traces can be sent in separate payloads (yay partial flushing). This PR mocks `AgentWriter.flush_queue()` to ensure traces are not submitted. With this change the `BufferFull` exception will be consistently raised and `"trace buffer (%s traces %db/%db) cannot fit trace of size %db, dropping (writer status: %s)"` will always be logged.

This PR: 
 - Removes time interval env var this not required since the mechanism that submits traces is being mocked.
 - Removes `tracer.shutdown()` this test should not submit traces to the agent.
 - Decreases the total size of the trace from 200,000 to 30,000.
    - Generating 200,000 spans is overkill and very slow. We only need to queue 30,000 spans to fill the agent writer's buffer and log the buffer full warning.

## Background

This test consistently passes locally but often fails in ci (and mainly on older versions of python). My hypothesis is that the time interval to submit traces to the agent is too short. The test does not have enough time to add the trace chunks to overflow the trace encoder's buffer. 

Sample failure: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/37860/workflows/4da477db-5289-40b1-8375-5d6152f14b8f/jobs/2546383

## Testing Strategy 

YOLO. If `test_single_trace_too_large` is still flaky after this PR is merged then I have failed my reviewers and myself. 

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
