### PR TITLE
fix(profiling): ensure correct thread link [backport #6798 to 1.17]

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -250,3 +250,5 @@ programmatically
 DES
 Blowfish
 Gitlab
+hotspot
+CMake

--- a/releasenotes/notes/fix-profiler-thread-link-cbe14bf53e6071db.yaml
+++ b/releasenotes/notes/fix-profiler-thread-link-cbe14bf53e6071db.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    profiling: fixed a bug that prevented profiles from being correctly
+    correlated to traces in gevent-based applications, thus causing code hotspot
+    and end point data to be missing from the UI.


### PR DESCRIPTION
Backport of #6798 to 1.17

We use the C API to retrieve the thread ID of the current thread to create a link between threads and objects. This way we protect ourselves from frameworks such as gevent that might turn thread IDs into task IDs.

## Testing strategy

Tested with a sample application that the endpoint information is attached to profiles with this change.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
