### PR TITLE
chore(asm): add exponential backoff and more retries to prevent flakiness in appsec test

### DIFF
--- a/tests/appsec/test_remoteconfiguration_e2e.py
+++ b/tests/appsec/test_remoteconfiguration_e2e.py
@@ -255,7 +255,7 @@ def _multi_requests(client, debug_mode=False):
     return results
 
 
-def _request_200(client, debug_mode=False, max_retries=7, sleep_time=1):
+def _request_200(client, debug_mode=False, max_retries=40, sleep_time=1):
     """retry until it gets at least 2 successful checks"""
     time.sleep(sleep_time)
     previous = False
@@ -272,7 +272,7 @@ def _request_200(client, debug_mode=False, max_retries=7, sleep_time=1):
     assert False, "request_200 failed, max_retries=%d, sleep_time=%f" % (max_retries, sleep_time)
 
 
-def _request_403(client, debug_mode=False, max_retries=7, sleep_time=1):
+def _request_403(client, debug_mode=False, max_retries=40, sleep_time=1):
     """retry until it gets at least 2 successful checks"""
     time.sleep(sleep_time)
     previous = False

--- a/tests/appsec/test_remoteconfiguration_e2e.py
+++ b/tests/appsec/test_remoteconfiguration_e2e.py
@@ -259,7 +259,7 @@ def _request_200(client, debug_mode=False, max_retries=40, sleep_time=1):
     """retry until it gets at least 2 successful checks"""
     time.sleep(sleep_time)
     previous = False
-    for _ in range(max_retries):
+    for id_try in range(max_retries):
         results = _multi_requests(client, debug_mode)
         check = all(response.status_code == 200 and response.content == b"OK" for response in results)
         if check:
@@ -268,7 +268,7 @@ def _request_200(client, debug_mode=False, max_retries=40, sleep_time=1):
             previous = True
         else:
             previous = False
-        time.sleep(sleep_time)
+        time.sleep(sleep_time * pow(8, id_try / max_retries))
     assert False, "request_200 failed, max_retries=%d, sleep_time=%f" % (max_retries, sleep_time)
 
 
@@ -276,7 +276,7 @@ def _request_403(client, debug_mode=False, max_retries=40, sleep_time=1):
     """retry until it gets at least 2 successful checks"""
     time.sleep(sleep_time)
     previous = False
-    for _ in range(max_retries):
+    for id_try in range(max_retries):
         results = _multi_requests(client, debug_mode)
         check = all(
             response.status_code == 403 and response.content.startswith(b'{"errors": [{"title": "You\'ve been blocked"')
@@ -288,7 +288,7 @@ def _request_403(client, debug_mode=False, max_retries=40, sleep_time=1):
             previous = True
         else:
             previous = False
-        time.sleep(sleep_time)
+        time.sleep(sleep_time * pow(8, id_try / max_retries))
     assert False, "request_403 failed, max_retries=%d, sleep_time=%f" % (max_retries, sleep_time)
 
 


### PR DESCRIPTION
Add exponential backoff and more retries to prevent flakiness in appsec test: `tests/appsec/test_remoteconfiguration_e2e.py`

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
