### PR TITLE
chore(sampling): remove config and release note for resource matching

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -231,13 +231,11 @@ The following environment variables for the tracer are supported:
    DD_TRACE_SAMPLING_RULES:
      type: JSON array
      description: |
-         A JSON array of objects. Each object must have a “sample_rate”, and the “name”, “service”, and "resource" fields are optional. The “sample_rate” value must be between 0.0 and 1.0 (inclusive).
+         A JSON array of objects. Each object must have a “sample_rate”, and the “name”, and “service” fields are optional. The “sample_rate” value must be between 0.0 and 1.0 (inclusive).
 
-         **Example:** ``DD_TRACE_SAMPLING_RULES='[{"sample_rate":0.5,"service":"my-service","resource":"my-url"}]'``
+         **Example:** ``DD_TRACE_SAMPLING_RULES='[{"sample_rate":0.5,"service":"my-service"}]'``
 
          **Note** that the JSON object must be included in single quotes (') to avoid problems with escaping of the double quote (") character.
-     version_added:
-       v1.19.0: added support for "resource"
 
    DD_SPAN_SAMPLING_RULES:
      type: string

--- a/releasenotes/notes/resource-sampling-f80db0b13d995c83.yaml
+++ b/releasenotes/notes/resource-sampling-f80db0b13d995c83.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    tracing: This introduces the keyword parameter "resource" to the SamplingRule constructor, allowing sampling
-    rules to be defined based on an exact string match with span resource names. These rules are only evaluated
-    at the beginning of a span's lifetime, so changes to Span.resource after span creation are not seen
-    by SamplingRules.


### PR DESCRIPTION
We want to make the following updates to resource matching before anouncing its release:
1. Merge tags matching
2. Evaluate which integrations we set resource name on late, change the ones that can have resource set upon span creation, and have a list of those for which resource matching will not currently work.

To that end we'll revert the release note and config option for now.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
