### PR TITLE
refactor: move V2 logwriter into internal module

### DIFF
--- a/ddtrace/contrib/openai/patch.py
+++ b/ddtrace/contrib/openai/patch.py
@@ -10,8 +10,8 @@ from ddtrace.internal.agent import get_stats_url
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.dogstatsd import get_dogstatsd_client
 from ddtrace.internal.hostname import get_hostname
-from ddtrace.internal.logger import get_logger
 from ddtrace.internal.log_writer import V2LogWriter
+from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.wrapping import wrap
 from ddtrace.sampler import RateSampler

--- a/ddtrace/contrib/openai/patch.py
+++ b/ddtrace/contrib/openai/patch.py
@@ -11,6 +11,7 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.dogstatsd import get_dogstatsd_client
 from ddtrace.internal.hostname import get_hostname
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.log_writer import V2LogWriter
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.wrapping import wrap
 from ddtrace.sampler import RateSampler
@@ -18,7 +19,6 @@ from ddtrace.sampler import RateSampler
 from . import _endpoint_hooks
 from .. import trace_utils
 from ...pin import Pin
-from ._logging import V2LogWriter
 from .utils import _format_openai_api_key
 
 

--- a/ddtrace/internal/log_writer.py
+++ b/ddtrace/internal/log_writer.py
@@ -72,7 +72,6 @@ class V2LogWriter(PeriodicService):
             self._buffer.append(log)
 
     def on_shutdown(self):
-        # type: (...) -> None
         self.periodic()
 
     @property

--- a/tests/contrib/openai/test_logger.py
+++ b/tests/contrib/openai/test_logger.py
@@ -5,7 +5,7 @@ import mock
 import pytest
 import vcr
 
-from ddtrace.contrib.openai._logging import V2LogWriter
+from ddtrace.internal.log_writer import V2LogWriter
 from tests.utils import request_token
 
 
@@ -34,7 +34,7 @@ def vcr_logs(request):
 
 @pytest.fixture
 def mock_logs():
-    with mock.patch("ddtrace.contrib.openai._logging.logger") as m:
+    with mock.patch("ddtrace.internal.log_writer.logger") as m:
         yield m
 
 
@@ -118,7 +118,7 @@ def test_send_on_exit():
     import os
     import time
 
-    from ddtrace.contrib.openai._logging import V2LogWriter
+    from ddtrace.internal.log_writer import V2LogWriter
     from tests.contrib.openai.test_logger import logs_vcr
 
     ctx = logs_vcr.use_cassette("tests.contrib.openai.test_logger.test_send_on_exit.yaml")


### PR DESCRIPTION
This PR moves the `V2LogWriter` class into `ddtrace.internal.log_writer` from `ddtrace.contrib.openai._logging` as this will be reused by the LangChain integration, and will no longer be specific to the OpenAI integration.

The test file `tests.contrib.openai.test_logging` will remain in the `contrib.openai` module as this reflects the openai integration.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
