### PR TITLE
chore: move constants to internal module

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -3,6 +3,19 @@ from typing import TYPE_CHECKING
 
 import six
 
+from ddtrace.internal.constants import HTTP_REQUEST_BLOCKED
+from ddtrace.internal.constants import HTTP_REQUEST_BODY
+from ddtrace.internal.constants import HTTP_REQUEST_COOKIE_NAME
+from ddtrace.internal.constants import HTTP_REQUEST_COOKIE_VALUE
+from ddtrace.internal.constants import HTTP_REQUEST_HEADER
+from ddtrace.internal.constants import HTTP_REQUEST_HEADER_NAME
+from ddtrace.internal.constants import HTTP_REQUEST_PARAMETER
+from ddtrace.internal.constants import HTTP_REQUEST_PATH
+from ddtrace.internal.constants import HTTP_REQUEST_PATH_PARAMETER
+from ddtrace.internal.constants import HTTP_REQUEST_QUERY
+from ddtrace.internal.constants import REQUEST_PATH_PARAMS
+from ddtrace.internal.constants import RESPONSE_HEADERS
+
 
 if TYPE_CHECKING:
     from typing import Any
@@ -76,15 +89,15 @@ class IAST(object):
     PATCH_MODULES = "_DD_IAST_PATCH_MODULES"
     DENY_MODULES = "_DD_IAST_DENY_MODULES"
     SEP_MODULES = ","
-    HTTP_REQUEST_BODY = "http.request.body"
-    HTTP_REQUEST_HEADER = "http.request.header"
-    HTTP_REQUEST_HEADER_NAME = "http.request.header.name"
-    HTTP_REQUEST_PARAMETER = "http.request.parameter"
-    HTTP_REQUEST_PATH = "http.request.path"
-    HTTP_REQUEST_PATH_PARAMETER = "http.request.path.parameter"
-    HTTP_REQUEST_QUERYSTRING = "http.request.query"
-    HTTP_REQUEST_COOKIE_NAME = "http.request.cookie.name"
-    HTTP_REQUEST_COOKIE_VALUE = "http.request.cookie.value"
+    HTTP_REQUEST_BODY = HTTP_REQUEST_BODY
+    HTTP_REQUEST_HEADER = HTTP_REQUEST_HEADER
+    HTTP_REQUEST_HEADER_NAME = HTTP_REQUEST_HEADER_NAME
+    HTTP_REQUEST_PARAMETER = HTTP_REQUEST_PARAMETER
+    HTTP_REQUEST_PATH = HTTP_REQUEST_PATH
+    HTTP_REQUEST_PATH_PARAMETER = HTTP_REQUEST_PATH_PARAMETER
+    HTTP_REQUEST_QUERYSTRING = HTTP_REQUEST_QUERY
+    HTTP_REQUEST_COOKIE_NAME = HTTP_REQUEST_COOKIE_NAME
+    HTTP_REQUEST_COOKIE_VALUE = HTTP_REQUEST_COOKIE_VALUE
 
 
 @six.add_metaclass(Constant_Class)  # required for python2/3 compatibility
@@ -115,12 +128,12 @@ class SPAN_DATA_NAMES(object):
     REQUEST_URI_RAW = "http.request.uri"
     REQUEST_ROUTE = "http.request.route"
     REQUEST_METHOD = "http.request.method"
-    REQUEST_PATH_PARAMS = "http.request.path_params"
+    REQUEST_PATH_PARAMS = REQUEST_PATH_PARAMS
     REQUEST_COOKIES = "http.request.cookies"
     REQUEST_HTTP_IP = "http.request.remote_ip"
     REQUEST_USER_ID = "usr.id"
     RESPONSE_STATUS = "http.response.status"
-    RESPONSE_HEADERS_NO_COOKIES = "http.response.headers"
+    RESPONSE_HEADERS_NO_COOKIES = RESPONSE_HEADERS
     RESPONSE_BODY = "http.response.body"
 
 
@@ -144,7 +157,7 @@ class WAF_CONTEXT_NAMES(object):
     """string names used by the library for tagging data from requests in context"""
 
     RESULTS = "http.request.waf.results"
-    BLOCKED = "http.request.blocked"
+    BLOCKED = HTTP_REQUEST_BLOCKED
     CALLBACK = "http.request.waf.callback"
 
 

--- a/ddtrace/internal/constants.py
+++ b/ddtrace/internal/constants.py
@@ -47,5 +47,17 @@ APPSEC_BLOCKED_RESPONSE_JSON = (
     '{"errors": [{"title": "You\'ve been blocked", "detail": "Sorry, you cannot access '
     'this page. Please contact the customer service team. Security provided by Datadog."}]}'
 )
+HTTP_REQUEST_BLOCKED = "http.request.blocked"
+RESPONSE_HEADERS = "http.response.headers"
+HTTP_REQUEST_QUERY = "http.request.query"
+HTTP_REQUEST_COOKIE_VALUE = "http.request.cookie.value"
+HTTP_REQUEST_COOKIE_NAME = "http.request.cookie.name"
+HTTP_REQUEST_PATH = "http.request.path"
+HTTP_REQUEST_HEADER_NAME = "http.request.header.name"
+HTTP_REQUEST_HEADER = "http.request.header"
+HTTP_REQUEST_PARAMETER = "http.request.parameter"
+HTTP_REQUEST_BODY = "http.request.body"
+HTTP_REQUEST_PATH_PARAMETER = "http.request.path.parameter"
+REQUEST_PATH_PARAMS = "http.request.path_params"
 
 MESSAGING_SYSTEM = "messaging.system"


### PR DESCRIPTION
This change moves many of the constants used in IAST taint tracking to `ddtrace.internal.constants`. We're moving toward a more clear separation of concerns between Products like AppSec and Contrib integrations like Flask and Django.

In the case of request blocking, the separation of concerns ideally breaks down as follows. The AppSec Product code in the `ddtrace/appsec` directory knows how to make a block/don't block decision based on communication with libddwaf. The Django code in `ddtrace/contrib` knows how to take that blocking decision into account when processing requests.

According to this separation of concerns, these constants will be used by both the Product and the Contrib. Moving them to `internal.constants` means that the Contrib won't have to talk about AppSec when it imports them.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
