### PR TITLE
chore(test): pin setuptools version in test frameworks

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -407,7 +407,7 @@ jobs:
         run: pip install ../ddtrace
       - name: Install dependencies
         run: |
-          python -m pip install -U pip setuptools wheel pytest
+          python -m pip install -U pip setuptools==67.8.0 wheel pytest
           python -m pip install -e .[test]
       - name: Run tests
         # Disable tests checking GC references since profiling can interfere
@@ -442,7 +442,7 @@ jobs:
       - name: Pin PasteDeploy to Python 2.7 compatible version
         run: pip install pastedeploy==2.1.1
       - name: MarkupSafe fix
-        run: pip install --upgrade MarkupSafe==0.18 pip setuptools --force
+        run: pip install --upgrade MarkupSafe==0.18 pip setuptools==67.8.0 --force
       - name: Disable failing tests
         run: |
           sed -i'' "s/test_detect_lang/detect_lang/g" tests/test_units/test_basic_app.py


### PR DESCRIPTION
Last version of setuptools is breaking github action test frameworks.
Fix it by pinning the version of setuptools.

This is a temporary solution


## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
