### PR TITLE
fix(runtime metrics): ensure collection lambda reference isn't reused between loops

### DIFF
--- a/ddtrace/internal/runtime/metric_collectors.py
+++ b/ddtrace/internal/runtime/metric_collectors.py
@@ -82,7 +82,7 @@ class PSUtilRuntimeMetricCollector(RuntimeMetricCollector):
                 metrics[metric] = delta
 
             # Populate metrics that just take instantaneous reading
-            for metric, fun in self.abs_funs.items():
+            for metric, func in self.abs_funs.items():
                 try:
                     value = func(self.proc)
                 except Exception:


### PR DESCRIPTION
A typo in the new runtime metrics implementation led to all instantaneous-type metrics to shadow the value (in procfs) of a "delta" metric.  This led to values such as `num_threads` monotonically increasing over the lifetime of a process, as well as just being outrageously incorrect.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
