### PR TITLE
chore(telemetry): track the number of dropped spans

### DIFF
--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -90,7 +90,9 @@ class TraceSamplingProcessor(TraceProcessor):
                     # When any span is marked as keep by a single span sampling
                     # decision then we still send all and only those spans.
                     single_spans = [_ for _ in trace if is_single_span_sampled(_)]
-
+                    telemetry_writer.add_count_metric(
+                        "tracers", "spans_dropped", len(trace) - len(single_spans), (("reason", "p0"),)
+                    )
                     return single_spans or None
 
             for span in trace:
@@ -98,6 +100,7 @@ class TraceSamplingProcessor(TraceProcessor):
                     return trace
 
             log.debug("dropping trace %d with %d spans", trace[0].trace_id, len(trace))
+            telemetry_writer.add_count_metric("tracers", "spans_dropped", len(trace), (("reason", "p0"),))
 
         return None
 


### PR DESCRIPTION
## Description

Unless stats computation is enabled, all traces generated in a process should be sent to a datadog agent. This change will allow to use the instrumentation telemetry platform to track the number of spans are that dropped within a process.

### 1) Track the number of spans stored in trace Encoders

Currently there is no way to track the number of spans that have been encoded. This PR renames `EncoderBase._count` to `EncoderBase._count_traces` and  adds a field to track the number of encoded spans (`EncoderBase._count_spans`). These new fields can be accessed via `EncoderBase._get_counts()` method.

This change can be broken up into it's own PR but it does not make sense in isolation. We only need the number of encoded spans to track the number of spans that are dropped after encoding. This count will be used to compute the number of spans that are dropped due to http/udp connection issues.
 
### 2) Track the number of spans dropped

This is the core change. This PR tracks the number of spans that are dropped by the tracer. Spans can be dropped in the following scenarios:
 -  Stats computation is enabled, all spans marked with a priority of 0 or -1 will be dropped in the process. 
 - When an error is raised while adding spans to the trace encoder's buffers. 
 - When the trace writer fails to encode spans 
 - When an 400-599 status code is returned  by the agent endpoint (and the maximum number of retries is reached)

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
