### PR TITLE
chore(tests): make sure pytest tests run with a clean environment

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -140,7 +140,7 @@ commands:
                   RIOT_RUN_RECOMPILE_REQS: "<< pipeline.parameters.riot_run_latest >>"
                 command: |
                   # Sort the hashes to ensure a consistent ordering/division between each node
-                  riot list --hash-only '<<parameters.pattern>>' | sort | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --exitfirst --pass-env -s {} --ddtrace $([[ << pipeline.parameters.coverage >> == false ]] && echo '--no-cov' )
+                  riot list --hash-only '<<parameters.pattern>>' | sort | circleci tests split | xargs -n 1 -I {} ./scripts/ddtest riot -v run --exitfirst --pass-env -s {} $([ -v _CI_DD_API_KEY ] && echo '--ddtrace' ) $([[ << pipeline.parameters.coverage >> == false ]] && echo '--no-cov' )
                   ./scripts/check-diff ".riot/requirements/" "Changes detected after running riot. Consider deleting changed files, running scripts/compile-and-prune-test-requirements and committing the result."
       - unless:
           condition:
@@ -167,7 +167,7 @@ commands:
                   RIOT_RUN_RECOMPILE_REQS: "<< pipeline.parameters.riot_run_latest >>"
                 command: |
                   # Sort the hashes to ensure a consistent ordering/division between each node
-                  riot list --hash-only '<<parameters.pattern>>' | sort | circleci tests split | xargs -n 1 -I {} riot -v run --exitfirst --pass-env -s {} --ddtrace $([[ << pipeline.parameters.coverage >> == false ]] && echo '--no-cov' )
+                  riot list --hash-only '<<parameters.pattern>>' | sort | circleci tests split | xargs -n 1 -I {} riot -v run --exitfirst --pass-env -s {} $([ -v _CI_DD_API_KEY ] && echo '--ddtrace' ) $([[ << pipeline.parameters.coverage >> == false ]] && echo '--no-cov' )
                   ./scripts/check-diff ".riot/requirements/" "Changes detected after running riot. Consider deleting changed files, running scripts/compile-and-prune-test-requirements and committing the result."
       - when:
           condition:

--- a/tests/ci_visibility/test_ci_visibility.py
+++ b/tests/ci_visibility/test_ci_visibility.py
@@ -223,6 +223,7 @@ def test_git_client_worker_agentless(_do_request, git_repo):
             DD_API_KEY="foobar.baz",
             DD_APPLICATION_KEY="banana",
             DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
+            DD_SITE="datadoghq.com",
         )
     ):
         ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -47,7 +47,8 @@ class PytestTestCase(TracerTestCase):
 
     def subprocess_run(self, *args):
         """Execute test script with test tracer."""
-        return self.testdir.runpytest_subprocess(*args)
+        with override_env(dict(DD_API_KEY="foobar.baz")):
+            return self.testdir.runpytest_subprocess(*args)
 
     @pytest.mark.skipif(sys.version_info[0] == 2, reason="Triggers a bug with coverage, sqlite and Python 2")
     def test_patch_all(self):
@@ -522,9 +523,6 @@ class PytestTestCase(TracerTestCase):
 
     def test_service_name_repository_name(self):
         """Test span's service name is set to repository name."""
-        self.monkeypatch.setenv("APPVEYOR", "true")
-        self.monkeypatch.setenv("APPVEYOR_REPO_PROVIDER", "github")
-        self.monkeypatch.setenv("APPVEYOR_REPO_NAME", "test-repository-name")
         py_file = self.testdir.makepyfile(
             """
             import os
@@ -534,7 +532,14 @@ class PytestTestCase(TracerTestCase):
         """
         )
         file_name = os.path.basename(py_file.strpath)
-        rec = self.subprocess_run("--ddtrace", file_name)
+        with override_env(
+            {
+                "APPVEYOR": "true",
+                "APPVEYOR_REPO_PROVIDER": "github",
+                "APPVEYOR_REPO_NAME": "test-repository-name",
+            }
+        ):
+            rec = self.subprocess_run("--ddtrace", file_name)
         rec.assert_outcomes(passed=1)
 
     def test_default_service_name(self):
@@ -555,7 +560,6 @@ class PytestTestCase(TracerTestCase):
 
     def test_dd_service_name(self):
         """Test dd service name."""
-        self.monkeypatch.setenv("DD_SERVICE", "mysvc")
         if "DD_PYTEST_SERVICE" in os.environ:
             self.monkeypatch.delenv("DD_PYTEST_SERVICE")
 
@@ -570,15 +574,12 @@ class PytestTestCase(TracerTestCase):
         """
         )
         file_name = os.path.basename(py_file.strpath)
-        rec = self.subprocess_run("--ddtrace", file_name)
+        with override_env({"DD_SERVICE": "mysvc"}):
+            rec = self.subprocess_run("--ddtrace", file_name)
         assert 0 == rec.ret
 
     def test_dd_pytest_service_name(self):
         """Test integration service name."""
-        self.monkeypatch.setenv("DD_SERVICE", "mysvc")
-        self.monkeypatch.setenv("DD_PYTEST_SERVICE", "pymysvc")
-        self.monkeypatch.setenv("DD_PYTEST_OPERATION_NAME", "mytest")
-
         py_file = self.testdir.makepyfile(
             """
             import os
@@ -591,7 +592,10 @@ class PytestTestCase(TracerTestCase):
         """
         )
         file_name = os.path.basename(py_file.strpath)
-        rec = self.subprocess_run("--ddtrace", file_name)
+        with override_env(
+            {"DD_SERVICE": "mysvc", "DD_PYTEST_SERVICE": "pymysvc", "DD_PYTEST_OPERATION_NAME": "mytest"}
+        ):
+            rec = self.subprocess_run("--ddtrace", file_name)
         assert 0 == rec.ret
 
     def test_dd_origin_tag_propagated_to_every_span(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,7 +71,7 @@ def override_env(env):
     original = dict(os.environ)
 
     for k in os.environ.keys():
-        if k.startswith(("_CI_DD_", "DD_CIVISIBILITY_")):
+        if k.startswith(("_CI_DD_", "DD_CIVISIBILITY_", "DD_SITE")):
             del os.environ[k]
 
     # Update based on the passed in arguments


### PR DESCRIPTION
Pytest: Tests using `subprocess_run` should use `override_env` to avoid CI_Visibility env vars from leaking to the inner execution.

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
