### PR TITLE
Romain.komorn/chore force guess next dev in 1.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ Homepage = "https://github.com/DataDog/dd-trace-py"
 "Source Code" = "https://github.com/DataDog/dd-trace-py/"
 
 [tool.setuptools_scm]
-version_scheme = "release-branch-semver"
+version_scheme = "guess-next-dev"
 write_to = "ddtrace/_version.py"
 
 [tool.isort]

--- a/releasenotes/notes/iast-private-beta-20fe19c2dff7862e.yaml
+++ b/releasenotes/notes/iast-private-beta-20fe19c2dff7862e.yaml
@@ -1,0 +1,4 @@
+---
+prelude: >
+  Vulnerability Management for Code-level (IAST) is now available in private beta. Use the environment variable 
+  ``DD_IAST_ENABLED=True`` to enable this feature.

--- a/tests/suitespec.py
+++ b/tests/suitespec.py
@@ -26,12 +26,16 @@ def get_patterns(suite: str) -> t.Set[str]:
     >>> sorted(get_patterns("urllib3"))  # doctest: +NORMALIZE_WHITESPACE
     ['ddtrace/__init__.py', 'ddtrace/_hooks.py', 'ddtrace/_logger.py', 'ddtrace/_monkey.py', 'ddtrace/_tracing/*',
     'ddtrace/auto.py', 'ddtrace/bootstrap/*', 'ddtrace/commands/*', 'ddtrace/constants.py', 'ddtrace/context.py',
-    'ddtrace/contrib/urllib3/*', 'ddtrace/filters.py', 'ddtrace/internal/*', 'ddtrace/pin.py', 'ddtrace/provider.py',
-    'ddtrace/py.typed', 'ddtrace/sampler.py', 'ddtrace/settings/__init__.py', 'ddtrace/settings/config.py',
-    'ddtrace/settings/http.py', 'ddtrace/settings/integration.py', 'ddtrace/span.py', 'ddtrace/tracer.py',
-    'ddtrace/tracing/*', 'ddtrace/version.py', 'hatch.toml', 'pyproject.toml', 'riotfile.py', 'scripts/ddtest',
-    'setup.cfg', 'setup.py', 'tests/.suitespec.json', 'tests/__init__.py', 'tests/conftest.py',
-    'tests/contrib/urllib3/*', 'tests/snapshots/tests.contrib.urllib3.*']
+    'ddtrace/contrib/__init__.py', 'ddtrace/contrib/_trace_utils_llm.py', 'ddtrace/contrib/trace_utils.py',
+    'ddtrace/contrib/trace_utils_async.py', 'ddtrace/contrib/urllib3/*', 'ddtrace/ext/__init__.py',
+    'ddtrace/ext/http.py', 'ddtrace/ext/net.py', 'ddtrace/ext/sql.py', 'ddtrace/ext/test.py', 'ddtrace/ext/user.py',
+    'ddtrace/filters.py', 'ddtrace/internal/*', 'ddtrace/pin.py', 'ddtrace/propagation/*', 'ddtrace/provider.py',
+    'ddtrace/py.typed', 'ddtrace/sampler.py', 'ddtrace/settings/__init__.py',
+    'ddtrace/settings/_database_monitoring.py', 'ddtrace/settings/config.py', 'ddtrace/settings/http.py',
+    'ddtrace/settings/integration.py', 'ddtrace/span.py', 'ddtrace/tracer.py', 'ddtrace/tracing/*',
+    'ddtrace/version.py', 'hatch.toml', 'pyproject.toml', 'riotfile.py', 'scripts/ddtest', 'setup.cfg', 'setup.py',
+    'tests/.suitespec.json', 'tests/__init__.py', 'tests/conftest.py', 'tests/contrib/__init__.py',
+    'tests/contrib/patch.py', 'tests/contrib/urllib3/*', 'tests/snapshots/tests.contrib.urllib3.*']
     """
     compos = SUITESPEC["components"]
     if suite not in SUITESPEC["suites"]:


### PR DESCRIPTION
To make system-tests pass in the 1.19 branch, this switches the setuptools_scm version_scheme to guess-next-dev.

In the CI environment where the repo is in a detached HEAD state that the branch's commit, guess-next-dev will properly guess the version as 1.19 instead of 1.20.

eg:
```
(setuptools-test) romain.komorn@COMP-CLXFH7L2J3 dd-trace-py % git checkout 5a1343ec68fd8b8c38abfd4cfca891dc5dc6d19d
Note: switching to '5a1343ec68fd8b8c38abfd4cfca891dc5dc6d19d'.

You are in 'detached HEAD' state. You can look around, make experimental
```
```
(setuptools-test) romain.komorn@COMP-CLXFH7L2J3 dd-trace-py % python -m setuptools_scm
...
1.19.0rc2.dev21+g5a1343ec6
```

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
