### PR TITLE
chore(tests): fix pytest hooks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -281,7 +281,8 @@ def pytest_runtest_protocol(item):
             ihook.pytest_runtest_logreport(report=report)
 
             # Call
-            report = run_function_from_file(item, ps)
+            item.runtest = lambda: run_function_from_file(item, ps)
+            report = call_and_report(item, "call", log=False)
             report.nodeid = nodeid
             ihook.pytest_runtest_logreport(report=report)
 


### PR DESCRIPTION
Conftest: The way we're using the ``pytest_runtest_protocol`` hook in our conftest blocks the subsequent calls to ``pytest_runtest_makereport`` hooks for the ``call`` step. This change fixes that issue.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
