### PR TITLE
chore(ci): update pip cache path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,15 +83,15 @@ commands:
     steps:
       - save_cache:
           # DEV: Cache misses can still occur as venvs are not necessarily always created on the same node index
-          key: pip-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ checksum "riotfile.py" }}-{{ checksum "setup.py" }}
+          key: pip-cache-xdg-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ checksum "riotfile.py" }}-{{ checksum "setup.py" }}
           paths:
-            - ".cache/pip"
+            - "~/.cache/pip"
 
   restore_pip_cache:
     description: "Restore pip cache directory"
     steps:
       - restore_cache:
-          key: pip-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ checksum "riotfile.py" }}-{{ checksum "setup.py" }}
+          key: pip-cache-xdg-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ checksum "riotfile.py" }}-{{ checksum "setup.py" }}
 
   start_docker_services:
     description: "Start Docker services"


### PR DESCRIPTION
The CircleCI step for saving the pip cache assumes it is located in a directory different than that set by `XDG_CACHE_HOME`. This environment variable is not set anywhere so the default path should be `~/.cache/pip`.

Before this change, the file size of the cache reported in the restore step is empty (32 bytes): 

https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/38618/workflows/a576c222-5886-470d-81ce-82b57cd2eb0f/jobs/2599223/parallel-runs/0/steps/0-104

After this change, the cache will not be empty.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
