### PR TITLE
ci: undo change that appears to have broken suite selection

### DIFF
--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -38,8 +38,6 @@
             "ddtrace/settings/config.py",
             "ddtrace/settings/http.py",
             "ddtrace/settings/integration.py",
-        ],
-        "tracing_tests": [
             "tests/tracer/*",
             "tests/integration/*"
         ],
@@ -387,7 +385,6 @@
         ],
         "tracer": [
             "@tracing",
-            "@tracing_tests",
             "@bootstrap",
             "@core"
         ],


### PR DESCRIPTION
This reverts a change to the suitespec from #6523 that appears to have broken test suite selection on 1.x. See [this CI run](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/42187/workflows/51fe1083-51c5-4a69-8703-6c3a8bbb8989) for an example: a run on the 1.x did not run any suites, when it should run *all* suites.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
