### PR TITLE
ci: run lib-injection workflow only when needed on PRs

### DIFF
--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -2,7 +2,12 @@ name: "Library Injection"
 on:
   # Build each branch for testing
   push:
-
+  pull_request:
+    paths:
+      - ddtrace/**
+      - lib-injection/**
+      - setup*
+      - pyproject.toml
 jobs:
   build-and-publish-test-image:
     uses: ./.github/workflows/lib-inject-publish.yml


### PR DESCRIPTION
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
