### PR TITLE
fix(profiler): add protection against bad frames

### DIFF
--- a/ddtrace/profiling/collector/_traceback.pyx
+++ b/ddtrace/profiling/collector/_traceback.pyx
@@ -43,7 +43,19 @@ cpdef traceback_to_frames(traceback, max_nframes):
     while tb is not None:
         if nframes < max_nframes:
             frame = tb.tb_frame
+            IF PY_VERSION_HEX >= 0x030b0000:
+                if not isinstance(frame, FrameType):
+                    log.warning(
+                        "Got object of type '%s' instead of a frame object during stack unwinding [tb]", type(frame).__name__
+                    )
+                    return [], 0
             code = frame.f_code
+            IF PY_VERSION_HEX >= 0x030b0000:
+                if not isinstance(code, CodeType):
+                    log.warning(
+                        "Got object of type '%s' instead of a code object during stack unwinding [tb]", type(code).__name__
+                    )
+                    return [], 0
             lineno = 0 if frame.f_lineno is None else frame.f_lineno
             frames.insert(0, DDFrame(code.co_filename, lineno, code.co_name, _extract_class_name(frame)))
         nframes += 1
@@ -75,7 +87,7 @@ cpdef pyframe_to_frames(frame, max_nframes):
         IF PY_VERSION_HEX >= 0x030b0000:
             if not isinstance(frame, FrameType):
                 log.warning(
-                    "Got object of type '%s' instead of a frame object during stack unwinding", type(frame).__name__
+                    "Got object of type '%s' instead of a frame object during stack unwinding [pf]", type(frame).__name__
                 )
                 return [], 0
 
@@ -84,7 +96,7 @@ cpdef pyframe_to_frames(frame, max_nframes):
             IF PY_VERSION_HEX >= 0x030b0000:
                 if not isinstance(code, CodeType):
                     log.warning(
-                        "Got object of type '%s' instead of a code object during stack unwinding", type(code).__name__
+                        "Got object of type '%s' instead of a code object during stack unwinding [pf]", type(code).__name__
                     )
                     return [], 0
 

--- a/releasenotes/notes/profiler-protect-tracebacks-311-09b9776b2dbe1d1d.yaml
+++ b/releasenotes/notes/profiler-protect-tracebacks-311-09b9776b2dbe1d1d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    profiler: Adds a speculative fix when frames are of incorrect type on Python 3.11


### PR DESCRIPTION
In responding to one of our internal escalations, I discovered that bad frames appear in both of the traceback processing paths.  This is slightly counter-intuitive, but it worked in that escalation (...although it didn't fix all their problems...), so I'm proposing it here.

Like the other similar 3.11 protections, I don't know what precisely causes this.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
