### PR TITLE
ci: run framework tests only when necessary

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -13,8 +13,23 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+  needs-run:
+    runs-on: ubuntu-latest
+    outputs:
+      outcome: ${{ steps.run_needed.outcome }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: run_needed
+        name: Check if run is needed
+        run:  |
+          git fetch origin ${{ github.event.pull_request.base.sha }}
+          export PATHS=$(git diff --name-only HEAD ${{ github.event.pull_request.base.sha }})
+          python -c "import os,sys,fnmatch;sys.exit(not bool([_ for pattern in {'ddtrace/*', 'setup*', 'pyproject.toml'} for _ in fnmatch.filter(os.environ['PATHS'].splitlines(), pattern)]))"
+        continue-on-error: true
+
   bottle-testsuite-0_12_19:
     runs-on: ubuntu-latest
+    needs: needs-run
     env:
       DD_PROFILING_ENABLED: true
       DD_TESTING_RAISE: true
@@ -23,19 +38,24 @@ jobs:
         working-directory: bottle
     steps:
       - uses: actions/setup-python@v4
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: bottlepy/bottle
           ref: master
           path: bottle
       - name: Install Dependencies
+        if: needs.needs-run.outputs.outcome == 'success'
         run: sudo apt-get install -y libev-dev
       - name: Test dependencies (Server back-ends and template engines)
+        if: needs.needs-run.outputs.outcome == 'success'
       # Taken from install script inside of .github/workflows of test suite (https://github.com/bottlepy/bottle/blob/master/.github/workflows/run_tests.yml)
         run: |
           pip install -U pip pytest
@@ -45,15 +65,18 @@ jobs:
             pip install $name || echo "Failed to install $name with $(python -V 2>&1)" 1>&2
           done
       - name: Inject ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install ../ddtrace
         # Allows tests to continue through deprecation warnings for jinja2 and mako
       - name: Run tests
+        if: needs.needs-run.outputs.outcome == 'success'
         # Disable all test_simple tests because they check for
         # log output and it contains phony error messages.
         run: PYTHONPATH=../ddtrace/tests/debugging/exploration/ ddtrace-run pytest test --continue-on-collection-errors -v -k 'not test_simple'
 
   sanic-testsuite-22_12:
     runs-on: ubuntu-20.04
+    needs: needs-run
     env:
       # Regression test for DataDog/dd-trace-py/issues/5722
       DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE: true
@@ -62,21 +85,27 @@ jobs:
         working-directory: sanic
     steps:
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: sanic-org/sanic
           ref: v22.12.0
           path: sanic
       - uses: actions/setup-python@v4
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: "3.11"
       - name: Install sanic and dependencies required to run tests
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip3 install '.[test]' aioquic
       - name: Install ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip3 install ../ddtrace
       - name: Run tests
+        if: needs.needs-run.outputs.outcome == 'success'
         run: ddtrace-run pytest -k "not test_add_signal and not test_ode_removes and not test_skip_touchup and not test_dispatch_signal_triggers and not test_keep_alive_connection_context"
 
   django-testsuite-3_1:
@@ -90,6 +119,7 @@ jobs:
             expl_profiler: 0
             expl_coverage: 1
     runs-on: ubuntu-latest
+    needs: needs-run
     name: Django 3.1 (with ${{ matrix.suffix }})
     env:
       DD_PROFILING_ENABLED: true
@@ -106,29 +136,37 @@ jobs:
         working-directory: django
     steps:
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: django/django
           ref: stable/3.1.x
           path: django
       - uses: actions/setup-python@v4
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: "3.8"
       - name: Install pylibmc libmemcached package
+        if: needs.needs-run.outputs.outcome == 'success'
         # Django-specific: pylibmc in Ubuntu requires libmemcached package
         run: |
           sudo apt update -qq
           sudo apt install --no-install-recommends -qqyf libmemcached-dev zlib1g
       - name: Install dependencies
+        if: needs.needs-run.outputs.outcome == 'success'
         # Django-specific: separate dependencies for tests
         run: pip install -r tests/requirements/py3.txt
       - name: Install ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install ../ddtrace
       - name: Install django
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install -e .
       - name: Disable unsupported tests
+        if: needs.needs-run.outputs.outcome == 'success'
         run: |
           # Note: test_supports_json_field_operational_error will fail with the tracer
           # DEV: Insert @skipUnless before the test definition
@@ -145,11 +183,13 @@ jobs:
           sed -i'' 's/test_custom_fields/custom_fields/' tests/inspectdb/tests.py
 
       - name: Run tests
+        if: needs.needs-run.outputs.outcome == 'success'
         # django.tests.requests module interferes with requests library patching in the tracer -> disable requests patch
         run: DD_TRACE_REQUESTS_ENABLED=0 ddtrace-run tests/runtests.py
 
   graphene-testsuite-3_0:
     runs-on: ubuntu-latest
+    needs: needs-run
     env:
       DD_PROFILING_ENABLED: true
       DD_TESTING_RAISE: true
@@ -159,9 +199,11 @@ jobs:
         working-directory: graphene
     steps:
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: graphql-python/graphene
           # TODO: bump ref to `graphene>3.0.0`.
@@ -169,21 +211,27 @@ jobs:
           ref: 03277a55123fd2f8a8465c5fa671f7fb0d004c26
           path: graphene
       - uses: actions/setup-python@v4
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: "3.9"
       - name: Install graphene
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install -e "../graphene[test]"
       - name: "Upgrade pytest_asyncio"
+        if: needs.needs-run.outputs.outcome == 'success'
         # pytest_asyncio==0.17 raises `assert type in (None, "pathlist", "args", "linelist", "bool")`
         # https://github.com/graphql-python/graphene/blob/03277a55123fd2f8a8465c5fa671f7fb0d004c26/setup.py#L52
         run: pip install "pytest-asyncio>0.17,<2"
       - name: Install ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install ../ddtrace
       - name: Run tests
+        if: needs.needs-run.outputs.outcome == 'success'
         run: ddtrace-run pytest graphene
 
   fastapi-testsuite-0_92:
     runs-on: ubuntu-latest
+    needs: needs-run
     env:
       DD_TESTING_RAISE: true
       DD_PROFILING_ENABLED: true
@@ -192,31 +240,38 @@ jobs:
         working-directory: fastapi
     steps:
       - uses: actions/setup-python@v4
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: tiangolo/fastapi
           ref: 0.92.0
           path: fastapi
       - uses: actions/cache@v3.3.1
+        if: needs.needs-run.outputs.outcome == 'success'
         id: cache
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-python-${{ env.pythonLocation }}-fastapi
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'true' && needs.needs-run.outputs.outcome == 'success'
         run: pip install -e .[all,dev,doc,test]
       - name: Inject ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install ../ddtrace
       - name: Test
+        if: needs.needs-run.outputs.outcome == 'success'
         run: PYTHONPATH=../ddtrace/tests/debugging/exploration/ ddtrace-run pytest -p no:warnings tests
 
   flask-testsuite-1_1_4:
     runs-on: ubuntu-latest
+    needs: needs-run
     env:
       TOX_TESTENV_PASSENV: DD_TESTING_RAISE DD_PROFILING_ENABLED
       DD_TESTING_RAISE: true
@@ -227,23 +282,30 @@ jobs:
         working-directory: flask
     steps:
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: pallets/flask
           ref: 1.1.4
           path: flask
       - uses: actions/setup-python@v4
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.8'
       - name: Install tox
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install tox
       - name: Create tox env
+        if: needs.needs-run.outputs.outcome == 'success'
         run: tox -e py38 --notest
       - name: Add pytest configuration for ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: echo -e "[pytest]\nddtrace-patch-all = 1" > pytest.ini
       - name: Run tests
+        if: needs.needs-run.outputs.outcome == 'success'
         # test_exception_propagation is broken upstream
         run: |
           source .tox/py38/bin/activate
@@ -254,28 +316,36 @@ jobs:
 
   httpx-testsuite-0_22_0:
     runs-on: ubuntu-latest
+    needs: needs-run
     defaults:
       run:
         working-directory: httpx
     steps:
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: encode/httpx
           ref: 0.22.0
           path: httpx
       - uses: actions/setup-python@v4
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
       - name: Install dependencies
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install -r requirements.txt
       - name: Inject ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install ../ddtrace
       - name: Add pytest configuration for ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: echo -e "[pytest]\nddtrace-patch-all = 1" > pytest.ini
       - name: Run tests
+        if: needs.needs-run.outputs.outcome == 'success'
         env:
           # Disabled distributed tracing since there are a lot of tests that assert on headers
           DD_HTTPX_DISTRIBUTED_TRACING: "false"
@@ -286,6 +356,7 @@ jobs:
 
   mako-testsuite-1_1_4:
     runs-on: ubuntu-latest
+    needs: needs-run
     env:
       TOX_TESTENV_PASSENV: DD_TESTING_RAISE DD_PROFILING_ENABLED
       DD_TESTING_RAISE: true
@@ -296,25 +367,33 @@ jobs:
         working-directory: mako
     steps:
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: sqlalchemy/mako
           ref: rel_1_1_4
           path: mako
       - uses: actions/setup-python@v4
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.8'
       - name: Install tox
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install tox
       - name: Pin pygments to avoid breaking test
+        if: needs.needs-run.outputs.outcome == 'success'
         run: sed -i 's/pygments/pygments~=2.11.0/' tox.ini
       - name: Create tox env
+        if: needs.needs-run.outputs.outcome == 'success'
         run: tox -e py --notest
       - name: Add pytest configuration for ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: echo -e "[pytest]\nddtrace-patch-all = 1" > pytest.ini
       - name: Run tests
+        if: needs.needs-run.outputs.outcome == 'success'
         run: |
           source .tox/py/bin/activate
           pip install ../ddtrace
@@ -323,6 +402,7 @@ jobs:
 
   starlette-testsuite-0_17_1:
     runs-on: "ubuntu-latest"
+    needs: needs-run
     env:
       DD_TESTING_RAISE: true
       DD_PROFILING_ENABLED: true
@@ -332,30 +412,38 @@ jobs:
         working-directory: starlette
     steps:
       - uses: actions/setup-python@v4
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: encode/starlette
           ref: 0.17.1
           path: starlette
       - name: Install ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install ../ddtrace
       - name: Install dependencies
+        if: needs.needs-run.outputs.outcome == 'success'
         run: scripts/install
       # with urllib3 2.0 we are seeing IncompleteRead errors, pinning while investigating root issue.
       - name: Pin urllib3
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install urllib3==1.26.15
       #Parameters for keyword expression skip 3 failing tests that are expected due to asserting on headers. The errors are because our context propagation headers are being added
       #test_staticfiles_with_invalid_dir_permissions_returns_401 fails with and without ddtrace enabled
       - name: Run tests
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pytest -W ignore --ddtrace-patch-all tests -k 'not test_request_headers and not test_subdomain_route and not test_websocket_headers and not test_staticfiles_with_invalid_dir_permissions_returns_401'
 
   requests-testsuite-2_26_0:
     runs-on: "ubuntu-latest"
+    needs: needs-run
     env:
       DD_TESTING_RAISE: true
       DD_PROFILING_ENABLED: true
@@ -364,28 +452,36 @@ jobs:
         working-directory: requests
     steps:
       - uses: actions/setup-python@v4
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: psf/requests
           ref: v2.26.0
           path: requests
       - name: Install ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install ../ddtrace
       - name: Install dependencies
+        if: needs.needs-run.outputs.outcome == 'success'
         run: "make init"
       - name: MarkupSafe fix
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install --upgrade MarkupSafe==2.0.1
       - name: Run tests
+        if: needs.needs-run.outputs.outcome == 'success'
         run: PYTHONPATH=../ddtrace/tests/debugging/exploration/ ddtrace-run pytest -p no:warnings tests
 
   asyncpg-testsuite-0_27_0:
     # https://github.com/MagicStack/asyncpg/blob/v0.25.0/.github/workflows/tests.yml#L125
     runs-on: "ubuntu-latest"
+    needs: needs-run
     env:
       DD_TESTING_RAISE: true
       DD_PROFILING_ENABLED: true
@@ -394,12 +490,15 @@ jobs:
         working-directory: asyncpg
     steps:
       - uses: actions/setup-python@v4
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: magicstack/asyncpg
           ref: v0.27.0
@@ -407,18 +506,22 @@ jobs:
           fetch-depth: 50
           submodules: true
       - name: Install ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install ../ddtrace
       - name: Install dependencies
+        if: needs.needs-run.outputs.outcome == 'success'
         run: |
           python -m pip install -U pip setuptools wheel pytest
           python -m pip install -e .[test]
       - name: Run tests
+        if: needs.needs-run.outputs.outcome == 'success'
         # Disable tests checking GC references since profiling can interfere
         run: ddtrace-run python -m pytest -k 'not test_record_gc and not test_record_get and not test_record_items and not test_record_iter' tests
 
   pylons-testsuite-1_0_3:
     name: Pylons 1.0.3
     runs-on: "ubuntu-20.04"
+    needs: needs-run
     # Ubuntu 20.04 is the last version of ubuntu on github setup actions to provide Python 2.7.
     container:
       image: python:2.7.18-buster
@@ -430,31 +533,40 @@ jobs:
         working-directory: pylons
     steps:
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: pylons/pylons
           ref: master
           path: pylons
       - name: Install ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install ../ddtrace
       - name: Install test dependencies
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install -e .[test]
       - name: Pin PasteDeploy to Python 2.7 compatible version
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install pastedeploy==2.1.1
       - name: MarkupSafe fix
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install --upgrade MarkupSafe==0.18 pip setuptools --force
       - name: Disable failing tests
+        if: needs.needs-run.outputs.outcome == 'success'
         run: |
           sed -i'' "s/test_detect_lang/detect_lang/g" tests/test_units/test_basic_app.py
           sed -i'' "s/test_langs/langs/g" tests/test_units/test_basic_app.py
       - name: Run tests
+        if: needs.needs-run.outputs.outcome == 'success'
         run: nosetests
 
   gunicorn-testsuite-20_1_0:
     name: gunicorn 20.1.0
     runs-on: "ubuntu-latest"
+    needs: needs-run
     env:
       DD_TESTING_RAISE: true
       # PYTHONPATH: ../ddtrace/tests/debugging/exploration/
@@ -463,17 +575,21 @@ jobs:
         working-directory: gunicorn
     steps:
       - uses: actions/setup-python@v4
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: benoitc/gunicorn
           ref: 20.1.0
           path: gunicorn
       - name: Run tests
+        if: needs.needs-run.outputs.outcome == 'success'
         run: |
           . ../ddtrace/.github/workflows/setup-tox.sh py39
           
@@ -483,6 +599,7 @@ jobs:
   uwsgi-testsuite-2_0_21:
     name: uwsgi 2.0.21
     runs-on: "ubuntu-latest"
+    needs: needs-run
     env:
       DD_TESTING_RAISE: true
       DD_PROFILING_ENABLED: true
@@ -492,33 +609,43 @@ jobs:
         working-directory: uwsgi
     steps:
       - uses: actions/setup-python@v4
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
       - uses: actions/checkout@v3
+        if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: unbit/uwsgi
           ref: 2.0.21
           path: uwsgi
       - name: Install dependencies
+        if: needs.needs-run.outputs.outcome == 'success'
         run: |
           sudo apt update -qq
           sudo apt install --no-install-recommends -qqyf python3-dev \
             libpcre3-dev libjansson-dev libcap2-dev \
             curl check
       - name: Install distutils
+        if: needs.needs-run.outputs.outcome == 'success'
         run: sudo apt install --no-install-recommends -qqyf python3-distutils
       - name: Install ddtrace
+        if: needs.needs-run.outputs.outcome == 'success'
         run: pip install ../ddtrace
       - name: Build uwsgi binary
+        if: needs.needs-run.outputs.outcome == 'success'
         run: make
       - name: Build Python plugin
+        if: needs.needs-run.outputs.outcome == 'success'
         run: |
           python -V
           python uwsgiconfig.py --plugin plugins/python base python39
       - name: Run Python tests
+        if: needs.needs-run.outputs.outcome == 'success'
         run: ddtrace-run ./tests/gh-python.sh python39
       - name: Run deadlock tests
+        if: needs.needs-run.outputs.outcome == 'success'
         run: ddtrace-run ./tests/gh-deadlocks.sh python39


### PR DESCRIPTION
We filter on paths within the repository that require the framework tests to run to avoid running them when not necessary. To do this we introduce an extra check job that we make a dependency for the test suites. If the check job determines that no tests are required, the steps within each framework test is not run. This way we can still effectively run the job, which is required by PRs, but turn them into no-op for a quicker and cheaper feedback.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
