### PR TITLE
chore(internal): make square brackets mostly optional in dispatch() calls

### DIFF
--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -93,7 +93,7 @@ flask_version = parse_version(flask_version_str)
 
 def wrapped_request_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
-    core.dispatch("flask.request_init", [instance])
+    core.dispatch("flask.request_init", instance)
 
 
 def wrap_with_event(module, name, origin):
@@ -118,7 +118,7 @@ class _FlaskWSGIMiddleware(_DDWSGIMiddlewareBase):
     _response_call_name = "flask.response"
 
     def _wrapped_start_response(self, start_response, ctx, status_code, headers, exc_info=None):
-        core.dispatch("flask.start_response.pre", [flask.request, ctx, config.flask, status_code, headers])
+        core.dispatch("flask.start_response.pre", flask.request, ctx, config.flask, status_code, headers)
 
         if not core.get_item(HTTP_REQUEST_BLOCKED):
             headers_from_context = ""
@@ -130,7 +130,7 @@ class _FlaskWSGIMiddleware(_DDWSGIMiddlewareBase):
                 ctype = "text/html" if "text/html" in headers_from_context else "text/json"
                 response_headers = [("content-type", ctype)]
                 result = start_response("403 FORBIDDEN", response_headers)
-                core.dispatch("flask.start_response.blocked", [config.flask, response_headers])
+                core.dispatch("flask.start_response.blocked", config.flask, response_headers)
             else:
                 result = start_response(status_code, headers)
         else:
@@ -146,14 +146,20 @@ class _FlaskWSGIMiddleware(_DDWSGIMiddlewareBase):
         req_body = None
         results, exceptions = core.dispatch(
             "flask.request_call_modifier",
-            [ctx, config.flask, request, environ, _HAS_JSON_MIXIN, FLASK_VERSION, flask_version_str],
+            ctx,
+            config.flask,
+            request,
+            environ,
+            _HAS_JSON_MIXIN,
+            FLASK_VERSION,
+            flask_version_str,
         )
         if not any(exceptions) and results and any(results):
             for result in results:
                 if result is not None:
                     req_body = result
                     break
-        core.dispatch("flask.request_call_modifier.post", [ctx, config.flask, request, req_body])
+        core.dispatch("flask.request_call_modifier.post", ctx, config.flask, request, req_body)
 
 
 def patch():
@@ -409,7 +415,7 @@ def patched_finalize_request(wrapped, instance, args, kwargs):
     Wrapper for flask.app.Flask.finalize_request
     """
     rv = wrapped(*args, **kwargs)
-    core.dispatch("flask.finalize_request.post", [rv])
+    core.dispatch("flask.finalize_request.post", rv)
     return rv
 
 
@@ -495,7 +501,7 @@ def patched_render(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     def _wrap(template, context, app):
-        core.dispatch("flask.render", [template, config.flask])
+        core.dispatch("flask.render", template, config.flask)
         return wrapped(*args, **kwargs)
 
     return _wrap(*args, **kwargs)
@@ -517,7 +523,7 @@ def patched_register_error_handler(wrapped, instance, args, kwargs):
 
 def _block_request_callable(call):
     core.set_item(HTTP_REQUEST_BLOCKED, True)
-    core.dispatch("flask.blocked_request_callable", [call])
+    core.dispatch("flask.blocked_request_callable", call)
     ctype = "text/html" if "text/html" in flask.request.headers.get("Accept", "").lower() else "text/json"
     abort(flask.Response(http_utils._get_blocked_template(ctype), content_type=ctype, status=403))
 

--- a/ddtrace/internal/core.py
+++ b/ddtrace/internal/core.py
@@ -47,8 +47,16 @@ class EventHub:
             del self._listeners
         self._listeners = defaultdict(list)
 
-    def dispatch(self, event_id, args):
-        # type: (str, List[Optional[Any]]) -> Tuple[List[Optional[Any]], List[Optional[Exception]]]
+    def dispatch(self, event_id, args, *other_args):
+        # type: (str, Any, ...) -> Tuple[List[Optional[Any]], List[Optional[Exception]]]
+        if not isinstance(args, list):
+            args = [args] + list(other_args)
+        else:
+            assert not other_args, (
+                "When the first argument expected by the event handler is a list, all arguments "
+                "must be passed in a list. For example, use dispatch('foo', [[l1, l2], arg2]) "
+                "instead of dispatch('foo', [l1, l2], arg2)."
+            )
         log.debug("Dispatching event %s", event_id)
         results = []
         exceptions = []
@@ -83,9 +91,9 @@ def reset_listeners():
     _EVENT_HUB.get().reset()  # type: ignore
 
 
-def dispatch(event_id, args):
+def dispatch(event_id, args, *other_args):
     # type: (str, List[Optional[Any]]) -> Tuple[List[Optional[Any]], List[Optional[Exception]]]
-    return _EVENT_HUB.get().dispatch(event_id, args)  # type: ignore
+    return _EVENT_HUB.get().dispatch(event_id, args, *other_args)  # type: ignore
 
 
 class ExecutionContext:


### PR DESCRIPTION
This change makes `core.dispatch` accept either a list of arguments or a variable number of arguments, removing the need for most calls to use square brackets around argument lists. Calls that use no arguments still have to pass an empty list, as well as calls that build their argument lists dynamically.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
