### PR TITLE
chore(ci): update typing-extensions to 4.7.0

### DIFF
--- a/.riot/requirements/100e6c3.txt
+++ b/.riot/requirements/100e6c3.txt
@@ -53,7 +53,7 @@ tenacity==8.2.2
 threadpoolctl==3.1.0
 tomli==2.0.1
 tqdm==4.65.0
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.16
 vcrpy==4.2.1
 wrapt==1.15.0

--- a/.riot/requirements/10212ca.txt
+++ b/.riot/requirements/10212ca.txt
@@ -23,5 +23,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/102421e.txt
+++ b/.riot/requirements/102421e.txt
@@ -58,7 +58,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/102cf0a.txt
+++ b/.riot/requirements/102cf0a.txt
@@ -25,7 +25,7 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 uwsgi==2.0.21
 zipp==3.15.0
 

--- a/.riot/requirements/1032b18.txt
+++ b/.riot/requirements/1032b18.txt
@@ -33,7 +33,7 @@ redis==3.5.3
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 vine==5.0.0
 wcwidth==0.2.6
 zipp==3.15.0

--- a/.riot/requirements/103e4a0.txt
+++ b/.riot/requirements/103e4a0.txt
@@ -43,7 +43,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tenacity==8.2.2
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.16
 wrapt==1.15.0
 xmltodict==0.13.0

--- a/.riot/requirements/1050ad9.txt
+++ b/.riot/requirements/1050ad9.txt
@@ -21,5 +21,5 @@ pytest-mock==3.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1067092.txt
+++ b/.riot/requirements/1067092.txt
@@ -35,5 +35,5 @@ sortedcontainers==2.4.0
 sqlalchemy==1.4.46
 starlette==0.26.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/10990fb.txt
+++ b/.riot/requirements/10990fb.txt
@@ -24,5 +24,5 @@ pytest-mock==3.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/10a9168.txt
+++ b/.riot/requirements/10a9168.txt
@@ -58,7 +58,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/10b912a.txt
+++ b/.riot/requirements/10b912a.txt
@@ -21,6 +21,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 vine==1.3.0
 zipp==3.15.0

--- a/.riot/requirements/10cc35f.txt
+++ b/.riot/requirements/10cc35f.txt
@@ -21,7 +21,7 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0
 zope-event==4.6
 zope-interface==6.0

--- a/.riot/requirements/111163f.txt
+++ b/.riot/requirements/111163f.txt
@@ -20,6 +20,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1124194.txt
+++ b/.riot/requirements/1124194.txt
@@ -58,7 +58,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/1133f63.txt
+++ b/.riot/requirements/1133f63.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1134537.txt
+++ b/.riot/requirements/1134537.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/116a45d.txt
+++ b/.riot/requirements/116a45d.txt
@@ -50,7 +50,7 @@ sqlparse==0.4.4
 tomli==2.0.1
 twisted[tls]==22.10.0
 txaio==23.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zope-interface==6.0
 

--- a/.riot/requirements/116c409.txt
+++ b/.riot/requirements/116c409.txt
@@ -23,5 +23,5 @@ pytest-mock==3.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1182da4.txt
+++ b/.riot/requirements/1182da4.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/11b2766.txt
+++ b/.riot/requirements/11b2766.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/11c6a9d.txt
+++ b/.riot/requirements/11c6a9d.txt
@@ -23,6 +23,6 @@ pytz==2022.7.1
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 vertica-python==0.7.4
 zipp==3.15.0

--- a/.riot/requirements/120f342.txt
+++ b/.riot/requirements/120f342.txt
@@ -36,7 +36,7 @@ sanic-testing==22.3.1
 sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 ujson==5.7.0
 urllib3==1.26.15
 uvloop==0.17.0

--- a/.riot/requirements/12115db.txt
+++ b/.riot/requirements/12115db.txt
@@ -24,7 +24,7 @@ pytest-cov==4.1.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 uwsgi==2.0.21
 zipp==3.15.0
 

--- a/.riot/requirements/12497dd.txt
+++ b/.riot/requirements/12497dd.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1277d97.txt
+++ b/.riot/requirements/1277d97.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1295177.txt
+++ b/.riot/requirements/1295177.txt
@@ -18,4 +18,4 @@ pytest-asyncio==0.21.0
 pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
-typing-extensions==4.6.3
+typing-extensions==4.7.0

--- a/.riot/requirements/12b2f26.txt
+++ b/.riot/requirements/12b2f26.txt
@@ -38,7 +38,7 @@ pytest-mock==3.10.0
 requests==2.28.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 werkzeug==2.1.2
 wrapt==1.15.0

--- a/.riot/requirements/12b6c4d.txt
+++ b/.riot/requirements/12b6c4d.txt
@@ -20,4 +20,4 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0

--- a/.riot/requirements/12e2d81.txt
+++ b/.riot/requirements/12e2d81.txt
@@ -23,7 +23,7 @@ pytest-mock==3.10.0
 redis==4.5.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0
 zope-event==4.6
 zope-interface==5.5.2

--- a/.riot/requirements/130f79e.txt
+++ b/.riot/requirements/130f79e.txt
@@ -24,5 +24,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/131d266.txt
+++ b/.riot/requirements/131d266.txt
@@ -22,6 +22,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/132b64a.txt
+++ b/.riot/requirements/132b64a.txt
@@ -38,7 +38,7 @@ pytest-mock==3.10.0
 requests==2.28.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 werkzeug==2.1.2
 wrapt==1.15.0

--- a/.riot/requirements/1338e26.txt
+++ b/.riot/requirements/1338e26.txt
@@ -30,5 +30,5 @@ rfc3986[idna2008]==1.5.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/133da29.txt
+++ b/.riot/requirements/133da29.txt
@@ -33,7 +33,7 @@ python-dateutil==2.8.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 wrapt==1.15.0
 yarl==1.8.2

--- a/.riot/requirements/135f985.txt
+++ b/.riot/requirements/135f985.txt
@@ -24,6 +24,6 @@ pytest-mock==3.10.0
 requests==2.28.2
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1384d27.txt
+++ b/.riot/requirements/1384d27.txt
@@ -20,5 +20,5 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==5.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1399486.txt
+++ b/.riot/requirements/1399486.txt
@@ -22,7 +22,7 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 soupsieve==2.4
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0

--- a/.riot/requirements/13debc6.txt
+++ b/.riot/requirements/13debc6.txt
@@ -36,6 +36,6 @@ sortedcontainers==2.4.0
 sqlalchemy==1.4.46
 starlette==0.26.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1411bd3.txt
+++ b/.riot/requirements/1411bd3.txt
@@ -22,5 +22,5 @@ pytest-mock==3.10.0
 redis==4.5.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/14240b7.txt
+++ b/.riot/requirements/14240b7.txt
@@ -20,6 +20,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/14346e4.txt
+++ b/.riot/requirements/14346e4.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/143e207.txt
+++ b/.riot/requirements/143e207.txt
@@ -23,5 +23,5 @@ six==1.16.0
 sortedcontainers==2.4.0
 structlog==22.3.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1445065.txt
+++ b/.riot/requirements/1445065.txt
@@ -35,7 +35,7 @@ six==1.16.0
 snowflake-connector-python==2.9.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/.riot/requirements/144b616.txt
+++ b/.riot/requirements/144b616.txt
@@ -26,7 +26,7 @@ pytest-mock==3.10.0
 requests==2.28.2
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0
 zope-event==4.6

--- a/.riot/requirements/1451cde.txt
+++ b/.riot/requirements/1451cde.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/145d12f.txt
+++ b/.riot/requirements/145d12f.txt
@@ -50,7 +50,7 @@ sqlparse==0.4.3
 tomli==2.0.1
 twisted[tls]==22.10.0
 txaio==23.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zope-interface==5.5.2
 

--- a/.riot/requirements/145f708.txt
+++ b/.riot/requirements/145f708.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1492115.txt
+++ b/.riot/requirements/1492115.txt
@@ -45,7 +45,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tenacity==8.2.2
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.16
 wrapt==1.15.0
 xmltodict==0.13.0

--- a/.riot/requirements/14ad548.txt
+++ b/.riot/requirements/14ad548.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/14b8cbe.txt
+++ b/.riot/requirements/14b8cbe.txt
@@ -21,4 +21,4 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0

--- a/.riot/requirements/14e7000.txt
+++ b/.riot/requirements/14e7000.txt
@@ -35,7 +35,7 @@ python-dateutil==2.8.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 wrapt==1.15.0
 yarl==1.8.2

--- a/.riot/requirements/14ec914.txt
+++ b/.riot/requirements/14ec914.txt
@@ -29,5 +29,5 @@ rfc3986[idna2008]==1.5.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/150ecef.txt
+++ b/.riot/requirements/150ecef.txt
@@ -20,4 +20,4 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0

--- a/.riot/requirements/15117c9.txt
+++ b/.riot/requirements/15117c9.txt
@@ -38,7 +38,7 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 tracerite==1.1.0
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 ujson==5.7.0
 urllib3==2.0.2
 uvloop==0.17.0

--- a/.riot/requirements/1522394.txt
+++ b/.riot/requirements/1522394.txt
@@ -32,6 +32,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 yarl==1.8.2
 zipp==3.15.0

--- a/.riot/requirements/152c4cd.txt
+++ b/.riot/requirements/152c4cd.txt
@@ -19,5 +19,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/154e4ca.txt
+++ b/.riot/requirements/154e4ca.txt
@@ -19,7 +19,7 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/.riot/requirements/15694e6.txt
+++ b/.riot/requirements/15694e6.txt
@@ -40,7 +40,7 @@ sanic==20.12.7
 sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 ujson==5.7.0
 urllib3==1.26.15
 uvloop==0.17.0

--- a/.riot/requirements/1589bf7.txt
+++ b/.riot/requirements/1589bf7.txt
@@ -66,7 +66,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.2.3

--- a/.riot/requirements/15a8287.txt
+++ b/.riot/requirements/15a8287.txt
@@ -35,5 +35,5 @@ sortedcontainers==2.4.0
 sqlalchemy==1.4.46
 starlette==0.26.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/15c8ec7.txt
+++ b/.riot/requirements/15c8ec7.txt
@@ -33,7 +33,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tempora==5.2.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zc-lockfile==3.0.post1
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/.riot/requirements/15eeaa6.txt
+++ b/.riot/requirements/15eeaa6.txt
@@ -23,6 +23,6 @@ pytz==2022.7.1
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 vertica-python==0.6.14
 zipp==3.15.0

--- a/.riot/requirements/1610924.txt
+++ b/.riot/requirements/1610924.txt
@@ -20,6 +20,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1624bfc.txt
+++ b/.riot/requirements/1624bfc.txt
@@ -38,7 +38,7 @@ pytest-mock==3.10.0
 requests==2.28.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 werkzeug==2.1.2
 wrapt==1.15.0

--- a/.riot/requirements/163ddfd.txt
+++ b/.riot/requirements/163ddfd.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1641558.txt
+++ b/.riot/requirements/1641558.txt
@@ -33,7 +33,7 @@ python-dateutil==2.8.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 wrapt==1.15.0
 yarl==1.8.2

--- a/.riot/requirements/1645c7b.txt
+++ b/.riot/requirements/1645c7b.txt
@@ -39,7 +39,7 @@ requests==2.28.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 wrapt==1.15.0
 yarl==1.8.2

--- a/.riot/requirements/1650743.txt
+++ b/.riot/requirements/1650743.txt
@@ -59,7 +59,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/1661781.txt
+++ b/.riot/requirements/1661781.txt
@@ -22,5 +22,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1663153.txt
+++ b/.riot/requirements/1663153.txt
@@ -28,5 +28,5 @@ rfc3986[idna2008]==1.5.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/166b1d0.txt
+++ b/.riot/requirements/166b1d0.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1676eaa.txt
+++ b/.riot/requirements/1676eaa.txt
@@ -35,7 +35,7 @@ six==1.16.0
 snowflake-connector-python==2.9.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/.riot/requirements/1681b1c.txt
+++ b/.riot/requirements/1681b1c.txt
@@ -24,6 +24,6 @@ pytest-mock==3.10.0
 requests==2.28.2
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1686d8b.txt
+++ b/.riot/requirements/1686d8b.txt
@@ -58,7 +58,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/1698728.txt
+++ b/.riot/requirements/1698728.txt
@@ -40,7 +40,7 @@ sortedcontainers==2.4.0
 threadpoolctl==3.1.0
 tomli==2.0.1
 tqdm==4.65.0
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.16
 vcrpy==4.2.1
 wrapt==1.15.0

--- a/.riot/requirements/169ef0a.txt
+++ b/.riot/requirements/169ef0a.txt
@@ -31,5 +31,5 @@ rfc3986[idna2008]==1.5.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.20.4
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/16e6050.txt
+++ b/.riot/requirements/16e6050.txt
@@ -29,6 +29,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 yarl==1.8.2
 zipp==3.15.0

--- a/.riot/requirements/16faa60.txt
+++ b/.riot/requirements/16faa60.txt
@@ -24,6 +24,6 @@ pytest-mock==3.10.0
 requests==2.28.2
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1710908.txt
+++ b/.riot/requirements/1710908.txt
@@ -21,5 +21,5 @@ pytest-cov==2.9.0
 pytest-mock==2.0.0
 sortedcontainers==2.4.0
 toml==0.10.2
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1737be8.txt
+++ b/.riot/requirements/1737be8.txt
@@ -23,5 +23,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1753595.txt
+++ b/.riot/requirements/1753595.txt
@@ -32,7 +32,7 @@ sortedcontainers==2.4.0
 soupsieve==2.4
 tomli==2.0.1
 translationstring==1.4
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 venusian==3.0.0
 waitress==2.1.2

--- a/.riot/requirements/17564fc.txt
+++ b/.riot/requirements/17564fc.txt
@@ -24,5 +24,5 @@ pytz==2022.7.1
 sortedcontainers==2.4.0
 sqlparse==0.4.3
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1774b5c.txt
+++ b/.riot/requirements/1774b5c.txt
@@ -22,7 +22,7 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 soupsieve==2.4
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0

--- a/.riot/requirements/17c63d9.txt
+++ b/.riot/requirements/17c63d9.txt
@@ -33,7 +33,7 @@ python-dateutil==2.8.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 wrapt==1.15.0
 yarl==1.8.2

--- a/.riot/requirements/17f4253.txt
+++ b/.riot/requirements/17f4253.txt
@@ -33,7 +33,7 @@ python-dateutil==2.8.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 wrapt==1.15.0
 yarl==1.8.2

--- a/.riot/requirements/17f9c1d.txt
+++ b/.riot/requirements/17f9c1d.txt
@@ -33,7 +33,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tempora==5.2.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zc-lockfile==3.0.post1
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/.riot/requirements/18115c3.txt
+++ b/.riot/requirements/18115c3.txt
@@ -22,5 +22,5 @@ pytest-mock==3.10.0
 redis==4.5.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1847958.txt
+++ b/.riot/requirements/1847958.txt
@@ -48,7 +48,7 @@ sortedcontainers==2.4.0
 sqlparse==0.4.4
 twisted[tls]==22.10.0
 txaio==23.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zope-interface==6.0
 

--- a/.riot/requirements/18550a0.txt
+++ b/.riot/requirements/18550a0.txt
@@ -34,7 +34,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tempora==5.2.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zc-lockfile==3.0.post1
 zipp==3.15.0
 

--- a/.riot/requirements/185a58c.txt
+++ b/.riot/requirements/185a58c.txt
@@ -35,5 +35,5 @@ sortedcontainers==2.4.0
 sqlalchemy==1.4.46
 starlette==0.26.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/189950a.txt
+++ b/.riot/requirements/189950a.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/18f2aec.txt
+++ b/.riot/requirements/18f2aec.txt
@@ -45,7 +45,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tenacity==8.2.2
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.16
 wrapt==1.15.0
 xmltodict==0.13.0

--- a/.riot/requirements/190ec9f.txt
+++ b/.riot/requirements/190ec9f.txt
@@ -35,5 +35,5 @@ six==1.16.0
 snowflake-connector-python==3.0.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/1943579.txt
+++ b/.riot/requirements/1943579.txt
@@ -21,4 +21,4 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0

--- a/.riot/requirements/1953f64.txt
+++ b/.riot/requirements/1953f64.txt
@@ -23,5 +23,5 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 sqlalchemy==2.0.6
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1970a2a.txt
+++ b/.riot/requirements/1970a2a.txt
@@ -20,5 +20,5 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==6.2
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/19727de.txt
+++ b/.riot/requirements/19727de.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1973b17.txt
+++ b/.riot/requirements/1973b17.txt
@@ -29,5 +29,5 @@ rfc3986[idna2008]==1.5.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/19a842e.txt
+++ b/.riot/requirements/19a842e.txt
@@ -29,5 +29,5 @@ pytest-mock==3.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/19adb24.txt
+++ b/.riot/requirements/19adb24.txt
@@ -39,7 +39,7 @@ pytest-mock==3.10.0
 requests==2.28.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 werkzeug==2.1.2
 wrapt==1.15.0

--- a/.riot/requirements/19b3e1d.txt
+++ b/.riot/requirements/19b3e1d.txt
@@ -58,7 +58,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/19b678e.txt
+++ b/.riot/requirements/19b678e.txt
@@ -39,7 +39,7 @@ requests==2.28.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 wrapt==1.15.0
 yarl==1.8.2

--- a/.riot/requirements/19c5102.txt
+++ b/.riot/requirements/19c5102.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/19dce27.txt
+++ b/.riot/requirements/19dce27.txt
@@ -22,5 +22,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/19e259d.txt
+++ b/.riot/requirements/19e259d.txt
@@ -32,7 +32,7 @@ sortedcontainers==2.4.0
 soupsieve==2.4
 tomli==2.0.1
 translationstring==1.4
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 venusian==3.0.0
 waitress==2.1.2

--- a/.riot/requirements/19faf53.txt
+++ b/.riot/requirements/19faf53.txt
@@ -35,7 +35,7 @@ python-dateutil==2.8.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 wrapt==1.15.0
 yarl==1.8.2

--- a/.riot/requirements/1a7460c.txt
+++ b/.riot/requirements/1a7460c.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1a754f3.txt
+++ b/.riot/requirements/1a754f3.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1a79c45.txt
+++ b/.riot/requirements/1a79c45.txt
@@ -35,7 +35,7 @@ python-dateutil==2.8.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 wrapt==1.15.0
 yarl==1.8.2

--- a/.riot/requirements/1a7adb4.txt
+++ b/.riot/requirements/1a7adb4.txt
@@ -33,5 +33,5 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.26.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/1a9d32d.txt
+++ b/.riot/requirements/1a9d32d.txt
@@ -59,7 +59,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/1aa96d6.txt
+++ b/.riot/requirements/1aa96d6.txt
@@ -22,5 +22,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1aaf16c.txt
+++ b/.riot/requirements/1aaf16c.txt
@@ -20,6 +20,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1ab03fc.txt
+++ b/.riot/requirements/1ab03fc.txt
@@ -22,5 +22,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1ab1806.txt
+++ b/.riot/requirements/1ab1806.txt
@@ -35,5 +35,5 @@ six==1.16.0
 snowflake-connector-python==3.0.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/1ad7acc.txt
+++ b/.riot/requirements/1ad7acc.txt
@@ -29,5 +29,5 @@ rfc3986[idna2008]==1.5.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1adac83.txt
+++ b/.riot/requirements/1adac83.txt
@@ -25,6 +25,6 @@ requests-mock==1.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1adaf57.txt
+++ b/.riot/requirements/1adaf57.txt
@@ -22,5 +22,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1ae5586.txt
+++ b/.riot/requirements/1ae5586.txt
@@ -33,5 +33,5 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.23.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/1b2a61e.txt
+++ b/.riot/requirements/1b2a61e.txt
@@ -35,5 +35,5 @@ six==1.16.0
 snowflake-connector-python==3.0.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/1b38e24.txt
+++ b/.riot/requirements/1b38e24.txt
@@ -19,6 +19,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1b51cd7.txt
+++ b/.riot/requirements/1b51cd7.txt
@@ -33,7 +33,7 @@ python-dateutil==2.8.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 wrapt==1.15.0
 yarl==1.8.2

--- a/.riot/requirements/1b52a0b.txt
+++ b/.riot/requirements/1b52a0b.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1b81325.txt
+++ b/.riot/requirements/1b81325.txt
@@ -22,5 +22,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1b9504f.txt
+++ b/.riot/requirements/1b9504f.txt
@@ -32,7 +32,7 @@ sortedcontainers==2.4.0
 soupsieve==2.4
 tomli==2.0.1
 translationstring==1.4
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 venusian==3.0.0
 waitress==2.1.2

--- a/.riot/requirements/1beef99.txt
+++ b/.riot/requirements/1beef99.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1bf9bf1.txt
+++ b/.riot/requirements/1bf9bf1.txt
@@ -51,7 +51,7 @@ sqlparse==0.4.4
 tomli==2.0.1
 twisted[tls]==22.10.0
 txaio==23.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zope-interface==6.0
 

--- a/.riot/requirements/1c1ee74.txt
+++ b/.riot/requirements/1c1ee74.txt
@@ -53,7 +53,7 @@ tenacity==8.2.2
 threadpoolctl==3.1.0
 tomli==2.0.1
 tqdm==4.65.0
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.16
 vcrpy==4.2.1
 wrapt==1.15.0

--- a/.riot/requirements/1c55fa9.txt
+++ b/.riot/requirements/1c55fa9.txt
@@ -21,4 +21,4 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0

--- a/.riot/requirements/1c6b6fb.txt
+++ b/.riot/requirements/1c6b6fb.txt
@@ -23,5 +23,5 @@ pytest-mock==3.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1c92dfd.txt
+++ b/.riot/requirements/1c92dfd.txt
@@ -66,7 +66,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.2.3

--- a/.riot/requirements/1cd5079.txt
+++ b/.riot/requirements/1cd5079.txt
@@ -33,7 +33,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tempora==5.2.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zc-lockfile==3.0.post1
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/.riot/requirements/1ce6732.txt
+++ b/.riot/requirements/1ce6732.txt
@@ -20,5 +20,5 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==6.2
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1d02c3a.txt
+++ b/.riot/requirements/1d02c3a.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1d3adbd.txt
+++ b/.riot/requirements/1d3adbd.txt
@@ -25,7 +25,7 @@ pytest-mock==3.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 uwsgi==2.0.21
 zipp==3.15.0
 

--- a/.riot/requirements/1d3fa10.txt
+++ b/.riot/requirements/1d3fa10.txt
@@ -24,6 +24,6 @@ pytest-mock==3.10.0
 requests==2.28.2
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1d5b563.txt
+++ b/.riot/requirements/1d5b563.txt
@@ -58,7 +58,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/1d64e2a.txt
+++ b/.riot/requirements/1d64e2a.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1d67674.txt
+++ b/.riot/requirements/1d67674.txt
@@ -28,7 +28,7 @@ python-memcached==1.59
 redis==2.10.6
 six==1.16.0
 sortedcontainers==2.4.0
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 werkzeug==0.16.1
 zipp==3.15.0
 

--- a/.riot/requirements/1da26a5.txt
+++ b/.riot/requirements/1da26a5.txt
@@ -22,5 +22,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1db8171.txt
+++ b/.riot/requirements/1db8171.txt
@@ -22,5 +22,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1dc2fb8.txt
+++ b/.riot/requirements/1dc2fb8.txt
@@ -30,6 +30,6 @@ redis==2.10.6
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 werkzeug==2.2.3
 zipp==3.15.0

--- a/.riot/requirements/1dc7353.txt
+++ b/.riot/requirements/1dc7353.txt
@@ -33,5 +33,5 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.23.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/1dcadda.txt
+++ b/.riot/requirements/1dcadda.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1dcc382.txt
+++ b/.riot/requirements/1dcc382.txt
@@ -20,6 +20,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1dd34d2.txt
+++ b/.riot/requirements/1dd34d2.txt
@@ -25,6 +25,6 @@ requests-mock==1.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1dfb2b8.txt
+++ b/.riot/requirements/1dfb2b8.txt
@@ -45,7 +45,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tenacity==8.2.2
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.16
 wrapt==1.15.0
 xmltodict==0.13.0

--- a/.riot/requirements/1e12fd7.txt
+++ b/.riot/requirements/1e12fd7.txt
@@ -38,7 +38,7 @@ pytest-mock==3.10.0
 requests==2.28.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 werkzeug==2.1.2
 wrapt==1.15.0

--- a/.riot/requirements/1e264b1.txt
+++ b/.riot/requirements/1e264b1.txt
@@ -23,5 +23,5 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 stevedore==3.5.2
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1e649a3.txt
+++ b/.riot/requirements/1e649a3.txt
@@ -20,5 +20,5 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==4.5.3
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1e7f4cb.txt
+++ b/.riot/requirements/1e7f4cb.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1eb0d77.txt
+++ b/.riot/requirements/1eb0d77.txt
@@ -45,7 +45,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tenacity==8.2.2
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.16
 wrapt==1.15.0
 xmltodict==0.13.0

--- a/.riot/requirements/1ed5122.txt
+++ b/.riot/requirements/1ed5122.txt
@@ -29,7 +29,7 @@ pytest-mock==3.10.0
 requests==2.29.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 werkzeug==2.2.3
 zipp==3.15.0

--- a/.riot/requirements/1eee2f4.txt
+++ b/.riot/requirements/1eee2f4.txt
@@ -33,5 +33,5 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.26.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/1efe655.txt
+++ b/.riot/requirements/1efe655.txt
@@ -29,7 +29,7 @@ pytest-mock==3.10.0
 requests==2.28.2
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 werkzeug==1.0.1
 zipp==3.15.0

--- a/.riot/requirements/1f08f0f.txt
+++ b/.riot/requirements/1f08f0f.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1f0c579.txt
+++ b/.riot/requirements/1f0c579.txt
@@ -20,6 +20,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1f21b24.txt
+++ b/.riot/requirements/1f21b24.txt
@@ -34,7 +34,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tempora==5.2.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zc-lockfile==3.0.post1
 zipp==3.15.0
 

--- a/.riot/requirements/1f6511d.txt
+++ b/.riot/requirements/1f6511d.txt
@@ -31,7 +31,7 @@ requests==2.29.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 werkzeug==2.2.3
 zipp==3.15.0

--- a/.riot/requirements/1f69efa.txt
+++ b/.riot/requirements/1f69efa.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1f6e601.txt
+++ b/.riot/requirements/1f6e601.txt
@@ -19,6 +19,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/1f716b0.txt
+++ b/.riot/requirements/1f716b0.txt
@@ -39,7 +39,7 @@ requests==2.28.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 wrapt==1.15.0
 yarl==1.8.2

--- a/.riot/requirements/1f99b32.txt
+++ b/.riot/requirements/1f99b32.txt
@@ -50,7 +50,7 @@ sqlparse==0.4.3
 tomli==2.0.1
 twisted[tls]==22.10.0
 txaio==23.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zope-interface==5.5.2
 

--- a/.riot/requirements/1fa94f6.txt
+++ b/.riot/requirements/1fa94f6.txt
@@ -64,7 +64,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.2.3

--- a/.riot/requirements/1fccaf0.txt
+++ b/.riot/requirements/1fccaf0.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1fd9240.txt
+++ b/.riot/requirements/1fd9240.txt
@@ -19,5 +19,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/1fe32d2.txt
+++ b/.riot/requirements/1fe32d2.txt
@@ -31,5 +31,5 @@ rfc3986[idna2008]==1.5.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.26.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/1fea16b.txt
+++ b/.riot/requirements/1fea16b.txt
@@ -32,6 +32,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 yarl==1.8.2
 zipp==3.15.0

--- a/.riot/requirements/213fc7a.txt
+++ b/.riot/requirements/213fc7a.txt
@@ -36,7 +36,7 @@ sanic-testing==0.8.3
 sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 ujson==5.7.0
 urllib3==1.26.15
 uvloop==0.17.0

--- a/.riot/requirements/241e1de.txt
+++ b/.riot/requirements/241e1de.txt
@@ -35,7 +35,7 @@ six==1.16.0
 snowflake-connector-python==2.9.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/.riot/requirements/243af71.txt
+++ b/.riot/requirements/243af71.txt
@@ -43,7 +43,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tenacity==8.2.2
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.16
 wrapt==1.15.0
 xmltodict==0.13.0

--- a/.riot/requirements/251271e.txt
+++ b/.riot/requirements/251271e.txt
@@ -58,7 +58,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/25a9886.txt
+++ b/.riot/requirements/25a9886.txt
@@ -28,7 +28,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tempora==5.2.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zc-lockfile==3.0.post1
 zipp==3.15.0
 

--- a/.riot/requirements/2628377.txt
+++ b/.riot/requirements/2628377.txt
@@ -29,6 +29,6 @@ redis==2.10.6
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 werkzeug==2.2.3
 zipp==3.15.0

--- a/.riot/requirements/2749e18.txt
+++ b/.riot/requirements/2749e18.txt
@@ -22,4 +22,4 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 sqlalchemy==2.0.6
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0

--- a/.riot/requirements/28acfbb.txt
+++ b/.riot/requirements/28acfbb.txt
@@ -31,7 +31,7 @@ pytz==2022.7.1
 six==1.16.0
 sortedcontainers==2.4.0
 tempora==5.2.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zc-lockfile==3.0.post1
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/.riot/requirements/2d11a4c.txt
+++ b/.riot/requirements/2d11a4c.txt
@@ -25,5 +25,5 @@ pytz==2022.7.1
 sortedcontainers==2.4.0
 sqlparse==0.4.3
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/2fffba6.txt
+++ b/.riot/requirements/2fffba6.txt
@@ -21,5 +21,5 @@ pytest-mock==3.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/3135617.txt
+++ b/.riot/requirements/3135617.txt
@@ -59,7 +59,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/32bd6c2.txt
+++ b/.riot/requirements/32bd6c2.txt
@@ -19,5 +19,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/3358777.txt
+++ b/.riot/requirements/3358777.txt
@@ -21,5 +21,5 @@ redis==3.0.1
 redis-py-cluster==2.0.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/357a02f.txt
+++ b/.riot/requirements/357a02f.txt
@@ -21,6 +21,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/369c4e2.txt
+++ b/.riot/requirements/369c4e2.txt
@@ -32,6 +32,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 yarl==1.8.2
 zipp==3.15.0

--- a/.riot/requirements/36d23da.txt
+++ b/.riot/requirements/36d23da.txt
@@ -20,6 +20,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 yaaredis==3.0.0
 zipp==3.15.0

--- a/.riot/requirements/3887c46.txt
+++ b/.riot/requirements/3887c46.txt
@@ -23,6 +23,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/3913418.txt
+++ b/.riot/requirements/3913418.txt
@@ -26,7 +26,7 @@ pytest-mock==3.10.0
 requests==2.28.2
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0
 zope-event==4.6

--- a/.riot/requirements/3cad3c8.txt
+++ b/.riot/requirements/3cad3c8.txt
@@ -20,5 +20,5 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==5.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/410808e.txt
+++ b/.riot/requirements/410808e.txt
@@ -35,5 +35,5 @@ sortedcontainers==2.4.0
 sqlalchemy==1.4.46
 starlette==0.26.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/4251737.txt
+++ b/.riot/requirements/4251737.txt
@@ -57,7 +57,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/433fef7.txt
+++ b/.riot/requirements/433fef7.txt
@@ -34,6 +34,6 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.26.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/43ad9ea.txt
+++ b/.riot/requirements/43ad9ea.txt
@@ -19,5 +19,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/4430638.txt
+++ b/.riot/requirements/4430638.txt
@@ -21,5 +21,5 @@ pytest-mock==3.10.0
 six==1.12.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/44e11b6.txt
+++ b/.riot/requirements/44e11b6.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/4654b0c.txt
+++ b/.riot/requirements/4654b0c.txt
@@ -29,5 +29,5 @@ pytest-mock==3.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/4b58569.txt
+++ b/.riot/requirements/4b58569.txt
@@ -33,5 +33,5 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.13.6
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/4b8086d.txt
+++ b/.riot/requirements/4b8086d.txt
@@ -51,7 +51,7 @@ sqlparse==0.4.3
 tomli==2.0.1
 twisted[tls]==22.10.0
 txaio==23.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0
 zope-interface==5.5.2

--- a/.riot/requirements/4b92fdb.txt
+++ b/.riot/requirements/4b92fdb.txt
@@ -25,6 +25,6 @@ requests==2.28.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/4bd8537.txt
+++ b/.riot/requirements/4bd8537.txt
@@ -33,5 +33,5 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.13.6
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/4ed0642.txt
+++ b/.riot/requirements/4ed0642.txt
@@ -38,7 +38,7 @@ pytest-mock==3.10.0
 requests==2.28.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 werkzeug==2.1.2
 wrapt==1.15.0

--- a/.riot/requirements/4f84272.txt
+++ b/.riot/requirements/4f84272.txt
@@ -50,7 +50,7 @@ sqlparse==0.4.4
 tomli==2.0.1
 twisted[tls]==22.10.0
 txaio==23.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zope-interface==6.0
 

--- a/.riot/requirements/5291970.txt
+++ b/.riot/requirements/5291970.txt
@@ -33,5 +33,5 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.26.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/52a6601.txt
+++ b/.riot/requirements/52a6601.txt
@@ -35,7 +35,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tempora==5.2.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zc-lockfile==3.0.post1
 zipp==3.15.0
 

--- a/.riot/requirements/52cba92.txt
+++ b/.riot/requirements/52cba92.txt
@@ -21,7 +21,7 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 soupsieve==2.4
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0

--- a/.riot/requirements/53ccfbc.txt
+++ b/.riot/requirements/53ccfbc.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/543c254.txt
+++ b/.riot/requirements/543c254.txt
@@ -24,5 +24,5 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 sqlalchemy==1.4.46
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/564af17.txt
+++ b/.riot/requirements/564af17.txt
@@ -21,5 +21,5 @@ redis==3.5.3
 redis-py-cluster==2.1.3
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/57c9f87.txt
+++ b/.riot/requirements/57c9f87.txt
@@ -36,7 +36,7 @@ sanic-testing==0.8.3
 sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 ujson==5.7.0
 urllib3==1.26.15
 uvloop==0.17.0

--- a/.riot/requirements/5accd4b.txt
+++ b/.riot/requirements/5accd4b.txt
@@ -26,6 +26,6 @@ requests==2.28.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/5d37e91.txt
+++ b/.riot/requirements/5d37e91.txt
@@ -33,5 +33,5 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.13.6
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/5d6f54d.txt
+++ b/.riot/requirements/5d6f54d.txt
@@ -25,7 +25,7 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 uwsgi==2.0.21
 zipp==3.15.0
 zope-event==4.6

--- a/.riot/requirements/5d7fe4a.txt
+++ b/.riot/requirements/5d7fe4a.txt
@@ -51,7 +51,7 @@ sqlparse==0.4.3
 tomli==2.0.1
 twisted[tls]==22.10.0
 txaio==23.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0
 zope-interface==5.5.2

--- a/.riot/requirements/5ea5e85.txt
+++ b/.riot/requirements/5ea5e85.txt
@@ -35,7 +35,7 @@ requests==2.30.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==2.0.2
 werkzeug==2.2.3
 wheel==0.40.0

--- a/.riot/requirements/5ec5473.txt
+++ b/.riot/requirements/5ec5473.txt
@@ -22,4 +22,4 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 sqlalchemy==2.0.6
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0

--- a/.riot/requirements/5f26ddd.txt
+++ b/.riot/requirements/5f26ddd.txt
@@ -45,7 +45,7 @@ six==1.16.0
 snowflake-connector-python==2.3.10
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0
 

--- a/.riot/requirements/60d2d5a.txt
+++ b/.riot/requirements/60d2d5a.txt
@@ -24,5 +24,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/62bea76.txt
+++ b/.riot/requirements/62bea76.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/63ac241.txt
+++ b/.riot/requirements/63ac241.txt
@@ -21,4 +21,4 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0

--- a/.riot/requirements/6638eec.txt
+++ b/.riot/requirements/6638eec.txt
@@ -35,7 +35,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tempora==5.2.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zc-lockfile==3.0.post1
 zipp==3.15.0
 

--- a/.riot/requirements/67d3ae5.txt
+++ b/.riot/requirements/67d3ae5.txt
@@ -34,6 +34,6 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.23.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/6a1d128.txt
+++ b/.riot/requirements/6a1d128.txt
@@ -36,7 +36,7 @@ sanic-testing==22.3.1
 sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 ujson==5.7.0
 urllib3==1.26.15
 uvloop==0.17.0

--- a/.riot/requirements/6a89a76.txt
+++ b/.riot/requirements/6a89a76.txt
@@ -22,5 +22,5 @@ pytest-mock==3.10.0
 redis==4.5.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/6c0cd0f.txt
+++ b/.riot/requirements/6c0cd0f.txt
@@ -30,6 +30,6 @@ redis==2.10.6
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 werkzeug==1.0.1
 zipp==3.15.0

--- a/.riot/requirements/6c346af.txt
+++ b/.riot/requirements/6c346af.txt
@@ -27,5 +27,5 @@ rfc3986[idna2008]==1.5.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/6e07469.txt
+++ b/.riot/requirements/6e07469.txt
@@ -23,5 +23,5 @@ redis==4.5.1
 rq==1.8.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/6eacf15.txt
+++ b/.riot/requirements/6eacf15.txt
@@ -36,6 +36,6 @@ sortedcontainers==2.4.0
 sqlalchemy==1.4.46
 starlette==0.26.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/729b5a8.txt
+++ b/.riot/requirements/729b5a8.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/72c4e5c.txt
+++ b/.riot/requirements/72c4e5c.txt
@@ -44,7 +44,7 @@ six==1.16.0
 snowflake-connector-python==2.4.6
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/.riot/requirements/73059a9.txt
+++ b/.riot/requirements/73059a9.txt
@@ -33,5 +33,5 @@ responses==0.16.0
 six==1.16.0
 snowflake-connector-python==3.0.1
 sortedcontainers==2.4.0
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/735ef18.txt
+++ b/.riot/requirements/735ef18.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/73a2d0b.txt
+++ b/.riot/requirements/73a2d0b.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/7731a63.txt
+++ b/.riot/requirements/7731a63.txt
@@ -22,5 +22,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/78030e7.txt
+++ b/.riot/requirements/78030e7.txt
@@ -33,7 +33,7 @@ redis==3.5.3
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 vine==5.0.0
 wcwidth==0.2.6
 zipp==3.15.0

--- a/.riot/requirements/79334db.txt
+++ b/.riot/requirements/79334db.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/7c2e6ed.txt
+++ b/.riot/requirements/7c2e6ed.txt
@@ -35,5 +35,5 @@ sortedcontainers==2.4.0
 sqlalchemy==1.4.46
 starlette==0.26.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/7c388bd.txt
+++ b/.riot/requirements/7c388bd.txt
@@ -29,7 +29,7 @@ pytest-mock==3.10.0
 requests==2.29.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 werkzeug==2.2.3
 zipp==3.15.0

--- a/.riot/requirements/8542334.txt
+++ b/.riot/requirements/8542334.txt
@@ -36,7 +36,7 @@ six==1.16.0
 snowflake-connector-python==2.9.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0
 

--- a/.riot/requirements/8587af4.txt
+++ b/.riot/requirements/8587af4.txt
@@ -50,7 +50,7 @@ sqlparse==0.4.4
 tomli==2.0.1
 twisted[tls]==22.10.0
 txaio==23.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zope-interface==6.0
 

--- a/.riot/requirements/8a49ff1.txt
+++ b/.riot/requirements/8a49ff1.txt
@@ -25,5 +25,5 @@ pytz==2022.7.1
 sortedcontainers==2.4.0
 sqlparse==0.4.3
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/8c29f31.txt
+++ b/.riot/requirements/8c29f31.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/8c823f4.txt
+++ b/.riot/requirements/8c823f4.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/922d429.txt
+++ b/.riot/requirements/922d429.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/9423397.txt
+++ b/.riot/requirements/9423397.txt
@@ -24,7 +24,7 @@ pytest-mock==3.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0
 zope-event==4.6
 zope-interface==6.0

--- a/.riot/requirements/98b9655.txt
+++ b/.riot/requirements/98b9655.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/9974bca.txt
+++ b/.riot/requirements/9974bca.txt
@@ -25,6 +25,6 @@ requests==2.28.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/999352d.txt
+++ b/.riot/requirements/999352d.txt
@@ -21,6 +21,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/9b5dcfa.txt
+++ b/.riot/requirements/9b5dcfa.txt
@@ -41,7 +41,7 @@ requests==2.28.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 wrapt==1.15.0
 yarl==1.8.2

--- a/.riot/requirements/9d67df3.txt
+++ b/.riot/requirements/9d67df3.txt
@@ -29,7 +29,7 @@ pytest-mock==3.10.0
 requests==2.28.2
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 werkzeug==1.0.1
 zipp==3.15.0

--- a/.riot/requirements/9fb8994.txt
+++ b/.riot/requirements/9fb8994.txt
@@ -29,6 +29,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 yarl==1.8.2
 zipp==3.15.0

--- a/.riot/requirements/a05353d.txt
+++ b/.riot/requirements/a05353d.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/a35fc7c.txt
+++ b/.riot/requirements/a35fc7c.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/a622fe6.txt
+++ b/.riot/requirements/a622fe6.txt
@@ -21,6 +21,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 vine==5.0.0
 zipp==3.15.0

--- a/.riot/requirements/a658791.txt
+++ b/.riot/requirements/a658791.txt
@@ -23,5 +23,5 @@ redis==4.5.1
 rq==1.13.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/a77c0cc.txt
+++ b/.riot/requirements/a77c0cc.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/aa0c838.txt
+++ b/.riot/requirements/aa0c838.txt
@@ -29,6 +29,6 @@ redis==2.10.6
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 werkzeug==1.0.1
 zipp==3.15.0

--- a/.riot/requirements/ae3c891.txt
+++ b/.riot/requirements/ae3c891.txt
@@ -32,6 +32,6 @@ requests==2.28.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 yarl==1.8.2

--- a/.riot/requirements/b2e4e56.txt
+++ b/.riot/requirements/b2e4e56.txt
@@ -58,7 +58,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/b53f31c.txt
+++ b/.riot/requirements/b53f31c.txt
@@ -32,6 +32,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 yarl==1.8.2
 zipp==3.15.0

--- a/.riot/requirements/b7ac594.txt
+++ b/.riot/requirements/b7ac594.txt
@@ -25,7 +25,7 @@ pytz==2022.7.1
 redis==3.5.3
 six==1.16.0
 sortedcontainers==2.4.0
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 vine==1.3.0
 zipp==3.15.0
 

--- a/.riot/requirements/ba45059.txt
+++ b/.riot/requirements/ba45059.txt
@@ -51,7 +51,7 @@ sqlparse==0.4.4
 tomli==2.0.1
 twisted[tls]==22.10.0
 txaio==23.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zope-interface==6.0
 

--- a/.riot/requirements/bc50138.txt
+++ b/.riot/requirements/bc50138.txt
@@ -33,5 +33,5 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.23.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/bc7c1d4.txt
+++ b/.riot/requirements/bc7c1d4.txt
@@ -27,4 +27,4 @@ types-protobuf==3.20.4.5
 types-pyyaml==6.0.12.2
 types-setuptools==65.6.0.0
 types-six==1.16.21.4
-typing-extensions==4.6.3
+typing-extensions==4.7.0

--- a/.riot/requirements/bd1ac0d.txt
+++ b/.riot/requirements/bd1ac0d.txt
@@ -49,7 +49,7 @@ sqlparse==0.4.3
 tomli==2.0.1
 twisted[tls]==22.10.0
 txaio==23.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zope-interface==5.5.2
 

--- a/.riot/requirements/bd9ab6d.txt
+++ b/.riot/requirements/bd9ab6d.txt
@@ -37,7 +37,7 @@ pytest-mock==3.10.0
 requests==2.28.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 werkzeug==1.0.1
 wrapt==1.15.0

--- a/.riot/requirements/be400d2.txt
+++ b/.riot/requirements/be400d2.txt
@@ -56,7 +56,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/be85b44.txt
+++ b/.riot/requirements/be85b44.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/c1104a7.txt
+++ b/.riot/requirements/c1104a7.txt
@@ -21,6 +21,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/c62bbbb.txt
+++ b/.riot/requirements/c62bbbb.txt
@@ -34,6 +34,6 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 starlette==0.13.6
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/c8d7a6a.txt
+++ b/.riot/requirements/c8d7a6a.txt
@@ -56,7 +56,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/ca1140c.txt
+++ b/.riot/requirements/ca1140c.txt
@@ -23,5 +23,5 @@ six==1.16.0
 sortedcontainers==2.4.0
 structlog==22.3.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/cbc1770.txt
+++ b/.riot/requirements/cbc1770.txt
@@ -44,7 +44,7 @@ six==1.16.0
 snowflake-connector-python==2.3.10
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/.riot/requirements/cc86ab5.txt
+++ b/.riot/requirements/cc86ab5.txt
@@ -22,5 +22,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/cdd5082.txt
+++ b/.riot/requirements/cdd5082.txt
@@ -58,7 +58,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/ce59c0a.txt
+++ b/.riot/requirements/ce59c0a.txt
@@ -24,5 +24,5 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 sqlalchemy==1.4.46
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/cf77227.txt
+++ b/.riot/requirements/cf77227.txt
@@ -35,7 +35,7 @@ six==1.16.0
 snowflake-connector-python==2.7.12
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/.riot/requirements/d3a74c5.txt
+++ b/.riot/requirements/d3a74c5.txt
@@ -22,5 +22,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/d4e7de6.txt
+++ b/.riot/requirements/d4e7de6.txt
@@ -23,5 +23,5 @@ pytest-mock==3.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/d7252fb.txt
+++ b/.riot/requirements/d7252fb.txt
@@ -56,7 +56,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.1.2

--- a/.riot/requirements/d764cf7.txt
+++ b/.riot/requirements/d764cf7.txt
@@ -36,6 +36,6 @@ sortedcontainers==2.4.0
 sqlalchemy==1.4.46
 starlette==0.26.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/d78240a.txt
+++ b/.riot/requirements/d78240a.txt
@@ -35,5 +35,5 @@ sortedcontainers==2.4.0
 sqlalchemy==1.4.46
 starlette==0.26.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15

--- a/.riot/requirements/d7ae6a5.txt
+++ b/.riot/requirements/d7ae6a5.txt
@@ -25,6 +25,6 @@ requests-mock==1.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/d8ceb6a.txt
+++ b/.riot/requirements/d8ceb6a.txt
@@ -33,7 +33,7 @@ six==1.16.0
 sortedcontainers==2.4.0
 tempora==5.2.1
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zc-lockfile==3.0.post1
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/.riot/requirements/d9c085c.txt
+++ b/.riot/requirements/d9c085c.txt
@@ -19,5 +19,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/db05d90.txt
+++ b/.riot/requirements/db05d90.txt
@@ -21,5 +21,5 @@ pytest-cov==2.12.0
 pytest-mock==2.0.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/dbc3334.txt
+++ b/.riot/requirements/dbc3334.txt
@@ -23,5 +23,5 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 stevedore==3.5.2
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/dc068d4.txt
+++ b/.riot/requirements/dc068d4.txt
@@ -20,6 +20,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 yaaredis==2.0.4
 zipp==3.15.0

--- a/.riot/requirements/dc17681.txt
+++ b/.riot/requirements/dc17681.txt
@@ -68,7 +68,7 @@ sortedcontainers==2.4.0
 sshpubkeys==3.3.1
 tomli==2.0.1
 types-pyyaml==6.0.12.8
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 websocket-client==1.5.1
 werkzeug==2.2.3

--- a/.riot/requirements/e41dfb1.txt
+++ b/.riot/requirements/e41dfb1.txt
@@ -33,7 +33,7 @@ python-dateutil==2.8.2
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 wrapt==1.15.0
 yarl==1.8.2

--- a/.riot/requirements/ed89a4c.txt
+++ b/.riot/requirements/ed89a4c.txt
@@ -23,5 +23,5 @@ pytest-mock==3.10.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/ee5c026.txt
+++ b/.riot/requirements/ee5c026.txt
@@ -21,5 +21,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/ee6d531.txt
+++ b/.riot/requirements/ee6d531.txt
@@ -31,7 +31,7 @@ pytz==2022.7.1
 six==1.16.0
 sortedcontainers==2.4.0
 tempora==5.2.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zc-lockfile==3.0.post1
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/.riot/requirements/f04bd43.txt
+++ b/.riot/requirements/f04bd43.txt
@@ -21,5 +21,5 @@ pytest-mock==3.10.0
 sortedcontainers==2.4.0
 toml==0.10.2
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/f220563.txt
+++ b/.riot/requirements/f220563.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/f433975.txt
+++ b/.riot/requirements/f433975.txt
@@ -49,7 +49,7 @@ sqlparse==0.4.3
 tomli==2.0.1
 twisted[tls]==22.10.0
 txaio==23.1.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zope-interface==5.5.2
 

--- a/.riot/requirements/f48d192.txt
+++ b/.riot/requirements/f48d192.txt
@@ -22,6 +22,6 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 vine==5.0.0
 zipp==3.15.0

--- a/.riot/requirements/f7e0d19.txt
+++ b/.riot/requirements/f7e0d19.txt
@@ -22,5 +22,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/f7ff1b5.txt
+++ b/.riot/requirements/f7ff1b5.txt
@@ -36,6 +36,6 @@ six==1.16.0
 snowflake-connector-python==3.0.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 urllib3==1.26.15
 zipp==3.15.0

--- a/.riot/requirements/fa92741.txt
+++ b/.riot/requirements/fa92741.txt
@@ -23,5 +23,5 @@ redis==4.5.1
 rq==1.10.1
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/facdff3.txt
+++ b/.riot/requirements/facdff3.txt
@@ -20,5 +20,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 sortedcontainers==2.4.0
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0

--- a/.riot/requirements/fc14133.txt
+++ b/.riot/requirements/fc14133.txt
@@ -24,5 +24,5 @@ pytz==2022.7.1
 sortedcontainers==2.4.0
 sqlparse==0.4.3
 tomli==2.0.1
-typing-extensions==4.6.3
+typing-extensions==4.7.0
 zipp==3.15.0


### PR DESCRIPTION
Temporary fix to CI, follow up to #6007.

`typing-extensions` released a new version `4.7.0` which seems to be interfering with riot's base virtualenv. As a temporary fix to unblock CI, we're updating the version of `typing-extensions` stored on every riot lockfile accordingly.

This is only a temporary fix and `cherrypy, django, debugger` test suites will fail again when there is a new release. We should investigate this problem in greater detail.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
