### PR TITLE
chore(telemetry): track the integrations used to finish spans

### DIFF
--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -209,7 +209,7 @@ class SpanAggregator(SpanProcessor):
     def on_span_finish(self, span):
         # type: (Span) -> None
         with self._lock:
-            # If the span does not have a component tag the integration name should default to the span api (otel/datadog/..)
+            # If a span does not have a component tag, set the integration name to the span api (otel/datadog/..)
             integration_name = span.get_tag(COMPONENT) or span._span_api
             self._span_metrics["spans_finished"][integration_name] += 1
             trace = self._traces[span.trace_id]

--- a/tests/tracer/test_processors.py
+++ b/tests/tracer/test_processors.py
@@ -17,6 +17,7 @@ from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MECHANISM
 from ddtrace.constants import _SINGLE_SPAN_SAMPLING_RATE
 from ddtrace.context import Context
 from ddtrace.ext import SpanTypes
+from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.constants import HIGHER_ORDER_TRACE_ID_BITS
 from ddtrace.internal.processor.endpoint_call_counter import EndpointCallCounterProcessor
 from ddtrace.internal.processor.trace import SpanAggregator
@@ -386,6 +387,7 @@ def test_span_creation_metrics():
             span.finish()
 
         span = Span("span", on_finish=[aggr.on_span_finish])
+        span.set_tag(COMPONENT, "flask")
         aggr.on_span_start(span)
         span.finish()
 
@@ -404,7 +406,7 @@ def test_span_creation_metrics():
         mock_tm.assert_has_calls(
             [
                 mock.call("tracers", "spans_created", 1, tags=(("integration_name", "datadog"),)),
-                mock.call("tracers", "spans_finished", 1, tags=(("integration_name", "datadog"),)),
+                mock.call("tracers", "spans_finished", 1, tags=(("integration_name", "flask"),)),
             ]
         )
 


### PR DESCRIPTION
## Motivation

With this change the span finish metric will track the usage of ddtrace integrations.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
