### PR TITLE
ci: remove erroneously committed breakpoint

### DIFF
--- a/tests/contrib/psycopg/test_psycopg_async.py
+++ b/tests/contrib/psycopg/test_psycopg_async.py
@@ -332,6 +332,18 @@ class PsycopgCore(AsyncioTestCase):
             assert rows[0][0] == "one"
 
     @mark_asyncio
+    async def test_cursor_context_execute(self):
+        """Checks whether cursor context manager works as normal."""
+
+        query = SQL("""select 'one' as x""")
+        async with (await psycopg.AsyncConnection.connect(**POSTGRES_CONFIG)).cursor() as cur:
+            await cur.execute(query)
+            rows = await cur.fetchall()
+
+            assert len(rows) == 1, rows
+            assert rows[0][0] == "one"
+
+    @mark_asyncio
     async def test_cursor_from_connection_shortcut(self):
         """Checks whether connection execute shortcute method works as normal"""
 

--- a/tests/contrib/psycopg/test_psycopg_async.py
+++ b/tests/contrib/psycopg/test_psycopg_async.py
@@ -332,19 +332,6 @@ class PsycopgCore(AsyncioTestCase):
             assert rows[0][0] == "one"
 
     @mark_asyncio
-    async def test_cursor_context_execute(self):
-        """Checks whether cursor context manager works as normal."""
-
-        query = SQL("""select 'one' as x""")
-        async with (await psycopg.AsyncConnection.connect(**POSTGRES_CONFIG)).cursor() as cur:
-            breakpoint()
-            await cur.execute(query)
-            rows = await cur.fetchall()
-
-            assert len(rows) == 1, rows
-            assert rows[0][0] == "one"
-
-    @mark_asyncio
     async def test_cursor_from_connection_shortcut(self):
         """Checks whether connection execute shortcute method works as normal"""
 


### PR DESCRIPTION
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
