### PR TITLE
chore(ci-visibility): unshallow repository when git >= 2.27 [backport 1.17]

### DIFF
--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -272,6 +272,7 @@ def pytest_configure(config):
 
 def pytest_sessionstart(session):
     if _CIVisibility.enabled:
+        log.debug("CI Visibility enabled - starting test session")
         test_session_span = _CIVisibility._instance.tracer.trace(
             "pytest.test_session",
             service=_CIVisibility._instance._service,
@@ -289,6 +290,7 @@ def pytest_sessionstart(session):
 
 def pytest_sessionfinish(session, exitstatus):
     if _CIVisibility.enabled:
+        log.debug("CI Visibility enabled - finishing test session")
         test_session_span = _extract_span(session)
         if test_session_span is not None:
             _mark_test_status(session, test_session_span)

--- a/ddtrace/internal/ci_visibility/git_client.py
+++ b/ddtrace/internal/ci_visibility/git_client.py
@@ -7,11 +7,14 @@ from typing import Optional  # noqa
 from typing import Tuple  # noqa
 
 from ddtrace.ext import ci
+from ddtrace.ext.git import _get_rev_list
+from ddtrace.ext.git import _is_shallow_repository
+from ddtrace.ext.git import _unshallow_repository
 from ddtrace.ext.git import build_git_packfiles
 from ddtrace.ext.git import extract_commit_sha
+from ddtrace.ext.git import extract_git_version
 from ddtrace.ext.git import extract_latest_commits
 from ddtrace.ext.git import extract_remote_url
-from ddtrace.ext.git import get_rev_list_excluding_commits
 from ddtrace.internal.agent import get_trace_url
 from ddtrace.internal.compat import JSONDecodeError
 from ddtrace.internal.logger import get_logger
@@ -76,9 +79,22 @@ class CIVisibilityGitClient(object):
     def _run_protocol(cls, serializer, requests_mode, base_url, _tags={}, _response=None, cwd=None):
         # type: (CIVisibilityGitClientSerializerV1, int, str, Dict[str, str], Optional[Response], Optional[str]) -> None
         repo_url = cls._get_repository_url(tags=_tags, cwd=cwd)
+
+        if cls._is_shallow_repository(cwd=cwd) and extract_git_version(cwd=cwd) >= (2, 27, 0):
+            log.debug("Shallow repository detected on git > 2.27 detected, unshallowing")
+            try:
+                cls._unshallow_repository(cwd=cwd)
+                log.debug("Unshallowing done")
+            except ValueError:
+                log.warning("Failed to unshallow repository, continuing to send pack data", exc_info=True)
+
         latest_commits = cls._get_latest_commits(cwd=cwd)
         backend_commits = cls._search_commits(requests_mode, base_url, repo_url, latest_commits, serializer, _response)
-        rev_list = cls._get_filtered_revisions(backend_commits, cwd=cwd)
+        commits_not_in_backend = list(set(latest_commits) - set(backend_commits))
+
+        rev_list = cls._get_filtered_revisions(
+            excluded_commits=backend_commits, included_commits=commits_not_in_backend, cwd=cwd
+        )
         if rev_list:
             with cls._build_packfiles(rev_list, cwd=cwd) as packfiles_prefix:
                 cls._upload_packfiles(
@@ -128,9 +144,9 @@ class CIVisibilityGitClient(object):
         return result
 
     @classmethod
-    def _get_filtered_revisions(cls, excluded_commits, cwd=None):
-        # type: (list[str], Optional[str]) -> list[str]
-        return get_rev_list_excluding_commits(excluded_commits, cwd=cwd)
+    def _get_filtered_revisions(cls, excluded_commits, included_commits=None, cwd=None):
+        # type: (list[str], Optional[list[str]], Optional[str]) -> str
+        return _get_rev_list(excluded_commits, included_commits, cwd=cwd)
 
     @classmethod
     def _build_packfiles(cls, revisions, cwd=None):
@@ -155,6 +171,16 @@ class CIVisibilityGitClient(object):
             if response.status != 204:
                 return False
         return True
+
+    @classmethod
+    def _is_shallow_repository(cls, cwd=None):
+        # type () -> bool
+        return _is_shallow_repository(cwd=cwd)
+
+    @classmethod
+    def _unshallow_repository(cls, cwd=None):
+        # type () -> None
+        _unshallow_repository(cwd=cwd)
 
 
 class CIVisibilityGitClientSerializerV1(object):

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -292,6 +292,8 @@ class CIVisibility(Service):
             self._test_suites_to_skip = []
             return
 
+        self._test_suites_to_skip = []
+
         if response.status >= 400:
             log.warning("Test skips request responded with status %d", response.status)
             return
@@ -301,7 +303,6 @@ class CIVisibility(Service):
             log.warning("Test skips request responded with invalid JSON '%s'", response.body)
             return
 
-        self._test_suites_to_skip = []
         for item in parsed["data"]:
             if item["type"] == TEST_SKIPPING_LEVEL and "suite" in item["attributes"]:
                 module = item["attributes"].get("configurations", {}).get("test.bundle", "").replace(".", "/")

--- a/tests/tracer/test_ci.py
+++ b/tests/tracer/test_ci.py
@@ -227,3 +227,73 @@ def test_os_runtime_metadata_tagging():
     assert extracted_tags.get(ci.OS_VERSION) is not None
     assert extracted_tags.get(ci.RUNTIME_NAME) is not None
     assert extracted_tags.get(ci.RUNTIME_VERSION) is not None
+
+
+def test_get_rev_list_no_args_git_ge_223(git_repo):
+    with mock.patch("ddtrace.ext.git._git_subprocess_cmd") as mock_git_subprocess, mock.patch(
+        "ddtrace.ext.git.extract_git_version", return_value=(2, 23, 0)
+    ):
+        mock_git_subprocess.return_value = ["commithash1", "commithash2"]
+        assert git._get_rev_list(cwd=git_repo) == ["commithash1", "commithash2"]
+        mock_git_subprocess.assert_called_once_with(
+            ["rev-list", "--objects", "--filter=blob:none", '--since="1 month ago"', "--no-object-names", "HEAD"],
+            cwd=git_repo,
+        )
+
+
+def test_get_rev_list_git_lt_223(git_repo):
+    with mock.patch("ddtrace.ext.git._git_subprocess_cmd") as mock_git_subprocess, mock.patch(
+        "ddtrace.ext.git.extract_git_version", return_value=(2, 22, 0)
+    ):
+        mock_git_subprocess.return_value = ["commithash1", "commithash2"]
+        assert git._get_rev_list(
+            excluded_commit_shas=["exclude1", "exclude2"], included_commit_shas=["include1", "include2"], cwd=git_repo
+        ) == ["commithash1", "commithash2"]
+        mock_git_subprocess.assert_called_once_with(
+            ["rev-list", "--objects", "--filter=blob:none", "HEAD", "^exclude1", "^exclude2", "include1", "include2"],
+            cwd=git_repo,
+        )
+
+
+def test_is_shallow_repository_true(git_repo):
+    with mock.patch("ddtrace.ext.git._git_subprocess_cmd", return_value="true") as mock_git_subprocess:
+        assert git._is_shallow_repository(cwd=git_repo) is True
+        mock_git_subprocess.assert_called_once_with("rev-parse --is-shallow-repository", cwd=git_repo)
+
+
+def test_is_shallow_repository_false(git_repo):
+    with mock.patch("ddtrace.ext.git._git_subprocess_cmd", return_value="false") as mock_git_subprocess:
+        assert git._is_shallow_repository(cwd=git_repo) is False
+        mock_git_subprocess.assert_called_once_with("rev-parse --is-shallow-repository", cwd=git_repo)
+
+
+def test_unshallow_repository(git_repo):
+    with mock.patch(
+        "ddtrace.ext.git._extract_clone_defaultremotename", return_value="myremote"
+    ) as mock_defaultremotename:
+        with mock.patch(
+            "ddtrace.ext.git.extract_commit_sha", return_value="mycommitshaaaaaaaaaaaa123"
+        ) as mock_extract_sha:
+            with mock.patch("ddtrace.ext.git._git_subprocess_cmd") as mock_git_subprocess:
+                git._unshallow_repository(cwd=git_repo)
+
+                mock_defaultremotename.assert_called_once_with(git_repo)
+                mock_extract_sha.assert_called_once_with(git_repo)
+                mock_git_subprocess.assert_called_once_with(
+                    [
+                        "fetch",
+                        "--update-shallow",
+                        "--filter=blob:none",
+                        "--recurse-submodules=no",
+                        '--shallow-since="1 month ago"',
+                        "myremote",
+                        "mycommitshaaaaaaaaaaaa123",
+                    ],
+                    cwd=git_repo,
+                )
+
+
+def test_extract_clone_defaultremotename():
+    with mock.patch("ddtrace.ext.git._git_subprocess_cmd", return_value="default_remote_name") as mock_git_subprocess:
+        assert git._extract_clone_defaultremotename(cwd=git_repo) == "default_remote_name"
+        mock_git_subprocess.assert_called_once_with("config --default origin --get clone.defaultRemoteName")


### PR DESCRIPTION
Backport https://github.com/DataDog/dd-trace-py/commit/d4d2f78 from https://github.com/DataDog/dd-trace-py/pull/6268 to 1.17.

An unshallow command compatible with git >= 2.27 is now used when a shallow repository is detected.

Additionally, packfile upload is improved by searching for commits found in the repo that are not known to the ITR backend, rather than just HEAD.

For tests, a shallow clone was created using `git clone --depth=1 https://github.com/pallets/flask.git`, with git log showing only one result:
```
% git log --pretty=oneline
cb825687a592709f902f3d320d93987a0546fd28 (grafted, HEAD -> main, origin/main, origin/HEAD) Bump actions/checkout from 3.5.2 to 3.5.3 (#5186)
```

After:
```
cb825687a592709f902f3d320d93987a0546fd28 (HEAD -> main, origin/main, origin/HEAD) Bump actions/checkout from 3.5.2 to 3.5.3 (#5186)
51bf0fdd9018d63b7bc09db52a66b726c2c4bad8 Bump slsa-framework/slsa-github-generator from 1.6.0 to 1.7.0 (#5185)
0da5788efbda92b6b6239352c2b9a835efe0888f Bump dessant/lock-threads from 4.0.0 to 4.0.1 (#5184)
# ... ~20 lines
32d2f47ed1bf3f27fd46e1a54dd136688de9ab81 [pre-commit.ci] pre-commit autoupdate
c9b6110dec52ff483b42b1428221f903bf143788 (grafted) Merge branch '2.3.x'
7dbb2f7e05d2c0963e90016b1f7a3a45e98a865a (grafted) retarget pre-commit.ci
```

This is gated behind the unreleased Intelligent Test Runner (ITR) functionality, so there is no risk of unexpectedly unshallowing repositories.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

