### PR TITLE
chore(asm): add api security django support

### DIFF
--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -306,7 +306,6 @@ def traced_func(django, name, resource=None, ignored_excs=None):
                 )
                 if kwargs:
                     try:
-
                         for k, v in kwargs.items():
                             kwargs[k] = taint_pyobject(v, Input_info(k, v, IAST.HTTP_REQUEST_PATH_PARAMETER))
                     except Exception:
@@ -532,6 +531,8 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
             finally:
                 # DEV: Always set these tags, this is where `span.resource` is set
                 utils._after_request_tags(pin, span, request, response)
+                if config._appsec_enbled and config._api_security_enabled:
+                    trace_utils.set_http_meta(span, config.django, route=span.get_tag("http.route"))
                 # if not blocked yet, try blocking rules on response
                 if config._appsec_enabled and not _context.get_item(WAF_CONTEXT_NAMES.BLOCKED, span=span):
                     log.debug("Django WAF call for Suspicious Request Blocking on response")
@@ -761,7 +762,7 @@ def wrap_wsgi_environ(wrapped, _instance, args, kwargs):
 
         return wrapped(
             *((LazyTaintDict(args[0], origins=(IAST.HTTP_REQUEST_HEADER_NAME, IAST.HTTP_REQUEST_HEADER)),) + args[1:]),
-            **kwargs
+            **kwargs,
         )
 
     return wrapped(*args, **kwargs)

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -762,7 +762,7 @@ def wrap_wsgi_environ(wrapped, _instance, args, kwargs):
 
         return wrapped(
             *((LazyTaintDict(args[0], origins=(IAST.HTTP_REQUEST_HEADER_NAME, IAST.HTTP_REQUEST_HEADER)),) + args[1:]),
-            **kwargs,
+            **kwargs
         )
 
     return wrapped(*args, **kwargs)

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -395,6 +395,8 @@ def _after_request_tags(pin, span, request, response):
                 peer_ip=_context.get_item("http.request.remote_ip", span=span),
                 headers_are_case_sensitive=_context.get_item("http.request.headers_case_sensitive", span=span),
             )
+            if config._appsec_enabled and config._api_security_enabled:
+                _asm_request_context.set_body_response(response.content)
     finally:
         if span.resource == REQUEST_DEFAULT_RESOURCE:
             span.resource = request.method

--- a/tests/contrib/django/django_app/appsec_urls.py
+++ b/tests/contrib/django/django_app/appsec_urls.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 import django
 from django.db import connection
 from django.http import HttpResponse
+from django.http import JsonResponse
 
 from ddtrace import tracer
 from ddtrace.appsec import _asm_request_context
@@ -38,7 +39,7 @@ def include_view(request):
 
 
 def path_params_view(request, year, month):
-    return HttpResponse(status=200)
+    return JsonResponse({"year": year, "month": month})
 
 
 def body_view(request):

--- a/tests/contrib/django/test_django_appsec_api_security.py
+++ b/tests/contrib/django/test_django_appsec_api_security.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+import base64
+import gzip
+import json
+import sys
+
+import pytest
+
+from ddtrace import config
+from tests.appsec.api_security.test_schema_fuzz import equal_without_meta
+from tests.appsec.test_processor import RULES_SRB
+from tests.utils import override_env
+from tests.utils import override_global_config
+
+
+def _aux_appsec_get_root_span(
+    client,
+    test_spans,
+    tracer,
+    payload=None,
+    url="/",
+    content_type="text/plain",
+    headers=None,
+    cookies={},
+):
+    tracer._appsec_enabled = config._appsec_enabled
+    tracer._iast_enabled = config._iast_enabled
+    # Hack: need to pass an argument to configure so that the processors are recreated
+    tracer.configure(api_version="v0.4")
+    # Set cookies
+    client.cookies.load(cookies)
+    if payload is None:
+        if headers:
+            response = client.get(url, **headers)
+        else:
+            response = client.get(url)
+    else:
+        if headers:
+            response = client.post(url, payload, content_type=content_type, **headers)
+        else:
+            response = client.post(url, payload, content_type=content_type)
+    return test_spans.spans[0], response
+
+
+@pytest.mark.skipif(sys.version_info.major < 3, reason="Python 2 not supported for api security")
+def test_api_security(client, test_spans, tracer):
+    import django
+
+    with override_global_config(dict(_appsec_enabled=True, _api_security_enabled=True)), override_env(
+        dict(DD_APPSEC_RULES=RULES_SRB)
+    ):
+        payload = {"key": "secret", "ids": [0, 1, 2, 3]}
+        root_span, response = _aux_appsec_get_root_span(
+            client,
+            test_spans,
+            tracer,
+            url="/appsec/path-params/2022/path_param/?x=1",
+            payload=payload,
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+
+        assert config._api_security_enabled
+
+        headers_schema = {
+            "1": [
+                {
+                    "Content-Type": [8],
+                    "Content-Length": [8],
+                    "X-Frame-Options": [8],
+                }
+            ],
+            "2": [
+                {
+                    "Content-Type": [8],
+                    "Content-Length": [8],
+                    "X-Frame-Options": [8],
+                }
+            ],
+            "3": [
+                {
+                    "Content-Type": [8],
+                    "X-Content-Type-Options": [8],
+                    "Referrer-Policy": [8],
+                    "X-Frame-Options": [8],
+                    "Content-Length": [8],
+                }
+            ],
+            "4": [
+                {
+                    "Content-Type": [8],
+                    "Cross-Origin-Opener-Policy": [8],
+                    "X-Content-Type-Options": [8],
+                    "Referrer-Policy": [8],
+                    "X-Frame-Options": [8],
+                    "Content-Length": [8],
+                }
+            ],
+        }
+
+        for name, expected_value in [
+            ("_dd.appsec.s.req.body", [{"key": [8], "ids": [[[4]], {"len": 4}]}]),
+            (
+                "_dd.appsec.s.req.headers",
+                [{"Cookie": [8], "Content-Length": [8], "Content-Type": [8]}],
+            ),
+            ("_dd.appsec.s.req.query", [{"x": [[[8]], {"len": 1}]}]),
+            ("_dd.appsec.s.req.params", [{"year": [4], "month": [8]}]),
+            ("_dd.appsec.s.res.headers", headers_schema[django.__version__[0]]),
+            ("_dd.appsec.s.res.body", [{"year": [4], "month": [8]}]),
+        ]:
+            value = root_span.get_tag(name)
+            assert value, name
+            api = json.loads(gzip.decompress(base64.b64decode(value)).decode())
+            assert equal_without_meta(api, expected_value)


### PR DESCRIPTION
Only to be merged after https://github.com/DataDog/dd-trace-py/pull/6163 and https://github.com/DataDog/dd-trace-py/pull/6180 (it's ok for now).
Activate full support of API security into the Django framework.

This feature is still in private phase and not officially released.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
