### PR TITLE
chore(telemetry): implement batch events

### DIFF
--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -64,6 +64,21 @@ class TelemetryTestSession(object):
 
         return sorted(requests, key=lambda r: r["body"]["seq_id"], reverse=True)
 
+    def get_payloads(self):
+        """Get a list of the payloads sent to the test agent
+
+        Results are in reverse order by ``seq_id``
+        """
+        events = self.get_events()
+        payloads = []
+        for event in events:
+            if event["request_type"] == "message-batch":
+                payloads += event["payload"]
+            else:
+                payloads.append(event["payload"])
+
+        return payloads
+
     def get_events(self):
         """Get a list of the event payloads sent to the test agent
 

--- a/tests/telemetry/test_telemetry_metrics.py
+++ b/tests/telemetry/test_telemetry_metrics.py
@@ -20,7 +20,7 @@ def _assert_metric(
     seq_id=1,
 ):
     test_agent.telemetry_writer.periodic()
-    events = test_agent.get_events()
+    events = test_agent.get_payloads()
 
     assert len([event for event in events if event["request_type"] == type_paypload]) == seq_id
 
@@ -37,7 +37,6 @@ def _assert_metric(
         metric["tags"].sort()
     expected_body_sorted.sort(key=lambda x: (x["metric"], x["tags"], x.get("type")), reverse=False)
 
-    events.sort(key=lambda x: x["seq_id"], reverse=True)
     result_event = events[0]["payload"]["series"]
     for metric in result_event:
         metric["tags"].sort()
@@ -52,7 +51,7 @@ def _assert_logs(
     seq_id=1,
 ):
     test_agent.telemetry_writer.periodic()
-    events = test_agent.get_events()
+    events = test_agent.get_payloads()
 
     assert len([event for event in events if event["request_type"] == TELEMETRY_TYPE_LOGS]) == seq_id
 

--- a/tests/telemetry/test_telemetry_metrics_e2e.py
+++ b/tests/telemetry/test_telemetry_metrics_e2e.py
@@ -82,7 +82,7 @@ def parse_payload(data):
 @pytest.mark.skipif(sys.version_info < (3, 6, 0), reason="Python 3.6+ only")
 def test_telemetry_metrics_enabled_on_gunicorn_child_process(test_agent_session):
     token = "tests.telemetry.test_telemetry_metrics_e2e.test_telemetry_metrics_enabled_on_gunicorn_child_process"
-    assert len(test_agent_session.get_events()) == 0
+    assert len(test_agent_session.get_payloads()) == 0
     with gunicorn_server(telemetry_metrics_enabled="true", token=token) as context:
         _, gunicorn_client = context
 
@@ -96,7 +96,7 @@ def test_telemetry_metrics_enabled_on_gunicorn_child_process(test_agent_session)
         response = gunicorn_client.get("/count_metric")
         assert response.status_code == 200
 
-    events = test_agent_session.get_events()
+    events = test_agent_session.get_payloads()
     metrics = list(filter(lambda event: event["request_type"] == "generate-metrics", events))
     assert len(metrics) == 2
     assert metrics[0]["payload"]["series"][0]["metric"] == "test_metric"
@@ -114,7 +114,7 @@ for _ in range(10):
 """
     _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code)
     assert status == 0, stderr
-    events = test_agent_session.get_events()
+    events = test_agent_session.get_payloads()
 
     metrics = get_metrics_from_events(events)
     assert len(metrics) == 2
@@ -140,7 +140,7 @@ for _ in range(9):
     env["DD_TRACE_OTEL_ENABLED"] = "true"
     _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, stderr
-    events = test_agent_session.get_events()
+    events = test_agent_session.get_payloads()
 
     metrics = get_metrics_from_events(events)
     assert len(metrics) == 2
@@ -163,7 +163,7 @@ for _ in range(9):
 """
     _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code)
     assert status == 0, stderr
-    events = test_agent_session.get_events()
+    events = test_agent_session.get_payloads()
 
     metrics = get_metrics_from_events(events)
     assert len(metrics) == 2
@@ -197,7 +197,7 @@ for _ in range(4):
     _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, stderr
 
-    events = test_agent_session.get_events()
+    events = test_agent_session.get_payloads()
     metrics = get_metrics_from_events(events)
     assert len(metrics) == 3
 


### PR DESCRIPTION
The instrumentation telemetry platform now supports sending multiple telemetry events with one http request. This will help reduce the overhead of the sending telemetry events.

Note: This change to the instrumentation telemetry writer will require a significant refactor of instrumentation telemetry tests.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
