### PR TITLE
chore(asm): rework on lazytaintdict

### DIFF
--- a/ddtrace/appsec/iast/_taint_utils.py
+++ b/ddtrace/appsec/iast/_taint_utils.py
@@ -89,7 +89,7 @@ class LazyTaintDict(dict):
             yield (k, self[k])
 
     def keys(self):
-        for k in self.keys():
+        for k in super(LazyTaintDict, self).keys():
             if (
                 k
                 and isinstance(k, (str, bytes, bytearray))

--- a/ddtrace/appsec/iast/_taint_utils.py
+++ b/ddtrace/appsec/iast/_taint_utils.py
@@ -10,6 +10,42 @@ DBAPI_PREFIXES = ("django-",)
 log = get_logger(__name__)
 
 
+class LazyTaintList(list):
+    def __init__(self, *args, origins=(0, 0), override_pyobject_tainted=False):
+        self.origin_key = origins[0]
+        self.origin_value = origins[1]
+        self.override_pyobject_tainted = override_pyobject_tainted
+        super(LazyTaintList, self).__init__(*args)
+
+    def __getitem__(self, key):
+        value = super(LazyTaintDict, self).__getitem__(key)
+        if value:
+            if isinstance(value, dict) and not isinstance(value, LazyTaintDict):
+                value = LazyTaintDict(value)
+                self[key] = value
+            elif isinstance(value, list) and not isinstance(value, LazyTaintList):
+                value = LazyTaintList(value)
+                if isinstance(key, int):
+                    self[key] = value
+            elif isinstance(value, (str, bytes, bytearray)):
+                if not is_pyobject_tainted(value) or self.override_pyobject_tainted:
+                    try:
+                        value = taint_pyobject(
+                            pyobject=value, source_name=key, source_value=value, source_origin=self.origin_value
+                        )
+                        self[key] = value
+                    except SystemError:
+                        # TODO: Find the root cause for
+                        # SystemError: NULL object passed to Py_BuildValue
+                        log.debug("SystemError while tainting value: %s with key: %s", value, key, exc_info=True)
+                    except Exception:
+                        log.debug("Unexpected exception while tainting value", exc_info=True)
+        return value
+
+    def __iter__(self):
+        return (self[i] for i in range(len(self)))
+
+
 class LazyTaintDict(dict):
     def __init__(self, *args, origins=(0, 0), override_pyobject_tainted=False):
         self.origin_key = origins[0]
@@ -20,7 +56,13 @@ class LazyTaintDict(dict):
     def __getitem__(self, key):
         value = super(LazyTaintDict, self).__getitem__(key)
         if value:
-            if isinstance(value, (str, bytes, bytearray)):
+            if isinstance(value, dict) and not isinstance(value, LazyTaintDict):
+                value = LazyTaintDict(value)
+                self[key] = value
+            elif isinstance(value, list) and not isinstance(value, LazyTaintList):
+                value = LazyTaintList(value)
+                self[key] = value
+            elif isinstance(value, (str, bytes, bytearray)):
                 if not is_pyobject_tainted(value) or self.override_pyobject_tainted:
                     try:
                         value = taint_pyobject(
@@ -33,26 +75,6 @@ class LazyTaintDict(dict):
                         log.debug("SystemError while tainting value: %s with key: %s", value, key, exc_info=True)
                     except Exception:
                         log.debug("Unexpected exception while tainting value", exc_info=True)
-            elif isinstance(value, (list,)):
-                new_value = list()
-                try:
-                    for v in value:
-                        if isinstance(v, (str, bytes, bytearray)) and (
-                            not is_pyobject_tainted(v) or self.override_pyobject_tainted
-                        ):
-                            new_value.append(
-                                taint_pyobject(
-                                    pyobject=v, source_name=key, source_value=v, source_origin=self.origin_value
-                                )
-                            )
-                        else:
-                            new_value.append(v)
-                    value = new_value
-                    super(LazyTaintDict, self).__setitem__(key, value)
-                except SystemError:
-                    log.debug("SystemError while tainting value: %s with key: %s", value, key, exc_info=True)
-                except Exception:
-                    log.debug("Unexpected exception while tainting value", exc_info=True)
         return value
 
     def get(self, key, default=None):
@@ -63,24 +85,20 @@ class LazyTaintDict(dict):
         return default
 
     def items(self):
-        for k, v in super(LazyTaintDict, self).items():
-            if k and isinstance(k, (str, bytes, bytearray)) and not is_pyobject_tainted(k):
+        for k in self.keys():
+            yield (k, self[k])
+
+    def keys(self):
+        for k in self.keys():
+            if (
+                k
+                and isinstance(k, (str, bytes, bytearray))
+                and (self.override_pyobject_tainted or not is_pyobject_tainted(k))
+            ):
                 try:
                     k = taint_pyobject(pyobject=k, source_name=k, source_value=k, source_origin=self.origin_key)
                 except Exception:
                     log.debug("Unexpected exception while tainting key", exc_info=True)
-
-            if v and isinstance(v, (str, bytes, bytearray)) and not is_pyobject_tainted(v):
-                try:
-                    v = taint_pyobject(pyobject=v, source_name=k, source_value=v, source_origin=self.origin_value)
-                    super(LazyTaintDict, self).__setitem__(k, v)
-                except Exception:
-                    log.debug("Unexpected exception while tainting value", exc_info=True)
-
-            yield (k, v)
-
-    def keys(self):
-        for k, _ in self.items():
             yield k
 
     def values(self):

--- a/tests/appsec/iast/test_taint_utils.py
+++ b/tests/appsec/iast/test_taint_utils.py
@@ -23,7 +23,6 @@ def setup():
 
 
 def test_tainted_types():
-
     tainted = taint_pyobject(
         pyobject="hello", source_name="request_body", source_value="hello", source_origin=OriginType.PARAMETER
     )


### PR DESCRIPTION
Rework on LazyTaintDict:

1. make it recursive, tainting lazily any list or dict at any level in the structure
2. force taint is now working on keys and values if the dict is iterated
3. add LazyTaintList working as LazyTaintDict
4. refactor some code

Also add a unit test to check for recursive tainting.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
