### PR TITLE
ci: do not use pip cache

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -78,21 +78,6 @@ commands:
       # Make sure we install and run riot on Python 3
       - run: pip3 install riot==0.17.7
 
-  save_pip_cache:
-    description: "Save pip cache directory"
-    steps:
-      - save_cache:
-          # DEV: Cache misses can still occur as venvs are not necessarily always created on the same node index
-          key: pip-cache-xdg-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ checksum "riotfile.py" }}-{{ checksum "setup.py" }}
-          paths:
-            - "~/.cache/pip"
-
-  restore_pip_cache:
-    description: "Restore pip cache directory"
-    steps:
-      - restore_cache:
-          key: pip-cache-xdg-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ checksum "riotfile.py" }}-{{ checksum "setup.py" }}
-
   start_docker_services:
     description: "Start Docker services"
     parameters:
@@ -133,7 +118,6 @@ commands:
         default: "http://localhost:9126"
     steps:
       - checkout
-      - restore_pip_cache
       - attach_workspace:
           at: .
       - when:
@@ -179,7 +163,6 @@ commands:
                   # Sort the hashes to ensure a consistent ordering/division between each node
                   riot list --hash-only '<<parameters.pattern>>' | sort | circleci tests split | xargs -n 1 -I {} riot -v run --exitfirst --pass-env -s {} $([[ << pipeline.parameters.coverage >> == false ]] && echo '--no-cov' )
                   ./scripts/check-diff ".riot/requirements/" "Changes detected after running riot. Consider deleting changed files, running scripts/compile-and-prune-test-requirements and committing the result."
-      - save_pip_cache
       - when:
           condition:
             and:


### PR DESCRIPTION
In an effort to reduce the occurance of the following error, this PR proposes to remove the pip cache, at least temporarily to try and bisect where the problem could be coming from.

> ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE.

Since the error only seems to occur in CircleCI, and is intermittent running/re-running this PR's tests a few times might not be enough to validate if this actually resolves the issue or not.


**Negative impact of this change:**

- We save/restore the pip cache for each job and node hashed on `riotfile.py` and `setup.py`. This is meant to save us time and bandwidth from downloading packages from pip every time they are installed. With this cache removed we may see job runtimes to increase a bit because more downloads need to happen. The CI run from this PR did not increase very much/at all.

**Why might this be related to the issue we are trying to solve?**

- If any files get corrupted in the pip cache, then pip will not able to validate their hashes (pip will compare against the remote file hashes regardless of a local file being used or not).

**What do we do if this doesn't work?**

- We can revert this PR since it is unrelated to the problem
- We can enable PIP verbose logging for a period of time to help further debug the root cause/source of the issue to try and reproduce.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))