### PR TITLE
chore(internal): reduce log volume from core api (#6886) [backport 1.19]

### DIFF
--- a/ddtrace/internal/core.py
+++ b/ddtrace/internal/core.py
@@ -160,11 +160,9 @@ class EventHub:
                     "must be passed in a list. For example, use dispatch('foo', [[l1, l2], arg2]) "
                     "instead of dispatch('foo', [l1, l2], arg2)."
                 )
-        log.debug("Dispatching event %s", event_id)
         results = []
         exceptions = []
         for listener in self._listeners.get(event_id, []):
-            log.debug("Calling listener %s", listener)
             result = None
             exception = None
             try:
@@ -261,7 +259,6 @@ class ExecutionContext:
         # NB mimic the behavior of `ddtrace.internal._context` by doing lazy inheritance
         current = self
         while current is not None:
-            log.debug("Checking context '%s' for data at key '%s'", current.identifier, data_key)
             if data_key in current._data:
                 return current._data.get(data_key)
             current = current.parent


### PR DESCRIPTION
This change reduces the very large amount of debug logs that the Core API can generate in the course of normal usage, especially with AppSec enabled.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))