### PR TITLE
fix(profiling): use re-entrant lock in recorder [backport #6374 to 1.17]

### DIFF
--- a/ddtrace/profiling/recorder.py
+++ b/ddtrace/profiling/recorder.py
@@ -38,7 +38,7 @@ class Recorder(object):
     """A dict of {event_type_class: max events} to limit the number of events to record."""
 
     events = attr.ib(init=False, repr=False, eq=False, type=EventsType)
-    _events_lock = attr.ib(init=False, repr=False, factory=threading.Lock, eq=False)
+    _events_lock = attr.ib(init=False, repr=False, factory=threading.RLock, eq=False)
 
     def __attrs_post_init__(self):
         # type: (...) -> None

--- a/releasenotes/notes/fix-profiler-recorder-rrlock-3c16195829e29acd.yaml
+++ b/releasenotes/notes/fix-profiler-recorder-rrlock-3c16195829e29acd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    profiling: prevent deadlocks while recording events of different type.


### PR DESCRIPTION
Backport of #6374 to 1.17

Prevent the event recorder from deadlocking on itself when multiple events are being recorded along the same call stack

## Testing Strategy

The occurrence of the issue seems to be circumstantial, which makes it reproducing it difficult. We have evidence from user reports that the proposed fix does indeed solve the issue.

## Risks

It is unclear at the moment whether a re-entrant lock would expose the recorder to an infinite recursion issue instead of a deadlock. Possible reports of such issues might be related to this, in which case a more sophisticated fix would be required.

Fixes #6308.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
