### PR TITLE
ci: run tests when riotfile changes

### DIFF
--- a/scripts/needs_testrun.py
+++ b/scripts/needs_testrun.py
@@ -199,7 +199,7 @@ def get_patterns(suite: str) -> t.Set[str]:
 def needs_testrun(suite: str, pr_number: int) -> bool:
     """Check if a testrun is needed for a suite and PR
 
-    >>> needs_testrun("debugger", 6412)
+    >>> needs_testrun("debugger", 6485)
     False
     >>> needs_testrun("debugger", 6388)
     True

--- a/scripts/needs_testrun.py
+++ b/scripts/needs_testrun.py
@@ -169,8 +169,8 @@ def get_patterns(suite: str) -> t.Set[str]:
     'ddtrace/sampler.py', 'ddtrace/settings/__init__.py', 'ddtrace/settings/config.py',
     'ddtrace/settings/dynamic_instrumentation.py', 'ddtrace/settings/exception_debugging.py',
     'ddtrace/settings/http.py', 'ddtrace/settings/integration.py', 'ddtrace/span.py', 'ddtrace/tracer.py',
-    'tests/commands/*', 'tests/debugging/*', 'tests/integration/*', 'tests/internal/*', 'tests/lib-injection',
-    'tests/tracer/*']
+    'riotfile.py', 'scripts/ddtest', 'tests/commands/*', 'tests/debugging/*', 'tests/integration/*',
+    'tests/internal/*', 'tests/lib-injection', 'tests/tracer/*']
     >>> get_patterns("foobar")
     set()
     """

--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -5,7 +5,9 @@
             "ddtrace/__init__.py",
             "tests/internal/*",
             "tests/integration/*",
-            "tests/lib-injection"
+            "tests/lib-injection",
+            "riotfile.py",
+            "scripts/ddtest"
         ],
         "bootstrap": [
             "ddtrace/bootstrap/*",


### PR DESCRIPTION
This change ensures that test suites run when changes to the riotfile or testrunner script are pull requested.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
