### PR TITLE
ci: fix dynamic config on default branch

### DIFF
--- a/scripts/needs_testrun.py
+++ b/scripts/needs_testrun.py
@@ -84,7 +84,7 @@ def get_changed_files(pr_number: int) -> t.Set[str]:
                     "diff",
                     "--name-only",
                     "HEAD",
-                    get_merge_base(pr_number),
+                    get_merge_base(pr_number) if pr_number != 0 else "HEAD~1",
                 ]
             )
             .decode("utf-8")


### PR DESCRIPTION
The dynamic CI configuration is broken on 1.x for merge commits, causing us not to run `build_docs`, `pre_checks` steps, and `check`.

See https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/42828/workflows/0510ed4b-8f27-4a9d-8c65-6fff21065fc5/jobs/2849569?invite=true#step-102-18007_113

```
INFO: Configuration generation steps:
INFO: - gen_required_suites: Generate the list of test suites that need to be run. [took 34ms]
WARNING: Failed to get changed files from GitHub API, using git diff instead
ERROR: - gen_pre_checks: Generate the list of pre-checks that need to be run. [reason: HTTP Error 404: Not Found]
```

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

