### PR TITLE
ci: fail the job when tests fail

### DIFF
--- a/scripts/run-test-suite
+++ b/scripts/run-test-suite
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 CHECKPOINT_FILENAME="latest-success-commit"
 
 RIOT_PATTERN=${1}

--- a/scripts/run-test-suite
+++ b/scripts/run-test-suite
@@ -26,7 +26,7 @@ riot_hashes=$(riot list --hash-only $RIOT_PATTERN | sort | circleci tests split)
 all_passed=false
 for hash in $riot_hashes; do
     $DDTEST_CMD riot -v run --exitfirst --pass-env -s $hash $DDTRACE_FLAG $COVERAGE_FLAG
-    [[ $? > 0 ]] && circleci step halt && exit 1
+    [[ $? > 0 ]] && circleci step halt && exit $?
     all_passed=true
 done
 

--- a/scripts/run-test-suite
+++ b/scripts/run-test-suite
@@ -26,7 +26,7 @@ riot_hashes=$(riot list --hash-only $RIOT_PATTERN | sort | circleci tests split)
 all_passed=false
 for hash in $riot_hashes; do
     $DDTEST_CMD riot -v run --exitfirst --pass-env -s $hash $DDTRACE_FLAG $COVERAGE_FLAG
-    [[ $? > 0 ]] && break
+    [[ $? > 0 ]] && circleci step halt && exit 1
     all_passed=true
 done
 

--- a/tests/appsec/test_asm_request_context.py
+++ b/tests/appsec/test_asm_request_context.py
@@ -9,7 +9,6 @@ _TEST_HEADERS = {"foo": "bar"}
 
 
 def test_context_set_and_reset():
-    assert False
     with override_global_config({"_appsec_enabled": True}):
         with _asm_request_context.asm_request_context_manager(_TEST_IP, _TEST_HEADERS, True, lambda: True):
             assert _asm_request_context.get_ip() == _TEST_IP

--- a/tests/appsec/test_asm_request_context.py
+++ b/tests/appsec/test_asm_request_context.py
@@ -9,6 +9,7 @@ _TEST_HEADERS = {"foo": "bar"}
 
 
 def test_context_set_and_reset():
+    assert False
     with override_global_config({"_appsec_enabled": True}):
         with _asm_request_context.asm_request_context_manager(_TEST_IP, _TEST_HEADERS, True, lambda: True):
             assert _asm_request_context.get_ip() == _TEST_IP


### PR DESCRIPTION
This pull request fixes a regression in the test runner that caused jobs with failing tests to get green checkmarks.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
