### PR TITLE
chore(fmt): make isort changes caught by precheck job

### DIFF
--- a/ddtrace/internal/_encoding.pyi
+++ b/ddtrace/internal/_encoding.pyi
@@ -5,6 +5,7 @@ from typing import Union
 
 from ddtrace.span import Span
 
+
 Trace = List[Span]
 
 class ListStringTable(object):

--- a/ddtrace/internal/_tagset.pyi
+++ b/ddtrace/internal/_tagset.pyi
@@ -1,5 +1,6 @@
 from typing import Dict
 
+
 class TagsetDecodeError(ValueError): ...
 class TagsetEncodeError(ValueError): ...
 

--- a/ddtrace/internal/datadog/profiling/ddup.pyi
+++ b/ddtrace/internal/datadog/profiling/ddup.pyi
@@ -3,6 +3,7 @@ from typing import Optional
 
 from ddtrace.span import Span
 
+
 def init(
     env: Optional[str],
     service: Optional[str],

--- a/ddtrace/profiling/_build.pyi
+++ b/ddtrace/profiling/_build.pyi
@@ -1,3 +1,4 @@
 import typing
 
+
 compiled_with: typing.Tuple[int, int, int]

--- a/ddtrace/profiling/_threading.pyi
+++ b/ddtrace/profiling/_threading.pyi
@@ -1,6 +1,7 @@
 import typing
 import weakref
 
+
 def get_thread_name(thread_id: int) -> str: ...
 def get_thread_native_id(thread_id: int) -> int: ...
 

--- a/ddtrace/profiling/collector/_memalloc.pyi
+++ b/ddtrace/profiling/collector/_memalloc.pyi
@@ -1,5 +1,6 @@
 import typing
 
+
 # (filename, line number, function name)
 FrameType = typing.Tuple[str, int, str]
 

--- a/ddtrace/profiling/collector/_task.pyi
+++ b/ddtrace/profiling/collector/_task.pyi
@@ -1,6 +1,7 @@
 import types
 import typing
 
+
 def get_task(
     thread_id: int,
 ) -> typing.Tuple[typing.Optional[int], typing.Optional[str], typing.Optional[types.FrameType]]: ...

--- a/ddtrace/profiling/collector/_traceback.pyi
+++ b/ddtrace/profiling/collector/_traceback.pyi
@@ -3,6 +3,7 @@ import typing
 
 from .. import event
 
+
 def traceback_to_frames(
     traceback: types.TracebackType, max_nframes: int
 ) -> typing.Tuple[typing.List[event.FrameType], int]: ...

--- a/ddtrace/profiling/collector/stack.pyi
+++ b/ddtrace/profiling/collector/stack.pyi
@@ -3,5 +3,6 @@ import typing
 import ddtrace
 from ddtrace.profiling import collector
 
+
 class StackCollector(collector.PeriodicCollector):
     tracer: typing.Optional[ddtrace.Tracer]

--- a/ddtrace/profiling/exporter/pprof.pyi
+++ b/ddtrace/profiling/exporter/pprof.pyi
@@ -8,6 +8,7 @@ from ddtrace.profiling.collector import memalloc
 from ddtrace.profiling.collector import stack_event
 from ddtrace.profiling.collector import threading as threading
 
+
 stdlib_path: Any
 platstdlib_path: Any
 purelib_path: Any


### PR DESCRIPTION
The `precheck:formatting` job on CircleCI has been catching 10 formatting issues but has never failed. This PR makes the suggested isort changes.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
