### PR TITLE
test(debugging): remove flakiness in RCM tests

### DIFF
--- a/tests/debugging/probe/test_remoteconfig.py
+++ b/tests/debugging/probe/test_remoteconfig.py
@@ -1,6 +1,4 @@
 import random
-from time import sleep
-from time import time
 from uuid import uuid4
 
 import mock
@@ -142,10 +140,6 @@ def test_poller_remove_probe():
     def cb(e, ps):
         events.add((e, frozenset({p.probe_id if isinstance(p, Probe) else p for p in ps})))
 
-    def validate_events(expected):
-        assert events == expected
-        events.clear()
-
     old_interval = di_config.diagnostics_interval
     di_config.diagnostics_interval = 0.5
     try:
@@ -167,11 +161,9 @@ def test_poller_remove_probe():
         )
         remoteconfig_poller._poll_data()
 
-        validate_events(
-            {
-                (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
-            }
-        )
+        assert events == {
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
+        }
 
         adapter.append_and_publish(
             False,
@@ -180,11 +172,10 @@ def test_poller_remove_probe():
         )
         remoteconfig_poller._poll_data()
 
-        validate_events(
-            {
-                (ProbePollerEvent.DELETED_PROBES, frozenset({"probe1"})),
-            }
-        )
+        assert events == {
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
+            (ProbePollerEvent.DELETED_PROBES, frozenset({"probe1"})),
+        }
 
     finally:
         di_config.diagnostics_interval = old_interval
@@ -196,15 +187,10 @@ def test_poller_remove_multiple_probe():
     def cb(e, ps):
         events.add((e, frozenset({p.probe_id if isinstance(p, Probe) else p for p in ps})))
 
-    def validate_events(expected):
-        assert events == expected
-        events.clear()
-
     old_interval = di_config.diagnostics_interval
-    di_config.diagnostics_interval = 0.5
+    di_config.diagnostics_interval = float("inf")
     try:
         adapter = ProbeRCAdapter(None, cb, status_logger=None)
-        # Wait to allow the next call to the adapter to generate a status event
         remoteconfig_poller.register("TEST", adapter, skip_enabled=True)
         adapter.append(
             {
@@ -235,12 +221,10 @@ def test_poller_remove_multiple_probe():
         adapter.publish()
         remoteconfig_poller._poll_data()
 
-        validate_events(
-            {
-                (ProbePollerEvent.NEW_PROBES, frozenset({"probe2"})),
-                (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
-            }
-        )
+        assert events == {
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe2"})),
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
+        }
 
         adapter.append_and_publish(
             False,
@@ -249,11 +233,12 @@ def test_poller_remove_multiple_probe():
         )
         remoteconfig_poller._poll_data()
 
-        validate_events(
-            {
-                (ProbePollerEvent.DELETED_PROBES, frozenset({"probe1"})),
-            }
-        )
+        assert events == {
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe2"})),
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
+            (ProbePollerEvent.DELETED_PROBES, frozenset({"probe1"})),
+        }
+
         adapter.append_and_publish(
             False,
             "",
@@ -261,11 +246,12 @@ def test_poller_remove_multiple_probe():
         )
         remoteconfig_poller._poll_data()
 
-        validate_events(
-            {
-                (ProbePollerEvent.DELETED_PROBES, frozenset({"probe2"})),
-            }
-        )
+        assert events == {
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe2"})),
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
+            (ProbePollerEvent.DELETED_PROBES, frozenset({"probe1"})),
+            (ProbePollerEvent.DELETED_PROBES, frozenset({"probe2"})),
+        }
     finally:
         di_config.diagnostics_interval = old_interval
 
@@ -307,7 +293,7 @@ def test_poller_events(remote_config_worker, mock_config):
 
     metadata = config_metadata()
     old_interval = di_config.diagnostics_interval
-    di_config.diagnostics_interval = 0.5
+    di_config.diagnostics_interval = float("inf")
     try:
         adapter = ProbeRCAdapter(None, callback, status_logger=None)
         remoteconfig_poller.register("TEST2", adapter, skip_enabled=True)
@@ -335,11 +321,13 @@ def test_poller_events(remote_config_worker, mock_config):
         adapter.append_and_publish({"test": 3}, "", metadata)
         remoteconfig_poller._poll_data()
 
-        # Wait to allow the next call to the adapter to generate a status event
-        sleep(0.5)
+        adapter._subscriber._send_status_update()
+
         adapter.append_and_publish({"test": 4}, "", metadata)
         remoteconfig_poller._poll_data()
-        sleep(0.5)
+
+        adapter._subscriber._send_status_update()
+
         assert events == {
             (ProbePollerEvent.NEW_PROBES, frozenset(["probe4", "probe1", "probe2", "probe3"])),
             (ProbePollerEvent.DELETED_PROBES, frozenset(["probe1"])),
@@ -356,17 +344,8 @@ def test_multiple_configs(remote_config_worker):
     def cb(e, ps):
         events.add((e, frozenset({p.probe_id if isinstance(p, Probe) else p for p in ps})))
 
-    def validate_events(expected, timeout=1.0):
-        end = time() + timeout
-        while time() <= end:
-            if events == expected:
-                events.clear()
-                break
-        else:
-            raise AssertionError("Expected events: %s, got: %s" % (expected, events))
-
     old_interval = di_config.diagnostics_interval
-    di_config.diagnostics_interval = 0.1
+    di_config.diagnostics_interval = float("inf")
     try:
         adapter = ProbeRCAdapter(None, cb, status_logger=mock.Mock())
         # Wait to allow the next call to the adapter to generate a status event
@@ -386,11 +365,9 @@ def test_multiple_configs(remote_config_worker):
         )
         remoteconfig_poller._poll_data()
 
-        validate_events(
-            {
-                (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
-            }
-        )
+        assert events == {
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
+        }
 
         adapter.append_and_publish(
             {
@@ -407,11 +384,10 @@ def test_multiple_configs(remote_config_worker):
         )
         remoteconfig_poller._poll_data()
 
-        validate_events(
-            {
-                (ProbePollerEvent.NEW_PROBES, frozenset({"probe2"})),
-            }
-        )
+        assert events == {
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe2"})),
+        }
 
         adapter.append_and_publish(
             {
@@ -428,36 +404,36 @@ def test_multiple_configs(remote_config_worker):
         )
         remoteconfig_poller._poll_data()
 
-        validate_events(
-            {
-                (ProbePollerEvent.NEW_PROBES, frozenset({"probe3"})),
-            }
-        )
+        assert events == {
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe2"})),
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe3"})),
+        }
 
-        sleep(0.1)
+        adapter._subscriber._send_status_update()
 
-        # testing two things:
-        #  1. after sleep 0.5 probe status should report 2 probes
-        #  2. bad config raises ValueError
         with pytest.raises(InvalidProbeConfiguration):
             adapter.append_and_publish({}, "", config_metadata("not-supported"))
             remoteconfig_poller._poll_data()
 
-        validate_events(
-            {
-                (ProbePollerEvent.STATUS_UPDATE, frozenset({"probe1", "probe2", "probe3"})),
-            }
-        )
+        assert events == {
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe2"})),
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe3"})),
+            (ProbePollerEvent.STATUS_UPDATE, frozenset({"probe1", "probe2", "probe3"})),
+        }
 
         # remove configuration
         adapter.append_and_publish(None, "", config_metadata("metricProbe_probe2"))
         remoteconfig_poller._poll_data()
 
-        validate_events(
-            {
-                (ProbePollerEvent.DELETED_PROBES, frozenset({"probe2"})),
-            }
-        )
+        assert events == {
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe2"})),
+            (ProbePollerEvent.NEW_PROBES, frozenset({"probe3"})),
+            (ProbePollerEvent.STATUS_UPDATE, frozenset({"probe1", "probe2", "probe3"})),
+            (ProbePollerEvent.DELETED_PROBES, frozenset({"probe2"})),
+        }
 
     finally:
         di_config.diagnostics_interval = old_interval
@@ -562,12 +538,14 @@ def test_modified_probe_events(remote_config_worker, mock_config):
 
     metadata = config_metadata()
     old_interval = di_config.diagnostics_interval
-    di_config.diagnostics_interval = 0.5
+    di_config.diagnostics_interval = float("inf")
     try:
         adapter = ProbeRCAdapter(None, cb, None)
         # Wait to allow the next call to the adapter to generate a status event
         remoteconfig_poller.register("TEST", adapter, skip_enabled=True)
-        sleep(0.5)
+
+        adapter._subscriber._send_status_update()
+
         adapter.append_and_publish({"test": 5}, "", metadata)
         remoteconfig_poller._poll_data()
 
@@ -584,8 +562,9 @@ def test_modified_probe_events(remote_config_worker, mock_config):
         )
         adapter.append_and_publish({"test": 6}, "", metadata)
         remoteconfig_poller._poll_data()
-        # Wait to allow the next call to the adapter to generate a status event
-        sleep(0.5)
+
+        adapter._subscriber._send_status_update()
+
         adapter.append_and_publish({"test": 7}, "", metadata)
         remoteconfig_poller._poll_data()
 
@@ -607,7 +586,7 @@ def test_expression_compilation_error(remote_config_worker, mock_config_exc):
 
     metadata = config_metadata()
     old_interval = di_config.diagnostics_interval
-    di_config.diagnostics_interval = 0.1
+    di_config.diagnostics_interval = float("inf")
     try:
         status_logger = mock.Mock()
         adapter = ProbeRCAdapter(None, cb, status_logger=status_logger)


### PR DESCRIPTION
We make a slight refactor of the DI remote config adapter to allow manually emitting probe status message. This way we can remove the `sleep` calls in tests and force the probe status emission, thus removing any potential race conditions. This should remove the flakiness in these tests.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
