### PR TITLE
fix: use a sentinel value that is not also a valid patch version specifier

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -88,7 +88,7 @@ def create_release_draft(dd_repo, base, rc, patch):
         # figure out the patch version we want
         search = r"v%s.((\d+))" % base
         tags = dd_repo.get_tags()
-        latest_patch_version = 1
+        latest_patch_version = -1
         for tag in tags:
             try:
                 other_patch_num = re.findall(search, tag.name)[0][0]
@@ -97,7 +97,7 @@ def create_release_draft(dd_repo, base, rc, patch):
                 continue
             if other_patch_num > latest_patch_version:
                 latest_patch_version = other_patch_num
-        new_patch_version = latest_patch_version if latest_patch_version == 1 else latest_patch_version + 1
+        new_patch_version = 1 if latest_patch_version == -1 else latest_patch_version + 1
 
         name = "%s.%s" % (base, str(new_patch_version))
         tag = "v%s" % name


### PR DESCRIPTION
This change fixes a bug in the release script that caused the patch number not to increment when the latest existing patch release had a patch number of `1`. It accomplishes this by using `-1` as a sentinel value indicating that there are no existing patch releases on the given release line. This replaces the previous sentinel of `1`, which is also a valid patch release number.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
