### PR TITLE
chore(ci-visibility): improve intake_cov_url logic

### DIFF
--- a/ddtrace/internal/ci_visibility/writer.py
+++ b/ddtrace/internal/ci_visibility/writer.py
@@ -88,6 +88,7 @@ class CIVisibilityWriter(HTTPWriter):
         headers=None,  # type: Optional[Dict[str, str]]
         use_evp=False,  # type: bool
     ):
+        intake_cov_url = None
         if use_evp:
             intake_url = agent.get_trace_url()
             intake_cov_url = agent.get_trace_url()
@@ -96,12 +97,13 @@ class CIVisibilityWriter(HTTPWriter):
             intake_cov_url = config._ci_visibility_agentless_url
         if not intake_url:
             intake_url = "%s.%s" % (AGENTLESS_BASE_URL, os.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE))
-            intake_cov_url = "%s.%s" % (AGENTLESS_COVERAGE_BASE_URL, os.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE))
 
         clients = (
             [CIVisibilityProxiedEventClient()] if use_evp else [CIVisibilityAgentlessEventClient()]
         )  # type: List[WriterClientBase]
         if coverage_enabled():
+            if not intake_cov_url:
+                intake_cov_url = "%s.%s" % (AGENTLESS_COVERAGE_BASE_URL, os.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE))
             clients.append(
                 CIVisibilityProxiedCoverageClient(
                     intake_url=intake_cov_url, headers={EVP_SUBDOMAIN_HEADER_NAME: EVP_SUBDOMAIN_HEADER_COVERAGE_VALUE}

--- a/tests/ci_visibility/test_ci_visibility.py
+++ b/tests/ci_visibility/test_ci_visibility.py
@@ -408,6 +408,24 @@ def test_civisibilitywriter_coverage_agentless_url():
             _get_connection.assert_called_once_with("https://citestcov-intake.datadoghq.com", 2.0)
 
 
+def test_civisibilitywriter_coverage_agentless_with_intake_url_param():
+    with override_env(
+        dict(
+            DD_API_KEY="foobar.baz",
+            DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
+        )
+    ), mock.patch("ddtrace.internal.ci_visibility.writer.coverage_enabled", return_value=True):
+        dummy_writer = DummyCIVisibilityWriter(intake_url="https://some-url.com")
+        assert dummy_writer.intake_url == "https://some-url.com"
+
+        cov_client = dummy_writer._clients[1]
+        assert cov_client._intake_url == "https://citestcov-intake.datadoghq.com"
+
+        with mock.patch("ddtrace.internal.writer.writer.get_connection") as _get_connection:
+            dummy_writer._put("", {}, cov_client)
+            _get_connection.assert_called_once_with("https://citestcov-intake.datadoghq.com", 2.0)
+
+
 def test_civisibilitywriter_coverage_evp_proxy_url():
     with override_env(
         dict(


### PR DESCRIPTION
CI Visibility: Small refactor to set `intake_cov_url` value properly (ultimately independent from `intake_url` argument)

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist
- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
