### PR TITLE
ci: rename lib-injection job name

### DIFF
--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -8,6 +8,7 @@ on:
       - lib-injection/**
       - setup*
       - pyproject.toml
+      - .github/workflows/lib-injection.yml
 jobs:
   build-and-publish-test-image:
     uses: ./.github/workflows/lib-inject-publish.yml
@@ -17,7 +18,7 @@ jobs:
       ddtrace-version: v1.16.1
       image-tag: ${{ github.sha }}
 
-  test:
+  test-runner-test:
     needs:
       - build-and-publish-test-image
     runs-on: ubuntu-latest


### PR DESCRIPTION
The lib injection workflow defined a job called test which might race and conflict with the test job from the CircleCI configuration. This would case the state of the test suite to be reported by a GitHub app that is not the expected one, thus blocking PRs where the CircleCI run terminates quickly.

We also include the workflow file as a trigger for these jobs.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
