### PR TITLE
feat(iast): report telemetry error logs

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -6,7 +6,6 @@ from ddtrace import config
 from ddtrace.appsec import handlers
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.appsec._constants import WAF_CONTEXT_NAMES
-from ddtrace.appsec.iast._metrics import _set_metric_iast_instrumented_source
 from ddtrace.appsec.iast._util import _is_iast_enabled
 from ddtrace.internal import core
 from ddtrace.internal.compat import parse
@@ -407,6 +406,7 @@ def _on_wrapped_view(kwargs):
 
 def _on_set_request_tags(request, span, flask_config):
     if _is_iast_enabled():
+        from ddtrace.appsec.iast._metrics import _set_metric_iast_instrumented_source
         from ddtrace.appsec.iast._taint_tracking import OriginType
         from ddtrace.appsec.iast._taint_utils import LazyTaintDict
 

--- a/ddtrace/appsec/_metrics.py
+++ b/ddtrace/appsec/_metrics.py
@@ -1,9 +1,7 @@
-import time
-from typing import Set
-
 from ddtrace.appsec import _asm_request_context
 from ddtrace.appsec.ddwaf import DDWaf_info
 from ddtrace.appsec.ddwaf import version
+from ddtrace.appsec.utils import deduplication
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE_TAG_APPSEC
@@ -12,29 +10,7 @@ from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE_TAG_APPSEC
 log = get_logger(__name__)
 
 
-class DeduplicationLogs:
-    def __init__(self, func):
-        self.func = func
-        self._last_timestamp = time.time()
-        self._next_report_timestamp()
-
-    def _next_report_timestamp(self):
-        # type: () -> None
-        self._last_timestamp = time.time() + 3600
-        self.reported_logs = set()  # type: Set[int]
-
-    def __call__(self, *args, **kwargs):
-        result = None
-        if time.time() > self._last_timestamp:
-            raw_log = hash(sum(str(arg) for arg in args))
-            if raw_log not in self.reported_logs:
-                self.reported_logs.add(raw_log)
-                result = self.func(*args, **kwargs)
-            self._next_report_timestamp()
-        return result
-
-
-@DeduplicationLogs
+@deduplication
 def _set_waf_error_metric(msg, stack_trace, info):
     # type: (str, str, DDWaf_info) -> None
     try:

--- a/ddtrace/appsec/handlers.py
+++ b/ddtrace/appsec/handlers.py
@@ -5,7 +5,6 @@ from six import BytesIO
 import xmltodict
 
 from ddtrace import config
-from ddtrace.appsec.iast._metrics import _set_metric_iast_instrumented_source
 from ddtrace.appsec.iast._patch import if_iast_taint_returned_object_for
 from ddtrace.appsec.iast._patch import if_iast_taint_yield_tuple_for
 from ddtrace.appsec.iast._util import _is_iast_enabled
@@ -83,6 +82,7 @@ def _on_request_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
     if _is_iast_enabled():
         try:
+            from ddtrace.appsec.iast._metrics import _set_metric_iast_instrumented_source
             from ddtrace.appsec.iast._taint_tracking import OriginType
             from ddtrace.appsec.iast._taint_tracking import taint_pyobject
 
@@ -108,6 +108,7 @@ def _on_request_init(wrapped, instance, args, kwargs):
 def _on_flask_patch(flask_version):
     if _is_iast_enabled():
         try:
+            from ddtrace.appsec.iast._metrics import _set_metric_iast_instrumented_source
             from ddtrace.appsec.iast._taint_tracking import OriginType
 
             _w(
@@ -210,6 +211,7 @@ def _on_wsgi_environ(wrapped, _instance, args, kwargs):
         if not args:
             return wrapped(*args, **kwargs)
 
+        from ddtrace.appsec.iast._metrics import _set_metric_iast_instrumented_source
         from ddtrace.appsec.iast._taint_tracking import OriginType  # noqa: F401
         from ddtrace.appsec.iast._taint_utils import LazyTaintDict
 

--- a/ddtrace/appsec/iast/_metrics.py
+++ b/ddtrace/appsec/iast/_metrics.py
@@ -1,7 +1,7 @@
 import os
 
 from ddtrace.appsec._constants import IAST
-from ddtrace.appsec._metrics import DeduplicationLogs
+from ddtrace.appsec.utils import deduplication
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE_TAG_IAST
@@ -49,7 +49,7 @@ def metric_verbosity(lvl):
 
 
 @metric_verbosity(TELEMETRY_MANDATORY_VERBOSITY)
-@DeduplicationLogs
+@deduplication
 def _set_iast_error_metric(msg, stack_trace):
     # type: (str, str) -> None
     try:

--- a/ddtrace/appsec/iast/_metrics.py
+++ b/ddtrace/appsec/iast/_metrics.py
@@ -1,6 +1,7 @@
 import os
 
 from ddtrace.appsec._constants import IAST
+from ddtrace.appsec._metrics import DeduplicationLogs
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE_TAG_IAST
@@ -45,6 +46,19 @@ def metric_verbosity(lvl):
         return lambda: None  # noqa: E731
 
     return wrapper
+
+
+@metric_verbosity(TELEMETRY_MANDATORY_VERBOSITY)
+@DeduplicationLogs
+def _set_iast_error_metric(msg, stack_trace):
+    # type: (str, str) -> None
+    try:
+        tags = {
+            "lib_language": "python",
+        }
+        telemetry_writer.add_log("ERROR", msg, stack_trace=stack_trace, tags=tags)
+    except Exception:
+        log.warning("Error reporting ASM WAF logs metrics", exc_info=True)
 
 
 @metric_verbosity(TELEMETRY_MANDATORY_VERBOSITY)

--- a/ddtrace/appsec/iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/iast/_taint_tracking/aspects.py
@@ -2,9 +2,10 @@ from builtins import bytearray as builtin_bytearray
 from builtins import bytes as builtin_bytes
 from builtins import str as builtin_str
 import codecs
-import sys
+import traceback
 from typing import TYPE_CHECKING
 
+from ddtrace.appsec.iast._metrics import _set_iast_error_metric
 from ddtrace.appsec.iast._taint_tracking import OriginType
 from ddtrace.appsec.iast._taint_tracking import TagMappingMode
 from ddtrace.appsec.iast._taint_tracking import TaintRange
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
     from typing import Union
 
 TEXT_TYPES = (str, bytes, bytearray)
+TEXT_TYPE = Union[str, bytes, bytearray]
 
 _add_aspect = aspects.add_aspect
 _extend_aspect = aspects.extend_aspect
@@ -62,14 +64,22 @@ def join_aspect(joiner, *args, **kwargs):
     # type: (Any, Any, Any) -> Any
     if not isinstance(joiner, TEXT_TYPES):
         return joiner.join(*args, **kwargs)
-    return _join_aspect(joiner, *args, **kwargs)
+    try:
+        return _join_aspect(joiner, *args, **kwargs)
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. join_aspect. {}".format(e), traceback.format_exc())
+        return joiner.join(*args, **kwargs)
 
 
 def bytearray_extend_aspect(op1, op2):
     # type: (Any, Any) -> Any
     if not isinstance(op1, bytearray) or not isinstance(op2, (bytearray, bytes)):
         return op1.extend(op2)
-    return _extend_aspect(op1, op2)
+    try:
+        return _extend_aspect(op1, op2)
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. extend_aspect. {}".format(e), traceback.format_exc())
+        return op1.extend(op2)
 
 
 def bytes_aspect(*args, **kwargs):
@@ -122,7 +132,8 @@ def modulo_aspect(candidate_text, candidate_tuple):
             ),
             ranges_orig=ranges_orig,
         )
-    except Exception:
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. modulo_aspect. {}".format(e), traceback.format_exc())
         return candidate_text % candidate_tuple
 
 
@@ -134,20 +145,23 @@ def ljust_aspect(candidate_text, *args, **kwargs):
     # type: (Any, Any, Any) -> Union[str, bytes, bytearray]
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.ljust(*args, **kwargs)
+    try:
+        ranges_new = get_ranges(candidate_text)
+        fillchar = parse_params(1, "fillchar", " ", *args, **kwargs)
+        fillchar_ranges = get_ranges(fillchar)
+        if ranges_new is None or (not ranges_new and not fillchar_ranges):
+            return candidate_text.ljust(*args, **kwargs)
 
-    ranges_new = get_ranges(candidate_text)
-    fillchar = parse_params(1, "fillchar", " ", *args, **kwargs)
-    fillchar_ranges = get_ranges(fillchar)
-    if ranges_new is None or (not ranges_new and not fillchar_ranges):
+        if fillchar_ranges:
+            # Can only be one char, so we create one range to cover from the start to the end
+            ranges_new = ranges_new + [shift_taint_range(fillchar_ranges[0], len(candidate_text))]
+
+        res = candidate_text.ljust(parse_params(0, "width", None, *args, **kwargs), fillchar)
+        taint_pyobject_with_ranges(res, ranges_new)
+        return res
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. ljust_aspect. {}".format(e), traceback.format_exc())
         return candidate_text.ljust(*args, **kwargs)
-
-    if fillchar_ranges:
-        # Can only be one char, so we create one range to cover from the start to the end
-        ranges_new = ranges_new + [shift_taint_range(fillchar_ranges[0], len(candidate_text))]
-
-    res = candidate_text.ljust(parse_params(0, "width", None, *args, **kwargs), fillchar)
-    taint_pyobject_with_ranges(res, ranges_new)
-    return res
 
 
 def zfill_aspect(candidate_text, *args, **kwargs):
@@ -162,56 +176,62 @@ def format_aspect(
 ):  # type: (...) -> str
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.format(*args, **kwargs)
+    try:
+        params = tuple(args) + tuple(kwargs.values())
+        ranges_orig, candidate_text_ranges = are_all_text_all_ranges(candidate_text, params)
+        if not ranges_orig:
+            return candidate_text.format(*args, **kwargs)
 
-    params = tuple(args) + tuple(kwargs.values())
-    ranges_orig, candidate_text_ranges = are_all_text_all_ranges(candidate_text, params)
-    if not ranges_orig:
+        new_template = as_formatted_evidence(
+            candidate_text, candidate_text_ranges, tag_mapping_function=TagMappingMode.Mapper
+        )
+        fun = (
+            lambda arg: as_formatted_evidence(arg, tag_mapping_function=TagMappingMode.Mapper)
+            if isinstance(arg, TEXT_TYPES)
+            else arg
+        )
+
+        new_args = list(map(fun, args))
+        new_kwargs = {key: fun(value) for key, value in iteritems(kwargs)}
+
+        return _convert_escaped_text_to_tainted_text(
+            new_template.format(*new_args, **new_kwargs),
+            ranges_orig=ranges_orig,
+        )
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. format_aspect. {}".format(e), traceback.format_exc())
         return candidate_text.format(*args, **kwargs)
-
-    new_template = as_formatted_evidence(
-        candidate_text, candidate_text_ranges, tag_mapping_function=TagMappingMode.Mapper
-    )
-    fun = (
-        lambda arg: as_formatted_evidence(arg, tag_mapping_function=TagMappingMode.Mapper)
-        if isinstance(arg, TEXT_TYPES)
-        else arg
-    )
-
-    new_args = list(map(fun, args))
-    new_kwargs = {key: fun(value) for key, value in iteritems(kwargs)}
-
-    return _convert_escaped_text_to_tainted_text(
-        new_template.format(*new_args, **new_kwargs),
-        ranges_orig=ranges_orig,
-    )
 
 
 def format_map_aspect(candidate_text, *args, **kwargs):  # type: (str, Any, Any) -> str
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.format_map(*args, **kwargs)
+    try:
+        mapping = parse_params(0, "mapping", None, *args, **kwargs)
+        mapping_tuple = tuple(mapping if not isinstance(mapping, dict) else mapping.values())
+        ranges_orig, candidate_text_ranges = are_all_text_all_ranges(
+            candidate_text,
+            args + mapping_tuple,
+        )
+        if not ranges_orig:
+            return candidate_text.format_map(*args, **kwargs)
 
-    mapping = parse_params(0, "mapping", None, *args, **kwargs)
-    mapping_tuple = tuple(mapping if not isinstance(mapping, dict) else mapping.values())
-    ranges_orig, candidate_text_ranges = are_all_text_all_ranges(
-        candidate_text,
-        args + mapping_tuple,
-    )
-    if not ranges_orig:
+        return _convert_escaped_text_to_tainted_text(
+            as_formatted_evidence(
+                candidate_text, candidate_text_ranges, tag_mapping_function=TagMappingMode.Mapper
+            ).format_map(
+                {
+                    key: as_formatted_evidence(value, tag_mapping_function=TagMappingMode.Mapper)
+                    if isinstance(value, TEXT_TYPES)
+                    else value
+                    for key, value in iteritems(mapping)
+                }
+            ),
+            ranges_orig=ranges_orig,
+        )
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. format_map_aspect. {}".format(e), traceback.format_exc())
         return candidate_text.format_map(*args, **kwargs)
-
-    return _convert_escaped_text_to_tainted_text(
-        as_formatted_evidence(
-            candidate_text, candidate_text_ranges, tag_mapping_function=TagMappingMode.Mapper
-        ).format_map(
-            {
-                key: as_formatted_evidence(value, tag_mapping_function=TagMappingMode.Mapper)
-                if isinstance(value, TEXT_TYPES)
-                else value
-                for key, value in iteritems(mapping)
-            }
-        ),
-        ranges_orig=ranges_orig,
-    )
 
 
 def format_value_aspect(
@@ -219,35 +239,35 @@ def format_value_aspect(
     options=0,  # type: int
     format_spec=None,  # type: Optional[str]
 ):  # type: (...) -> str
-
     if options == 115:
         new_text = str(element)
     elif options == 114:
         # TODO: use our repr once we have implemented it
         new_text = repr(element)
     elif options == 97:
-        # TODO: use our ascii once we have implemented it
-        if sys.version_info[0] >= 3:
-            new_text = ascii(element)
+        new_text = ascii(element)
     else:
         new_text = element
+    try:
+        if format_spec:
+            # Apply formatting
+            new_text = format_aspect("{:%s}" % format_spec, new_text)  # type:ignore
+        else:
+            new_text = str(new_text)
 
-    if format_spec:
-        # Apply formatting
-        new_text = format_aspect("{:%s}" % format_spec, new_text)  # type:ignore
-    else:
-        new_text = str(new_text)
+        # FIXME: can we return earlier here?
+        if not isinstance(new_text, TEXT_TYPES):
+            return new_text
 
-    # FIXME: can we return earlier here?
-    if not isinstance(new_text, TEXT_TYPES):
+        ranges_new = get_tainted_ranges(new_text) if isinstance(element, TEXT_TYPES) else ()
+        if not ranges_new:
+            return new_text
+
+        taint_pyobject_with_ranges(new_text, ranges_new)
         return new_text
-
-    ranges_new = get_tainted_ranges(new_text) if isinstance(element, TEXT_TYPES) else ()
-    if not ranges_new:
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. format_value_aspect. {}".format(e), traceback.format_exc())
         return new_text
-
-    taint_pyobject_with_ranges(new_text, ranges_new)
-    return new_text
 
 
 def incremental_translation(self, incr_coder, funcode, empty):
@@ -293,61 +313,95 @@ def incremental_translation(self, incr_coder, funcode, empty):
 def decode_aspect(self, *args, **kwargs):
     if not is_pyobject_tainted(self) or not isinstance(self, bytes):
         return self.decode(*args, **kwargs)
-    codec = args[0] if args else "utf-8"
-    inc_dec = codecs.getincrementaldecoder(codec)(**kwargs)
-    return incremental_translation(self, inc_dec, inc_dec.decode, "")
+    try:
+        codec = args[0] if args else "utf-8"
+        inc_dec = codecs.getincrementaldecoder(codec)(**kwargs)
+        return incremental_translation(self, inc_dec, inc_dec.decode, "")
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. decode_aspect. {}".format(e), traceback.format_exc())
+        return self.decode(*args, **kwargs)
 
 
 def encode_aspect(self, *args, **kwargs):
     if not is_pyobject_tainted(self) or not isinstance(self, str):
         return self.encode(*args, **kwargs)
-    codec = args[0] if args else "utf-8"
-    inc_enc = codecs.getincrementalencoder(codec)(**kwargs)
-    return incremental_translation(self, inc_enc, inc_enc.encode, b"")
+    try:
+        codec = args[0] if args else "utf-8"
+        inc_enc = codecs.getincrementalencoder(codec)(**kwargs)
+        return incremental_translation(self, inc_enc, inc_enc.encode, b"")
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. encode_aspect. {}".format(e), traceback.format_exc())
+        return self.encode(*args, **kwargs)
 
 
-def upper_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> str
+def upper_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.upper(*args, **kwargs)
 
-    return common_replace("upper", candidate_text, *args, **kwargs)
+    try:
+        return common_replace("upper", candidate_text, *args, **kwargs)
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. upper_aspect. {}".format(e), traceback.format_exc())
+        return candidate_text.upper(*args, **kwargs)
 
 
-def lower_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> str
+def lower_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.lower(*args, **kwargs)
 
-    return common_replace("lower", candidate_text, *args, **kwargs)
+    try:
+        return common_replace("lower", candidate_text, *args, **kwargs)
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. lower_aspect. {}".format(e), traceback.format_exc())
+        return candidate_text.lower(*args, **kwargs)
 
 
-def swapcase_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> str
+def swapcase_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.swapcase(*args, **kwargs)
+    try:
+        return common_replace("swapcase", candidate_text, *args, **kwargs)
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. swapcase_aspect. {}".format(e), traceback.format_exc())
+        return candidate_text.swapcase(*args, **kwargs)
 
-    return common_replace("swapcase", candidate_text, *args, **kwargs)
 
-
-def title_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> str
+def title_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.title(*args, **kwargs)
+    try:
+        return common_replace("title", candidate_text, *args, **kwargs)
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. title_aspect. {}".format(e), traceback.format_exc())
+        return candidate_text.title(*args, **kwargs)
 
-    return common_replace("title", candidate_text, *args, **kwargs)
 
-
-def capitalize_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> str
+def capitalize_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.capitalize(*args, **kwargs)
 
-    return common_replace("capitalize", candidate_text, *args, **kwargs)
+    try:
+        return common_replace("capitalize", candidate_text, *args, **kwargs)
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. capitalize_aspect. {}".format(e), traceback.format_exc())
+        return candidate_text.capitalize(*args, **kwargs)
 
 
-def casefold_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> str
+def casefold_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.casefold(*args, **kwargs)
-    return common_replace("casefold", candidate_text, *args, **kwargs)
+    try:
+        return common_replace("casefold", candidate_text, *args, **kwargs)
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. casefold_aspect. {}".format(e), traceback.format_exc())
+        return candidate_text.casefold(*args, **kwargs)  # type: ignore[union-attr]
 
 
-def translate_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> str
+def translate_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.translate(*args, **kwargs)
-    return common_replace("translate", candidate_text, *args, **kwargs)
+    try:
+        return common_replace("translate", candidate_text, *args, **kwargs)
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. translate_aspect. {}".format(e), traceback.format_exc())
+        return candidate_text.translate(*args, **kwargs)

--- a/ddtrace/appsec/iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/iast/_taint_tracking/aspects.py
@@ -31,8 +31,10 @@ if TYPE_CHECKING:
     from typing import Optional
     from typing import Union
 
+    TEXT_TYPE = Union[str, bytes, bytearray]
+
 TEXT_TYPES = (str, bytes, bytearray)
-TEXT_TYPE = Union[str, bytes, bytearray]
+
 
 _add_aspect = aspects.add_aspect
 _extend_aspect = aspects.extend_aspect

--- a/ddtrace/appsec/iast/taint_sinks/_base.py
+++ b/ddtrace/appsec/iast/taint_sinks/_base.py
@@ -91,12 +91,17 @@ class VulnerabilityBase(Operation):
         """
         if cls.acquire_quota():
             if not tracer or not hasattr(tracer, "current_root_span"):
-                log.debug("Not tracer or tracer has no root span")
+                log.debug(
+                    "[IAST] VulnerabilityReporter is trying to report an evidence, "
+                    "but not tracer or tracer has no root span"
+                )
                 return None
 
             span = tracer.current_root_span()
             if not span:
-                log.debug("No root span in the current execution. Skipping IAST taint sink.")
+                log.debug(
+                    "[IAST] VulnerabilityReporter. No root span in the current execution. Skipping IAST taint sink."
+                )
                 return None
 
             frame_info = get_info_frame(CWD)

--- a/ddtrace/appsec/utils.py
+++ b/ddtrace/appsec/utils.py
@@ -193,17 +193,15 @@ class deduplication:
     def __init__(self, func):
         self.func = func
         self._last_timestamp = time.time()
-        self._next_report_timestamp()
-
-    def _next_report_timestamp(self):
-        # type: () -> None
-        self._last_timestamp = time.time() + self._time_lapse
         self.reported_logs = dict()  # type: Dict[int, float]
+
+    def get_last_time_reported(self, raw_log_hash):
+        return self.reported_logs.get(raw_log_hash)
 
     def __call__(self, *args, **kwargs):
         result = None
         raw_log_hash = hash("".join([str(arg) for arg in args]))
-        last_reported_timestamp = self.reported_logs.get(raw_log_hash)
+        last_reported_timestamp = self.get_last_time_reported(raw_log_hash)
         if last_reported_timestamp is None or time.time() > last_reported_timestamp:
             result = self.func(*args, **kwargs)
             self.reported_logs[raw_log_hash] = time.time() + self._time_lapse

--- a/ddtrace/appsec/utils.py
+++ b/ddtrace/appsec/utils.py
@@ -198,11 +198,17 @@ class deduplication:
     def get_last_time_reported(self, raw_log_hash):
         return self.reported_logs.get(raw_log_hash)
 
+    def is_deduplication_enabled(self):
+        return asbool(os.environ.get("_DD_APPSEC_DEDUPLICATION_ENABLED", "true"))
+
     def __call__(self, *args, **kwargs):
         result = None
-        raw_log_hash = hash("".join([str(arg) for arg in args]))
-        last_reported_timestamp = self.get_last_time_reported(raw_log_hash)
-        if last_reported_timestamp is None or time.time() > last_reported_timestamp:
+        if self.is_deduplication_enabled() is False:
             result = self.func(*args, **kwargs)
-            self.reported_logs[raw_log_hash] = time.time() + self._time_lapse
+        else:
+            raw_log_hash = hash("".join([str(arg) for arg in args]))
+            last_reported_timestamp = self.get_last_time_reported(raw_log_hash)
+            if last_reported_timestamp is None or time.time() > last_reported_timestamp:
+                result = self.func(*args, **kwargs)
+                self.reported_logs[raw_log_hash] = time.time() + self._time_lapse
         return result

--- a/tests/appsec/test_telemetry.py
+++ b/tests/appsec/test_telemetry.py
@@ -2,6 +2,7 @@ import os
 import sys
 from time import sleep
 
+import mock
 import pytest
 
 from ddtrace.appsec import _asm_request_context
@@ -164,9 +165,13 @@ def test_log_metric_error_ddwaf_update_deduplication(mock_logs_telemetry_lifecyc
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6, 0), reason="Python 3.6+ only")
-def test_log_metric_error_ddwaf_update_deduplication_timelapse(mock_logs_telemetry_lifecycle_writer):
+@mock.patch.object(deduplication, "get_last_time_reported")
+def test_log_metric_error_ddwaf_update_deduplication_timelapse(
+    mock_last_time_reported, mock_logs_telemetry_lifecycle_writer
+):
     old_value = deduplication._time_lapse
     deduplication._time_lapse = 0.3
+    mock_last_time_reported.return_value = 1592357416.0
     try:
         with override_global_config(dict(_appsec_enabled=True)):
             span_processor = AppSecSpanProcessor()


### PR DESCRIPTION
Aspects handle all kinds of errors with an Exception and report an error log metric if something goes wrong.
There is a Deduplication class that controls duplicate messages, preventing the reporting of numerous repeated errors.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
