### PR TITLE
ci: generate base venvs and report coverage if there are jobs to run

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -1097,9 +1097,3 @@ workflows:
       # Pre-checking before running all jobs
       - pre_check
       - ccheck
-
-      # Build necessary base venvs for integration tests
-      - build_base_venvs
-
-      # Final reports
-      - coverage_report: *requires_tests

--- a/scripts/gen_circleci_config.py
+++ b/scripts/gen_circleci_config.py
@@ -19,8 +19,21 @@ def gen_required_suites(template: dict) -> None:
     required_suites = template["requires_tests"]["requires"] = []
     fetn(suites=sorted(suites & jobs), action=lambda suite: required_suites.append(suite))
 
+    if not required_suites:
+        # Nothing to generate
+        return
+
+    jobs = template["workflows"]["test"]["jobs"]
+
+    # Create the base venvs
+    jobs.append("build_base_venvs")
+
+    # Add the jobs
     requires_base_venvs = template["requires_base_venvs"]
-    template["workflows"]["test"]["jobs"].extend([{suite: requires_base_venvs} for suite in required_suites])
+    jobs.extend([{suite: requires_base_venvs} for suite in required_suites])
+
+    # Collect coverage
+    jobs.append({"coverage_report": template["requires_tests"]})
 
 
 def gen_pre_checks(template: dict) -> None:


### PR DESCRIPTION
## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
