### PR TITLE
chore(asm): security scanners for api security

### DIFF
--- a/ddtrace/appsec/_api_security/api_manager.py
+++ b/ddtrace/appsec/_api_security/api_manager.py
@@ -159,7 +159,7 @@ class APIManager(Service):
                 value = transform(value)
             waf_payload[address] = value
         if waf_payload:
-            waf_payload["SETTINGS"] = {"extract-schema": True}
+            waf_payload["PROCESSOR_SETTINGS"] = {"extract-schema": True}
             result = call_waf_callback(waf_payload)
             if result is None:
                 return

--- a/ddtrace/appsec/_api_security/processors.json
+++ b/ddtrace/appsec/_api_security/processors.json
@@ -107,10 +107,131 @@
             ],
             "output": "_dd.appsec.s.res.body"
           }
+        ],
+        "scanners": [
+          {
+            "tags": {
+              "category": "pii"
+            }
+          }
         ]
       },
       "evaluate": false,
       "output": true
+    }
+  ],
+  "scanners": [
+    {
+      "id": "d962f7ddb3f55041e39195a60ff79d4814a7c331",
+      "name": "US Passport Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "passport",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[0-9A-Z]{9}\\b|\\b[0-9]{6}[A-Z][0-9]{2}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "tags": {
+        "type": "passport_number",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "ac6d683cbac77f6e399a14990793dd8fd0fca333",
+      "name": "US Vehicle Identification Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "vehicle[_\\s-]*identification[_\\s-]*number|vin",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[A-HJ-NPR-Z0-9]{17}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "vin",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "de0899e0cbaaa812bb624cf04c912071012f616d",
+      "name": "UK National Insurance Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "national[\\s_]?(?:insurance(?:\\s+number)?)?|NIN|NI[\\s_]?number|insurance[\\s_]?number",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[A-Z]{2}\\d{6}[A-Z]?\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "tags": {
+        "type": "uk_nin",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "450239afc250a19799b6c03dc0e16fd6a4b2a1af",
+      "name": "Canadian Social Insurance Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "social[\\s_]?(?:insurance(?:\\s+number)?)?|SIN|Canadian[\\s_]?(?:social[\\s_]?(?:insurance)?|insurance[\\s_]?number)?",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b\\d{3}-\\d{3}-\\d{3}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 11
+          }
+        }
+      },
+      "tags": {
+        "type": "canadian_sin",
+        "category": "pii"
+      }
     }
   ]
 }

--- a/ddtrace/appsec/_api_security/processors.json
+++ b/ddtrace/appsec/_api_security/processors.json
@@ -38,7 +38,7 @@
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.settings",
+                "address": "waf.context.processor",
                 "key_path": [
                   "extract-schema"
                 ]

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -107,7 +107,7 @@ class WAF_DATA_NAMES(object):
     RESPONSE_STATUS = "server.response.status"
     RESPONSE_HEADERS_NO_COOKIES = "server.response.headers.no_cookies"
     RESPONSE_BODY = "http.response.body"
-    SETTINGS = "waf.context.settings"
+    PROCESSOR_SETTINGS = "waf.context.processor"
 
 
 @six.add_metaclass(Constant_Class)  # required for python2/3 compatibility

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -159,6 +159,7 @@ class AppSecSpanProcessor(SpanProcessor):
                         with open(DEFAULT.API_SECURITY_PARAMETERS, "r") as f_apisec:
                             processors = json.load(f_apisec)
                             rules["processors"] = processors["processors"]
+                            rules["scanners"] = processors["scanners"]
                     self._update_actions(rules)
 
             except EnvironmentError as err:

--- a/ddtrace/appsec/processor.py
+++ b/ddtrace/appsec/processor.py
@@ -290,7 +290,7 @@ class AppSecSpanProcessor(SpanProcessor):
 
         if core.get_item(WAF_CONTEXT_NAMES.BLOCKED, span=span) or core.get_item(WAF_CONTEXT_NAMES.BLOCKED):
             # We still must run the waf if we need to extract schemas for API SECURITY
-            if not custom_data or not custom_data.get("SETTINGS", {}).get("extract-schema", False):
+            if not custom_data or not custom_data.get("PROCESSOR_SETTINGS", {}).get("extract-schema", False):
                 return None
 
         data = {}
@@ -301,7 +301,7 @@ class AppSecSpanProcessor(SpanProcessor):
 
         # type ignore because mypy seems to not detect that both results of the if
         # above can iter if not None
-        force_keys = custom_data.get("SETTINGS", {}).get("extract-schema", False) if custom_data else False
+        force_keys = custom_data.get("PROCESSOR_SETTINGS", {}).get("extract-schema", False) if custom_data else False
         for key, waf_name in iter_data:  # type: ignore[attr-defined]
             if key in data_already_sent:
                 continue

--- a/tests/appsec/api_security/test_schema_fuzz.py
+++ b/tests/appsec/api_security/test_schema_fuzz.py
@@ -16,7 +16,7 @@ def build_schema(obj):
     waf = ddwaf.DDWaf(rules, b"", b"")
     ctx = waf._at_request_start()
     res = waf.run(
-        ctx, {"server.request.body": obj, constants.WAF_DATA_NAMES.SETTINGS: {"extract-schema": True}}
+        ctx, {"server.request.body": obj, constants.WAF_DATA_NAMES.PROCESSOR_SETTINGS: {"extract-schema": True}}
     ).derivatives
     return res["_dd.appsec.s.req.body"]
 

--- a/tests/appsec/api_security/test_schema_fuzz.py
+++ b/tests/appsec/api_security/test_schema_fuzz.py
@@ -112,3 +112,16 @@ def deep_build_schema(n, mini=0):
 def test_limits(obj, res):
     schema = build_schema(obj)
     assert equal_with_meta(schema, res)  # max_depth=18, max_girth=255, max_types_in_array=10
+
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason="dict iteration order is different in python <= 3.5")
+@pytest.mark.parametrize(
+    "obj, res",
+    [
+        ({"US PASSPORT": "C03005988"}, [{"US PASSPORT": [8, {"category": "pii", "type": "passport_number"}]}]),
+        ({"ViN": "1HGBH41JXMN109186"}, [{"ViN": [8, {"category": "pii", "type": "vin"}]}]),
+    ],
+)
+def test_scanners(obj, res):
+    schema = build_schema(obj)
+    assert equal_with_meta(schema, res)  # max_depth=18, max_girth=255, max_types_in_array=10


### PR DESCRIPTION
Add first support for security scanners for api security.

- use libddwaf to find and track confidential and pii data into api security schemas
- use `waf.context.processor` for processor input address to be compliant with last version of the RFC
- add tests

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
