### PR TITLE
fix(tracer): fix sampling mechanism tag propagation bug

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -34,6 +34,7 @@ from .internal import compat
 from .internal import debug
 from .internal import forksafe
 from .internal import hostname
+from .internal.constants import SAMPLING_DECISION_TRACE_TAG_KEY
 from .internal.constants import SPAN_API_DATADOG
 from .internal.dogstatsd import get_dogstatsd_client
 from .internal.logger import get_logger
@@ -718,6 +719,8 @@ class Tracer(object):
 
             if span._local_root is None:
                 span._local_root = span
+            if SAMPLING_DECISION_TRACE_TAG_KEY in context._meta:
+                span._meta[SAMPLING_DECISION_TRACE_TAG_KEY] = context._meta[SAMPLING_DECISION_TRACE_TAG_KEY]
         else:
             # this is the root span of a new trace
             span = Span(

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_fork.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_fork.json
@@ -11,17 +11,17 @@
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
-      "runtime-id": "6f2eeb0b30c54268b96f6eca8a2d66ba"
+      "runtime-id": "7fcf456c657a442d8e637e5adda7270d"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 15844
+      "process_id": 52166
     },
-    "duration": 10582283,
-    "start": 1690574476657116319
+    "duration": 306192000,
+    "start": 1631827407437680000
   },
      {
        "name": "child",
@@ -33,15 +33,16 @@
        "type": "",
        "error": 0,
        "meta": {
+         "_dd.p.dm": "-0",
          "language": "python",
-         "runtime-id": "23d0b2399e7a4048a7daf8719cf73083"
+         "runtime-id": "409d5f5531a54659b762419af6a3abc5"
        },
        "metrics": {
          "_dd.top_level": 1,
          "_dd.tracer_kr": 1.0,
          "_sampling_priority_v1": 1,
-         "process_id": 15948
+         "process_id": 52180
        },
-       "duration": 46115,
-       "start": 1690574476662529362
+       "duration": 158000,
+       "start": 1631827407498354000
      }]]

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_multiple_forks.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_multiple_forks.json
@@ -11,17 +11,17 @@
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
-      "runtime-id": "6f2eeb0b30c54268b96f6eca8a2d66ba"
+      "runtime-id": "7fcf456c657a442d8e637e5adda7270d"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 15844
+      "process_id": 52166
     },
-    "duration": 19137969,
-    "start": 1690574476674109144
+    "duration": 861500000,
+    "start": 1631827407768929000
   },
      {
        "name": "child1",
@@ -33,17 +33,18 @@
        "type": "",
        "error": 0,
        "meta": {
+         "_dd.p.dm": "-0",
          "language": "python",
-         "runtime-id": "ef8fdd21134f4cb384f180b7081041a8"
+         "runtime-id": "da86c61045c247d78f3484fe9e693377"
        },
        "metrics": {
          "_dd.top_level": 1,
          "_dd.tracer_kr": 1.0,
          "_sampling_priority_v1": 1,
-         "process_id": 15952
+         "process_id": 52181
        },
-       "duration": 9437228,
-       "start": 1690574476678256374
+       "duration": 660665000,
+       "start": 1631827407811098000
      },
         {
           "name": "child2",
@@ -55,15 +56,16 @@
           "type": "",
           "error": 0,
           "meta": {
+            "_dd.p.dm": "-0",
             "language": "python",
-            "runtime-id": "b54c862359724885833fbbf42b940efb"
+            "runtime-id": "9181d9085f7e47f5a3eb66709923c2f6"
           },
           "metrics": {
             "_dd.top_level": 1,
             "_dd.tracer_kr": 1.0,
             "_sampling_priority_v1": 1,
-            "process_id": 15953
+            "process_id": 52186
           },
-          "duration": 57675,
-          "start": 1690574476681738176
+          "duration": 162000,
+          "start": 1631827408305852000
         }]]

--- a/tests/snapshots/tests.integration.test_propagation.test_sampling_decision_downstream.json
+++ b/tests/snapshots/tests.integration.test_propagation.test_sampling_decision_downstream.json
@@ -9,15 +9,16 @@
     "type": "",
     "error": 0,
     "meta": {
+      "_dd.p.dm": "-1",
       "language": "python",
-      "runtime-id": "6f2eeb0b30c54268b96f6eca8a2d66ba"
+      "runtime-id": "d3cc0a07d5e745aebadf0c641fd542e6"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": -1,
-      "process_id": 15844
+      "process_id": 50361
     },
-    "duration": 26329,
-    "start": 1690574477951050218
+    "duration": 29000,
+    "start": 1655132809265595000
   }]]

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer0].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer0].json
@@ -12,16 +12,16 @@
       "_dd.p.dm": "-1",
       "_dd.p.test": "value",
       "language": "python",
-      "runtime-id": "6f2eeb0b30c54268b96f6eca8a2d66ba"
+      "runtime-id": "07b9d728a8cc4e46826183565c0f2077"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 15844
+      "process_id": 55659
     },
-    "duration": 62019,
-    "start": 1690574477933582762
+    "duration": 112000,
+    "start": 1655133503389105000
   },
      {
        "name": "c1",
@@ -32,8 +32,11 @@
        "parent_id": 1,
        "type": "",
        "error": 0,
-       "duration": 5463,
-       "start": 1690574477933604011
+       "meta": {
+         "_dd.p.dm": "-1"
+       },
+       "duration": 7000,
+       "start": 1655133503389164000
      },
      {
        "name": "c2",
@@ -44,8 +47,11 @@
        "parent_id": 1,
        "type": "",
        "error": 0,
-       "duration": 9405,
-       "start": 1690574477933620814
+       "meta": {
+         "_dd.p.dm": "-1"
+       },
+       "duration": 14000,
+       "start": 1655133503389188000
      },
         {
           "name": "gc",
@@ -56,6 +62,9 @@
           "parent_id": 3,
           "type": "",
           "error": 0,
-          "duration": 24856,
-          "start": 1690574477933626617
+          "meta": {
+            "_dd.p.dm": "-1"
+          },
+          "duration": 24000,
+          "start": 1655133503389197000
         }]]

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer1].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer1].json
@@ -12,16 +12,16 @@
       "_dd.p.dm": "-1",
       "_dd.p.test": "value",
       "language": "python",
-      "runtime-id": "6f2eeb0b30c54268b96f6eca8a2d66ba"
+      "runtime-id": "07b9d728a8cc4e46826183565c0f2077"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 15844
+      "process_id": 55659
     },
-    "duration": 88632,
-    "start": 1690574477939371352
+    "duration": 79000,
+    "start": 1655133503431107000
   },
      {
        "name": "c1",
@@ -32,8 +32,11 @@
        "parent_id": 1,
        "type": "",
        "error": 0,
-       "duration": 8989,
-       "start": 1690574477939399229
+       "meta": {
+         "_dd.p.dm": "-1"
+       },
+       "duration": 7000,
+       "start": 1655133503431128000
      },
      {
        "name": "c2",
@@ -44,8 +47,11 @@
        "parent_id": 1,
        "type": "",
        "error": 0,
-       "duration": 16283,
-       "start": 1690574477939424609
+       "meta": {
+         "_dd.p.dm": "-1"
+       },
+       "duration": 17000,
+       "start": 1655133503431153000
      },
         {
           "name": "gc",
@@ -56,6 +62,9 @@
           "parent_id": 3,
           "type": "",
           "error": 0,
-          "duration": 34994,
-          "start": 1690574477939434462
+          "meta": {
+            "_dd.p.dm": "-1"
+          },
+          "duration": 26000,
+          "start": 1655133503431164000
         }]]

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer2].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer2].json
@@ -12,17 +12,17 @@
       "_dd.p.dm": "-1",
       "_dd.p.test": "value",
       "language": "python",
-      "runtime-id": "6f2eeb0b30c54268b96f6eca8a2d66ba"
+      "runtime-id": "07b9d728a8cc4e46826183565c0f2077"
     },
     "metrics": {
       "_dd.py.partial_flush": 2,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 15844
+      "process_id": 55659
     },
-    "duration": 1006930,
-    "start": 1690574477945296966
+    "duration": 4940000,
+    "start": 1655133503444976000
   },
      {
        "name": "c1",
@@ -43,8 +43,8 @@
          "_dd.tracer_kr": 1.0,
          "_sampling_priority_v1": 1
        },
-       "duration": 5520,
-       "start": 1690574477945314845
+       "duration": 7000,
+       "start": 1655133503444997000
      },
      {
        "name": "c2",
@@ -55,8 +55,11 @@
        "parent_id": 1,
        "type": "",
        "error": 0,
-       "duration": 9831,
-       "start": 1690574477945330638
+       "meta": {
+         "_dd.p.dm": "-1"
+       },
+       "duration": 18000,
+       "start": 1655133503445018000
      },
         {
           "name": "gc",
@@ -67,6 +70,9 @@
           "parent_id": 3,
           "type": "",
           "error": 0,
-          "duration": 980324,
-          "start": 1690574477945336832
+          "meta": {
+            "_dd.p.dm": "-1"
+          },
+          "duration": 4898000,
+          "start": 1655133503445029000
         }]]


### PR DESCRIPTION
This change fixes a bug causing the `_dd.p.dm` span tag not to be inherited by child spans when there is a process boundary between the parent and child spans.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
