### PR TITLE
chore(ci): reduce test flakyness

### DIFF
--- a/tests/internal/test_context_events_api.py
+++ b/tests/internal/test_context_events_api.py
@@ -1,4 +1,5 @@
 import threading
+from time import sleep
 import unittest
 
 import mock
@@ -64,6 +65,7 @@ class TestContextEventsApi(unittest.TestCase):
 
                 core.on(event_name, listener)
 
+            sleep(make_target_id * 0.0001)  # ensure threads finish in order
             return target
 
         threads = []


### PR DESCRIPTION
CI: Ensure threads finish in order in flaky test

Example failure: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/42438/workflows/51ccc96a-6882-4042-bb74-9b5741c116e0/jobs/2826034/tests#failed-test-0

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
