### PR TITLE
chore(ci-visibility): decouple from tracer

### DIFF
--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -104,10 +104,10 @@ class CIVisibility(Service):
             self.tracer = CITracer(context_provider=CIContextProvider())
 
         self._app_key = os.getenv(
-            "CI_DD_APP_KEY",
+            "_CI_DD_APP_KEY",
             os.getenv("DD_APP_KEY", os.getenv("DD_APPLICATION_KEY", os.getenv("DATADOG_APPLICATION_KEY"))),
         )
-        self._api_key = os.getenv("CI_DD_API_KEY", os.getenv("DD_API_KEY"))
+        self._api_key = os.getenv("_CI_DD_API_KEY", os.getenv("DD_API_KEY"))
 
         self._dd_site = os.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE)
         self._suite_skipping_mode = asbool(os.getenv("_DD_CIVISIBILITY_ITR_SUITE_MODE", default=False))

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -83,10 +83,6 @@ def _do_request(method, url, payload, headers):
     return result
 
 
-class CITracer(Tracer):
-    pass
-
-
 class CIVisibility(Service):
     _instance = None  # type: Optional[CIVisibility]
     enabled = False
@@ -101,7 +97,7 @@ class CIVisibility(Service):
             self.tracer = tracer
         else:
             # Create a new CI tracer
-            self.tracer = CITracer(context_provider=CIContextProvider())
+            self.tracer = Tracer(context_provider=CIContextProvider())
 
         self._app_key = os.getenv(
             "_CI_DD_APP_KEY",

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -4,7 +4,7 @@ import os
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-import ddtrace
+from ddtrace import Tracer
 from ddtrace import config as ddconfig
 from ddtrace.contrib import trace_utils
 from ddtrace.ext import ci
@@ -22,6 +22,7 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.service import Service
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.writer.writer import Response
+from ddtrace.provider import CIContextProvider
 
 from .. import agent
 from .constants import AGENTLESS_DEFAULT_SITE
@@ -46,7 +47,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Optional
     from typing import Tuple
 
-    from ddtrace import Tracer
     from ddtrace.settings import IntegrationConfig
 
 log = get_logger(__name__)
@@ -83,6 +83,10 @@ def _do_request(method, url, payload, headers):
     return result
 
 
+class CITracer(Tracer):
+    pass
+
+
 class CIVisibility(Service):
     _instance = None  # type: Optional[CIVisibility]
     enabled = False
@@ -93,9 +97,18 @@ class CIVisibility(Service):
         # type: (Optional[Tracer], Optional[IntegrationConfig], Optional[str]) -> None
         super(CIVisibility, self).__init__()
 
-        self.tracer = tracer or ddtrace.tracer
-        self._app_key = os.getenv("DD_APP_KEY", os.getenv("DD_APPLICATION_KEY", os.getenv("DATADOG_APPLICATION_KEY")))
-        self._api_key = os.getenv("DD_API_KEY")
+        if tracer:
+            self.tracer = tracer
+        else:
+            # Create a new CI tracer
+            self.tracer = CITracer(context_provider=CIContextProvider())
+
+        self._app_key = os.getenv(
+            "CI_DD_APP_KEY",
+            os.getenv("DD_APP_KEY", os.getenv("DD_APPLICATION_KEY", os.getenv("DATADOG_APPLICATION_KEY"))),
+        )
+        self._api_key = os.getenv("CI_DD_API_KEY", os.getenv("DD_API_KEY"))
+
         self._dd_site = os.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE)
         self._suite_skipping_mode = asbool(os.getenv("_DD_CIVISIBILITY_ITR_SUITE_MODE", default=False))
         self.config = config  # type: Optional[IntegrationConfig]

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -218,6 +218,7 @@ class Tracer(object):
         self,
         url=None,  # type: Optional[str]
         dogstatsd_url=None,  # type: Optional[str]
+        context_provider=None,  # type: Optional[DefaultContextProvider]
     ):
         # type: (...) -> None
         """
@@ -246,7 +247,7 @@ class Tracer(object):
         self._pid = getpid()
 
         self.enabled = asbool(os.getenv("DD_TRACE_ENABLED", default=True))
-        self.context_provider = DefaultContextProvider()
+        self.context_provider = context_provider or DefaultContextProvider()
         self._sampler = DatadogSampler()  # type: BaseSampler
         if asbool(os.getenv("DD_PRIORITY_SAMPLING", True)):
             self._priority_sampler = RateByServiceSampler()  # type: Optional[BasePrioritySampler]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,7 +71,7 @@ def override_env(env):
     original = dict(os.environ)
 
     for k in os.environ.keys():
-        if k.startswith(("CI_DD_", "DD_CIVISIBILITY_")):
+        if k.startswith(("_CI_DD_", "DD_CIVISIBILITY_")):
             del os.environ[k]
 
     # Update based on the passed in arguments

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -70,6 +70,10 @@ def override_env(env):
     # Copy the full original environment
     original = dict(os.environ)
 
+    for k in os.environ.keys():
+        if k.startswith(("CI_DD_", "DD_CIVISIBILITY_")):
+            del os.environ[k]
+
     # Update based on the passed in arguments
     os.environ.update(env)
     try:


### PR DESCRIPTION
CI Visibility: decouple from regular Tracer and ContextProvider to avoid issues when self-instrumenting ddtrace.

Also decouple env vars so we can have 2 separate sets of DD_API_KEY and DD_APP_KEY

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
