### PR TITLE
ci: run only the necessary pre-checks

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -253,36 +253,8 @@ jobs:
       - checkout
       - setup_riot
       - run:
-          name: "Formatting check"
-          command: riot -v run -s fmt && git diff --exit-code
-      - run:
-          name: "Flake8 check"
-          command: riot -v run -s flake8
-      - run:
-          name: "Slots check"
-          command: riot -v run slotscheck
-      - run:
-          name: "Mypy check"
-          command: riot -v run -s mypy
-      - run:
-          name: "cython-lint check"
-          command: riot -v run -s cython-lint
-      - run:
           name: "Codespell check"
           command: riot -v run -s codespell
-      - run:
-          name: "Run riotfile.py tests"
-          command: riot -v run -s riot-helpers
-      - run:
-          name: "Test agent snapshot check"
-          command: riot -v run -s snapshot-fmt && git diff --exit-code
-      - run:
-          name: "Run scripts/*.py tests"
-          command: riot -v run -s scripts
-      - run:
-          name: "Running security analysis checks with bandit"
-          command: riot -v run -s bandit
-
   ccheck:
     executor: cimg_base
     steps:

--- a/scripts/gen_circleci_config.py
+++ b/scripts/gen_circleci_config.py
@@ -5,6 +5,8 @@
 # file in .circleci/config.templ.yml, add a function named gen_<name> to this
 # file. The function will be called automatically when this script is run.
 
+import typing as t
+
 
 def gen_required_suites(template: dict) -> None:
     """Generate the list of test suites that need to be run."""
@@ -19,6 +21,61 @@ def gen_required_suites(template: dict) -> None:
 
     requires_base_venvs = template["requires_base_venvs"]
     template["workflows"]["test"]["jobs"].extend([{suite: requires_base_venvs} for suite in required_suites])
+
+
+def gen_pre_checks(template: dict) -> None:
+    """Generate the list of pre-checks that need to be run."""
+    from needs_testrun import pr_matches_patterns
+
+    def check(name: str, command: str, paths: t.Set[str]) -> None:
+        if pr_matches_patterns(paths):
+            template["jobs"]["pre_check"]["steps"].append({"run": {"name": name, "command": command}})
+
+    check(
+        name="Formatting check",
+        command="riot -v run -s fmt && git diff --exit-code",
+        paths={"*.py", "*.pyi"},
+    ),
+    check(
+        name="Flake8 check",
+        command="riot -v run -s flake8",
+        paths={"*.py", "*.pyi"},
+    ),
+    check(
+        name="Mypy check",
+        command="riot -v run -s mypy",
+        paths={"*.py", "*.pyi"},
+    ),
+    check(
+        name="Slots check",
+        command="riot -v run slotscheck",
+        paths={"ddtrace/*.py"},
+    ),
+    check(
+        name="cython-lint check",
+        command="riot -v run -s cython-lint",
+        paths={"*.pyx", "*.pxd"},
+    ),
+    check(
+        name="Run riotfile.py tests",
+        command="riot -v run -s riot-helpers",
+        paths={"riotfile.py"},
+    )
+    check(
+        name="Test agent snapshot check",
+        command="riot -v run -s snapshot-fmt && git diff --exit-code",
+        paths={"tests/snapshots/*"},
+    )
+    check(
+        name="Run scripts/*.py tests",
+        command="riot -v run -s scripts",
+        paths={"scripts/*.py"},
+    )
+    check(
+        name="Running security analysis checks with bandit",
+        command="riot -v run -s bandit",
+        paths={"ddtrace/*"},
+    )
 
 
 # -----------------------------------------------------------------------------

--- a/scripts/needs_testrun.py
+++ b/scripts/needs_testrun.py
@@ -151,6 +151,11 @@ def for_each_testrun_needed(suites: t.List[str], action: t.Callable[[str], None]
             action(suite)
 
 
+def pr_matches_patterns(patterns: t.Set[str]) -> bool:
+    changed_files = get_changed_files(_get_pr_number())
+    return bool([_ for p in patterns for _ in fnmatch.filter(changed_files, p)])
+
+
 def main() -> bool:
     argp = ArgumentParser()
 


### PR DESCRIPTION
We dynamically generate the list of pre-checks to run on a PR based on the paths included in the PR.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
