### PR TITLE
chore(ci): add exceptiongroup test dependency to riot lockfile

### DIFF
--- a/.riot/requirements/11ee002.txt
+++ b/.riot/requirements/11ee002.txt
@@ -9,6 +9,7 @@ attrs==23.1.0
 blinker==1.6.2
 click==8.1.3
 coverage==7.2.5
+exceptiongroup==1.1.1
 flask==0.12.5
 flask-cache==0.13.1
 hypothesis==6.45.0

--- a/.riot/requirements/8f570cd.txt
+++ b/.riot/requirements/8f570cd.txt
@@ -9,6 +9,7 @@ attrs==23.1.0
 blinker==1.6.2
 click==8.1.3
 coverage==7.2.5
+exceptiongroup==1.1.1
 flask==0.12.5
 flask-cache==0.13.1
 hypothesis==6.45.0

--- a/.riot/requirements/b7ac594.txt
+++ b/.riot/requirements/b7ac594.txt
@@ -10,6 +10,7 @@ attrs==22.2.0
 billiard==3.6.4.0
 celery==4.4.7
 coverage==7.2.2
+exceptiongroup==1.1.1
 hypothesis==6.45.0
 importlib-metadata==4.13.0
 kombu==4.6.11


### PR DESCRIPTION
Temporary fix to `exceptiongroup` module not being found in the `celery, flask` test suites. The reason behind this issue is currently unknown, possibly related to #6007.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
