### PR TITLE
ci: don't use set -e in a script that relies on exit codes internally

### DIFF
--- a/scripts/run-test-suite
+++ b/scripts/run-test-suite
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-
 CHECKPOINT_FILENAME="latest-success-commit"
 
 RIOT_PATTERN=${1}


### PR DESCRIPTION
## Checklist

- [x] Change(s) are motivated and described in the PR description.