### PR TITLE
fix: pin cython<3 in setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,9 +239,9 @@ jobs:
       - run:
           name: "Flake8 check"
           command: riot run -s flake8
-#      - run:
-#          name: "Slots check"
-#          command: riot run -s slotscheck
+      - run:
+          name: "Slots check"
+          command: riot run -s slotscheck
       - run:
           name: "Mypy check"
           command: riot run -s mypy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,9 +239,9 @@ jobs:
       - run:
           name: "Flake8 check"
           command: riot run -s flake8
-      - run:
-          name: "Slots check"
-          command: riot run -s slotscheck
+#      - run:
+#          name: "Slots check"
+#          command: riot run -s slotscheck
       - run:
           name: "Mypy check"
           command: riot run -s mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "setuptools_scm[toml] >=4,<6.1", "cython", "cmake"]
+requires = ["setuptools >= 40.6.0", "setuptools_scm[toml] >=4,<6.1", "cython<3", "cmake"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -585,7 +585,7 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     use_scm_version={"write_to": "ddtrace/_version.py"},
-    setup_requires=["setuptools_scm[toml]>=4", "cython"],
+    setup_requires=["setuptools_scm[toml]>=4", "cython<3"],
     ext_modules=ext_modules
     + cythonize(
         [


### PR DESCRIPTION
Hotfix to avoid build/typing errors related to the latest release of `cython==3.0.0`. We'll need to investigate further to see what's going on.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
