### PR TITLE
chore(datastreams): enable datastreams in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,6 +353,12 @@ jobs:
       - run_test:
           pattern: "internal"
 
+  datastreams:
+    <<: *contrib_job
+    steps:
+      - run_test:
+          pattern: "datastreams"
+
   tracer:
     <<: *contrib_job_large
     steps:
@@ -1115,6 +1121,7 @@ requires_tests: &requires_tests
     - ci_visibility
     - consul
     - ddtracerun
+    - datastreams
     - dogpile_cache
     - django
     - django_hosts
@@ -1214,6 +1221,7 @@ workflows:
       - cherrypy: *requires_base_venvs
       - ci_visibility: *requires_base_venvs
       - consul: *requires_base_venvs
+      - datastreams: *requires_base_venvs
       - ddtracerun: *requires_base_venvs
       - django: *requires_base_venvs
       - django_hosts: *requires_base_venvs

--- a/tests/datastreams/test_encoding.py
+++ b/tests/datastreams/test_encoding.py
@@ -22,7 +22,7 @@ def test_pathway_encoding():
 
     def on_checkpoint_creation(hash_value, parent_hash, edge_tags, now_sec, edge_latency_sec, full_pathway_latency_sec):
         assert parent_hash == ctx.hash
-        assert edge_tags == ["direction:in", "type:kafka", "topic:topic1"]
+        assert sorted(edge_tags) == sorted(["direction:in", "type:kafka", "topic:topic1"])
 
     processor.on_checkpoint_creation = on_checkpoint_creation
     decoded = processor.decode_pathway(data)

--- a/tests/datastreams/test_encoding.py
+++ b/tests/datastreams/test_encoding.py
@@ -5,7 +5,7 @@ from ddtrace.internal.datastreams.processor import DataStreamsProcessor
 
 def test_encoding():
     n = 1679672748
-    expected_encoded = bytes([216, 150, 238, 193, 12])
+    expected_encoded = bytearray([216, 150, 238, 193, 12])
     encoded = encode_var_int_64(n)
     assert encoded == expected_encoded
     decoded, b = decode_var_int_64(encoded)


### PR DESCRIPTION
This change adds a workflow to run datastreams tests in circleci.  Prior to this change, we relied on reviewers to know to run the test.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
