### PR TITLE
chore(ci suitespec): default to diffing against base branch if exactly 30 changed files returned

### DIFF
--- a/scripts/needs_testrun.py
+++ b/scripts/needs_testrun.py
@@ -74,15 +74,16 @@ def get_changed_files(pr_number: int, sha: t.Optional[str] = None) -> t.Set[str]
         try:
             url = f"https://api.github.com/repos/datadog/dd-trace-py/pulls/{pr_number}/files"
             headers = {"Accept": "application/vnd.github+json"}
-            return {_["filename"] for _ in json.load(urlopen(Request(url, headers=headers)))}
+            result = {_["filename"] for _ in json.load(urlopen(Request(url, headers=headers)))}
+            if len(result) != 30:  # 30 files is an unreliable return because it's the maximum
+                return result
         except Exception as exc:
             LOGGER.warning("Failed to get changed files from GitHub API")
             LOGGER.warning(exc)
 
-    if sha is not None:
-        diff_base = sha or get_merge_base(pr_number)
-        LOGGER.info("Checking changed files against commit %s", diff_base)
-        return set(check_output(["git", "diff", "--name-only", "HEAD", diff_base]).decode("utf-8").strip().splitlines())
+    diff_base = sha or get_merge_base(pr_number)
+    LOGGER.info("Checking changed files against commit %s", diff_base)
+    return set(check_output(["git", "diff", "--name-only", "HEAD", diff_base]).decode("utf-8").strip().splitlines())
 
 
 @cache
@@ -174,7 +175,9 @@ def main() -> bool:
 
     argp.add_argument("suite", help="The suite to use", type=str)
     argp.add_argument("--pr", help="The PR number", type=int, default=_get_pr_number())
-    argp.add_argument("--sha", help="Commit hash to use as diff base (defaults to PR merge root)", type=lambda v: v or None)
+    argp.add_argument(
+        "--sha", help="Commit hash to use as diff base (defaults to PR merge root)", type=lambda v: v or None
+    )
     argp.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
 
     args = argp.parse_args()


### PR DESCRIPTION
This is a cherry-pick of test commit https://github.com/DataDog/dd-trace-py/pull/6626/commits/c5c7d0a7872033218979eab5ea39fd2c7a7b40f1. 

We currently use the Github REST API to see all changed files in a PR, and default to using a `git diff` against a base commit if that fails. However, the REST API call will return at most 30 changed files which are used to compute which test suites to run, so large PRs (potentially with many lockfiles changed) will potentially not trigger test suites.

This PR adds a workaround where if we get exactly 30 changed files in the Github REST call, we will default to using `git diff` instead. The only risk is PRs with exactly 30 changed files, but using `git diff` should not significantly change any result.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
