### PR TITLE
ci: make PR match patterns if unable to get changed files

### DIFF
--- a/scripts/needs_testrun.py
+++ b/scripts/needs_testrun.py
@@ -84,7 +84,7 @@ def get_changed_files(pr_number: int) -> t.Set[str]:
                     "diff",
                     "--name-only",
                     "HEAD",
-                    get_merge_base(pr_number) if pr_number != 0 else "HEAD~1",
+                    get_merge_base(pr_number),
                 ]
             )
             .decode("utf-8")
@@ -169,7 +169,11 @@ def for_each_testrun_needed(suites: t.List[str], action: t.Callable[[str], None]
 
 
 def pr_matches_patterns(patterns: t.Set[str]) -> bool:
-    changed_files = get_changed_files(_get_pr_number())
+    try:
+        changed_files = get_changed_files(_get_pr_number())
+    except Exception:
+        LOGGER.error("Failed to get changed files. Assuming the PR matches for precaution.")
+        return True
     return bool([_ for p in patterns for _ in fnmatch.filter(changed_files, p)])
 
 


### PR DESCRIPTION
We ensure that a PR is reported as matching a given set of file patterns when we fail to retrieve a list of changed files. This ensures that we run all the jobs out of precaution instead of potentially skipping them.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
