### PR TITLE
chore(debugging): fix dynamic span tags to be _dd.di

### DIFF
--- a/ddtrace/debugging/_signal/tracing.py
+++ b/ddtrace/debugging/_signal/tracing.py
@@ -107,11 +107,11 @@ class SpanDecoration(LogSignal):
                         tag_value = tag.value.render(_locals, serialize)
                     except DDExpressionEvaluationError as e:
                         span.set_tag_str(
-                            "_dd.%s.evaluation_error" % tag.name, ", ".join([serialize(v) for v in e.args])
+                            "_dd.di.%s.evaluation_error" % tag.name, ", ".join([serialize(v) for v in e.args])
                         )
                     else:
                         span.set_tag_str(tag.name, tag_value if _isinstance(tag_value, str) else serialize(tag_value))
-                        span.set_tag_str("_dd.%s.probe_id" % tag.name, t.cast(Probe, probe).probe_id)
+                        span.set_tag_str("_dd.di.%s.probe_id" % tag.name, t.cast(Probe, probe).probe_id)
 
     def enter(self):
         # type: () -> None

--- a/tests/debugging/test_debugger_span_decoration.py
+++ b/tests/debugging/test_debugger_span_decoration.py
@@ -63,9 +63,9 @@ class SpanDecorationProbeTestCase(TracerTestCase):
 
             assert span.name == "traceme"
             assert span.get_tag("test.tag") == "42"
-            assert span.get_tag("_dd.test.tag.probe_id") == "span-decoration"
+            assert span.get_tag("_dd.di.test.tag.probe_id") == "span-decoration"
             assert (
-                span.get_tag("_dd.test.bad.evaluation_error")
+                span.get_tag("_dd.di.test.bad.evaluation_error")
                 == "'Failed to evaluate expression \"test\": \\'notathing\\''"
             )
 
@@ -105,9 +105,9 @@ class SpanDecorationProbeTestCase(TracerTestCase):
 
             assert span.name == "traceme"
             assert int(span.get_tag("test.tag"))
-            assert span.get_tag("_dd.test.tag.probe_id") == "span-decoration"
+            assert span.get_tag("_dd.di.test.tag.probe_id") == "span-decoration"
             assert (
-                span.get_tag("_dd.test.bad.evaluation_error")
+                span.get_tag("_dd.di.test.bad.evaluation_error")
                 == "'Failed to evaluate expression \"test\": \\'notathing\\''"
             )
 
@@ -141,7 +141,7 @@ class SpanDecorationProbeTestCase(TracerTestCase):
 
             assert span.name == "traceme"
             assert span.get_tag("test.tag") == "test.value"
-            assert span.get_tag("_dd.test.tag.probe_id") == "span-decoration"
+            assert span.get_tag("_dd.di.test.tag.probe_id") == "span-decoration"
 
     def test_debugger_span_decoration_probe_on_traced_function_active_span(self):
         with debugger() as d:
@@ -168,7 +168,7 @@ class SpanDecorationProbeTestCase(TracerTestCase):
 
             assert span.name == "traceme"
             assert span.get_tag("test.tag") == "test.value"
-            assert span.get_tag("_dd.test.tag.probe_id") == "span-decoration"
+            assert span.get_tag("_dd.di.test.tag.probe_id") == "span-decoration"
 
     def test_debugger_span_decoration_probe_in_traced_function_active_span(self):
         with debugger() as d:
@@ -194,7 +194,7 @@ class SpanDecorationProbeTestCase(TracerTestCase):
 
             assert span.name == "traceme"
             assert span.get_tag("test.tag") == "test.value"
-            assert span.get_tag("_dd.test.tag.probe_id") == "span-decoration"
+            assert span.get_tag("_dd.di.test.tag.probe_id") == "span-decoration"
 
     def test_debugger_span_decoration_probe_in_traced_function_root_span(self):
         with debugger() as d:
@@ -226,8 +226,8 @@ class SpanDecorationProbeTestCase(TracerTestCase):
             else:
                 # String coertions in Python 2 change the value of the string
                 assert parent.get_tag("test.tag") is not None
-            assert parent.get_tag("_dd.test.tag.probe_id") == "span-decoration"
+            assert parent.get_tag("_dd.di.test.tag.probe_id") == "span-decoration"
 
             assert child.name == "traceme"
             assert child.get_tag("test.tag") is None
-            assert child.get_tag("_dd.test.tag.probe_id") is None
+            assert child.get_tag("_dd.di.test.tag.probe_id") is None


### PR DESCRIPTION
dynamic span tags also generate 'instrumentation tags'. they should start with a prefix "_dd.di" as defined by the spec.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
