### PR TITLE
Revert "chore(ci-visibility): rename fixture filenames in tests"

### DIFF
--- a/tests/ci_visibility/test_coverage_per_suite.py
+++ b/tests/ci_visibility/test_coverage_per_suite.py
@@ -33,18 +33,19 @@ class PytestTestCase(TracerTestCase):
                         CIVisibility.disable()
                         CIVisibility.enable(tracer=self.tracer, config=ddtrace.config.pytest)
 
-        return self.testdir.inline_run(*args, plugins=[CIVisibilityPlugin()])
+        with override_env(dict(DD_API_KEY="foobar.baz")):
+            return self.testdir.inline_run(*args, plugins=[CIVisibilityPlugin()])
 
     @pytest.mark.skipif(compat.PY2, reason="ddtrace does not support coverage on Python 2")
     def test_pytest_will_report_coverage_by_suite_with_pytest_skipped(self):
         self.testdir.makepyfile(
-            ret_false="""
+            test_ret_false="""
         def ret_false():
             return False
         """
         )
         self.testdir.makepyfile(
-            lib_fn="""
+            test_module="""
         def lib_fn():
             return True
         """
@@ -52,13 +53,13 @@ class PytestTestCase(TracerTestCase):
         py_cov_file = self.testdir.makepyfile(
             test_cov="""
         import pytest
-        from lib_fn import lib_fn
+        from test_module import lib_fn
 
         def test_cov():
             assert lib_fn()
 
         def test_second():
-            from ret_false import ret_false
+            from test_ret_false import ret_false
             assert not ret_false()
 
         def test_pytest_skip():
@@ -104,12 +105,12 @@ class PytestTestCase(TracerTestCase):
         import pytest
 
         def test_second():
-            from ret_false import ret_false
+            from test_ret_false import ret_false
             assert not ret_false()
         """
         )
 
-        with override_env({"DD_API_KEY": "foobar.baz", "_DD_CIVISIBILITY_ITR_SUITE_MODE": "True"}), mock.patch(
+        with override_env({"_DD_CIVISIBILITY_ITR_SUITE_MODE": "True"}), mock.patch(
             "ddtrace.internal.ci_visibility.recorder.CIVisibility._check_enabled_features", return_value=(True, False)
         ):
             self.inline_run("--ddtrace", os.path.basename(py_cov_file.strpath), os.path.basename(py_cov_file2.strpath))
@@ -124,21 +125,21 @@ class PytestTestCase(TracerTestCase):
 
         assert len(files) == 3
 
-        assert files[2]["filename"] == "test_cov.py"
-        assert len(files[2]["segments"]) == 5
-        assert files[2]["segments"][0] == [5, 0, 5, 0, -1]
-        assert files[2]["segments"][1] == [8, 0, 9, 0, -1]
-        assert files[2]["segments"][2] == [12, 0, 13, 0, -1]
-        assert files[2]["segments"][3] == [21, 0, 22, 0, -1]
-        assert files[2]["segments"][4] == [35, 0, 36, 0, -1]
+        assert files[0]["filename"] == "test_cov.py"
+        assert len(files[0]["segments"]) == 5
+        assert files[0]["segments"][0] == [5, 0, 5, 0, -1]
+        assert files[0]["segments"][1] == [8, 0, 9, 0, -1]
+        assert files[0]["segments"][2] == [12, 0, 13, 0, -1]
+        assert files[0]["segments"][3] == [21, 0, 22, 0, -1]
+        assert files[0]["segments"][4] == [35, 0, 36, 0, -1]
 
-        assert files[0]["filename"] == "lib_fn.py"
-        assert len(files[0]["segments"]) == 1
-        assert files[0]["segments"][0] == [2, 0, 2, 0, -1]
-
-        assert files[1]["filename"] == "ret_false.py"
+        assert files[1]["filename"] == "test_module.py"
         assert len(files[1]["segments"]) == 1
-        assert files[1]["segments"][0] == [1, 0, 2, 0, -1]
+        assert files[1]["segments"][0] == [2, 0, 2, 0, -1]
+
+        assert files[2]["filename"] == "test_ret_false.py"
+        assert len(files[2]["segments"]) == 1
+        assert files[2]["segments"][0] == [1, 0, 2, 0, -1]
 
         second_suite_span = test_suite_spans[-1]
         assert second_suite_span.get_tag("type") == "test_suite_end"
@@ -146,23 +147,23 @@ class PytestTestCase(TracerTestCase):
         tag_data = json.loads(second_suite_span.get_tag(COVERAGE_TAG_NAME))
         files = sorted(tag_data["files"], key=lambda x: x["filename"])
         assert len(files) == 2
-        assert files[1]["filename"] == "test_cov_second.py"
-        assert files[0]["filename"] == "ret_false.py"
-        assert len(files[1]["segments"]) == 1
-        assert files[1]["segments"][0] == [4, 0, 5, 0, -1]
+        assert files[0]["filename"] == "test_cov_second.py"
+        assert files[1]["filename"] == "test_ret_false.py"
         assert len(files[0]["segments"]) == 1
-        assert files[0]["segments"][0] == [2, 0, 2, 0, -1]
+        assert files[0]["segments"][0] == [4, 0, 5, 0, -1]
+        assert len(files[1]["segments"]) == 1
+        assert files[1]["segments"][0] == [2, 0, 2, 0, -1]
 
     @pytest.mark.skipif(compat.PY2, reason="ddtrace does not support coverage on Python 2")
     def test_pytest_will_report_coverage_by_suite_with_itr_skipped(self):
         self.testdir.makepyfile(
-            ret_false="""
+            test_ret_false="""
         def ret_false():
             return False
         """
         )
         self.testdir.makepyfile(
-            lib_fn="""
+            test_module="""
         def lib_fn():
             return True
         """
@@ -170,13 +171,13 @@ class PytestTestCase(TracerTestCase):
         py_cov_file = self.testdir.makepyfile(
             test_cov="""
         import pytest
-        from lib_fn import lib_fn
+        from test_module import lib_fn
 
         def test_cov():
             assert lib_fn()
 
         def test_second():
-            from ret_false import ret_false
+            from test_ret_false import ret_false
             assert not ret_false()
         """
         )
@@ -185,14 +186,13 @@ class PytestTestCase(TracerTestCase):
         import pytest
 
         def test_second():
-            from ret_false import ret_false
+            from test_ret_false import ret_false
             assert not ret_false()
         """
         )
 
         with override_env(
             {
-                "DD_API_KEY": "foobar.baz",
                 "_DD_CIVISIBILITY_ITR_SUITE_MODE": "True",
                 "DD_APPLICATION_KEY": "not_an_app_key_at_all",
                 "DD_CIVISIBILITY_AGENTLESS_ENABLED": "True",
@@ -224,18 +224,18 @@ class PytestTestCase(TracerTestCase):
 
         assert len(files) == 3
 
-        assert files[2]["filename"] == "test_cov.py"
-        assert len(files[2]["segments"]) == 2
-        assert files[2]["segments"][0] == [5, 0, 5, 0, -1]
-        assert files[2]["segments"][1] == [8, 0, 9, 0, -1]
+        assert files[0]["filename"] == "test_cov.py"
+        assert len(files[0]["segments"]) == 2
+        assert files[0]["segments"][0] == [5, 0, 5, 0, -1]
+        assert files[0]["segments"][1] == [8, 0, 9, 0, -1]
 
-        assert files[0]["filename"] == "lib_fn.py"
-        assert len(files[0]["segments"]) == 1
-        assert files[0]["segments"][0] == [2, 0, 2, 0, -1]
-
-        assert files[1]["filename"] == "ret_false.py"
+        assert files[1]["filename"] == "test_module.py"
         assert len(files[1]["segments"]) == 1
-        assert files[1]["segments"][0] == [1, 0, 2, 0, -1]
+        assert files[1]["segments"][0] == [2, 0, 2, 0, -1]
+
+        assert files[2]["filename"] == "test_ret_false.py"
+        assert len(files[2]["segments"]) == 1
+        assert files[2]["segments"][0] == [1, 0, 2, 0, -1]
 
         second_suite_span = test_suite_spans[1]
         assert second_suite_span.get_tag("type") == "test_suite_end"

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -1414,7 +1414,7 @@ class PytestTestCase(TracerTestCase):
         Test that running pytest without module will create an empty module span with empty path.
         """
         self.testdir.makepyfile(
-            lib_fn="""
+            test_module="""
         def lib_fn():
             return True
         """
@@ -1423,7 +1423,7 @@ class PytestTestCase(TracerTestCase):
         self.testdir.makepyfile(
             test_cov="""
         import pytest
-        from lib_fn import lib_fn
+        from test_module import lib_fn
 
         def test_cov():
             assert lib_fn()
@@ -1445,13 +1445,13 @@ class PytestTestCase(TracerTestCase):
     @pytest.mark.skipif(compat.PY2, reason="ddtrace does not support coverage on Python 2")
     def test_pytest_will_report_coverage_by_test(self):
         self.testdir.makepyfile(
-            ret_false="""
+            test_ret_false="""
         def ret_false():
             return False
         """
         )
         self.testdir.makepyfile(
-            lib_fn="""
+            test_module="""
         def lib_fn():
             return True
         """
@@ -1461,11 +1461,11 @@ class PytestTestCase(TracerTestCase):
         import pytest
 
         def test_cov():
-            from lib_fn import lib_fn
+            from test_module import lib_fn
             assert lib_fn()
 
         def test_second():
-            from ret_false import ret_false
+            from test_ret_false import ret_false
             assert not ret_false()
         """
         )
@@ -1483,12 +1483,12 @@ class PytestTestCase(TracerTestCase):
         first_tag_data = json.loads(first_test_span.get_tag(COVERAGE_TAG_NAME))
         files = sorted(first_tag_data["files"], key=lambda x: x["filename"])
         assert len(files) == 2
-        assert files[0]["filename"] == "lib_fn.py"
-        assert files[1]["filename"] == "test_cov.py"
+        assert files[0]["filename"] == "test_cov.py"
+        assert files[1]["filename"] == "test_module.py"
         assert len(files[0]["segments"]) == 1
-        assert files[0]["segments"][0] == [1, 0, 2, 0, -1]
+        assert files[0]["segments"][0] == [4, 0, 5, 0, -1]
         assert len(files[1]["segments"]) == 1
-        assert files[1]["segments"][0] == [4, 0, 5, 0, -1]
+        assert files[1]["segments"][0] == [1, 0, 2, 0, -1]
 
         second_test_span = spans[1]
         assert second_test_span.get_tag("type") == "test"
@@ -1497,12 +1497,12 @@ class PytestTestCase(TracerTestCase):
         second_tag_data = json.loads(second_test_span.get_tag(COVERAGE_TAG_NAME))
         files = sorted(second_tag_data["files"], key=lambda x: x["filename"])
         assert len(files) == 2
-        assert files[0]["filename"] == "ret_false.py"
-        assert files[1]["filename"] == "test_cov.py"
+        assert files[0]["filename"] == "test_cov.py"
+        assert files[1]["filename"] == "test_ret_false.py"
         assert len(files[0]["segments"]) == 1
-        assert files[0]["segments"][0] == [1, 0, 2, 0, -1]
+        assert files[0]["segments"][0] == [8, 0, 9, 0, -1]
         assert len(files[1]["segments"]) == 1
-        assert files[1]["segments"][0] == [8, 0, 9, 0, -1]
+        assert files[1]["segments"][0] == [1, 0, 2, 0, -1]
 
     @pytest.mark.skipif(compat.PY2, reason="ddtrace does not support coverage on Python 2")
     def test_pytest_will_report_coverage_by_test_with_itr_skipped(self):


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#6487

Breaks `integration_agent` job: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/42612/workflows/9d3bdd81-8dcb-4403-b750-98de951a29b5/jobs/2836219

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))