### PR TITLE
chore(telemetry): rename span metrics

### DIFF
--- a/ddtrace/contrib/wsgi/wsgi.py
+++ b/ddtrace/contrib/wsgi/wsgi.py
@@ -61,7 +61,7 @@ class _TracedIterable(wrapt.ObjectProxy):
         super(_TracedIterable, self).__init__(wrapped)
         self._self_span = span
         self._self_parent_span = parent_span
-        self._self_span_finished = False
+        self._self_spans_finished = False
 
     def __iter__(self):
         return self
@@ -86,10 +86,10 @@ class _TracedIterable(wrapt.ObjectProxy):
         self._finish_spans()
 
     def _finish_spans(self):
-        if not self._self_span_finished:
+        if not self._self_spans_finished:
             self._self_span.finish()
             self._self_parent_span.finish()
-            self._self_span_finished = True
+            self._self_spans_finished = True
 
     def __getattribute__(self, name):
         if name == "__len__":

--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -186,8 +186,8 @@ class SpanAggregator(SpanProcessor):
     _span_api_to_count = attr.ib(
         init=False,
         factory=lambda: {
-            "span_created": defaultdict(int),
-            "span_finished": defaultdict(int),
+            "spans_created": defaultdict(int),
+            "spans_finished": defaultdict(int),
         },
         type=Dict[str, DefaultDict],
     )
@@ -197,16 +197,16 @@ class SpanAggregator(SpanProcessor):
         with self._lock:
             trace = self._traces[span.trace_id]
             trace.spans.append(span)
-            self._span_api_to_count["span_created"][span._span_api] += 1
+            self._span_api_to_count["spans_created"][span._span_api] += 1
             # perf: telemetry_metrics_writer.add_count_metric(...) is an expensive operation.
             # We should avoid calling this method on every invocation of ``SpanAggregator.on_span_start()``
-            if sum(self._span_api_to_count["span_created"].values()) >= 100:
+            if sum(self._span_api_to_count["spans_created"].values()) >= 100:
                 # self._span_api_to_count should only have 1-3 keys, calculating the sum here is not expensive.
-                for api, count in self._span_api_to_count["span_created"].items():
+                for api, count in self._span_api_to_count["spans_created"].items():
                     telemetry_metrics_writer.add_count_metric(
-                        TELEMETRY_NAMESPACE_TAG_TRACER, "span_created", count, tags=(("integration_name", api),)
+                        TELEMETRY_NAMESPACE_TAG_TRACER, "spans_created", count, tags=(("integration_name", api),)
                     )
-                self._span_api_to_count["span_created"] = defaultdict(int)
+                self._span_api_to_count["spans_created"] = defaultdict(int)
 
     def on_span_finish(self, span):
         # type: (Span) -> None
@@ -238,16 +238,16 @@ class SpanAggregator(SpanProcessor):
                 if len(trace.spans) == 0:
                     del self._traces[span.trace_id]
 
-                self._span_api_to_count["span_finished"][span._span_api] += num_finished
+                self._span_api_to_count["spans_finished"][span._span_api] += num_finished
                 # perf: telemetry_metrics_writer.add_count_metric(...) is an expensive operation.
                 # We should avoid calling this method on every invocation of ``SpanAggregator.on_span_finish()``
-                if sum(self._span_api_to_count["span_finished"].values()) >= 100:
+                if sum(self._span_api_to_count["spans_finished"].values()) >= 100:
                     # self._span_api_to_count should only have 1-3 keys, calculating the sum here is not expensive
-                    for api, count in self._span_api_to_count["span_finished"].items():
+                    for api, count in self._span_api_to_count["spans_finished"].items():
                         telemetry_metrics_writer.add_count_metric(
-                            TELEMETRY_NAMESPACE_TAG_TRACER, "span_finished", count, tags=(("integration_name", api),)
+                            TELEMETRY_NAMESPACE_TAG_TRACER, "spans_finished", count, tags=(("integration_name", api),)
                         )
-                    self._span_api_to_count["span_finished"] = defaultdict(int)
+                    self._span_api_to_count["spans_finished"] = defaultdict(int)
 
                 spans = finished  # type: Optional[List[Span]]
                 for tp in self._trace_processors:
@@ -276,19 +276,19 @@ class SpanAggregator(SpanProcessor):
         """
         # on_span_start queue span created counts in batches of 100. This ensures all remaining counts are sent
         # before the tracer is shutdown.
-        for api, count in self._span_api_to_count["span_created"].items():
+        for api, count in self._span_api_to_count["spans_created"].items():
             telemetry_metrics_writer.add_count_metric(
-                TELEMETRY_NAMESPACE_TAG_TRACER, "span_created", count, tags=(("integration_name", api),)
+                TELEMETRY_NAMESPACE_TAG_TRACER, "spans_created", count, tags=(("integration_name", api),)
             )
-        self._span_api_to_count["span_created"] = defaultdict(int)
+        self._span_api_to_count["spans_created"] = defaultdict(int)
 
         # on_span_finish(...) queues span finish metrics in batches of 100. This ensures all remaining counts are sent
         # before the tracer is shutdown.
-        for api, count in self._span_api_to_count["span_finished"].items():
+        for api, count in self._span_api_to_count["spans_finished"].items():
             telemetry_metrics_writer.add_count_metric(
-                TELEMETRY_NAMESPACE_TAG_TRACER, "span_finished", count, tags=(("integration_name", api),)
+                TELEMETRY_NAMESPACE_TAG_TRACER, "spans_finished", count, tags=(("integration_name", api),)
             )
-        self._span_api_to_count["span_finished"] = defaultdict(int)
+        self._span_api_to_count["spans_finished"] = defaultdict(int)
 
         # The telemetry metrics writer can be shutdown before the tracer. This ensures all tracer metrics always sent.
         telemetry_metrics_writer.periodic()

--- a/tests/telemetry/test_telemetry_metrics_e2e.py
+++ b/tests/telemetry/test_telemetry_metrics_e2e.py
@@ -118,10 +118,10 @@ for _ in range(10):
 
     metrics = get_metrics_from_events(events)
     assert len(metrics) == 2
-    assert metrics[0]["metric"] == "span_created"
+    assert metrics[0]["metric"] == "spans_created"
     assert metrics[0]["tags"] == ["integration_name:datadog"]
     assert metrics[0]["points"][0][1] == 10
-    assert metrics[1]["metric"] == "span_finished"
+    assert metrics[1]["metric"] == "spans_finished"
     assert metrics[1]["tags"] == ["integration_name:datadog"]
     assert metrics[1]["points"][0][1] == 10
 
@@ -144,10 +144,10 @@ for _ in range(9):
 
     metrics = get_metrics_from_events(events)
     assert len(metrics) == 2
-    assert metrics[0]["metric"] == "span_created"
+    assert metrics[0]["metric"] == "spans_created"
     assert metrics[0]["tags"] == ["integration_name:otel"]
     assert metrics[0]["points"][0][1] == 9
-    assert metrics[1]["metric"] == "span_finished"
+    assert metrics[1]["metric"] == "spans_finished"
     assert metrics[1]["tags"] == ["integration_name:otel"]
     assert metrics[1]["points"][0][1] == 9
 
@@ -169,10 +169,10 @@ for _ in range(9):
 
     metrics = get_metrics_from_events(events)
     assert len(metrics) == 2
-    assert metrics[0]["metric"] == "span_created"
+    assert metrics[0]["metric"] == "spans_created"
     assert metrics[0]["tags"] == ["integration_name:opentracing"]
     assert metrics[0]["points"][0][1] == 9
-    assert metrics[1]["metric"] == "span_finished"
+    assert metrics[1]["metric"] == "spans_finished"
     assert metrics[1]["tags"] == ["integration_name:opentracing"]
     assert metrics[1]["points"][0][1] == 9
 
@@ -203,13 +203,13 @@ for _ in range(4):
     metrics = get_metrics_from_events(events)
     assert len(metrics) == 3
 
-    assert metrics[0]["metric"] == "span_created"
+    assert metrics[0]["metric"] == "spans_created"
     assert metrics[0]["tags"] == ["integration_name:datadog"]
     assert metrics[0]["points"][0][1] == 4
-    assert metrics[1]["metric"] == "span_created"
+    assert metrics[1]["metric"] == "spans_created"
     assert metrics[1]["tags"] == ["integration_name:opentracing"]
     assert metrics[1]["points"][0][1] == 4
-    assert metrics[2]["metric"] == "span_created"
+    assert metrics[2]["metric"] == "spans_created"
     assert metrics[2]["tags"] == ["integration_name:otel"]
     assert metrics[2]["points"][0][1] == 4
 

--- a/tests/tracer/test_processors.py
+++ b/tests/tracer/test_processors.py
@@ -391,20 +391,20 @@ def test_span_creation_metrics():
 
         mock_tm.assert_has_calls(
             [
-                mock.call("tracers", "span_created", 100, tags=(("integration_name", "datadog"),)),
-                mock.call("tracers", "span_finished", 100, tags=(("integration_name", "datadog"),)),
-                mock.call("tracers", "span_created", 100, tags=(("integration_name", "datadog"),)),
-                mock.call("tracers", "span_finished", 100, tags=(("integration_name", "datadog"),)),
-                mock.call("tracers", "span_created", 100, tags=(("integration_name", "datadog"),)),
-                mock.call("tracers", "span_finished", 100, tags=(("integration_name", "datadog"),)),
+                mock.call("tracers", "spans_created", 100, tags=(("integration_name", "datadog"),)),
+                mock.call("tracers", "spans_finished", 100, tags=(("integration_name", "datadog"),)),
+                mock.call("tracers", "spans_created", 100, tags=(("integration_name", "datadog"),)),
+                mock.call("tracers", "spans_finished", 100, tags=(("integration_name", "datadog"),)),
+                mock.call("tracers", "spans_created", 100, tags=(("integration_name", "datadog"),)),
+                mock.call("tracers", "spans_finished", 100, tags=(("integration_name", "datadog"),)),
             ]
         )
         mock_tm.reset_mock()
         aggr.shutdown(None)
         mock_tm.assert_has_calls(
             [
-                mock.call("tracers", "span_created", 1, tags=(("integration_name", "datadog"),)),
-                mock.call("tracers", "span_finished", 1, tags=(("integration_name", "datadog"),)),
+                mock.call("tracers", "spans_created", 1, tags=(("integration_name", "datadog"),)),
+                mock.call("tracers", "spans_finished", 1, tags=(("integration_name", "datadog"),)),
             ]
         )
 

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -399,7 +399,7 @@ def test_span_key(span_log):
     assert s.get_tag(123.32) is None
 
 
-def test_span_finished():
+def test_spans_finished():
     span = Span(None)
     assert span.finished is False
     assert span.duration_ns is None


### PR DESCRIPTION
## Description
- Renames `span_finished` metric to `spans_finished`
- Renames `span_created` metric to `spans_created`

## Motivation
- Last week the specification was updated to make the metric names plural.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
