### PR TITLE
feat(telemetry): validate unique telemetry log messages

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -7,6 +7,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Set
 from typing import Tuple
 from typing import Union
 
@@ -42,6 +43,11 @@ from .metrics_namespaces import NamespaceMetricType
 
 
 log = get_logger(__name__)
+
+
+class LogData(dict):
+    def __hash__(self):
+        return hash(tuple(sorted(self.items())))
 
 
 def _get_heartbeat_interval_or_default():
@@ -241,7 +247,7 @@ class TelemetryLogsMetricsWriter(TelemetryBase):
         # type: () -> None
         super(TelemetryLogsMetricsWriter, self).__init__(interval=_get_telemetry_metrics_interval_or_default())
         self._namespace = MetricNamespace()
-        self._logs = []  # type: List[Dict[str, Any]]
+        self._logs = set()  # type: Set[Dict[str, Any]]
 
     def enable(self, start_worker_thread=True):
         # type: (bool) -> bool
@@ -259,16 +265,18 @@ class TelemetryLogsMetricsWriter(TelemetryBase):
         This will make support cycles easier and ensure we know about potentially silent issues in libraries.
         """
         if self.enable():
-            data = {
-                "message": message,
-                "level": level,
-                "tracer_time": int(time.time()),
-            }
+            data = LogData(
+                {
+                    "message": message,
+                    "level": level,
+                    "tracer_time": int(time.time()),
+                }
+            )
             if tags:
                 data["tags"] = ",".join(["%s:%s" % (k, str(v).lower()) for k, v in tags.items()])
             if stack_trace:
                 data["stack_trace"] = stack_trace
-            self._logs.append(data)
+            self._logs.add(data)
 
     def add_gauge_metric(self, namespace, name, value, tags=None):
         # type: (str,str, float, MetricTagType) -> None
@@ -342,10 +350,10 @@ class TelemetryLogsMetricsWriter(TelemetryBase):
             self._client.send_event(telemetry_event)
 
     def _flush_log_metrics(self):
-        # type () -> List[Metric]
+        # type () -> Set[Metric]
         with self._lock:
             log_metrics = self._logs
-            self._logs = []
+            self._logs = set()
         return log_metrics
 
     def _generate_metrics_event(self, namespace_metrics):
@@ -364,9 +372,9 @@ class TelemetryLogsMetricsWriter(TelemetryBase):
                         self.add_event(payload, TELEMETRY_TYPE_GENERATE_METRICS)
 
     def _generate_logs_event(self, payload):
-        # type: (List[Dict[str, str]]) -> None
+        # type: (Set[Dict[str, str]]) -> None
         log.debug("%s request payload", TELEMETRY_TYPE_LOGS)
-        self.add_event(payload, TELEMETRY_TYPE_LOGS)
+        self.add_event(list(payload), TELEMETRY_TYPE_LOGS)
 
     def on_shutdown(self):
         self.periodic()
@@ -375,7 +383,7 @@ class TelemetryLogsMetricsWriter(TelemetryBase):
         # type: () -> None
         super(TelemetryLogsMetricsWriter, self).reset_queues()
         self._namespace.flush()
-        self._logs = []
+        self._logs = set()
 
 
 class TelemetryWriter(TelemetryBase):

--- a/releasenotes/notes/telemetry-logs-validate-unique-messages-5a020f0531952e0c.yaml
+++ b/releasenotes/notes/telemetry-logs-validate-unique-messages-5a020f0531952e0c.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Telemetry logs: telemetry writer validates unique messages for each interval.

--- a/tests/telemetry/test_telemetry_metrics.py
+++ b/tests/telemetry/test_telemetry_metrics.py
@@ -409,3 +409,44 @@ def test_send_multiple_log_metric(telemetry_metrics_writer, test_agent_metrics_s
         telemetry_metrics_writer.add_log("WARNING", "test error 1", "Traceback:\nValueError", {"a": "b"})
 
         _assert_logs(test_agent_metrics_session, expected_payload, seq_id=2)
+
+
+def test_send_multiple_log_metric_no_duplicates(telemetry_metrics_writer, test_agent_metrics_session, mock_time):
+    with override_global_config(dict(_telemetry_metrics_enabled=True)):
+        for _ in range(10):
+            telemetry_metrics_writer.add_log("WARNING", "test error 1", "Traceback:\nValueError", {"a": "b"})
+
+        expected_payload = [
+            {
+                "level": "WARNING",
+                "message": "test error 1",
+                "stack_trace": "Traceback:\nValueError",
+                "tracer_time": 1642544540,
+                "tags": "a:b",
+            },
+        ]
+
+        _assert_logs(test_agent_metrics_session, expected_payload)
+
+
+def test_send_multiple_log_metric_no_duplicates_for_each_interval(
+    telemetry_metrics_writer, test_agent_metrics_session, mock_time
+):
+    with override_global_config(dict(_telemetry_metrics_enabled=True)):
+        for _ in range(10):
+            telemetry_metrics_writer.add_log("WARNING", "test error 1")
+
+        expected_payload = [
+            {
+                "level": "WARNING",
+                "message": "test error 1",
+                "tracer_time": 1642544540,
+            },
+        ]
+
+        _assert_logs(test_agent_metrics_session, expected_payload)
+
+        for _ in range(10):
+            telemetry_metrics_writer.add_log("WARNING", "test error 1")
+
+        _assert_logs(test_agent_metrics_session, expected_payload, seq_id=2)


### PR DESCRIPTION
Telemetry logs: telemetry writer validates unique messages for each interval.

e.g: if an application implements:
```
telemetry_metrics_writer.add_log("WARNING", "test error 1")
telemetry_metrics_writer.add_log("WARNING", "test error 1")
telemetry_metrics_writer.add_log("WARNING", "test error 2")
telemetry_metrics_writer.add_log("WARNING", "test error 2")
```
Telemetry writer reports 2 logs

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
