### PR TITLE
fix(ci-visibility): use unicode strings and values for spans payload so ... [backport 1.17]

### DIFF
--- a/ddtrace/internal/ci_visibility/encoder.py
+++ b/ddtrace/internal/ci_visibility/encoder.py
@@ -15,6 +15,8 @@ from ddtrace.internal.ci_visibility.constants import SESSION_TYPE
 from ddtrace.internal.ci_visibility.constants import SUITE_ID
 from ddtrace.internal.ci_visibility.constants import SUITE_TYPE
 from ddtrace.internal.ci_visibility.constants import TEST
+from ddtrace.internal.compat import PY2
+from ddtrace.internal.compat import ensure_text
 from ddtrace.internal.encoding import JSONEncoderV2
 from ddtrace.internal.writer.writer import NoEncodableSpansError
 
@@ -72,12 +74,35 @@ class CIVisibilityEncoderV01(BufferedEncoder):
         ]
         self._metadata = {k: v for k, v in self._metadata.items() if k in self.ALLOWED_METADATA_KEYS}
         # TODO: Split the events in several payloads as needed to avoid hitting the intake's maximum payload size.
-        return msgpack_packb(
+        return CIVisibilityEncoderV01._pack_payload(
             {"version": self.PAYLOAD_FORMAT_VERSION, "metadata": {"*": self._metadata}, "events": normalized_spans}
         )
 
     @staticmethod
-    def _convert_span(span, dd_origin):
+    def _pack_payload(payload):
+        if PY2:
+            payload = CIVisibilityEncoderV01._py2_payload_force_unicode_strings(payload)
+
+        return msgpack_packb(payload)
+
+    @staticmethod
+    def _py2_payload_force_unicode_strings(payload):
+        def _ensure_text_strings(o):
+            if type(o) == str:
+                return ensure_text(o)
+            return o
+
+        if type(payload) == list:
+            return [CIVisibilityEncoderV01._py2_payload_force_unicode_strings(item) for item in payload]
+        if type(payload) == dict:
+            return {
+                _ensure_text_strings(k): CIVisibilityEncoderV01._py2_payload_force_unicode_strings(v)
+                for k, v in payload.items()
+            }
+
+        return _ensure_text_strings(payload)
+
+    def _convert_span(self, span, dd_origin):
         # type: (Span, str) -> Dict[str, Any]
         sp = JSONEncoderV2._span_to_dict(span)
         sp = JSONEncoderV2._normalize_span(sp)

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -141,6 +141,7 @@ mypy
 mysql
 mysqlclient
 mysqldb
+msgpack
 namespace
 NeedsAppKey
 obfuscator

--- a/releasenotes/notes/fix_civisibility_py27-62e8bb558f4c6e47.yaml
+++ b/releasenotes/notes/fix_civisibility_py27-62e8bb558f4c6e47.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    CI Visibility: fixes that Python 2.7 test results were not visible in UI
+    due to improperly msgpack-ed data

--- a/tests/ci_visibility/test_ci_visibility.py
+++ b/tests/ci_visibility/test_ci_visibility.py
@@ -11,10 +11,12 @@ from ddtrace.constants import AUTO_KEEP
 from ddtrace.ext import ci
 from ddtrace.internal.ci_visibility import CIVisibility
 from ddtrace.internal.ci_visibility.constants import REQUESTS_MODE
+from ddtrace.internal.ci_visibility.encoder import CIVisibilityEncoderV01
 from ddtrace.internal.ci_visibility.filters import TraceCiVisibilityFilter
 from ddtrace.internal.ci_visibility.git_client import CIVisibilityGitClient
 from ddtrace.internal.ci_visibility.git_client import CIVisibilityGitClientSerializerV1
 from ddtrace.internal.ci_visibility.recorder import _extract_repository_name_from_url
+from ddtrace.internal.compat import PY2
 from ddtrace.internal.compat import TimeoutError
 from ddtrace.internal.utils.http import Response
 from ddtrace.span import Span
@@ -962,3 +964,26 @@ def test_unshallow_repository():
     with mock.patch("ddtrace.internal.ci_visibility.git_client._unshallow_repository") as mock_unshallow_repository:
         CIVisibilityGitClient._unshallow_repository(cwd="/path/to/repo")
         mock_unshallow_repository.assert_called_once_with(cwd="/path/to/repo")
+
+
+def test_encoder_pack_payload():
+    packed_payload = CIVisibilityEncoderV01._pack_payload(
+        {"string_key": [1, {u"unicode_key": "string_value"}, u"unicode_value", {"string_key": u"unicode_value"}]}
+    )
+    if PY2:
+        assert (
+            packed_payload == "\x81\xaastring_key\x94\x01\x81\xabunicode_key\xacstring_value"
+            "\xadunicode_value\x81\xaastring_key\xadunicode_value"
+        )
+    else:
+        assert (
+            packed_payload == b"\x81\xaastring_key\x94\x01\x81\xabunicode_key\xacstring_value"
+            b"\xadunicode_value\x81\xaastring_key\xadunicode_value"
+        )
+
+
+@pytest.mark.skipif(not PY2, reason="py2 payload encoder only tested in Python 2.x")
+def test_encoder_py2_payload_force_unicode_strings():
+    assert CIVisibilityEncoderV01._py2_payload_force_unicode_strings(
+        {"string_key": [1, {u"unicode_key": "string_value"}, u"unicode_value", {"string_key": u"unicode_value"}]}
+    ) == {u"string_key": [1, {u"unicode_key": u"string_value"}, u"unicode_value", {u"string_key": u"unicode_value"}]}


### PR DESCRIPTION
Backport 982d374f2a0eef96e4de74d15187edaf1693ebf3 from #6808 to 1.17.

... msgpack is correct 

msgpack in Python 2.7 requires strings to be unicode in order to produce the correct msgpack format expected by our backend.

Another potential fix for this would've been to `import msgpack` and use `msgpack.packb(..., use_bin_type=False)`, but that option was discarded since this repo provides its own `msgpack.packb` implementaton.

The tests only use single-key dictionaries because key ordering is not stable in Python 2.7 and may lead to flaky tests.

Since the `bytes` and `str` type are synonyms in Python 2.7, and are the only values that need to be coerced to unicode, there should not be increased risk from `_py2_payload_force_unicode_strings`.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
