### PR TITLE
chore(asm): add LazyTaintList Django QueryDict support

### DIFF
--- a/ddtrace/appsec/iast/_taint_utils.py
+++ b/ddtrace/appsec/iast/_taint_utils.py
@@ -204,10 +204,7 @@ class LazyTaintDict:
                     try:
                         # TODO: migrate this part to shift ranges instead of creating a new one
                         value = taint_pyobject(
-                            pyobject=value,
-                            source_name=key,
-                            source_value=value,
-                            source_origin=origin,
+                            pyobject=value, source_name=key, source_value=value, source_origin=origin,
                         )
                     except SystemError:
                         # TODO: Find the root cause for
@@ -286,9 +283,7 @@ class LazyTaintDict:
         if _is_tainted_struct(other):
             other = other._obj
         return LazyTaintDict(
-            self._obj | other,
-            origins=self._origins,
-            override_pyobject_tainted=self._override_pyobject_tainted,
+            self._obj | other, origins=self._origins, override_pyobject_tainted=self._override_pyobject_tainted,
         )
 
     def __repr__(self):
@@ -309,9 +304,7 @@ class LazyTaintDict:
 
     def copy(self):
         return LazyTaintDict(
-            self._obj.copy(),
-            origins=self._origins,
-            override_pyobject_tainted=self._override_pyobject_tainted,
+            self._obj.copy(), origins=self._origins, override_pyobject_tainted=self._override_pyobject_tainted,
         )
 
     @classmethod
@@ -352,6 +345,28 @@ class LazyTaintDict:
     def values(self):
         for _, v in self.items():
             yield v
+
+    # Django Query Dict support
+    def getlist(self, key, default=None):
+        return self._taint(self._obj.getlist(key, default=default), key)
+
+    def setlist(self, key, list_):
+        self._obj.setlist(key, list_)
+
+    def appendlist(self, key, item):
+        self._obj.appendlist(key, item)
+
+    def setlistdefault(self, key, default_list=None):
+        return self._taint(self._obj.setlistdefault(key, default_list=default_list), key)
+
+    def lists(self):
+        return self._taint(self._obj.lists(), self._origin_value)
+
+    def dict(self):
+        return self
+
+    def urlencode(self, safe=None):
+        return self._taint(self._obj.urlencode(safe=safe), self._origin_value)
 
 
 def supported_dbapi_integration(integration_name):


### PR DESCRIPTION
https://github.com/DataDog/dd-trace-py/pull/6556 introduced a critical error in ASM support for Django. This PR add what was missing to support QueryDict in the Django Framework for our lazy tainting data structures.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
