### PR TITLE
chore(ci-visibility): git repo url: use env vars over git output

### DIFF
--- a/tests/ci_visibility/test_ci_visibility.py
+++ b/tests/ci_visibility/test_ci_visibility.py
@@ -263,6 +263,18 @@ def test_git_client_get_repository_url(git_repo):
     assert remote_url == "git@github.com:test-repo-url.git"
 
 
+def test_git_client_get_repository_url_env_var_precedence(git_repo):
+    remote_url = CIVisibilityGitClient._get_repository_url(
+        tags={ci.git.REPOSITORY_URL: "https://github.com/Datadog/dd-trace-py"}, cwd=git_repo
+    )
+    assert remote_url == "https://github.com/Datadog/dd-trace-py"
+
+
+def test_git_client_get_repository_url_env_var_precedence_empty_tags(git_repo):
+    remote_url = CIVisibilityGitClient._get_repository_url(tags={}, cwd=git_repo)
+    assert remote_url == "git@github.com:test-repo-url.git"
+
+
 def test_git_client_get_latest_commits(git_repo):
     latest_commits = CIVisibilityGitClient._get_latest_commits(cwd=git_repo)
     assert latest_commits == [TEST_SHA]


### PR DESCRIPTION
CI Visibility: git repository url uses env vars if available, and git output as fallback

See [Jira task](https://datadoghq.atlassian.net/browse/CIAPP-6676) for more info

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
