### PR TITLE
fix(tracing): disallow the propagation of negative trace IDs

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -209,7 +209,6 @@ class _DatadogMultiHeader:
     @staticmethod
     def _extract(headers):
         # type: (Dict[str, str]) -> Optional[Context]
-        assert False
         trace_id_str = _extract_header_value(POSSIBLE_HTTP_HEADER_TRACE_IDS, headers)
         if trace_id_str is None:
             return None

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -209,6 +209,7 @@ class _DatadogMultiHeader:
     @staticmethod
     def _extract(headers):
         # type: (Dict[str, str]) -> Optional[Context]
+        assert False
         trace_id_str = _extract_header_value(POSSIBLE_HTTP_HEADER_TRACE_IDS, headers)
         if trace_id_str is None:
             return None

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -217,7 +217,7 @@ class _DatadogMultiHeader:
         except ValueError:
             trace_id = 0
 
-        if trace_id == 0 or trace_id > _MAX_UINT_64BITS:
+        if trace_id <= 0 or trace_id > _MAX_UINT_64BITS:
             log.warning(
                 "Invalid trace id: %r. `x-datadog-trace-id` must be greater than zero and less than 2**64", trace_id_str
             )

--- a/releasenotes/notes/negative-trace-id-813bd867c1c8553e.yaml
+++ b/releasenotes/notes/negative-trace-id-813bd867c1c8553e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    tracing: This fix resolves an issue where negative trace ID values were allowed to propagate via Datadog
+    distributed tracing HTTP headers.

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -1571,7 +1571,6 @@ else:
         env["DD_TRACE_PROPAGATION_STYLE"] = ",".join(styles)
     stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
     assert status == 0, (stdout, stderr)
-    assert stderr == b"", (stdout, stderr)
 
     result = json.loads(stdout.decode())
     assert result == expected_context

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -1076,6 +1076,17 @@ EXTRACT_FIXTURES = [
         },
     ),
     (
+        "invalid_datadog_negative_trace_id",
+        [PROPAGATION_STYLE_DATADOG],
+        {
+            HTTP_HEADER_TRACE_ID: "-1",
+            HTTP_HEADER_PARENT_ID: "5678",
+            HTTP_HEADER_SAMPLING_PRIORITY: "1",
+            HTTP_HEADER_ORIGIN: "synthetics",
+        },
+        CONTEXT_EMPTY,
+    ),
+    (
         "valid_datadog_explicit_style_wsgi",
         [PROPAGATION_STYLE_DATADOG],
         {get_wsgi_header(name): value for name, value in DATADOG_HEADERS_VALID.items()},


### PR DESCRIPTION
This pull request fixes the symptom reported in https://github.com/DataDog/dd-trace-py/issues/6125 by ensuring that ddtrace does not set negative values in the trace ID propagation header. Whatever underlying issue is causing the trace ID to be negative still exists despite this change.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)