### PR TITLE
docs: pin furo in readthedocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,5 +7,5 @@ sphinxcontrib-spelling
 PyEnchant
 furo
 sphinx-copybutton
-# Later release of furro breaks formatting for code blocks
+# Later release of furo breaks formatting for code blocks
 furo<=2023.05.20

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,5 @@ sphinxcontrib-spelling
 PyEnchant
 furo
 sphinx-copybutton
+# Later release of furro breaks formatting for code blocks
+furo<=2023.05.20

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,6 @@ opentracing
 reno
 sphinxcontrib-spelling
 PyEnchant
-furo
 sphinx-copybutton
 # Later release of furo breaks formatting for code blocks
 furo<=2023.05.20

--- a/hatch.toml
+++ b/hatch.toml
@@ -71,7 +71,7 @@ extra-dependencies = [
     "sphinxcontrib-spelling==7.7.0",
     "PyEnchant==3.2.2",
     "sphinx-copybutton==0.5.1",
-    # Later release of furro breaks formatting for code blocks
+    # Later release of furo breaks formatting for code blocks
     "furo<=2023.05.20",
 ]
 pre-install-commands = [


### PR DESCRIPTION
Follow up to: https://github.com/DataDog/dd-trace-py/commit/463855774f3bf11da62110511d284167345ea378

Unfortunately the dependencies used to generate [docs in read the docs](https://github.com/DataDog/dd-trace-py/blob/9ee956f1e970c49b6d6a9fbac5fc97e959bc3ce2/docs/requirements.txt#L8) differ from the [dependencies used in ci](https://github.com/DataDog/dd-trace-py/blob/1.x/hatch.toml#L75). This problem is beyond the scope of this PR.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
