### PR TITLE
chore(peer.service): report hostname for elasticsearch

### DIFF
--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -1,5 +1,4 @@
 import os
-import typing
 
 from yarl import URL
 
@@ -14,7 +13,6 @@ from ddtrace.vendor import wrapt
 
 from ...ext import SpanKind
 from ...ext import SpanTypes
-from ...internal.compat import parse
 from ...internal.schema import schematize_url_operation
 from ...pin import Pin
 from ...propagation.http import HTTPPropagator

--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -19,6 +19,7 @@ from ...internal.schema import schematize_url_operation
 from ...pin import Pin
 from ...propagation.http import HTTPPropagator
 from ..trace_utils import ext_service
+from ..trace_utils import extract_info_from_url
 from ..trace_utils import set_http_meta
 from ..trace_utils import unwrap
 from ..trace_utils import with_traced_module as with_traced_module_sync
@@ -64,20 +65,6 @@ class _WrappedConnectorClass(wrapt.ObjectProxy):
             span.set_tag(COMPONENT, config.aiohttp.integration_name)
             result = await self.__wrapped__._create_connection(req, *args, **kwargs)
             return result
-
-
-def extract_info_from_url(url):
-    # type: (str) -> typing.Tuple[str, str]
-    parse_result = parse.urlparse(url)
-    query = parse_result.query
-
-    # Relative URLs don't have a netloc, so we force them
-    if not parse_result.netloc:
-        parse_result = parse.urlparse("//{url}".format(url=url))
-
-    netloc = parse_result.netloc.split("@", 1)[-1]  # Discard auth info
-    netloc = netloc.split(":", 1)[0]  # Discard port information
-    return netloc, query
 
 
 @with_traced_module

--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -17,7 +17,7 @@ from ...internal.schema import schematize_url_operation
 from ...pin import Pin
 from ...propagation.http import HTTPPropagator
 from ..trace_utils import ext_service
-from ..trace_utils import extract_info_from_url
+from ..trace_utils import extract_netloc_and_query_info_from_url
 from ..trace_utils import set_http_meta
 from ..trace_utils import unwrap
 from ..trace_utils import with_traced_module as with_traced_module_sync
@@ -89,7 +89,7 @@ async def _traced_clientsession_request(aiohttp, pin, func, instance, args, kwar
         # Params can be included separate of the URL so the URL has to be constructed
         # with the passed params.
         url_str = str(url.update_query(params) if params else url)
-        host, query = extract_info_from_url(url_str)
+        host, query = extract_netloc_and_query_info_from_url(url_str)
         set_http_meta(
             span,
             config.aiohttp_client,

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -3,6 +3,7 @@ from importlib import import_module
 from ddtrace import config
 from ddtrace._tracing import _limits
 from ddtrace.contrib.trace_utils import ext_service
+from ddtrace.contrib.trace_utils import extract_info_from_url
 from ddtrace.ext import net
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
@@ -109,7 +110,7 @@ def _get_perform_request(elasticsearch):
             span.set_tag_str(metadata.URL, url)
             span.set_tag_str(metadata.PARAMS, encoded_params)
             for connection in instance.connection_pool.connections:
-                hostname = parse.urlparse(connection.host).hostname
+                hostname, _ = extract_info_from_url(connection.host)
                 if hostname:
                     span.set_tag_str(net.TARGET_HOST, hostname)
                     break

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -16,7 +16,6 @@ from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...ext import elasticsearch as metadata
 from ...ext import http
-from ...internal.compat import parse
 from ...internal.compat import urlencode
 from ...internal.schema import schematize_service_name
 from ...internal.utils.wrappers import unwrap as _u

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -3,7 +3,7 @@ from importlib import import_module
 from ddtrace import config
 from ddtrace._tracing import _limits
 from ddtrace.contrib.trace_utils import ext_service
-from ddtrace.contrib.trace_utils import extract_info_from_url
+from ddtrace.contrib.trace_utils import extract_netloc_and_query_info_from_url
 from ddtrace.ext import net
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
@@ -109,7 +109,7 @@ def _get_perform_request(elasticsearch):
             span.set_tag_str(metadata.URL, url)
             span.set_tag_str(metadata.PARAMS, encoded_params)
             for connection in instance.connection_pool.connections:
-                hostname, _ = extract_info_from_url(connection.host)
+                hostname, _ = extract_netloc_and_query_info_from_url(connection.host)
                 if hostname:
                     span.set_tag_str(net.TARGET_HOST, hostname)
                     break

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -652,7 +652,7 @@ def set_user(tracer, user_id, name=None, email=None, scope=None, role=None, sess
         )
 
 
-def extract_info_from_url(url):
+def extract_netloc_and_query_info_from_url(url):
     # type: (str) -> Tuple[str, str]
     parse_result = parse.urlparse(url)
     query = parse_result.query

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -653,7 +653,7 @@ def set_user(tracer, user_id, name=None, email=None, scope=None, role=None, sess
 
 
 def extract_info_from_url(url):
-    # type: (str) -> typing.Tuple[str, str]
+    # type: (str) -> Tuple[str, str]
     parse_result = parse.urlparse(url)
     query = parse_result.query
 

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -650,3 +650,17 @@ def set_user(tracer, user_id, name=None, email=None, scope=None, role=None, sess
             "See https://docs.datadoghq.com/security_platform/application_security/setup_and_configure/"
             "?tab=set_user&code-lang=python for more information.",
         )
+
+
+def extract_info_from_url(url):
+    # type: (str) -> typing.Tuple[str, str]
+    parse_result = parse.urlparse(url)
+    query = parse_result.query
+
+    # Relative URLs don't have a netloc, so we force them
+    if not parse_result.netloc:
+        parse_result = parse.urlparse("//{url}".format(url=url))
+
+    netloc = parse_result.netloc.split("@", 1)[-1]  # Discard auth info
+    netloc = netloc.split(":", 1)[0]  # Discard port information
+    return netloc, query

--- a/tests/contrib/aiohttp/test_aiohttp_client.py
+++ b/tests/contrib/aiohttp/test_aiohttp_client.py
@@ -7,7 +7,7 @@ import pytest
 from ddtrace import Pin
 from ddtrace.contrib.aiohttp import patch
 from ddtrace.contrib.aiohttp import unpatch
-from ddtrace.contrib.trace_utils import extract_info_from_url
+from ddtrace.contrib.aiohttp.patch import extract_netloc_and_query_info_from_url
 from tests.utils import override_http_config
 
 from ..config import HTTPBIN_CONFIG
@@ -39,7 +39,7 @@ URL_500 = "{}/status/500".format(URL)
 )
 def test_extract_from_urlparse(url, netloc, qs, query_res):
     query_url = url + qs
-    host, query = extract_info_from_url(query_url)
+    host, query = extract_netloc_and_query_info_from_url(query_url)
     if query_res is not None:
         assert query == query_res
     assert host == netloc

--- a/tests/contrib/aiohttp/test_aiohttp_client.py
+++ b/tests/contrib/aiohttp/test_aiohttp_client.py
@@ -7,7 +7,7 @@ import pytest
 from ddtrace import Pin
 from ddtrace.contrib.aiohttp import patch
 from ddtrace.contrib.aiohttp import unpatch
-from ddtrace.contrib.aiohttp.patch import extract_info_from_url
+from ddtrace.contrib.trace_utils import extract_info_from_url
 from tests.utils import override_http_config
 
 from ..config import HTTPBIN_CONFIG

--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -84,6 +84,7 @@ class ElasticsearchPatchTest(TracerTestCase):
         assert span.get_tag("component") == "elasticsearch"
         assert span.get_tag("span.kind") == "client"
         assert span.get_tag("elasticsearch.url") == "/%s" % self.ES_INDEX
+        assert span.get_tag("out.host") == "localhost"
         assert span.resource == "PUT /%s" % self.ES_INDEX
 
         args = self._get_index_args()

--- a/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch.json
+++ b/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch.json
@@ -16,6 +16,7 @@
       "elasticsearch.url": "/ddtrace_index",
       "http.status_code": "200",
       "language": "python",
+      "out.host": "localhost",
       "runtime-id": "48d5633e5196471c87a429e6e232c9da",
       "span.kind": "client"
     },
@@ -48,6 +49,7 @@
       "elasticsearch.url": "/ddtrace_index",
       "http.status_code": "200",
       "language": "python",
+      "out.host": "localhost",
       "runtime-id": "48d5633e5196471c87a429e6e232c9da",
       "span.kind": "client"
     },

--- a/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch6.json
+++ b/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch6.json
@@ -15,6 +15,7 @@
       "elasticsearch.params": "ignore=400",
       "elasticsearch.url": "/ddtrace_index",
       "language": "python",
+      "out.host": "localhost",
       "runtime-id": "87b450ba30ec4f2e8fd734e998aaaa85",
       "span.kind": "client"
     },
@@ -46,6 +47,7 @@
       "elasticsearch.params": "ignore=%5B400%2C+404%5D",
       "elasticsearch.url": "/ddtrace_index",
       "language": "python",
+      "out.host": "localhost",
       "runtime-id": "87b450ba30ec4f2e8fd734e998aaaa85",
       "span.kind": "client"
     },

--- a/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch7.json
+++ b/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch7.json
@@ -15,6 +15,7 @@
       "elasticsearch.params": "ignore=400",
       "elasticsearch.url": "/ddtrace_index",
       "language": "python",
+      "out.host": "localhost",
       "runtime-id": "3807722d39f54d3bbd1c513c835fc694",
       "span.kind": "client"
     },
@@ -46,6 +47,7 @@
       "elasticsearch.params": "ignore=%5B400%2C+404%5D",
       "elasticsearch.url": "/ddtrace_index",
       "language": "python",
+      "out.host": "localhost",
       "runtime-id": "3807722d39f54d3bbd1c513c835fc694",
       "span.kind": "client"
     },


### PR DESCRIPTION
The peer.service initiative allows Datadog to set better defaults for service names, and to build a more intuitive service map, by mapping outgoing connections with the destinations service names.  In order to implement this functionality, various 'precursor' tags must be added to

This change adds one such precursor tag required for peer.service, for elasticache, which allows us to identify the cluster being connected to.

This change adds the 'out.host' tag for elasticsearch spans using the first connection which returns a valid hostname. If none are found, the tag is not added.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
