### PR TITLE
chore(asm): raw body django tainting for IAST

### DIFF
--- a/ddtrace/appsec/handlers.py
+++ b/ddtrace/appsec/handlers.py
@@ -169,32 +169,43 @@ def _on_django_func_wrapped(fn_args, fn_kwargs, first_arg_expected_type):
     # path parameters)
     if _is_iast_enabled() and fn_args and isinstance(fn_args[0], first_arg_expected_type):
         from ddtrace.appsec.iast._taint_tracking import OriginType  # noqa: F401
+        from ddtrace.appsec.iast._taint_tracking import is_pyobject_tainted
         from ddtrace.appsec.iast._taint_tracking import taint_pyobject
         from ddtrace.appsec.iast._taint_utils import LazyTaintDict
 
-        if not isinstance(fn_args[0].COOKIES, LazyTaintDict):
-            fn_args[0].COOKIES = LazyTaintDict(fn_args[0].COOKIES, origins=(OriginType.COOKIE_NAME, OriginType.COOKIE))
-        if not isinstance(fn_args[0].GET, LazyTaintDict):
-            fn_args[0].GET = LazyTaintDict(fn_args[0].GET, origins=(OriginType.PARAMETER_NAME, OriginType.PARAMETER))
-        if not isinstance(fn_args[0].POST, LazyTaintDict):
-            fn_args[0].POST = LazyTaintDict(fn_args[0].POST, origins=(OriginType.BODY, OriginType.BODY))
-        if not isinstance(fn_args[0].META, LazyTaintDict):
-            fn_args[0].META = LazyTaintDict(fn_args[0].META, origins=(OriginType.HEADER_NAME, OriginType.HEADER))
-        if not isinstance(fn_args[0].headers, LazyTaintDict):
-            fn_args[0].headers = LazyTaintDict(fn_args[0].headers, origins=(OriginType.HEADER_NAME, OriginType.HEADER))
-        fn_args[0].path = taint_pyobject(
-            fn_args[0].path, source_name="path", source_value=fn_args[0].path, source_origin=OriginType.PATH
+        http_req = fn_args[0]
+
+        if not isinstance(http_req.COOKIES, LazyTaintDict):
+            http_req.COOKIES = LazyTaintDict(http_req.COOKIES, origins=(OriginType.COOKIE_NAME, OriginType.COOKIE))
+        if not isinstance(http_req.GET, LazyTaintDict):
+            http_req.GET = LazyTaintDict(http_req.GET, origins=(OriginType.PARAMETER_NAME, OriginType.PARAMETER))
+        if not isinstance(http_req.POST, LazyTaintDict):
+            http_req.POST = LazyTaintDict(http_req.POST, origins=(OriginType.BODY, OriginType.BODY))
+        if not is_pyobject_tainted(getattr(http_req, "_body", None)):
+            http_req._body = taint_pyobject(
+                http_req.body,
+                source_name="body",
+                source_value=http_req.body,
+                source_origin=OriginType.BODY,
+            )
+
+        if not isinstance(http_req.META, LazyTaintDict):
+            http_req.META = LazyTaintDict(http_req.META, origins=(OriginType.HEADER_NAME, OriginType.HEADER))
+        if not isinstance(http_req.headers, LazyTaintDict):
+            http_req.headers = LazyTaintDict(http_req.headers, origins=(OriginType.HEADER_NAME, OriginType.HEADER))
+        http_req.path = taint_pyobject(
+            http_req.path, source_name="path", source_value=http_req.path, source_origin=OriginType.PATH
         )
-        fn_args[0].path_info = taint_pyobject(
-            fn_args[0].path_info,
+        http_req.path_info = taint_pyobject(
+            http_req.path_info,
             source_name="path",
-            source_value=fn_args[0].path,
+            source_value=http_req.path,
             source_origin=OriginType.PATH,
         )
-        fn_args[0].environ["PATH_INFO"] = taint_pyobject(
-            fn_args[0].environ["PATH_INFO"],
+        http_req.environ["PATH_INFO"] = taint_pyobject(
+            http_req.environ["PATH_INFO"],
             source_name="path",
-            source_value=fn_args[0].path,
+            source_value=http_req.path,
             source_origin=OriginType.PATH,
         )
         if fn_kwargs:

--- a/tests/contrib/django/django_app/appsec_urls.py
+++ b/tests/contrib/django/django_app/appsec_urls.py
@@ -197,8 +197,6 @@ def sqli_http_request_body(request):
         value = request.POST[key]
     else:
         value = decode_aspect(request.body)
-
-    print("VALUE", value)
     with connection.cursor() as cursor:
         # label iast_enabled_sqli_http_body
         cursor.execute(add_aspect("SELECT 1 FROM sqlite_", value))

--- a/tests/contrib/django/django_app/appsec_urls.py
+++ b/tests/contrib/django/django_app/appsec_urls.py
@@ -14,6 +14,7 @@ from ddtrace.appsec.trace_utils import block_request_if_user_blocked
 
 try:
     from ddtrace.appsec.iast._taint_tracking.aspects import add_aspect
+    from ddtrace.appsec.iast._taint_tracking.aspects import decode_aspect
 except ImportError:
     # Python 2 compatibility
     from operator import add as add_aspect
@@ -190,6 +191,21 @@ def sqli_http_request_cookie_value(request):
     return HttpResponse(request.COOKIES["master"], status=200)
 
 
+def sqli_http_request_body(request):
+    key = "master_key"
+    if key in request.POST:
+        value = request.POST[key]
+    else:
+        value = decode_aspect(request.body)
+
+    print("VALUE", value)
+    with connection.cursor() as cursor:
+        # label iast_enabled_sqli_http_body
+        cursor.execute(add_aspect("SELECT 1 FROM sqlite_", value))
+
+    return HttpResponse(value, status=200)
+
+
 def validate_querydict(request):
     qd = request.GET
     res = qd.getlist("x")
@@ -212,6 +228,7 @@ urlpatterns = [
     handler("sqli_http_request_header_value/$", sqli_http_request_header_value, name="sqli_http_request_header_value"),
     handler("sqli_http_request_cookie_name/$", sqli_http_request_cookie_name, name="sqli_http_request_cookie_name"),
     handler("sqli_http_request_cookie_value/$", sqli_http_request_cookie_value, name="sqli_http_request_cookie_value"),
+    handler("sqli_http_request_body/$", sqli_http_request_body, name="sqli_http_request_body"),
     path(
         "sqli_http_path_parameter/<str:q_http_path_parameter>/",
         sqli_http_path_parameter,

--- a/tests/contrib/django/test_django_appsec_iast.py
+++ b/tests/contrib/django/test_django_appsec_iast.py
@@ -18,7 +18,14 @@ TEST_FILE = "tests/contrib/django/django_app/appsec_urls.py"
 
 
 def _aux_appsec_get_root_span(
-    client, test_spans, tracer, payload=None, url="/", content_type="text/plain", headers=None, cookies={},
+    client,
+    test_spans,
+    tracer,
+    payload=None,
+    url="/",
+    content_type="text/plain",
+    headers=None,
+    cookies={},
 ):
     tracer._appsec_enabled = config._appsec_enabled
     tracer._iast_enabled = config._iast_enabled
@@ -351,7 +358,11 @@ def test_django_tainted_user_agent_iast_enabled_sqli_http_cookies_name(client, t
         setup(bytes.join, bytearray.join)
 
         root_span, response = _aux_appsec_get_root_span(
-            client, test_spans, tracer, url="/appsec/sqli_http_request_cookie_name/", cookies={"master": "test/1.2.3"},
+            client,
+            test_spans,
+            tracer,
+            url="/appsec/sqli_http_request_cookie_name/",
+            cookies={"master": "test/1.2.3"},
         )
         vuln_type = "SQL_INJECTION"
 
@@ -383,7 +394,11 @@ def test_django_tainted_iast_disabled_sqli_http_cookies_name(client, test_spans,
         setup(bytes.join, bytearray.join)
 
         root_span, response = _aux_appsec_get_root_span(
-            client, test_spans, tracer, url="/appsec/sqli_http_request_cookie_name/", cookies={"master": "test/1.2.3"},
+            client,
+            test_spans,
+            tracer,
+            url="/appsec/sqli_http_request_cookie_name/",
+            cookies={"master": "test/1.2.3"},
         )
 
         assert root_span.get_tag(IAST.JSON) is None
@@ -403,7 +418,11 @@ def test_django_tainted_user_agent_iast_enabled_sqli_http_cookies_value(client, 
         setup(bytes.join, bytearray.join)
 
         root_span, response = _aux_appsec_get_root_span(
-            client, test_spans, tracer, url="/appsec/sqli_http_request_cookie_value/", cookies={"master": "master"},
+            client,
+            test_spans,
+            tracer,
+            url="/appsec/sqli_http_request_cookie_value/",
+            cookies={"master": "master"},
         )
         vuln_type = "SQL_INJECTION"
         loaded = json.loads(root_span.get_tag(IAST.JSON))
@@ -434,7 +453,79 @@ def test_django_tainted_iast_disabled_sqli_http_cookies_value(client, test_spans
         setup(bytes.join, bytearray.join)
 
         root_span, response = _aux_appsec_get_root_span(
-            client, test_spans, tracer, url="/appsec/sqli_http_request_cookie_value/", cookies={"master": "master"},
+            client,
+            test_spans,
+            tracer,
+            url="/appsec/sqli_http_request_cookie_value/",
+            cookies={"master": "master"},
+        )
+
+        assert root_span.get_tag(IAST.JSON) is None
+
+        assert response.status_code == 200
+        assert response.content == b"master"
+
+
+@pytest.mark.parametrize(
+    ("payload", "content_type"),
+    [
+        ("master", "application/json"),
+        ("master", "text/plain"),
+    ],
+)
+@pytest.mark.django_db()
+@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+def test_django_tainted_user_agent_iast_enabled_sqli_http_body(client, test_spans, tracer, payload, content_type):
+    from ddtrace.appsec.iast._taint_tracking import setup
+
+    with override_global_config(dict(_iast_enabled=True)), mock.patch(
+        "ddtrace.contrib.dbapi._is_iast_enabled", return_value=True
+    ):
+        setup(bytes.join, bytearray.join)
+
+        root_span, response = _aux_appsec_get_root_span(
+            client,
+            test_spans,
+            tracer,
+            url="/appsec/sqli_http_request_body/",
+            payload=payload,
+            content_type=content_type,
+        )
+        vuln_type = "SQL_INJECTION"
+        loaded = json.loads(root_span.get_tag(IAST.JSON))
+
+        line, hash_value = get_line_and_hash("iast_enabled_sqli_http_body", vuln_type, filename=TEST_FILE)
+
+        assert loaded["sources"] == [{"origin": "http.request.body", "name": "body", "value": "master"}]
+        assert loaded["vulnerabilities"][0]["type"] == "SQL_INJECTION"
+        assert loaded["vulnerabilities"][0]["hash"] == hash_value
+        assert loaded["vulnerabilities"][0]["evidence"] == {
+            "valueParts": [{"value": "SELECT 1 FROM sqlite_"}, {"source": 0, "value": "master"}]
+        }
+        assert loaded["vulnerabilities"][0]["location"]["line"] == line
+        assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+
+        assert response.status_code == 200
+        assert response.content == b"master"
+
+
+@pytest.mark.django_db()
+@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+def test_django_tainted_iast_disabled_sqli_http_body(client, test_spans, tracer):
+    from ddtrace.appsec.iast._taint_tracking import setup
+
+    with override_global_config(dict(_iast_enabled=False)), mock.patch(
+        "ddtrace.contrib.dbapi._is_iast_enabled", return_value=False
+    ):
+        setup(bytes.join, bytearray.join)
+
+        root_span, response = _aux_appsec_get_root_span(
+            client,
+            test_spans,
+            tracer,
+            url="/appsec/sqli_http_request_body/",
+            payload="master",
+            content_type="application/json",
         )
 
         assert root_span.get_tag(IAST.JSON) is None
@@ -453,7 +544,10 @@ def test_querydict_django_with_iast(client, test_spans, tracer):
         setup(bytes.join, bytearray.join)
 
         root_span, response = _aux_appsec_get_root_span(
-            client, test_spans, tracer, url="/appsec/validate_querydict/?x=1&y=2&x=3",
+            client,
+            test_spans,
+            tracer,
+            url="/appsec/validate_querydict/?x=1&y=2&x=3",
         )
 
         assert root_span.get_tag(IAST.JSON) is None


### PR DESCRIPTION
- add request body tainting for Django framework
- add 2 tests with and without iast

It works by tainting an internal private field of Django HttpRequest `_body`

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
