### PR TITLE
chore(dep): remove jsonschema dependency from package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -542,7 +542,6 @@ setup(
         "typing_extensions",
         "importlib_metadata; python_version<'3.8'",
         "pathlib2; python_version<'3.5'",
-        "jsonschema",
         "xmltodict>=0.12",
         "ipaddress; python_version<'3.7'",
         "envier",

--- a/tests/tracer/test_single_span_sampling_rules.py
+++ b/tests/tracer/test_single_span_sampling_rules.py
@@ -1,6 +1,5 @@
 import sys
 
-from jsonschema import ValidationError
 import pytest
 
 from ddtrace import Tracer
@@ -65,7 +64,7 @@ def test_sampling_rule_init_via_env():
 
     # Testing error thrown when neither name nor service is set
     with override_env(dict(DD_SPAN_SAMPLING_RULES='[{"sample_rate":1.0}]')):
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValueError):
             sampling_rules = get_span_sampling_rules()
 
     # Testing exception thrown when service pattern contains unsupported char


### PR DESCRIPTION
We have had issues recently with newer versions of `jsonschema`. Most importantly, it caused issues with our build/release process (mainly `rpds-py` which is a dependency of `jsonschema`s): https://github.com/DataDog/dd-trace-py/actions/runs/5476876584/jobs/9975064818

Looking over the usage of `jsonschema`, there isn't much it is really doing for us. This PR attempts to replace the usage with other/similar manual checks.

If the existing test cases/edge cases continue to pass, then we have successfully replaced `jsonschema`.

The risk with this change is a user ends up with an opaque error message. Instead of getting a message saying `max_per_second` must be an integer, they might instead get an operation error when trying to multiply `None` (or some non-integer value) against another number. We can consider adding more/additional checks.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
