### PR TITLE
docs: fix broken links in pr checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 - [ ] Change is maintainable (easy to change, telemetry, documentation).
 - [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
 - [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
-- [ ] Backport labels are set (if [applicable](../docs/contributing.rst#release-branch-maintenance))
+- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/stable/contributing.rst#release-branch-maintenance))
 
 ## Reviewer Checklist
 
@@ -18,4 +18,4 @@
 - [ ] Change is maintainable (easy to change, telemetry, documentation).
 - [ ] Release note makes sense to a user of the library.
 - [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
-- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
+- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/stable/contributing.rst#release-branch-maintenance)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 - [ ] Change is maintainable (easy to change, telemetry, documentation).
 - [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
 - [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
-- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/stable/contributing.rst#release-branch-maintenance))
+- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
 
 ## Reviewer Checklist
 
@@ -18,4 +18,4 @@
 - [ ] Change is maintainable (easy to change, telemetry, documentation).
 - [ ] Release note makes sense to a user of the library.
 - [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
-- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/stable/contributing.rst#release-branch-maintenance)
+- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


### PR DESCRIPTION
This change makes the links to the backport policy point to the newly updated backporting documentation, where before they had been 404s.

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](../docs/contributing.rst#release-branch-maintenance)
