### PR TITLE
chore(tracing): decrease the maximum size of span tags

### DIFF
--- a/releasenotes/notes/decrease_max_string_size-6a2802b4ce6a90af.yaml
+++ b/releasenotes/notes/decrease_max_string_size-6a2802b4ce6a90af.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    tracing: Previously the maximum size of a span tag was set to the full size of trace writer buffer (via DD_TRACE_WRITER_BUFFER_SIZE_BYTES).
+    With this change the maximum size of span tags will be set to 10% of the size of the writer's buffer. This should decrease the frequency 
+    of encoding errors due to large span tags.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -159,13 +159,14 @@ def test_resource_name_too_large(monkeypatch):
     t = Tracer()
     assert t._writer._buffer_size == FOUR_KB
     s = t.trace("operation", service="foo")
-    s.resource = "B" * (FOUR_KB + 1)
+    # Maximum string length is set to 10% of the maximum buffer size
+    s.resource = "B" * int(0.1*FOUR_KB + 1)
     try:
         s.finish()
     except ValueError:
         pytest.fail()
     encoded_spans = t._writer._encoder.encode()
-    assert b"<dropped string of length 4097 because it's too long (max allowed length 4096)>" in encoded_spans
+    assert b"<dropped string of length 410 because it's too long (max allowed length 409)>" in encoded_spans
 
 
 @parametrize_with_all_encodings


### PR DESCRIPTION
Resolves: https://github.com/DataDog/dd-trace-py/issues/6587

Previously the maximum size of a span tag was set to the full size of trace writer buffer (via DD_TRACE_WRITER_BUFFER_SIZE_BYTES).With this change the maximum size of span tags will be set to 10% of the size of the writer's buffer. This should decrease the frequency of encoding errors due to large span tags.

Note: The new maximum size of span tags (10% of the buffer size) was chosen arbitrary. Feel free to suggest a more appropriate value.

Note: This change intentionally avoids adding a new tracer configuration. Allowing two configurations could add unnecessary complexity. Making the max string size a function of buffer size should be good enough. 

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
