### PR TITLE
chore(profiling): map loops to threads without custom policy [backport #5732 to 1.13]

### DIFF
--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -1,77 +1,71 @@
 # -*- encoding: utf-8 -*-
+from functools import partial
 import sys
 import typing
 
-
-try:
-    import asyncio
-except ImportError:
-    DefaultEventLoopPolicy = object
-
-    def get_event_loop_policy():
-        # type: (...) -> None
-        return None
-
-    def set_event_loop_policy(loop_policy):
-        # type: (...) -> None
-        pass
-
-    asyncio_available = False
-
-else:
-    asyncio_available = True
-    DefaultEventLoopPolicy = asyncio.DefaultEventLoopPolicy  # type: ignore[misc]
-
-    get_event_loop_policy = asyncio.get_event_loop_policy  # type: ignore[assignment]
-    set_event_loop_policy = asyncio.set_event_loop_policy  # type: ignore[assignment]
-
-    if hasattr(asyncio, "current_task"):
-        current_task = asyncio.current_task
-    elif hasattr(asyncio.Task, "current_task"):
-        current_task = asyncio.Task.current_task
-    else:
-
-        def current_task(loop=None):
-            return None
-
-    if hasattr(asyncio, "all_tasks"):
-        all_tasks = asyncio.all_tasks
-    elif hasattr(asyncio.Task, "all_tasks"):
-        all_tasks = asyncio.Task.all_tasks
-    else:
-
-        def all_tasks(loop=None):
-            return []
-
-    if hasattr(asyncio.Task, "get_name"):
-        # `get_name` is only available in Python ≥ 3.8
-        def _task_get_name(task):
-            return task.get_name()
-
-    else:
-
-        def _task_get_name(task):
-            return "Task-%d" % id(task)
-
+from ddtrace.internal.compat import PY3
+from ddtrace.internal.module import ModuleWatchdog
+from ddtrace.internal.module import find_loader
+from ddtrace.internal.utils import get_argument_value
+from ddtrace.internal.wrapping import wrap
 
 from . import _threading
 
 
-class DdtraceProfilerEventLoopPolicy(DefaultEventLoopPolicy):
-    def __init__(self):
-        # type: (...) -> None
-        super(DdtraceProfilerEventLoopPolicy, self).__init__()
-        self.loop_per_thread = _threading._ThreadLink()  # type: _threading._ThreadLink[asyncio.AbstractEventLoop]
+THREAD_LINK = None  # type: typing.Optional[_threading._ThreadLink]
 
-    def _clear_threads(self):
-        self.loop_per_thread.clear_threads(set(sys._current_frames().keys()))
 
-    def set_event_loop(self, loop):
-        super(DdtraceProfilerEventLoopPolicy, self).set_event_loop(loop)
-        self._clear_threads()
-        if loop is not None:
-            self.loop_per_thread.link_object(loop)
+def current_task(loop=None):
+    return None
 
-    def _ddtrace_get_loop(self, thread_id):
-        # type: (...) -> typing.Optional[asyncio.AbstractEventLoop]
-        return self.loop_per_thread.get_object(thread_id)
+
+def all_tasks(loop=None):
+    return []
+
+
+def _task_get_name(task):
+    return "Task-%d" % id(task)
+
+
+@ModuleWatchdog.after_module_imported("asyncio.events")
+def _(ae):
+    global THREAD_LINK
+
+    import asyncio
+
+    if hasattr(asyncio, "current_task"):
+        globals()["current_task"] = asyncio.current_task
+    elif hasattr(asyncio.Task, "current_task"):
+        globals()["current_task"] = asyncio.Task.current_task
+
+    if hasattr(asyncio, "all_tasks"):
+        globals()["all_tasks"] = asyncio.all_tasks
+    elif hasattr(asyncio.Task, "all_tasks"):
+        globals()["all_tasks"] = asyncio.Task.all_tasks
+
+    if hasattr(asyncio.Task, "get_name"):
+        # `get_name` is only available in Python ≥ 3.8
+        globals()["_task_get_name"] = lambda task: task.get_name()
+
+    if THREAD_LINK is None:
+        THREAD_LINK = _threading._ThreadLink()
+
+    @partial(wrap, ae.BaseDefaultEventLoopPolicy.set_event_loop)
+    def _(f, args, kwargs):
+        try:
+            return f(*args, **kwargs)
+        finally:
+            THREAD_LINK.clear_threads(set(sys._current_frames().keys()))
+            loop = get_argument_value(args, kwargs, 1, "loop")
+            if loop is not None:
+                THREAD_LINK.link_object(loop)
+
+
+def get_event_loop_for_thread(thread_id):
+    global THREAD_LINK
+
+    return THREAD_LINK.get_object(thread_id) if THREAD_LINK is not None else None
+
+
+def is_asyncio_available():
+    return PY3 and find_loader("asyncio") is not None

--- a/ddtrace/profiling/collector/_task.pyx
+++ b/ddtrace/profiling/collector/_task.pyx
@@ -78,15 +78,13 @@ cpdef get_task(thread_id):
     task_name = None
     frame = None
 
-    policy = _asyncio.get_event_loop_policy()
-    if isinstance(policy, _asyncio.DdtraceProfilerEventLoopPolicy):
-        loop = policy._ddtrace_get_loop(thread_id)
-        if loop is not None:
-            task = _asyncio.current_task(loop)
-            if task is not None:
-                task_id = id(task)
-                task_name = _asyncio._task_get_name(task)
-                frame = _asyncio_task_get_frame(task)
+    loop = _asyncio.get_event_loop_for_thread(thread_id)
+    if loop is not None:
+        task = _asyncio.current_task(loop)
+        if task is not None:
+            task_id = id(task)
+            task_name = _asyncio._task_get_name(task)
+            frame = _asyncio_task_get_frame(task)
 
     # gevent greenlet support:
     # - we only support tracing tasks in the greenlets run in the MainThread.
@@ -129,15 +127,13 @@ cpdef list_tasks(thread_id):
                 ]
             )
 
-    policy = _asyncio.get_event_loop_policy()
-    if isinstance(policy, _asyncio.DdtraceProfilerEventLoopPolicy):
-        loop = policy._ddtrace_get_loop(thread_id)
-        if loop is not None:
-            tasks.extend([
-                (id(task),
-                 _asyncio._task_get_name(task),
-                 _asyncio_task_get_frame(task))
-                for task in _asyncio.all_tasks(loop)
-            ])
+    loop = _asyncio.get_event_loop_for_thread(thread_id)
+    if loop is not None:
+        tasks.extend([
+            (id(task),
+                _asyncio._task_get_name(task),
+                _asyncio_task_get_frame(task))
+            for task in _asyncio.all_tasks(loop)
+        ])
 
     return tasks

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -14,8 +14,7 @@ from ddtrace.internal import forksafe
 from ddtrace.internal import service
 from ddtrace.internal import uwsgi
 from ddtrace.internal import writer
-from ddtrace.internal.utils import attr as attr_utils
-from ddtrace.internal.utils import formats
+from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.profiling import collector
 from ddtrace.profiling import exporter
 from ddtrace.profiling import recorder
@@ -29,7 +28,6 @@ from ddtrace.profiling.exporter import file
 from ddtrace.profiling.exporter import http
 
 from . import _asyncio
-from ._asyncio import DdtraceProfilerEventLoopPolicy
 
 
 LOG = logging.getLogger(__name__)
@@ -114,18 +112,10 @@ class _ProfilerInstance(service.Service):
     version = attr.ib(factory=lambda: os.environ.get("DD_VERSION"))
     tracer = attr.ib(default=ddtrace.tracer)
     api_key = attr.ib(factory=lambda: os.environ.get("DD_API_KEY"), type=Optional[str])
-    agentless = attr.ib(factory=lambda: formats.asbool(os.environ.get("DD_PROFILING_AGENTLESS", "False")), type=bool)
-    asyncio_loop_policy_class = attr.ib(default=DdtraceProfilerEventLoopPolicy)
-    _memory_collector_enabled = attr.ib(
-        factory=lambda: formats.asbool(os.environ.get("DD_PROFILING_MEMORY_ENABLED", "True")), type=bool
-    )
-    enable_code_provenance = attr.ib(
-        factory=attr_utils.from_env("DD_PROFILING_ENABLE_CODE_PROVENANCE", False, formats.asbool),
-        type=bool,
-    )
-    endpoint_collection_enabled = attr.ib(
-        factory=attr_utils.from_env("DD_PROFILING_ENDPOINT_COLLECTION_ENABLED", True, formats.asbool)
-    )
+    agentless = attr.ib(type=bool, default=config.agentless)
+    _memory_collector_enabled = attr.ib(type=bool, default=config.memory.enabled)
+    enable_code_provenance = attr.ib(type=bool, default=config.code_provenance)
+    endpoint_collection_enabled = attr.ib(type=bool, default=config.endpoint_collection)
 
     _recorder = attr.ib(init=False, default=None)
     _collectors = attr.ib(init=False, default=None)
@@ -215,8 +205,26 @@ class _ProfilerInstance(service.Service):
             ),  # type: ignore[call-arg]
             threading.ThreadingLockCollector(r, tracer=self.tracer),
         ]
-        if _asyncio.asyncio_available:
-            self._collectors.append(asyncio.AsyncioLockCollector(r, tracer=self.tracer))
+
+        if _asyncio.is_asyncio_available():
+
+            @ModuleWatchdog.after_module_imported("asyncio")
+            def _(_):
+                with self._service_lock:
+                    col = asyncio.AsyncioLockCollector(r, tracer=self.tracer)
+
+                    if self.status == service.ServiceStatus.RUNNING:
+                        # The profiler is already running so we need to start the collector
+                        try:
+                            col.start()
+                        except collector.CollectorUnavailable:
+                            LOG.debug("Collector %r is unavailable, disabling", col)
+                            return
+                        except Exception:
+                            LOG.error("Failed to start collector %r, disabling.", col, exc_info=True)
+                            return
+
+                    self._collectors.append(col)
 
         if self._memory_collector_enabled:
             self._collectors.append(memalloc.MemoryCollector(r))
@@ -229,12 +237,6 @@ class _ProfilerInstance(service.Service):
             else:
                 scheduler_class = scheduler.ServerlessScheduler
             self._scheduler = scheduler_class(recorder=r, exporters=exporters, before_flush=self._collectors_snapshot)
-
-        self.set_asyncio_event_loop_policy()
-
-    def set_asyncio_event_loop_policy(self):
-        if self.asyncio_loop_policy_class is not None:
-            _asyncio.set_event_loop_policy(self.asyncio_loop_policy_class())
 
     def _collectors_snapshot(self):
         for c in self._collectors:


### PR DESCRIPTION
Backport of #5732 to 1.13

Create a mapping between threads and event loops without installing a custom policy. We do so by patching the base event loop policy class, which is subclassed by all the `asyncio` default policies, as well as by policies from other frameworks (e.g. `uvloop`).

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html#Release-Note-Guidelines) are followed.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] PR description includes explicit acknowledgement/acceptance of the performance implications of this PR as reported in the benchmarks PR comment.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
