### PR TITLE
ci(integration): increase timeout to make integration_agent tests less flaky

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -679,10 +679,10 @@ def test_bad_payload_log_payload_non_bytes(monkeypatch):
             # False
             # >>> isinstance(u"", bytes)
             # False
-            return "bad_payload"
+            return u"bad_payload"
 
         def encode_traces(self, traces):
-            return "bad_payload"
+            return u"bad_payload"
 
     for client in t._writer._clients:
         client.encoder = BadEncoder()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -679,10 +679,10 @@ def test_bad_payload_log_payload_non_bytes(monkeypatch):
             # False
             # >>> isinstance(u"", bytes)
             # False
-            return u"bad_payload"
+            return "bad_payload"
 
         def encode_traces(self, traces):
-            return u"bad_payload"
+            return "bad_payload"
 
     for client in t._writer._clients:
         client.encoder = BadEncoder()
@@ -826,7 +826,7 @@ s2.finish()
         [sys.executable, "test.py"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=str(tmpdir), env=env
     )
     try:
-        p.wait(timeout=10)
+        p.wait(timeout=25)
     except TypeError:
         # timeout argument added in Python 3.3
         p.wait()


### PR DESCRIPTION
Increase timeout to make integration_agent tests less flaky on CircleCI.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
