### PR TITLE
fix(lib-inject): allow all users to read and modify installed packages [backport #6569 to 1.17]

### DIFF
--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -77,6 +77,13 @@ jobs:
           # Wait for the app to start
           sleep 60
           docker-compose logs
+      - name: Check Permissions on ddtrace pkgs
+        run: |
+           cd lib-injection
+           # Ensure /datadog-lib/ddtrace_pkgs is a valid directory that is not empty
+           docker-compose run lib_inject find /datadog-init/ddtrace_pkgs -maxdepth 0 -empty | wc -l && if [ $? -ne 0 ]; then exit 1; fi
+           # Ensure non-datadog users have read and write permissions to files stored in /datadog-lib/ddtrace_pkgs
+           docker-compose run lib_inject find /datadog-init/ddtrace_pkgs ! -perm -a=rw | wc -l && if [ $? -ne 0 ]; then exit 1; fi
       - name: Test the app
         run: |
           curl http://localhost:18080

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -104,6 +104,7 @@ https
 httpx
 iPython
 ini
+InitContainer
 initializer
 integration
 integrations

--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -29,6 +29,7 @@ ARG UID=10000
 RUN addgroup -g 10000 -S datadog && \
     adduser -u ${UID} -S datadog -G datadog
 RUN chown -R datadog:datadog /datadog-init/ddtrace_pkgs
+RUN chmod -R a+rw /datadog-init/ddtrace_pkgs
 USER ${UID}
 WORKDIR /datadog-init
 ADD sitecustomize.py /datadog-init/sitecustomize.py

--- a/releasenotes/notes/lib-injection-pkg-dir-permissions-aaac0059b6c21f30.yaml
+++ b/releasenotes/notes/lib-injection-pkg-dir-permissions-aaac0059b6c21f30.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    lib-injection: Resolves permissions errors raised when ddtrace packages are copied from the InitContainer to the shared volume.


### PR DESCRIPTION
Backport of #6569 to 1.17

## Descriptions

When library injection is used the `/datadog-lib/ddtrace_pkg` directory is created with permissions that prevents other users from reading certain files. This PR ensures all files in`/datadog-lib/ddtrace_pkgs` are readable to all users.

When  `find /datadog-lib/ddtrace_pkgs ! -perm -a=r` is run on a host using library injection with `ddtrace==1.17.3` the following output is generated:

<details>
  /datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.10-manylinux2014/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.10-manylinux2014/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.10-manylinux2014/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.10-musllinux_1_1/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.10-musllinux_1_1/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.10-musllinux_1_1/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.11-manylinux2014/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.10-manylinux2014/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.10-manylinux2014/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.10-manylinux2014/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.10-musllinux_1_1/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.10-musllinux_1_1/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.10-musllinux_1_1/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.11-manylinux2014/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.11-manylinux2014/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.11-manylinux2014/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.11-musllinux_1_1/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.11-musllinux_1_1/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.11-musllinux_1_1/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.7-manylinux2014/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.7-manylinux2014/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.7-manylinux2014/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.7-musllinux_1_1/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.7-musllinux_1_1/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.7-musllinux_1_1/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.8-manylinux2014/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.8-manylinux2014/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.8-manylinux2014/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.8-musllinux_1_1/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.8-musllinux_1_1/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.8-musllinux_1_1/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.9-manylinux2014/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.9-manylinux2014/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.9-manylinux2014/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.9-musllinux_1_1/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.9-musllinux_1_1/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/ddtrace_pkgs/site-packages-ddtrace-py3.9-musllinux_1_1/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.10-manylinux2014/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.10-manylinux2014/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.10-manylinux2014/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.10-musllinux_1_1/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.10-musllinux_1_1/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.10-musllinux_1_1/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.11-manylinux2014/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.11-manylinux2014/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.11-manylinux2014/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.11-musllinux_1_1/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.11-musllinux_1_1/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.11-musllinux_1_1/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.7-manylinux2014/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.7-manylinux2014/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.7-manylinux2014/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.7-musllinux_1_1/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.7-musllinux_1_1/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.7-musllinux_1_1/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.8-manylinux2014/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.8-manylinux2014/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.8-manylinux2014/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.8-musllinux_1_1/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.8-musllinux_1_1/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.8-musllinux_1_1/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.9-manylinux2014/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.9-manylinux2014/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.9-manylinux2014/protobuf-4.23.4.dist-info/WHEEL
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.9-musllinux_1_1/protobuf-4.23.4.dist-info/METADATA
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.9-musllinux_1_1/protobuf-4.23.4.dist-info/RECORD
/datadog-lib/ddtrace_pkgs/site-packages-ddtrace-py3.9-musllinux_1_1/protobuf-4.23.4.dist-info/WHEEL
</details>



## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
