### PR TITLE
chore(debugging): general coding improvements

### DIFF
--- a/tests/debugging/exception/test_auto_instrument.py
+++ b/tests/debugging/exception/test_auto_instrument.py
@@ -121,7 +121,6 @@ class ExceptionDebuggingTestCase(TracerTestCase):
             assert len(d.test_queue) == 3
 
             snapshots = {str(s.uuid): s for s in d.test_queue}
-            print(snapshots.keys())
 
             if PY < (3, 0):
                 stacks = [["c", "b_chain"], ["b_chain"], ["a"]]
@@ -136,8 +135,6 @@ class ExceptionDebuggingTestCase(TracerTestCase):
                 exc_id = span.get_tag("_dd.debug.error.exception_id")
 
                 info = {k: v for k, v in enumerate(stacks[n], start=1)}
-
-                print(span._meta["error.stack"], info)
 
                 for i in range(1, len(info) + 1):
                     fn = info[i]

--- a/tests/debugging/probe/test_remoteconfig.py
+++ b/tests/debugging/probe/test_remoteconfig.py
@@ -339,7 +339,7 @@ def test_poller_events(remote_config_worker, mock_config):
             (ProbePollerEvent.NEW_PROBES, frozenset(["probe4", "probe1", "probe2", "probe3"])),
             (ProbePollerEvent.DELETED_PROBES, frozenset(["probe1"])),
             (ProbePollerEvent.NEW_PROBES, frozenset(["probe5"])),
-            (ProbePollerEvent.STATUS_UPDATE, frozenset(["probe4", "probe2", "probe3", "probe5"])),
+            (ProbePollerEvent.STATUS_UPDATE, frozenset()),
         }, events
     finally:
         di_config.diagnostics_interval = old_interval
@@ -427,7 +427,7 @@ def test_multiple_configs(remote_config_worker):
             (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
             (ProbePollerEvent.NEW_PROBES, frozenset({"probe2"})),
             (ProbePollerEvent.NEW_PROBES, frozenset({"probe3"})),
-            (ProbePollerEvent.STATUS_UPDATE, frozenset({"probe1", "probe2", "probe3"})),
+            (ProbePollerEvent.STATUS_UPDATE, frozenset()),
         }
 
         # remove configuration
@@ -438,7 +438,7 @@ def test_multiple_configs(remote_config_worker):
             (ProbePollerEvent.NEW_PROBES, frozenset({"probe1"})),
             (ProbePollerEvent.NEW_PROBES, frozenset({"probe2"})),
             (ProbePollerEvent.NEW_PROBES, frozenset({"probe3"})),
-            (ProbePollerEvent.STATUS_UPDATE, frozenset({"probe1", "probe2", "probe3"})),
+            (ProbePollerEvent.STATUS_UPDATE, frozenset()),
             (ProbePollerEvent.DELETED_PROBES, frozenset({"probe2"})),
         }
 
@@ -579,7 +579,7 @@ def test_modified_probe_events(remote_config_worker, mock_config):
             (ProbePollerEvent.STATUS_UPDATE, frozenset()),
             (ProbePollerEvent.NEW_PROBES, frozenset(["probe1"])),
             (ProbePollerEvent.MODIFIED_PROBES, frozenset(["probe1"])),
-            (ProbePollerEvent.STATUS_UPDATE, frozenset(["probe1"])),
+            (ProbePollerEvent.STATUS_UPDATE, frozenset()),
         ]
     finally:
         di_config.diagnostics_interval = old_interval


### PR DESCRIPTION
We improve some of the coding in the debugging area to make the logic easier to follow and to remove some unnecessary complexity.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
