### PR TITLE
feat: drop sql.query from aiopg and aiomysql

### DIFF
--- a/ddtrace/contrib/aiomysql/patch.py
+++ b/ddtrace/contrib/aiomysql/patch.py
@@ -6,7 +6,6 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.constants import SPAN_MEASURED_KEY
 from ddtrace.contrib import dbapi
-from ddtrace.ext import sql
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_database_operation
 from ddtrace.internal.utils.wrappers import unwrap
@@ -75,7 +74,6 @@ class AIOTracedCursor(wrapt.ObjectProxy):
             s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
             s.set_tag(SPAN_MEASURED_KEY)
-            s.set_tag_str(sql.QUERY, resource)
             s.set_tags(pin.tags)
             s.set_tags(extra_tags)
 

--- a/ddtrace/contrib/aiopg/connection.py
+++ b/ddtrace/contrib/aiopg/connection.py
@@ -11,7 +11,6 @@ from ddtrace.contrib import dbapi
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import db
-from ddtrace.ext import sql
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_database_operation
 from ddtrace.internal.schema import schematize_service_name
@@ -47,7 +46,6 @@ class AIOTracedCursor(wrapt.ObjectProxy):
             s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
             s.set_tag(SPAN_MEASURED_KEY)
-            s.set_tag_str(sql.QUERY, resource)
             s.set_tags(pin.tags)
             s.set_tags(extra_tags)
 

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -8,10 +8,6 @@ from ddtrace.vendor.debtcollector import deprecate
 
 log = get_logger(__name__)
 
-# tags
-QUERY = "sql.query"  # the query text
-DB = "sql.db"  # the name of the database
-
 
 def normalize_vendor(vendor):
     # type: (str) -> str

--- a/tests/contrib/aiopg/test.py
+++ b/tests/contrib/aiopg/test.py
@@ -71,7 +71,6 @@ class AiopgTestCase(AsyncioTestCase):
         assert span.name == "postgres.query"
         assert span.resource == q
         assert span.service == service
-        assert span.get_tag("sql.query") == q
         assert span.error == 0
         assert span.span_type == "sql"
         assert start <= span.start <= end
@@ -97,7 +96,6 @@ class AiopgTestCase(AsyncioTestCase):
         assert dd_span.name == "postgres.query"
         assert dd_span.resource == q
         assert dd_span.service == service
-        assert dd_span.get_tag("sql.query") == q
         assert dd_span.error == 0
         assert dd_span.span_type == "sql"
         assert dd_span.get_tag("component") == "aiopg"
@@ -119,7 +117,6 @@ class AiopgTestCase(AsyncioTestCase):
         assert span.name == "postgres.query"
         assert span.resource == q
         assert span.service == service
-        assert span.get_tag("sql.query") == q
         assert span.error == 1
         assert span.get_metric("network.destination.port") == TEST_PORT
         assert span.span_type == "sql"

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_async_with_usage.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_async_with_usage.json
@@ -17,8 +17,7 @@
       "language": "python",
       "out.host": "127.0.0.1",
       "runtime-id": "f09816a4d96c4c51abaf8769c10b0a7a",
-      "span.kind": "client",
-      "sql.query": "SELECT 1"
+      "span.kind": "client"
     },
     "metrics": {
       "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_pin_override[True].json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_pin_override[True].json
@@ -17,8 +17,7 @@
       "language": "python",
       "out.host": "127.0.0.1",
       "runtime-id": "d3f10746b2a042468b3a6ca5a8b5106d",
-      "span.kind": "client",
-      "sql.query": "SELECT 1"
+      "span.kind": "client"
     },
     "metrics": {
       "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_queries.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_queries.json
@@ -17,8 +17,7 @@
       "language": "python",
       "out.host": "127.0.0.1",
       "runtime-id": "5fd399879b2c43628ee3ab3b6470b8b7",
-      "span.kind": "client",
-      "sql.query": "select 'Jellysmack'"
+      "span.kind": "client"
     },
     "metrics": {
       "_dd.measured": 1,
@@ -55,8 +54,7 @@
       "language": "python",
       "out.host": "127.0.0.1",
       "runtime-id": "5fd399879b2c43628ee3ab3b6470b8b7",
-      "span.kind": "client",
-      "sql.query": "select * from some_non_existant_table"
+      "span.kind": "client"
     },
     "metrics": {
       "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v0].json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v0].json
@@ -17,8 +17,7 @@
       "language": "python",
       "out.host": "127.0.0.1",
       "runtime-id": "10185724725e43958ae66f62b7c6216d",
-      "span.kind": "client",
-      "sql.query": "select 'dba4x4'"
+      "span.kind": "client"
     },
     "metrics": {
       "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v1].json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v1].json
@@ -19,8 +19,7 @@
       "out.host": "127.0.0.1",
       "peer.service": "test",
       "runtime-id": "9f466d3fd1ef4e59ab6d72707e720ecf",
-      "span.kind": "client",
-      "sql.query": "select 'dba4x4'"
+      "span.kind": "client"
     },
     "metrics": {
       "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_unspecified_service_v1.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_unspecified_service_v1.json
@@ -19,8 +19,7 @@
       "out.host": "127.0.0.1",
       "peer.service": "test",
       "runtime-id": "f446781b5d244b95abc64fb246064c81",
-      "span.kind": "client",
-      "sql.query": "select 'dba4x4'"
+      "span.kind": "client"
     },
     "metrics": {
       "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v0.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v0.json
@@ -17,8 +17,7 @@
       "language": "python",
       "out.host": "127.0.0.1",
       "runtime-id": "edd004724e314daf9ff1e51e8234b4df",
-      "span.kind": "client",
-      "sql.query": "select 'dba4x4'"
+      "span.kind": "client"
     },
     "metrics": {
       "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v1.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v1.json
@@ -19,8 +19,7 @@
       "out.host": "127.0.0.1",
       "peer.service": "test",
       "runtime-id": "ae2b5fb6b2b849ed9a299852cb4df1d5",
-      "span.kind": "client",
-      "sql.query": "select 'dba4x4'"
+      "span.kind": "client"
     },
     "metrics": {
       "_dd.measured": 1,


### PR DESCRIPTION
## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
