### PR TITLE
ci: use check diff arguments in black and isort checks

### DIFF
--- a/ddtrace/appsec/iast/_taint_utils.py
+++ b/ddtrace/appsec/iast/_taint_utils.py
@@ -204,7 +204,10 @@ class LazyTaintDict:
                     try:
                         # TODO: migrate this part to shift ranges instead of creating a new one
                         value = taint_pyobject(
-                            pyobject=value, source_name=key, source_value=value, source_origin=origin,
+                            pyobject=value,
+                            source_name=key,
+                            source_value=value,
+                            source_origin=origin,
                         )
                     except SystemError:
                         # TODO: Find the root cause for
@@ -283,7 +286,9 @@ class LazyTaintDict:
         if _is_tainted_struct(other):
             other = other._obj
         return LazyTaintDict(
-            self._obj | other, origins=self._origins, override_pyobject_tainted=self._override_pyobject_tainted,
+            self._obj | other,
+            origins=self._origins,
+            override_pyobject_tainted=self._override_pyobject_tainted,
         )
 
     def __repr__(self):
@@ -304,7 +309,9 @@ class LazyTaintDict:
 
     def copy(self):
         return LazyTaintDict(
-            self._obj.copy(), origins=self._origins, override_pyobject_tainted=self._override_pyobject_tainted,
+            self._obj.copy(),
+            origins=self._origins,
+            override_pyobject_tainted=self._override_pyobject_tainted,
         )
 
     @classmethod

--- a/ddtrace/contrib/httplib/patch.py
+++ b/ddtrace/contrib/httplib/patch.py
@@ -11,12 +11,12 @@ from ddtrace.vendor import wrapt
 from .. import trace_utils
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
-from ...internal.constants import _HTTPLIB_NO_TRACE_REQUEST
 from ...ext import SpanKind
 from ...ext import SpanTypes
 from ...internal.compat import PY2
 from ...internal.compat import httplib
 from ...internal.compat import parse
+from ...internal.constants import _HTTPLIB_NO_TRACE_REQUEST
 from ...internal.logger import get_logger
 from ...internal.schema import schematize_url_operation
 from ...internal.utils.formats import asbool

--- a/ddtrace/ext/ci.py
+++ b/ddtrace/ext/ci.py
@@ -7,8 +7,8 @@ import os
 import platform
 import re
 from typing import Dict
-from typing import MutableMapping
 from typing import List
+from typing import MutableMapping
 from typing import Optional
 
 from ddtrace.ext import git

--- a/ddtrace/internal/datadog/profiling/ddup.py
+++ b/ddtrace/internal/datadog/profiling/ddup.py
@@ -1,8 +1,9 @@
 try:
-    from ._ddup import * # noqa: F403, F401
+    from ._ddup import *  # noqa: F403, F401
 except ImportError:
-    from typing import Optional
     from typing import Dict
+    from typing import Optional
+
     from ddtrace.span import Span
 
     # Decorator for not-implemented
@@ -12,75 +13,75 @@ except ImportError:
 
     @not_implemented
     def init(
-        env,     # type: Optional[str]
-        service, # type: Optional[str]
-        version, # type: Optional[str]
-        tags,    # type: Optional[Dict[str, str]]
-        max_nframes, # type: Optional[int]
-        url,     # type: Optional[str]
+        env,  # type: Optional[str]
+        service,  # type: Optional[str]
+        version,  # type: Optional[str]
+        tags,  # type: Optional[Dict[str, str]]
+        max_nframes,  # type: Optional[int]
+        url,  # type: Optional[str]
     ):
         pass
 
     @not_implemented
-    def start_sample(nframes): # type: (int) -> None
+    def start_sample(nframes):  # type: (int) -> None
         pass
 
     @not_implemented
-    def push_cputime(value, count): # type: (int, int) -> None
+    def push_cputime(value, count):  # type: (int, int) -> None
         pass
 
     @not_implemented
-    def push_walltime(value, count): # type: (int, int) -> None
+    def push_walltime(value, count):  # type: (int, int) -> None
         pass
 
     @not_implemented
-    def push_acquire(value, count): # type: (int, int) -> None
+    def push_acquire(value, count):  # type: (int, int) -> None
         pass
 
     @not_implemented
-    def push_release(value, count): # type: (int, int) -> None
+    def push_release(value, count):  # type: (int, int) -> None
         pass
 
     @not_implemented
-    def push_alloc(value, count): # type: (int, int) -> None
+    def push_alloc(value, count):  # type: (int, int) -> None
         pass
 
     @not_implemented
-    def push_heap(value): # type: (int) -> None
+    def push_heap(value):  # type: (int) -> None
         pass
 
     @not_implemented
-    def push_lock_name(lock_name): # type: (str) -> None
+    def push_lock_name(lock_name):  # type: (str) -> None
         pass
 
     @not_implemented
-    def push_frame(name, filename, address, line): # type: (str, str, int, int) -> None
+    def push_frame(name, filename, address, line):  # type: (str, str, int, int) -> None
         pass
 
     @not_implemented
-    def push_threadinfo(thread_id, thread_native_id, thread_name): # type: (int, int, Optional[str]) -> None
+    def push_threadinfo(thread_id, thread_native_id, thread_name):  # type: (int, int, Optional[str]) -> None
         pass
 
     @not_implemented
-    def push_taskinfo(task_id, task_name): # type: (int, str) -> None
+    def push_taskinfo(task_id, task_name):  # type: (int, str) -> None
         pass
 
     @not_implemented
-    def push_exceptioninfo(exc_type, count): # type: (type, int) -> None
+    def push_exceptioninfo(exc_type, count):  # type: (type, int) -> None
         pass
 
     @not_implemented
-    def push_class_name(class_name): # type: (str) -> None
+    def push_class_name(class_name):  # type: (str) -> None
         pass
 
     @not_implemented
-    def push_span(span, endpoint_collection_enabled): # type: (Optional[Span], bool) -> None
+    def push_span(span, endpoint_collection_enabled):  # type: (Optional[Span], bool) -> None
         pass
 
     @not_implemented
-    def flush_sample(): # type: () -> None
+    def flush_sample():  # type: () -> None
         pass
 
     @not_implemented
-    def upload(): # type: () -> None
+    def upload():  # type: () -> None
         pass

--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -184,7 +184,6 @@ class MemoryCollector(collector.PeriodicCollector):
                     #      need to cleanup.
                     LOG.debug("Invalid state detected in memalloc module, suppressing profile")
 
-
         if self._export_py_enabled:
             return (
                 tuple(

--- a/ddtrace/profiling/exporter/pprof.pyx
+++ b/ddtrace/profiling/exporter/pprof.pyx
@@ -13,13 +13,13 @@ from ddtrace.internal import packages
 from ddtrace.internal._encoding import ListStringTable as _StringTable
 from ddtrace.internal.compat import ensure_str
 from ddtrace.internal.utils import config
-from ddtrace.profiling.collector import threading
 from ddtrace.profiling import event
 from ddtrace.profiling import exporter
 from ddtrace.profiling import recorder
 from ddtrace.profiling.collector import _lock
 from ddtrace.profiling.collector import memalloc
 from ddtrace.profiling.collector import stack_event
+from ddtrace.profiling.collector import threading
 
 
 if hasattr(typing, "TypedDict"):

--- a/hatch.toml
+++ b/hatch.toml
@@ -33,8 +33,8 @@ dependencies = [
 
 [envs.lint.scripts]
 style = [
-    "isort -q {args:.}",
-    "black -q {args:.}",
+    "isort --check --diff {args:.}",
+    "black --check --diff {args:.}",
     "flake8 {args}",
     "cython-lint {args:.}",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ force_sort_within_sections = true
 known_first_party = "ddtrace"
 default_section = "THIRDPARTY"
 skip = ["ddtrace/vendor/", ".riot", ".ddriot", ".tox", ".ddtox", ".eggs", "build", "setup.py"]
-skip_glob = [".venv*", "ddtrace/profiling/exporter/pprof_*pb2.py", "ddtrace/appsec/iast/_taint_tracking/_vendor/*"]
+skip_glob = [".venv*", "ddtrace/profiling/exporter/pprof_*pb2.py", "ddtrace/appsec/iast/_taint_tracking/_vendor/*", "ddtrace/**/*.pyi"]
 line_length = 120
 
 [tool.cython-lint]

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -135,7 +135,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, TracerTestCase):
         request = self.get_http_connection(parsed.hostname, parsed.port)
         pin = Pin.get_from(request)
         self.assertTrue(should_skip_request(pin, request))
-    
+
     def test_httplib_request_get_request_no_ddtrace(self):
         """
         When making a GET request via httplib.HTTPConnection.request

--- a/tests/contrib/pytest_benchmark/test_pytest_benchmark.py
+++ b/tests/contrib/pytest_benchmark/test_pytest_benchmark.py
@@ -79,24 +79,54 @@ class PytestTestCase(TracerTestCase):
         assert spans[0].get_tag(TEST_TYPE) == "benchmark"
         assert spans[0].get_tag(BENCHMARK_INFO) == "Time"
 
-        assert isinstance(spans[0].get_metric(BENCHMARK_MEAN), float) or isinstance(spans[0].get_metric(BENCHMARK_MEAN), int)
+        assert isinstance(spans[0].get_metric(BENCHMARK_MEAN), float) or isinstance(
+            spans[0].get_metric(BENCHMARK_MEAN), int
+        )
         assert isinstance(spans[0].get_metric(BENCHMARK_RUN), int)
-        assert isinstance(spans[0].get_metric(STATISTICS_HD15IQR), float) or isinstance(spans[0].get_metric(STATISTICS_HD15IQR), int)
-        assert isinstance(spans[0].get_metric(STATISTICS_IQR), float) or isinstance(spans[0].get_metric(STATISTICS_IQR), int)
-        assert isinstance(spans[0].get_metric(STATISTICS_IQR_OUTLIERS), int) or isinstance(spans[0].get_metric(STATISTICS_IQR_OUTLIERS), int)
-        assert isinstance(spans[0].get_metric(STATISTICS_LD15IQR), float) or isinstance(spans[0].get_metric(STATISTICS_LD15IQR), int)
-        assert isinstance(spans[0].get_metric(STATISTICS_MAX), float) or isinstance(spans[0].get_metric(STATISTICS_MAX), int)
-        assert isinstance(spans[0].get_metric(STATISTICS_MEAN), float) or isinstance(spans[0].get_metric(STATISTICS_MEAN), int)
-        assert isinstance(spans[0].get_metric(STATISTICS_MEDIAN), float) or isinstance(spans[0].get_metric(STATISTICS_MEDIAN), int)
-        assert isinstance(spans[0].get_metric(STATISTICS_MIN), float) or isinstance(spans[0].get_metric(STATISTICS_MIN), int)
-        assert isinstance(spans[0].get_metric(STATISTICS_OPS), float) or isinstance(spans[0].get_metric(STATISTICS_OPS), int)
+        assert isinstance(spans[0].get_metric(STATISTICS_HD15IQR), float) or isinstance(
+            spans[0].get_metric(STATISTICS_HD15IQR), int
+        )
+        assert isinstance(spans[0].get_metric(STATISTICS_IQR), float) or isinstance(
+            spans[0].get_metric(STATISTICS_IQR), int
+        )
+        assert isinstance(spans[0].get_metric(STATISTICS_IQR_OUTLIERS), int) or isinstance(
+            spans[0].get_metric(STATISTICS_IQR_OUTLIERS), int
+        )
+        assert isinstance(spans[0].get_metric(STATISTICS_LD15IQR), float) or isinstance(
+            spans[0].get_metric(STATISTICS_LD15IQR), int
+        )
+        assert isinstance(spans[0].get_metric(STATISTICS_MAX), float) or isinstance(
+            spans[0].get_metric(STATISTICS_MAX), int
+        )
+        assert isinstance(spans[0].get_metric(STATISTICS_MEAN), float) or isinstance(
+            spans[0].get_metric(STATISTICS_MEAN), int
+        )
+        assert isinstance(spans[0].get_metric(STATISTICS_MEDIAN), float) or isinstance(
+            spans[0].get_metric(STATISTICS_MEDIAN), int
+        )
+        assert isinstance(spans[0].get_metric(STATISTICS_MIN), float) or isinstance(
+            spans[0].get_metric(STATISTICS_MIN), int
+        )
+        assert isinstance(spans[0].get_metric(STATISTICS_OPS), float) or isinstance(
+            spans[0].get_metric(STATISTICS_OPS), int
+        )
         assert isinstance(spans[0].get_tag(STATISTICS_OUTLIERS), str)
-        assert isinstance(spans[0].get_metric(STATISTICS_Q1), float) or isinstance(spans[0].get_metric(STATISTICS_Q1), int)
-        assert isinstance(spans[0].get_metric(STATISTICS_Q3), float) or isinstance(spans[0].get_metric(STATISTICS_Q3), int)
+        assert isinstance(spans[0].get_metric(STATISTICS_Q1), float) or isinstance(
+            spans[0].get_metric(STATISTICS_Q1), int
+        )
+        assert isinstance(spans[0].get_metric(STATISTICS_Q3), float) or isinstance(
+            spans[0].get_metric(STATISTICS_Q3), int
+        )
         assert isinstance(spans[0].get_metric(STATISTICS_N), int)
-        assert isinstance(spans[0].get_metric(STATISTICS_STDDEV), float) or isinstance(spans[0].get_metric(STATISTICS_STDDEV), int)
-        assert isinstance(spans[0].get_metric(STATISTICS_STDDEV_OUTLIERS), float) or isinstance(spans[0].get_metric(STATISTICS_STDDEV_OUTLIERS), int)
-        assert isinstance(spans[0].get_metric(STATISTICS_TOTAL), float) or isinstance(spans[0].get_metric(STATISTICS_TOTAL), int)
+        assert isinstance(spans[0].get_metric(STATISTICS_STDDEV), float) or isinstance(
+            spans[0].get_metric(STATISTICS_STDDEV), int
+        )
+        assert isinstance(spans[0].get_metric(STATISTICS_STDDEV_OUTLIERS), float) or isinstance(
+            spans[0].get_metric(STATISTICS_STDDEV_OUTLIERS), int
+        )
+        assert isinstance(spans[0].get_metric(STATISTICS_TOTAL), float) or isinstance(
+            spans[0].get_metric(STATISTICS_TOTAL), int
+        )
 
         assert spans[0].get_metric(BENCHMARK_MEAN) > 0.0002
         assert spans[0].get_metric(BENCHMARK_RUN) > 0

--- a/tests/contrib/tornado/utils.py
+++ b/tests/contrib/tornado/utils.py
@@ -1,9 +1,9 @@
 from tornado.testing import AsyncHTTPTestCase
 
-from ddtrace.contrib.tornado import patch
-from ddtrace.contrib.tornado import unpatch
 from ddtrace.contrib.futures import patch as patch_futures
 from ddtrace.contrib.futures import unpatch as unpatch_futures
+from ddtrace.contrib.tornado import patch
+from ddtrace.contrib.tornado import unpatch
 from ddtrace.internal.compat import reload_module
 from tests.utils import TracerTestCase
 


### PR DESCRIPTION
This change fixes the `pre_check` job, which had become a noop in many cases after a regression a few weeks ago.

All of the non-toml changed files are the result of running `black` and `isort` against the repo.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))