### PR TITLE
docs: flesh out contribution guidelines

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,3 +1,4 @@
+==============
  Contributing
 ==============
 
@@ -34,7 +35,7 @@ Branches and Pull Requests
 
 This library follows the practice of `trunk-based development <https://trunkbaseddevelopment.com/>`_.
 
-The "trunk" branch, which new pull requests should target, is `1.x`.
+The "trunk" branch, which new pull requests should target, is ``1.x``.
 Roughly every two weeks, we checkpoint the current state of this branch as a new
 release branch, whose naming follows `semantic versioning <https://semver.org/>`_.
 You can find the list of past released versions `here <https://github.com/DataDog/dd-trace-py/releases>`_.
@@ -44,7 +45,7 @@ standard, which is enforced by a continuous integration job. The standardized "s
 in pull request names are enumerated `here <releasenotes.rst#Scope>`_.
 
 Pull requests that change the library's public API require a `release note <releasenotes.rst>`_.
-If your pull request doesn't change the public API, apply the `no-changelog` label.
+If your pull request doesn't change the public API, apply the ``no-changelog`` label.
 
 Backporting
 -----------
@@ -54,10 +55,10 @@ minor version branches according to the `version support policy <versioning.rst#
 
 * **Fix PRs** are backported to all maintained release branches.
 * **CI PRs** are backported to the maintained release branches.
-* **New features** (`feat` PRs) are not backported.
+* **New features** (``feat`` PRs) are not backported.
 * **Chore, documentation, and other PRs** are not backported.
 
-If your pull request is a `fix` or `ci` change, apply the backport labels corresponding to the minor
+If your pull request is a ``fix`` or ``ci`` change, apply the backport labels corresponding to the minor
 versions that need the change.
 
 Implementation Guidelines
@@ -102,14 +103,14 @@ communication.
 If a pull request fixes a bug, it should include a test that, on the trunk branch, would replicate the bug.
 Seeing this test pass on the fix branch gives us confidence that the bug was actually fixed.
 
-Put your code's tests in the appropriate subdirectory of the `tests` directory based on what they are testing.
-If your feature is substantially new, you may decide to create a new `tests` subdirectory in the interest
+Put your code's tests in the appropriate subdirectory of the ``tests`` directory based on what they are testing.
+If your feature is substantially new, you may decide to create a new ``tests`` subdirectory in the interest
 of code organization.
 
-`.riot/requirements` contains requirements files generated with `pip-compile` for every environment specified
-by `riotfile.py`. Riot uses these files to build its environments, and they do not get rebuilt automatically
+``.riot/requirements`` contains requirements files generated with ``pip-compile`` for every environment specified
+by ``riotfile.py``. Riot uses these files to build its environments, and they do not get rebuilt automatically
 when the riotfile changes. Thus, if you make changes to the riotfile, you need to run either
-`scripts/compile-and-prune-test-requirements` or `riot run -c <mytests>` to regenerate the requirements
+``scripts/compile-and-prune-test-requirements`` or ``riot run -c <mytests>`` to regenerate the requirements
 files for the environments that changed. In order to run the script, you need to have all minor versions
 of Python that the tracer supports. The easiest way to accomplish this and generate the files is to simply
 spin up the testagent container, exec into it, and run the script from there.
@@ -122,30 +123,31 @@ spin up the testagent container, exec into it, and run the script from there.
 
 
 This can also be accomplished using pyenv and installing all of the Python versions before running the script.
-You can commit and pull request changes to files in `.riot/requirements` alongside the corresponding changes to `riotfile.py`.
+You can commit and pull request changes to files in ``.riot/requirements`` alongside the corresponding changes to ``riotfile.py``.
 
 Documentation
 -------------
 
 Pull requests implementing new features should include documentation for those features. The audience for this
 documentation is the public population of library users. The Products and Core logic are documented alongside
-this document, in the `docs` directory. The documentation for each Integration is contained in a docstring
-in that integration's `__init__.py` file. See `this page <contributing-integrations.rst>`_ for more information
+this document, in the ``docs`` directory. The documentation for each Integration is contained in a docstring
+in that integration's ``__init__.py`` file. See `this page <contributing-integrations.rst>`_ for more information
 on writing documentation for Integrations.
 
 Logging
 -------
 
-Use `ddtrace.internal.logger.get_logger(__name__)` to initialize/retrieve a `DDLogger` object you can use
+Use ``ddtrace.internal.logger.get_logger(__name__)`` to initialize/retrieve a ``DDLogger`` object you can use
 to emit well-formatted log messages from your code.
 
 Keep the following in mind when writing logging code:
 
-* Logs should be generated with the level `DEBUG`, `INFO`, `WARNING`, or `ERROR` according to conventions
+* Logs should be generated with the level ``DEBUG``, ``INFO``, ``WARNING``, or ``ERROR`` according to conventions
   `like these <https://stackoverflow.com/a/2031209/735204>`_.
 * Log messages should be grammatically correct and should not contain spelling errors.
 * Log messages should be standalone and actionable. They should not require context from other logs, metrics or trace data.
 * Log data is sensitive and should not contain application secrets or other sensitive data.
+
 
 .. toctree::
     :hidden:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -38,11 +38,11 @@ This library follows the practice of `trunk-based development <https://trunkbase
 The "trunk" branch, which new pull requests should target, is ``1.x``.
 Roughly every two weeks, we checkpoint the current state of this branch as a new
 release branch, whose naming follows `semantic versioning <https://semver.org/>`_.
-You can find the list of past released versions `here <https://github.com/DataDog/dd-trace-py/releases>`_.
+You can find the list of past released versions `on this GitHub page <https://github.com/DataDog/dd-trace-py/releases>`_.
 
 Pull requests are named according to the `conventional commit <https://www.conventionalcommits.org/en/v1.0.0/>`_
 standard, which is enforced by a continuous integration job. The standardized "scopes" we use
-in pull request names are enumerated `here <releasenotes.rst#Scope>`_.
+in pull request names are enumerated `in the release notes documentation <releasenotes.rst#Scope>`_.
 
 Pull requests that change the library's public API require a `release note <releasenotes.rst>`_.
 If your pull request doesn't change the public API, apply the ``no-changelog`` label.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -84,7 +84,7 @@ that is specific to the library being integrated with, and no code related to Pr
 The **core** of the library is the abstraction layer that allows Products and Integrations to keep their concerns
 separate. It is implemented in the Python files in the `top level of ddtracepy <https://github.com/DataDog/dd-trace-py/tree/1.x/ddtrace>`_
 and in the `internal` module. As an implementation detail, the core logic also happens to directly support
-`Application Performance Monitoring <https://docs.datadoghq.com/tracing/`_.
+`Application Performance Monitoring <https://docs.datadoghq.com/tracing/>`_.
 
 Be mindful and intentional about which of these categories your change fits into, and avoid mixing concerns between
 categories. If doing so requires more foundational refactoring or additional layers of abstraction, consider
@@ -118,7 +118,7 @@ spin up the testagent container, exec into it, and run the script from there.
 .. code-block:: bash
 
   cd dd-trace-py && docker run --network host --userns=host --rm -w /root/project -v $PWD/:/root/project \
-    -it ghcr.io/datadog/dd-trace-py/testrunner:1ed971833a2a3c97f43cbaeabcbb3f1e28745a00 \
+    -it ghcr.io/datadog/dd-trace-py/testrunner \
     bash -c "git config --global --add safe.directory /root/project && pip install riot && bash -i './scripts/compile-and-prune-test-requirements'"
 
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -2,23 +2,28 @@
  Contributing
 ==============
 
-When contributing to this repository, we advise you to discuss the change you
-wish to make via an `issue <https://github.com/DataDog/dd-trace-py/issues>`_.
+Contributions are welcome!
 
+The best way to suggest a change to the library is to open a
+`pull request <https://github.com/DataDog/dd-trace-py/pulls>`_.
+
+You may also consider opening an `issue <https://github.com/DataDog/dd-trace-py/issues>`_
+if you'd like to report a bug or request a new feature.
+
+Thanks for working with us!
 
 Branches
 ========
 
-Development happens in the `1.x` branch. When all the features for the next
-milestone are merged, the next version is released and tagged on the `1.x`
-branch as `vVERSION`.
+This library follows the practice of `trunk-based development <https://trunkbaseddevelopment.com/>`_.
 
-Your pull request should target the `1.x` branch.
+The "trunk" branch, which new pull requests should target, is `1.x`.
+Roughly every two weeks, we checkpoint the current state of this branch as a new
+release branch, whose naming follows `semantic versioning <https://semver.org/>`_.
+You can find the list of past released versions `here <https://github.com/DataDog/dd-trace-py/releases>`_.
 
-Once a new version is released, a `VERSION` branch might be created to
-support micro releases to `VERSION`. Patches should be cherry-picking from the
-`1.x` branch where possible — or otherwise created from scratch.
-
+Each minor version has its own branch. Bug fixes are "backported" from trunk to certain
+minor version branches according to the `version support policy <???>`_.
 
 Internal API
 ============
@@ -78,12 +83,6 @@ This can also be accomplished using pyenv and installing all of the Python versi
 You can commit and pull request changes to files in `.riot/requirements` alongside the corresponding changes to `riotfile.py`.
 
 
-.. toctree::
-    :hidden:
-
-    contributing-integrations
-    releasenotes
-
 Pre-commit Hooks
 ================
 
@@ -117,4 +116,10 @@ Chore and documentation PRs
 ---------------------------
 
 These are PRs that do not fall into any of the previous categories. In general there should be no need to backport these PRs.
+
+.. toctree::
+    :hidden:
+
+    contributing-integrations
+    releasenotes
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -78,7 +78,7 @@ functionality for `Continuous Profiling <https://docs.datadoghq.com/profiler/>`_
 that is specific to the Datadog product being supported, and no code related to Integrations.
 
 An **integration** is one of the modules in the `contrib <https://github.com/DataDog/dd-trace-py/tree/f26a526a6f79870e6e6a21d281f4796a434616bb/ddtrace/contrib>`_
-directory, hooking ddtracepy into the internal logic of a given Python library. Ideally it only contains code
+directory, hooking our code into the internal logic of a given Python library. Ideally it only contains code
 that is specific to the library being integrated with, and no code related to Products.
 
 The **core** of the library is the abstraction layer that allows Products and Integrations to keep their concerns

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,4 +1,3 @@
-==============
  Contributing
 ==============
 
@@ -12,8 +11,26 @@ if you'd like to report a bug or request a new feature.
 
 Thanks for working with us!
 
+Change Process
+==============
+
+The process of making a change to the library starts with a pull request. When you open one,
+reviewers are automatically assigned based on the CODEOWNERS file. Many different continuous integration
+jobs are also triggered, including unit tests, integration tests, benchmarks, and linters.
+
+Marking your pull request as a draft using the "Convert to draft" link communicates to potential reviewers
+that your pull request is not ready to be reviewed. Use the "ready for review" button when this changes.
+It's often beneficial to open an in-progress pull request and mark it as a draft while you confirm that the test
+suite passes.
+
+Within a few business days, one of the maintainers will respond with a code review. The review will
+primarily focus on idiomatic Python usage, efficiency, testing, and adherence to the versioning policy.
+Correctness and code style are automatically checked in continuous integration, with style linting managed by
+various tools including Flake8, Black, and MyPy. This means that code reviews don't need to worry about style
+and can focus on substance.
+
 Branches and Pull Requests
-==========================
+--------------------------
 
 This library follows the practice of `trunk-based development <https://trunkbaseddevelopment.com/>`_.
 
@@ -27,7 +44,7 @@ standard, which is enforced by a continuous integration job. The standardized "s
 in pull request names are enumerated `here <releasenotes.rst#Scope>`_.
 
 Backporting
-===========
+-----------
 
 Each minor version has its own branch. Bug fixes are "backported" from trunk to certain
 minor version branches according to the `version support policy <versioning.rst#release-versions>`_.
@@ -37,17 +54,35 @@ minor version branches according to the `version support policy <versioning.rst#
 * **New features** (`feat` PRs) are not backported.
 * **Chore, documentation, and other PRs** are not backported.
 
-Change Process
-==============
+If your pull request is a `fix` or `ci` change, apply the backport labels corresponding to the minor
+versions that need the change.
 
-code reviews, requesting
-seeing if CI passes
+Implementation Guidelines
+=========================
 
-Code style is automatically checked by various tools including Flake8, Black, and MyPy. This
-means that code reviews don't need to worry about style and can focus on substance.
+Parts of the Library
+--------------------
+
+When designing a change, one of the first decisions to make is where it should be made. This is an overview
+of the main functional areas of the library.
+
+A **product** is a unit of code within the library that implements functionality specific to a small set of
+customer-facing Datadog products. Examples include the `appsec module <https://github.com/DataDog/dd-trace-py/tree/1.x/ddtrace/appsec>`_
+implementing functionality for `Application Security Management <https://www.datadoghq.com/product/application-security-management/>`_
+and the `profiling <https://github.com/DataDog/dd-trace-py/tree/1.x/ddtrace/profiling>`_ module implementing functionality for
+`Continuous Profiling <https://docs.datadoghq.com/profiler/>`_.
+
+An **integration** is one of the modules in the `contrib <https://github.com/DataDog/dd-trace-py/tree/f26a526a6f79870e6e6a21d281f4796a434616bb/ddtrace/contrib>`_
+directory, building the context tree for a given Python library. Ideally it only contains code that is specific to the
+library being integrated with, and no code related to Products.
+
+The **core** of the library is the abstraction layer that allows Products and Integrations to keep their concerns separate.
+It is implemented in the Python files in the `top level of ddtracepy <https://github.com/DataDog/dd-trace-py/tree/1.x/ddtrace>`_
+and in the `internal` module. As an implementation detail, the core logic also happens to directly support
+`Application Performance Monitoring <https://docs.datadoghq.com/tracing/`_.
 
 Logging
-=======
+-------
 
 The ddtrace logger should be used to log events in the dd-trace-py library. Use ``ddtrace.internal.logger.get_logger(__name__)`` to initialize/retrieve an instance of the ddtrace logger (DDLogger).
 
@@ -59,7 +94,7 @@ To ensure the ddtrace library produces consistent and secure logs the following 
 * Log data is sensitive and should not contain application secrets or other sensitive data.
 
 Changing Test Requirements
-==========================
+--------------------------
 
 `.riot/requirements` contains requirements files generated with `pip-compile` for every environment specified by `riotfile.py`.
 Riot uses these files to build its environments, and they do not get rebuilt automatically when the riotfile changes.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -93,7 +93,7 @@ opening an issue describing the limitations of the current design.
 Tests
 -----
 
-If your change touches Python code, it should probably include at least one test. We use hueristics to
+If your change touches Python code, it should probably include at least one test. We use heuristics to
 decide when and what sort of tests to write. For example, a pull request implementing a new feature
 should include enough unit tests to cover the feature's "happy path" use cases in addition to any known
 likely edge cases. If the feature involves a new form of communication with another component (like the

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -12,8 +12,8 @@ if you'd like to report a bug or request a new feature.
 
 Thanks for working with us!
 
-Branches
-========
+Branches and Pull Requests
+==========================
 
 This library follows the practice of `trunk-based development <https://trunkbaseddevelopment.com/>`_.
 
@@ -22,34 +22,29 @@ Roughly every two weeks, we checkpoint the current state of this branch as a new
 release branch, whose naming follows `semantic versioning <https://semver.org/>`_.
 You can find the list of past released versions `here <https://github.com/DataDog/dd-trace-py/releases>`_.
 
+Pull requests are named according to the `conventional commit <https://www.conventionalcommits.org/en/v1.0.0/>`_
+standard, which is enforced by a continuous integration job. The standardized "scopes" we use
+in pull request names are enumerated `here <releasenotes.rst#Scope>`_.
+
+Backporting
+===========
+
 Each minor version has its own branch. Bug fixes are "backported" from trunk to certain
-minor version branches according to the `version support policy <???>`_.
+minor version branches according to the `version support policy <versioning.rst#release-versions>`_.
 
-Internal API
-============
+* **Fix PRs** are backported to all maintained release branches.
+* **CI PRs** are backported to the maintained release branches.
+* **New features** (`feat` PRs) are not backported.
+* **Chore, documentation, and other PRs** are not backported.
 
-The `ddtrace.internal` module contains code that must only be used inside
-`ddtrace` itself. Relying on the API of this module is dangerous and can break
-at anytime. Don't do it.
+Change Process
+==============
 
-Python Versions and Implementations Support
-===========================================
+code reviews, requesting
+seeing if CI passes
 
-The following Python implementations are supported:
-
-- CPython
-
-Versions of those implementations that are supported are the Python versions
-that are currently supported by the community.
-
-Code Style
-==========
-
-The code style is enforced by `flake8 <https://pypi.org/project/flake8>`_, its
-configuration, and possibly extensions. No code style review should be done by
-a human. All code style enforcement must be automated to avoid bikeshedding
-and losing time.
-
+Code style is automatically checked by various tools including Flake8, Black, and MyPy. This
+means that code reviews don't need to worry about style and can focus on substance.
 
 Logging
 =======
@@ -82,44 +77,8 @@ The easiest way to accomplish this and generate the files is to simply spin up t
 This can also be accomplished using pyenv and installing all of the Python versions before running the script.
 You can commit and pull request changes to files in `.riot/requirements` alongside the corresponding changes to `riotfile.py`.
 
-
-Pre-commit Hooks
-================
-
-The tracer library uses formatting/linting tools including black, flake8, and mypy.
-While these are run in each CI pipeline for pull requests, they are also **optionally** available to be automated to run
-when you call git commit as pre-commit hooks to catch any formatting errors before you commit.
-To initialize the pre-commit hook script to run in your development branch, run the following command:
-
-    $ rm .git/hooks/pre-commit
-
-
-Release Branch Maintenance
-==========================
-
-Fix PRs
--------
-
-These PRs are generally opened to fix a bug reported by a user of the library. Fix PRs should be backported to all impacted and maintained release branches.
-
-CI PRs
-------
-
-These PRs are generally opened to fix or improve the current status of the CI. As a general rule, these PRs should all be backported to all the maintained release branches.
-
-New features
-------------
-
-New features introduced by feat PRs should not be backported.
-
-Chore and documentation PRs
----------------------------
-
-These are PRs that do not fall into any of the previous categories. In general there should be no need to backport these PRs.
-
 .. toctree::
     :hidden:
 
     contributing-integrations
     releasenotes
-

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -43,6 +43,9 @@ Pull requests are named according to the `conventional commit <https://www.conve
 standard, which is enforced by a continuous integration job. The standardized "scopes" we use
 in pull request names are enumerated `here <releasenotes.rst#Scope>`_.
 
+Pull requests that change the library's public API require a `release note <releasenotes.rst>`_.
+If your pull request doesn't change the public API, apply the `no-changelog` label.
+
 Backporting
 -----------
 
@@ -69,38 +72,47 @@ of the main functional areas of the library.
 A **product** is a unit of code within the library that implements functionality specific to a small set of
 customer-facing Datadog products. Examples include the `appsec module <https://github.com/DataDog/dd-trace-py/tree/1.x/ddtrace/appsec>`_
 implementing functionality for `Application Security Management <https://www.datadoghq.com/product/application-security-management/>`_
-and the `profiling <https://github.com/DataDog/dd-trace-py/tree/1.x/ddtrace/profiling>`_ module implementing functionality for
-`Continuous Profiling <https://docs.datadoghq.com/profiler/>`_.
+and the `profiling <https://github.com/DataDog/dd-trace-py/tree/1.x/ddtrace/profiling>`_ module implementing
+functionality for `Continuous Profiling <https://docs.datadoghq.com/profiler/>`_. Ideally it only contains code
+that is specific to the Datadog product being supported, and no code related to Integrations.
 
 An **integration** is one of the modules in the `contrib <https://github.com/DataDog/dd-trace-py/tree/f26a526a6f79870e6e6a21d281f4796a434616bb/ddtrace/contrib>`_
-directory, building the context tree for a given Python library. Ideally it only contains code that is specific to the
-library being integrated with, and no code related to Products.
+directory, hooking ddtracepy into the internal logic of a given Python library. Ideally it only contains code
+that is specific to the library being integrated with, and no code related to Products.
 
-The **core** of the library is the abstraction layer that allows Products and Integrations to keep their concerns separate.
-It is implemented in the Python files in the `top level of ddtracepy <https://github.com/DataDog/dd-trace-py/tree/1.x/ddtrace>`_
+The **core** of the library is the abstraction layer that allows Products and Integrations to keep their concerns
+separate. It is implemented in the Python files in the `top level of ddtracepy <https://github.com/DataDog/dd-trace-py/tree/1.x/ddtrace>`_
 and in the `internal` module. As an implementation detail, the core logic also happens to directly support
 `Application Performance Monitoring <https://docs.datadoghq.com/tracing/`_.
 
-Logging
--------
+Be mindful and intentional about which of these categories your change fits into, and avoid mixing concerns between
+categories. If doing so requires more foundational refactoring or additional layers of abstraction, consider
+opening an issue describing the limitations of the current design.
 
-The ddtrace logger should be used to log events in the dd-trace-py library. Use ``ddtrace.internal.logger.get_logger(__name__)`` to initialize/retrieve an instance of the ddtrace logger (DDLogger).
+Tests
+-----
 
-To ensure the ddtrace library produces consistent and secure logs the following best practices should be followed:
+If your change touches Python code, it should probably include at least one test. We use hueristics to
+decide when and what sort of tests to write. For example, a pull request implementing a new feature
+should include enough unit tests to cover the feature's "happy path" use cases in addition to any known
+likely edge cases. If the feature involves a new form of communication with another component (like the
+Datadog Agent or libddwaf), it should probably include at least one integration test exercising the end-to-end
+communication.
 
-* Logs should be generated with the level DEBUG, INFO, WARNING, or ERROR.
-* Log messages are grammatically correct and do not contain spelling errors.
-* Log messages should be standalone and actionable. They should not require context from other logs, metrics or trace data.
-* Log data is sensitive and should not contain application secrets or other sensitive data.
+If a pull request fixes a bug, it should include a test that, on the trunk branch, would replicate the bug.
+Seeing this test pass on the fix branch gives us confidence that the bug was actually fixed.
 
-Changing Test Requirements
---------------------------
+Put your code's tests in the appropriate subdirectory of the `tests` directory based on what they are testing.
+If your feature is substantially new, you may decide to create a new `tests` subdirectory in the interest
+of code organization.
 
-`.riot/requirements` contains requirements files generated with `pip-compile` for every environment specified by `riotfile.py`.
-Riot uses these files to build its environments, and they do not get rebuilt automatically when the riotfile changes.
-Thus, if you make changes to the riotfile, you need to run either `scripts/compile-and-prune-test-requirements` or `riot run -c <mytests>`
-to regenerate the requirements files for the environments that changed. In order to run the script, you need to have all minor versions of Python that the tracer supports.
-The easiest way to accomplish this and generate the files is to simply spin up the testagent container, exec into it, and run the script from there.
+`.riot/requirements` contains requirements files generated with `pip-compile` for every environment specified
+by `riotfile.py`. Riot uses these files to build its environments, and they do not get rebuilt automatically
+when the riotfile changes. Thus, if you make changes to the riotfile, you need to run either
+`scripts/compile-and-prune-test-requirements` or `riot run -c <mytests>` to regenerate the requirements
+files for the environments that changed. In order to run the script, you need to have all minor versions
+of Python that the tracer supports. The easiest way to accomplish this and generate the files is to simply
+spin up the testagent container, exec into it, and run the script from there.
 
 .. code-block:: bash
 
@@ -111,6 +123,29 @@ The easiest way to accomplish this and generate the files is to simply spin up t
 
 This can also be accomplished using pyenv and installing all of the Python versions before running the script.
 You can commit and pull request changes to files in `.riot/requirements` alongside the corresponding changes to `riotfile.py`.
+
+Documentation
+-------------
+
+Pull requests implementing new features should include documentation for those features. The audience for this
+documentation is the public population of library users. The Products and Core logic are documented alongside
+this document, in the `docs` directory. The documentation for each Integration is contained in a docstring
+in that integration's `__init__.py` file. See `this page <contributing-integrations.rst>`_ for more information
+on writing documentation for Integrations.
+
+Logging
+-------
+
+Use `ddtrace.internal.logger.get_logger(__name__)` to initialize/retrieve a `DDLogger` object you can use
+to emit well-formatted log messages from your code.
+
+Keep the following in mind when writing logging code:
+
+* Logs should be generated with the level `DEBUG`, `INFO`, `WARNING`, or `ERROR` according to conventions
+  `like these <https://stackoverflow.com/a/2031209/735204>`_.
+* Log messages should be grammatically correct and should not contain spelling errors.
+* Log messages should be standalone and actionable. They should not require context from other logs, metrics or trace data.
+* Log data is sensitive and should not contain application secrets or other sensitive data.
 
 .. toctree::
     :hidden:

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -39,6 +39,7 @@ backend
 backends
 backport
 backported
+backporting
 bdd
 bikeshedding
 booleans
@@ -68,6 +69,7 @@ dbapi
 ddtrace
 deprecations
 django
+docstring
 doctest
 dogpile
 dogpile.cache
@@ -115,6 +117,7 @@ kubernetes
 kwarg
 kwargs
 lifecycle
+linters
 lookups
 loopback
 macOS
@@ -195,6 +198,7 @@ starlette
 statsd
 stringable
 subclass
+subdirectory
 subdomains
 submodule
 submodules

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -90,7 +90,7 @@ The definition of the **internal** interface:
 
     Any module, function, class or attribute that is contained within an internal module is internal
 
-Internal code may be subject to breaking changes in bugfix and minor releases.
+Internal code may be subject to breaking changes in bug fix and minor releases.
 
 .. _versioning_supported_runtimes:
 

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -76,6 +76,10 @@ PATCH
 Interfaces
 ==========
 
+For semantic versioning purposes, the public API is defined as follows.
+
+The definition of the **public** interface:
+    Any module, function, class or attribute that is not internal
 
 The definition of the **internal** interface:
     The ``ddtrace.internal`` module is internal
@@ -86,10 +90,7 @@ The definition of the **internal** interface:
 
     Any module, function, class or attribute that is contained within an internal module is internal
 
-
-The definition of the **public** interface:
-    Any module, function, class or attribute that is not internal
-
+Internal code may be subject to breaking changes in bugfix and minor releases.
 
 .. _versioning_supported_runtimes:
 


### PR DESCRIPTION
This change updates the contribution guidelines to assume minimal knowledge of ddtrace's development practices and expectations.

## Checklist

- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Change is maintainable (easy to change, telemetry, documentation).