### PR TITLE
fix(ci): use container to run Python 2.7 in pylons framework test [backport #6167 to 1.13] 

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -417,6 +417,8 @@ jobs:
     name: Pylons 1.0.3
     runs-on: "ubuntu-20.04"
     # Ubuntu 20.04 is the last version of ubuntu on github setup actions to provide Python 2.7.
+    container:
+      image: python:2.7.18-buster
     env:
       DD_TESTING_RAISE: true
       PYTHONPATH: ../ddtrace/tests/debugging/exploration/
@@ -424,9 +426,6 @@ jobs:
       run:
         working-directory: pylons
     steps:
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '2.7'
       - uses: actions/checkout@v3
         with:
           path: ddtrace


### PR DESCRIPTION
Related to https://github.com/actions/setup-python/issues/672.

Setup-python removed Python 2.7 from their list of python-versions as of June 19, 2023, meaning our framework tests for Pylons (which is based on Python 2) now fail. The recommended solution was to instead use a Python 2.7 container within the ubuntu-20.04 image, which this PR does.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](../docs/contributing.rst#release-branch-maintenance)

