### PR TITLE
chore(asm): fix 2 subprocess integration tests

### DIFF
--- a/tests/contrib/subprocess/test_subprocess.py
+++ b/tests/contrib/subprocess/test_subprocess.py
@@ -435,9 +435,9 @@ def test_subprocess_wait_shell_false(tracer):
             subp = subprocess.Popen(args=args, shell=False)
             subp.wait()
 
-            assert not core.get_item(COMMANDS.CTX_SUBP_IS_SHELL, span=span)
-            assert not core.get_item(COMMANDS.CTX_SUBP_TRUNCATED, span=span)
-            assert core.get_item(COMMANDS.CTX_SUBP_LINE, span=span) == args
+            assert not core.get_item(COMMANDS.CTX_SUBP_IS_SHELL)
+            assert not core.get_item(COMMANDS.CTX_SUBP_TRUNCATED)
+            assert core.get_item(COMMANDS.CTX_SUBP_LINE) == args
 
 
 def test_subprocess_wait_shell_true(tracer):
@@ -448,7 +448,7 @@ def test_subprocess_wait_shell_true(tracer):
             subp = subprocess.Popen(args=["dir", "-li", "/"], shell=True)
             subp.wait()
 
-            assert core.get_item(COMMANDS.CTX_SUBP_IS_SHELL, span=span)
+            assert core.get_item(COMMANDS.CTX_SUBP_IS_SHELL)
 
 
 @pytest.mark.skipif(PY2, reason="Python2 does not have subprocess.run")


### PR DESCRIPTION
## Description

Fix two subprocess integration tests that were failing after the latest changes to 1.x

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
