### PR TITLE
fix(profiling): use re-entrant lock in recorder

### DIFF
--- a/ddtrace/profiling/recorder.py
+++ b/ddtrace/profiling/recorder.py
@@ -38,7 +38,7 @@ class Recorder(object):
     """A dict of {event_type_class: max events} to limit the number of events to record."""
 
     events = attr.ib(init=False, repr=False, eq=False, type=EventsType)
-    _events_lock = attr.ib(init=False, repr=False, factory=threading.Lock, eq=False)
+    _events_lock = attr.ib(init=False, repr=False, factory=threading.RLock, eq=False)
 
     def __attrs_post_init__(self):
         # type: (...) -> None

--- a/releasenotes/notes/fix-profiler-recorder-rrlock-3c16195829e29acd.yaml
+++ b/releasenotes/notes/fix-profiler-recorder-rrlock-3c16195829e29acd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    profiling: prevent deadlocks while recording events of different type.


### PR DESCRIPTION
Prevent the event recorder from deadlocking on itself when multiple events are being recorded along the same call stack

Fixes #6308.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
