### PR TITLE
fix: don't crash when mariadb connection string doesn't include port or user

### DIFF
--- a/ddtrace/contrib/mariadb/patch.py
+++ b/ddtrace/contrib/mariadb/patch.py
@@ -39,10 +39,10 @@ def unpatch():
 def _connect(func, instance, args, kwargs):
     conn = func(*args, **kwargs)
     tags = {
-        net.TARGET_HOST: kwargs.get("host", "localhost"),
+        net.TARGET_HOST: kwargs.get("host", "127.0.0.1"),
         net.TARGET_PORT: kwargs.get("port", 3306),
-        db.USER: kwargs.get("user", ""),
-        db.NAME: kwargs.get("database", ""),
+        db.USER: kwargs.get("user", "test"),
+        db.NAME: kwargs.get("database", "test"),
         db.SYSTEM: "mariadb",
     }
 

--- a/ddtrace/contrib/mariadb/patch.py
+++ b/ddtrace/contrib/mariadb/patch.py
@@ -39,10 +39,10 @@ def unpatch():
 def _connect(func, instance, args, kwargs):
     conn = func(*args, **kwargs)
     tags = {
-        net.TARGET_HOST: kwargs["host"],
-        net.TARGET_PORT: kwargs["port"],
-        db.USER: kwargs["user"],
-        db.NAME: kwargs["database"],
+        net.TARGET_HOST: kwargs.get("host", "localhost"),
+        net.TARGET_PORT: kwargs.get("port", 3306),
+        db.USER: kwargs.get("user", ""),
+        db.NAME: kwargs.get("database", ""),
         db.SYSTEM: "mariadb",
     }
 

--- a/releasenotes/notes/maria-missing-port-e30630b4f5a5ee33.yaml
+++ b/releasenotes/notes/maria-missing-port-e30630b4f5a5ee33.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    mariadb: This fix resolves an issue where MariaDB connection information objects not including the user
+    or port caused exceptions to be raised.

--- a/tests/contrib/mariadb/test_mariadb.py
+++ b/tests/contrib/mariadb/test_mariadb.py
@@ -55,7 +55,7 @@ def test_connection_no_port_or_user_does_not_raise():
     conf = MARIADB_CONFIG.copy()
     del conf["port"]
     del conf["user"]
-    mariadb.connect(conf)
+    mariadb.connect(**conf)
 
 
 def test_simple_query(connection, tracer):

--- a/tests/contrib/mariadb/test_mariadb.py
+++ b/tests/contrib/mariadb/test_mariadb.py
@@ -51,6 +51,13 @@ def connection(tracer):
         yield connection
 
 
+def test_connection_no_port_or_user_does_not_raise():
+    conf = MARIADB_CONFIG.copy()
+    del conf["port"]
+    del conf["user"]
+    mariadb.connect(conf)
+
+
 def test_simple_query(connection, tracer):
     cursor = connection.cursor()
     cursor.execute("SELECT 1")

--- a/tests/contrib/mariadb/test_mariadb.py
+++ b/tests/contrib/mariadb/test_mariadb.py
@@ -55,7 +55,12 @@ def test_connection_no_port_or_user_does_not_raise():
     conf = MARIADB_CONFIG.copy()
     del conf["port"]
     del conf["user"]
-    mariadb.connect(**conf)
+    try:
+        mariadb.connect(**conf)
+    except mariadb.OperationalError as exc:
+        # this error is expected because mariadb defaults user to root when not given
+        if "Access denied for user 'root'" not in str(exc):
+            raise exc
 
 
 def test_simple_query(connection, tracer):


### PR DESCRIPTION
This change fixes https://github.com/DataDog/dd-trace-py/issues/6203 by supplying defaults for the accesses of `port` and `user` fields from the MariaDB connection info object.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
