### PR TITLE
chore: update flask and wsgi imports to avoid mentioning appsec

### DIFF
--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -8,21 +8,28 @@ from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import abort
 import xmltodict
 
-from ddtrace.appsec._constants import IAST
-from ddtrace.appsec._constants import WAF_CONTEXT_NAMES
 from ddtrace.appsec.iast._patch import if_iast_taint_returned_object_for
 from ddtrace.appsec.iast._patch import if_iast_taint_yield_tuple_for
 from ddtrace.appsec.iast._util import _is_iast_enabled
 from ddtrace.constants import SPAN_KIND
 from ddtrace.ext import SpanKind
 from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal.constants import HTTP_REQUEST_BLOCKED
+from ddtrace.internal.constants import HTTP_REQUEST_BODY
+from ddtrace.internal.constants import HTTP_REQUEST_COOKIE_NAME
+from ddtrace.internal.constants import HTTP_REQUEST_COOKIE_VALUE
+from ddtrace.internal.constants import HTTP_REQUEST_HEADER
+from ddtrace.internal.constants import HTTP_REQUEST_HEADER_NAME
+from ddtrace.internal.constants import HTTP_REQUEST_PARAMETER
+from ddtrace.internal.constants import HTTP_REQUEST_PATH
+from ddtrace.internal.constants import HTTP_REQUEST_QUERY
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
 from ...appsec import _asm_request_context
-from ...appsec import utils
 from ...internal import core
 from ...internal.schema import schematize_service_name
 from ...internal.schema import schematize_url_operation
+from ...internal.utils import http as http_utils
 
 
 # Not all versions of flask/werkzeug have this mixin
@@ -121,9 +128,9 @@ def taint_request_init(wrapped, instance, args, kwargs):
 
             taint_pyobject(
                 instance.query_string,
-                Input_info(IAST.HTTP_REQUEST_QUERYSTRING, instance.query_string, IAST.HTTP_REQUEST_QUERYSTRING),
+                Input_info(HTTP_REQUEST_QUERY, instance.query_string, HTTP_REQUEST_QUERY),
             )
-            taint_pyobject(instance.path, Input_info(IAST.HTTP_REQUEST_PATH, instance.path, IAST.HTTP_REQUEST_PATH))
+            taint_pyobject(instance.path, Input_info(HTTP_REQUEST_PATH, instance.path, HTTP_REQUEST_PATH))
         except Exception:
             log.debug("Unexpected exception while tainting pyobject", exc_info=True)
 
@@ -151,10 +158,10 @@ class _FlaskWSGIMiddleware(_DDWSGIMiddlewareBase):
             req_span, config.flask, status_code=code, response_headers=headers, route=req_span.get_tag(FLASK_URL_RULE)
         )
 
-        if config._appsec_enabled and not core.get_item(WAF_CONTEXT_NAMES.BLOCKED, span=req_span):
+        if config._appsec_enabled and not core.get_item(HTTP_REQUEST_BLOCKED, span=req_span):
             log.debug("Flask WAF call for Suspicious Request Blocking on response")
             _asm_request_context.call_waf_callback()
-            if core.get_item(WAF_CONTEXT_NAMES.BLOCKED, span=req_span):
+            if core.get_item(HTTP_REQUEST_BLOCKED, span=req_span):
                 # response code must be set here, or it will be too late
                 ctype = (
                     "text/html"
@@ -267,29 +274,29 @@ def patch():
     _w(
         "werkzeug.datastructures",
         "Headers.items",
-        functools.partial(if_iast_taint_yield_tuple_for, (IAST.HTTP_REQUEST_HEADER_NAME, IAST.HTTP_REQUEST_HEADER)),
+        functools.partial(if_iast_taint_yield_tuple_for, (HTTP_REQUEST_HEADER_NAME, HTTP_REQUEST_HEADER)),
     )
     _w(
         "werkzeug.datastructures",
         "EnvironHeaders.__getitem__",
-        functools.partial(if_iast_taint_returned_object_for, IAST.HTTP_REQUEST_HEADER),
+        functools.partial(if_iast_taint_returned_object_for, HTTP_REQUEST_HEADER),
     )
     _w(
         "werkzeug.datastructures",
         "ImmutableMultiDict.__getitem__",
-        functools.partial(if_iast_taint_returned_object_for, IAST.HTTP_REQUEST_PARAMETER),
+        functools.partial(if_iast_taint_returned_object_for, HTTP_REQUEST_PARAMETER),
     )
     _w("werkzeug.wrappers.request", "Request.__init__", taint_request_init)
     _w(
         "werkzeug.wrappers.request",
         "Request.get_data",
-        functools.partial(if_iast_taint_returned_object_for, IAST.HTTP_REQUEST_BODY),
+        functools.partial(if_iast_taint_returned_object_for, HTTP_REQUEST_BODY),
     )
     if flask_version < (2, 0, 0):
         _w(
             "werkzeug._internal",
             "_DictAccessorProperty.__get__",
-            functools.partial(if_iast_taint_returned_object_for, IAST.HTTP_REQUEST_QUERYSTRING),
+            functools.partial(if_iast_taint_returned_object_for, HTTP_REQUEST_QUERY),
         )
 
     # flask.app.Flask methods that have custom tracing (add metadata, wrap functions, etc)
@@ -666,10 +673,10 @@ def _set_block_tags(span):
 
 def _block_request_callable(span):
     request = flask.request
-    core.set_item(WAF_CONTEXT_NAMES.BLOCKED, True, span=span)
+    core.set_item(HTTP_REQUEST_BLOCKED, True, span=span)
     _set_block_tags(span)
     ctype = "text/html" if "text/html" in request.headers.get("Accept", "").lower() else "text/json"
-    abort(flask.Response(utils._get_blocked_template(ctype), content_type=ctype, status=403))
+    abort(flask.Response(http_utils._get_blocked_template(ctype), content_type=ctype, status=403))
 
 
 def request_tracer(name):
@@ -697,7 +704,7 @@ def request_tracer(name):
             request_span.set_tag_str(COMPONENT, config.flask.integration_name)
 
             request_span._ignore_exception(werkzeug.exceptions.NotFound)
-            if config._appsec_enabled and core.get_item(WAF_CONTEXT_NAMES.BLOCKED, span=span):
+            if config._appsec_enabled and core.get_item(HTTP_REQUEST_BLOCKED, span=span):
                 _asm_request_context.block_request()
             return wrapped(*args, **kwargs)
 
@@ -755,7 +762,7 @@ def _set_request_tags(span):
 
             request.cookies = LazyTaintDict(
                 request.cookies,
-                origins=(IAST.HTTP_REQUEST_COOKIE_NAME, IAST.HTTP_REQUEST_COOKIE_VALUE),
+                origins=(HTTP_REQUEST_COOKIE_NAME, HTTP_REQUEST_COOKIE_VALUE),
                 override_pyobject_tainted=True,
             )
 

--- a/ddtrace/contrib/flask/wrappers.py
+++ b/ddtrace/contrib/flask/wrappers.py
@@ -1,9 +1,9 @@
 from ddtrace import config
 import ddtrace.appsec._asm_request_context as _asmrc
-from ddtrace.appsec._constants import IAST
-from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.appsec.iast._util import _is_iast_enabled
 from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal.constants import HTTP_REQUEST_PATH_PARAMETER
+from ddtrace.internal.constants import REQUEST_PATH_PARAMS
 from ddtrace.vendor.wrapt import function_wrapper
 
 from .. import trace_utils
@@ -37,7 +37,7 @@ def wrap_view(instance, func, name=None, resource=None):
             if config._appsec_enabled and _asmrc.in_context():
                 log.debug("Flask WAF call for Suspicious Request Blocking on request")
                 if kwargs:
-                    _asmrc.set_waf_address(SPAN_DATA_NAMES.REQUEST_PATH_PARAMS, kwargs)
+                    _asmrc.set_waf_address(REQUEST_PATH_PARAMS, kwargs)
                 _asmrc.call_waf_callback()
                 if _asmrc.is_blocked():
                     callback_block = _asmrc.get_value(_asmrc._CALLBACKS, "flask_block")
@@ -50,7 +50,7 @@ def wrap_view(instance, func, name=None, resource=None):
                 from ddtrace.appsec.iast._taint_tracking import taint_pyobject
 
                 for k, v in kwargs.items():
-                    kwargs[k] = taint_pyobject(v, Input_info(k, v, IAST.HTTP_REQUEST_PATH_PARAMETER))
+                    kwargs[k] = taint_pyobject(v, Input_info(k, v, HTTP_REQUEST_PATH_PARAMETER))
 
             return wrapped(*args, **kwargs)
 


### PR DESCRIPTION
This change updates some import statements in the flask and wsgi contribs to avoid referencing the AppSec product code when importing internal code. This helps clarify the separation of concerns between AppSec and contribs.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
