### PR TITLE
chore(ci): improve kafka tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,26 +56,18 @@ services:
         image: redis:4.0-alpine
         ports:
             - "127.0.0.1:6379:6379"
-    zookeeper:
-      image: confluentinc/cp-zookeeper:7.3.1
-      environment:
-        - ZOOKEEPER_CLIENT_PORT=2181
-        - ZOOKEEPER_TICK_TIME=2000
-      ports:
-        - "127.0.0.1:22181:2181"
     kafka:
-      image: confluentinc/cp-kafka:7.3.2
+      image: bitnami/kafka:3.5.1
       ports:
         - "127.0.0.1:29092:29092"
       environment:
-        - KAFKA_BROKER_ID=1
-        - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-        - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
-        - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-        - KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT
-        - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
-      depends_on:
-        - zookeeper
+        - ALLOW_PLAINTEXT_LISTENER=yes
+        - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:29092
+        - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:29092
+        - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+        - KAFKA_CFG_BROKER_ID=1
+        - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+        - KAFKA_CFGOFFSETS_TOPIC_REPLICATION_FACTOR=1
     rediscluster:
         platform: linux/amd64
         image: grokzen/redis-cluster:6.2.0

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -299,7 +299,6 @@ def _generate_in_subprocess(random_topic):
 @pytest.mark.snapshot(
     token="tests.contrib.kafka.test_kafka.test_service_override_env_var", ignores=["metrics.kafka.message_offset"]
 )
-@pytest.mark.flaky(retries=5)  # The kafka-confluent API encounters segfaults occasionally
 def test_service_override_env_var(ddtrace_run_python_code_in_subprocess, kafka_topic):
     code = """
 import sys
@@ -324,7 +323,6 @@ if __name__ == "__main__":
 
 
 @pytest.mark.snapshot(ignores=["metrics.kafka.message_offset"])
-@pytest.mark.flaky(retries=5)  # The kafka-confluent API encounters segfaults occasionally
 @pytest.mark.parametrize("service", [None, "mysvc"])
 @pytest.mark.parametrize("schema", [None, "v0", "v1"])
 def test_schematized_span_service_and_operation(ddtrace_run_python_code_in_subprocess, service, schema, kafka_topic):


### PR DESCRIPTION
This improves the Kafka test suite by not having it using the global tracer but instead creating a new instance for each test case. This way we can do a flush and shutdown at the end of every snapshot test.

This means we can isolate any test case modifications like the ones used by DSM.

This updates and simplifies the kafka polling filter.

We have removed the unused `@pytest.mark.flaky` annotations which removes this warning log:
> PytestUnknownMarkWarning: Unknown pytest.mark.flaky - is this a typo?

Lastly, this updated the docker image to use `bitnami/kafka` and removes the requirement to also run `zookeeper`.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
