### PR TITLE
chore(telemetry): remove unnecessary fields from metrics payloads

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -355,8 +355,6 @@ class TelemetryLogsMetricsWriter(TelemetryBase):
                 if metrics:
                     payload = {
                         "namespace": namespace,
-                        "lib_language": "python",
-                        "lib_version": _pep440_to_semver(),
                         "series": [m.to_dict() for m in metrics.values()],
                     }
                     log.debug("%s request payload, namespace %s", payload_type, namespace)

--- a/tests/telemetry/test_telemetry_metrics.py
+++ b/tests/telemetry/test_telemetry_metrics.py
@@ -3,7 +3,6 @@ from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE_TAG_TRACER
 from ddtrace.internal.telemetry.constants import TELEMETRY_TYPE_DISTRIBUTION
 from ddtrace.internal.telemetry.constants import TELEMETRY_TYPE_GENERATE_METRICS
 from ddtrace.internal.telemetry.constants import TELEMETRY_TYPE_LOGS
-from ddtrace.internal.utils.version import _pep440_to_semver
 from tests.telemetry.test_writer import _get_request_body
 from tests.utils import override_global_config
 
@@ -22,8 +21,6 @@ def _assert_metric(
 
     payload = {
         "namespace": namespace,
-        "lib_language": "python",
-        "lib_version": _pep440_to_semver(),
         "series": expected_series,
     }
     assert events[0]["request_type"] == type_paypload


### PR DESCRIPTION
- Sending language and library version in the `generate-metrics` payload is not part of the telemetry spec:  https://github.com/DataDog/dd-trace-py/pull/new/telemetry-metrics-clean-up 
   - These fields are sent in main request body. Including it here is redundant. 

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
