### PR TITLE
test(debugger): synchronous probe status generation

### DIFF
--- a/tests/debugging/mocking.py
+++ b/tests/debugging/mocking.py
@@ -153,6 +153,9 @@ class TestDebugger(Debugger):
     def probe_status_logger(self):
         return self._probe_registry.logger
 
+    def log_probe_status(self):
+        self._probe_registry.log_probes_status()
+
     def assert_no_snapshots(self):
         assert len(self.test_queue) == 0
 

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -594,7 +594,7 @@ def test_debugger_line_probe_on_wrapped_function(stuff):
 def test_probe_status_logging(remote_config_worker):
     assert remoteconfig_poller.status == ServiceStatus.STOPPED
 
-    with rcm_endpoint(), debugger(diagnostics_interval=0, enabled=True) as d:
+    with rcm_endpoint(), debugger(diagnostics_interval=float("inf"), enabled=True) as d:
         d.add_probes(
             create_snapshot_line_probe(
                 probe_id="line-probe-ok",
@@ -617,15 +617,17 @@ def test_probe_status_logging(remote_config_worker):
 
         logger.wait(lambda q: count_status(q) == {"INSTALLED": 1, "RECEIVED": 2, "ERROR": 1})
 
+        d.log_probe_status()
         logger.wait(lambda q: count_status(q) == {"INSTALLED": 2, "RECEIVED": 2, "ERROR": 2})
 
+        d.log_probe_status()
         logger.wait(lambda q: count_status(q) == {"INSTALLED": 3, "RECEIVED": 2, "ERROR": 3})
 
 
 def test_probe_status_logging_reemit_on_modify(remote_config_worker):
     assert remoteconfig_poller.status == ServiceStatus.STOPPED
 
-    with rcm_endpoint(), debugger(diagnostics_interval=0, enabled=True) as d:
+    with rcm_endpoint(), debugger(diagnostics_interval=float("inf"), enabled=True) as d:
         d.add_probes(
             create_snapshot_line_probe(
                 version=1,
@@ -662,6 +664,7 @@ def test_probe_status_logging_reemit_on_modify(remote_config_worker):
         assert versions(queue, "INSTALLED") == [1, 2]
         assert versions(queue, "RECEIVED") == [1]
 
+        d.log_probe_status()
         logger.wait(lambda q: count_status(q) == {"INSTALLED": 3, "RECEIVED": 1})
         assert versions(queue, "INSTALLED") == [1, 2, 2]
 


### PR DESCRIPTION
We make the probe status log message generation synchronous to prevent race conditions in tests that might result in flakiness.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
