### PR TITLE
chore(iast): repr propagation

### DIFF
--- a/ddtrace/appsec/iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/iast/_taint_tracking/aspects.py
@@ -241,10 +241,12 @@ def repr_aspect(*args, **kwargs):
     result = repr(*args, **kwargs)
     if isinstance(args[0], TEXT_TYPES) and is_pyobject_tainted(args[0]):
         try:
-            new_ranges = list()
-            text_ranges = get_tainted_ranges(args[0])
-            for text_range in text_ranges:
-                new_ranges.append(shift_taint_range(text_range, result.index(args[0])))  # type: ignore[arg-type]
+            if isinstance(args[0], (bytes, bytearray)):
+                check_offset = args[0].decode("utf-8")
+            else:
+                check_offset = args[0]
+            offset = result.index(check_offset)
+            new_ranges = [shift_taint_range(text_range, offset) for text_range in get_tainted_ranges(args[0])]
             if new_ranges:
                 taint_pyobject_with_ranges(result, tuple(new_ranges))
         except Exception as e:

--- a/ddtrace/appsec/iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/iast/_taint_tracking/aspects.py
@@ -250,7 +250,7 @@ def repr_aspect(*args, **kwargs):
             if new_ranges:
                 taint_pyobject_with_ranges(result, tuple(new_ranges))
         except Exception as e:
-            _set_iast_error_metric("IAST propagation error. bytearray_aspect. {}".format(e), traceback.format_exc())
+            _set_iast_error_metric("IAST propagation error. repr_aspect. {}".format(e), traceback.format_exc())
     return result
 
 

--- a/tests/appsec/iast/aspects/test_str_aspect.py
+++ b/tests/appsec/iast/aspects/test_str_aspect.py
@@ -72,6 +72,32 @@ def test_str_aspect_tainting(obj, kwargs, should_be_tainted):
     assert result == str(obj, **kwargs)
 
 
+@pytest.mark.parametrize(
+    "obj, expected_result",
+    [
+        ("3.5", "'3.5'"),
+        ("Hi", "'Hi'"),
+        ("🙀", "'🙀'"),
+        (b"Hi", "b'Hi'"),
+        (bytearray(b"Hi"), "bytearray(b'Hi')"),
+    ],
+)
+def test_repr_aspect_tainting(obj, expected_result):
+    from ddtrace.appsec.iast._taint_tracking import OriginType
+    from ddtrace.appsec.iast._taint_tracking import is_pyobject_tainted
+    from ddtrace.appsec.iast._taint_tracking import taint_pyobject
+    import ddtrace.appsec.iast._taint_tracking.aspects as ddtrace_aspects
+
+    assert repr(obj) == expected_result
+
+    obj = taint_pyobject(
+        obj, source_name="test_repr_aspect_tainting", source_value=obj, source_origin=OriginType.PARAMETER
+    )
+
+    result = ddtrace_aspects.repr_aspect(obj)
+    assert is_pyobject_tainted(result) is True
+
+
 class TestOperatorsReplacement(BaseReplacement):
     def test_aspect_ljust_str_tainted(self):
         # type: () -> None


### PR DESCRIPTION
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
