### PR TITLE
chore(dev): fix version for trunk branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ Homepage = "https://github.com/DataDog/dd-trace-py"
 
 [tool.setuptools_scm]
 version_scheme = "release-branch-semver"
+write_to = "ddtrace/_version.py"
 
 [tool.isort]
 force_single_line = true

--- a/scripts/needs_testrun.py
+++ b/scripts/needs_testrun.py
@@ -3,6 +3,7 @@
 from argparse import ArgumentParser
 import fnmatch
 from functools import cache
+from itertools import count
 import json
 import logging
 import os
@@ -71,15 +72,17 @@ def get_changed_files(pr_number: int, sha: t.Optional[str] = None) -> t.Set[str]
     'tests/debugging/test_expressions.py']
     """
     if sha is None:
+        files = set()
         try:
-            url = f"https://api.github.com/repos/datadog/dd-trace-py/pulls/{pr_number}/files"
-            headers = {"Accept": "application/vnd.github+json"}
-            result = {_["filename"] for _ in json.load(urlopen(Request(url, headers=headers)))}
-            if len(result) != 30:  # 30 files is an unreliable return because it's the maximum
-                return result
-        except Exception as exc:
-            LOGGER.warning("Failed to get changed files from GitHub API")
-            LOGGER.warning(exc)
+            for page in count(1):
+                url = f"https://api.github.com/repos/datadog/dd-trace-py/pulls/{pr_number}/files?page={page}"
+                headers = {"Accept": "application/vnd.github+json"}
+                result = {_["filename"] for _ in json.load(urlopen(Request(url, headers=headers)))}
+                if not result:
+                    return files
+                files |= result
+        except Exception:
+            LOGGER.warning("Failed to get changed files from GitHub API", exc_info=True)
 
     diff_base = sha or get_merge_base(pr_number)
     LOGGER.info("Checking changed files against commit %s", diff_base)

--- a/setup.py
+++ b/setup.py
@@ -593,7 +593,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    setup_requires=["cython<3", "cmake>=3.24.2; python_version>='3.6'"],
+    setup_requires=["setuptools_scm[toml]>=4", "cython<3", "cmake>=3.24.2; python_version>='3.6'"],
     ext_modules=ext_modules
     + cythonize(
         [

--- a/setup.py
+++ b/setup.py
@@ -593,10 +593,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    use_scm_version={
-        "write_to": "ddtrace/_version.py",
-        "version_scheme": "release-branch-semver",
-    },
     setup_requires=["setuptools_scm[toml]>=4", "cython<3", "cmake>=3.24.2; python_version>='3.6'"],
     ext_modules=ext_modules
     + cythonize(

--- a/setup.py
+++ b/setup.py
@@ -593,7 +593,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    setup_requires=["setuptools_scm[toml]>=4", "cython<3", "cmake>=3.24.2; python_version>='3.6'"],
+    setup_requires=["cython<3", "cmake>=3.24.2; python_version>='3.6'"],
     ext_modules=ext_modules
     + cythonize(
         [

--- a/setup.py
+++ b/setup.py
@@ -593,7 +593,10 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    use_scm_version={"write_to": "ddtrace/_version.py"},
+    use_scm_version={
+        "write_to": "ddtrace/_version.py",
+        "version_scheme": "release-branch-semver",
+    },
     setup_requires=["setuptools_scm[toml]>=4", "cython<3", "cmake>=3.24.2; python_version>='3.6'"],
     ext_modules=ext_modules
     + cythonize(


### PR DESCRIPTION
1.x branch was reporting a wrong version number in ddtrace/_version.py
- ensure setuptools scm configuration is given both in toml file and in setup.py to fix that problem

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
