### PR TITLE
chore(langchain): ignore tagging complex prompt templates

### DIFF
--- a/ddtrace/contrib/langchain/patch.py
+++ b/ddtrace/contrib/langchain/patch.py
@@ -27,6 +27,7 @@ from ddtrace.internal.agent import get_stats_url
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import asbool
+from ddtrace.internal.utils.formats import deep_getattr
 from ddtrace.pin import Pin
 
 
@@ -564,8 +565,9 @@ def traced_chain_call(langchain, pin, func, instance, args, kwargs):
         if integration.is_pc_sampled_span(span):
             for k, v in inputs.items():
                 span.set_tag_str("langchain.request.inputs.%s" % k, integration.trunc(str(v)))
-            if hasattr(instance, "prompt"):
-                span.set_tag_str("langchain.request.prompt", integration.trunc(str(instance.prompt.template)))
+            template = deep_getattr(instance, "prompt.template", default="")
+            if template:
+                span.set_tag_str("langchain.request.prompt", integration.trunc(str(template)))
         final_outputs = func(*args, **kwargs)
         if integration.is_pc_sampled_span(span):
             for k, v in final_outputs.items():
@@ -590,7 +592,7 @@ def traced_chain_call(langchain, pin, func, instance, args, kwargs):
                 "sampled %s.%s" % (instance.__module__, instance.__class__.__name__),
                 attrs={
                     "inputs": log_inputs,
-                    "prompt": str(instance.prompt.template) if hasattr(instance, "prompt") else "",
+                    "prompt": str(deep_getattr(instance, "prompt.template", default="")),
                     "outputs": log_outputs,
                 },
             )
@@ -609,8 +611,9 @@ async def traced_chain_acall(langchain, pin, func, instance, args, kwargs):
         if integration.is_pc_sampled_span(span):
             for k, v in inputs.items():
                 span.set_tag_str("langchain.request.inputs.%s" % k, integration.trunc(str(v)))
-            if hasattr(instance, "prompt"):
-                span.set_tag_str("langchain.request.prompt", integration.trunc(str(instance.prompt.template)))
+            template = deep_getattr(instance, "prompt.template", default="")
+            if template:
+                span.set_tag_str("langchain.request.prompt", integration.trunc(str(template)))
         final_outputs = await func(*args, **kwargs)
         if integration.is_pc_sampled_span(span):
             for k, v in final_outputs.items():
@@ -635,7 +638,7 @@ async def traced_chain_acall(langchain, pin, func, instance, args, kwargs):
                 "sampled %s.%s" % (instance.__module__, instance.__class__.__name__),
                 attrs={
                     "inputs": log_inputs,
-                    "prompt": str(instance.prompt.template) if hasattr(instance, "prompt") else "",
+                    "prompt": str(deep_getattr(instance, "prompt.template", default="")),
                     "outputs": log_outputs,
                 },
             )

--- a/tests/contrib/langchain/test_langchain.py
+++ b/tests/contrib/langchain/test_langchain.py
@@ -1032,9 +1032,9 @@ def test_chain_logs(langchain, ddtrace_config_langchain, request_vcr, mock_logs,
 
 def test_chat_prompt_template_does_not_parse_template(langchain, mock_tracer):
     """
-    Test that tracing a chain with a ChatPromptTemplate does not try to parse the template,
-    as ChatPromptTemplates contain multiple messages each with their own prompt template and
-    are not trivial to tag.
+    Test that tracing a chain with a ChatPromptTemplate does not try to directly parse the template,
+    as ChatPromptTemplates do not contain a specific template attribute (which will lead to an attribute error)
+    but instead contain multiple messages each with their own prompt template and are not trivial to tag.
     """
     with mock.patch("langchain.chat_models.openai.ChatOpenAI._generate", side_effect=Exception("Mocked Error")):
         with pytest.raises(Exception) as exc_info:


### PR DESCRIPTION
Builds on top of work done by @NarekA in #6369. This PR does not need a changelog as the LangChain integration has not been released yet.

Current behavior of the traced LangChain chain is to grab the `prompt.template` attribute from the chain instance, but certain `PromptTemplate` classes do not have simple string `template` attributes which causes errors when we look these items up in code. For example the `ChatPromptTemplate` class stores a list of messages each with their own prompt template, making this non-trivial to parse and tag.

As a result, we'll check if simple string templates are available on the PromptTemplate, and do nothing otherwise. In the future, we can consider tagging complex prompt values, but this is outside the scope of this PR (which aims to avoid raising errors by us looking up non-existent template attributes).

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no rexease note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
