### PR TITLE
chore(iast): zfill propagation

### DIFF
--- a/ddtrace/appsec/iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/iast/_taint_tracking/aspects.py
@@ -167,8 +167,36 @@ def ljust_aspect(candidate_text, *args, **kwargs):
 
 
 def zfill_aspect(candidate_text, *args, **kwargs):
-    # type: (Any, Any, Any) -> str
-    return candidate_text.zfill(*args, **kwargs)
+    # type: (Any, Any, Any) -> Any
+    if not isinstance(candidate_text, TEXT_TYPES):
+        return candidate_text.zfill(*args, **kwargs)
+    try:
+        ranges_orig = get_ranges(candidate_text)
+        if not ranges_orig:
+            return candidate_text.zfill(*args, **kwargs)
+        prefix = candidate_text[0] in ("-", "+")
+        res = candidate_text.zfill(*args, **kwargs)
+
+        difflen = len(res) - len(candidate_text)
+        ranges_new = []  # type: List[TaintRange]
+        ranges_new_append = ranges_new.append
+        ranges_new_extend = ranges_new.extend
+
+        for r in ranges_orig:
+            if not prefix or r.start > 0:
+                ranges_new_append(TaintRange(start=r.start + difflen, length=r.length, source=r.source))
+            else:
+                ranges_new_extend(
+                    [
+                        TaintRange(start=0, length=1, source=r.source),
+                        TaintRange(start=r.start + difflen + 1, length=r.length - 1, source=r.source),
+                    ]
+                )
+        taint_pyobject_with_ranges(res, tuple(ranges_new))
+        return res
+    except Exception as e:
+        _set_iast_error_metric("IAST propagation error. format_aspect. {}".format(e), traceback.format_exc())
+        return candidate_text.zfill(*args, **kwargs)
 
 
 def format_aspect(

--- a/tests/appsec/iast/aspects/test_str_aspect.py
+++ b/tests/appsec/iast/aspects/test_str_aspect.py
@@ -85,3 +85,22 @@ class TestOperatorsReplacement(BaseReplacement):
         string_input = create_taint_range_with_format(":+-foo-+:")
         ljusted = mod.do_ljust(string_input, 4)  # pylint: disable=no-member
         assert as_formatted_evidence(ljusted) == ":+-foo-+: "
+
+    def test_zfill(self):
+        # Not tainted
+        string_input = '-1234'
+        res = mod.do_zfill(string_input, 6)  # pylint: disable=no-member
+        assert as_formatted_evidence(res) == '-01234'
+
+        # Tainted
+        string_input = create_taint_range_with_format(':+--12-+:34')
+        res = mod.do_zfill(string_input, 6)  # pylint: disable=no-member
+        assert as_formatted_evidence(res) == ':+---+:0:+-12-+:34'
+
+        string_input = create_taint_range_with_format(':+-+12-+:34')
+        res = mod.do_zfill(string_input, 7)  # pylint: disable=no-member
+        assert as_formatted_evidence(res) == ':+-+-+:00:+-12-+:34'
+
+        string_input = create_taint_range_with_format(':+-012-+:34')
+        res = mod.do_zfill(string_input, 7)  # pylint: disable=no-member
+        assert as_formatted_evidence(res) == '00:+-012-+:34'

--- a/tests/appsec/iast/aspects/test_str_aspect.py
+++ b/tests/appsec/iast/aspects/test_str_aspect.py
@@ -88,19 +88,19 @@ class TestOperatorsReplacement(BaseReplacement):
 
     def test_zfill(self):
         # Not tainted
-        string_input = '-1234'
+        string_input = "-1234"
         res = mod.do_zfill(string_input, 6)  # pylint: disable=no-member
-        assert as_formatted_evidence(res) == '-01234'
+        assert as_formatted_evidence(res) == "-01234"
 
         # Tainted
-        string_input = create_taint_range_with_format(':+--12-+:34')
+        string_input = create_taint_range_with_format(":+--12-+:34")
         res = mod.do_zfill(string_input, 6)  # pylint: disable=no-member
-        assert as_formatted_evidence(res) == ':+---+:0:+-12-+:34'
+        assert as_formatted_evidence(res) == ":+---+:0:+-12-+:34"
 
-        string_input = create_taint_range_with_format(':+-+12-+:34')
+        string_input = create_taint_range_with_format(":+-+12-+:34")
         res = mod.do_zfill(string_input, 7)  # pylint: disable=no-member
-        assert as_formatted_evidence(res) == ':+-+-+:00:+-12-+:34'
+        assert as_formatted_evidence(res) == ":+-+-+:00:+-12-+:34"
 
-        string_input = create_taint_range_with_format(':+-012-+:34')
+        string_input = create_taint_range_with_format(":+-012-+:34")
         res = mod.do_zfill(string_input, 7)  # pylint: disable=no-member
-        assert as_formatted_evidence(res) == '00:+-012-+:34'
+        assert as_formatted_evidence(res) == "00:+-012-+:34"

--- a/tests/appsec/iast/fixtures/aspects/str_methods.py
+++ b/tests/appsec/iast/fixtures/aspects/str_methods.py
@@ -939,7 +939,7 @@ class MyObject(object):
         return self.str_param + " a"
 
 
-def do_repr_fstring(a):  # type: (Any) -> str
+def do_format_fill(a):  # type: (Any) -> str
     return "{:10}".format(a)
 
 


### PR DESCRIPTION
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
