### PR TITLE
chore(ci): re-add circleci config coverage parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,15 @@ python310_image: &python310_image cimg/python:3.10
 
 setup: true
 
+parameters:
+  coverage:
+    type: boolean
+    default: false
+  riot_run_latest:
+    type: boolean
+    default: false
+
+
 orbs:
   continuation: circleci/continuation@0.1.2
 


### PR DESCRIPTION
#6412 changed our circleci configuration setup to be dynamic, but this inadvertently removed the `coverage` and `riot_run_latest` circleci pipeline parameters from the main `.circleci/config.yml` file, which breaks our nightly 1.x coverage pipeline runs. This PR re-adds those parameters back and re-enables coverage reporting. 

Note that `datastreams`, `langchain`, `elasticsearch`, `integration-snapshot` test suites are still failing on 1.x nightly coverage runs and will need to be fixed.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
