### PR TITLE
refactor(ci-visibility): tests refactor

### DIFF
--- a/tests/ci_visibility/test_coverage_per_suite.py
+++ b/tests/ci_visibility/test_coverage_per_suite.py
@@ -9,7 +9,7 @@ from ddtrace.contrib.pytest.plugin import is_enabled
 from ddtrace.internal import compat
 from ddtrace.internal.ci_visibility import CIVisibility
 from ddtrace.internal.ci_visibility.constants import COVERAGE_TAG_NAME
-from tests.ci_visibility.test_encoder import _patch_dummy_writer
+from tests.ci_visibility.util import _patch_dummy_writer
 from tests.utils import TracerTestCase
 from tests.utils import override_env
 

--- a/tests/ci_visibility/test_encoder.py
+++ b/tests/ci_visibility/test_encoder.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 import json
 import os
 
@@ -16,7 +15,7 @@ from ddtrace.internal.ci_visibility.encoder import CIVisibilityEncoderV01
 from ddtrace.internal.compat import msgpack_type
 from ddtrace.internal.encoding import JSONEncoder
 from ddtrace.span import Span
-from tests.utils import DummyCIVisibilityWriter
+from tests.ci_visibility.util import _patch_dummy_writer
 from tests.utils import TracerTestCase
 from tests.utils import override_env
 
@@ -221,14 +220,6 @@ def test_encode_traces_civisibility_v2_coverage_empty_traces():
 
     complete_payload = encoder.encode()
     assert complete_payload is None
-
-
-@contextmanager
-def _patch_dummy_writer():
-    original = ddtrace.internal.ci_visibility.recorder.CIVisibilityWriter
-    ddtrace.internal.ci_visibility.recorder.CIVisibilityWriter = DummyCIVisibilityWriter
-    yield
-    ddtrace.internal.ci_visibility.recorder.CIVisibilityWriter = original
 
 
 class PytestEncodingTestCase(TracerTestCase):

--- a/tests/ci_visibility/util.py
+++ b/tests/ci_visibility/util.py
@@ -1,0 +1,12 @@
+from contextlib import contextmanager
+
+import ddtrace
+from tests.utils import DummyCIVisibilityWriter
+
+
+@contextmanager
+def _patch_dummy_writer():
+    original = ddtrace.internal.ci_visibility.recorder.CIVisibilityWriter
+    ddtrace.internal.ci_visibility.recorder.CIVisibilityWriter = DummyCIVisibilityWriter
+    yield
+    ddtrace.internal.ci_visibility.recorder.CIVisibilityWriter = original

--- a/tests/contrib/asynctest/test_asynctest.py
+++ b/tests/contrib/asynctest/test_asynctest.py
@@ -7,6 +7,7 @@ import ddtrace
 from ddtrace.contrib.pytest.plugin import is_enabled
 from ddtrace.ext import test
 from ddtrace.internal.ci_visibility import CIVisibility
+from tests.ci_visibility.util import _patch_dummy_writer
 from tests.utils import DummyCIVisibilityWriter
 from tests.utils import TracerTestCase
 from tests.utils import override_env
@@ -25,9 +26,10 @@ class TestPytest(TracerTestCase):
             @staticmethod
             def pytest_configure(config):
                 if is_enabled(config):
-                    assert CIVisibility.enabled
-                    CIVisibility.disable()
-                    CIVisibility.enable(tracer=self.tracer, config=ddtrace.config.pytest)
+                    with _patch_dummy_writer():
+                        assert CIVisibility.enabled
+                        CIVisibility.disable()
+                        CIVisibility.enable(tracer=self.tracer, config=ddtrace.config.pytest)
 
         with override_env(dict(DD_API_KEY="foobar.baz")):
             self.tracer.configure(writer=DummyCIVisibilityWriter("https://citestcycle-intake.banana"))

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -18,7 +18,7 @@ from ddtrace.internal.ci_visibility import CIVisibility
 from ddtrace.internal.ci_visibility.constants import COVERAGE_TAG_NAME
 from ddtrace.internal.ci_visibility.encoder import CIVisibilityEncoderV01
 from ddtrace.internal.compat import PY2
-from tests.ci_visibility.test_encoder import _patch_dummy_writer
+from tests.ci_visibility.util import _patch_dummy_writer
 from tests.utils import TracerTestCase
 from tests.utils import override_env
 

--- a/tests/contrib/pytest_bdd/test_pytest_bdd.py
+++ b/tests/contrib/pytest_bdd/test_pytest_bdd.py
@@ -10,6 +10,7 @@ from ddtrace.contrib.pytest.plugin import is_enabled
 from ddtrace.contrib.pytest_bdd.plugin import _get_step_func_args_json
 from ddtrace.ext import test
 from ddtrace.internal.ci_visibility import CIVisibility
+from tests.ci_visibility.util import _patch_dummy_writer
 from tests.utils import DummyCIVisibilityWriter
 from tests.utils import TracerTestCase
 from tests.utils import override_env
@@ -37,9 +38,10 @@ class TestPytest(TracerTestCase):
             @staticmethod
             def pytest_configure(config):
                 if is_enabled(config):
-                    assert CIVisibility.enabled
-                    CIVisibility.disable()
-                    CIVisibility.enable(tracer=self.tracer, config=ddtrace.config.pytest)
+                    with _patch_dummy_writer():
+                        assert CIVisibility.enabled
+                        CIVisibility.disable()
+                        CIVisibility.enable(tracer=self.tracer, config=ddtrace.config.pytest)
 
         with override_env(dict(DD_API_KEY="foobar.baz")):
             self.tracer.configure(writer=DummyCIVisibilityWriter("https://citestcycle-intake.banana"))

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -16,12 +16,7 @@ from ddtrace.constants import AUTO_KEEP
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.internal import agent
 from ddtrace.internal import compat
-from ddtrace.internal.ci_visibility.constants import AGENTLESS_ENDPOINT
 from ddtrace.internal.ci_visibility.constants import COVERAGE_TAG_NAME
-from ddtrace.internal.ci_visibility.constants import EVP_PROXY_AGENT_ENDPOINT
-from ddtrace.internal.ci_visibility.constants import EVP_SUBDOMAIN_HEADER_EVENT_VALUE
-from ddtrace.internal.ci_visibility.constants import EVP_SUBDOMAIN_HEADER_NAME
-from ddtrace.internal.ci_visibility.recorder import CIVisibility
 from ddtrace.internal.ci_visibility.writer import CIVisibilityWriter
 from ddtrace.internal.encoding import JSONEncoder
 from ddtrace.internal.encoding import MsgpackEncoderV03 as Encoder
@@ -532,38 +527,6 @@ def test_priority_sampling_rate_honored(encoding, monkeypatch):
         ), "the proportion of sampled spans should approximate the sample rate given by the agent"
 
         t.shutdown()
-
-
-@pytest.mark.skipif(AGENT_VERSION == "testagent", reason="Test agent doesn't support evp proxy.")
-def test_civisibility_intake_with_evp_available():
-    with override_env(dict(DD_API_KEY="foobar.baz", DD_SITE="foo.bar")):
-        with override_global_config({"_ci_visibility_agentless_enabled": False}):
-            t = Tracer()
-            CIVisibility.enable(tracer=t)
-            assert CIVisibility._instance.tracer._writer._endpoint == EVP_PROXY_AGENT_ENDPOINT
-            assert CIVisibility._instance.tracer._writer.intake_url == agent.get_trace_url()
-            assert (
-                CIVisibility._instance.tracer._writer._headers[EVP_SUBDOMAIN_HEADER_NAME]
-                == EVP_SUBDOMAIN_HEADER_EVENT_VALUE
-            )
-            CIVisibility.disable()
-
-
-def test_civisibility_intake_with_missing_apikey():
-    with override_env(dict(DD_SITE="foobar.baz")):
-        with override_global_config({"_ci_visibility_agentless_enabled": True}):
-            with pytest.raises(EnvironmentError):
-                CIVisibility.enable()
-
-
-def test_civisibility_intake_with_apikey():
-    with override_env(dict(DD_API_KEY="foobar.baz", DD_SITE="foo.bar")):
-        with override_global_config({"_ci_visibility_agentless_enabled": True}):
-            t = Tracer()
-            CIVisibility.enable(tracer=t)
-            assert CIVisibility._instance.tracer._writer._endpoint == AGENTLESS_ENDPOINT
-            assert CIVisibility._instance.tracer._writer.intake_url == "https://citestcycle-intake.foo.bar"
-            CIVisibility.disable()
 
 
 def test_bad_endpoint():

--- a/tests/integration/test_integration_civisibility.py
+++ b/tests/integration/test_integration_civisibility.py
@@ -1,0 +1,48 @@
+import os
+
+import pytest
+
+import ddtrace
+from ddtrace.internal import agent
+from ddtrace.internal.ci_visibility import CIVisibility
+from ddtrace.internal.ci_visibility.constants import AGENTLESS_ENDPOINT
+from ddtrace.internal.ci_visibility.constants import EVP_PROXY_AGENT_ENDPOINT
+from ddtrace.internal.ci_visibility.constants import EVP_SUBDOMAIN_HEADER_EVENT_VALUE
+from ddtrace.internal.ci_visibility.constants import EVP_SUBDOMAIN_HEADER_NAME
+from ddtrace.internal.ci_visibility.recorder import CITracer
+from tests.utils import override_env
+
+
+AGENT_VERSION = os.environ.get("AGENT_VERSION")
+
+
+@pytest.mark.skipif(AGENT_VERSION == "testagent", reason="Test agent doesn't support evp proxy.")
+def test_civisibility_intake_with_evp_available():
+    with override_env(dict(DD_API_KEY="foobar.baz", DD_SITE="foo.bar", DD_CIVISIBILITY_AGENTLESS_ENABLED="0")):
+        ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
+        t = CITracer()
+        CIVisibility.enable(tracer=t)
+        assert CIVisibility._instance.tracer._writer._endpoint == EVP_PROXY_AGENT_ENDPOINT
+        assert CIVisibility._instance.tracer._writer.intake_url == agent.get_trace_url()
+        assert (
+            CIVisibility._instance.tracer._writer._headers[EVP_SUBDOMAIN_HEADER_NAME]
+            == EVP_SUBDOMAIN_HEADER_EVENT_VALUE
+        )
+        CIVisibility.disable()
+
+
+def test_civisibility_intake_with_missing_apikey():
+    with override_env(dict(DD_SITE="foobar.baz", DD_CIVISIBILITY_AGENTLESS_ENABLED="1")):
+        ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
+        with pytest.raises(EnvironmentError):
+            CIVisibility.enable()
+
+
+def test_civisibility_intake_with_apikey():
+    with override_env(dict(DD_API_KEY="foobar.baz", DD_SITE="foo.bar", DD_CIVISIBILITY_AGENTLESS_ENABLED="1")):
+        ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
+        t = CITracer()
+        CIVisibility.enable(tracer=t)
+        assert CIVisibility._instance.tracer._writer._endpoint == AGENTLESS_ENDPOINT
+        assert CIVisibility._instance.tracer._writer.intake_url == "https://citestcycle-intake.foo.bar"
+        CIVisibility.disable()

--- a/tests/integration/test_integration_civisibility.py
+++ b/tests/integration/test_integration_civisibility.py
@@ -9,7 +9,7 @@ from ddtrace.internal.ci_visibility.constants import AGENTLESS_ENDPOINT
 from ddtrace.internal.ci_visibility.constants import EVP_PROXY_AGENT_ENDPOINT
 from ddtrace.internal.ci_visibility.constants import EVP_SUBDOMAIN_HEADER_EVENT_VALUE
 from ddtrace.internal.ci_visibility.constants import EVP_SUBDOMAIN_HEADER_NAME
-from ddtrace.internal.ci_visibility.recorder import CITracer
+from ddtrace.tracer import Tracer
 from tests.utils import override_env
 
 
@@ -20,7 +20,7 @@ AGENT_VERSION = os.environ.get("AGENT_VERSION")
 def test_civisibility_intake_with_evp_available():
     with override_env(dict(DD_API_KEY="foobar.baz", DD_SITE="foo.bar", DD_CIVISIBILITY_AGENTLESS_ENABLED="0")):
         ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
-        t = CITracer()
+        t = Tracer()
         CIVisibility.enable(tracer=t)
         assert CIVisibility._instance.tracer._writer._endpoint == EVP_PROXY_AGENT_ENDPOINT
         assert CIVisibility._instance.tracer._writer.intake_url == agent.get_trace_url()
@@ -41,7 +41,7 @@ def test_civisibility_intake_with_missing_apikey():
 def test_civisibility_intake_with_apikey():
     with override_env(dict(DD_API_KEY="foobar.baz", DD_SITE="foo.bar", DD_CIVISIBILITY_AGENTLESS_ENABLED="1")):
         ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
-        t = CITracer()
+        t = Tracer()
         CIVisibility.enable(tracer=t)
         assert CIVisibility._instance.tracer._writer._endpoint == AGENTLESS_ENDPOINT
         assert CIVisibility._instance.tracer._writer.intake_url == "https://citestcycle-intake.foo.bar"


### PR DESCRIPTION
CI Visibility: Refactored tests

1. Extract `_patch_dummy_writer` for better reusability
2. Extract ci_visibility integration tests to a separate suite

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
