### PR TITLE
remove asm context code from wsgi contrib

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -1,4 +1,5 @@
 import contextlib
+import contextvars
 from typing import TYPE_CHECKING
 
 from ddtrace import config
@@ -318,26 +319,54 @@ def asm_request_context_manager(
     """
     The ASM context manager
     """
-    if config._appsec_enabled:
-        resources = _on_context_started(remote_ip, headers, headers_case_sensitive, block_request_callable)
+    resources = _start_context(remote_ip, headers, headers_case_sensitive, block_request_callable)
+    if resources is not None:
         try:
             yield resources
         finally:
-            _on_context_ended(resources)
+            _end_context(resources)
     else:
         yield None
 
 
-def _on_context_started(remote_ip, headers, headers_case_sensitive, block_request_callable):
-    resources = _DataHandler()
-    asm_request_context_set(remote_ip, headers, headers_case_sensitive, block_request_callable)
-    core.on("wsgi.block_decided", _on_block_decided)
-    return resources
+def _start_context(remote_ip, headers, headers_case_sensitive, block_request_callable):
+    if config._appsec_enabled:
+        resources = _DataHandler()
+        asm_request_context_set(remote_ip, headers, headers_case_sensitive, block_request_callable)
+        core.on("wsgi.block_decided", _on_block_decided)
+        return resources
 
 
-def _on_context_ended(resources):
+RESOURCES = contextvars.ContextVar("asm_resources")
+
+
+def _on_context_started(ctx):
+    resources = _start_context(
+        ctx.get_item("remote_addr"),
+        ctx.get_item("headers"),
+        ctx.get_item("headers_case_sensitive"),
+        ctx.get_item("block_request_callable"),
+    )
+    token = RESOURCES.set(resources)
+    ctx.set_item("token_resources", token)
+
+
+def _end_context(resources):
     resources.finalise()
     core.set_item("asm_env", None)
+
+
+def _on_context_ended(ctx):
+    resources = RESOURCES.get()
+    if resources is not None:
+        _end_context(resources)
+        token = ctx.get_item("token_resources")
+        if token:
+            RESOURCES.reset(token)
+
+
+core.on("context.started.wsgi.__call__", _on_context_started)
+core.on("context.ended.wsgi.__call__", _on_context_ended)
 
 
 def _on_block_decided(callback):

--- a/ddtrace/contrib/wsgi/wsgi.py
+++ b/ddtrace/contrib/wsgi/wsgi.py
@@ -164,7 +164,9 @@ class _DDWSGIMiddlewareBase(object):
         headers = get_request_headers(environ)
         closing_iterator = ()
         not_blocked = True
-        with _asm_request_context.asm_request_context_manager(environ.get("REMOTE_ADDR"), headers, True):
+        with core.context_with_data(
+            "wsgi.__call__", remote_addr=environ.get("REMOTE_ADDR"), headers=headers, headers_case_sensitive=True
+        ):
             req_span = self.tracer.trace(
                 self._request_span_name,
                 service=trace_utils.int_service(self._pin, self._config),


### PR DESCRIPTION
This change removes the use of `asm_request_context_manager` from the wsgi contrib, making separation of concerns clearer.

In the case of request blocking, the separation of concerns ideally breaks down as follows. The AppSec Product code in the `ddtrace/appsec` directory knows how to make a block/don't block decision based on communication with libddwaf. The Wsgi code in `ddtrace/contrib` knows how to take that blocking decision into account when processing requests.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
