### PR TITLE
docs(asgi): clarify python version requirements for AsyncioContextProvider

### DIFF
--- a/ddtrace/contrib/asgi/__init__.py
+++ b/ddtrace/contrib/asgi/__init__.py
@@ -12,8 +12,7 @@ Then use ddtrace-run when serving your application. For example, if serving with
 
     ddtrace-run uvicorn app:app
 
-If using Python 3.6, the legacy ``AsyncioContextProvider`` will have to be
-enabled before using the middleware::
+On Python 3.6 and below, you must enable the legacy ``AsyncioContextProvider`` before using the middleware::
 
     from ddtrace.contrib.asyncio.provider import AsyncioContextProvider
     from ddtrace import tracer  # Or whichever tracer instance you plan to use

--- a/ddtrace/contrib/fastapi/__init__.py
+++ b/ddtrace/contrib/fastapi/__init__.py
@@ -16,8 +16,7 @@ Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
     app = FastAPI()
 
 
-If using Python 3.6, the legacy ``AsyncioContextProvider`` will have to be
-enabled before using the middleware::
+On Python 3.6 and below, you must enable the legacy ``AsyncioContextProvider`` before using the middleware::
 
     from ddtrace.contrib.asyncio.provider import AsyncioContextProvider
     from ddtrace import tracer  # Or whichever tracer instance you plan to use

--- a/ddtrace/contrib/sanic/__init__.py
+++ b/ddtrace/contrib/sanic/__init__.py
@@ -23,8 +23,7 @@ Sanic tracing can also be enabled manually::
     if __name__ == '__main__':
         app.run()
 
-If using Python 3.6, the legacy ``AsyncioContextProvider`` will have to be
-enabled before using the middleware::
+On Python 3.6 and below, you must enable the legacy ``AsyncioContextProvider`` before using the middleware::
 
     from ddtrace.contrib.asyncio.provider import AsyncioContextProvider
     from ddtrace import tracer  # Or whichever tracer instance you plan to use

--- a/ddtrace/contrib/starlette/__init__.py
+++ b/ddtrace/contrib/starlette/__init__.py
@@ -17,8 +17,7 @@ Or use :func:`patch()<ddtrace.patch>` to manually enable the integration::
     app = Starlette()
 
 
-If using Python 3.6, the legacy ``AsyncioContextProvider`` will have to be
-enabled before using the middleware::
+On Python 3.6 and below, you must enable the legacy ``AsyncioContextProvider`` before using the middleware::
 
     from ddtrace.contrib.asyncio.provider import AsyncioContextProvider
     from ddtrace import tracer  # Or whichever tracer instance you plan to use


### PR DESCRIPTION
This pull request updates the documentation of ASGI integrations to be clearer about the requirements of legacy Python versions, and to conform with [this docstring](https://github.com/DataDog/dd-trace-py/blob/45532233f6e9e70c84c2946aab06513c947f4500/ddtrace/contrib/asyncio/provider.py#L12).

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
