### PR TITLE
test(debugging): reduce flakiness in status logger

### DIFF
--- a/tests/debugging/mocking.py
+++ b/tests/debugging/mocking.py
@@ -71,6 +71,19 @@ class MockProbeStatusLogger(DummyProbeStatusLogger):
         super(MockProbeStatusLogger, self).__init__(service, encoder)
         self.queue = []
 
+    def clear(self):
+        self.queue[:] = []
+
+    def wait(self, cond, timeout=1.0):
+        end = monotonic() + timeout
+
+        while monotonic() < end:
+            if cond(self.queue):
+                return True
+            sleep(0.01)
+
+        raise PayloadWaitTimeout()
+
 
 class TestSignalCollector(SignalCollector):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
We remove some flakiness around probe status message testing by adding a wait logic to the mocked probe status logger.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
