### PR TITLE
fix(ci): break wheel building into multiple jobs

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -18,10 +18,7 @@ on:
     types:
       - published
   workflow_dispatch:
-    inputs:
-      expectedVersion:
-        description: 'Expected version string'
-        required: true
+    # Allow manually triggering, but do NOT upload the result
   schedule:
     # Nightly builds after weekdays
     - cron:  0 2 * * 2-6
@@ -83,56 +80,35 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
-  build_wheels_py3:
-    name: Build and test wheels on ${{ matrix.os }} (${{ matrix.archs }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-         - os: ubuntu-latest
-           archs: x86_64 i686
-         - os: ubuntu-latest
-           archs: aarch64
-         - os: windows-latest
-           archs: AMD64 x86
-         - os: macos-latest
-           archs: x86_64 universal2
-    steps:
-      - uses: actions/checkout@v3
-        # Include all history and tags
-        with:
-          fetch-depth: 0
+  build_wheels_py36:
+    uses: ./.github/workflows/build_python_3.yml
+    with:
+      cibw_build: 'cp36*'
 
-      - uses: actions/setup-python@v4
-        name: Install Python
-        with:
-          python-version: '3.8'
+  build_wheels_py37:
+    uses: ./.github/workflows/build_python_3.yml
+    with:
+      cibw_build: 'cp37*'
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
+  build_wheels_py38:
+    uses: ./.github/workflows/build_python_3.yml
+    with:
+      cibw_build: 'cp38*'
 
-      - name: Build wheels python 3.6 and above
-        uses: pypa/cibuildwheel@v2.12.3
-        env:
-          # configure cibuildwheel to build native archs ('auto'), and some
-          # emulated ones
-          CIBW_ARCHS: ${{ matrix.archs }}
-          CIBW_BUILD: cp3*
-          # Run a smoke test on every supported platform
-          CIBW_TEST_COMMAND: python {project}/tests/smoke_test.py
-          # Testing arm on MacOS is currently not supported by Github
-          CIBW_TEST_SKIP: "*-macosx_universal2:arm64"
-          # Workaround for Macos 11.0 versioning issue, a.k.a.
-          # `platform.mac_ver()` reports incorrect MacOS version at 11.0
-          # See: https://stackoverflow.com/a/65402241
-          CIBW_ENVIRONMENT_MACOS: SYSTEM_VERSION_COMPAT=0
+  build_wheels_py39:
+    uses: ./.github/workflows/build_python_3.yml
+    with:
+      cibw_build: 'cp39*'
 
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./wheelhouse/*.whl
+  build_wheels_py310:
+    uses: ./.github/workflows/build_python_3.yml
+    with:
+      cibw_build: 'cp310*'
+
+  build_wheels_py311:
+    uses: ./.github/workflows/build_python_3.yml
+    with:
+      cibw_build: 'cp311*'
 
   build_sdist:
     name: Build source distribution
@@ -187,24 +163,23 @@ jobs:
         working-directory: /
 
   upload_pypi:
-    needs: [build_wheels_py27_35, build_wheels_py3, test_alpine_sdist]
+    needs:
+      - build_wheels_py27_35
+      - build_wheels_py36
+      - build_wheels_py37
+      - build_wheels_py38
+      - build_wheels_py39
+      - build_wheels_py310
+      - build_wheels_py311
+      - test_alpine_sdist
     runs-on: ubuntu-latest
-    if: (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch')
+    if: (github.event_name == 'release' && github.event.action == 'published')
     steps:
       - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
 
-      - uses: actions/checkout@v3
-        if: github.event_name == 'workflow_dispatch'
-        # Include all history and tags
-        with:
-          fetch-depth: 0
-      - name: Validate deploy version
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          ./scripts/validate-version "${{ github.event.inputs.expectedVersion }}"
       - uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -1,0 +1,63 @@
+name: Build Python 3.6+
+
+on:
+  workflow_call:
+    inputs:
+      cibw_build:
+        required: true
+        type: string
+      cibw_skip:
+        required: false
+        type: string
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+         - os: ubuntu-latest
+           archs: x86_64 i686
+         - os: ubuntu-latest
+           archs: aarch64
+         - os: windows-latest
+           archs: AMD64 x86
+         - os: macos-latest
+           archs: x86_64 universal2
+    steps:
+      - uses: actions/checkout@v3
+        # Include all history and tags
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.8'
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
+      - name: Build wheels python 3.6 and above
+        uses: pypa/cibuildwheel@v2.12.3
+        env:
+          # configure cibuildwheel to build native archs ('auto'), and some
+          # emulated ones
+          CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_BUILD: ${{ inputs.cibw_build }}
+          CIBW_SKIp: ${{ inputs.cibw_skip }}
+          # Run a smoke test on every supported platform
+          CIBW_TEST_COMMAND: python {project}/tests/smoke_test.py
+          # Testing arm on MacOS is currently not supported by Github
+          CIBW_TEST_SKIP: "*-macosx_universal2:arm64"
+          # Workaround for Macos 11.0 versioning issue, a.k.a.
+          # `platform.mac_ver()` reports incorrect MacOS version at 11.0
+          # See: https://stackoverflow.com/a/65402241
+          CIBW_ENVIRONMENT_MACOS: SYSTEM_VERSION_COMPAT=0
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl


### PR DESCRIPTION
In order to combat the ever increasing build/release time we are breaking up the build/publish job into multiple jobs so the work can be better parallelized.

Before this change the build process would take at least 4 hours (sometimes more, or timing out at 6 hours), after this change it completes in about 1.5 hours.

The Python 2.7 + 3.5 build job is kept as-is with no changes.

For Python 3.6+ we have created a reusable workflow and then creates one build step per-python version that we want to support (3.6, 3.7, 3.8, 3.9, 3.10, 3.11).

This change also changes the `workflow_dispatch` trigger to not publish to PyPI so it can be used to validate the build process without releasing.

This change was validated by running manually, and then validating that the number of release files and the release tags created match what was published on PyPI for ddtrace==1.16.1.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
