### PR TITLE
fix(benchmarks): resolve syntax error

### DIFF
--- a/benchmarks/bm/utils.py
+++ b/benchmarks/bm/utils.py
@@ -72,7 +72,7 @@ def drop_traces(tracer):
 def drop_telemetry_events():
     # Avoids sending instrumentation telemetry payloads to the agent
     try:
-        if telemetry.telemetry_writer.is_periodic():
+        if telemetry.telemetry_writer.is_periodic:
             telemetry.telemetry_writer.stop()
         telemetry.telemetry_writer.reset_queues()
         telemetry.telemetry_writer.enable(start_worker_thread=False)


### PR DESCRIPTION
Fixes the following error ([link](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/293082432)):  

```
 File "/app/baseline/benchmarks/bm/_scenario.py", line 73, in _pyperf
    run = next(rungen)
  File "/app/baseline/benchmarks/scenario.py", line 34, in run
    utils.drop_telemetry_events()
  File "/app/baseline/benchmarks/bm/utils.py", line 75, in drop_telemetry_events
    if telemetry.telemetry_writer.is_periodic():
TypeError: 'bool' object is not callable
```


## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
