### PR TITLE
use shared constant for asm blocking flag

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -6,6 +6,7 @@ import six
 from ddtrace.internal.constants import HTTP_REQUEST_BLOCKED
 from ddtrace.internal.constants import REQUEST_PATH_PARAMS
 from ddtrace.internal.constants import RESPONSE_HEADERS
+from ddtrace.internal.constants import STATUS_403_TYPE_AUTO
 
 
 if TYPE_CHECKING:
@@ -152,7 +153,7 @@ class WAF_ACTIONS(object):
     PARAMETERS = "parameters"
     TYPE = "type"
     ID = "id"
-    DEFAULT_PARAMETERS = {"status_code": 403, "type": "auto"}
+    DEFAULT_PARAMETERS = STATUS_403_TYPE_AUTO
     BLOCK_ACTION = "block_request"
     DEFAULT_ACTONS = {
         BLOCK: {

--- a/ddtrace/appsec/handlers.py
+++ b/ddtrace/appsec/handlers.py
@@ -5,12 +5,14 @@ from six import BytesIO
 import xmltodict
 
 from ddtrace import config
+import ddtrace.appsec._constants as asm_constants
 from ddtrace.appsec.iast._metrics import _set_metric_iast_instrumented_source
 from ddtrace.appsec.iast._patch import if_iast_taint_returned_object_for
 from ddtrace.appsec.iast._patch import if_iast_taint_yield_tuple_for
 from ddtrace.appsec.iast._util import _is_iast_enabled
 from ddtrace.contrib import trace_utils
 from ddtrace.internal import core
+from ddtrace.internal.constants import HTTP_REQUEST_BLOCKED
 from ddtrace.internal.logger import get_logger
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 from ddtrace.vendor.wrapt.importer import when_imported
@@ -242,6 +244,10 @@ def _on_django_patch():
         )
     except Exception:
         log.debug("Unexpected exception while patch IAST functions", exc_info=True)
+
+
+def _on_flask_blocked_request(span):
+    core.set_item(HTTP_REQUEST_BLOCKED, asm_constants.WAF_ACTIONS.DEFAULT_PARAMETERS)
 
 
 def listen():

--- a/ddtrace/appsec/handlers.py
+++ b/ddtrace/appsec/handlers.py
@@ -5,14 +5,12 @@ from six import BytesIO
 import xmltodict
 
 from ddtrace import config
-import ddtrace.appsec._constants as asm_constants
 from ddtrace.appsec.iast._metrics import _set_metric_iast_instrumented_source
 from ddtrace.appsec.iast._patch import if_iast_taint_returned_object_for
 from ddtrace.appsec.iast._patch import if_iast_taint_yield_tuple_for
 from ddtrace.appsec.iast._util import _is_iast_enabled
 from ddtrace.contrib import trace_utils
 from ddtrace.internal import core
-from ddtrace.internal.constants import HTTP_REQUEST_BLOCKED
 from ddtrace.internal.logger import get_logger
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 from ddtrace.vendor.wrapt.importer import when_imported

--- a/ddtrace/appsec/handlers.py
+++ b/ddtrace/appsec/handlers.py
@@ -246,10 +246,6 @@ def _on_django_patch():
         log.debug("Unexpected exception while patch IAST functions", exc_info=True)
 
 
-def _on_flask_blocked_request(span):
-    core.set_item(HTTP_REQUEST_BLOCKED, asm_constants.WAF_ACTIONS.DEFAULT_PARAMETERS)
-
-
 def listen():
     core.on("flask.request_span_modifier", _on_request_span_modifier)
 

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -542,9 +542,6 @@ def traced_register_error_handler(wrapped, instance, args, kwargs):
 
 def _block_request_callable(call):
     request = flask.request
-    import ddtrace.appsec._constants as asm_constants
-
-    core.set_item(HTTP_REQUEST_BLOCKED, asm_constants.WAF_ACTIONS.DEFAULT_PARAMETERS)
     core.dispatch("flask.blocked_request_callable", [call])
     ctype = "text/html" if "text/html" in request.headers.get("Accept", "").lower() else "text/json"
     abort(flask.Response(http_utils._get_blocked_template(ctype), content_type=ctype, status=403))

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -8,6 +8,7 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.constants import FLASK_ENDPOINT
 from ddtrace.internal.constants import FLASK_URL_RULE
 from ddtrace.internal.constants import HTTP_REQUEST_BLOCKED
+from ddtrace.internal.constants import STATUS_403_TYPE_AUTO
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
 from ...internal import core
@@ -542,6 +543,7 @@ def traced_register_error_handler(wrapped, instance, args, kwargs):
 
 def _block_request_callable(call):
     request = flask.request
+    core.set_item(HTTP_REQUEST_BLOCKED, STATUS_403_TYPE_AUTO)
     core.dispatch("flask.blocked_request_callable", [call])
     ctype = "text/html" if "text/html" in request.headers.get("Accept", "").lower() else "text/json"
     abort(flask.Response(http_utils._get_blocked_template(ctype), content_type=ctype, status=403))

--- a/ddtrace/internal/constants.py
+++ b/ddtrace/internal/constants.py
@@ -60,6 +60,7 @@ HTTP_REQUEST_PARAMETER = "http.request.parameter"
 HTTP_REQUEST_BODY = "http.request.body"
 HTTP_REQUEST_PATH_PARAMETER = "http.request.path.parameter"
 REQUEST_PATH_PARAMS = "http.request.path_params"
+STATUS_403_TYPE_AUTO = {"status_code": 403, "type": "auto"}
 
 MESSAGING_SYSTEM = "messaging.system"
 

--- a/ddtrace/tracing/trace_handlers.py
+++ b/ddtrace/tracing/trace_handlers.py
@@ -14,6 +14,7 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.constants import FLASK_ENDPOINT
 from ddtrace.internal.constants import FLASK_URL_RULE
 from ddtrace.internal.constants import FLASK_VIEW_ARGS
+from ddtrace.internal.constants import HTTP_REQUEST_BLOCKED
 from ddtrace.internal.constants import RESPONSE_HEADERS
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import http as http_utils
@@ -80,15 +81,13 @@ def _on_context_started(ctx):
 
 
 def _make_block_content(ctx, construct_url):
-    from ddtrace.appsec import _constants as _asm_constants
-
     middleware = ctx.get_item("middleware")
     req_span = ctx.get_item("req_span")
     headers = ctx.get_item("headers")
     environ = ctx.get_item("environ")
     if req_span is None:
         raise ValueError("request span not found")
-    block_config = core.get_item(_asm_constants.WAF_CONTEXT_NAMES.BLOCKED, span=req_span)
+    block_config = core.get_item(HTTP_REQUEST_BLOCKED, span=req_span)
     if block_config.get("type", "auto") == "auto":
         ctype = "text/html" if "text/html" in headers.get("Accept", "").lower() else "text/json"
     else:


### PR DESCRIPTION
This change leverages the fact that the constant denoting WAF request blocking is [defined](https://github.com/DataDog/dd-trace-py/blob/8918337c84d6da8a8a3fbcc972723bb7f7bb508c/ddtrace/appsec/_constants.py#L143) in `ddtrace.internal` to move logic mentioning ASM out of the flask contrib and trace handlers code.