### PR TITLE
chore(ci): add meta-testing to hatch

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -110,3 +110,14 @@ extra-dependencies = [
 test = [
     "python -m doctest {args} scripts/get-target-milestone.py scripts/needs_testrun.py tests/suitespec.py",
 ]
+
+[envs.meta-testing]
+extra-dependencies = [
+    "pytest",
+    "pytest-cov",
+    "hypothesis<6.45.1"
+]
+[envs.meta-testing.scripts]
+meta-testing = [
+  "pytest {args} tests/meta"
+]

--- a/scripts/gen_circleci_config.py
+++ b/scripts/gen_circleci_config.py
@@ -81,7 +81,7 @@ def gen_pre_checks(template: dict) -> None:
     )
     check(
         name="Run conftest tests",
-        command="riot -v run meta-testing",
+        command="hatch run meta-testing:meta-testing",
         paths={"tests/*conftest.py", "tests/meta/*"},
     )
     check(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# Comment to force running test
 import ast
 import contextlib
 from itertools import product

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# Comment to force running test
 import ast
 import contextlib
 from itertools import product


### PR DESCRIPTION
`riot` was removed from the pre-check CircleCI setup by https://github.com/DataDog/dd-trace-py/pull/6640/files#diff-8166c31d8ba62357b4a7cac4407d8744e60cf6b6ba32b09af939807db4c8f490L246 .

This updates config to run the `meta-testing` check via `hatch` instead of via `riot`.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
