### PR TITLE
feat(ci-visibility): change how test module and suite names are reported

### DIFF
--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -126,11 +126,16 @@ def _get_module_path(item):
 
 
 def _get_module_name(item):
-    """Extract module name from a `pytest.Item` instance."""
+    """Extract module name (fully qualified) from a `pytest.Item` instance."""
     module_path = _get_module_path(item)
     if module_path is None:
         return None
-    return module_path.rpartition("/")[-1]
+    return module_path.replace("/", ".")
+
+
+def _get_suite_name(item):
+    """Extract suite name from a `pytest.Item` instance."""
+    return item.nodeid.rpartition("/")[-1]
 
 
 def _start_test_module_span(item):
@@ -191,7 +196,7 @@ def _start_test_suite_span(item):
         test_suite_span.set_tag_str(_MODULE_ID, str(test_module_span.span_id))
         test_suite_span.set_tag_str(test.MODULE, test_module_span.get_tag(test.MODULE))
         test_suite_span.set_tag_str(test.MODULE_PATH, test_module_span.get_tag(test.MODULE_PATH))
-    test_suite_span.set_tag_str(test.SUITE, item.name)
+    test_suite_span.set_tag_str(test.SUITE, _get_suite_name(item))
     _store_span(item, test_suite_span)
     return test_suite_span
 

--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -131,10 +131,7 @@ def _get_module_path(item):
 
 def _get_module_name(item):
     """Extract module name (fully qualified) from a `pytest.Item` instance."""
-    module_path = _get_module_path(item)
-    if module_path is None:
-        return None
-    return module_path.replace("/", ".")
+    return item.module.__name__
 
 
 def _get_suite_name(item):

--- a/releasenotes/notes/feat-pytest-changes-in-modules-and-suites-bbdda83c3c40bfee.yaml
+++ b/releasenotes/notes/feat-pytest-changes-in-modules-and-suites-bbdda83c3c40bfee.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Pytest modules and test suites tags will be reported differently, modules will be their fully qualified name, whereas test suites will be the file name

--- a/releasenotes/notes/feat-pytest-changes-in-modules-and-suites-bbdda83c3c40bfee.yaml
+++ b/releasenotes/notes/feat-pytest-changes-in-modules-and-suites-bbdda83c3c40bfee.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-   ci-visibility: Updates how pytest modules and test suites are reported. Modules names are now set to the fully qualified name, whereas test suites will be set to the file name.
+   CI Visibility: Updates how pytest modules and test suites are reported. Modules names are now set to the fully qualified name, whereas test suites will be set to the file name.
     Before this change: {"module": "tests", "suite":"my_module/tests/test_suite.py"}
     After this change: {"module": "my_module.tests", "suite": "test_suite.py"}

--- a/releasenotes/notes/feat-pytest-changes-in-modules-and-suites-bbdda83c3c40bfee.yaml
+++ b/releasenotes/notes/feat-pytest-changes-in-modules-and-suites-bbdda83c3c40bfee.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    Pytest modules and test suites tags will be reported differently, modules will be their fully qualified name, whereas test suites will be the file name:
-    before this change: {"module": "tests", "suite":"my_module/tests/test_suite.py"}
-    after this change: {"module": "my_module.tests", "suite": "test_suite.py"}
+   ci-visibility: Updates how pytest modules and test suites are reported. Modules names are now set to the fully qualified name, whereas test suites will be set to the file name.
+    Before this change: {"module": "tests", "suite":"my_module/tests/test_suite.py"}
+    After this change: {"module": "my_module.tests", "suite": "test_suite.py"}

--- a/releasenotes/notes/feat-pytest-changes-in-modules-and-suites-bbdda83c3c40bfee.yaml
+++ b/releasenotes/notes/feat-pytest-changes-in-modules-and-suites-bbdda83c3c40bfee.yaml
@@ -1,4 +1,6 @@
 ---
 features:
   - |
-    Pytest modules and test suites tags will be reported differently, modules will be their fully qualified name, whereas test suites will be the file name
+    Pytest modules and test suites tags will be reported differently, modules will be their fully qualified name, whereas test suites will be the file name:
+    before this change: {"module": "tests", "suite":"my_module/tests/test_suite.py"}
+    after this change: {"module": "my_module.tests", "suite": "test_suite.py"}

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -1228,8 +1228,11 @@ class PytestTestCase(TracerTestCase):
         test_module_spans = [span for span in spans if span.get_tag("type") == "test_module_end"]
         assert test_module_spans[0].get_tag("test.module") == "test_outer_package"
         assert test_module_spans[0].get_tag("test.module_path") == "test_outer_package"
-        assert test_module_spans[1].get_tag("test.module") == "test_inner_package"
+        assert test_module_spans[1].get_tag("test.module") == "test_outer_package.test_inner_package"
         assert test_module_spans[1].get_tag("test.module_path") == "test_outer_package/test_inner_package"
+        test_suite_spans = [span for span in spans if span.get_tag("type") == "test_suite_end"]
+        assert test_suite_spans[0].get_tag("test.suite") == "test_outer_abc.py"
+        assert test_suite_spans[1].get_tag("test.suite") == "test_inner_abc.py"
 
     @pytest.mark.skipif(compat.PY2, reason="ddtrace does not support coverage on Python 2")
     def test_pytest_will_report_coverage(self):


### PR DESCRIPTION
CI Visibility: Report tests suites as the filename and test modules as a fully qualified name

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
