### PR TITLE
chore(profiling): resolve bandit warnings

### DIFF
--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -119,7 +119,7 @@ class _ProfiledLock(wrapt.ObjectProxy):
 
                 self._self_recorder.push_event(event)
             except Exception:
-                pass
+                pass  # nosec
 
     def release(self, *args, **kwargs):
         # type (typing.Any, typing.Any) -> None
@@ -161,7 +161,7 @@ class _ProfiledLock(wrapt.ObjectProxy):
                     finally:
                         del self._self_acquired_at
             except Exception:
-                pass
+                pass  # nosec
 
     acquire_lock = acquire
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,6 @@ exclude_dirs = [
   "ddtrace/internal/serverless/mini_agent.py",
   "ddtrace/internal/uwsgi.py",
   "ddtrace/internal/wrapping.py",
-  "ddtrace/profiling/collector/_lock.py",
   "ddtrace/sourcecode/_utils.py",
 ]
 


### PR DESCRIPTION
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
