### PR TITLE
(chore)asm: lazy taint dict as capsules

### DIFF
--- a/ddtrace/appsec/iast/_taint_utils.py
+++ b/ddtrace/appsec/iast/_taint_utils.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+from collections import abc
+from typing import Any
+
 from ddtrace.appsec.iast._taint_tracking import is_pyobject_tainted
 from ddtrace.appsec.iast._taint_tracking import taint_pyobject
 from ddtrace.internal.logger import get_logger
@@ -10,31 +13,22 @@ DBAPI_PREFIXES = ("django-",)
 log = get_logger(__name__)
 
 
-class LazyTaintList(list):
-    def __init__(self, *args, origins=(0, 0), override_pyobject_tainted=False, source_name="[]"):
+class LazyTaintList:
+    def __init__(self, original_list, origins=(0, 0), override_pyobject_tainted=False, source_name="[]"):
+        self.obj = original_list
         self.origins = origins
         self.origin_value = origins[1]
         self.override_pyobject_tainted = override_pyobject_tainted
         self.source_name = source_name
-        super(LazyTaintList, self).__init__(*args)
 
     def __getitem__(self, key):
-        value = super(LazyTaintList, self).__getitem__(key)
+        value = self.obj[key]
         if value:
-            if isinstance(value, dict) and not isinstance(value, LazyTaintDict):
+            if isinstance(value, abc.Mapping) and not isinstance(value, LazyTaintDict):
                 value = LazyTaintDict(
                     value, origins=self.origins, override_pyobject_tainted=self.override_pyobject_tainted
                 )
-                self[key] = value
-            elif isinstance(value, list) and not isinstance(value, LazyTaintList):
-                value = LazyTaintList(
-                    value,
-                    origins=self.origins,
-                    override_pyobject_tainted=self.override_pyobject_tainted,
-                    source_name=self.source_name,
-                )
-                if isinstance(key, int):
-                    self[key] = value
+                self.obj[key] = value
             elif isinstance(value, (str, bytes, bytearray)):
                 if not is_pyobject_tainted(value) or self.override_pyobject_tainted:
                     try:
@@ -51,36 +45,40 @@ class LazyTaintList(list):
                         log.debug("SystemError while tainting value: %s with key: %s", value, key, exc_info=True)
                     except Exception:
                         log.debug("Unexpected exception while tainting value", exc_info=True)
-        return value
-
-    def __iter__(self):
-        return (self[i] for i in range(len(self)))
-
-
-class LazyTaintDict(dict):
-    def __init__(self, *args, origins=(0, 0), override_pyobject_tainted=False):
-        self.origins = origins
-        self.origin_key = origins[0]
-        self.origin_value = origins[1]
-        self.override_pyobject_tainted = override_pyobject_tainted
-        super(LazyTaintDict, self).__init__(*args)
-
-    def __getitem__(self, key):
-        value = super(LazyTaintDict, self).__getitem__(key)
-        if value:
-            if isinstance(value, dict) and not isinstance(value, LazyTaintDict):
-                value = LazyTaintDict(
-                    value, origins=self.origins, override_pyobject_tainted=self.override_pyobject_tainted
-                )
-                self[key] = value
-            elif isinstance(value, list) and not isinstance(value, LazyTaintList):
+            elif isinstance(value, abc.Mapping) and not isinstance(value, LazyTaintList):
                 value = LazyTaintList(
                     value,
                     origins=self.origins,
                     override_pyobject_tainted=self.override_pyobject_tainted,
-                    source_name=key,
+                    source_name=self.source_name,
                 )
-                self[key] = value
+                if isinstance(key, int):
+                    self.obj[key] = value
+        return value
+
+    def __iter__(self):
+        return (self.obj[i] for i in range(len(self)))
+
+    def __getattr__(self, name):
+        return getattr(self.obj, name)
+
+
+class LazyTaintDict:
+    def __init__(self, original_dict, origins=(0, 0), override_pyobject_tainted=False):
+        self.obj = original_dict
+        self.origins = origins
+        self.origin_key = origins[0]
+        self.origin_value = origins[1]
+        self.override_pyobject_tainted = override_pyobject_tainted
+
+    def __getitem__(self, key):
+        value = self.obj[key]
+        if value:
+            if isinstance(value, abc.Mapping) and not isinstance(value, LazyTaintDict):
+                value = LazyTaintDict(
+                    value, origins=self.origins, override_pyobject_tainted=self.override_pyobject_tainted
+                )
+                self.obj[key] = value
             elif isinstance(value, (str, bytes, bytearray)):
                 if not is_pyobject_tainted(value) or self.override_pyobject_tainted:
                     try:
@@ -94,6 +92,14 @@ class LazyTaintDict(dict):
                         log.debug("SystemError while tainting value: %s with key: %s", value, key, exc_info=True)
                     except Exception:
                         log.debug("Unexpected exception while tainting value", exc_info=True)
+            elif isinstance(value, abc.Sequence) and not isinstance(value, LazyTaintList):
+                value = LazyTaintList(
+                    value,
+                    origins=self.origins,
+                    override_pyobject_tainted=self.override_pyobject_tainted,
+                    source_name=key,
+                )
+                self.obj[key] = value
         return value
 
     def get(self, key, default=None):
@@ -108,7 +114,7 @@ class LazyTaintDict(dict):
             yield (k, self[k])
 
     def keys(self):
-        for k in super(LazyTaintDict, self).keys():
+        for k in self.obj.keys():
             if (
                 k
                 and isinstance(k, (str, bytes, bytearray))
@@ -123,6 +129,10 @@ class LazyTaintDict(dict):
     def values(self):
         for _, v in self.items():
             yield v
+
+    def __getattr__(self, name):
+        # type: (str) -> Any
+        return getattr(self.obj, name)
 
 
 def supported_dbapi_integration(integration_name):

--- a/ddtrace/appsec/iast/_taint_utils.py
+++ b/ddtrace/appsec/iast/_taint_utils.py
@@ -77,12 +77,7 @@ class LazyTaintDict:
         self.override_pyobject_tainted = override_pyobject_tainted
 
     def __getitem__(self, key):
-        try:
-            value = self.obj[key]
-            print(">> VALUE", value)
-        except KeyError:
-            print(">> KEYERROR", self.obj, key)
-            raise
+        value = self.obj[key]
 
         if value:
             if isinstance(value, abc.Mapping) and not isinstance(value, LazyTaintDict):
@@ -147,13 +142,8 @@ class LazyTaintDict:
     def __setitem__(self, key, value):
         self.obj[key] = value
 
-    def __getattribute__(self, __name: str) -> Any:
-        print(">> GETA", __name)
-        return super().__getattribute__(__name)
-
     def __getattr__(self, name):
         # type: (str) -> Any
-        print(">> GETATTR", name)
         return getattr(self.obj, name)
 
 


### PR DESCRIPTION
To keep to original behaviour of tainted dict and tainted list that can have overrided method, switch from a lazy taint object model that was inheriting from base classes to a model that encapsulate the object to taint.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
