### PR TITLE
fix(lib-inject): use alpine base image

### DIFF
--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -23,7 +23,7 @@ RUN python3 dl_wheels.py \
         --output-dir /build/pkgs \
         --verbose
 
-FROM busybox
+FROM alpine:3.18.3
 COPY --from=0 /build/pkgs /datadog-init/ddtrace_pkgs
 ARG UID=10000
 RUN addgroup -g 10000 -S datadog && \

--- a/releasenotes/notes/lib-inject-8dcd6537312fddf3.yaml
+++ b/releasenotes/notes/lib-inject-8dcd6537312fddf3.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    lib-inject: This fix resolves an issue where ``libdl.so.2: cannot open shared object file: No such file or directory`` errors occurred when the
+      injection image started.


### PR DESCRIPTION
Change the base library injection image from `busybox` to `alpine` to make the image more compatible with other software environments.

## Motivation 
`libdl.so.2: cannot open shared object file: No such file or directory` errors have been reported in customer environments which prevents application containers from starting up when using [library injection](https://docs.datadoghq.com/tracing/trace_collection/library_injection_local/?tab=kubernetes#step-3---tag-your-pods-with-unified-service-tags). Likely this is due to some other software such as instrumentation or security that modifies the command run in the container. The modified command fails as the `libdl.so.2` shared library isn't present in the `busybox`-based image.

The `busybox` image [lacks many standard C libraries](https://github.com/docker-library/busybox/issues/46). `alpine` is a similarly sized image which does provide the standard C libraries and mitigates the issue.

## Testing

The existing tests should cover the change sufficiently. We have not been able to repro the issue customers have experienced.

## Risk
There is little risk in changing the base image to `alpine` as the only command required is to copy files from the image to a volume. However, it is possible that the command that is being added to the container is not compatible with alpine images.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
