### PR TITLE
chore: migrate to ruff

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -4,9 +4,9 @@ from builtins import str as builtin_str
 import codecs
 import traceback
 from types import BuiltinFunctionType
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import TYPE_CHECKING
 
 from ddtrace.internal.compat import iteritems
 
@@ -281,7 +281,7 @@ def format_aspect(
         new_template = as_formatted_evidence(
             candidate_text, candidate_text_ranges, tag_mapping_function=TagMappingMode.Mapper
         )
-        fun = (
+        fun = (  # noqa: E731
             lambda arg: as_formatted_evidence(arg, tag_mapping_function=TagMappingMode.Mapper)
             if isinstance(arg, TEXT_TYPES)
             else arg

--- a/ddtrace/appsec/_iast/processor.py
+++ b/ddtrace/appsec/_iast/processor.py
@@ -10,8 +10,8 @@ from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.processor import SpanProcessor
 
-from . import oce
 from .._trace_utils import _asm_manual_keep
+from . import oce
 from ._metrics import _set_metric_iast_request_tainted
 from ._utils import _iast_report_to_str
 from ._utils import _is_iast_enabled

--- a/ddtrace/appsec/_iast/reporter.py
+++ b/ddtrace/appsec/_iast/reporter.py
@@ -2,9 +2,9 @@ from functools import reduce
 import json
 import operator
 import os
+from typing import TYPE_CHECKING
 from typing import List
 from typing import Set
-from typing import TYPE_CHECKING
 import zlib
 
 import attr

--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -2,9 +2,9 @@ import os
 import re
 import shlex
 import subprocess  # nosec
+from typing import TYPE_CHECKING
 from typing import List
 from typing import Set
-from typing import TYPE_CHECKING
 from typing import Union
 
 import six

--- a/ddtrace/appsec/_iast/taint_sinks/ssrf.py
+++ b/ddtrace/appsec/_iast/taint_sinks/ssrf.py
@@ -12,8 +12,8 @@ from .._utils import _has_to_scrub
 from .._utils import _scrub
 from .._utils import _scrub_get_tokens_positions
 from ..constants import EVIDENCE_SSRF
-from ..constants import VULNERABILITY_TOKEN_TYPE
 from ..constants import VULN_SSRF
+from ..constants import VULNERABILITY_TOKEN_TYPE
 from ..reporter import IastSpanReporter
 from ..reporter import Vulnerability
 from ._base import VulnerabilityBase

--- a/ddtrace/context.py
+++ b/ddtrace/context.py
@@ -1,16 +1,16 @@
 import base64
 import re
 import threading
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Text
 
 from .constants import ORIGIN_KEY
 from .constants import SAMPLING_PRIORITY_KEY
 from .constants import USER_ID_KEY
-from .internal.compat import NumericType
 from .internal.compat import PY2
+from .internal.compat import NumericType
 from .internal.constants import W3C_TRACEPARENT_KEY
 from .internal.constants import W3C_TRACESTATE_KEY
 from .internal.logger import get_logger

--- a/ddtrace/contrib/_trace_utils_llm.py
+++ b/ddtrace/contrib/_trace_utils_llm.py
@@ -1,11 +1,11 @@
 import abc
 import os
 import time
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import TYPE_CHECKING
 
 from ddtrace.constants import SPAN_MEASURED_KEY
 from ddtrace.contrib.trace_utils import int_service

--- a/ddtrace/contrib/aiohttp/middlewares.py
+++ b/ddtrace/contrib/aiohttp/middlewares.py
@@ -2,7 +2,6 @@ from ddtrace import config
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
@@ -11,6 +10,7 @@ from ...ext import SpanTypes
 from ...ext import http
 from ...internal.compat import stringify
 from ...internal.schema import schematize_url_operation
+from .. import trace_utils
 from ..asyncio import context_provider
 
 

--- a/ddtrace/contrib/aioredis/patch.py
+++ b/ddtrace/contrib/aioredis/patch.py
@@ -10,7 +10,6 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.pin import Pin
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
@@ -23,6 +22,7 @@ from ...internal.schema import schematize_cache_operation
 from ...internal.schema import schematize_service_name
 from ...internal.utils.formats import CMD_MAX_LEN
 from ...internal.utils.formats import stringify_cache_args
+from .. import trace_utils
 from ..redis.asyncio_patch import _run_redis_command_async
 from ..trace_utils_redis import ROW_RETURNING_COMMANDS
 from ..trace_utils_redis import _trace_redis_cmd

--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -9,9 +9,9 @@ from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.pin import Pin
 
-from .. import trace_utils
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
+from .. import trace_utils
 
 
 DD_PATCH_ATTR = "_datadog_patch"

--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -14,11 +14,11 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from .. import trace_utils
 from ...appsec._constants import WAF_CONTEXT_NAMES
 from ...internal import core
 from ...internal.compat import reraise
 from ...internal.logger import get_logger
+from .. import trace_utils
 from .utils import guarantee_single_callable
 
 

--- a/ddtrace/contrib/bottle/trace.py
+++ b/ddtrace/contrib/bottle/trace.py
@@ -8,7 +8,6 @@ from ddtrace import config
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
@@ -16,6 +15,7 @@ from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...internal.schema import schematize_url_operation
 from ...internal.utils.formats import asbool
+from .. import trace_utils
 
 
 class TracePlugin(object):

--- a/ddtrace/contrib/celery/app.py
+++ b/ddtrace/contrib/celery/app.py
@@ -5,12 +5,12 @@ from ddtrace import Pin
 from ddtrace import config
 from ddtrace.pin import _DD_PIN_NAME
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanKind
 from ...ext import SpanTypes
+from .. import trace_utils
 from .signals import trace_after_publish
 from .signals import trace_before_publish
 from .signals import trace_failure

--- a/ddtrace/contrib/celery/signals.py
+++ b/ddtrace/contrib/celery/signals.py
@@ -5,8 +5,6 @@ from ddtrace import Pin
 from ddtrace import config
 from ddtrace.internal.constants import COMPONENT
 
-from . import constants as c
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
@@ -15,6 +13,8 @@ from ...ext import SpanTypes
 from ...ext import net
 from ...internal.logger import get_logger
 from ...propagation.http import HTTPPropagator
+from .. import trace_utils
+from . import constants as c
 from .utils import attach_span
 from .utils import detach_span
 from .utils import retrieve_span

--- a/ddtrace/contrib/cherrypy/middleware.py
+++ b/ddtrace/contrib/cherrypy/middleware.py
@@ -14,7 +14,6 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.constants import SPAN_KIND
 from ddtrace.internal.constants import COMPONENT
 
-from .. import trace_utils
 from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...internal import compat
@@ -22,6 +21,7 @@ from ...internal.schema import SpanDirection
 from ...internal.schema import schematize_service_name
 from ...internal.schema import schematize_url_operation
 from ...internal.utils.formats import asbool
+from .. import trace_utils
 
 
 log = logging.getLogger(__name__)

--- a/ddtrace/contrib/django/_asgi.py
+++ b/ddtrace/contrib/django/_asgi.py
@@ -3,8 +3,8 @@ Module providing async hooks. Do not import this module unless using Python >= 3
 """
 from ddtrace.contrib.asgi import span_from_scope
 
-from .. import trace_utils
 from ...internal.utils import get_argument_value
+from .. import trace_utils
 from .utils import REQUEST_DEFAULT_RESOURCE
 from .utils import _after_request_tags
 from .utils import _before_request_tags

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -40,9 +40,9 @@ from ddtrace.internal.utils import http as http_utils
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.settings.integration import IntegrationConfig
 
-from .. import trace_utils
 from ...appsec._utils import _UserInfoRetriever
 from ...internal.utils import get_argument_value
+from .. import trace_utils
 from ..trace_utils import _get_request_header_user_agent
 from ..trace_utils import _set_url_tag
 

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -22,10 +22,10 @@ from ddtrace.internal.utils.http import parse_form_multipart
 from ddtrace.internal.utils.http import parse_form_params
 from ddtrace.propagation._utils import from_wsgi_header
 
-from .. import trace_utils
 from ...internal import core
 from ...internal.logger import get_logger
 from ...internal.utils.formats import stringify_cache_args
+from .. import trace_utils
 from .compat import get_resolver
 from .compat import user_is_authenticated
 

--- a/ddtrace/contrib/dogpile_cache/patch.py
+++ b/ddtrace/contrib/dogpile_cache/patch.py
@@ -8,9 +8,9 @@ except AttributeError:
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace.internal.schema import schematize_service_name
-from ddtrace.pin import Pin
 from ddtrace.pin import _DD_PIN_NAME
 from ddtrace.pin import _DD_PIN_PROXY_NAME
+from ddtrace.pin import Pin
 
 from .lock import _wrap_lock_ctor
 from .region import _wrap_get_create

--- a/ddtrace/contrib/falcon/middleware.py
+++ b/ddtrace/contrib/falcon/middleware.py
@@ -6,7 +6,6 @@ from ddtrace.ext import SpanTypes
 from ddtrace.ext import http as httpx
 from ddtrace.internal.constants import COMPONENT
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
@@ -14,6 +13,7 @@ from ...internal.compat import iteritems
 from ...internal.schema import SpanDirection
 from ...internal.schema import schematize_service_name
 from ...internal.schema import schematize_url_operation
+from .. import trace_utils
 
 
 class TraceMiddleware(object):

--- a/ddtrace/contrib/flask_login/patch.py
+++ b/ddtrace/contrib/flask_login/patch.py
@@ -8,10 +8,10 @@ from ddtrace.appsec.trace_utils import track_user_login_failure_event
 from ddtrace.appsec.trace_utils import track_user_login_success_event
 from ddtrace.internal.logger import get_logger
 
-from .. import trace_utils
 from ...appsec._utils import _UserInfoRetriever
 from ...ext import SpanTypes
 from ...internal.utils import get_argument_value
+from .. import trace_utils
 from ..flask.wrappers import get_current_app
 
 

--- a/ddtrace/contrib/graphql/patch.py
+++ b/ddtrace/contrib/graphql/patch.py
@@ -40,8 +40,8 @@ from ddtrace.internal.wrapping import unwrap
 from ddtrace.internal.wrapping import wrap
 from ddtrace.pin import Pin
 
-from .. import trace_utils
 from ...ext import SpanTypes
+from .. import trace_utils
 
 
 _graphql_version_str = graphql.__version__

--- a/ddtrace/contrib/grpc/aio_client_interceptor.py
+++ b/ddtrace/contrib/grpc/aio_client_interceptor.py
@@ -15,7 +15,6 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from .. import trace_utils
 from ... import Pin
 from ... import Span
 from ... import config
@@ -28,6 +27,7 @@ from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...internal.compat import to_unicode
 from ...propagation.http import HTTPPropagator
+from .. import trace_utils
 from ..grpc import constants
 from ..grpc import utils
 

--- a/ddtrace/contrib/grpc/aio_server_interceptor.py
+++ b/ddtrace/contrib/grpc/aio_server_interceptor.py
@@ -20,7 +20,6 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import ERROR_MSG
 from ...constants import ERROR_TYPE
@@ -29,6 +28,7 @@ from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...internal.compat import to_unicode
+from .. import trace_utils
 from ..grpc import constants
 from ..grpc.utils import set_grpc_method_meta
 

--- a/ddtrace/contrib/grpc/client_interceptor.py
+++ b/ddtrace/contrib/grpc/client_interceptor.py
@@ -11,9 +11,6 @@ from ddtrace.internal.compat import to_unicode
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from . import constants
-from . import utils
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import ERROR_MSG
 from ...constants import ERROR_STACK
@@ -23,6 +20,9 @@ from ...constants import SPAN_MEASURED_KEY
 from ...internal.logger import get_logger
 from ...internal.schema import schematize_url_operation
 from ...propagation.http import HTTPPropagator
+from .. import trace_utils
+from . import constants
+from . import utils
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/grpc/patch.py
+++ b/ddtrace/contrib/grpc/patch.py
@@ -5,9 +5,9 @@ from ddtrace import Pin
 from ddtrace import config
 from ddtrace.internal.schema import schematize_service_name
 
+from ..trace_utils import unwrap as _u
 from . import constants
 from . import utils
-from ..trace_utils import unwrap as _u
 from .client_interceptor import create_client_interceptor
 from .client_interceptor import intercept_channel
 from .server_interceptor import create_server_interceptor

--- a/ddtrace/contrib/grpc/server_interceptor.py
+++ b/ddtrace/contrib/grpc/server_interceptor.py
@@ -7,8 +7,6 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from . import constants
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import ERROR_MSG
 from ...constants import ERROR_TYPE
@@ -16,6 +14,8 @@ from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanKind
 from ...ext import SpanTypes
+from .. import trace_utils
+from . import constants
 from .utils import set_grpc_method_meta
 
 

--- a/ddtrace/contrib/grpc/utils.py
+++ b/ddtrace/contrib/grpc/utils.py
@@ -2,8 +2,8 @@ import logging
 
 from ddtrace.internal.compat import parse
 
-from . import constants
 from ...ext import net
+from . import constants
 
 
 log = logging.getLogger(__name__)

--- a/ddtrace/contrib/httplib/patch.py
+++ b/ddtrace/contrib/httplib/patch.py
@@ -8,7 +8,6 @@ from ddtrace import config
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...ext import SpanKind
@@ -22,6 +21,7 @@ from ...internal.schema import schematize_url_operation
 from ...internal.utils.formats import asbool
 from ...pin import Pin
 from ...propagation.http import HTTPPropagator
+from .. import trace_utils
 from ..trace_utils import unwrap as _u
 
 

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -10,8 +10,6 @@ from ddtrace.internal.schema import schematize_messaging_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-# project
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
@@ -22,6 +20,9 @@ from ...internal.utils import get_argument_value
 from ...internal.utils.wrappers import unwrap
 from ...pin import Pin
 from ...propagation.http import HTTPPropagator
+
+# project
+from .. import trace_utils
 from .constants import DEFAULT_SERVICE
 from .utils import HEADER_POS
 from .utils import extract_conn_tags

--- a/ddtrace/contrib/langchain/patch.py
+++ b/ddtrace/contrib/langchain/patch.py
@@ -1,9 +1,9 @@
 import os
 import sys
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import Optional
-from typing import TYPE_CHECKING
 
 import langchain
 from langchain.callbacks.openai_info import get_openai_token_cost_for_model

--- a/ddtrace/contrib/molten/patch.py
+++ b/ddtrace/contrib/molten/patch.py
@@ -7,7 +7,6 @@ from wrapt import wrap_function_wrapper as _w
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from .. import trace_utils
 from ... import Pin
 from ... import config
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -21,6 +20,7 @@ from ...internal.schema import schematize_url_operation
 from ...internal.utils.formats import asbool
 from ...internal.utils.importlib import func_name
 from ...internal.utils.version import parse_version
+from .. import trace_utils
 from ..trace_utils import unwrap as _u
 from .wrappers import MOLTEN_ROUTE
 from .wrappers import WrapperComponent

--- a/ddtrace/contrib/molten/wrappers.py
+++ b/ddtrace/contrib/molten/wrappers.py
@@ -5,10 +5,10 @@ from ddtrace import config
 from ddtrace.constants import SPAN_KIND
 from ddtrace.internal.constants import COMPONENT
 
-from .. import trace_utils
 from ... import Pin
 from ...ext import SpanKind
 from ...internal.utils.importlib import func_name
+from .. import trace_utils
 
 
 MOLTEN_ROUTE = "molten.route"

--- a/ddtrace/contrib/openai/patch.py
+++ b/ddtrace/contrib/openai/patch.py
@@ -1,7 +1,7 @@
 import os
 import sys
-from typing import Optional
 from typing import TYPE_CHECKING
+from typing import Optional
 
 from openai import version
 
@@ -15,8 +15,8 @@ from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import deep_getattr
 from ddtrace.internal.wrapping import wrap
 
-from . import _endpoint_hooks
 from ...pin import Pin
+from . import _endpoint_hooks
 from .utils import _format_openai_api_key
 
 

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -14,7 +14,6 @@ from ddtrace.internal.compat import iteritems
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
@@ -26,6 +25,7 @@ from ...internal.logger import get_logger
 from ...internal.schema import schematize_service_name
 from ...internal.schema import schematize_url_operation
 from ...internal.utils.formats import asbool
+from .. import trace_utils
 from .constants import CONFIG_MIDDLEWARE
 from .renderer import trace_rendering
 

--- a/ddtrace/contrib/pymemcache/patch.py
+++ b/ddtrace/contrib/pymemcache/patch.py
@@ -3,9 +3,9 @@ import pymemcache.client.hash
 
 from ddtrace.ext import memcached as memcachedx
 from ddtrace.internal.schema import schematize_service_name
-from ddtrace.pin import Pin
 from ddtrace.pin import _DD_PIN_NAME
 from ddtrace.pin import _DD_PIN_PROXY_NAME
+from ddtrace.pin import Pin
 
 from .client import WrappedClient
 from .client import WrappedHashClient

--- a/ddtrace/contrib/pynamodb/patch.py
+++ b/ddtrace/contrib/pynamodb/patch.py
@@ -10,7 +10,6 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_cloud_api_operation
 from ddtrace.internal.schema import schematize_service_name
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
@@ -21,6 +20,7 @@ from ...internal.utils import ArgumentError
 from ...internal.utils import get_argument_value
 from ...internal.utils.formats import deep_getattr
 from ...pin import Pin
+from .. import trace_utils
 from ..trace_utils import unwrap
 
 

--- a/ddtrace/contrib/pyramid/trace.py
+++ b/ddtrace/contrib/pyramid/trace.py
@@ -9,7 +9,6 @@ from ddtrace import config
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
@@ -18,12 +17,13 @@ from ...ext import SpanTypes
 from ...internal.logger import get_logger
 from ...internal.schema import schematize_service_name
 from ...internal.schema import schematize_url_operation
+from .. import trace_utils
 from .constants import SETTINGS_ANALYTICS_ENABLED
 from .constants import SETTINGS_ANALYTICS_SAMPLE_RATE
 from .constants import SETTINGS_DISTRIBUTED_TRACING
 from .constants import SETTINGS_SERVICE
-from .constants import SETTINGS_TRACER
 from .constants import SETTINGS_TRACE_ENABLED
+from .constants import SETTINGS_TRACER
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/requests/connection.py
+++ b/ddtrace/contrib/requests/connection.py
@@ -5,7 +5,6 @@ from ddtrace import config
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
@@ -16,6 +15,7 @@ from ...internal.logger import get_logger
 from ...internal.schema import schematize_url_operation
 from ...internal.utils import get_argument_value
 from ...propagation.http import HTTPPropagator
+from .. import trace_utils
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/rq/__init__.py
+++ b/ddtrace/contrib/rq/__init__.py
@@ -86,12 +86,12 @@ from ddtrace.internal.schema import schematize_messaging_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from .. import trace_utils
 from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...internal.utils import get_argument_value
 from ...internal.utils.formats import asbool
 from ...propagation.http import HTTPPropagator
+from .. import trace_utils
 
 
 __all__ = ["patch", "unpatch", "get_version"]

--- a/ddtrace/contrib/sanic/patch.py
+++ b/ddtrace/contrib/sanic/patch.py
@@ -17,8 +17,8 @@ from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.pin import Pin
 
-from .. import trace_utils
 from ...internal.logger import get_logger
+from .. import trace_utils
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/tornado/handlers.py
+++ b/ddtrace/contrib/tornado/handlers.py
@@ -6,7 +6,6 @@ from ddtrace import config
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
@@ -15,6 +14,7 @@ from ...ext import SpanTypes
 from ...internal.schema import schematize_url_operation
 from ...internal.utils import ArgumentError
 from ...internal.utils import get_argument_value
+from .. import trace_utils
 from ..trace_utils import set_http_meta
 from .constants import CONFIG_KEY
 from .constants import REQUEST_SPAN_KEY

--- a/ddtrace/contrib/tornado/patch.py
+++ b/ddtrace/contrib/tornado/patch.py
@@ -6,13 +6,13 @@ from wrapt import wrap_function_wrapper as _w
 import ddtrace
 from ddtrace import config
 
+from ...internal.utils.formats import asbool
+from ...internal.utils.wrappers import unwrap as _u
 from . import application
 from . import context_provider
 from . import decorators
 from . import handlers
 from . import template
-from ...internal.utils.formats import asbool
-from ...internal.utils.wrappers import unwrap as _u
 
 
 config._add(

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -4,6 +4,7 @@ This module contains utility functions for writing ddtrace integrations.
 from collections import deque
 import ipaddress
 import re
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -12,7 +13,6 @@ from typing import Iterator
 from typing import List
 from typing import Mapping
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Tuple
 from typing import Union
 from typing import cast

--- a/ddtrace/contrib/urllib3/patch.py
+++ b/ddtrace/contrib/urllib3/patch.py
@@ -8,7 +8,6 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.pin import Pin
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...ext import SpanKind
@@ -21,6 +20,7 @@ from ...internal.utils import get_argument_value
 from ...internal.utils.formats import asbool
 from ...internal.utils.wrappers import unwrap as _u
 from ...propagation.http import HTTPPropagator
+from .. import trace_utils
 
 
 # Ports which, if set, will not be used in hostnames/service names

--- a/ddtrace/contrib/vertica/patch.py
+++ b/ddtrace/contrib/vertica/patch.py
@@ -6,7 +6,6 @@ import ddtrace
 from ddtrace import config
 from ddtrace.internal.constants import COMPONENT
 
-from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
 from ...constants import SPAN_MEASURED_KEY
@@ -20,6 +19,7 @@ from ...internal.schema import schematize_service_name
 from ...internal.utils import get_argument_value
 from ...internal.utils.wrappers import unwrap
 from ...pin import Pin
+from .. import trace_utils
 
 
 log = get_logger(__name__)

--- a/ddtrace/debugging/_probe/remoteconfig.py
+++ b/ddtrace/debugging/_probe/remoteconfig.py
@@ -14,11 +14,11 @@ import six
 from ddtrace import config as tracer_config
 from ddtrace.debugging._config import di_config
 from ddtrace.debugging._expressions import dd_compile
-from ddtrace.debugging._probe.model import CaptureLimits
-from ddtrace.debugging._probe.model import DDExpression
 from ddtrace.debugging._probe.model import DEFAULT_PROBE_CONDITION_ERROR_RATE
 from ddtrace.debugging._probe.model import DEFAULT_PROBE_RATE
 from ddtrace.debugging._probe.model import DEFAULT_SNAPSHOT_PROBE_RATE
+from ddtrace.debugging._probe.model import CaptureLimits
+from ddtrace.debugging._probe.model import DDExpression
 from ddtrace.debugging._probe.model import ExpressionTemplateSegment
 from ddtrace.debugging._probe.model import FunctionProbe
 from ddtrace.debugging._probe.model import LineProbe

--- a/ddtrace/debugging/_probe/status.py
+++ b/ddtrace/debugging/_probe/status.py
@@ -5,8 +5,8 @@ from typing import Optional
 from typing import Tuple
 
 from ddtrace.debugging._config import di_config
-from ddtrace.debugging._encoding import BufferFull
 from ddtrace.debugging._encoding import BufferedEncoder
+from ddtrace.debugging._encoding import BufferFull
 from ddtrace.debugging._encoding import add_tags
 from ddtrace.debugging._metrics import metrics
 from ddtrace.debugging._probe.model import Probe

--- a/ddtrace/debugging/_safety.py
+++ b/ddtrace/debugging/_safety.py
@@ -9,7 +9,7 @@ from typing import Tuple
 from ddtrace.internal.safety import get_slots
 
 
-GetSetDescriptor = type(type.__dict__["__dict__"])  # type: ignore[index]
+GetSetDescriptor = type(type.__dict__["__dict__"])  # type: ignore[index]  # noqa: F821
 
 
 def get_args(frame: FrameType) -> Iterator[Tuple[str, Any]]:

--- a/ddtrace/debugging/_signal/snapshot.py
+++ b/ddtrace/debugging/_signal/snapshot.py
@@ -10,8 +10,8 @@ import attr
 
 from ddtrace.debugging import _safety
 from ddtrace.debugging._expressions import DDExpressionEvaluationError
-from ddtrace.debugging._probe.model import CaptureLimits
 from ddtrace.debugging._probe.model import DEFAULT_CAPTURE_LIMITS
+from ddtrace.debugging._probe.model import CaptureLimits
 from ddtrace.debugging._probe.model import FunctionLocationMixin
 from ddtrace.debugging._probe.model import LineLocationMixin
 from ddtrace.debugging._probe.model import LiteralTemplateSegment

--- a/ddtrace/ext/aws.py
+++ b/ddtrace/ext/aws.py
@@ -1,6 +1,6 @@
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
-from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/ddtrace/filters.py
+++ b/ddtrace/filters.py
@@ -1,8 +1,8 @@
 import abc
 import re
+from typing import TYPE_CHECKING
 from typing import List
 from typing import Optional
-from typing import TYPE_CHECKING
 
 from ddtrace.ext import http
 from ddtrace.internal.processor.trace import TraceProcessor

--- a/ddtrace/internal/assembly.py
+++ b/ddtrace/internal/assembly.py
@@ -257,7 +257,7 @@ class Assembly:
         return self.bind(bind_args, lineno=lineno).to_code()
 
     def _label_ident(self, label: bc.Label) -> str:
-        return next(ident for ident, l in self._labels.items() if l is label)
+        return next(ident for ident, l in self._labels.items() if l is label)  # noqa: E741
 
     def dis(self) -> None:
         for entry in self._instrs:

--- a/ddtrace/internal/ci_visibility/filters.py
+++ b/ddtrace/internal/ci_visibility/filters.py
@@ -1,7 +1,7 @@
+from typing import TYPE_CHECKING
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Union
 
 import ddtrace

--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -4,9 +4,9 @@ import os
 import platform
 import re
 import sys
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
-from typing import TYPE_CHECKING
 from typing import Union
 
 import ddtrace

--- a/ddtrace/internal/encoding.py
+++ b/ddtrace/internal/encoding.py
@@ -1,9 +1,9 @@
 import json
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import TYPE_CHECKING
 
 from ._encoding import ListStringTable
 from ._encoding import MsgpackEncoderV03

--- a/ddtrace/internal/processor/stats.py
+++ b/ddtrace/internal/processor/stats.py
@@ -12,7 +12,6 @@ from ddtrace import config
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.span import _is_top_level
 
-from . import SpanProcessor
 from ...constants import SPAN_MEASURED_KEY
 from .._encoding import packb
 from ..agent import get_connection
@@ -22,6 +21,7 @@ from ..hostname import get_hostname
 from ..logger import get_logger
 from ..periodic import PeriodicService
 from ..writer import _human_size
+from . import SpanProcessor
 
 
 if typing.TYPE_CHECKING:  # pragma: no cover

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -5,13 +5,13 @@ import json
 import os
 import re
 import sys
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Mapping
 from typing import Optional
 from typing import Set
-from typing import TYPE_CHECKING
 import uuid
 
 import attr

--- a/ddtrace/internal/sampling.py
+++ b/ddtrace/internal/sampling.py
@@ -1,7 +1,7 @@
 import json
 import re
-from typing import Optional
 from typing import TYPE_CHECKING
+from typing import Optional
 
 
 # TypedDict was added to typing in python 3.8
@@ -10,18 +10,18 @@ try:
 except ImportError:
     from typing_extensions import TypedDict
 
-from ddtrace.constants import SAMPLING_AGENT_DECISION
-from ddtrace.constants import SAMPLING_LIMIT_DECISION
-from ddtrace.constants import SAMPLING_RULE_DECISION
-from ddtrace.constants import USER_REJECT
 from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MAX_PER_SEC
 from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MAX_PER_SEC_NO_LIMIT
 from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MECHANISM
 from ddtrace.constants import _SINGLE_SPAN_SAMPLING_RATE
-from ddtrace.internal.constants import SAMPLING_DECISION_TRACE_TAG_KEY
+from ddtrace.constants import SAMPLING_AGENT_DECISION
+from ddtrace.constants import SAMPLING_LIMIT_DECISION
+from ddtrace.constants import SAMPLING_RULE_DECISION
+from ddtrace.constants import USER_REJECT
 from ddtrace.internal.constants import _CATEGORY_TO_PRIORITIES
 from ddtrace.internal.constants import _KEEP_PRIORITY_INDEX
 from ddtrace.internal.constants import _REJECT_PRIORITY_INDEX
+from ddtrace.internal.constants import SAMPLING_DECISION_TRACE_TAG_KEY
 from ddtrace.internal.glob_matching import GlobMatcher
 from ddtrace.internal.logger import get_logger
 from ddtrace.sampling_rule import SamplingRule

--- a/ddtrace/internal/schema/__init__.py
+++ b/ddtrace/internal/schema/__init__.py
@@ -3,9 +3,9 @@ import os
 
 from ddtrace.internal.utils.formats import asbool
 
-from .span_attribute_schema import SpanDirection
 from .span_attribute_schema import _DEFAULT_SPAN_SERVICE_NAMES
 from .span_attribute_schema import _SPAN_ATTRIBUTE_TO_FUNCTION
+from .span_attribute_schema import SpanDirection
 
 
 log = logging.getLogger(__name__)

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -5,10 +5,10 @@ import logging
 import os
 import sys
 import threading
+from typing import TYPE_CHECKING
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import TextIO
 
 import six
@@ -18,9 +18,6 @@ from ddtrace import config
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.vendor.dogstatsd import DogStatsd
 
-from .. import compat
-from .. import periodic
-from .. import service
 from ...constants import KEEP_SPANS_RATE_KEY
 from ...internal.telemetry import telemetry_writer
 from ...internal.utils.formats import parse_tags_str
@@ -28,6 +25,9 @@ from ...internal.utils.http import Response
 from ...internal.utils.time import StopWatch
 from ...sampler import BasePrioritySampler
 from ...sampler import BaseSampler
+from .. import compat
+from .. import periodic
+from .. import service
 from .._encoding import BufferFull
 from .._encoding import BufferItemTooLarge
 from ..agent import get_connection
@@ -36,9 +36,9 @@ from ..encoding import JSONEncoderV2
 from ..logger import get_logger
 from ..runtime import container
 from ..sma import SimpleMovingAverage
+from .writer_client import WRITER_CLIENTS
 from .writer_client import AgentWriterClientV3
 from .writer_client import AgentWriterClientV4
-from .writer_client import WRITER_CLIENTS
 from .writer_client import WriterClientBase
 
 

--- a/ddtrace/opentelemetry/_span.py
+++ b/ddtrace/opentelemetry/_span.py
@@ -20,8 +20,8 @@ if TYPE_CHECKING:
     from typing import Optional
     from typing import Union
 
-    from opentelemetry.util.types import AttributeValue
     from opentelemetry.util.types import Attributes
+    from opentelemetry.util.types import AttributeValue
 
     from ddtrace.span import Span as DDSpan
 

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -1,8 +1,8 @@
 import threading
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Text
 from typing import Union
 
@@ -117,7 +117,7 @@ class Span(OpenTracingSpan):
         """
 
         # match opentracing defined keys to datadog functionality
-        # opentracing/specification/blob/1be630515dafd4d2a468d083300900f89f28e24d/semantic_conventions.md#log-fields-table
+        # opentracing/specification/blob/1be630515dafd4d2a468d083300900f89f28e24d/semantic_conventions.md#log-fields-table  # noqa: E501
         for key, val in key_values.items():
             if key == "event" and val == "error":
                 # TODO: not sure if it's actually necessary to set the error manually

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -1,7 +1,7 @@
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import Optional
-from typing import TYPE_CHECKING
 
 import wrapt
 

--- a/ddtrace/profiling/collector/asyncio.py
+++ b/ddtrace/profiling/collector/asyncio.py
@@ -2,9 +2,9 @@ import typing
 
 import attr
 
-from . import _lock
 from .. import collector
 from .. import event
+from . import _lock
 
 
 @event.event_class

--- a/ddtrace/profiling/collector/threading.py
+++ b/ddtrace/profiling/collector/threading.py
@@ -5,8 +5,8 @@ import typing
 
 import attr
 
-from . import _lock
 from .. import event
+from . import _lock
 
 
 @event.event_class

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -21,6 +21,8 @@ from ..internal._tagset import decode_tagset_string
 from ..internal._tagset import encode_tagset_values
 from ..internal.compat import ensure_str
 from ..internal.compat import ensure_text
+from ..internal.constants import _PROPAGATION_STYLE_NONE
+from ..internal.constants import _PROPAGATION_STYLE_W3C_TRACECONTEXT
 from ..internal.constants import HIGHER_ORDER_TRACE_ID_BITS as _HIGHER_ORDER_TRACE_ID_BITS
 from ..internal.constants import MAX_UINT_64BITS as _MAX_UINT_64BITS
 from ..internal.constants import PROPAGATION_STYLE_B3_MULTI
@@ -28,13 +30,11 @@ from ..internal.constants import PROPAGATION_STYLE_B3_SINGLE
 from ..internal.constants import PROPAGATION_STYLE_DATADOG
 from ..internal.constants import W3C_TRACEPARENT_KEY
 from ..internal.constants import W3C_TRACESTATE_KEY
-from ..internal.constants import _PROPAGATION_STYLE_NONE
-from ..internal.constants import _PROPAGATION_STYLE_W3C_TRACECONTEXT
 from ..internal.logger import get_logger
 from ..internal.sampling import validate_sampling_decision
-from ..span import _MetaDictType
 from ..span import _get_64_highest_order_bits_as_hex
 from ..span import _get_64_lowest_order_bits_as_int
+from ..span import _MetaDictType
 from ._utils import get_wsgi_header
 
 

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -4,10 +4,10 @@ Any `sampled = False` trace won't be written, and can be ignored by the instrume
 """
 import abc
 import json
+from typing import TYPE_CHECKING
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Tuple
 
 import six
@@ -15,9 +15,9 @@ import six
 from .constants import ENV_KEY
 from .constants import SAMPLE_RATE_METRIC_KEY
 from .internal.compat import iteritems
+from .internal.constants import _PRIORITY_CATEGORY
 from .internal.constants import DEFAULT_SAMPLING_RATE_LIMIT
 from .internal.constants import MAX_UINT_64BITS as _MAX_UINT_64BITS
-from .internal.constants import _PRIORITY_CATEGORY
 from .internal.logger import get_logger
 from .internal.rate_limiter import RateLimiter
 from .internal.sampling import _apply_rate_limit

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -19,6 +19,7 @@ from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.vendor.debtcollector import deprecate
 
 from ..internal import gitmetadata
+from ..internal.constants import _PROPAGATION_STYLE_DEFAULT
 from ..internal.constants import DEFAULT_BUFFER_SIZE
 from ..internal.constants import DEFAULT_MAX_PAYLOAD_SIZE
 from ..internal.constants import DEFAULT_PROCESSING_INTERVAL
@@ -27,7 +28,6 @@ from ..internal.constants import DEFAULT_SAMPLING_RATE_LIMIT
 from ..internal.constants import DEFAULT_TIMEOUT
 from ..internal.constants import PROPAGATION_STYLE_ALL
 from ..internal.constants import PROPAGATION_STYLE_B3_SINGLE
-from ..internal.constants import _PROPAGATION_STYLE_DEFAULT
 from ..internal.logger import get_logger
 from ..internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ..internal.utils.formats import asbool

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -68,8 +68,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import List
     from typing import Optional
     from typing import Set
-    from typing import Union
     from typing import Tuple
+    from typing import Union
 
 from typing import Callable
 from typing import TypeVar

--- a/hatch.toml
+++ b/hatch.toml
@@ -3,14 +3,13 @@ detached = true
 python = "3.10"
 dependencies = [
     "black==21.4b2",
-    "isort==5.12.0",
     # See https://github.com/psf/black/issues/2964 for incompatibility with click==8.1.0
     "click<8.1.0",
-    "cython-lint",
+    "cython-lint==0.15.0",
     "codespell==2.1.0",
-    "bandit",
+    "bandit==1.7.5",
     "mypy==0.991",
-    "coverage",
+    "coverage==7.3.0",
     "envier==0.4.0",
     "types-attrs==19.1.0",
     "types-docutils==0.19.1.1",
@@ -19,25 +18,22 @@ dependencies = [
     "types-setuptools==65.6.0.0",
     "types-six==1.16.21.4",
     "ddapm-test-agent>=1.2.0",
-    "packaging",
-    "flake8>=3.8,<3.9",
-    "flake8-blind-except",
-    "flake8-builtins",
-    "flake8-docstrings",
-    "flake8-bugbear",
-    "flake8-logging-format",
-    "flake8-rst-docstrings",
-    "flake8-isort",
-    "pygments",
+    "packaging==23.1",
+    "pygments==2.16.1",
     "riot==0.19.0",
+    "ruff~=0.1.3",
 ]
 
 [envs.lint.scripts]
 style = [
-    "isort --check --diff {args:.}",
-    "black --check --diff {args:.}",
-    "flake8 {args}",
+    "black -q {args:.}",
+    "ruff {args:.}",
     "cython-lint {args:.}",
+]
+fmt = [
+    "black {args:.}",
+    "ruff --fix {args:.}",
+    "style",
 ]
 spelling = [
     "codespell --skip='ddwaf.h' {args:ddtrace/ tests/}",
@@ -53,10 +49,6 @@ fmt-snapshots = [
 ]
 riot = [
     "python -m doctest {args} riotfile.py"
-]
-fmt = [
-    "black {args:.}",
-    "isort {args:.}",
 ]
 
 [envs.docs]

--- a/hooks/pre-commit/01-black
+++ b/hooks/pre-commit/01-black
@@ -1,0 +1,1 @@
+../scripts/run-black.sh

--- a/hooks/pre-commit/01-style
+++ b/hooks/pre-commit/01-style
@@ -1,1 +1,0 @@
-../scripts/run-style.sh

--- a/hooks/pre-commit/03-run-ruff
+++ b/hooks/pre-commit/03-run-ruff
@@ -1,0 +1,1 @@
+../scripts/run-ruff.sh

--- a/hooks/scripts/run-black.sh
+++ b/hooks/scripts/run-black.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.py$')
 if [ -n "$staged_files" ]; then
-    hatch -v run lint:flake8 $staged_files
+    hatch -v run lint:black $staged_files
 else
-    echo 'Run flake8 skipped: No Python files were found in git diff --staged'
+    echo 'hatch style check skipped: No Python files were found in `git diff --staged`'
 fi

--- a/hooks/scripts/run-ruff.sh
+++ b/hooks/scripts/run-ruff.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+hatch -v run lint:ruff .

--- a/hooks/scripts/run-style.sh
+++ b/hooks/scripts/run-style.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.py$')
-if [ -n "$staged_files" ]; then
-    hatch -v run lint:style $staged_files
-else
-    echo 'hatch style check skipped: No Python files were found in `git diff --staged`'
-fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,16 +66,6 @@ Homepage = "https://github.com/DataDog/dd-trace-py"
 version_scheme = "release-branch-semver"
 write_to = "ddtrace/_version.py"
 
-[tool.isort]
-force_single_line = true
-lines_after_imports = 2
-force_sort_within_sections = true
-known_first_party = "ddtrace"
-default_section = "THIRDPARTY"
-skip = ["ddtrace/vendor/", ".riot", ".ddriot", ".tox", ".ddtox", ".eggs", "build", "setup.py"]
-skip_glob = [".venv*", "ddtrace/profiling/exporter/pprof_*pb2.py", "ddtrace/appsec/_iast/_taint_tracking/_vendor/*", "ddtrace/**/*.pyi"]
-line_length = 120
-
 [tool.cython-lint]
 max-line-length = 120
 exclude = '''
@@ -188,3 +178,75 @@ test-skip = "*-macosx_universal2:arm64"
 # `platform.mac_ver()` reports incorrect MacOS version at 11.0
 # See: https://stackoverflow.com/a/65402241
 SYSTEM_VERSION_COMPAT = "0"
+
+[tool.ruff]
+exclude = [
+    ".riot",
+    ".ddriot",
+    ".venv*",
+    ".git",
+    "__pycache__",
+    ".eggs",
+    "*.egg",
+    "build",
+    "ddtrace/__init__.py",
+    "ddtrace/vendor/*",
+    "ddtrace/appsec/_iast/_taint_tracking/_vendor/*",
+    "ddtrace/profiling/exporter/pprof_*pb2.py",
+    "tests/profiling/simple_program_gevent.py",
+    "tests/contrib/grpc/hello_pb2.py",
+    "tests/contrib/django_celery/app/*",
+    "tests/appsec/iast/fixtures/ast/str/non_utf8_content.py",
+    "tests/appsec/iast/fixtures/aspects/str/non_utf8_content.py",
+]
+ignore = [
+    "A003",
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D200",
+    "D202",
+    "D204",
+    "D205",
+    "D208",
+    "D210",
+    "D300",
+    "D400",
+    "D401",
+    "D403",
+    "D404",
+    "D413",
+    "E203",
+    "E231",
+    "E721",
+    "G201",
+]
+line-length = 120
+select = [
+    "A",
+    "D",
+    "E",
+    "G",
+    "I",
+    "W",
+]
+
+[tool.ruff.pydocstyle]
+convention = "pep257"
+
+[tool.ruff.isort]
+force-single-line = true
+lines-after-imports = 2
+force-sort-within-sections = true
+known-first-party = [ "ddtrace" ]
+relative-imports-order = "furthest-to-closest"
+
+[tool.ruff.per-file-ignores]
+# Exclude typing stubs as vertical line spacing incompatibility with black
+# See: https://github.com/astral-sh/ruff/pull/6501
+"*.pyi" = ["I001"]

--- a/scripts/gen_circleci_config.py
+++ b/scripts/gen_circleci_config.py
@@ -47,7 +47,7 @@ def gen_pre_checks(template: dict) -> None:
     check(
         name="Style",
         command="hatch run lint:style",
-        paths={"*.py", "*.pyi", "hatch.toml"},
+        paths={"*.py", "*.pyi", "hatch.toml", "pyproject.toml"},
     )
     check(
         name="Typing",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -15,7 +15,7 @@ for release candidates, patches, and minor releases.
 
 Setup:
 1. Create a Personal access token (classic), not a fine grained one, on Github:
-https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic # noqa
+https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic
 2. Give the Github token repo, user, audit_log, project permissions. On the next page authorize your token for Datadog SSO.
 3. Add `export GH_TOKEN=<github token>` to your `.zhrc` file.
 
@@ -47,7 +47,7 @@ Generate release notes and staging testing notebook for next release candidate v
 Generate release notes for next patch version of 2.13: `BASE=2.13 PATCH=1 python release.py`
 
 Generate release notes for the 2.15 release: `BASE=2.15 python release.py`
-"""
+"""  # noqa
 
 
 def create_release_draft(dd_repo, base, rc, patch, latest_branch):
@@ -353,7 +353,7 @@ def create_notebook(dd_repo, name, rn, base, latest_branch):
         "#  Release notes to test\n-[ ] Relenv is checked: https://ddstaging.datadoghq.com/dashboard/h8c-888-v2e/python-reliability-env-dashboard \n\n%s\n<Tester> \n<PR>\n\n\n## Release Notes that will not be tested\n- <any release notes for PRs that don't need manual testing>\n\n\n"  # noqa
         % (rn)
     )
-    # grab the latest commit id on the lastest branch to mark the rc notebook with
+    # grab the latest commit id on the latest branch to mark the rc notebook with
     main_branch = dd_repo.get_branch(branch=latest_branch)
     commit_id = main_branch.commit
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,36 +6,6 @@ skip = *.json,*.h,*.cpp,*.c,.riot,.tox,.mypy_cache,.git,ddtrace/vendor/*,tests/c
 exclude-file = .codespellignorelines
 ignore-words-list = asend,dne,fo,medias,ment,nin,ot,setttings,statics,ba,spawnve,doas
 
-[flake8]
-max-line-length=120
-exclude=
-  .ddtox,.tox,.riot,.ddriot,.venv*
-  .git,__pycache__,
-  .eggs,*.egg,
-  build,
-  ddtrace/__init__.py,
-  # We shouldn't lint our vendored dependencies
-  ddtrace/vendor/*
-  ddtrace/appsec/_iast/_taint_tracking/cmake-build-debug/*
-  ddtrace/appsec/_iast/_taint_tracking/_vendor/*
-  ddtrace/profiling/exporter/pprof_3_pb2.py
-  ddtrace/profiling/exporter/pprof_312_pb2.py
-  ddtrace/profiling/exporter/pprof_319_pb2.py
-  ddtrace/profiling/exporter/pprof_421_pb2.py
-  tests/profiling/simple_program_gevent.py
-  tests/contrib/grpc/hello_pb2.py
-  tests/contrib/django_celery/app/*
-
-# Ignore:
-# A003: XXX is a python builtin, consider renaming the class attribute
-# G201 Logging: .exception(...) should be used instead of .error(..., exc_info=True)
-# E231,W503,E203: not respected by black
-# We ignore most of the D errors because there are too many; the goal is to fix them eventually
-ignore = W503,E231,A003,G201,D100,D101,D102,D103,D104,D105,D106,D107,D200,D202,D204,D205,D208,D210,D300,D400,D401,D403,D413,G200,RST301,B902,E203
-enable-extensions=G
-rst-roles = class,meth,obj,ref,func
-rst-directives = py:data
-
 # DEV: We use `conftest.py` as a local pytest plugin to configure hooks for collection
 [tool:pytest]
 # --cov-report is intentionally empty else pytest-cov will default to generating a report

--- a/tests/appsec/iast/fixtures/aspects/str_methods.py
+++ b/tests/appsec/iast/fixtures/aspects/str_methods.py
@@ -10,9 +10,9 @@ import random
 import re
 import sys
 import threading
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Text
 
 from six import StringIO

--- a/tests/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/test_remoteconfiguration.py
@@ -29,8 +29,8 @@ from ddtrace.internal.remoteconfig.client import ConfigMetadata
 from ddtrace.internal.remoteconfig.client import TargetFile
 from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
 from ddtrace.internal.utils.formats import asbool
-from tests.appsec.test_processor import Config
 from tests.appsec.test_processor import ROOT_DIR
+from tests.appsec.test_processor import Config
 from tests.utils import override_env
 from tests.utils import override_global_config
 

--- a/tests/appsec/test_telemetry.py
+++ b/tests/appsec/test_telemetry.py
@@ -14,10 +14,10 @@ from ddtrace.ext import SpanTypes
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE_TAG_APPSEC
 from ddtrace.internal.telemetry.constants import TELEMETRY_TYPE_DISTRIBUTION
 from ddtrace.internal.telemetry.constants import TELEMETRY_TYPE_GENERATE_METRICS
-from tests.appsec.test_processor import Config
+from tests.appsec.test_processor import _IP
 from tests.appsec.test_processor import ROOT_DIR
 from tests.appsec.test_processor import RULES_GOOD_PATH
-from tests.appsec.test_processor import _IP
+from tests.appsec.test_processor import Config
 from tests.appsec.test_processor import _enable_appsec
 from tests.utils import override_env
 from tests.utils import override_global_config

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -15,14 +15,14 @@ from ddtrace.internal.compat import PY3
 from ddtrace.internal.compat import urlencode
 from ddtrace.internal.constants import BLOCKED_RESPONSE_HTML
 from ddtrace.internal.constants import BLOCKED_RESPONSE_JSON
+from tests.appsec.test_processor import _IP
 from tests.appsec.test_processor import RESPONSE_CUSTOM_HTML
 from tests.appsec.test_processor import RESPONSE_CUSTOM_JSON
 from tests.appsec.test_processor import RULES_GOOD_PATH
 from tests.appsec.test_processor import RULES_SRB
-from tests.appsec.test_processor import RULES_SRBCA
 from tests.appsec.test_processor import RULES_SRB_METHOD
 from tests.appsec.test_processor import RULES_SRB_RESPONSE
-from tests.appsec.test_processor import _IP
+from tests.appsec.test_processor import RULES_SRBCA
 from tests.utils import override_env
 from tests.utils import override_global_config
 
@@ -390,7 +390,11 @@ def test_django_client_ip_headers(client, test_spans, tracer, kwargs, expected):
 def test_django_client_ip_header_set_by_env_var_invalid_2(client, test_spans, tracer):
     with override_global_config(dict(_appsec_enabled=True, client_ip_header="Fooipheader")):
         root_span, response = _aux_appsec_get_root_span(
-            client, test_spans, tracer, url="/?a=1&b&c=d", headers={"HTTP_FOOIPHEADER": "", "HTTP_X_REAL_IP": "アスダス"}
+            client,
+            test_spans,
+            tracer,
+            url="/?a=1&b&c=d",
+            headers={"HTTP_FOOIPHEADER": "", "HTTP_X_REAL_IP": "アスダス"},  # noqa: E501
         )
         assert response.status_code == 200
         # X_REAL_IP should be ignored since the client provided a header

--- a/tests/contrib/django/test_django_appsec_snapshots.py
+++ b/tests/contrib/django/test_django_appsec_snapshots.py
@@ -7,8 +7,8 @@ import pytest
 
 from ddtrace.internal.compat import PY3
 import ddtrace.internal.constants as constants
-from tests.appsec.test_processor import RULES_GOOD_PATH
 from tests.appsec.test_processor import _IP
+from tests.appsec.test_processor import RULES_GOOD_PATH
 from tests.utils import snapshot
 from tests.webclient import Client
 

--- a/tests/contrib/fastapi/app.py
+++ b/tests/contrib/fastapi/app.py
@@ -5,8 +5,8 @@ from typing import Optional
 
 from fastapi import BackgroundTasks
 from fastapi import FastAPI
-from fastapi import HTTPException
 from fastapi import Header
+from fastapi import HTTPException
 from fastapi.responses import FileResponse
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel

--- a/tests/contrib/flask/test_appsec_flask_snapshot.py
+++ b/tests/contrib/flask/test_appsec_flask_snapshot.py
@@ -16,8 +16,8 @@ from ddtrace.internal.compat import PY2
 from ddtrace.internal.constants import BLOCKED_RESPONSE_HTML
 from ddtrace.internal.constants import BLOCKED_RESPONSE_JSON
 from ddtrace.internal.utils.retry import RetryError
-from tests.appsec.test_processor import RULES_GOOD_PATH
 from tests.appsec.test_processor import _IP
+from tests.appsec.test_processor import RULES_GOOD_PATH
 from tests.contrib.flask.test_flask_appsec import _ALLOWED_USER
 from tests.contrib.flask.test_flask_appsec import _BLOCKED_USER
 from tests.webclient import Client

--- a/tests/contrib/flask/test_flask_appsec.py
+++ b/tests/contrib/flask/test_flask_appsec.py
@@ -13,15 +13,15 @@ from ddtrace.ext import http
 from ddtrace.internal import constants
 from ddtrace.internal import core
 from ddtrace.internal.compat import urlencode
+from tests.appsec.test_processor import _IP
 from tests.appsec.test_processor import RESPONSE_CUSTOM_HTML
 from tests.appsec.test_processor import RESPONSE_CUSTOM_JSON
 from tests.appsec.test_processor import RULES_BAD_VERSION
 from tests.appsec.test_processor import RULES_GOOD_PATH
 from tests.appsec.test_processor import RULES_SRB
-from tests.appsec.test_processor import RULES_SRBCA
 from tests.appsec.test_processor import RULES_SRB_METHOD
 from tests.appsec.test_processor import RULES_SRB_RESPONSE
-from tests.appsec.test_processor import _IP
+from tests.appsec.test_processor import RULES_SRBCA
 from tests.contrib.flask import BaseFlaskTestCase
 from tests.utils import override_env
 from tests.utils import override_global_config

--- a/tests/contrib/flask/test_flask_appsec_telemetry.py
+++ b/tests/contrib/flask/test_flask_appsec_telemetry.py
@@ -7,8 +7,8 @@ from ddtrace.internal import core
 from ddtrace.internal.compat import urlencode
 from ddtrace.internal.constants import BLOCKED_RESPONSE_JSON
 from tests.appsec.conftest import mock_telemetry_lifecycle_writer  # noqa: F401
-from tests.appsec.test_processor import RULES_GOOD_PATH
 from tests.appsec.test_processor import _IP
+from tests.appsec.test_processor import RULES_GOOD_PATH
 from tests.appsec.test_telemetry import _assert_generate_metrics
 from tests.contrib.flask import BaseFlaskTestCase
 from tests.utils import override_env

--- a/tests/contrib/httplib/test_httplib_distributed.py
+++ b/tests/contrib/httplib/test_httplib_distributed.py
@@ -9,8 +9,8 @@ from ddtrace.internal.compat import httplib
 from ddtrace.pin import Pin
 from tests.utils import TracerTestCase
 
-from .test_httplib import HTTPLibBaseMixin
 from .test_httplib import SOCKET
+from .test_httplib import HTTPLibBaseMixin
 
 
 class TestHTTPLibDistributed(HTTPLibBaseMixin, TracerTestCase):

--- a/tests/contrib/openai/test_openai.py
+++ b/tests/contrib/openai/test_openai.py
@@ -6,8 +6,8 @@ from typing import Generator
 from typing import List
 from typing import Optional
 
-from PIL import Image
 import mock
+from PIL import Image
 import pytest
 import vcr
 

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -3,10 +3,10 @@ import time
 
 import mock
 import psycopg
+from psycopg.sql import SQL
 from psycopg.sql import Composed
 from psycopg.sql import Identifier
 from psycopg.sql import Literal
-from psycopg.sql import SQL
 
 from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY

--- a/tests/contrib/psycopg/test_psycopg_async.py
+++ b/tests/contrib/psycopg/test_psycopg_async.py
@@ -2,8 +2,8 @@
 import time
 
 import psycopg
-from psycopg.sql import Literal
 from psycopg.sql import SQL
+from psycopg.sql import Literal
 
 from ddtrace import Pin
 from ddtrace.contrib.psycopg.patch import patch

--- a/tests/contrib/psycopg2/test_psycopg.py
+++ b/tests/contrib/psycopg2/test_psycopg.py
@@ -24,10 +24,10 @@ PSYCOPG2_VERSION = parse_version(psycopg2.__version__)
 
 
 if PSYCOPG2_VERSION >= (2, 7):
+    from psycopg2.sql import SQL
     from psycopg2.sql import Composed
     from psycopg2.sql import Identifier
     from psycopg2.sql import Literal
-    from psycopg2.sql import SQL
 
 TEST_PORT = POSTGRES_CONFIG["port"]
 

--- a/tests/contrib/pymemcache/test_client.py
+++ b/tests/contrib/pymemcache/test_client.py
@@ -20,9 +20,9 @@ from tests.utils import TracerTestCase
 from tests.utils import override_config
 
 from .test_client_mixin import PYMEMCACHE_VERSION
-from .test_client_mixin import PymemcacheClientTestCaseMixin
 from .test_client_mixin import TEST_HOST
 from .test_client_mixin import TEST_PORT
+from .test_client_mixin import PymemcacheClientTestCaseMixin
 from .utils import MockSocket
 from .utils import _str
 

--- a/tests/contrib/pyramid/pserve_app/setup.py
+++ b/tests/contrib/pyramid/pserve_app/setup.py
@@ -1,4 +1,6 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
+
 
 setup(
     name="pserve_test_app",

--- a/tests/debugging/test_encoding.py
+++ b/tests/debugging/test_encoding.py
@@ -9,8 +9,8 @@ import pytest
 
 from ddtrace.debugging._encoding import BatchJsonEncoder
 from ddtrace.debugging._encoding import LogSignalJsonEncoder
-from ddtrace.debugging._probe.model import CaptureLimits
 from ddtrace.debugging._probe.model import MAXSIZE
+from ddtrace.debugging._probe.model import CaptureLimits
 from ddtrace.debugging._signal import utils
 from ddtrace.debugging._signal.snapshot import Snapshot
 from ddtrace.debugging._signal.snapshot import _capture_context

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -26,9 +26,9 @@ from ddtrace.internal._encoding import ListStringTable
 from ddtrace.internal._encoding import MsgpackStringTable
 from ddtrace.internal.compat import msgpack_type
 from ddtrace.internal.compat import string_type
+from ddtrace.internal.encoding import MSGPACK_ENCODERS
 from ddtrace.internal.encoding import JSONEncoder
 from ddtrace.internal.encoding import JSONEncoderV2
-from ddtrace.internal.encoding import MSGPACK_ENCODERS
 from ddtrace.internal.encoding import MsgpackEncoderV03
 from ddtrace.internal.encoding import MsgpackEncoderV05
 from ddtrace.internal.encoding import _EncoderBase

--- a/tests/tracer/test_processors.py
+++ b/tests/tracer/test_processors.py
@@ -6,15 +6,15 @@ import pytest
 
 from ddtrace import Span
 from ddtrace import Tracer
+from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MAX_PER_SEC
+from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MECHANISM
+from ddtrace.constants import _SINGLE_SPAN_SAMPLING_RATE
 from ddtrace.constants import AUTO_KEEP
 from ddtrace.constants import AUTO_REJECT
 from ddtrace.constants import MANUAL_KEEP_KEY
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.constants import USER_KEEP
 from ddtrace.constants import USER_REJECT
-from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MAX_PER_SEC
-from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MECHANISM
-from ddtrace.constants import _SINGLE_SPAN_SAMPLING_RATE
 from ddtrace.context import Context
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.constants import HIGHER_ORDER_TRACE_ID_BITS

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -6,17 +6,12 @@ import os
 import pytest
 
 from ddtrace.context import Context
+from ddtrace.internal.constants import _PROPAGATION_STYLE_NONE
+from ddtrace.internal.constants import _PROPAGATION_STYLE_W3C_TRACECONTEXT
 from ddtrace.internal.constants import PROPAGATION_STYLE_B3_MULTI
 from ddtrace.internal.constants import PROPAGATION_STYLE_B3_SINGLE
 from ddtrace.internal.constants import PROPAGATION_STYLE_DATADOG
-from ddtrace.internal.constants import _PROPAGATION_STYLE_NONE
-from ddtrace.internal.constants import _PROPAGATION_STYLE_W3C_TRACECONTEXT
 from ddtrace.propagation._utils import get_wsgi_header
-from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.propagation.http import HTTP_HEADER_ORIGIN
-from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
-from ddtrace.propagation.http import HTTP_HEADER_SAMPLING_PRIORITY
-from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
 from ddtrace.propagation.http import _HTTP_HEADER_B3_FLAGS
 from ddtrace.propagation.http import _HTTP_HEADER_B3_SAMPLED
 from ddtrace.propagation.http import _HTTP_HEADER_B3_SINGLE
@@ -25,6 +20,11 @@ from ddtrace.propagation.http import _HTTP_HEADER_B3_TRACE_ID
 from ddtrace.propagation.http import _HTTP_HEADER_TAGS
 from ddtrace.propagation.http import _HTTP_HEADER_TRACEPARENT
 from ddtrace.propagation.http import _HTTP_HEADER_TRACESTATE
+from ddtrace.propagation.http import HTTP_HEADER_ORIGIN
+from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
+from ddtrace.propagation.http import HTTP_HEADER_SAMPLING_PRIORITY
+from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
+from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.propagation.http import _TraceContext
 
 from ..utils import override_global_config

--- a/tests/tracer/test_rate_limiter.py
+++ b/tests/tracer/test_rate_limiter.py
@@ -5,8 +5,8 @@ import pytest
 
 from ddtrace.internal import compat
 from ddtrace.internal.rate_limiter import BudgetRateLimiterWithJitter
-from ddtrace.internal.rate_limiter import RateLimitExceeded
 from ddtrace.internal.rate_limiter import RateLimiter
+from ddtrace.internal.rate_limiter import RateLimitExceeded
 
 
 def nanoseconds(x):

--- a/tests/tracer/test_single_span_sampling_rules.py
+++ b/tests/tracer/test_single_span_sampling_rules.py
@@ -3,10 +3,10 @@ import sys
 import pytest
 
 from ddtrace import Tracer
-from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MAX_PER_SEC
 from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MECHANISM
 from ddtrace.constants import _SINGLE_SPAN_SAMPLING_RATE
+from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.internal.sampling import SamplingMechanism
 from ddtrace.internal.sampling import SpanSamplingRule
 from ddtrace.internal.sampling import _get_file_json

--- a/tests/vendor/msgpack/test_limits.py
+++ b/tests/vendor/msgpack/test_limits.py
@@ -5,11 +5,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from msgpack import Packer
 from msgpack import PackOverflowError
 from msgpack import PackValueError
-from msgpack import Packer
-from msgpack import UnpackValueError
 from msgpack import Unpacker
+from msgpack import UnpackValueError
 from msgpack import unpackb
 import pytest
 


### PR DESCRIPTION
We migrate to ruff as a drop-in replacement for isort and flake8.

We try our best to match the existing results from isort and flake8 but do make minimal changes as necessary.

**BEFORE:**

```
$ time hatch run lint:isort --check --diff .
Skipped 21 files

real    0m3.556s
user    0m2.030s
sys     0m1.047s
$ time hatch run lint:flake8

real    0m42.019s
user    0m40.353s
sys     0m1.261s
```

**AFTER:**

```
$ time hatch run lint:ruff check --diff .

real    0m0.864s
user    0m0.813s
sys     0m0.234s
```


## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
