### PR TITLE
chore(peer.service): perf - process traces instead of spans

### DIFF
--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -332,40 +332,41 @@ class SpanSamplingProcessor(SpanProcessor):
                     break
 
 
-class PeerServiceProcessor(SpanProcessor):
+class PeerServiceProcessor(TraceProcessor):
     def __init__(self, peer_service_config):
         self._config = peer_service_config
         self._set_defaults_enabled = self._config.set_defaults_enabled
+        self._mapping = self._config.peer_service_mapping
 
-    def on_span_start(self, span):
-        """
-        We don't do anything on span start
-        """
-        pass
+    def process_trace(self, trace):
+        if not trace:
+            return
 
-    def on_span_finish(self, span):
-        if self._set_defaults_enabled:
-            self._set_span_tag(span)
-        self._remap_peer_service(span)  # Remap regardless of whether defaults are enabled
+        traces_to_process = []
+        if not self._set_defaults_enabled:
+            traces_to_process = filter(lambda x: x.get_tag(self._config.tag_name), trace)
+        else:
+            traces_to_process = filter(
+                lambda x: x.get_tag(self._config.tag_name) or x.get_tag(SPAN_KIND) in self._config.enabled_span_kinds,
+                trace,
+            )
+        any(map(lambda x: self._update_peer_service_tags(x), traces_to_process))
 
-    def _set_span_tag(self, span):
-        if span.get_tag(self._config.tag_name):  # If the tag already exists, assume it is user generated
+        return trace
+
+    def _update_peer_service_tags(self, span):
+        tag = span.get_tag(self._config.tag_name)
+
+        if tag:  # If the tag already exists, assume it is user generated
             span.set_tag_str(self._config.source_tag_name, self._config.tag_name)
-            return
+        else:
+            for data_source in self._config.prioritized_data_sources:
+                tag = span.get_tag(data_source)
+                if tag:
+                    span.set_tag_str(self._config.tag_name, tag)
+                    span.set_tag_str(self._config.source_tag_name, data_source)
+                    break
 
-        if span.get_tag(SPAN_KIND) not in self._config.enabled_span_kinds:
-            return
-
-        for data_source in self._config.prioritized_data_sources:
-            peer_service_definition = span.get_tag(data_source)
-            if peer_service_definition:
-                span.set_tag_str(self._config.tag_name, peer_service_definition)
-                span.set_tag_str(self._config.source_tag_name, data_source)
-                return
-
-    def _remap_peer_service(self, span):
-        current_peer_service = span.get_tag(self._config.tag_name)
-
-        if current_peer_service in self._config.peer_service_mapping:
-            span.set_tag_str(self._config.remap_tag_name, current_peer_service)
-            span.set_tag_str(self._config.tag_name, self._config.peer_service_mapping[current_peer_service])
+        if tag in self._mapping:
+            span.set_tag_str(self._config.remap_tag_name, tag)
+            span.set_tag_str(self._config.tag_name, self._config.peer_service_mapping[tag])

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -139,13 +139,12 @@ def _default_span_processors_factory(
     single_span_sampling_rules,  # type: List[SpanSamplingRule]
     agent_url,  # type: str
     profiling_span_processor,  # type: EndpointCallCounterProcessor
-    peer_service_processor,  # type: PeerServiceProcessor
 ):
     # type: (...) -> Tuple[List[SpanProcessor], Optional[Any], List[SpanProcessor]]
     # FIXME: type should be AppsecSpanProcessor but we have a cyclic import here
     """Construct the default list of span processors to use."""
     trace_processors = []  # type: List[TraceProcessor]
-    trace_processors += [TraceTagsProcessor(), peer_service_processor]
+    trace_processors += [TraceTagsProcessor(), PeerServiceProcessor(PeerServiceConfig())]
     trace_processors += [TraceSamplingProcessor(compute_stats_enabled)]
     trace_processors += trace_filters
 
@@ -279,7 +278,6 @@ class Tracer(object):
         self._appsec_processor = None
         self._iast_enabled = config._iast_enabled
         self._endpoint_call_counter_span_processor = EndpointCallCounterProcessor()
-        self._peer_service_processor = PeerServiceProcessor(PeerServiceConfig())
         self._span_processors, self._appsec_processor, self._deferred_processors = _default_span_processors_factory(
             self._filters,
             self._writer,
@@ -291,7 +289,6 @@ class Tracer(object):
             self._single_span_sampling_rules,
             self._agent_url,
             self._endpoint_call_counter_span_processor,
-            self._peer_service_processor,
         )
         if config._data_streams_enabled:
             # Inline the import to avoid pulling in ddsketch or protobuf
@@ -534,7 +531,6 @@ class Tracer(object):
                 self._single_span_sampling_rules,
                 self._agent_url,
                 self._endpoint_call_counter_span_processor,
-                self._peer_service_processor,
             )
 
         if context_provider is not None:
@@ -586,7 +582,6 @@ class Tracer(object):
             self._single_span_sampling_rules,
             self._agent_url,
             self._endpoint_call_counter_span_processor,
-            self._peer_service_processor,
         )
 
         self._new_process = True

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -145,7 +145,7 @@ def _default_span_processors_factory(
     # FIXME: type should be AppsecSpanProcessor but we have a cyclic import here
     """Construct the default list of span processors to use."""
     trace_processors = []  # type: List[TraceProcessor]
-    trace_processors += [TraceTagsProcessor()]
+    trace_processors += [TraceTagsProcessor(), peer_service_processor]
     trace_processors += [TraceSamplingProcessor(compute_stats_enabled)]
     trace_processors += trace_filters
 
@@ -189,8 +189,6 @@ def _default_span_processors_factory(
 
     if single_span_sampling_rules:
         span_processors.append(SpanSamplingProcessor(single_span_sampling_rules))
-
-    span_processors.append(peer_service_processor)
 
     # These need to run after all the other processors
     deferred_processors = [


### PR DESCRIPTION
Prior to this change, the peer.service processor (PeerServiceProcessor) processed invidual spans on_finish.  After this change, the processor now operates at a (partial) trace level.  Whenever a whole or part of a trace is being completed, all spans will be processed at once.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
