### PR TITLE
fix(debugging): handle multiple injection points [backport #6759 to 1.18]

### DIFF
--- a/ddtrace/internal/utils/inspection.py
+++ b/ddtrace/internal/utils/inspection.py
@@ -9,7 +9,11 @@ from ddtrace.internal.compat import PYTHON_VERSION_INFO as PY
 def linenos(f):
     # type: (FunctionType) -> Set[int]
     """Get the line numbers of a function."""
-    ls = {instr.lineno for instr in Bytecode.from_code(f.__code__) if hasattr(instr, "lineno")}
+    ls = {
+        _
+        for _ in (instr.lineno for instr in Bytecode.from_code(f.__code__) if hasattr(instr, "lineno"))
+        if _ is not None
+    }
     if PY >= (3, 11):
         # Python 3.11 has introduced some no-op instructions that are used as
         # part of the specialisation process. These new opcodes appear on a

--- a/releasenotes/notes/fix-debugger-multiple-inject-locs-2dd1d33810cf6405.yaml
+++ b/releasenotes/notes/fix-debugger-multiple-inject-locs-2dd1d33810cf6405.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: fixed an issue that prevented line probes from
+    being injected in some finally blocks.

--- a/tests/submod/stuff.py
+++ b/tests/submod/stuff.py
@@ -144,3 +144,15 @@ def age_checker(people, age, name=None):
 
 def caller(f, *args, **kwargs):
     return f(*args, **kwargs)
+
+
+def finallystuff():
+    a = 0
+    try:
+        if a == 0:
+            Exception("Hello", "world!", 42)
+    except Exception:
+        return a
+    finally:
+        a = 42
+    return a


### PR DESCRIPTION
Backport of #6759 to 1.18

Some code constructs might be translated into non-linear bytecode, meaning that some line numbers might appear multiple time, as code blocks might be copied in multiple place (e.g. finally blocks).

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
