### PR TITLE
chore(debugging): convert type comments to annotations

### DIFF
--- a/ddtrace/debugging/_async.py
+++ b/ddtrace/debugging/_async.py
@@ -6,8 +6,7 @@ from ddtrace.debugging._signal.collector import SignalContext
 from ddtrace.internal import compat
 
 
-async def dd_coroutine_wrapper(coro, contexts):
-    # type: (CoroutineType, List[SignalContext]) -> CoroutineType
+async def dd_coroutine_wrapper(coro: CoroutineType, contexts: List[SignalContext]) -> CoroutineType:
     start_time = compat.monotonic_ns()
     try:
         retval = await coro

--- a/ddtrace/debugging/_exception/auto_instrument.py
+++ b/ddtrace/debugging/_exception/auto_instrument.py
@@ -41,12 +41,11 @@ FRAME_LINE_TAG = "_dd.debug.error.%d.line"
 
 
 def unwind_exception_chain(
-    exc,  # type: t.Optional[BaseException]
-    tb,  # type: t.Optional[TracebackType]
-):
-    # type: (...) -> t.Tuple[t.Deque[t.Tuple[BaseException, t.Optional[TracebackType]]], t.Optional[uuid.UUID]]
+    exc: t.Optional[BaseException],
+    tb: t.Optional[TracebackType],
+) -> t.Tuple[t.Deque[t.Tuple[BaseException, t.Optional[TracebackType]]], t.Optional[uuid.UUID]]:
     """Unwind the exception chain and assign it an ID."""
-    chain = deque()  # type: t.Deque[t.Tuple[BaseException, t.Optional[TracebackType]]]
+    chain: t.Deque[t.Tuple[BaseException, t.Optional[TracebackType]]] = deque()
 
     while exc is not None:
         chain.append((exc, tb))
@@ -80,8 +79,7 @@ def unwind_exception_chain(
 @attr.s
 class SpanExceptionProbe(LogLineProbe):
     @classmethod
-    def build(cls, exc_id, tb):
-        # type: (uuid.UUID, TracebackType) -> SpanExceptionProbe
+    def build(cls, exc_id: uuid.UUID, tb: TracebackType) -> "SpanExceptionProbe":
         _exc_id = str(exc_id)
         frame = tb.tb_frame
         filename = frame.f_code.co_filename
@@ -110,8 +108,7 @@ class SpanExceptionSnapshot(Snapshot):
     exc_id = attr.ib(type=t.Optional[uuid.UUID], default=None)
 
     @property
-    def data(self):
-        # type: () -> t.Dict[str, t.Any]
+    def data(self) -> t.Dict[str, t.Any]:
         data = super(SpanExceptionSnapshot, self).data
 
         data.update({"exception-id": str(self.exc_id)})
@@ -119,8 +116,7 @@ class SpanExceptionSnapshot(Snapshot):
         return data
 
 
-def can_capture(span):
-    # type: (Span) -> bool
+def can_capture(span: Span) -> bool:
     # We determine if we should capture the exception information from the span
     # by looking at its local root. If we have budget to capture, we mark the
     # root as "info captured" and return True. If we don't have budget, we mark
@@ -150,12 +146,10 @@ def can_capture(span):
 class SpanExceptionProcessor(SpanProcessor):
     collector = attr.ib(type=SignalCollector)
 
-    def on_span_start(self, span):
-        # type: (Span) -> None
+    def on_span_start(self, span: Span) -> None:
         pass
 
-    def on_span_finish(self, span):
-        # type: (Span) -> None
+    def on_span_finish(self, span: Span) -> None:
         if not (span.error and can_capture(span)):
             # No error or budget to capture
             return

--- a/ddtrace/debugging/_expressions.py
+++ b/ddtrace/debugging/_expressions.py
@@ -49,20 +49,17 @@ DDASTType = Union[Dict[str, Any], Dict[str, List[Any]], Any]
 if PY < (3, 0):
     IDENT_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
-    def _is_identifier(name):
-        # type: (str) -> bool
+    def _is_identifier(name: str) -> bool:
         return isinstance(name, str) and IDENT_RE.match(name) is not None
 
 
 else:
 
-    def _is_identifier(name):
-        # type: (str) -> bool
+    def _is_identifier(name: str) -> bool:
         return isinstance(name, str) and name.isidentifier()
 
 
-def _make_function(ast, args, name):
-    # type: (DDASTType, Tuple[str,...], str) -> FunctionType
+def _make_function(ast: DDASTType, args: Tuple[str, ...], name: str) -> FunctionType:
     compiled = _compile_predicate(ast)
     if compiled is None:
         raise ValueError("Invalid predicate: %r" % ast)
@@ -79,13 +76,11 @@ def _make_function(ast, args, name):
     return FunctionType(abstract_code.to_code(), {}, name, (), None)
 
 
-def _make_lambda(ast):
-    # type: (DDASTType) -> Callable[[Any, Any], Any]
+def _make_lambda(ast: DDASTType) -> Callable[[Any, Any], Any]:
     return _make_function(ast, ("_dd_it", "_locals"), "<lambda>")
 
 
-def _compile_direct_predicate(ast):
-    # type: (DDASTType) -> Optional[List[Instr]]
+def _compile_direct_predicate(ast: DDASTType) -> Optional[List[Instr]]:
     # direct_predicate       =>  {"<direct_predicate_type>": <predicate>}
     # direct_predicate_type  =>  not | isEmpty | isUndefined
     if not isinstance(ast, dict):
@@ -107,8 +102,7 @@ def _compile_direct_predicate(ast):
     return value
 
 
-def _compile_arg_predicate(ast):
-    # type: (DDASTType) -> Optional[List[Instr]]
+def _compile_arg_predicate(ast: DDASTType) -> Optional[List[Instr]]:
     # arg_predicate       =>  {"<arg_predicate_type>": [<argument_list>]}
     # arg_predicate_type  =>  eq | ne | gt | ge | lt | le | any | all | and | or
     #                            | startsWith | endsWith | contains | matches
@@ -180,8 +174,7 @@ def _compile_arg_predicate(ast):
     return None
 
 
-def _compile_direct_operation(ast):
-    # type: (DDASTType) -> Optional[List[Instr]]
+def _compile_direct_operation(ast: DDASTType) -> Optional[List[Instr]]:
     # direct_opearation  =>  {"<direct_op_type>": <value_source>}
     # direct_op_type     =>  len | count | ref
     if not isinstance(ast, dict):
@@ -211,8 +204,7 @@ def _compile_direct_operation(ast):
     return None
 
 
-def _call_function(func, *args):
-    # type: (Callable, List[Instr]) -> List[Instr]
+def _call_function(func: Callable, *args: List[Instr]) -> List[Instr]:
     if PY < (3, 11):
         return [Instr("LOAD_CONST", func)] + list(chain(*args)) + [Instr("CALL_FUNCTION", len(args))]
     elif PY >= (3, 12):
@@ -226,8 +218,7 @@ def _call_function(func, *args):
     )
 
 
-def _compile_arg_operation(ast):
-    # type: (DDASTType) -> Optional[List[Instr]]
+def _compile_arg_operation(ast: DDASTType) -> Optional[List[Instr]]:
     # arg_operation  =>  {"<arg_op_type>": [<argument_list>]}
     # arg_op_type    =>  filter | substring
     if not isinstance(ast, dict):
@@ -287,14 +278,12 @@ def _compile_arg_operation(ast):
     return None
 
 
-def _compile_operation(ast):
-    # type: (DDASTType) -> Optional[List[Instr]]
+def _compile_operation(ast: DDASTType) -> Optional[List[Instr]]:
     # operation  =>  <direct_operation> | <arg_operation>
     return _compile_direct_operation(ast) or _compile_arg_operation(ast)
 
 
-def _compile_literal(ast):
-    # type: (DDASTType) -> Optional[List[Instr]]
+def _compile_literal(ast: DDASTType) -> Optional[List[Instr]]:
     # literal  =>  <number> | true | false | "string" | null
     if not (isinstance(ast, (str, int, float, bool)) or ast is None):
         return None
@@ -302,20 +291,17 @@ def _compile_literal(ast):
     return [Instr("LOAD_CONST", ast)]
 
 
-def _compile_value_source(ast):
-    # type: (DDASTType) -> Optional[List[Instr]]
+def _compile_value_source(ast: DDASTType) -> Optional[List[Instr]]:
     # value_source  =>  <literal> | <operation>
     return _compile_operation(ast) or _compile_literal(ast)
 
 
-def _compile_predicate(ast):
-    # type: (DDASTType) -> Optional[List[Instr]]
+def _compile_predicate(ast: DDASTType) -> Optional[List[Instr]]:
     # predicate  =>  <direct_predicate> | <arg_predicate> | <value_source>
     return _compile_direct_predicate(ast) or _compile_arg_predicate(ast) or _compile_value_source(ast)
 
 
-def dd_compile(ast):
-    # type: (DDASTType) -> Callable[[Dict[str, Any]], Any]
+def dd_compile(ast: DDASTType) -> Callable[[Dict[str, Any]], Any]:
     return _make_function(ast, ("_locals",), "<expr>")
 
 
@@ -330,8 +316,8 @@ class DDExpressionEvaluationError(Exception):
 
 @attr.s
 class DDExpression(object):
-    dsl = attr.ib(type=str)  # type: str
-    callable = attr.ib(type=Callable[[Dict[str, Any]], Any])  # type: Callable[[Dict[str, Any]], Any]
+    dsl = attr.ib(type=str)
+    callable = attr.ib(type=Callable[[Dict[str, Any]], Any])
 
     def eval(self, _locals):
         try:

--- a/ddtrace/debugging/_function/store.py
+++ b/ddtrace/debugging/_function/store.py
@@ -39,10 +39,9 @@ class FunctionStore(object):
     removed when the functions are restored.
     """
 
-    def __init__(self, extra_attrs=None):
-        # type: (Optional[List[str]]) -> None
-        self._code_map = {}  # type: Dict[FunctionType, CodeType]
-        self._wrapper_map = {}  # type: Dict[FunctionType, Wrapper]
+    def __init__(self, extra_attrs: Optional[List[str]] = None) -> None:
+        self._code_map: Dict[FunctionType, CodeType] = {}
+        self._wrapper_map: Dict[FunctionType, Wrapper] = {}
         self._extra_attrs = ["__dd_wrapped__"]
         if extra_attrs:
             self._extra_attrs.extend(extra_attrs)
@@ -53,13 +52,11 @@ class FunctionStore(object):
     def __exit__(self, *exc):
         self.restore_all()
 
-    def _store(self, function):
-        # type: (FunctionType) -> None
+    def _store(self, function: FunctionType) -> None:
         if function not in self._code_map:
             self._code_map[function] = function.__code__
 
-    def inject_hooks(self, function, hooks):
-        # type: (FullyNamedWrappedFunction, List[HookInfoType]) -> Set[str]
+    def inject_hooks(self, function: FullyNamedWrappedFunction, hooks: List[HookInfoType]) -> Set[str]:
         """Bulk-inject hooks into a function.
 
         Returns the set of probe IDs for those probes that failed to inject.
@@ -71,8 +68,7 @@ class FunctionStore(object):
             self._store(f)
             return {p.probe_id for _, _, p in inject_hooks(f, hooks)}
 
-    def eject_hooks(self, function, hooks):
-        # type: (FunctionType, List[HookInfoType]) -> Set[str]
+    def eject_hooks(self, function: FunctionType, hooks: List[HookInfoType]) -> Set[str]:
         """Bulk-eject hooks from a function.
 
         Returns the set of probe IDs for those probes that failed to eject.
@@ -86,30 +82,25 @@ class FunctionStore(object):
             # Try on the wrapped function.
             return self.eject_hooks(cast(FunctionType, wrapped), hooks)
 
-    def inject_hook(self, function, hook, line, arg):
-        # type: (FullyNamedWrappedFunction, HookType, int, Any) -> bool
+    def inject_hook(self, function: FullyNamedWrappedFunction, hook: HookType, line: int, arg: Any) -> bool:
         """Inject a hook into a function."""
         return not not self.inject_hooks(function, [(hook, line, arg)])
 
-    def eject_hook(self, function, hook, line, arg):
-        # type: (FunctionType, HookType, int, Any) -> bool
+    def eject_hook(self, function: FunctionType, hook: HookType, line: int, arg: Any) -> bool:
         """Eject a hook from a function."""
         return not not self.eject_hooks(function, [(hook, line, arg)])
 
-    def wrap(self, function, wrapper):
-        # type: (FunctionType, Wrapper) -> None
+    def wrap(self, function: FunctionType, wrapper: Wrapper) -> None:
         """Wrap a function with a hook."""
         self._store(function)
         self._wrapper_map[function] = wrapper
         wrap(function, wrapper)
 
-    def unwrap(self, function):
-        # type: (FullyNamedWrappedFunction) -> None
+    def unwrap(self, function: FullyNamedWrappedFunction) -> None:
         """Unwrap a hook around a wrapped function."""
         unwrap(function, self._wrapper_map.pop(cast(FunctionType, function)))
 
-    def restore_all(self):
-        # type: () -> None
+    def restore_all(self) -> None:
         """Restore all the patched functions to their original form."""
         for function, code in self._code_map.items():
             function.__code__ = code

--- a/ddtrace/debugging/_probe/model.py
+++ b/ddtrace/debugging/_probe/model.py
@@ -32,8 +32,7 @@ DEFAULT_PROBE_CONDITION_ERROR_RATE = 1.0 / 60 / 5
 
 
 @cached()
-def _resolve_source_file(path):
-    # type: (str) -> Optional[str]
+def _resolve_source_file(path: str) -> Optional[str]:
     """Resolve the source path for the given path.
 
     This recursively strips parent directories until it finds a file that
@@ -61,10 +60,10 @@ MAXFIELDS = 20
 
 @attr.s
 class CaptureLimits(object):
-    max_level = attr.ib(type=int, default=MAXLEVEL)  # type: int
-    max_size = attr.ib(type=int, default=MAXSIZE)  # type: int
-    max_len = attr.ib(type=int, default=MAXLEN)  # type: int
-    max_fields = attr.ib(type=int, default=MAXFIELDS)  # type: int
+    max_level = attr.ib(type=int, default=MAXLEVEL)
+    max_size = attr.ib(type=int, default=MAXSIZE)
+    max_len = attr.ib(type=int, default=MAXLEN)
+    max_fields = attr.ib(type=int, default=MAXFIELDS)
 
 
 DEFAULT_CAPTURE_LIMITS = CaptureLimits()
@@ -76,8 +75,7 @@ class Probe(six.with_metaclass(abc.ABCMeta)):
     version = attr.ib(type=int)
     tags = attr.ib(type=dict, eq=False)
 
-    def update(self, other):
-        # type: (Probe) -> None
+    def update(self, other: "Probe") -> None:
         """Update the mutable fields from another probe."""
         if self.probe_id != other.probe_id:
             log.error("Probe ID mismatch when updating mutable fields")
@@ -96,7 +94,7 @@ class Probe(six.with_metaclass(abc.ABCMeta)):
 @attr.s
 class RateLimitMixin(six.with_metaclass(abc.ABCMeta)):
     rate = attr.ib(type=float, eq=False)
-    limiter = attr.ib(type=RateLimiter, init=False, repr=False, eq=False)  # type: RateLimiter
+    limiter = attr.ib(type=RateLimiter, init=False, repr=False, eq=False)
 
     @limiter.default
     def _(self):
@@ -117,9 +115,9 @@ class ProbeConditionMixin(object):
     probe.
     """
 
-    condition = attr.ib(type=Optional[DDExpression])  # type: Optional[DDExpression]
+    condition = attr.ib(type=Optional[DDExpression])
     condition_error_rate = attr.ib(type=float, eq=False)
-    condition_error_limiter = attr.ib(type=RateLimiter, init=False, repr=False, eq=False)  # type: RateLimiter
+    condition_error_limiter = attr.ib(type=RateLimiter, init=False, repr=False, eq=False)
 
     @condition_error_limiter.default
     def _(self):
@@ -134,8 +132,7 @@ class ProbeConditionMixin(object):
 
 @attr.s
 class ProbeLocationMixin(object):
-    def location(self):
-        # type: () -> Tuple[str,str]
+    def location(self) -> Tuple[str, str]:
         """return a turple of (location,sublocation) for the probe.
         For example, line probe returns the (file,line) and method probe return (module,method)
         """
@@ -196,8 +193,7 @@ class MetricFunctionProbe(Probe, FunctionLocationMixin, MetricProbeMixin, ProbeC
 @attr.s
 class TemplateSegment(six.with_metaclass(abc.ABCMeta)):
     @abc.abstractmethod
-    def eval(self, _locals):
-        # type: (Dict[str,Any]) -> str
+    def eval(self, _locals: Dict[str, Any]) -> str:
         pass
 
 
@@ -205,17 +201,15 @@ class TemplateSegment(six.with_metaclass(abc.ABCMeta)):
 class LiteralTemplateSegment(TemplateSegment):
     str_value = attr.ib(type=str, default=None)
 
-    def eval(self, _locals):
-        # type: (Dict[str,Any]) -> Any
+    def eval(self, _locals: Dict[str, Any]) -> Any:
         return self.str_value
 
 
 @attr.s
 class ExpressionTemplateSegment(TemplateSegment):
-    expr = attr.ib(type=DDExpression, default=None)  # type: DDExpression
+    expr = attr.ib(type=DDExpression, default=None)
 
-    def eval(self, _locals):
-        # type: (Dict[str,Any]) -> Any
+    def eval(self, _locals: Dict[str, Any]) -> Any:
         return self.expr.eval(_locals)
 
 
@@ -224,8 +218,7 @@ class StringTemplate(object):
     template = attr.ib(type=str)
     segments = attr.ib(type=List[TemplateSegment])
 
-    def render(self, _locals, serializer):
-        # type: (Dict[str,Any], Callable[[Any], str]) -> str
+    def render(self, _locals: Dict[str, Any], serializer: Callable[[Any], str]) -> str:
         def _to_str(value):
             return value if _isinstance(value, six.string_types) else serializer(value)
 
@@ -237,7 +230,7 @@ class LogProbeMixin(object):
     template = attr.ib(type=str)
     segments = attr.ib(type=List[TemplateSegment])
     take_snapshot = attr.ib(type=bool)
-    limits = attr.ib(type=CaptureLimits, eq=False)  # type: CaptureLimits
+    limits = attr.ib(type=CaptureLimits, eq=False)
 
 
 @attr.s

--- a/ddtrace/debugging/_probe/registry.py
+++ b/ddtrace/debugging/_probe/registry.py
@@ -17,29 +17,24 @@ logger = get_logger(__name__)
 class ProbeRegistryEntry(object):
     __slots__ = ("probe", "installed", "error_type", "message")
 
-    def __init__(self, probe):
-        # type: (Probe) -> None
+    def __init__(self, probe: Probe) -> None:
         self.probe = probe
         self.installed = False
-        self.error_type = None  # type: Optional[str]
-        self.message = None  # type: Optional[str]
+        self.error_type: Optional[str] = None
+        self.message: Optional[str] = None
 
-    def set_installed(self):
-        # type: () -> None
+    def set_installed(self) -> None:
         self.installed = True
 
-    def set_error(self, error_type, message):
-        # type: (str, str) -> None
+    def set_error(self, error_type: str, message: str) -> None:
         self.error_type = error_type
         self.message = message
 
-    def update(self, probe):
-        # type: (Probe) -> None
+    def update(self, probe: Probe) -> None:
         self.probe.update(probe)
 
 
-def _get_probe_location(probe):
-    # type: (Probe) -> Optional[str]
+def _get_probe_location(probe: Probe) -> Optional[str]:
     if isinstance(probe, ProbeLocationMixin):
         return probe.location()[0]
     else:
@@ -54,19 +49,17 @@ class ProbeRegistry(dict):
     probes can be retrieved with the ``get_pending`` method.
     """
 
-    def __init__(self, status_logger, *args, **kwargs):
-        # type: (ProbeStatusLogger, Any, Any) -> None
+    def __init__(self, status_logger: ProbeStatusLogger, *args: Any, **kwargs: Any) -> None:
         """Initialize the probe registry."""
         super(ProbeRegistry, self).__init__(*args, **kwargs)
         self.logger = status_logger
 
         # Used to keep track of probes pending installation
-        self._pending = defaultdict(list)  # type: Dict[str, List[Probe]]
+        self._pending: Dict[str, List[Probe]] = defaultdict(list)
 
         self._lock = forksafe.RLock()
 
-    def register(self, *probes):
-        # type: (Probe) -> None
+    def register(self, *probes: Probe) -> None:
         """Register a probe."""
         with self._lock:
             for probe in probes:
@@ -99,8 +92,7 @@ class ProbeRegistry(dict):
 
             self.log_probe_status(probe)
 
-    def set_installed(self, probe):
-        # type: (Probe) -> None
+    def set_installed(self, probe: Probe) -> None:
         """Set the installed flag for a probe."""
         with self._lock:
             self[probe.probe_id].set_installed()
@@ -110,15 +102,13 @@ class ProbeRegistry(dict):
 
             self.logger.installed(probe)
 
-    def set_error(self, probe, error_type, message):
-        # type: (Probe, str, str) -> None
+    def set_error(self, probe: Probe, error_type: str, message: str) -> None:
         """Set the error message for a probe."""
         with self._lock:
             self[probe.probe_id].set_error(error_type, message)
             self.logger.error(probe, (error_type, message))
 
-    def _log_probe_status_unlocked(self, entry):
-        # type: (ProbeRegistryEntry) -> None
+    def _log_probe_status_unlocked(self, entry: ProbeRegistryEntry) -> None:
         if entry.installed:
             self.logger.installed(entry.probe)
         elif entry.error_type:
@@ -127,21 +117,18 @@ class ProbeRegistry(dict):
         else:
             self.logger.received(entry.probe)
 
-    def log_probe_status(self, probe):
-        # type: (Probe) -> None
+    def log_probe_status(self, probe: Probe) -> None:
         """Log the status of a probe using the status logger."""
         with self._lock:
             self._log_probe_status_unlocked(self[probe.probe_id])
 
-    def log_probes_status(self):
-        # type: () -> None
+    def log_probes_status(self) -> None:
         """Log the status of all the probes using the status logger."""
         with self._lock:
             for entry in self.values():
                 self._log_probe_status_unlocked(entry)
 
-    def _remove_pending(self, probe):
-        # type: (Probe) -> None
+    def _remove_pending(self, probe: Probe) -> None:
         location = _get_probe_location(probe)
 
         # Pending probes must have valid location information
@@ -158,15 +145,13 @@ class ProbeRegistry(dict):
         if not pending_probes:
             del self._pending[location]
 
-    def has_probes(self, location):
-        # type: (str) -> bool
+    def has_probes(self, location: str) -> bool:
         for entry in self.values():
             if _get_probe_location(entry.probe) == location:
                 return True
         return False
 
-    def unregister(self, *probes):
-        # type: (Probe) -> List[Probe]
+    def unregister(self, *probes: Probe) -> List[Probe]:
         """Unregister a collection of probes.
 
         This also ensures that any pending probes are removed if they haven't
@@ -186,13 +171,11 @@ class ProbeRegistry(dict):
                     unregistered_probes.append(probe)
         return unregistered_probes
 
-    def get_pending(self, location):
-        # type: (str) -> List[Probe]
+    def get_pending(self, location: str) -> List[Probe]:
         """Get the currently pending probes by location."""
         return self._pending[location]
 
-    def __contains__(self, probe):
-        # type: (object) -> bool
+    def __contains__(self, probe: object) -> bool:
         """Check if a probe is in the registry."""
         assert isinstance(probe, Probe), probe  # nosec
 

--- a/ddtrace/debugging/_probe/status.py
+++ b/ddtrace/debugging/_probe/status.py
@@ -22,14 +22,14 @@ ErrorInfo = Tuple[str, str]
 
 
 class ProbeStatusLogger(object):
-    def __init__(self, service, encoder):
-        # type: (str, BufferedEncoder) -> None
+    def __init__(self, service: str, encoder: BufferedEncoder) -> None:
         self._service = service
         self._encoder = encoder
-        self._retry_queue = deque()  # type: deque[Tuple[str, float]]
+        self._retry_queue: deque[Tuple[str, float]] = deque()
 
-    def _payload(self, probe, status, message, timestamp, error=None):
-        # type: (Probe, str, str, float, Optional[ErrorInfo]) -> str
+    def _payload(
+        self, probe: Probe, status: str, message: str, timestamp: float, error: Optional[ErrorInfo] = None
+    ) -> str:
         payload = {
             "service": self._service,
             "timestamp": int(timestamp * 1e3),  # milliseconds
@@ -56,8 +56,7 @@ class ProbeStatusLogger(object):
 
         return json.dumps(payload)
 
-    def _write(self, probe, status, message, error=None):
-        # type: (Probe, str, str, Optional[ErrorInfo]) -> None
+    def _write(self, probe: Probe, status: str, message: str, error: Optional[ErrorInfo] = None) -> None:
         if self._retry_queue:
             meter.distribution("backlog.size", len(self._retry_queue))
 
@@ -91,22 +90,19 @@ class ProbeStatusLogger(object):
         except Exception:
             log.error("Failed to write probe status payload", exc_info=True)
 
-    def received(self, probe, message=None):
-        # type: (Probe, Optional[str]) -> None
+    def received(self, probe: Probe, message: Optional[str] = None) -> None:
         self._write(
             probe,
             "RECEIVED",
             message or "Probe %s has been received correctly" % probe.probe_id,
         )
 
-    def installed(self, probe, message=None):
-        # type: (Probe, Optional[str]) -> None
+    def installed(self, probe: Probe, message: Optional[str] = None) -> None:
         self._write(
             probe,
             "INSTALLED",
             message or "Probe %s instrumented correctly" % probe.probe_id,
         )
 
-    def error(self, probe, error=None):
-        # type: (Probe, Optional[ErrorInfo]) -> None
+    def error(self, probe: Probe, error: Optional[ErrorInfo] = None) -> None:
         self._write(probe, "ERROR", "Failed to instrument probe %s" % probe.probe_id, error)

--- a/ddtrace/debugging/_safety.py
+++ b/ddtrace/debugging/_safety.py
@@ -12,8 +12,7 @@ from ddtrace.internal.safety import get_slots
 GetSetDescriptor = type(type.__dict__["__dict__"])  # type: ignore[index]
 
 
-def get_args(frame):
-    # type: (FrameType) -> Iterator[Tuple[str, Any]]
+def get_args(frame: FrameType) -> Iterator[Tuple[str, Any]]:
     code = frame.f_code
     nargs = code.co_argcount + bool(code.co_flags & CO_VARARGS) + bool(code.co_flags & CO_VARKEYWORDS)
     arg_names = code.co_varnames[:nargs]
@@ -22,8 +21,7 @@ def get_args(frame):
     return zip(arg_names, arg_values)
 
 
-def get_locals(frame):
-    # type: (FrameType) -> Iterator[Tuple[str, Any]]
+def get_locals(frame: FrameType) -> Iterator[Tuple[str, Any]]:
     code = frame.f_code
     nargs = code.co_argcount + bool(code.co_flags & CO_VARARGS) + bool(code.co_flags & CO_VARKEYWORDS)
     names = code.co_varnames[nargs:]
@@ -32,16 +30,14 @@ def get_locals(frame):
     return zip(names, values)
 
 
-def get_globals(frame):
-    # type: (FrameType) -> Iterator[Tuple[str, Any]]
+def get_globals(frame: FrameType) -> Iterator[Tuple[str, Any]]:
     nonlocal_names = frame.f_code.co_names
     _globals = globals()
 
     return ((name, _globals[name]) for name in nonlocal_names if name in _globals)
 
 
-def safe_getattr(obj, name):
-    # type: (Any, str) -> Any
+def safe_getattr(obj: Any, name: str) -> Any:
     try:
         return object.__getattribute__(obj, name)
     except Exception as e:
@@ -58,8 +54,7 @@ def safe_getitem(obj, index):
     raise TypeError("Type is not indexable collection " + str(type(obj)))
 
 
-def _safe_dict(o):
-    # type: (Any) -> Dict[str, Any]
+def _safe_dict(o: Any) -> Dict[str, Any]:
     try:
         __dict__ = object.__getattribute__(o, "__dict__")
         if type(__dict__) is dict:
@@ -70,8 +65,7 @@ def _safe_dict(o):
     raise AttributeError("No safe __dict__")
 
 
-def get_fields(obj):
-    # type: (Any) -> Dict[str, Any]
+def get_fields(obj: Any) -> Dict[str, Any]:
     try:
         return _safe_dict(obj)
     except AttributeError:

--- a/ddtrace/debugging/_signal/collector.py
+++ b/ddtrace/debugging/_signal/collector.py
@@ -35,19 +35,17 @@ class SignalContext(object):
 
     def __init__(
         self,
-        signal,  # type: Signal
-        handler,  # type: Callable[[Signal],None]
-    ):
-        # type: (...) -> None
+        signal: Signal,
+        handler: Callable[[Signal], None],
+    ) -> None:
         self._on_exit_handler = handler
         self.signal = signal
-        self.return_value = NO_RETURN_VALUE  # type: Any
-        self.duration = None  # type: Optional[int]
+        self.return_value: Any = NO_RETURN_VALUE
+        self.duration: Optional[int] = None
 
         self.signal.enter()
 
-    def exit(self, retval, exc_info, duration_ns):
-        # type: (Any, ExcInfoType, int) -> None
+    def exit(self, retval: Any, exc_info: ExcInfoType, duration_ns: int) -> None:
         """Exit the snapshot context.
 
         The arguments are used to record either the return value or the exception, and
@@ -61,8 +59,7 @@ class SignalContext(object):
     def __enter__(self):
         return self
 
-    def __exit__(self, *exc_info):
-        # type: (ExcInfoType) -> None
+    def __exit__(self, *exc_info: ExcInfoType) -> None:
         self.signal.exit(self.return_value, exc_info, self.duration)
         self._on_exit_handler(self.signal)
 
@@ -79,12 +76,10 @@ class SignalCollector(object):
     data, such as the return value of the wrapped function.
     """
 
-    def __init__(self, encoder):
-        # type: (BufferedEncoder) -> None
+    def __init__(self, encoder: BufferedEncoder) -> None:
         self._encoder = encoder
 
-    def _enqueue(self, log_signal):
-        # type: (LogSignal) -> None
+    def _enqueue(self, log_signal: LogSignal) -> None:
         try:
             log.debug(
                 "[%s][P: %s] SignalCollector. _encoder (%s) _enqueue signal", os.getpid(), os.getppid(), self._encoder
@@ -94,8 +89,7 @@ class SignalCollector(object):
             log.debug("Encoder buffer full")
             meter.increment("encoder.buffer.full")
 
-    def push(self, signal):
-        # type: (Signal) -> None
+    def push(self, signal: Signal) -> None:
         if signal.state == SignalState.SKIP_COND:
             meter.increment("skip", tags={"cause": "cond", "probe_id": signal.probe.probe_id})
         elif signal.state in {SignalState.SKIP_COND_ERROR, SignalState.COND_ERROR}:
@@ -118,7 +112,6 @@ class SignalCollector(object):
                 "Skipping signal %s (has message: %s)", signal, isinstance(signal, LogSignal) and signal.has_message()
             )
 
-    def attach(self, signal):
-        # type: (Signal) -> SignalContext
+    def attach(self, signal: Signal) -> SignalContext:
         """Collect via a probe signal context manager."""
         return SignalContext(signal, lambda e: self.push(e))

--- a/ddtrace/debugging/_signal/model.py
+++ b/ddtrace/debugging/_signal/model.py
@@ -60,8 +60,7 @@ class Signal(six.with_metaclass(abc.ABCMeta)):
     timestamp = attr.ib(type=float, factory=time.time)
     uuid = attr.ib(type=str, init=False, factory=lambda: str(uuid4()))
 
-    def _eval_condition(self, _locals=None):
-        # type: (Optional[Dict[str, Any]]) -> bool
+    def _eval_condition(self, _locals: Optional[Dict[str, Any]] = None) -> bool:
         """Evaluate the probe condition against the collected frame."""
         probe = cast(ProbeConditionMixin, self.probe)
         condition = probe.condition

--- a/ddtrace/debugging/_signal/snapshot.py
+++ b/ddtrace/debugging/_signal/snapshot.py
@@ -34,12 +34,11 @@ CAPTURE_TIME_BUDGET = 0.2  # seconds
 
 
 def _capture_context(
-    arguments,  # type: List[Tuple[str, Any]]
-    _locals,  # type: List[Tuple[str, Any]]
-    throwable,  # type: ExcInfoType
-    limits=DEFAULT_CAPTURE_LIMITS,  # type: CaptureLimits
-):
-    # type: (...) -> Dict[str, Any]
+    arguments: List[Tuple[str, Any]],
+    _locals: List[Tuple[str, Any]],
+    throwable: ExcInfoType,
+    limits: CaptureLimits = DEFAULT_CAPTURE_LIMITS,
+) -> Dict[str, Any]:
     with HourGlass(duration=CAPTURE_TIME_BUDGET) as hg:
 
         def timeout(_):
@@ -65,8 +64,7 @@ def _capture_context(
 _EMPTY_CAPTURED_CONTEXT = _capture_context([], [], (None, None, None), DEFAULT_CAPTURE_LIMITS)
 
 
-def format_captured_value(value):
-    # type: (Any) -> str
+def format_captured_value(value: Any) -> str:
     v = value.get("value")
     if v is not None:
         return v
@@ -88,8 +86,7 @@ def format_captured_value(value):
     return "%s()" % value["type"]
 
 
-def format_message(function, args, retval=None):
-    # type: (str, Dict[str, Any], Optional[Any]) -> str
+def format_message(function: str, args: Dict[str, Any], retval: Optional[Any] = None) -> str:
     message = "%s(%s)" % (
         function,
         ", ".join(("=".join((n, format_captured_value(a))) for n, a in args.items())),
@@ -115,8 +112,7 @@ class Snapshot(LogSignal):
     _message = attr.ib(type=Optional[str], default=None)
     duration = attr.ib(type=Optional[int], default=None)  # nanoseconds
 
-    def _eval_segment(self, segment, _locals):
-        # type: (TemplateSegment, Dict[str, Any]) -> str
+    def _eval_segment(self, segment: TemplateSegment, _locals: Dict[str, Any]) -> str:
         probe = cast(LogProbeMixin, self.probe)
         capture = probe.limits
         try:
@@ -133,8 +129,7 @@ class Snapshot(LogSignal):
             self.errors.append(EvaluationError(expr=e.dsl, message=e.error))
             return "ERROR"
 
-    def _eval_message(self, _locals):
-        # type: (Dict[str, Any]) -> None
+    def _eval_message(self, _locals: Dict[str, Any]) -> None:
         probe = cast(LogProbeMixin, self.probe)
         self._message = "".join([self._eval_segment(s, _locals) for s in probe.segments])
 
@@ -223,12 +218,10 @@ class Snapshot(LogSignal):
         self.state = SignalState.DONE
 
     @property
-    def message(self):
-        # type: () -> Optional[str]
+    def message(self) -> Optional[str]:
         return self._message
 
-    def has_message(self):
-        # type: () -> bool
+    def has_message(self) -> bool:
         return self._message is not None or bool(self.errors)
 
     @property

--- a/ddtrace/debugging/_signal/tracing.py
+++ b/ddtrace/debugging/_signal/tracing.py
@@ -34,12 +34,10 @@ class DynamicSpan(Signal):
 
     _span_cm = attr.ib(type=t.Optional[t.ContextManager[Span]], init=False)
 
-    def __attrs_post_init__(self):
-        # type: () -> None
+    def __attrs_post_init__(self) -> None:
         self._span_cm = None
 
-    def enter(self):
-        # type: () -> None
+    def enter(self) -> None:
         probe = self.probe
         if not isinstance(probe, SpanFunctionProbe):
             log.debug("Dynamic span entered with non-span probe: %s", self.probe)
@@ -61,8 +59,7 @@ class DynamicSpan(Signal):
 
         self.state = SignalState.DONE
 
-    def exit(self, retval, exc_info, duration):
-        # type: (t.Any, ExcInfoType, float) -> None
+    def exit(self, retval: t.Any, exc_info: ExcInfoType, duration: float) -> None:
         if not isinstance(self.probe, SpanFunctionProbe):
             log.debug("Dynamic span exited with non-span probe: %s", self.probe)
             return
@@ -79,8 +76,7 @@ class DynamicSpan(Signal):
 class SpanDecoration(LogSignal):
     """Decorate a span."""
 
-    def _decorate_span(self, _locals):
-        # type: (t.Dict[str, t.Any]) -> None
+    def _decorate_span(self, _locals: t.Dict[str, t.Any]) -> None:
         probe = t.cast(SpanDecorationMixin, self.probe)
 
         if probe.target_span == SpanDecorationTargetSpan.ACTIVE:
@@ -113,8 +109,7 @@ class SpanDecoration(LogSignal):
                         span.set_tag_str(tag.name, tag_value if _isinstance(tag_value, str) else serialize(tag_value))
                         span.set_tag_str("_dd.di.%s.probe_id" % tag.name, t.cast(Probe, probe).probe_id)
 
-    def enter(self):
-        # type: () -> None
+    def enter(self) -> None:
         probe = self.probe
         if not isinstance(probe, SpanDecorationFunctionProbe):
             log.debug("Span decoration entered with non-span decoration probe: %s", self.probe)
@@ -124,8 +119,7 @@ class SpanDecoration(LogSignal):
             self._decorate_span(dict(self.args) if self.args else {})
             self.state = SignalState.DONE
 
-    def exit(self, retval, exc_info, duration):
-        # type: (t.Any, ExcInfoType, float) -> None
+    def exit(self, retval: t.Any, exc_info: ExcInfoType, duration: float) -> None:
         probe = self.probe
 
         if not isinstance(probe, SpanDecorationFunctionProbe):

--- a/ddtrace/debugging/_signal/utils.py
+++ b/ddtrace/debugging/_signal/utils.py
@@ -6,7 +6,6 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Type
 
 from ddtrace.debugging._probe.model import MAXFIELDS
@@ -17,6 +16,7 @@ from ddtrace.debugging._safety import get_fields
 from ddtrace.internal.compat import BUILTIN_CONTAINER_TYPES
 from ddtrace.internal.compat import BUILTIN_SIMPLE_TYPES
 from ddtrace.internal.compat import CALLABLE_TYPES
+from ddtrace.internal.compat import Collection
 from ddtrace.internal.compat import ExcInfoType
 from ddtrace.internal.compat import NoneType
 from ddtrace.internal.compat import stringify
@@ -24,15 +24,11 @@ from ddtrace.internal.safety import _isinstance
 from ddtrace.internal.utils.cache import cached
 
 
-if TYPE_CHECKING:  # pragma: no cover
-    from ddtrace.internal.compat import Collection
-
 EXCLUDED_FIELDS = frozenset(["__class__", "__dict__", "__weakref__", "__doc__", "__module__", "__hash__"])
 
 
 @cached()
-def qualname(_type):
-    # type: (Type) -> str
+def qualname(_type: Type) -> str:
     try:
         return stringify(_type.__qualname__)
     except AttributeError:
@@ -44,8 +40,9 @@ def qualname(_type):
             return repr(_type)
 
 
-def _serialize_collection(value, brackets, level, maxsize, maxlen, maxfields):
-    # type: (Collection, str, int, int, int, int) -> str
+def _serialize_collection(
+    value: Collection, brackets: str, level: int, maxsize: int, maxlen: int, maxfields: int
+) -> str:
     o, c = brackets[0], brackets[1]
     ellipsis = ", ..." if len(value) > maxsize else ""
     return "".join(
@@ -53,8 +50,9 @@ def _serialize_collection(value, brackets, level, maxsize, maxlen, maxfields):
     )
 
 
-def serialize(value, level=MAXLEVEL, maxsize=MAXSIZE, maxlen=MAXLEN, maxfields=MAXFIELDS):
-    # type: (Any, int, int, int, int) -> str
+def serialize(
+    value: Any, level: int = MAXLEVEL, maxsize: int = MAXSIZE, maxlen: int = MAXLEN, maxfields: int = MAXFIELDS
+) -> str:
     """Python object serializer.
 
     We provide our own serializer to avoid any potential side effects of calling
@@ -99,9 +97,8 @@ def serialize(value, level=MAXLEVEL, maxsize=MAXSIZE, maxlen=MAXLEN, maxfields=M
     raise TypeError("Unhandled type: %s", type(value))
 
 
-def capture_stack(top_frame, max_height=4096):
-    # type: (FrameType, int) -> List[dict]
-    frame = top_frame  # type: Optional[FrameType]
+def capture_stack(top_frame: FrameType, max_height: int = 4096) -> List[dict]:
+    frame: Optional[FrameType] = top_frame
     stack = []
     h = 0
     while frame and h < max_height:
@@ -118,8 +115,7 @@ def capture_stack(top_frame, max_height=4096):
     return stack
 
 
-def capture_exc_info(exc_info):
-    # type: (ExcInfoType) -> Optional[Dict[str, Any]]
+def capture_exc_info(exc_info: ExcInfoType) -> Optional[Dict[str, Any]]:
     _type, value, tb = exc_info
     if _type is None or value is None:
         return None
@@ -136,8 +132,14 @@ def capture_exc_info(exc_info):
     }
 
 
-def capture_value(value, level=MAXLEVEL, maxlen=MAXLEN, maxsize=MAXSIZE, maxfields=MAXFIELDS, stopping_cond=None):
-    # type: (Any, int, int, int, int, Optional[Callable[[Any], bool]]) -> Dict[str, Any]
+def capture_value(
+    value: Any,
+    level: int = MAXLEVEL,
+    maxlen: int = MAXLEN,
+    maxsize: int = MAXSIZE,
+    maxfields: int = MAXFIELDS,
+    stopping_cond: Optional[Callable[[Any], bool]] = None,
+) -> Dict[str, Any]:
     cond = stopping_cond if stopping_cond is not None else (lambda _: False)
 
     _type = type(value)
@@ -183,7 +185,7 @@ def capture_value(value, level=MAXLEVEL, maxlen=MAXLEN, maxsize=MAXSIZE, maxfiel
                 "size": len(value),
             }
 
-        collection = None  # type: Optional[List[Any]]
+        collection: Optional[List[Any]] = None
         if _type is dict:
             # Mapping
             collection = [

--- a/ddtrace/debugging/_uploader.py
+++ b/ddtrace/debugging/_uploader.py
@@ -27,8 +27,7 @@ class LogsIntakeUploaderV1(AwakeablePeriodicService):
 
     RETRY_ATTEMPTS = 3
 
-    def __init__(self, encoder, interval=None):
-        # type: (BufferedEncoder, Optional[float]) -> None
+    def __init__(self, encoder: BufferedEncoder, interval: Optional[float] = None) -> None:
         super(LogsIntakeUploaderV1, self).__init__(interval or di_config.upload_flush_interval)
         self._encoder = encoder
         self._headers = {
@@ -59,8 +58,7 @@ class LogsIntakeUploaderV1(AwakeablePeriodicService):
             self.interval,
         )
 
-    def _write(self, payload):
-        # type: (bytes) -> None
+    def _write(self, payload: bytes) -> None:
         try:
             with self._connect() as conn:
                 conn.request(
@@ -80,13 +78,11 @@ class LogsIntakeUploaderV1(AwakeablePeriodicService):
             log.error("Failed to write payload", exc_info=True)
             meter.increment("error")
 
-    def upload(self):
-        # type: () -> None
+    def upload(self) -> None:
         """Upload request."""
         self.awake()
 
-    def periodic(self):
-        # type: () -> None
+    def periodic(self) -> None:
         """Upload the buffer content to the logs intake."""
         count = self._encoder.count
         if count:

--- a/ddtrace/internal/module.py
+++ b/ddtrace/internal/module.py
@@ -5,31 +5,28 @@ from os.path import isdir
 from os.path import isfile
 from os.path import join
 import sys
-import typing
+from types import ModuleType
+from typing import Any
+from typing import Callable
+from typing import DefaultDict
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import Type
+from typing import Union
 from typing import cast
 from weakref import WeakValueDictionary as wvdict
-
-
-if typing.TYPE_CHECKING:
-    from types import ModuleType
-    from typing import Any
-    from typing import Callable
-    from typing import DefaultDict
-    from typing import Dict
-    from typing import List
-    from typing import Optional
-    from typing import Set
-    from typing import Tuple
-    from typing import Type
-    from typing import Union
-
-    ModuleHookType = Callable[[ModuleType], None]
-    PreExecHookType = Callable[[Any, ModuleType], None]
-    PreExecHookCond = Union[str, Callable[[str], bool]]
 
 from ddtrace.internal.compat import PY2
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
+
+
+ModuleHookType = Callable[[ModuleType], None]
+PreExecHookType = Callable[[Any, ModuleType], None]
+PreExecHookCond = Union[str, Callable[[str], bool]]
 
 
 log = get_logger(__name__)

--- a/tests/debugging/exploration/_config.py
+++ b/tests/debugging/exploration/_config.py
@@ -7,8 +7,7 @@ from envier import En
 from ddtrace.debugging._probe.model import CaptureLimits
 
 
-def parse_venv(value):
-    # type: (str) -> t.Optional[str]
+def parse_venv(value: str) -> t.Optional[str]:
     try:
         return os.path.abspath(value) if value is not None else None
     except TypeError:

--- a/tests/debugging/exploration/_coverage.py
+++ b/tests/debugging/exploration/_coverage.py
@@ -20,12 +20,11 @@ from ddtrace.internal.module import origin
 
 
 # Track all the covered modules and its lines. Indexed by module origin.
-_tracked_modules = {}  # type: t.Dict[str, t.Tuple[ModuleType, t.Set[int]]]
+_tracked_modules: t.Dict[str, t.Tuple[ModuleType, t.Set[int]]] = {}
 
 
 class LineCollector(ModuleCollector):
-    def on_collect(self, discovery):
-        # type: (FunctionDiscovery) -> None
+    def on_collect(self, discovery: FunctionDiscovery) -> None:
         o = origin(discovery._module)
         status("[coverage] collecting lines from %s" % o)
         _tracked_modules[o] = (discovery._module, {_ for _ in discovery.keys()})
@@ -48,8 +47,7 @@ class LineCoverage(ExplorationDebugger):
     __watchdog__ = LineCollector
 
     @classmethod
-    def report_coverage(cls):
-        # type: () -> None
+    def report_coverage(cls) -> None:
         seen_lines_map = defaultdict(set)
         for probe in (_ for _ in cls.get_triggered_probes() if isinstance(_, LogLineProbe)):
             seen_lines_map[probe.source_file].add(probe.line)
@@ -85,13 +83,11 @@ class LineCoverage(ExplorationDebugger):
         print("")
 
     @classmethod
-    def on_disable(cls):
-        # type: () -> None
+    def on_disable(cls) -> None:
         cls.report_coverage()
 
     @classmethod
-    def on_snapshot(cls, snapshot):
-        # type: (Snapshot) -> None
+    def on_snapshot(cls, snapshot: Snapshot) -> None:
         if config.coverage.delete_probes:
             cls.delete_probe(snapshot.probe)
 

--- a/tests/debugging/exploration/_profiler.py
+++ b/tests/debugging/exploration/_profiler.py
@@ -16,12 +16,11 @@ from ddtrace.internal.module import origin
 
 
 # Track all instrumented functions and their call count.
-_tracked_funcs = {}  # type: t.Dict[str, int]
+_tracked_funcs: t.Dict[str, int] = {}
 
 
 class FunctionCollector(ModuleCollector):
-    def on_collect(self, discovery):
-        # type: (FunctionDiscovery) -> None
+    def on_collect(self, discovery: FunctionDiscovery) -> None:
         module = discovery._module
         status("[profiler] Collecting functions from %s" % module.__name__)
         for fname, f in discovery._fullname_index.items():
@@ -46,8 +45,7 @@ class DeterministicProfiler(ExplorationDebugger):
     __watchdog__ = FunctionCollector
 
     @classmethod
-    def report_func_calls(cls):
-        # type: () -> None
+    def report_func_calls(cls) -> None:
         for probe in (_ for _ in cls.get_triggered_probes() if isinstance(_, FunctionLocationMixin)):
             _tracked_funcs[".".join([probe.module, probe.func_qname])] += 1
         print(("{:=^%ds}" % COLS).format(" Function coverage "))
@@ -67,13 +65,11 @@ class DeterministicProfiler(ExplorationDebugger):
         print("")
 
     @classmethod
-    def on_disable(cls):
-        # type: () -> None
+    def on_disable(cls) -> None:
         cls.report_func_calls()
 
     @classmethod
-    def on_snapshot(cls, snapshot):
-        # type: (Snapshot) -> None
+    def on_snapshot(cls, snapshot: Snapshot) -> None:
         if config.profiler.delete_probes:
             cls.delete_probe(snapshot.probe)
 

--- a/tests/debugging/exploration/debugger.py
+++ b/tests/debugging/exploration/debugger.py
@@ -36,14 +36,12 @@ CWD = os.path.abspath(os.getcwd())
 TESTS = os.path.join(CWD, "test")
 
 
-def from_editable_install(module):
-    # type: (ModuleType) -> bool
+def from_editable_install(module: ModuleType) -> bool:
     o = origin(module)
     return o.startswith(CWD) and not o.startswith(TESTS) and (config.venv is None or not o.startswith(config.venv))
 
 
-def is_included(module):
-    # type: (ModuleType) -> bool
+def is_included(module: ModuleType) -> bool:
     segments = module.__name__.split(".")
     for i in config.include:
         if i == segments[: len(i)]:
@@ -51,8 +49,7 @@ def is_included(module):
     return False
 
 
-def is_ddtrace(module):
-    # type: (ModuleType) -> bool
+def is_ddtrace(module: ModuleType) -> bool:
     name = module.__name__
     return name == "ddtrace" or name.startswith("ddtrace.")
 
@@ -61,10 +58,9 @@ class ModuleCollector(DebuggerModuleWatchdog):
     def __init__(self, *args, **kwargs):
         super(ModuleCollector, self).__init__(*args, **kwargs)
 
-        self._imported_modules = set()  # type: t.Set[str]
+        self._imported_modules: t.Set[str] = set()
 
-    def on_collect(self, discovery):
-        # type: (FunctionDiscovery) -> None
+    def on_collect(self, discovery: FunctionDiscovery) -> None:
         raise NotImplementedError()
 
     def _on_new_module(self, module):
@@ -91,8 +87,7 @@ class ModuleCollector(DebuggerModuleWatchdog):
             status("Error after module import %s: %s" % (module.__name__, e))
             raise e
 
-    def after_import(self, module):
-        # type: (ModuleType) -> None
+    def after_import(self, module: ModuleType) -> None:
         name = module.__name__
         if name in self._imported_modules:
             return
@@ -165,8 +160,7 @@ class NoopProbeStatusLogger(object):
 
 
 class NoopSnapshotJsonEncoder(LogSignalJsonEncoder):
-    def encode(self, snapshot):
-        # type: (Snapshot) -> bytes
+    def encode(self, snapshot: Snapshot) -> bytes:
         return b""
 
 
@@ -181,8 +175,7 @@ class ExplorationSignalCollector(SignalCollector):
         self._failed_encoding = []
         self.on_snapshot = None
 
-    def _enqueue(self, snapshot):
-        # type: (Snapshot) -> None
+    def _enqueue(self, snapshot: Snapshot) -> None:
         if config.encode:
             try:
                 self._snapshots.append(self._encoder.encode(snapshot))
@@ -194,13 +187,11 @@ class ExplorationSignalCollector(SignalCollector):
             self.on_snapshot(snapshot)
 
     @property
-    def snapshots(self):
-        # type: () -> t.List[Snapshot]
+    def snapshots(self) -> t.List[Snapshot]:
         return self._snapshots or [None]
 
     @property
-    def probes(self):
-        # type: () -> t.List[Probe]
+    def probes(self) -> t.List[Probe]:
         return self._probes or [None]
 
 
@@ -213,18 +204,15 @@ class ExplorationDebugger(Debugger):
     __poller__ = NoopProbePoller
 
     @classmethod
-    def on_disable(cls):
-        # type: () -> None
+    def on_disable(cls) -> None:
         raise NotImplementedError()
 
     @classmethod
-    def on_snapshot(cls, snapshot):
-        # type: (Snapshot) -> None
+    def on_snapshot(cls, snapshot: Snapshot) -> None:
         pass
 
     @classmethod
-    def enable(cls):
-        # type: () -> None
+    def enable(cls) -> None:
         di_config.max_probes = float("inf")
         di_config.global_rate_limit = float("inf")
         di_config.metrics = False
@@ -234,8 +222,7 @@ class ExplorationDebugger(Debugger):
         cls._instance._collector.on_snapshot = cls.on_snapshot
 
     @classmethod
-    def disable(cls, join=True):
-        # type: (bool) -> None
+    def disable(cls, join: bool = True) -> None:
         registry = cls._instance._probe_registry
 
         nprobes = len(registry)
@@ -256,44 +243,37 @@ class ExplorationDebugger(Debugger):
         super(ExplorationDebugger, cls).disable(join=join)
 
     @classmethod
-    def get_snapshots(cls):
-        # type: () -> t.List[Snapshot]
+    def get_snapshots(cls) -> t.List[Snapshot]:
         if cls._instance is None:
             return None
         return cls._instance._collector.snapshots
 
     @classmethod
-    def get_triggered_probes(cls):
-        # type: () -> t.List[Probe]
+    def get_triggered_probes(cls) -> t.List[Probe]:
         if cls._instance is None:
             return None
         return cls._instance._collector.probes
 
     @classmethod
-    def add_probe(cls, probe):
-        # type: (Probe) -> None
+    def add_probe(cls, probe: Probe) -> None:
         cls._instance._on_configuration(ProbePollerEvent.NEW_PROBES, [probe])
 
     @classmethod
-    def add_probes(cls, probes):
-        # type: (t.List[Probe]) -> None
+    def add_probes(cls, probes: t.List[Probe]) -> None:
         cls._instance._on_configuration(ProbePollerEvent.NEW_PROBES, probes)
 
     @classmethod
-    def delete_probe(cls, probe):
-        # type: (Probe) -> None
+    def delete_probe(cls, probe: Probe) -> None:
         cls._instance._on_configuration(ProbePollerEvent.DELETED_PROBES, [probe])
 
 
 if config.status_messages:
 
-    def status(msg):
-        # type: (str) -> None
+    def status(msg: str) -> None:
         print(("{:%d}" % COLS).format(msg))
 
 
 else:
 
-    def status(msg):
-        # type: (str) -> None
+    def status(msg: str) -> None:
         pass

--- a/tests/debugging/mocking.py
+++ b/tests/debugging/mocking.py
@@ -87,8 +87,7 @@ class MockProbeStatusLogger(DummyProbeStatusLogger):
 
 
 class TestSignalCollector(SignalCollector):
-    def __init__(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(TestSignalCollector, self).__init__(*args, **kwargs)
         self.test_queue = []
         self.signal_state_counter = Counter()
@@ -121,16 +120,13 @@ class TestDebugger(Debugger):
     __uploader__ = MockLogsIntakeUploaderV1
     __collector__ = TestSignalCollector
 
-    def add_probes(self, *probes):
-        # type: (Probe) -> None
+    def add_probes(self, *probes: Probe) -> None:
         self._on_configuration(ProbePollerEvent.NEW_PROBES, probes)
 
-    def remove_probes(self, *probes):
-        # type: (Probe) -> None
+    def remove_probes(self, *probes: Probe) -> None:
         self._on_configuration(ProbePollerEvent.DELETED_PROBES, probes)
 
-    def modify_probes(self, *probes):
-        # type: (Probe) -> None
+    def modify_probes(self, *probes: Probe) -> None:
         self._on_configuration(ProbePollerEvent.MODIFIED_PROBES, probes)
 
     @property
@@ -166,8 +162,7 @@ class TestDebugger(Debugger):
 
 
 @contextmanager
-def _debugger(config_to_override, config_overrides):
-    # type: (En, Any) -> Generator[TestDebugger, None, None]
+def _debugger(config_to_override: En, config_overrides: Any) -> Generator[TestDebugger, None, None]:
     """Test with the debugger enabled."""
     atexit_register = atexit.register
     try:
@@ -192,8 +187,7 @@ def _debugger(config_to_override, config_overrides):
 
 
 @contextmanager
-def debugger(**config_overrides):
-    # type: (Any) -> Generator[TestDebugger, None, None]
+def debugger(**config_overrides: Any) -> Generator[TestDebugger, None, None]:
     """Test with the debugger enabled."""
     with _debugger(di_config, config_overrides) as debugger:
         yield debugger

--- a/tests/debugging/test_async.py
+++ b/tests/debugging/test_async.py
@@ -16,8 +16,7 @@ class MockSignalContext:
 
 
 @pytest.mark.asyncio
-async def test_dd_coroutine_wrapper_return():
-    # type: () -> None
+async def test_dd_coroutine_wrapper_return() -> None:
     contexts = [MockSignalContext() for _ in range(10)]
 
     async def coro():
@@ -31,8 +30,7 @@ async def test_dd_coroutine_wrapper_return():
 
 
 @pytest.mark.asyncio
-async def test_dd_coroutine_wrapper_exc():
-    # type: () -> None
+async def test_dd_coroutine_wrapper_exc() -> None:
     contexts = [MockSignalContext() for _ in range(10)]
 
     class MyException(Exception):


### PR DESCRIPTION
With support for Python 2 now dropped we can switch to using type annotations instead of comments. This will allow us to use the latest versions of tools like mypy on the codebase.

The changes in this PR have been generated (and just slightly tweaked) with [com2ann](https://github.com/ilevkivskyi/com2ann).

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
