### PR TITLE
fix(ci-visibility): fix ITR test skipping [backport 1.17]

### DIFF
--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -29,22 +29,26 @@ from ddtrace.contrib.pytest.constants import XFAIL_REASON
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import test
 from ddtrace.internal.ci_visibility import CIVisibility as _CIVisibility
+from ddtrace.internal.ci_visibility.constants import COVERAGE_TAG_NAME
 from ddtrace.internal.ci_visibility.constants import EVENT_TYPE as _EVENT_TYPE
 from ddtrace.internal.ci_visibility.constants import MODULE_ID as _MODULE_ID
 from ddtrace.internal.ci_visibility.constants import MODULE_TYPE as _MODULE_TYPE
 from ddtrace.internal.ci_visibility.constants import SESSION_ID as _SESSION_ID
 from ddtrace.internal.ci_visibility.constants import SESSION_TYPE as _SESSION_TYPE
+from ddtrace.internal.ci_visibility.constants import SUITE
 from ddtrace.internal.ci_visibility.constants import SUITE_ID as _SUITE_ID
 from ddtrace.internal.ci_visibility.constants import SUITE_TYPE as _SUITE_TYPE
-from ddtrace.internal.ci_visibility.coverage import _coverage_end
-from ddtrace.internal.ci_visibility.coverage import _coverage_start
-from ddtrace.internal.ci_visibility.coverage import _initialize
+from ddtrace.internal.ci_visibility.constants import TEST
+from ddtrace.internal.ci_visibility.coverage import _initialize_coverage
+from ddtrace.internal.ci_visibility.coverage import build_payload as build_coverage_payload
+from ddtrace.internal.ci_visibility.recorder import _get_test_skipping_level
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
 
 
 SKIPPED_BY_ITR = "Skipped by Datadog Intelligent Test Runner"
 PATCH_ALL_HELP_MSG = "Call ddtrace.patch_all before running tests."
+
 log = get_logger(__name__)
 
 
@@ -68,6 +72,22 @@ def _extract_span(item):
 def _store_span(item, span):
     """Store span at `pytest.Item` instance."""
     setattr(item, "_datadog_span", span)
+
+
+def _attach_coverage(item):
+    coverage = _initialize_coverage(str(item.config.rootdir))
+    setattr(item, "_coverage", coverage)
+    coverage.start()
+
+
+def _detach_coverage(item, span):
+    if not hasattr(item, "_coverage"):
+        return
+    span_id = str(span.trace_id)
+    item._coverage.stop()
+    span.set_tag(COVERAGE_TAG_NAME, build_coverage_payload(item._coverage, test_id=span_id))
+    item._coverage.erase()
+    del item._coverage
 
 
 def _extract_module_span(item):
@@ -201,7 +221,7 @@ def _start_test_module_span(pytest_package_item=None, pytest_module_item=None):
     return test_module_span, is_package
 
 
-def _start_test_suite_span(item, test_module_span):
+def _start_test_suite_span(item, test_module_span, should_enable_coverage=False):
     """
     Starts a test suite span at the start of a new pytest test module.
     Note that ``item`` is a ``pytest.Module`` object referencing the test file being run.
@@ -209,7 +229,6 @@ def _start_test_suite_span(item, test_module_span):
     test_session_span = _extract_span(item.session)
     if test_module_span is None and isinstance(item.parent, pytest.Package):
         test_module_span = _extract_span(item.parent)
-
     parent_span = test_module_span
     if parent_span is None:
         parent_span = test_session_span
@@ -237,6 +256,9 @@ def _start_test_suite_span(item, test_module_span):
         test_suite_span.set_tag_str(test.MODULE_PATH, test_module_path)
     test_suite_span.set_tag_str(test.SUITE, _get_suite_name(item, test_module_path))
     _store_span(item, test_suite_span)
+
+    if should_enable_coverage:
+        _attach_coverage(item)
     return test_suite_span
 
 
@@ -350,7 +372,7 @@ def pytest_collection_modifyitems(session, config, items):
     if _CIVisibility.test_skipping_enabled():
         skip = pytest.mark.skip(reason=SKIPPED_BY_ITR)
         for item in items:
-            if _CIVisibility._instance._should_skip_path(str(get_fslocation_from_item(item)[0])):
+            if _CIVisibility._instance._should_skip_path(str(get_fslocation_from_item(item)[0]), item.name):
                 item.add_marker(skip)
 
 
@@ -366,97 +388,113 @@ def pytest_runtest_protocol(item, nextitem):
         if "reason" in marker.kwargs and marker.kwargs["reason"] == SKIPPED_BY_ITR
     ]
 
-    if is_skipped_by_itr:
+    test_session_span = _extract_span(item.session)
+
+    pytest_module_item = _find_pytest_item(item, pytest.Module)
+    pytest_package_item = _find_pytest_item(pytest_module_item, pytest.Package)
+
+    module_is_package = True
+
+    test_module_span = _extract_span(pytest_package_item)
+    if not test_module_span:
+        test_module_span = _extract_module_span(pytest_module_item)
+        if test_module_span:
+            module_is_package = False
+
+    if test_module_span is None:
+        test_module_span, module_is_package = _start_test_module_span(pytest_package_item, pytest_module_item)
+
+    test_suite_span = _extract_span(pytest_module_item)
+    if pytest_module_item is not None and test_suite_span is None:
+        # Start coverage for the test suite if coverage is enabled
+        test_suite_span = _start_test_suite_span(
+            pytest_module_item,
+            test_module_span,
+            should_enable_coverage=(
+                _get_test_skipping_level() == SUITE
+                and _CIVisibility._instance._collect_coverage_enabled
+                and not is_skipped_by_itr
+            ),
+        )
+
+    with _CIVisibility._instance.tracer._start_span(
+        ddtrace.config.pytest.operation_name,
+        service=_CIVisibility._instance._service,
+        resource=item.nodeid,
+        span_type=SpanTypes.TEST,
+        activate=True,
+    ) as span:
+        span.set_tag_str(COMPONENT, "pytest")
+        span.set_tag_str(SPAN_KIND, KIND)
+        span.set_tag_str(test.FRAMEWORK, FRAMEWORK)
+        span.set_tag_str(_EVENT_TYPE, SpanTypes.TEST)
+        span.set_tag_str(test.NAME, item.name)
+        span.set_tag_str(test.COMMAND, _get_pytest_command(item.config))
+        span.set_tag_str(_SESSION_ID, str(test_session_span.span_id))
+
+        span.set_tag_str(_MODULE_ID, str(test_module_span.span_id))
+        span.set_tag_str(test.MODULE, test_module_span.get_tag(test.MODULE))
+        span.set_tag_str(test.MODULE_PATH, test_module_span.get_tag(test.MODULE_PATH))
+
+        span.set_tag_str(_SUITE_ID, str(test_suite_span.span_id))
+        test_class_hierarchy = _get_test_class_hierarchy(item)
+        if test_class_hierarchy:
+            span.set_tag_str(test.CLASS_HIERARCHY, test_class_hierarchy)
+        if hasattr(item, "dtest") and isinstance(item.dtest, DocTest):
+            span.set_tag_str(test.SUITE, "{}.py".format(item.dtest.globs["__name__"]))
+        else:
+            span.set_tag_str(test.SUITE, test_suite_span.get_tag(test.SUITE))
+
+        span.set_tag_str(test.TYPE, SpanTypes.TEST)
+        span.set_tag_str(test.FRAMEWORK_VERSION, pytest.__version__)
+
+        if item.location and item.location[0]:
+            _CIVisibility.set_codeowners_of(item.location[0], span=span)
+
+        # We preemptively set FAIL as a status, because if pytest_runtest_makereport is not called
+        # (where the actual test status is set), it means there was a pytest error
+        span.set_tag_str(test.STATUS, test.Status.FAIL.value)
+
+        # Parameterized test cases will have a `callspec` attribute attached to the pytest Item object.
+        # Pytest docs: https://docs.pytest.org/en/6.2.x/reference.html#pytest.Function
+        if getattr(item, "callspec", None):
+            parameters = {"arguments": {}, "metadata": {}}  # type: Dict[str, Dict[str, str]]
+            for param_name, param_val in item.callspec.params.items():
+                try:
+                    parameters["arguments"][param_name] = encode_test_parameter(param_val)
+                except Exception:
+                    parameters["arguments"][param_name] = "Could not encode"
+                    log.warning("Failed to encode %r", param_name, exc_info=True)
+            span.set_tag_str(test.PARAMETERS, json.dumps(parameters))
+
+        markers = [marker.kwargs for marker in item.iter_markers(name="dd_tags")]
+        for tags in markers:
+            span.set_tags(tags)
+        _store_span(item, span)
+
+        coverage_per_test = (
+            _get_test_skipping_level() == TEST
+            and _CIVisibility._instance._collect_coverage_enabled
+            and not is_skipped_by_itr
+        )
+        if coverage_per_test:
+            _attach_coverage(item)
+        # Run the actual test
         yield
-    else:
-        test_session_span = _extract_span(item.session)
-
-        pytest_module_item = _find_pytest_item(item, pytest.Module)
-        pytest_package_item = _find_pytest_item(pytest_module_item, pytest.Package)
-
-        module_is_package = True
-
-        test_module_span = _extract_span(pytest_package_item)
-        if not test_module_span:
-            test_module_span = _extract_module_span(pytest_module_item)
-            if test_module_span:
-                module_is_package = False
-
-        if test_module_span is None:
-            test_module_span, module_is_package = _start_test_module_span(pytest_package_item, pytest_module_item)
-
-        test_suite_span = _extract_span(pytest_module_item)
-        if pytest_module_item is not None and test_suite_span is None:
-            test_suite_span = _start_test_suite_span(pytest_module_item, test_module_span)
-            # Start coverage for the test suite if coverage is enabled
-            if _CIVisibility._instance._collect_coverage_enabled:
-                _initialize(str(item.config.rootdir))
-                _coverage_start()
-
-        with _CIVisibility._instance.tracer._start_span(
-            ddtrace.config.pytest.operation_name,
-            service=_CIVisibility._instance._service,
-            resource=item.nodeid,
-            span_type=SpanTypes.TEST,
-            activate=True,
-        ) as span:
-            span.set_tag_str(COMPONENT, "pytest")
-            span.set_tag_str(SPAN_KIND, KIND)
-            span.set_tag_str(test.FRAMEWORK, FRAMEWORK)
-            span.set_tag_str(_EVENT_TYPE, SpanTypes.TEST)
-            span.set_tag_str(test.NAME, item.name)
-            span.set_tag_str(test.COMMAND, _get_pytest_command(item.config))
-            span.set_tag_str(_SESSION_ID, str(test_session_span.span_id))
-
-            span.set_tag_str(_MODULE_ID, str(test_module_span.span_id))
-            span.set_tag_str(test.MODULE, test_module_span.get_tag(test.MODULE))
-            span.set_tag_str(test.MODULE_PATH, test_module_span.get_tag(test.MODULE_PATH))
-
-            span.set_tag_str(_SUITE_ID, str(test_suite_span.span_id))
-            test_class_hierarchy = _get_test_class_hierarchy(item)
-            if test_class_hierarchy:
-                span.set_tag_str(test.CLASS_HIERARCHY, test_class_hierarchy)
-            if hasattr(item, "dtest") and isinstance(item.dtest, DocTest):
-                span.set_tag_str(test.SUITE, "{}.py".format(item.dtest.globs["__name__"]))
-            else:
-                span.set_tag_str(test.SUITE, test_suite_span.get_tag(test.SUITE))
-
-            span.set_tag_str(test.TYPE, SpanTypes.TEST)
-            span.set_tag_str(test.FRAMEWORK_VERSION, pytest.__version__)
-
-            if item.location and item.location[0]:
-                _CIVisibility.set_codeowners_of(item.location[0], span=span)
-
-            # We preemptively set FAIL as a status, because if pytest_runtest_makereport is not called
-            # (where the actual test status is set), it means there was a pytest error
-            span.set_tag_str(test.STATUS, test.Status.FAIL.value)
-
-            # Parameterized test cases will have a `callspec` attribute attached to the pytest Item object.
-            # Pytest docs: https://docs.pytest.org/en/6.2.x/reference.html#pytest.Function
-            if getattr(item, "callspec", None):
-                parameters = {"arguments": {}, "metadata": {}}  # type: Dict[str, Dict[str, str]]
-                for param_name, param_val in item.callspec.params.items():
-                    try:
-                        parameters["arguments"][param_name] = encode_test_parameter(param_val)
-                    except Exception:
-                        parameters["arguments"][param_name] = "Could not encode"
-                        log.warning("Failed to encode %r", param_name, exc_info=True)
-                span.set_tag_str(test.PARAMETERS, json.dumps(parameters))
-
-            markers = [marker.kwargs for marker in item.iter_markers(name="dd_tags")]
-            for tags in markers:
-                span.set_tags(tags)
-            _store_span(item, span)
-
-            # Run the actual test
-            yield
+        # Finish coverage for the test suite if coverage is enabled
+        if coverage_per_test:
+            _detach_coverage(item, span)
 
         nextitem_pytest_module_item = _find_pytest_item(nextitem, pytest.Module)
         if nextitem is None or nextitem_pytest_module_item != pytest_module_item and not test_suite_span.finished:
             _mark_test_status(pytest_module_item, test_suite_span)
             # Finish coverage for the test suite if coverage is enabled
-            if _CIVisibility._instance._collect_coverage_enabled:
-                _coverage_end(test_suite_span)
+            if (
+                _get_test_skipping_level() == SUITE
+                and _CIVisibility._instance._collect_coverage_enabled
+                and not is_skipped_by_itr
+            ):
+                _detach_coverage(pytest_module_item, test_suite_span)
             test_suite_span.finish()
 
             if not module_is_package:

--- a/ddtrace/internal/ci_visibility/constants.py
+++ b/ddtrace/internal/ci_visibility/constants.py
@@ -1,6 +1,9 @@
 from enum import IntEnum
 
 
+SUITE = "suite"
+TEST = "test"
+
 EVENT_TYPE = "type"
 
 

--- a/ddtrace/internal/ci_visibility/encoder.py
+++ b/ddtrace/internal/ci_visibility/encoder.py
@@ -1,7 +1,5 @@
 import json
 import threading
-from typing import Any
-from typing import Dict
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -16,11 +14,14 @@ from ddtrace.internal.ci_visibility.constants import SESSION_ID
 from ddtrace.internal.ci_visibility.constants import SESSION_TYPE
 from ddtrace.internal.ci_visibility.constants import SUITE_ID
 from ddtrace.internal.ci_visibility.constants import SUITE_TYPE
+from ddtrace.internal.ci_visibility.constants import TEST
 from ddtrace.internal.encoding import JSONEncoderV2
 from ddtrace.internal.writer.writer import NoEncodableSpansError
 
 
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import Any
+    from typing import Dict
     from typing import List
     from typing import Optional
 
@@ -195,8 +196,15 @@ class CIVisibilityCoverageEncoderV02(CIVisibilityEncoderV01):
     @staticmethod
     def _convert_span(span, dd_origin):
         # type: (Span, str) -> Dict[str, Any]
-        return {
+        converted_span = {
             "test_session_id": int(span.get_tag(SESSION_ID) or "1"),
             "test_suite_id": int(span.get_tag(SUITE_ID) or "1"),
             "files": json.loads(span.get_tag(COVERAGE_TAG_NAME))["files"],
         }
+
+        from ddtrace.internal.ci_visibility.recorder import _get_test_skipping_level
+
+        if _get_test_skipping_level() == TEST:
+            converted_span["span_id"] = span.span_id
+
+        return converted_span

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -1,14 +1,10 @@
+from collections import defaultdict
 import json
 import os
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Tuple
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import ddtrace
-from ddtrace import Tracer
 from ddtrace import config as ddconfig
 from ddtrace.contrib import trace_utils
 from ddtrace.ext import ci
@@ -24,8 +20,8 @@ from ddtrace.internal.compat import TimeoutError
 from ddtrace.internal.compat import parse
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.service import Service
+from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.writer.writer import Response
-from ddtrace.settings import IntegrationConfig
 
 from .. import agent
 from .constants import AGENTLESS_DEFAULT_SITE
@@ -36,13 +32,31 @@ from .constants import EVP_SUBDOMAIN_HEADER_NAME
 from .constants import REQUESTS_MODE
 from .constants import SETTING_ENDPOINT
 from .constants import SKIPPABLE_ENDPOINT
+from .constants import SUITE
+from .constants import TEST
 from .git_client import CIVisibilityGitClient
 from .writer import CIVisibilityWriter
 
 
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import Any
+    from typing import DefaultDict
+    from typing import Dict
+    from typing import List
+    from typing import Optional
+    from typing import Tuple
+
+    from ddtrace import Tracer
+    from ddtrace.settings import IntegrationConfig
+
 log = get_logger(__name__)
 
-TEST_SKIPPING_LEVEL = "suite"
+
+def _get_test_skipping_level():
+    return SUITE if asbool(os.getenv("_DD_CIVISIBILITY_ITR_SUITE_MODE", default=False)) else TEST
+
+
+TEST_SKIPPING_LEVEL = _get_test_skipping_level()
 DEFAULT_TIMEOUT = 15
 
 
@@ -79,6 +93,7 @@ class CIVisibility(Service):
     _instance = None  # type: Optional[CIVisibility]
     enabled = False
     _test_suites_to_skip = None  # type: Optional[List[str]]
+    _tests_to_skip = defaultdict(list)  # type: DefaultDict[str, List[str]]
 
     def __init__(self, tracer=None, config=None, service=None):
         # type: (Optional[Tracer], Optional[IntegrationConfig], Optional[str]) -> None
@@ -306,12 +321,19 @@ class CIVisibility(Service):
         for item in parsed["data"]:
             if item["type"] == TEST_SKIPPING_LEVEL and "suite" in item["attributes"]:
                 module = item["attributes"].get("configurations", {}).get("test.bundle", "").replace(".", "/")
-                self._test_suites_to_skip.append(
-                    "/".join((module, item["attributes"]["suite"])) if module else item["attributes"]["suite"]
-                )
+                path = "/".join((module, item["attributes"]["suite"])) if module else item["attributes"]["suite"]
 
-    def _should_skip_path(self, path):
-        return os.path.relpath(path) in self._test_suites_to_skip
+                if TEST_SKIPPING_LEVEL == SUITE:
+                    self._test_suites_to_skip.append(path)
+                else:
+                    self._tests_to_skip[path].append(item["attributes"]["name"])
+
+    def _should_skip_path(self, path, name):
+        if _get_test_skipping_level() == SUITE:
+            return os.path.relpath(path) in self._test_suites_to_skip
+        else:
+            return name in self._tests_to_skip[os.path.relpath(path)]
+        return False
 
     @classmethod
     def enable(cls, tracer=None, config=None, service=None):
@@ -353,7 +375,7 @@ class CIVisibility(Service):
             self.tracer.configure(settings={"FILTERS": tracer_filters})
         if self._git_client is not None:
             self._git_client.start(cwd=_get_git_repo())
-        if self.test_skipping_enabled() and self._test_suites_to_skip is None:
+        if self.test_skipping_enabled() and (not self._tests_to_skip and self._test_suites_to_skip is None):
             self._fetch_tests_to_skip()
 
     def _stop_service(self):

--- a/ddtrace/internal/ci_visibility/writer.py
+++ b/ddtrace/internal/ci_visibility/writer.py
@@ -1,16 +1,11 @@
 import os
-from typing import Dict
-from typing import List
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import ddtrace
 from ddtrace import config
-from ddtrace.vendor.dogstatsd import DogStatsd
 
 from .. import agent
 from .. import service
-from ...sampler import BasePrioritySampler
-from ...sampler import BaseSampler
 from ..runtime import get_runtime_id
 from ..writer import HTTPWriter
 from ..writer import WriterClientBase
@@ -26,6 +21,17 @@ from .constants import EVP_SUBDOMAIN_HEADER_COVERAGE_VALUE
 from .constants import EVP_SUBDOMAIN_HEADER_NAME
 from .encoder import CIVisibilityCoverageEncoderV02
 from .encoder import CIVisibilityEncoderV01
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import Dict
+    from typing import List
+    from typing import Optional
+
+    from ddtrace.vendor.dogstatsd import DogStatsd
+
+    from ...sampler import BasePrioritySampler
+    from ...sampler import BaseSampler
 
 
 class CIVisibilityEventClient(WriterClientBase):

--- a/releasenotes/notes/fix-itr-test-skipping-e4b99a581138a8fd.yaml
+++ b/releasenotes/notes/fix-itr-test-skipping-e4b99a581138a8fd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CI Visibility: This fix resolves an issue where test skipping was not working properly.

--- a/tests/ci_visibility/test_coverage.py
+++ b/tests/ci_visibility/test_coverage.py
@@ -1,15 +1,5 @@
-#!/usr/bin/env python3
-from ast import literal_eval
-from os import getcwd
-
 import pytest
 
-from ddtrace import Tracer
-from ddtrace.internal.ci_visibility.constants import COVERAGE_TAG_NAME
-from ddtrace.internal.ci_visibility.coverage import Coverage
-from ddtrace.internal.ci_visibility.coverage import _coverage_end
-from ddtrace.internal.ci_visibility.coverage import _coverage_start
-from ddtrace.internal.ci_visibility.coverage import _initialize
 from ddtrace.internal.ci_visibility.coverage import segments
 
 
@@ -25,28 +15,3 @@ from ddtrace.internal.ci_visibility.coverage import segments
 )
 def test_segments(lines, expected_segments):
     assert segments(lines) == expected_segments
-
-
-@pytest.mark.skipif(Coverage is None, reason="Coverage not available")
-def test_cover():
-    tracer = Tracer()
-    span = tracer.start_span("cover_span")
-
-    _initialize(getcwd())
-    _coverage_start()
-    pytest.main(["tests/utils.py"])
-    _coverage_end(span)
-
-    res = literal_eval(span.get_tag(COVERAGE_TAG_NAME))
-
-    assert "files" in res
-    assert len(res["files"]) == 3
-
-    for filename in [x["filename"] for x in res["files"]]:
-        assert filename.endswith(
-            (
-                "ddtrace/internal/module.py",
-                "ddtrace/contrib/pytest/plugin.py",
-                "ddtrace/internal/ci_visibility/coverage.py",
-            )
-        )

--- a/tests/ci_visibility/test_coverage_per_suite.py
+++ b/tests/ci_visibility/test_coverage_per_suite.py
@@ -1,0 +1,111 @@
+import json
+import os
+
+import mock
+import pytest
+
+import ddtrace
+from ddtrace.contrib.pytest.plugin import is_enabled
+from ddtrace.internal import compat
+from ddtrace.internal.ci_visibility import CIVisibility
+from ddtrace.internal.ci_visibility.constants import COVERAGE_TAG_NAME
+from tests.ci_visibility.test_encoder import _patch_dummy_writer
+from tests.utils import TracerTestCase
+from tests.utils import override_env
+
+
+class PytestTestCase(TracerTestCase):
+    @pytest.fixture(autouse=True)
+    def fixtures(self, testdir, monkeypatch, git_repo):
+        self.testdir = testdir
+        self.monkeypatch = monkeypatch
+        self.git_repo = git_repo
+
+    def inline_run(self, *args):
+        """Execute test script with test tracer."""
+
+        class CIVisibilityPlugin:
+            @staticmethod
+            def pytest_configure(config):
+                if is_enabled(config):
+                    with _patch_dummy_writer():
+                        assert CIVisibility.enabled
+                        CIVisibility.disable()
+                        CIVisibility.enable(tracer=self.tracer, config=ddtrace.config.pytest)
+
+        with override_env(dict(DD_API_KEY="foobar.baz")):
+            return self.testdir.inline_run(*args, plugins=[CIVisibilityPlugin()])
+
+    @pytest.mark.skipif(compat.PY2, reason="ddtrace does not support coverage on Python 2")
+    def test_pytest_will_report_coverage_by_suite(self):
+        self.testdir.makepyfile(
+            test_ret_false="""
+        def ret_false():
+            return False
+        """
+        )
+        self.testdir.makepyfile(
+            test_module="""
+        def lib_fn():
+            return True
+        """
+        )
+        py_cov_file = self.testdir.makepyfile(
+            test_cov="""
+        import pytest
+        from test_module import lib_fn
+
+        def test_cov():
+            assert lib_fn()
+
+        def test_second():
+            from test_ret_false import ret_false
+            assert not ret_false()
+        """
+        )
+        py_cov_file2 = self.testdir.makepyfile(
+            test_cov_second="""
+        import pytest
+
+        def test_second():
+            from test_ret_false import ret_false
+            assert not ret_false()
+        """
+        )
+
+        with mock.patch("ddtrace.contrib.pytest.plugin._get_test_skipping_level", return_value="suite"), mock.patch(
+            "ddtrace.internal.ci_visibility.recorder.CIVisibility._check_enabled_features", return_value=(True, False)
+        ):
+            self.inline_run("--ddtrace", os.path.basename(py_cov_file.strpath), os.path.basename(py_cov_file2.strpath))
+        spans = self.pop_spans()
+
+        test_suite_spans = [span for span in spans if span.get_tag("type") == "test_suite_end"]
+        first_suite_span = test_suite_spans[0]
+        assert first_suite_span.get_tag("type") == "test_suite_end"
+        assert COVERAGE_TAG_NAME in first_suite_span.get_tags()
+        tag_data = json.loads(first_suite_span.get_tag(COVERAGE_TAG_NAME))
+        files = sorted(tag_data["files"], key=lambda x: x["filename"])
+        assert len(files) == 3
+        assert files[0]["filename"] == "test_cov.py"
+        assert files[1]["filename"] == "test_module.py"
+        assert files[2]["filename"] == "test_ret_false.py"
+        assert len(files[0]["segments"]) == 2
+        assert files[0]["segments"][0] == [5, 0, 5, 0, -1]
+        assert files[0]["segments"][1] == [8, 0, 9, 0, -1]
+        assert len(files[1]["segments"]) == 1
+        assert files[1]["segments"][0] == [2, 0, 2, 0, -1]
+        assert len(files[2]["segments"]) == 1
+        assert files[2]["segments"][0] == [1, 0, 2, 0, -1]
+
+        second_suite_span = test_suite_spans[-1]
+        assert second_suite_span.get_tag("type") == "test_suite_end"
+        assert COVERAGE_TAG_NAME in second_suite_span.get_tags()
+        tag_data = json.loads(second_suite_span.get_tag(COVERAGE_TAG_NAME))
+        files = sorted(tag_data["files"], key=lambda x: x["filename"])
+        assert len(files) == 2
+        assert files[0]["filename"] == "test_cov_second.py"
+        assert files[1]["filename"] == "test_ret_false.py"
+        assert len(files[0]["segments"]) == 1
+        assert files[0]["segments"][0] == [4, 0, 5, 0, -1]
+        assert len(files[1]["segments"]) == 1
+        assert files[1]["segments"][0] == [2, 0, 2, 0, -1]

--- a/tests/ci_visibility/test_encoder.py
+++ b/tests/ci_visibility/test_encoder.py
@@ -1,7 +1,8 @@
-import contextlib
+from contextlib import contextmanager
 import json
 import os
 
+import mock
 import msgpack
 import pytest
 
@@ -86,7 +87,7 @@ def test_encode_traces_civisibility_v0():
         assert expected_event == received_event
 
 
-def test_encode_traces_civisibility_v2_coverage():
+def test_encode_traces_civisibility_v2_coverage_per_test():
     coverage_data = {
         "files": [
             {"filename": "test_cov.py", "segments": [[5, 0, 5, 0, -1]]},
@@ -116,6 +117,7 @@ def test_encode_traces_civisibility_v2_coverage():
     expected_cov = {
         b"test_session_id": int(coverage_span.get_tag(SESSION_ID)),
         b"test_suite_id": int(coverage_span.get_tag(SUITE_ID)),
+        b"span_id": 0xAAAAAA,
         b"files": [
             {k.encode("utf-8"): v.encode("utf-8") if isinstance(v, str) else v for k, v in file.items()}
             for file in coverage_data["files"]
@@ -124,6 +126,62 @@ def test_encode_traces_civisibility_v2_coverage():
     assert expected_cov == received_covs[0]
 
     complete_payload = encoder.encode()
+    assert isinstance(complete_payload, bytes)
+    payload_per_line = complete_payload.split(b"\r\n")
+    assert len(payload_per_line) == 11
+    assert payload_per_line[0].startswith(b"--")
+    boundary = payload_per_line[0][2:]
+    assert payload_per_line[1] == b'Content-Disposition: form-data; name="coverage1"; filename="coverage1.msgpack"'
+    assert payload_per_line[2] == b"Content-Type: application/msgpack"
+    assert payload_per_line[3] == b""
+    assert payload_per_line[4] == payload
+    assert payload_per_line[5] == payload_per_line[0]
+    assert payload_per_line[6] == b'Content-Disposition: form-data; name="event"; filename="event.json"'
+    assert payload_per_line[7] == b"Content-Type: application/json"
+    assert payload_per_line[8] == b""
+    assert payload_per_line[9] == b'{"dummy":true}'
+    assert payload_per_line[10] == b"--%s--" % boundary
+
+
+def test_encode_traces_civisibility_v2_coverage_per_suite():
+    coverage_data = {
+        "files": [
+            {"filename": "test_cov.py", "segments": [[5, 0, 5, 0, -1]]},
+            {"filename": "test_module.py", "segments": [[2, 0, 2, 0, -1]]},
+        ]
+    }
+    coverage_json = json.dumps(coverage_data)
+    coverage_span = Span(name=b"client.testing", span_id=0xAAAAAA, span_type="test", service="foo")
+    coverage_span.set_tag(COVERAGE_TAG_NAME, coverage_json)
+    coverage_span.set_tag(SUITE_ID, "12345")
+    coverage_span.set_tag(SESSION_ID, "67890")
+    traces = [
+        [Span(name=b"client.testing", span_id=0xAAAAAA, span_type="test", service="foo"), coverage_span],
+    ]
+
+    encoder = CIVisibilityCoverageEncoderV02(0, 0)
+    for trace in traces:
+        encoder.put(trace)
+    with mock.patch("ddtrace.internal.ci_visibility.recorder._get_test_skipping_level", return_value="suite"):
+        payload = encoder._build_data(traces)
+        complete_payload = encoder.encode()
+    assert isinstance(payload, msgpack_type)
+    decoded = msgpack.unpackb(payload, raw=True, strict_map_key=False)
+    assert decoded[b"version"] == 2
+
+    received_covs = decoded[b"coverages"]
+    assert len(received_covs) == 1
+
+    expected_cov = {
+        b"test_session_id": int(coverage_span.get_tag(SESSION_ID)),
+        b"test_suite_id": int(coverage_span.get_tag(SUITE_ID)),
+        b"files": [
+            {k.encode("utf-8"): v.encode("utf-8") if isinstance(v, str) else v for k, v in file.items()}
+            for file in coverage_data["files"]
+        ],
+    }
+    assert expected_cov == received_covs[0]
+
     assert isinstance(complete_payload, bytes)
     payload_per_line = complete_payload.split(b"\r\n")
     assert len(payload_per_line) == 11
@@ -165,7 +223,7 @@ def test_encode_traces_civisibility_v2_coverage_empty_traces():
     assert complete_payload is None
 
 
-@contextlib.contextmanager
+@contextmanager
 def _patch_dummy_writer():
     original = ddtrace.internal.ci_visibility.recorder.CIVisibilityWriter
     ddtrace.internal.ci_visibility.recorder.CIVisibilityWriter = DummyCIVisibilityWriter

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -145,7 +145,6 @@ class PytestTestCase(TracerTestCase):
             """
             import pytest
 
-
             @pytest.mark.parametrize('item', [1, 2, 3, 4, pytest.param([1, 2, 3], marks=pytest.mark.skip)])
             class Test1(object):
                 def test_1(self, item):
@@ -1409,7 +1408,13 @@ class PytestTestCase(TracerTestCase):
         assert test_suite_spans[0].get_tag("test.suite") == "test_cov.py"
 
     @pytest.mark.skipif(compat.PY2, reason="ddtrace does not support coverage on Python 2")
-    def test_pytest_will_report_coverage(self):
+    def test_pytest_will_report_coverage_by_test(self):
+        self.testdir.makepyfile(
+            test_ret_false="""
+        def ret_false():
+            return False
+        """
+        )
         self.testdir.makepyfile(
             test_module="""
         def lib_fn():
@@ -1419,10 +1424,14 @@ class PytestTestCase(TracerTestCase):
         py_cov_file = self.testdir.makepyfile(
             test_cov="""
         import pytest
-        from test_module import lib_fn
 
         def test_cov():
+            from test_module import lib_fn
             assert lib_fn()
+
+        def test_second():
+            from test_ret_false import ret_false
+            assert not ret_false()
         """
         )
 
@@ -1432,13 +1441,33 @@ class PytestTestCase(TracerTestCase):
             self.inline_run("--ddtrace", os.path.basename(py_cov_file.strpath))
         spans = self.pop_spans()
 
-        assert COVERAGE_TAG_NAME in spans[3].get_tags()
-        tag_data = json.loads(spans[3].get_tag(COVERAGE_TAG_NAME))
-        files = sorted(tag_data["files"], key=lambda x: x["filename"])
+        first_test_span = spans[0]
+        assert first_test_span.get_tag("test.name") == "test_cov"
+        assert first_test_span.get_tag("type") == "test"
+        assert COVERAGE_TAG_NAME in first_test_span.get_tags()
+        first_tag_data = json.loads(first_test_span.get_tag(COVERAGE_TAG_NAME))
+        files = sorted(first_tag_data["files"], key=lambda x: x["filename"])
+        assert len(files) == 2
         assert files[0]["filename"] == "test_cov.py"
         assert files[1]["filename"] == "test_module.py"
-        assert files[0]["segments"][0] == [5, 0, 5, 0, -1]
-        assert files[1]["segments"][0] == [2, 0, 2, 0, -1]
+        assert len(files[0]["segments"]) == 1
+        assert files[0]["segments"][0] == [4, 0, 5, 0, -1]
+        assert len(files[1]["segments"]) == 1
+        assert files[1]["segments"][0] == [1, 0, 2, 0, -1]
+
+        second_test_span = spans[1]
+        assert second_test_span.get_tag("type") == "test"
+        assert second_test_span.get_tag("test.name") == "test_second"
+        assert COVERAGE_TAG_NAME in second_test_span.get_tags()
+        second_tag_data = json.loads(second_test_span.get_tag(COVERAGE_TAG_NAME))
+        files = sorted(second_tag_data["files"], key=lambda x: x["filename"])
+        assert len(files) == 2
+        assert files[0]["filename"] == "test_cov.py"
+        assert files[1]["filename"] == "test_ret_false.py"
+        assert len(files[0]["segments"]) == 1
+        assert files[0]["segments"][0] == [8, 0, 9, 0, -1]
+        assert len(files[1]["segments"]) == 1
+        assert files[1]["segments"][0] == [1, 0, 2, 0, -1]
 
     def test_pytest_will_report_git_metadata(self):
         py_file = self.testdir.makepyfile(
@@ -1493,7 +1522,7 @@ class PytestTestCase(TracerTestCase):
                 assert True"""
             )
         self.testdir.chdir()
-        with mock.patch(
+        with override_env({"_DD_CIVISIBILITY_ITR_SUITE_MODE": "True"}), mock.patch(
             "ddtrace.internal.ci_visibility.recorder.CIVisibility.test_skipping_enabled",
             return_value=True,
         ), mock.patch("ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_tests_to_skip"), mock.patch.object(
@@ -1506,16 +1535,57 @@ class PytestTestCase(TracerTestCase):
             self.inline_run("--ddtrace")
 
         spans = self.pop_spans()
-        assert len(spans) == 4
-        test_suite_spans = [span for span in spans if span.get_tag("type") == "test_suite_end"]
-        assert len(test_suite_spans) == 1
-        assert test_suite_spans[0].get_tag("test.suite") == "test_inner_abc.py"
+        assert len(spans) == 7
+        passed_spans = [x for x in spans if x.get_tag("test.status") == "pass"]
+        assert len(passed_spans) == 4
+        skipped_spans = [x for x in spans if x.get_tag("test.status") == "skip"]
+        assert len(skipped_spans) == 3
 
-        test_spans = [span for span in spans if span.get_tag("type") == "test"]
-        assert len(test_spans) == 1
-        assert test_spans[0].get_tag("test.name") == "test_inner_ok"
+    def test_pytest_skip_tests_by_path(self):
+        """
+        Test that running pytest on two nested packages with 1 test each. It should generate
+        1 test session span, 2 test module spans, 2 test suite spans, and 2 test spans, but
+        the outer suite is skipped with ITR, so only 1 test suite span is created,
+        1 test module and 1 test span, hence 4 spans.
+        """
+        package_outer_dir = self.testdir.mkpydir("test_outer_package")
+        os.chdir(str(package_outer_dir))
+        with open("test_outer_abc.py", "w+") as fd:
+            fd.write(
+                """def test_outer_ok():
+                assert True"""
+            )
+        os.mkdir("test_inner_package")
+        os.chdir("test_inner_package")
+        with open("__init__.py", "w+"):
+            pass
+        with open("test_inner_abc.py", "w+") as fd:
+            fd.write(
+                """def test_inner_ok():
+                assert True"""
+            )
+        self.testdir.chdir()
+        with mock.patch(
+            "ddtrace.internal.ci_visibility.recorder.CIVisibility.test_skipping_enabled",
+            return_value=True,
+        ), mock.patch("ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_tests_to_skip"), mock.patch.object(
+            ddtrace.internal.ci_visibility.recorder.CIVisibility,
+            "_tests_to_skip",
+            {
+                "test_outer_package/test_outer_abc.py": ["test_outer_ok"],
+                "test_outer_package/test_inner_package/test_inner_abc.py": [],
+            },
+        ):
+            self.inline_run("--ddtrace")
 
-    def test_pytest_skip_all_suites(self):
+        spans = self.pop_spans()
+        assert len(spans) == 7
+        passed_spans = [x for x in spans if x.get_tag("test.status") == "pass"]
+        assert len(passed_spans) == 4
+        skipped_spans = [x for x in spans if x.get_tag("test.status") == "skip"]
+        assert len(skipped_spans) == 3
+
+    def test_pytest_skip_all_tests(self):
         """
         Test that running pytest on two nested packages with 1 test each. It should generate
         1 test session span, 2 test module spans, 2 test suite spans, and 2 test spans, but
@@ -1547,10 +1617,13 @@ class PytestTestCase(TracerTestCase):
             self.inline_run("--ddtrace")
 
         spans = self.pop_spans()
-        assert len(spans) == 1
-        assert spans[0].get_tag("type") == "test_session_end"
+        assert len(spans) == 7
+        passed_spans = [x for x in spans if x.get_tag("test.status") == "pass"]
+        assert len(passed_spans) == 0
+        skipped_spans = [x for x in spans if x.get_tag("test.status") == "skip"]
+        assert len(skipped_spans) == 7
 
-    def test_pytest_skip_all_suites_but_test_skipping_not_enabled(self):
+    def test_pytest_skip_all_tests_but_test_skipping_not_enabled(self):
         """
         Test that running pytest on two nested packages with 1 test each. It should generate
         1 test session span, 2 test module spans, 2 test suite spans, and 2 test spans.
@@ -1584,6 +1657,8 @@ class PytestTestCase(TracerTestCase):
         assert len(test_suite_spans) == 2
         test_spans = [span for span in spans if span.get_tag("type") == "test"]
         assert len(test_spans) == 2
+        passed_test_spans = [x for x in spans if x.get_tag("type") == "test" and x.get_tag("test.status") == "pass"]
+        assert len(passed_test_spans) == 2
 
     def test_pytest_skip_suite_by_path_but_test_skipping_not_enabled(self):
         """
@@ -1608,7 +1683,9 @@ class PytestTestCase(TracerTestCase):
                 assert True"""
             )
         self.testdir.chdir()
-        with mock.patch("ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_tests_to_skip"), mock.patch.object(
+        with override_env({"_DD_CIVISIBILITY_ITR_SUITE_MODE": "True"}), mock.patch(
+            "ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_tests_to_skip"
+        ), mock.patch.object(
             ddtrace.internal.ci_visibility.recorder.CIVisibility,
             "_test_suites_to_skip",
             [
@@ -1624,3 +1701,47 @@ class PytestTestCase(TracerTestCase):
         assert len(test_suite_spans) == 2
         test_spans = [span for span in spans if span.get_tag("type") == "test"]
         assert len(test_spans) == 2
+        passed_test_spans = [x for x in spans if x.get_tag("type") == "test" and x.get_tag("test.status") == "pass"]
+        assert len(passed_test_spans) == 2
+
+    def test_pytest_skip_tests_by_path_but_test_skipping_not_enabled(self):
+        """
+        Test that running pytest on two nested packages with 1 test each. It should generate
+        1 test session span, 2 test module spans, 2 test suite spans, and 2 test spans,
+        both suites are to be skipped with ITR, but test skipping is disabled.
+        """
+        package_outer_dir = self.testdir.mkpydir("test_outer_package")
+        os.chdir(str(package_outer_dir))
+        with open("test_outer_abc.py", "w+") as fd:
+            fd.write(
+                """def test_outer_ok():
+                assert True"""
+            )
+        os.mkdir("test_inner_package")
+        os.chdir("test_inner_package")
+        with open("__init__.py", "w+"):
+            pass
+        with open("test_inner_abc.py", "w+") as fd:
+            fd.write(
+                """def test_inner_ok():
+                assert True"""
+            )
+        self.testdir.chdir()
+        with mock.patch("ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_tests_to_skip"), mock.patch.object(
+            ddtrace.internal.ci_visibility.recorder.CIVisibility,
+            "_tests_to_skip",
+            {
+                "test_outer_package/test_inner_package/test_inner_abc.py": ["test_inner_ok"],
+                "test_outer_package/test_outer_abc.py": ["test_outer_ok"],
+            },
+        ):
+            self.inline_run("--ddtrace")
+
+        spans = self.pop_spans()
+        assert len(spans) == 7
+        test_suite_spans = [span for span in spans if span.get_tag("type") == "test_suite_end"]
+        assert len(test_suite_spans) == 2
+        test_spans = [span for span in spans if span.get_tag("type") == "test"]
+        assert len(test_spans) == 2
+        passed_test_spans = [x for x in spans if x.get_tag("type") == "test" and x.get_tag("test.status") == "pass"]
+        assert len(passed_test_spans) == 2


### PR DESCRIPTION
Backport [ddf8d41](https://github.com/DataDog/dd-trace-py/commit/ddf8d41a4b5174117ba8c096eba0f2ea9036307b) from https://github.com/DataDog/dd-trace-py/pull/6306 to 1.17.

CI Visibility:

- Fix for test or suite skipping (controlled by env var to use the latter)
- Create spans for ITR-skipped items (as agreed at ITR skipped tests/suites RFC)

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
