### PR TITLE
ci(langchain): add missing lockfile dependency for 1.x latest langchain suite

### DIFF
--- a/.riot/requirements/12df1f9.txt
+++ b/.riot/requirements/12df1f9.txt
@@ -20,6 +20,7 @@ exceptiongroup==1.1.2
 filelock==3.12.2
 frozenlist==1.3.3
 fsspec==2023.6.0
+greenlet==2.0.2
 huggingface-hub==0.15.1
 hypothesis==6.45.0
 idna==3.4

--- a/.riot/requirements/13bf6ae.txt
+++ b/.riot/requirements/13bf6ae.txt
@@ -20,6 +20,7 @@ exceptiongroup==1.1.2
 filelock==3.12.2
 frozenlist==1.3.3
 fsspec==2023.6.0
+greenlet==2.0.2
 huggingface-hub==0.15.1
 hypothesis==6.45.0
 idna==3.4


### PR DESCRIPTION
The nightly 1.x (latest dependency) test runs for the langchain test suite were failing due to a missing `greenlet==2.0.2` dependency in the 3.10 lockfiles. No tests were actually failing, it was just this missing dependency listing.
This PR adds those in to ensure that nightly langchain latest test runs will not fail.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
