### PR TITLE
ci: fix suitespec doctest

### DIFF
--- a/tests/suitespec.py
+++ b/tests/suitespec.py
@@ -18,8 +18,9 @@ def get_patterns(suite: str) -> t.Set[str]:
     'ddtrace/filter.py', 'ddtrace/internal/*', 'ddtrace/pin.py', 'ddtrace/provider.py', 'ddtrace/sampler.py',
     'ddtrace/settings/__init__.py', 'ddtrace/settings/config.py', 'ddtrace/settings/dynamic_instrumentation.py',
     'ddtrace/settings/exception_debugging.py', 'ddtrace/settings/http.py', 'ddtrace/settings/integration.py',
-    'ddtrace/span.py', 'ddtrace/tracer.py', 'riotfile.py', 'scripts/ddtest', 'tests/commands/*', 'tests/debugging/*',
-    'tests/integration/*', 'tests/internal/*', 'tests/lib-injection', 'tests/tracer/*']
+    'ddtrace/span.py', 'ddtrace/tracer.py', 'pyproject.toml', 'riotfile.py', 'scripts/ddtest', 'setup.cfg',
+    'setup.py', 'tests/commands/*', 'tests/debugging/*', 'tests/integration/*', 'tests/internal/*',
+    'tests/lib-injection', 'tests/tracer/*']
     >>> get_patterns("foobar")
     set()
     """


### PR DESCRIPTION
#6518 missed an update to the doctest, which can be skipped so was not caught.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))