### PR TITLE
test(profiling): unset DD_SITE variable in agentless URL check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,7 +211,13 @@ def run_function_from_file(item, params=None):
     pythonpath = os.getenv("PYTHONPATH", None)
     base_path = os.path.dirname(os.path.dirname(__file__))
     env["PYTHONPATH"] = os.pathsep.join((base_path, pythonpath)) if pythonpath is not None else base_path
-    env.update(marker.kwargs.get("env", {}))
+
+    for key, value in marker.kwargs.get("env", {}).items():
+        if value is None:  # None means remove the variable
+            env.pop(key, None)
+        else:
+            env[key] = value
+
     if params is not None:
         env.update(params)
 

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -181,7 +181,7 @@ def test_disable_memory():
 
 
 @pytest.mark.subprocess(
-    env=dict(DD_PROFILING_AGENTLESS="true", DD_API_KEY="foobar"),
+    env=dict(DD_PROFILING_AGENTLESS="true", DD_API_KEY="foobar", DD_SITE=None),
     err=None,
 )
 def test_env_agentless():


### PR DESCRIPTION
A test for the profiler exporter in agentless mode required the DD_SITE variable to be unset. We modify the test to ensure that this variable is unset in the subprocess to exercise and  test the correct logic.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
