### PR TITLE
chore: deprecate DD_LOG_FORMAT

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from ddtrace import config
 from ddtrace.filters import TraceFilter
+from ddtrace.internal.compat import ensure_pep562
 from ddtrace.internal.processor.endpoint_call_counter import EndpointCallCounterProcessor
 from ddtrace.internal.sampling import SpanSamplingRule
 from ddtrace.internal.sampling import get_span_sampling_rules
@@ -1109,3 +1110,20 @@ class Tracer(object):
     @staticmethod
     def _is_span_internal(span):
         return not span.span_type or span.span_type in _INTERNAL_APPLICATION_SPAN_TYPES
+
+
+def __getattr__(name):
+    if name == "DD_LOG_FORMAT":
+        debtcollector.deprecate(
+            ("%s.%s is deprecated." % (__name__, name)),
+            removal_version="2.0.0",
+        )
+        return DD_LOG_FORMAT
+
+    if name in globals():
+        return globals()[name]
+
+    raise AttributeError("'%s' has no attribute '%s'", __name__, name)
+
+
+ensure_pep562(__name__)

--- a/releasenotes/notes/deprecate_dd_log_format-bce67441fe2c92cb.yaml
+++ b/releasenotes/notes/deprecate_dd_log_format-bce67441fe2c92cb.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    ``DD_LOG_FORMAT`` is deprecated and will be removed in 2.0.0. As an alternative, please follow the
+    log injection formatting as provided in the `log injection docs <https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#update-log-format>`_.


### PR DESCRIPTION
`DD_LOG_FORMAT` has been part of the public API but is not used anywhere else other than our own log injection mechanisms in `bootstrap/sitecustomize.py` and `tracer.py`. As part of the 2.0 release, this will be made private in `ddtrace/_logger.py`, so we can deprecate it here and announce it to be removed from the 2.0 public API.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
