### PR TITLE
fix(docs): fix undefined variable reference in otel docs

### DIFF
--- a/ddtrace/opentelemetry/__init__.py
+++ b/ddtrace/opentelemetry/__init__.py
@@ -45,7 +45,7 @@ Datadog and OpenTelemetry APIs can be used interchangeably::
 
     with oteltracer.start_as_current_span("otel-span") as parent_span:
         parent_span.set_attribute("otel_key", "otel_val")
-        with ddtrace.trace("ddtrace-span") as child_span:
+        with ddtrace.tracer.trace("ddtrace-span") as child_span:
             child_span.set_tag("dd_key", "dd_val")
 
     @oteltracer.start_as_current_span("span_name")

--- a/ddtrace/opentelemetry/__init__.py
+++ b/ddtrace/opentelemetry/__init__.py
@@ -44,7 +44,7 @@ Datadog and OpenTelemetry APIs can be used interchangeably::
     oteltracer = opentelemetry.trace.get_tracer(__name__)
 
     with oteltracer.start_as_current_span("otel-span") as parent_span:
-        otel_span.set_attribute("otel_key", "otel_val")
+        parent_span.set_attribute("otel_key", "otel_val")
         with ddtrace.trace("ddtrace-span") as child_span:
             child_span.set_tag("dd_key", "dd_val")
 

--- a/releasenotes/notes/fix-undefined-var-in-otel-docs-508ff00a82264aef.yaml
+++ b/releasenotes/notes/fix-undefined-var-in-otel-docs-508ff00a82264aef.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    docs: Fix undefined variable reference in otel documentation


### PR DESCRIPTION
`otel_span` isn't declared, presumably the original author intended to use `parent_span` here, which is in scope.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
