### PR TITLE
fix(ci-visibility): add git unshallow fix release note

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -221,6 +221,7 @@ unix
 unpatch
 unpatched
 unregister
+unshallow
 unvendored
 uri
 url

--- a/releasenotes/notes/fix-git-unshallow-84b5b81db6e79287.yaml
+++ b/releasenotes/notes/fix-git-unshallow-84b5b81db6e79287.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CI Visibility: This fix solves an issue where the git unshallow command wasn't called


### PR DESCRIPTION
CI Visibility: Add git unshallow fix release note missing in original PR: https://github.com/DataDog/dd-trace-py/pull/6268

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
