### PR TITLE
docs: pin deps in one place

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,8 +2,10 @@ cmake
 cython
 sphinx
 opentracing
-reno
-sphinxcontrib-spelling
-PyEnchant
-furo
-sphinx-copybutton
+reno[sphinx]~=3.5.0
+sphinx~=4.0
+sphinxcontrib-spelling==7.7.0
+PyEnchant==3.2.2
+sphinx-copybutton==0.5.1
+# Later release of furo breaks formatting for code blocks
+furo<=2023.05.20

--- a/hatch.toml
+++ b/hatch.toml
@@ -65,15 +65,6 @@ template = "docs"
 dev-mode = false
 python = "3.10"
 features = ["opentracing"]
-extra-dependencies = [
-    "reno[sphinx]~=3.5.0",
-    "sphinx~=4.0",
-    "sphinxcontrib-spelling==7.7.0",
-    "PyEnchant==3.2.2",
-    "sphinx-copybutton==0.5.1",
-    # Later release of furro breaks formatting for code blocks
-    "furo<=2023.05.20",
-]
 pre-install-commands = [
     "scripts/docs/install.sh",
 ]


### PR DESCRIPTION
Follow up to: https://github.com/DataDog/dd-trace-py/pull/6842

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
